### PR TITLE
Correct link errors in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 source "http://rubygems.org"
 
-gem "rake-pipeline", :git => "https://github.com/livingsocial/rake-pipeline.git"
-gem "rake-pipeline-web-filters", :git => "https://github.com/wycats/rake-pipeline-web-filters.git"
+gem "rake-pipeline", :git => "git://github.com/livingsocial/rake-pipeline.git"
+gem "rake-pipeline-web-filters", :git => "git://github.com/wycats/rake-pipeline-web-filters.git"
 gem "colored"
 gem "uglifier", "~> 1.0.3"
 
 group :development do
   gem "rack"
   gem "github-upload"
-  gem "ember-docs", :git => "https://github.com/wagenet/ember-docs.git"
+  gem "ember-docs", :git => "git://github.com/emberjs/docs-generator.git"
   gem "kicker"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 GIT
-  remote: https://github.com/livingsocial/rake-pipeline.git
-  revision: b70ca6cad7655e58d13031f3e24df7dfc74f9030
-  specs:
-    rake-pipeline (0.6.0)
-      rake (~> 0.9.0)
-      thor
-
-GIT
-  remote: https://github.com/wagenet/ember-docs.git
-  revision: b32c0cb5ceea286c755a17640cb7f6750543e71c
+  remote: git://github.com/emberjs/docs-generator.git
+  revision: cfbb82496c1c342ff6da49fc46559dd8fddf8b55
   specs:
     ember-docs (0.1)
       rack
       thor
 
 GIT
-  remote: https://github.com/wycats/rake-pipeline-web-filters.git
+  remote: git://github.com/livingsocial/rake-pipeline.git
+  revision: 53dd95a52f93b30ba0bd2b780ff3b80e12b81d96
+  specs:
+    rake-pipeline (0.6.0)
+      rake (~> 0.9.0)
+      thor
+
+GIT
+  remote: git://github.com/wycats/rake-pipeline-web-filters.git
   revision: ba0b8a00356b4c854930a8e849b5629d51ffd70f
   specs:
     rake-pipeline-web-filters (0.6.0)


### PR DESCRIPTION
As-is one of the links in the Gemfile points to a non-existent repository.

The other change is to change the `https` preamble to `git` so that it doesn't ask for passwords or otherwise fail to authenticate when pulling (recent GitHub anomaly).
