### PR TITLE
Add support for custom findRecord functions to be passed to DS.hasMany

### DIFF
--- a/packages/ember-data/lib/system/associations/has_many.js
+++ b/packages/ember-data/lib/system/associations/has_many.js
@@ -14,8 +14,12 @@ var referencedFindRecord = function(store, type, data, key, one) {
 var hasAssociation = function(type, options) {
   options = options || {};
 
-  var embedded = options.embedded,
-      findRecord = embedded ? embeddedFindRecord : referencedFindRecord;
+  var findRecord;
+
+  if (options.findRecord)
+    findRecord = options.findRecord;
+  else
+    findRecord = options.embedded ? embeddedFindRecord : referencedFindRecord;
 
   var meta = { type: type, isAssociation: true, options: options, kind: 'hasMany' };
 


### PR DESCRIPTION
...allows for things like extracting id's from ref urls.

This isn't quite complete yet, I want to ensure that we have the same support for belongsTo as well.

There are related or potentially conflicting things in other issues, so I'm opening the discussion to see if the approach is agreeable.
