### PR TITLE
Fixes DS.RESTAdapter when used with a model with custom primaryKey

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -37,7 +37,8 @@ DS.RESTAdapter = DS.Adapter.extend({
   },
 
   updateRecord: function(store, type, model) {
-    var id = get(model, 'id');
+    var primaryKey = getPath(type, 'proto.primaryKey'),
+        id = get(model, primaryKey);
     var root = this.rootForType(type);
 
     var data = {};
@@ -75,7 +76,8 @@ DS.RESTAdapter = DS.Adapter.extend({
   },
 
   deleteRecord: function(store, type, model) {
-    var id = get(model, 'id');
+    var primaryKey = getPath(type, 'proto.primaryKey'),
+        id = get(model, primaryKey);
     var root = this.rootForType(type);
 
     var url = ["", this.pluralize(root), id].join("/");

--- a/packages/ember-data/tests/rest_adapter_test.js
+++ b/packages/ember-data/tests/rest_adapter_test.js
@@ -4,6 +4,7 @@ var get = SC.get, set = SC.set;
 
 var adapter, store, ajaxUrl, ajaxType, ajaxHash;
 var Person, person, people;
+var Role, role, roles;
 
 module("the REST adapter", {
   setup: function() {
@@ -31,6 +32,11 @@ module("the REST adapter", {
     Person.toString = function() {
       return "App.Person";
     }
+
+    Role = DS.Model.extend({ primaryKey: '_id' });
+    Role.toString = function() {
+      return "App.Role";
+    }
   },
 
   teardown: function() {
@@ -42,7 +48,7 @@ module("the REST adapter", {
 });
 
 var expectUrl = function(url, desc) {
-  equal(url, ajaxUrl, "the URL is " + desc);
+  equal(ajaxUrl, url, "the URL is " + desc);
 };
 
 var expectType = function(type) {
@@ -113,6 +119,20 @@ test("updating a person makes a POST to /people/:id with the data hash", functio
   equal(person, store.find(Person, 1), "the same person is retrieved by the same ID");
 });
 
+test("updating a record with custom primaryKey", function() {
+  set(adapter, 'bulkCommit', false);
+  store.load(Role, { _id: 1, name: "Developer" });
+
+  role = store.find(Role, 1)
+
+  set(role, 'name', "Manager");
+  store.commit();
+
+  expectUrl("/roles/1", "the plural of the model name with its ID");
+  ajaxHash.success({ person: { id: 1, name: "Manager" } });
+})
+
+
 test("deleting a person makes a DELETE to /people/:id", function() {
   set(adapter, 'bulkCommit', false);
 
@@ -136,6 +156,21 @@ test("deleting a person makes a DELETE to /people/:id", function() {
 
   ajaxHash.success({ success: true });
   expectState('deleted');
+});
+
+test("deleting a record with custom primaryKey", function() {
+  set(adapter, 'bulkCommit', false);
+
+  store.load(Role, { _id: 1, name: "Developer" });
+
+  role = store.find(Role, 1);
+
+  role.deleteRecord();
+
+  store.commit();
+
+  expectUrl("/roles/1", "the plural of the model name with its ID");
+  ajaxHash.success({ success: true });
 });
 
 test("finding a person by ID makes a GET to /people/:id", function() {


### PR DESCRIPTION
`updateRecord()` and `deleteRecord()` did not respect the model's `primaryKey` setting.
