### PR TITLE
Return undefined when transforming dates with value null

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -112,7 +112,7 @@ DS.attr.transforms = {
       } else if (serialized === null || serialized === undefined) {
         // if the value is not present in the data,
         // return undefined, not null.
-        return serialized;
+        return undefined;
       } else {
         return null;
       }


### PR DESCRIPTION
The comment says date transformations should return `undefined` when the value is `null` or `undefined`, but the code one line below said comment returns the value (which can be either).

This commit aligns the code with the comment accompanying it.

_If the comment is wrong, the code should be kept as is and the comment updated instead._

```
from: function(serialized) {
  var type = typeof serialized;

  if (type === "string" || type === "number") {
    return new Date(serialized);
  } else if (serialized === null || serialized === undefined) {
    // if the value is not present in the data,
    // return undefined, not null.
    return serialized;
  } else {
    return null;
  }
},
```
