### PR TITLE
Sideloaded data should be loaded prior to primary data

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -122,8 +122,8 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     this.ajax(this.buildURL(root, id), "GET", {
       success: function(json) {
-        store.load(type, json[root]);
         this.sideload(store, type, json, root);
+        store.load(type, json[root]);
       }
     });
   },
@@ -134,8 +134,8 @@ DS.RESTAdapter = DS.Adapter.extend({
     this.ajax(this.buildURL(root), "GET", {
       data: { ids: ids },
       success: function(json) {
-        store.loadMany(type, json[plural]);
         this.sideload(store, type, json, plural);
+        store.loadMany(type, json[plural]);
       }
     });
   },
@@ -145,8 +145,8 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     this.ajax(this.buildURL(root), "GET", {
       success: function(json) {
-        store.loadMany(type, json[plural]);
         this.sideload(store, type, json, plural);
+        store.loadMany(type, json[plural]);
       }
     });
   },
@@ -157,8 +157,8 @@ DS.RESTAdapter = DS.Adapter.extend({
     this.ajax(this.buildURL(root), "GET", {
       data: query,
       success: function(json) {
-        recordArray.load(json[plural]);
         this.sideload(store, type, json, plural);
+        recordArray.load(json[plural]);
       }
     });
   },

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -802,3 +802,18 @@ test("if you specify a namespace then it is prepended onto all URLs", function()
   store.load(Person, { id: 1 });
 });
 
+test("sideloaded data is loaded prior to primary data (to ensure relationship coherence)", function() {
+  expect(1);
+
+  group = store.find(Group, 1);
+  group.on("didLoad", function() {
+    equal(group.getPath('people.firstObject').get('name'), "Tom Dale", "sideloaded data are already loaded");
+  });
+
+  ajaxHash.success({
+    people: [
+      { id: 1, name: "Tom Dale" }
+    ],
+    group: { id: 1, name: "Tilde team", people: [1] }
+  });
+});


### PR DESCRIPTION
When loading a record with sideloaded relations, we should be able to use them from didLoad handler, e.g
