### PR TITLE
Set custom URL on the REST adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ The `RESTAdapter` supports the following options:
   REST URLs reside, without leading slash, e.g. `api` (for
   `/api/authors/1`-type URLs).
 
+* `url` (default: ""): A custom url for an API located on a different
+  url or a different subdomain, use the fully qualified domain name including
+  http, e.g. "http://api.emberjs.com".
+
 The RESTful adapter is still in progress. For Rails applications, we plan to make
 it work seamlessly with the `active_model_serializers` gem's conventions. In
 the meantime, see the section on rolling your own adapter.

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -225,8 +225,10 @@ DS.RESTAdapter = DS.Adapter.extend({
     }
   },
 
+  url: "",
+
   buildURL: function(record, suffix) {
-    var url = [""];
+    var url = [this.url];
 
     Ember.assert("Namespace URL (" + this.namespace + ") must not start with slash", !this.namespace || this.namespace.toString().charAt(0) !== "/");
     Ember.assert("Record URL (" + record + ") must not start with slash", !record || record.toString().charAt(0) !== "/");

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -797,7 +797,15 @@ test("bulk deletes can sideload data", function() {
 test("if you specify a namespace then it is prepended onto all URLs", function() {
   set(adapter, 'namespace', 'ember');
   person = store.find(Person, 1);
-  expectUrl("/ember/people/1", "the namespace, followed by by the plural of the model name and the id");
+  expectUrl("/ember/people/1", "the namespace, followed by the plural of the model name and the id");
+
+  store.load(Person, { id: 1 });
+});
+
+test("if you specify a url then that custom url is used", function() {
+  set(adapter, 'url', 'http://api.ember.dev');
+  person = store.find(Person, 1);
+  expectUrl("http://api.ember.dev/people/1", "the custom url, followed by the plural of the model name and the id");
 
   store.load(Person, { id: 1 });
 });


### PR DESCRIPTION
This lets you set a custom URL to be able to fetch data from an external API or a url with a different subdomain.
