### PR TITLE
typo in main.js means namespace file is not found

### DIFF
--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -18,7 +18,7 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
-require("ember-data/core.js");
+require("ember-data/core");
 require("ember-data/system/store");
 require("ember-data/system/model_array");
 require("ember-data/system/model");


### PR DESCRIPTION
minispade said "The module 'ember-data/core.js' could not be found"
we said "nay"
