### PR TITLE
Explicitly setting ajax charset to utf-8 to prevent encoding problems

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -181,7 +181,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     hash.url = url;
     hash.type = type;
     hash.dataType = 'json';
-    hash.contentType = 'application/json';
+    hash.contentType = 'application/json; charset=utf-8';
     hash.context = this;
 
     if (hash.data && type !== 'GET') {


### PR DESCRIPTION
I ran into problems transfering special characters throught the request body (PUT/POST). Setting the charset solved the problem.
