### PR TITLE
add 'array' attribute type to DS.Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,15 @@ App.Person = DS.Model.extend({
     firstName: DS.attr('string'),
     lastName: DS.attr('string'),
     birthday: DS.attr('date'),
+    luckyNumbers: DS.attr('array'),
 
     fullName: function() {
         return this.get('firstName') + ' ' + this.get('lastName');
-    }.property('firstName', 'lastName')
+    }.property('firstName', 'lastName'),
+
+    highestLuckyNumber: function() {
+        return Math.max.apply(Math, this.get('luckyNumbers'));
+    }.property('luckyNumbers.@each')
 });
 ```
 

--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -103,6 +103,15 @@ DS.attr.transforms = {
     }
   },
 
+  array: {
+    from: function(serialized) {
+      return (Ember.isArray(serialized) ? serialized : null);
+    },
+    to: function(deserialized){
+      return (Ember.isArray(deserialized) ? deserialized : null);
+    }
+  },
+
   date: {
     from: function(serialized) {
       var type = typeof serialized;

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -136,6 +136,15 @@ test("a DS.Model can describe Date attributes", function() {
   convertsWhenSet('date', date, dateString);
 });
 
+test("a DS.Model can describe array attributes", function(){
+  converts('array', null, null);
+  converts('array', undefined, null);
+  converts('array', '', null);
+  converts('array', [], []);
+  converts('array', [''], ['']);
+  converts('array', [1,true,"hello"], [1,true,"hello"]);
+});
+
 test("retrieving properties should return the same value as they would if they were not in the data hash if the record is not loaded", function() {
   var store = DS.Store.create({
     adapter: DS.Adapter.create({


### PR DESCRIPTION
Inspired by question of @cloke in IRC at 2012-03-05 "18:16 cloke_ with data is there a way to have one of the attributes be an array? The data from the server is just a flat array so an association seems overly complex."
