### PR TITLE
Minor documentation fix for states. 

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -27,7 +27,7 @@ var get = Ember.get, set = Ember.set, getPath = Ember.getPath, guidFor = Ember.g
   string. You can determine a record's current state by getting its manager's
   current state path:
 
-        record.getPath('manager.currentState.path');
+        record.getPath('stateManager.currentState.path');
         //=> "created.uncommitted"
 
   The `DS.Model` states are themselves stateless. What we mean is that,


### PR DESCRIPTION
I've just been stuck trying to work out why I couldn't access a model's state manager for a period of time I'm not proud of, but I think it was simply a typo in the documentation.

It seems you can access it through the `stateManager` property rather than 'manager`. 
Cheers
