### PR TITLE
Specify a namespace for the REST adaptor which is added to all the ajax URLs

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -7,7 +7,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     var data = {};
     data[root] = get(model, 'data');
 
-    this.ajax("/" + this.pluralize(root), "POST", {
+    this.ajax(this.buildURL(root), "POST", {
       data: data,
       success: function(json) {
         store.didCreateRecord(model, json[root]);
@@ -28,7 +28,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       return get(model, 'data');
     });
 
-    this.ajax("/" + this.pluralize(root), "POST", {
+    this.ajax(this.buildURL(root), "POST", {
       data: data,
       success: function(json) {
         store.didCreateRecords(type, models, json[plural]);
@@ -43,9 +43,9 @@ DS.RESTAdapter = DS.Adapter.extend({
     var data = {};
     data[root] = get(model, 'data');
 
-    var url = ["", this.pluralize(root), id].join("/");
+    var url = ["", store.namespace, this.pluralize(root), id].join("/");
 
-    this.ajax(url, "PUT", {
+    this.ajax(this.buildURL(root, id), "PUT", {
       data: data,
       success: function(json) {
         store.didUpdateRecord(model, json[root]);
@@ -66,7 +66,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       return get(model, 'data');
     });
 
-    this.ajax("/" + this.pluralize(root), "POST", {
+    this.ajax(this.buildURL(root), "POST", {
       data: data,
       success: function(json) {
         store.didUpdateRecords(models, json[plural]);
@@ -78,9 +78,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     var id = get(model, 'id');
     var root = this.rootForType(type);
 
-    var url = ["", this.pluralize(root), id].join("/");
-
-    this.ajax(url, "DELETE", {
+    this.ajax(this.buildURL(root, id), "DELETE", {
       success: function(json) {
         store.didDeleteRecord(model);
       }
@@ -101,7 +99,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       return get(model, primaryKey);
     });
 
-    this.ajax("/" + this.pluralize(root) + "/delete", "POST", {
+    this.ajax(this.buildURL(root, 'delete'), "POST", {
       data: data,
       success: function(json) {
         store.didDeleteRecords(models);
@@ -112,9 +110,7 @@ DS.RESTAdapter = DS.Adapter.extend({
   find: function(store, type, id) {
     var root = this.rootForType(type);
 
-    var url = ["", this.pluralize(root), id].join("/");
-
-    this.ajax(url, "GET", {
+    this.ajax(this.buildURL(root, id), "GET", {
       success: function(json) {
         store.load(type, json[root]);
       }
@@ -124,7 +120,7 @@ DS.RESTAdapter = DS.Adapter.extend({
   findMany: function(store, type, ids) {
     var root = this.rootForType(type), plural = this.pluralize(root);
 
-    this.ajax("/" + plural, "GET", {
+    this.ajax(this.buildURL(root), "GET", {
       data: { ids: ids },
       success: function(json) {
         store.loadMany(type, ids, json[plural]);
@@ -136,7 +132,7 @@ DS.RESTAdapter = DS.Adapter.extend({
   findAll: function(store, type) {
     var root = this.rootForType(type), plural = this.pluralize(root);
 
-    this.ajax("/" + plural, "GET", {
+    this.ajax(this.buildURL(root), "GET", {
       success: function(json) {
         store.loadMany(type, json[plural]);
       }
@@ -146,7 +142,7 @@ DS.RESTAdapter = DS.Adapter.extend({
   findQuery: function(store, type, query, modelArray) {
     var root = this.rootForType(type), plural = this.pluralize(root);
 
-    this.ajax("/" + plural, "GET", {
+    this.ajax(this.buildURL(root), "GET", {
       data: query,
       success: function(json) {
         modelArray.load(json[plural]);
@@ -179,6 +175,19 @@ DS.RESTAdapter = DS.Adapter.extend({
     hash.dataType = "json";
 
     jQuery.ajax(hash);
+  },
+
+  buildURL: function(model, suffix) {
+    url = [""];
+    if (this.namespace != undefined) {
+      url.push(this.namespace);
+    };
+    url.push(this.pluralize(model));
+    if (suffix != undefined) {
+      url.push(suffix);
+    };
+
+    return url.join("/");
   }
 });
 

--- a/packages/ember-data/tests/rest_adapter_test.js
+++ b/packages/ember-data/tests/rest_adapter_test.js
@@ -42,7 +42,7 @@ module("the REST adapter", {
 });
 
 var expectUrl = function(url, desc) {
-  equal(url, ajaxUrl, "the URL is " + desc);
+  equal(ajaxUrl, url, "the URL is " + desc);
 };
 
 var expectType = function(type) {
@@ -326,3 +326,11 @@ test("deleting several people (with bulkCommit) makes a POST to /people/delete_m
   expectStates('deleted');
   expectStates('dirty', false);
 });
+
+test("if you specify a namespace then it is prepended onto all URLs", function() {
+  set(adapter, 'namespace', 'ember');
+
+  person = store.find(Person, 1);
+
+  expectUrl("/ember/people/1", "the namespace, followed by by the plural of the model name and the id")
+})


### PR DESCRIPTION
Usage:
    App.store = DS.Store.create({ DS.RESTAdapter.create({ namespace: 'ember' }) });

Result: Calling App.store.find(App.Person, 1) would send a request to /ember/people/1 instead of /people/1

You can get the same result if you reopen all your models and add an url to them, but if you have lots then it isn't very DRY.
