### PR TITLE
put dataProxy in a consistent state after updated with an empty response

### DIFF
--- a/packages/ember-data/lib/system/model/data_proxy.js
+++ b/packages/ember-data/lib/system/model/data_proxy.js
@@ -67,6 +67,18 @@ DataProxy.prototype = {
   },
 
   commit: function() {
+    this.saveData();
+
+    this.record.notifyPropertyChange('data');
+  },
+
+  rollback: function() {
+    this.unsavedData = {};
+
+    this.record.notifyPropertyChange('data');
+  },
+
+  saveData: function() {
     var record = this.record;
 
     var unsavedData = this.unsavedData;
@@ -78,17 +90,9 @@ DataProxy.prototype = {
         delete unsavedData[prop];
       }
     }
-
-    record.notifyPropertyChange('data');
   },
 
-  rollback: function() {
-    this.unsavedData = {};
-
-    this.record.notifyPropertyChange('data');
-  },
-
-  adapterDidUpdate: function(data) {
+  adapterDidUpdate: function() {
     this.unsavedData = {};
   }
 };

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -577,6 +577,15 @@ createdState.states.uncommitted.reopen({
 // some logic defined in UpdatedUncommitted.
 updatedState.states.uncommitted.reopen(UpdatedUncommitted);
 updatedState.states.pending.states.uncommitted.reopen(UpdatedUncommitted);
+updatedState.states.inFlight.reopen({
+  didSaveData: function(manager) {
+    var record = get(manager, 'record'),
+        data = get(record, 'data');
+
+    data.saveData();
+    data.adapterDidUpdate();
+  }
+});
 
 var states = {
   rootState: Ember.State.create({

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -507,6 +507,8 @@ DS.Store = Ember.Object.extend({
       dataCache[clientId] = hash;
       record.send('didChangeData');
       record.hashWasUpdated();
+    } else {
+      record.send('didSaveData');
     }
 
     record.send('didCommit');
@@ -532,7 +534,7 @@ DS.Store = Ember.Object.extend({
       // of the data supercedes the local changes.
       record.beginPropertyChanges();
       record.send('didChangeData');
-      recordData.adapterDidUpdate(hash);
+      recordData.adapterDidUpdate();
       record.hashWasUpdated();
       record.endPropertyChanges();
 


### PR DESCRIPTION
If we do not return a hash in response to update request, we do not pout dataProxy in a consistent state

I am not calling anything that will trigger notifyPropertyChange('data'), as in this case we will potentially refresh all the attributes for nothing.
