### PR TITLE
Cacheable attributes

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -23,9 +23,9 @@ DS.attr = function(type, options) {
 
       value = transformTo(value);
       this.setProperty(key, value);
-      return value;
+      return transformFrom(value);
     }
-  }).property('data');
+  }).property('data').cacheable();
 };
 DS.attr.transforms = {
   string: {

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -131,6 +131,22 @@ test("a DS.Model can describe Date attributes", function() {
   convertsWhenSet('date', date, dateString);
 });
 
+test("it should cache attributes", function() {
+  var model = DS.Model._create({
+    updatedAt: DS.attr('date')
+  });
+
+  var dateString = "Sat, 31 Dec 2011 00:08:16 GMT";
+  var date = new Date(dateString);
+
+  model.send('loadingData');
+  model.send('setData', {});
+
+  model.set('updatedAt', date);
+  deepEqual(date, get(model, 'updatedAt'), "setting a date returns the same date");
+  strictEqual(get(model, 'updatedAt'), get(model, 'updatedAt'), "second get still returns the same object");
+});
+
 test("it can specify which key to use when looking up properties on the hash", function() {
   var model = DS.Model._create({
     name: DS.attr('string', { key: 'full_name' })


### PR DESCRIPTION
This makes possible bindings between view and date attribute. Or other attribute which returns object.
