### PR TITLE
Error when committing a newly created record

### DIFF
--- a/packages/ember-data/lib/system/model.js
+++ b/packages/ember-data/lib/system/model.js
@@ -80,7 +80,7 @@ var DirtyState = DS.State.extend({
     manager.goToState('saving');
   },
 
-  saving: DS.State.extend({
+  saving: DS.State.create({
     isSaving: true,
 
     didUpdate: function(manager) {
@@ -95,7 +95,7 @@ var DirtyState = DS.State.extend({
     }
   }),
 
-  invalid: DS.State.extend({
+  invalid: DS.State.create({
     isValid: false,
 
     setProperty: function(manager, context) {


### PR DESCRIPTION
When creating a record and calling commit on the store, I get the
following error:

```
Uncaught TypeError: Object (subclass of DS.State) has no method 'enter'
```

Here is some code that exhibits this error:

```
window.App = Ember.Application.create();

App.store = DS.Store.create({
  adapter: DS.Adapter.create({
    createRecord: function() {
      console.log('created record');
    }
  }),
});

App.Person = DS.Model.extend({
  name:       DS.attr('string'),
});

App.store.createRecord(App.Person, {name: 'Jeff T.'});
App.store.commit();
```

The problem was that we were attempting to enter a state class, rather
than a state instance.  This was caused by calling `DS.State.extend()`
within another `DS.State.extend()` call.
