### PR TITLE
Guard against URL components starting with slash

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -226,6 +226,10 @@ DS.RESTAdapter = DS.Adapter.extend({
   buildURL: function(record, suffix) {
     var url = [""];
 
+    ember_assert("Namespace URL (" + this.namespace + ") must not start with slash", !this.namespace || this.namespace.toString().charAt(0) !== "/");
+    ember_assert("Record URL (" + record + ") must not start with slash", !record || record.toString().charAt(0) !== "/");
+    ember_assert("URL suffix (" + suffix + ") must not start with slash", !suffix || suffix.toString().charAt(0) !== "/");
+
     if (this.namespace !== undefined) {
       url.push(this.namespace);
     }


### PR DESCRIPTION
If you set url: '/foo' or namespace: '/api', you get URLs with two
leading slashes, which then are interpreted protocol-relative
(http://foo). This is incredibly confusing, so this patch adds
assertions to guard against it.
