### PR TITLE
RESTAdapter invokes user-specified error callbacks.

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -14,6 +14,10 @@ DS.RESTAdapter = DS.Adapter.extend({
         this.sideload(store, type, json, root);
         store.didCreateRecord(model, json[root]);
       }
+    }, {
+      action: 'create',
+      store:  store,
+      models: [model]
     });
   },
 
@@ -53,6 +57,10 @@ DS.RESTAdapter = DS.Adapter.extend({
         this.sideload(store, type, json, root);
         store.didUpdateRecord(model, json && json[root]);
       }
+    }, {
+      action: 'update',
+      store:  store,
+      models: [model]
     });
   },
 
@@ -87,6 +95,10 @@ DS.RESTAdapter = DS.Adapter.extend({
         if (json) { this.sideload(store, type, json); }
         store.didDeleteRecord(model);
       }
+    }, {
+      action: 'delete',
+      store:  store,
+      models: [model]
     });
   },
 
@@ -120,6 +132,9 @@ DS.RESTAdapter = DS.Adapter.extend({
         store.load(type, json[root]);
         this.sideload(store, type, json, root);
       }
+    }, {
+      action: 'find',
+      store:  store
     });
   },
 
@@ -132,6 +147,9 @@ DS.RESTAdapter = DS.Adapter.extend({
         store.loadMany(type, ids, json[plural]);
         this.sideload(store, type, json, plural);
       }
+    }, {
+      action: 'find',
+      store:  store
     });
   },
 
@@ -143,6 +161,9 @@ DS.RESTAdapter = DS.Adapter.extend({
         store.loadMany(type, json[plural]);
         this.sideload(store, type, json, plural);
       }
+    }, {
+      action: 'find',
+      store:  store
     });
   },
 
@@ -155,6 +176,9 @@ DS.RESTAdapter = DS.Adapter.extend({
         modelArray.load(json[plural]);
         this.sideload(store, type, json, plural);
       }
+    }, {
+      action: 'find',
+      store:  store
     });
   },
 
