### PR TITLE
this.registerRecordArray() in findQuery() 

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -471,6 +471,7 @@ DS.Store = Ember.Object.extend({
 
   findQuery: function(type, query) {
     var array = DS.AdapterPopulatedRecordArray.create({ type: type, content: Ember.A([]), store: this });
+    this.registerRecordArray(array, type);
     var adapter = get(this, '_adapter');
     if (adapter && adapter.findQuery) { adapter.findQuery(this, type, query, array); }
     else { throw fmt("Adapter is either null or does not implement `findQuery` method", this); }


### PR DESCRIPTION
DS.Store's findQuery() method now registers the DS.AdapterPopulatedRedArray as a recordArray using this.registerRecordArray() just like findAll() and filter() does.

This fixes a bug when using findQuery() with a view: When trying to delete a record, the record wasn't removed from the view.
