### PR TITLE
add an alternative option in the hasOne association

### DIFF
--- a/packages/ember-data/lib/system/model.js
+++ b/packages/ember-data/lib/system/model.js
@@ -421,8 +421,17 @@ var hasAssociation = function(type, options, one) {
 
     key = (options && options.key) ? options.key : key;
     if (one) {
+      alternative = (options && options.alternative) ? options.alternative : null;
       id = findRecord(store, type, data, key, true);
-      association = id ? store.find(type, id) : null;
+      if (id) {
+        association = store.find(type, id);
+      } else {
+        if (typeof alternative == 'function') {
+          association = alternative(data);
+        } else {
+          association = alternative;
+        }
+      }
     } else {
       ids = findRecord(store, type, data, key);
       association = store.findMany(type, ids);

--- a/packages/ember-data/tests/associations_test.js
+++ b/packages/ember-data/tests/associations_test.js
@@ -366,3 +366,21 @@ test("hasOne embedded associations work the same as referenced ones, and have th
   strictEqual(get(person, 'tag'), get(person, 'tag'), "the returned object is always the same");
   strictEqual(get(person, 'tag'), store.find(Tag, 5), "association object are the same as object retrieved directly");
 });
+
+test("hasOne associations allow an alternative parameter, called instead of null", function() {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var Person = DS.Model.extend({
+    tag: DS.hasOne(Tag, {alternative: "hello world"}),
+    second_tag: DS.hasOne(Tag, {alternative: function() { return "hola mundo"; }})
+  });
+
+  var store = DS.Store.create();
+  store.load(Person, 1, { id: 1 });
+
+  var person = store.find(Person, 1);
+  equals(get(person, 'tag'), "hello world");
+  equals(get(person, 'second_tag'), "hola mundo");
+});


### PR DESCRIPTION
This allows to change the null retrieved when the result of the association is not available.

```
DS.Model.extend({
  tag: DS.hasOne(Tag, {alternative: function() { App.store.load(Tag, {})}})
});
```

This way, we can return a new record instead of a useless null when the association couldn't be found.

The alternative value can be a function, in which case it will be called and it's return value will be used.
Otherwise, it will just be used as it is (a string for example).
