### PR TITLE
More rest adapter refactoring

### DIFF
--- a/packages/ember-data/lib/system/adapters.js
+++ b/packages/ember-data/lib/system/adapters.js
@@ -117,9 +117,12 @@ DS.Adapter = Ember.Object.extend({
     }, this);
   },
 
-  findMany: function(store, type, ids) {
-    ids.forEach(function(id) {
-      this.find(store, type, id);
+  findMany: function(store, type, ids, manyArray) {
+    var clientIds = store.clientIdsForIds(type, ids);
+
+    ids.forEach(function(id, index) {
+      var record = store.findByClientId(type, clientIds[index], id);
+      this.find(store, type, id, record);
     }, this);
   }
 });

--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -29,7 +29,7 @@ DS.ManyArray = DS.RecordArray.extend({
         store = get(this, 'store'),
         type = get(this, 'type');
 
-    store.fetchUnloadedClientIds(type, clientIds);
+    store.fetchUnloadedClientIds(type, clientIds, this);
   },
 
   // Overrides Ember.Array's replace method to implement

--- a/packages/ember-data/lib/system/record_arrays/record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/record_array.js
@@ -34,5 +34,11 @@ DS.RecordArray = Ember.ArrayProxy.extend({
     if (clientId !== undefined) {
       return store.findByClientId(get(this, 'type'), clientId);
     }
+  },
+
+  load: function(array) {
+    var store = get(this, 'store'), type = get(this, 'type');
+
+    store.loadMany(type, array);
   }
 });

--- a/packages/ember-data/tests/integration/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/store_adapter_test.js
@@ -216,7 +216,7 @@ test("when a store is committed, the adapter's commit method is called with crea
     records.created.eachType(function(type, array) {
       equal(type, Person, "the type is correct");
       equal(get(array, 'length'), 1, "the array is the right length");
-      store.didCreateRecords(Person, array, [{ id: 1, name: "Tom Dale" }]);
+      store.didCreateRecords(array, [{ id: 1, name: "Tom Dale" }]);
     });
   };
 
@@ -264,7 +264,7 @@ test("by default, commit calls createRecords once per type", function() {
     equal(type, Person, "the type is correct");
     equal(get(array, 'length'), 2, "the array is the right length");
     var records = [{ id: 1, name: "Tom Dale", updated_at: 'right nao' }, { id: 2, name: "Yehuda Katz" }];
-    store.didCreateRecords(Person, array, records);
+    store.didCreateRecords(array, records);
   };
 
   var tom = store.createRecord(Person, { name: "Tom Dale", updatedAt: null });

--- a/packages/ember-data/tests/unit/record_array_test.js
+++ b/packages/ember-data/tests/unit/record_array_test.js
@@ -332,7 +332,7 @@ test("a Record Array can update its filter and notify array observers", function
   test("a Record Array can update its filter after server-side creates multiple records", function() {
     setup({
       createRecords: function(store, type, records) {
-        store.didCreateRecords(Person, records, [
+        store.didCreateRecords(records, [
           {id: 4, name: "Scumbag Server-side Mike"},
           {id: 5, name: "Scumbag Server-side David"}
         ]);


### PR DESCRIPTION
- didCreateRecords now take an array of records and json data for them
- finished extracting callback methods for find requests
- add didFindRecord in response to find request
- find get passed record instance that it should pass to `didFindRecord`. It will allow us eventually to set loading record in error state.
- add didFindQuery in response to recordArray based requests
- findAll, findQuery and findMany all get passed recordArray instance that they should pass to store method `didFindQuery`. This allow a simpler and more uniform interface on the adapter. It will also eventually allow us to put recordArray in error state
- in rest_adapter findAll and findMany are juste special cases of findQuery request
