### PR TITLE
Another modelCache fix. Re-arrange logic inside of DS.store.create.

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -153,11 +153,12 @@ DS.Store = SC.Object.extend({
     var models = get(this, 'models');
 
     var clientId = this.pushHash(hash, id, type);
-    this.updateModelArrays(type, clientId, hash);
 
     set(model, 'clientId', clientId);
 
-    get(this, 'models')[clientId] = model;
+    models[clientId] = model;
+    
+    this.updateModelArrays(type, clientId, hash);
 
     return model;
   },

--- a/packages/ember-data/tests/model_array_test.js
+++ b/packages/ember-data/tests/model_array_test.js
@@ -148,8 +148,6 @@ test("a model array that backs a collection view functions properly", function()
   store.load(Person, 5, { name: "Other Katz" });
   
   var container = Ember.CollectionView.create({
-    classNameBindings: ['name'],
-    name: 'foo',
     content: store.findAll(Person)
   });
 

--- a/packages/ember-data/tests/store_test.js
+++ b/packages/ember-data/tests/store_test.js
@@ -325,6 +325,40 @@ test("if an id is supplied in the initial data hash, it can be looked up using `
   strictEqual(person, again, "the store returns the loaded object");
 });
 
+test("models inside a collection view should have their ids updated", function() {
+  var Person = DS.Model.extend({
+    id: DS.attr("integer")
+  });
+  
+  idCounter = 1;
+  var adapter = DS.Adapter.create({
+    create: function(store, type, model) {
+      store.didCreateModel(model, {name: model.get('name'), id: idCounter++});
+    }
+  });
+
+  var store = DS.Store.create({
+    adapter: adapter
+  });
+  
+  var container = Ember.CollectionView.create({
+    content: store.findAll(Person)
+  });
+
+  Ember.run(function() {
+    container.appendTo('#qunit-fixture');
+  });
+  
+  console.log(store.create(Person, { name: "Newt Gingrich" }));
+  console.log(store.create(Person, { name: "Ron Paul" }));
+  store.commit();
+  
+  container.content.forEach(function(person, index) {
+    console.log(person);
+    equal(person.get('id'), index + 1, "The model's id should be correctly.");
+  });
+});
+
 module("DS.State - Lifecycle Callbacks");
 
 test("a model receives a didLoad callback when it has finished loading", function() {


### PR DESCRIPTION
... updated after the store's model array has been updated. Fix for #21.

Inside of `DS.Store.create`,  `updateModelArrays` was being called before `models[clientId] = model;`. This caused the ModelArray to update it's model cache against a store that wasn't in the correct state.
