### PR TITLE
Updates comments to reflect the model source code

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -128,11 +128,11 @@ DS.Model = Ember.Object.extend({
     return data && get(data, primaryKey);
   }).property('primaryKey', 'data'),
 
-  // The following methods are callbacks invoked by `getJSON`. You
+  // The following methods are callbacks invoked by `toJSON`. You
   // can override one of the callbacks to override specific behavior,
-  // or getJSON itself.
+  // or toJSON itself.
   //
-  // If you override getJSON, you can invoke these callbacks manually
+  // If you override toJSON, you can invoke these callbacks manually
   // to get the default behavior.
 
   /**


### PR DESCRIPTION
The comments in the model source file talked about a `getJSON` function although the function is called `toJSON` instead.
