### PR TITLE
Make DS.attr("date") accept a user inputted string as a date

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -119,6 +119,9 @@ DS.attr.transforms = {
     },
 
     to: function(date) {
+      if (typeof date === "string") {
+        date = new Date(date);
+      }
       if (date instanceof Date) {
         var days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -120,6 +120,8 @@ test("a DS.Model can describe Date attributes", function() {
 
   var dateString = "Sat, 31 Dec 2011 00:08:16 GMT";
   var date = new Date(dateString);
+  var inputDateString = "12-30-2011";
+  var inputDate = new Date(inputDateString).toUTCString();
 
   var store = DS.Store.create();
 
@@ -134,6 +136,7 @@ test("a DS.Model can describe Date attributes", function() {
   deepEqual(date, get(record, 'updatedAt'), "setting a date returns the same date");
   convertsFromServer('date', dateString, date);
   convertsWhenSet('date', date, dateString);
+  convertsWhenSet('date', inputDateString, inputDate);
 });
 
 test("retrieving properties should return the same value as they would if they were not in the data hash if the record is not loaded", function() {


### PR DESCRIPTION
Currently you can't set an DS date attribute on  a DS.model from a user input as it expects a JS Date object.

I'm not sure if this is the best implementation (should probably handle invalid dates) but now you can set a date in any format the JS Date object accepts.
