### PR TITLE
Fix RESTAdapter on FindMany

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -132,7 +132,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     this.ajax(this.buildURL(root), "GET", {
       data: { ids: ids },
       success: function(json) {
-        store.loadMany(type, ids, json[plural]);
+        store.loadMany(type, json[plural]);
         this.sideload(store, type, json, plural);
       }
     });

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -437,6 +437,35 @@ test("finding many people by a list of IDs", function() {
   });
 });
 
+test("finding many people by a list of IDs doesn't rely on the returned array order matching the passed list of ids", function() {
+  store.load(Group, { id: 1, people: [ 1, 2, 3 ] });
+
+  var group = store.find(Group, 1);
+
+  var people = get(group, 'people');
+
+  ajaxHash.success({
+    people: [
+      { id: 2, name: "Tom Dale" },
+      { id: 1, name: "Rein Heinrichs" },
+      { id: 3, name: "Yehuda Katz" }
+    ]
+  });
+
+  var rein = people.objectAt(0);
+  equal(get(rein, 'name'), "Rein Heinrichs");
+  equal(get(rein, 'id'), 1);
+
+  var tom = people.objectAt(1);
+  equal(get(tom, 'name'), "Tom Dale");
+  equal(get(tom, 'id'), 2);
+
+  var yehuda = people.objectAt(2);
+  equal(get(yehuda, 'name'), "Yehuda Katz");
+  equal(get(yehuda, 'id'), 3);
+
+});
+
 test("additional data can be sideloaded in a GET with many IDs", function() {
   //store.load(Group, { id: 1, people: [ 1, 2, 3 ] });
 


### PR DESCRIPTION
Currently a findMany call to the REST adapter assumes that the objects returned from the server come back in the same order as the list that they are requested in. 
This resulted in me having a call like this `App.store.find(App.Product, 1).get('id')` returning 28.
This PR fixes this by removing that assumption

Cheers
