### PR TITLE
Change to 'proto' to use ember master

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -16,7 +16,7 @@ DS.Model.reopenClass({
   processAttributeKeys: function() {
     if (this.processedAttributeKeys) { return; }
 
-    var namingConvention = getPath(this, 'proto.namingConvention');
+    var namingConvention = this.proto().namingConvention;
 
     this.eachComputedProperty(function(name, meta) {
       if (meta.isAttribute && !meta.options.key) {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -477,7 +477,7 @@ DS.Store = Ember.Object.extend({
 
 
   didCreateRecords: function(type, array, hashes) {
-    var primaryKey = getPath(type, 'proto.primaryKey'),
+    var primaryKey = type.proto().primaryKey,
         typeMap = this.typeMapFor(type),
         id, clientId;
 
@@ -497,7 +497,7 @@ DS.Store = Ember.Object.extend({
     // The hash is optional, but if it is not provided, the client must have
     // provided a primary key.
 
-    primaryKey = getPath(type, 'proto.primaryKey');
+    primaryKey = type.proto().primaryKey;
 
     // TODO: Make ember_assert more flexible and convert this into an ember_assert
     if (hash) {
@@ -670,7 +670,7 @@ DS.Store = Ember.Object.extend({
   load: function(type, id, hash) {
     if (hash === undefined) {
       hash = id;
-      var primaryKey = getPath(type, 'proto.primaryKey');
+      var primaryKey = type.proto().primaryKey;
       ember_assert("A data hash was loaded for a model of type " + type.toString() + " but no primary key '" + primaryKey + "' was provided.", primaryKey in hash);
       id = hash[primaryKey];
     }
@@ -703,7 +703,7 @@ DS.Store = Ember.Object.extend({
     if (hashes === undefined) {
       hashes = ids;
       ids = [];
-      var primaryKey = getPath(type, 'proto.primaryKey');
+      var primaryKey = type.proto().primaryKey;
 
       ids = Ember.ArrayUtils.map(hashes, function(hash) {
         return hash[primaryKey];


### PR DESCRIPTION
On ember master ( from commit https://github.com/emberjs/ember.js/commit/1520369d998c4cdeea95e2fe74b92fd6bc9c41c9 ), proto is no longer a computed property.

Ember data uses proto to get the primary key and naming convention. Change the code to call proto() as a normal function.

All tests are passing.
