### PR TITLE
Adds support for user-specified source keys in DS.hasMany associations.

### DIFF
--- a/packages/ember-data/lib/system/model.js
+++ b/packages/ember-data/lib/system/model.js
@@ -354,6 +354,7 @@ DS.hasMany = function(type, options) {
     var data = get(this, 'data'), ids;
     var store = get(this, 'store');
 
+    key = (options && options.key) ? options.key : key;
     ids = findMany(store, type, data, key);
     var hasMany = store.findMany(type, ids);
 

--- a/packages/ember-data/tests/associations_test.js
+++ b/packages/ember-data/tests/associations_test.js
@@ -26,6 +26,33 @@ test("hasMany lazily loads associations as needed", function() {
   strictEqual(get(person, 'tags').objectAt(0), store.find(Tag, 5), "association objects are the same as objects retrieved directly");
 });
 
+test("hasMany allows associations to be mapped to a user-specified key", function() {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tags: DS.hasMany(Tag, { key: 'tag_ids' })
+  });
+
+  var store = DS.Store.create();
+  store.loadMany(Tag, [5, 2, 8], [
+    { id: 5, name: 'curmudgeon' },
+    { id: 2, name: 'cuddly' },
+    { id: 8, name: 'drunk' }
+  ]);
+  store.load(Person, 1, { id: 1, name: 'Carsten Nielsen', tag_ids: [2, 8] });
+
+  var person = store.find(Person, 1);
+  equals(get(person, 'name'), "Carsten Nielsen", "precond - retrieves person record from store");
+  equals(getPath(person, 'tags.length'), 2, "the list of tags should have the correct length");
+  equals(get(get(person, 'tags').objectAt(0), 'name'), "cuddly", "the first tag should be a Tag");
+
+  strictEqual(get(person, 'tags').objectAt(0), get(person, 'tags').objectAt(0), "the returned object is always the same");
+  strictEqual(get(person, 'tags').objectAt(0), store.find(Tag, 2), "association objects are the same as objects retrieved directly");
+});
+
 test("associations work when the data hash has not been loaded", function() {
   expect(13);
 


### PR DESCRIPTION
In the same way that you can pass `key` to `DS.attr` this patch allows a key to be specified for `DS.hasMany` associations:

``` javascript
Person = DS.Model.extend({
  name: DS.attr('string'),
  tags: DS.hasMany(Tag, { key: 'tag_ids' })
});
```

The tests are not awesome, looking for feedback there.
