### PR TITLE
Pending child records should be preserved when data changes.

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -299,9 +299,18 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
           var clientIds = Ember.ArrayUtils.map(ids, function(id) {
             return store.clientIdForId(association.type, id);
           });
-
+          
+          var pendingRecords = cachedValue.filterProperty('isPending');
+          
           set(cachedValue, 'content', Ember.A(clientIds));
           cachedValue.fetch();
+          
+          // records which are pending should not be overwritten
+          // nor should they be fetched
+          var content = get(cachedValue, 'content');
+          Ember.ArrayUtils.forEach(pendingRecords, function(record) {
+            content.pushObject(record.get('clientId'));
+          });
         }
       }
     }, this);


### PR DESCRIPTION
Currently, when a transaction containing a fully new parent-child hierarchy is committed, hasMany associations are overwritten. This PR fixes this scenario.
