### PR TITLE
Fix computed properties for embedded hasMany relationships (fixes #191)

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -291,6 +291,12 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
 
         if (cachedValue) {
           var ids = data.get(name) || [];
+          if (association.options.embedded) {
+            var primaryKey = association.type.proto().primaryKey;
+            ids = Ember.ArrayUtils.map(ids, function(obj) {
+              return get(obj, primaryKey);
+            });
+          }
           var clientIds = Ember.ArrayUtils.map(ids, function(id) {
             return store.clientIdForId(association.type, id);
           });


### PR DESCRIPTION
This commit fixes Issue #191, where:
- a model A `hasMany` model B's,
- the model B objects are embedded in a model A object, and
- model A has a computed property that depends on _a property of_ the
  hasMany association.

In such a case, what should have been the IDs of the embedded model B
objects were actually the objects themselves, which was causing
problems.

This bug is fixed in this commit and covered by a new test.
