### PR TITLE
don't coerce null or undefined in string and integer attr transforms

### DIFF
--- a/packages/ember-data/lib/system/model.js
+++ b/packages/ember-data/lib/system/model.js
@@ -432,29 +432,21 @@ DS.hasMany = function(type, options) {
 DS.attr.transforms = {
   string: {
     from: function(serialized) {
-      if (serialized == null) {
-        return null;
-      }
-
-      return String(serialized);
+      return Em.none(serialized) ? null : String(serialized);
     },
 
     to: function(deserialized) {
-      if (deserialized === null) {
-        return null;
-      }
-
-      return String(deserialized);
+      return Em.none(deserialized) ? null : String(deserialized);
     }
   },
 
   integer: {
     from: function(serialized) {
-      return Number(serialized);
+      return Em.none(serialized) ? null : Number(serialized);
     },
 
     to: function(deserialized) {
-      return Number(deserialized);
+      return Em.none(deserialized) ? null : Number(deserialized);
     }
   },
 

--- a/packages/ember-data/tests/model_test.js
+++ b/packages/ember-data/tests/model_test.js
@@ -67,6 +67,7 @@ test("a DS.Model can describe String attributes", function() {
   converts('string', "Scumbag Tom", "Scumbag Tom");
   converts('string', 1, "1");
   converts('string', null, null);
+  converts('string', undefined, null);
   convertsFromServer('string', undefined, null);
 });
 
@@ -75,7 +76,8 @@ test("a DS.Model can describe Integer attributes", function() {
   converts('integer', "0", 0);
   converts('integer', 1, 1);
   converts('integer', 0, 0);
-  converts('integer', null, 0);
+  converts('integer', null, null);
+  converts('integer', undefined, null);
   converts('integer', true, 1);
   converts('integer', false, 0);
 });


### PR DESCRIPTION
Similar to the date attr transform, null and undefined should be passed through for string and number transforms.

Sending over a null attribute within a JSON document and have it show up as "null" on the client side is never desired behaviour. null -> 0 isn't quite as bad considering `null + 1 === 1` but you are still silently moving something from unset to set.

I also considered passing through null for boolean transforms (as sproutcore-data does) but I'm not sure that it is appropriate.

Feedback welcome.
