### PR TITLE
Added findAll method to fixturesAdapter

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -16,5 +16,15 @@ DS.fixtureAdapter = DS.Adapter.create({
 
   findMany: function() {
     this.find.apply(this, arguments);
+  },
+
+  findAll: function(store, type) {
+    var fixtures = type.FIXTURES;
+
+    ember_assert("Unable to find fixtures for model type "+type.toString(), !!fixtures);
+
+    var ids = fixtures.map(function(item, index, self){ return item.id });
+    store.loadMany(type, ids, fixtures);
   }
+
 });


### PR DESCRIPTION
When using fixturesAdapter for testing the adapter lacks of the findAll method. This simple implementation allows to retrieve all the objects of a given type for fast prototyping.
