### PR TITLE
Workaround to allow YUI Compressor to compress Ember Data.

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -70,7 +70,7 @@ DS.attr.transforms = {
     }
   },
 
-  boolean: {
+  'boolean': {
     from: function(serialized) {
       return Boolean(serialized);
     },


### PR DESCRIPTION
When trying to compress Ember Data using YUI Compressor, an error occurs because it thinks boolean is a reserved word. This just works around that by quoting boolean.
