### PR TITLE
Serialization of custom association's key.

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -124,7 +124,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
       }
     }
 
-    key = options.key || get(this, 'namingConvention').keyToJSONKey(key);
+    key = meta.options.key || get(this, 'namingConvention').keyToJSONKey(key);
     json[key] = records;
   },
 
@@ -141,12 +141,12 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   addBelongsToToJSON: function(json, data, meta, options) {
     var key = meta.key, value, id;
 
-    if (options.embedded) {
-      key = options.key || get(this, 'namingConvention').keyToJSONKey(key);
+    if (meta.options.embedded) {
+      key = meta.options.key || get(this, 'namingConvention').keyToJSONKey(key);
       value = get(data.record, key);
       json[key] = value ? value.toJSON(options) : null;
     } else {
-      key = options.key || get(this, 'namingConvention').foreignKey(key);
+      key = meta.options.key || get(this, 'namingConvention').foreignKey(key);
       id = data.get(key);
       json[key] = none(id) ? null : id;
     }


### PR DESCRIPTION
I've run into a bug with custom association key of hasMany association.
In my app there is a model like that:

```
App.set('Anchor', DS.Model.extend(
  people: DS.hasMany('Markapp.Person', {key: 'person_ids'})
)
```

Trying to serialize model's instance I've got `{id:1, people: [2,3]}` instead of expected `{id:1, person_ids: [2,3]}`. 

While fixing that I've figured out belongTo association has the same bug. I've wrote test cases for external hasMany association, embedded and external belongsTo association. Working on the solution I've realized I'm not completely sure if embedded belongsTo association could have a `key` option. So the test for it is not passing now. If it could, the solution would not be that straightforward as for other cases.

Please let me know of the proper belongsTo behavior so I could finish my patch.
