### PR TITLE
Trailing comma breaks IE7

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -495,7 +495,7 @@ var states = {
       // A record is in this state if it has already been
       // saved to the server, but there are new local changes
       // that have not yet been saved.
-      updated: updatedState,
+      updated: updatedState
     }),
 
     // A record is in this state if it was deleted from the store.


### PR DESCRIPTION
IE7 gets stuck on trailing commas. This fixes ember data so it doesn't cause an error in IE7.
