### PR TITLE
Allowing errors to be undefined

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -15,6 +15,14 @@ var isEmptyObject = function(object) {
   return true;
 };
 
+var hasDefinedProperties = function(object) {
+  for (var name in object) {
+    if (object.hasOwnProperty(name) && object[name]) { return true; }
+  }
+
+  return false;
+};
+
 DS.State = Ember.State.extend({
   isLoaded: stateProperty,
   isDirty: stateProperty,
@@ -31,15 +39,6 @@ DS.State = Ember.State.extend({
   // type of dirty state it is.
   dirtyType: stateProperty
 });
-
-var isEmptyObject = function(obj) {
-  for (var prop in obj) {
-    if (!obj.hasOwnProperty(prop)) { continue; }
-    return false;
-  }
-
-  return true;
-};
 
 var setProperty = function(manager, context) {
   var key = context.key, value = context.value;
@@ -320,7 +319,7 @@ var DirtyState = DS.State.extend({
 
       delete errors[key];
 
-      if (isEmptyObject(errors)) {
+      if (!hasDefinedProperties(errors)) {
         manager.send('becameValid');
       }
     },

--- a/packages/ember-data/tests/integration/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/store_adapter_test.js
@@ -492,7 +492,11 @@ test("if a created model is marked as invalid by the server, it enters an error 
   set(yehuda, 'updatedAt', true);
   equal(get(yehuda, 'isValid'), false, "the record is still invalid");
 
+  var errors = get(yehuda, 'errors');
+  errors['other_bound_property'] = undefined;
+  set(yehuda, 'errors', errors);
   set(yehuda, 'name', "Brohuda Brokatz");
+
   equal(get(yehuda, 'isValid'), true, "the record is no longer invalid after changing");
   equal(get(yehuda, 'isDirty'), true, "the record has outstanding changes");
 


### PR DESCRIPTION
When we bind to an error property in the view, it sets the
value to undefined.  This causes the errors to not be an empty
object, thus the model never transitions out of invalid.

Also deleted our least prefered version of isEmptyObject,
since having two did not seem necessary.
