### PR TITLE
'Expected string, identifier, or number' error in IE7

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -280,7 +280,7 @@ var waitingOn = function(manager, object) {
 // super points to the class definition.
 var Uncommitted = Ember.Mixin.create({
   setProperty: setProperty,
-  setAssociation: setAssociation,
+  setAssociation: setAssociation
 });
 
 // These mixins are mixed into substates of the concrete


### PR DESCRIPTION
Ember-data causes the 'Expected string, identifier, or number' error when loaded in IE7. This is the result of an extra comma on ln 1862 -- also known as the "dangling comma" bug.

Hurray for cross compatibility! 
