### PR TITLE
Failing Test + Fix:

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -65,6 +65,10 @@ DS.ManyArray = DS.RecordArray.extend({
       stateManager.send('recordWasAdded', record);
     }
 
+    added.forEach(function(clientId){
+      store.recordArraysForClientId(clientId).add(this);
+    }, this);
+
     this._super(index, removed, added);
   },
 

--- a/packages/ember-data/tests/unit/associations_test.js
+++ b/packages/ember-data/tests/unit/associations_test.js
@@ -457,3 +457,20 @@ test("calling createRecord and passing in an undefined value for an association 
   var person = store.find(Person, 1);
   equal(person.get('tag'), null, "undefined values should return null associations");
 });
+
+
+test("if a record is independently deleted, RecordArray which didn contain it, should no longer", function() {
+  var store = DS.Store.create();
+  var Person = DS.Model.extend({
+    people: DS.hasMany('Person'),
+  });
+  var parent = store.createRecord(Person);
+  var people = get(parent, 'people');
+  var person = store.createRecord(Person, {});
+
+  people.pushObject(person);
+  person.deleteRecord();
+
+  equal(people.contains(person), false, "it does not contain a deleted record");
+});
+


### PR DESCRIPTION
(moved from #325)
reason: rw is on vacation, and we want this merged into the relationship-improvements branch.
## TL;DR

Adding records client-side to RecordArrays does not properly update indexes.
## Problem

Given a model that has a relationship,

``` javascript
var Comment = DS.Model.extend({
  posts: DS.belongsTo("Post")
});

var Post = DS.Model.extend({
  comments: DS.hasMany("Comment")
});
```

when creating a client-side associated object,

``` javascript
var post = store.createRecord(Post);
var comment = store.createRecord(Comment);
post.comments.pushObject(comment);
```

and then deleting it,

``` javascript
post.deleteRecord();
```

the RecordArray is not informed of its deletion:

``` javascript
post.comments.contains(comment) === true;
```

When associations are created client-side, the appropriate indexes are not updated.
## Solution

Update the indexes of the collection on insertion (pushObject), so that the record is removed from the collection when it is deleted.
