### PR TITLE
add a setData method to the 'saved' state

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -422,7 +422,16 @@ var states = {
         waitingOn: function(manager, object) {
           waitingOn(manager, object);
           manager.goToState('updated.pending');
+        },
+
+        // If a saved model receives updates, eg. from a server-side
+        // push or as a result of a find(id) ajax callback returning
+        // load it again
+        setData: function(manager, data) {
+          manager.goToState('loading');
+          manager.send('setData', data);
         }
+
       }),
 
       // A record is in this state after it has been locally


### PR DESCRIPTION
...so that already loaded records can receive ajax/pusher callbacks

Currently if you do the following:

```
App = Ember.Application.create
  ready: ->
    @_super
    App.peopleController.findAll()
```

and then call

```
person = App.Store.find(App.Person, id)
```

you will end up with an error along the lines of this:

```
STATEMANAGER: Sending event 'setData' to state loading.
ember.js:13486STATEMANAGER: Sending event 'loadedData' to state loading.
ember.js:13610STATEMANAGER: Entering loaded
ember.js:13625STATEMANAGER: Entering saved
ember.js:4098Begin: Flush Sync Queue
ember.js:4104End: Flush Sync Queue
ember.js:4098Begin: Flush Sync Queue
ember.js:4104End: Flush Sync Queue
ember.js:13493Uncaught Error: <DS.StateManager:ember438> could not respond to event setData in state saved.
Ember.StateManager.Ember.State.extend.sendRecursivelyember.js:13493
Ember.StateManager.Ember.State.extend.sendRecursivelyember.js:13491
Ember.StateManager.Ember.State.extend.sendRecursivelyember.js:13491
Ember.StateManager.Ember.State.extend.sendRecursivelyember.js:13491
Ember.StateManager.Ember.State.extend.sendember.js:13477
DS.Model.Ember.Object.extend.sendember-data.js:1942
DS.Store.Ember.Object.extend.loadember-data.js:1248
```

with this change you get this

```
STATEMANAGER: Sending event 'setData' to state loading.
ember.js:13486STATEMANAGER: Sending event 'loadedData' to state loading.
ember.js:13610STATEMANAGER: Entering loaded
ember.js:13625STATEMANAGER: Entering saved
ember.js:13486STATEMANAGER: Sending event 'setData' to state saved.   <============
ember.js:13610STATEMANAGER: Entering loading
ember.js:13486STATEMANAGER: Sending event 'setData' to state loading.
ember.js:13486STATEMANAGER: Sending event 'loadedData' to state loading.
```

I realize this is a pretty basic implementation, and a more robust design may be necessary, but it serves to get some discussion underway