@@ -177,7 +201,11 @@ DS.RESTAdapter = DS.Adapter.extend({
     return name.replace(/([A-Z])/g, '_$1').toLowerCase().slice(1);
   },
 
-  ajax: function(url, type, hash) {
+  jQuery: jQuery,
+  error:  jQuery.noop,
+
+  ajax: function(url, type, hash, adapterContext) {
+    var self = this;
     hash.url = url;
     hash.type = type;
     hash.dataType = 'json';
@@ -188,7 +216,16 @@ DS.RESTAdapter = DS.Adapter.extend({
       hash.data = JSON.stringify(hash.data);
     }
 
-    jQuery.ajax(hash);
+    hash.error = function(jqXHR, textStatus, errorThrown) {
+      if (jqXHR.status === 422 && adapterContext.models && adapterContext.models.length === 1 && adapterContext.store) {
+        var data = JSON.parse( jqXHR.responseText );
+        adapterContext.store.recordWasInvalid(adapterContext.models[0], data['errors']);
+      } else {
+        self.error(jqXHR, textStatus, errorThrown, adapterContext);
+      }
+    };
+
+    this.jQuery.ajax(hash);
   },
 
   sideload: function(store, type, json, root) {

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -2,30 +2,42 @@ require('ember-data/adapters/rest_adapter');
 
 var get = Ember.get, set = Ember.set;
 
-var adapter, store, ajaxUrl, ajaxType, ajaxHash;
+var adapter, store, ajaxUrl, ajaxType, ajaxHash, ajaxErrorHandler;
+var userErrorHandlerXhr, userErrorHandlerAction, userErrorHandlerModels;
 var Person, person, people;
 var Role, role, roles;
 var Group, group;
 
 module("the REST adapter", {
   setup: function() {
-    ajaxUrl = undefined;
-    ajaxType = undefined;
-    ajaxHash = undefined;
+    resetMockXhr();
 
     adapter = DS.RESTAdapter.create({
-      ajax: function(url, type, hash) {
-        var success = hash.success, self = this;
+      jQuery: {
+        ajax: function( hash ) {
+          var success = hash.success;
 
-        ajaxUrl = url;
-        ajaxType = type;
-        ajaxHash = hash;
+          ajaxUrl = hash.url;
+          ajaxType = hash.type;
+          ajaxHash = hash;
+          ajaxErrorHandler = hash.error;
 
-        if (success) {
-          hash.success = function(json) {
-            success.call(self, json);
-          };
+          if(hash.data && typeof(hash.data) === "string") {
+            hash.data = JSON.parse(hash.data);
+          }
+
+          if (success) {
+            hash.success = function(json) {
+              success.call(store.adapter, json);
+            };
+          }
         }
+      },
+
+      error: function( jqXhr, textStatus, errorThrown, emberParams ) {
+        userErrorHandlerXhr = jqXhr;
+        userErrorHandlerAction = emberParams.action;
+        userErrorHandlerModels = emberParams.models;
       },
 
       plurals: {
@@ -65,12 +77,27 @@ module("the REST adapter", {
   },
 
   teardown: function() {
-    adapter.destroy();
-    store.destroy();
+    if (person) {
+      if( person.get('isSaving')) {
+        person.get('stateManager').goToState('saved');
+      }
+      person.destroy();
+    }
 
-    if (person) { person.destroy(); }
+    store.destroy();
+    adapter.destroy();
   }
 });
+
+var resetMockXhr = function() {
+  ajaxUrl =
+    ajaxType =
+    ajaxHash =
+    ajaxErrorHandler =
+    userErrorHandlerXhr =
+    userErrorHandlerAction =
+    userErrorHandlerModels = undefined;
+};
 
 var expectUrl = function(url, desc) {
   equal(ajaxUrl, url, "the URL is " + desc);
@@ -98,6 +125,125 @@ var expectStates = function(state, value) {
     expectState(state, value, person);
   });
 };
+
+var expectNoErrorHandlerInvoked = function( mockXhr ) {
+  mockXhr = mockXhr || {};
+  equal( typeof( ajaxErrorHandler ), "function", "RESTAdapter supplies an error handler to jQuery.ajax.");
+  ajaxErrorHandler( mockXhr, 'error', 'synthetic error'); // should not raise error, in particular no 'no method' error
+};
+
+var expectUserErrorHandlerInvoked = function( action, models ) {
+  var mockXhr = {};
+  if( arguments.length < 2 ){ models = [person]; }
+
+  equal( typeof( ajaxErrorHandler ), "function", "RESTAdapter supplies an error handler to jQuery.ajax.");
+  ajaxErrorHandler( mockXhr, 'error', 'synthetic error');
+  strictEqual( userErrorHandlerXhr, mockXhr, "User supplied error handlers are invoked on jQuery.ajax errors and passed jqXhr.");
+  strictEqual( userErrorHandlerAction, action, "User supplied error handlers are invoked on jQuery.ajax errors and passed action.");
+  deepEqual( userErrorHandlerModels, models, "User supplied error handlers are invoked on jQuery.ajax errors and passed models.");
+};
+
+var expectModelMarkedInvalidFromXhr = function( errors ) {
+  equal( typeof( ajaxErrorHandler ), "function", "RESTAdapter supplies an error handler to jQuery.ajax.");
+
+  var mockXhr = {
+    status:       422,
+    responseText: JSON.stringify({ errors: errors })
+  };
+  ajaxErrorHandler( mockXhr, 'error', 'synthetic error');
+
+  equal( person.get('isValid'), false, "Person is valid.");
+  deepEqual( person.get('errors'), errors, "Person has errors set.");
+  strictEqual( userErrorHandlerXhr, undefined, "User supplied error handlers are not invoked on jQuery.ajax 422 error.");
+};
+
+test("creating a single record with a server error invokes the user-specified error handler", function() {
+  set(adapter, 'bulkCommit', false);
+
+  person = store.createRecord(Person, { name: "Cyril Fluck" });
+  store.commit();
+  expectUserErrorHandlerInvoked('create');
+});
+
+test("updating a single record with a server error invokes the user-specified error handler", function() {
+  set(adapter, 'bulkCommit', false);
+
+  store.load(Person, { id: 1, name: "David J. Hamilton" });
+  person = store.find( Person, 1 );
+  person.set( 'name', 'Cyril Fluck');
+  store.commit();
+  expectUserErrorHandlerInvoked('update');
+});
+
+test("deleting a single record with a server error invokes the user-specified error handler", function() {
+  set(adapter, 'bulkCommit', false);
+
+  store.load(Person, { id: 1, name: "David J. Hamilton" });
+  person = store.find( Person, 1 );
+  person.deleteRecord();
+  store.commit();
+  expectUserErrorHandlerInvoked('delete');
+});
+
+test("creating a record with a 422 and no user-specified error handler does not raise an exception", function() {
+  set(adapter, 'bulkCommit', false);
+
+  person = store.createRecord(Person, { name: "Cyril Fluck" });
+  store.commit();
+
+  expectNoErrorHandlerInvoked({ status: 422, responseText: JSON.stringify({ errors: {}}) });
+});
+
+test("updating a record with a 422 and no user-specified error handler does not raise an exception", function() {
+  set(adapter, 'bulkCommit', false);
+
+  store.load(Person, { id: 1, name: "David J. Hamilton" });
+  person = store.find( Person, 1 );
+  person.set( 'name', 'Cyril Fluck');
+  store.commit();
+
+  expectNoErrorHandlerInvoked({ status: 422, responseText: JSON.stringify({ errors: {}}) });
+});
+
+test("creating a record with a 422 error marks the records as invalid", function(){
+  set(adapter, 'bulkCommit', false);
+
+  person = store.createRecord(Person, { name: "Cyril Fluck" });
+  store.commit();
+  expectModelMarkedInvalidFromXhr({ name: ["is French"]});
+  deepEqual( person.get('errors').name, ["is French"]);
+});
+
+test("updating a record with a 422 error marks the records as invalid", function(){
+  set(adapter, 'bulkCommit', false);
+
+  store.load(Person, { id: 1, name: "David J. Hamilton" });
+  person = store.find( Person, 1 );
+  person.set('name', 'Cyril Fluck');
+  store.commit();
+  expectModelMarkedInvalidFromXhr({ name: ["is English"]});
+  deepEqual( person.get('errors').name, ["is English"]);
+});
+
+test("finding a person by ID with a server error invokes the user-specified error handler", function() {
+  store.find( Person, 1 );
+  expectUserErrorHandlerInvoked('find', undefined);
+});
+
+test("finding many people by a list of IDs with a server error invokes the user-specified error handler", function() {
+  store.findMany( Person, [1,2,3]);
+  expectUserErrorHandlerInvoked('find', undefined);
+});
+
+test("finding all people with a server error invokes the user-specified error handler", function() {
+  store.findAll( Person );
+  expectUserErrorHandlerInvoked('find', undefined);
+});
+
+test("finding people by a query with a server error invokes the user-specified error handler", function() {
+  store.find( Person, { page: 1 });
+  expectUserErrorHandlerInvoked('find', undefined);
+});
 
 test("creating a person makes a POST to /people, with the data hash", function() {
   set(adapter, 'bulkCommit', false);


### PR DESCRIPTION
This PR allows users to specify an error handler that is invoked on server errors when records are created, updated or queried.

In the special case of a single record (create or update) with a status of 422, the record is invalidated with `store.recordWasInvalid`.

Example:

``` javascript

DS.RESTAdapter.create({
  error: function( jqXhr, textStatus, errorThrown, emberParams ) {
    // user-supplied error handling
  }
});
```

/cc @hjdivad @Cyril-sf
