### PR TITLE
Update Gemfile for the wagenet/ember-docs move to emberjs/docs-generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem "uglifier", "~> 1.0.3"
 group :development do
   gem "rack"
   gem "github-upload"
-  gem "ember-docs", :git => "https://github.com/wagenet/ember-docs.git"
+  gem "ember-docs", :git => "https://github.com/emberjs/docs-generator.git"
   gem "kicker"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
+  remote: https://github.com/emberjs/docs-generator.git
+  revision: cfbb82496c1c342ff6da49fc46559dd8fddf8b55
+  specs:
+    ember-docs (0.1)
+      rack
+      thor
+
+GIT
   remote: https://github.com/livingsocial/rake-pipeline.git
   revision: b70ca6cad7655e58d13031f3e24df7dfc74f9030
   specs:
     rake-pipeline (0.6.0)
       rake (~> 0.9.0)
-      thor
-
-GIT
-  remote: https://github.com/wagenet/ember-docs.git
-  revision: b32c0cb5ceea286c755a17640cb7f6750543e71c
-  specs:
-    ember-docs (0.1)
-      rack
       thor
 
 GIT


### PR DESCRIPTION
At some point the ember-docs repo was moved to emberjs/docs-generator and the Gemfile needs to be updated accordingly.
