### PR TITLE
Reset default transaction from the transaction itself and not from the store

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -827,10 +827,7 @@ DS.Store = Ember.Object.extend({
     a transaction.
   */
   commit: function() {
-    var defaultTransaction = get(this, 'defaultTransaction');
-    set(this, 'defaultTransaction', this.transaction());
-
-    defaultTransaction.commit();
+    get(this, 'defaultTransaction').commit();
   },
 
   /**

--- a/packages/ember-data/lib/system/transaction.js
+++ b/packages/ember-data/lib/system/transaction.js
@@ -179,6 +179,7 @@ DS.Transaction = Ember.Object.extend({
   commit: function() {
     var store = get(this, 'store');
     var adapter = get(store, '_adapter');
+    var defaultTransaction = get(store, 'defaultTransaction');
 
     var iterate = function(records) {
       var set = records.copy();
@@ -196,6 +197,10 @@ DS.Transaction = Ember.Object.extend({
       deleted: iterate(this.bucketForType('deleted')),
       relationships: relationships
     };
+
+    if (this === defaultTransaction) {
+      set(store, 'defaultTransaction', store.transaction());
+    }
 
     this.removeCleanRecords();
 

--- a/packages/ember-data/tests/unit/transaction_test.js
+++ b/packages/ember-data/tests/unit/transaction_test.js
@@ -442,3 +442,56 @@ test("If a child was added to one parent, and then another, the changes coalesce
   });
 });
 
+test("the store should have a new defaultTransaction after commit from store", function() {
+  store.load(Post, { id: 1, title: "Ohai" });
+
+  var record = store.find(Post, 1);
+  var transaction = record.get('transaction');
+  var defaultTransaction = store.get('defaultTransaction');
+
+  equal(transaction, defaultTransaction, 'record is in the defaultTransaction');
+
+  store.commit();
+
+  var newDefaultTransaction = store.get('defaultTransaction');
+  transaction = record.get('transaction');
+
+  ok(defaultTransaction !== newDefaultTransaction, "store should have a new defaultTransaction");
+  equal(transaction, newDefaultTransaction, 'record is in the new defaultTransaction');
+});
+
+test("the store should have a new defaultTransaction after commit from defaultTransaction", function() {
+  store.load(Post, { id: 1, title: "Ohai" });
+
+  var record = store.find(Post, 1);
+  var transaction = record.get('transaction');
+  var defaultTransaction = store.get('defaultTransaction');
+
+  equal(transaction, defaultTransaction, 'record is in the defaultTransaction');
+
+  defaultTransaction.commit();
+
+  var newDefaultTransaction = store.get('defaultTransaction');
+  transaction = record.get('transaction');
+
+  ok(defaultTransaction !== newDefaultTransaction, "store should have a new defaultTransaction");
+  equal(transaction, newDefaultTransaction, 'record is in the new defaultTransaction');
+});
+
+test("the store should have a new defaultTransaction after commit from record's transaction", function() {
+  store.load(Post, { id: 1, title: "Ohai" });
+
+  var record = store.find(Post, 1);
+  var transaction = record.get('transaction');
+  var defaultTransaction = store.get('defaultTransaction');
+
+  equal(transaction, defaultTransaction, 'record is in the defaultTransaction');
+
+  transaction.commit();
+
+  var newDefaultTransaction = store.get('defaultTransaction');
+  transaction = record.get('transaction');
+
+  ok(defaultTransaction !== newDefaultTransaction, "store should have a new defaultTransaction");
+  equal(transaction, newDefaultTransaction, 'record is in the new defaultTransaction');
+});


### PR DESCRIPTION
Otherwise, in case commit is called directly on the transaction, and the transaction is defaultTransaction, the store will be left with the old defaultTransaction
