### PR TITLE
Dirtying embedded belongsTo dirties parent.

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -203,6 +203,7 @@ var DirtyState = DS.State.extend({
 
     // EVENTS
     deleteRecord: Ember.K,
+    becameDirty: Ember.K,
 
     waitingOn: function(manager, object) {
       waitingOn(manager, object);
@@ -489,6 +490,10 @@ var states = {
 
         setAssociation: function(manager, context) {
           setAssociation(manager, context);
+          manager.goToState('updated');
+        },
+
+        becameDirty: function(manager){
           manager.goToState('updated');
         },
 


### PR DESCRIPTION
Fixes #187.

Note: This commit handles the simple case of one record belongsTo one other
record.  There are two cases not handled:
1. Two parents each embed the same associated record.
2. The parent of an embedded record changes.
