### PR TITLE
WIP - register DS.AdapterPopulatedModelArray as a result of findQuery an...

### DIFF
--- a/packages/ember-data/lib/system/model_array/adapter_populated_model_array.js
+++ b/packages/ember-data/lib/system/model_array/adapter_populated_model_array.js
@@ -2,14 +2,12 @@ require("ember-data/system/model_array");
 
 var get = Ember.get, set = Ember.set;
 
-DS.AdapterPopulatedModelArray = DS.ModelArray.extend({
+DS.AdapterPopulatedModelArray = DS.FilteredModelArray.extend({
   query: null,
   isLoaded: false,
 
-  replace: function() {
-    var type = get(this, 'type').toString();
-    throw new Error("The result of a server query (on " + type + ") is immutable.");
-  },
+  // don't accept new records by default
+  filterFunction: function() { return false; },
 
   load: function(array) {
     var store = get(this, 'store'), type = get(this, 'type');


### PR DESCRIPTION
...d allow passing in a filterFunction to filter subsequent additions.
## 

As per #183, this registers the <code>ModelArray</code> generated from <code>DS.Store#findQuery</code> so that it's notified of updates just like a findAll. 

It extends <code>FilteredModelArray</code> so that it can take a <code>filterFunction</code>, which defaults to returning false and so rejecting new records unless you explicitly set one up.

If no filterFunction is provided, we could look at the query hash and attempt to apply that, for example:

```
App.store.find(App.ChatMessage, {project_id: 123})
```

Could be equivalent to:

```
App.store.find(App.ChatMessage, {project_id: 123}, function(record) {
    return record.get("projectId") == 123;
})
```

Obviously it would need to run the query hash through <code>NamingConvention</code> for that to work.

The main problem at the moment is that the object passed to the filterFunction isn't actually the record object. It's an object which has the record data in <code>savedData</code> when data is initially loaded, and then later a <code>DS._DataProxy</code> object with a <code>record</code> property.

That means in my example app the filter is currently along the lines of:

```
App.store.find(App.ChatMessage, {project_id: 123}, function(proxy) {
    var record;
    if (record == proxy.get("record")) {
        return record.get("projectId") == 123;
    }
})
```

This works, but obviously isn't an interface which would want to be public!

I've not added any new tests, but was surprised to see that it didn't break any existing ones! Mainly looking for feedback as to whether this is a worthwhile angle of investigation and worth continuing development.
