### PR TITLE
belongsTo#hasAssociation catches null values, but not undefined

### DIFF
--- a/packages/ember-data/lib/system/associations/belongs_to.js
+++ b/packages/ember-data/lib/system/associations/belongs_to.js
@@ -28,7 +28,7 @@ var hasAssociation = function(type, options, one) {
 
     if (arguments.length === 2) {
       key = options.key || get(this, 'namingConvention').foreignKey(key);
-      this.send('setAssociation', { key: key, value: value === null ? null : get(value, 'clientId') });
+      this.send('setAssociation', { key: key, value: Ember.none(value) ? null : get(value, 'clientId') });
       //data.setAssociation(key, get(value, 'clientId'));
       // put the client id in `key` in the data hash
       return value;

--- a/packages/ember-data/tests/unit/associations_test.js
+++ b/packages/ember-data/tests/unit/associations_test.js
@@ -543,3 +543,22 @@ test("embedded associations should respect namingConvention", function() {
   var person = store.find(Person, 1);
   equal(getPath(person, 'myCustomTags.firstObject.name'), "UN-friendly", "hasMany tag should be set properly");
 });
+
+test("calling createRecord and passing in an undefined value for an association should be treated as if null", function () {
+  expect(1);
+  
+  var Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tag: DS.belongsTo(Tag, { embedded: true })
+  });
+  
+  var store = DS.Store.create();
+
+  store.createRecord(Person, {tag: undefined});
+  
+  ok(true);
+});


### PR DESCRIPTION
and as a result #get throws a fit. I changed the test to use Ember.none instead of value === null to catch undefined values as well as null values.
