### PR TITLE
The error object should be a Ember.Object so it's easy to bind to it

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -555,7 +555,7 @@ var DirtyState = DS.State.extend({
           errors = get(record, 'errors'),
           key = context.key;
 
-      delete errors[key];
+      errors.set(key, null);
 
       if (!hasDefinedProperties(errors)) {
         manager.send('becameValid');


### PR DESCRIPTION
At the moment the error object is threaded like a dictionary. I think an Ember.Object would be better, so the template can bind to errors.attribute
