### PR TITLE
Dirty relationships correctly when modifying belongsTo side of a belongsTo-hasMany relationship

### DIFF
--- a/packages/ember-data/lib/system/associations/belongs_to.js
+++ b/packages/ember-data/lib/system/associations/belongs_to.js
@@ -6,11 +6,37 @@ var hasAssociation = function(type, options, one) {
 
   var meta = { type: type, isAssociation: true, options: options, kind: 'belongsTo' };
 
-  return Ember.computed(function(key, value) {
-    if (arguments.length === 2) {
-      return value;
+  var assignInverse = function(record, newParent, oldParent) {
+    var associationMap = get(type, 'associations'),
+        possibleAssociations = associationMap.get(record.constructor),
+        possible, actual;
+
+    if (!possibleAssociations) { return; }
+
+    for (var i = 0, l = possibleAssociations.length; i < l; i++) {
+      possible = possibleAssociations[i];
+
+      if (possible.kind === 'hasMany') {
+        actual = possible;
+        break;
+      }
     }
 
+    if (actual) {
+      if (newParent) {
+        newParent.doInverseAssignment(function(){
+          get(newParent, actual.name).pushObject(record);
+        });
+      }
+      if (oldParent) {
+        oldParent.doInverseAssignment(function(){
+          get(oldParent, actual.name).removeObject(record);
+        });
+      }
+    }
+  };
+
+  return Ember.computed(function(key, value) {
     var data = get(this, 'data').belongsTo,
         store = get(this, 'store'), id;
 
@@ -19,7 +45,25 @@ var hasAssociation = function(type, options, one) {
     }
 
     id = data[key];
-    return id ? store.find(type, id) : null;
+    var currentValue = id ? store.find(type, id) : null;
+
+    if (arguments.length === 2) {
+      if (!this._performingInverseAssignment) {
+        var childRecord = this;
+        var newParent = value;
+        var oldParent = currentValue;
+        assignInverse(childRecord, newParent, oldParent);
+
+        this.get('transaction')
+           .relationshipBecameDirty(childRecord, oldParent, newParent);
+      }
+      if (value)
+        data[key] = value.get('id');
+      else
+        data[key] = null;
+      return value;
+    }
+    return currentValue;
   }).property('data').cacheable().meta(meta);
 };
 

--- a/packages/ember-data/lib/system/associations/ext.js
+++ b/packages/ember-data/lib/system/associations/ext.js
@@ -57,5 +57,10 @@ DS.Model.reopen({
     get(this.constructor, 'associationsByName').forEach(function(name, association) {
       callback.call(binding, name, association);
     });
+  },
+  doInverseAssignment: function(callback) {
+    this._performingInverseAssignment = true;
+    callback.call(this);
+    this._performingInverseAssignment = false;
   }
 });

--- a/packages/ember-data/tests/unit/associations_test.js
+++ b/packages/ember-data/tests/unit/associations_test.js
@@ -133,32 +133,6 @@ test("should be able to retrieve the type for a hasMany association specified us
   equal(Person.typeForAssociation('tags'), Tag, "returns the association type");
 });
 
-test("should be able to retrieve the type for a belongsTo association from its metadata", function() {
-  var Tag = DS.Model.extend({
-    name: DS.attr('string')
-  });
-
-  var Person = DS.Model.extend({
-    name: DS.attr('string'),
-    tags: DS.belongsTo(Tag)
-  });
-
-  equal(Person.typeForAssociation('tags'), Tag, "returns the association type");
-});
-
-test("should be able to retrieve the type for a belongsTo association specified using a string from its metadata", function() {
-  window.Tag = DS.Model.extend({
-    name: DS.attr('string')
-  });
-
-  var Person = DS.Model.extend({
-    name: DS.attr('string'),
-    tags: DS.belongsTo('Tag')
-  });
-
-  equal(Person.typeForAssociation('tags'), Tag, "returns the association type");
-});
-
 test("associations work when declared with a string path", function() {
   window.App = {};
 
@@ -362,6 +336,32 @@ test("can create child record from a hasMany association", function() {
 
 module("DS.belongsTo");
 
+test("should be able to retrieve the type for a belongsTo association from its metadata", function() {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tags: DS.belongsTo(Tag)
+  });
+
+  equal(Person.typeForAssociation('tags'), Tag, "returns the association type");
+});
+
+test("should be able to retrieve the type for a belongsTo association specified using a string from its metadata", function() {
+  window.Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tag: DS.belongsTo('Tag')
+  });
+
+  equal(Person.typeForAssociation('tag'), Tag, "returns the association type");
+});
+
 test("belongsTo lazily loads associations as needed", function() {
   var Tag = DS.Model.extend({
     name: DS.attr('string')
@@ -380,7 +380,7 @@ test("belongsTo lazily loads associations as needed", function() {
   equal(get(person, 'name'), "Tom Dale", "precond - retrieves person record from store");
 
   equal(get(person, 'tag') instanceof Tag, true, "the tag property should return a tag");
-  equal(getPath(person, 'tag.name'), "friendly", "the tag shuld have name");
+  equal(getPath(person, 'tag.name'), "friendly", "the tag should have name");
 
   strictEqual(get(person, 'tag'), get(person, 'tag'), "the returned object is always the same");
   strictEqual(get(person, 'tag'), store.find(Tag, 5), "association object is the same as object retrieved directly");

--- a/packages/ember-data/tests/unit/transaction_test.js
+++ b/packages/ember-data/tests/unit/transaction_test.js
@@ -326,7 +326,7 @@ Post.reopen({
 });
 
 var store, adapter;
-module("DS.Transaction - relationships", {
+module("DS.Transaction - relationships modifying hasMany side", {
   setup: function() {
     adapter = DS.Adapter.create();
     store = DS.Store.create({
@@ -401,8 +401,83 @@ test("If a child is removed from a parent it was recently added to, the dirty re
   deepEqual(relationships.byOldParent.get(post), [ ]);
 });
 
-test("If a child was added to one parent, and then another, the changes coalesce. A->B, B->C", function() {
+module("DS.Transaction - relationships modifying belongsTo side", {
+  setup: function() {
+    adapter = DS.Adapter.create();
+    store = DS.Store.create({
+      adapter: adapter
+    });
+  },
+
+  teardown: function() {
+    adapter.destroy();
+    store.destroy();
+  }
+});
+
+test("If both the parent and child are clean and in the same transaction, a dirty relationship is added to the transaction null->A", function() {
+  store.load(Post, { id: 1, title: "Ohai", body: "FIRST POST ZOMG" });
   store.load(Comment, { id: 1, body: "Kthx" });
+
+  var post = store.find(Post, 1);
+  var comment = store.find(Comment, 1);
+
+  var transaction = store.transaction();
+
+  transaction.add(post);
+  transaction.add(comment);
+
+  comment.set('post', post);
+
+  var relationships = transaction.dirtyRelationships;
+
+  deepEqual(relationships.byChild.get(comment), [ { oldParent: null, newParent: post, child: comment } ]);
+  deepEqual(relationships.byNewParent.get(post), [ { oldParent: null, newParent: post, child: comment } ]);
+});
+
+test("If a child is removed from a parent, a dirty relationship is added to the transaction A->null", function() {
+  store.load(Comment, { id: 1, body: "Kthx", post: 1 });
+  store.load(Post, { id: 1, title: "Ohai", body: "FIRST POST ZOMG", comments: [ 1 ] });
+
+  var post = store.find(Post, 1);
+  var comment = store.find(Comment, 1);
+
+  var transaction = store.transaction();
+
+  transaction.add(post);
+  transaction.add(comment);
+
+  comment.set('post', null);
+
+  var relationships = transaction.dirtyRelationships;
+
+  deepEqual(relationships.byChild.get(comment), [ { oldParent: post, newParent: null, child: comment } ]);
+  deepEqual(relationships.byOldParent.get(post), [ { oldParent: post, newParent: null, child: comment } ]);
+});
+
+test("If a child is removed from a parent it was recently added to, the dirty relationship is removed. null->A, A->null", function() {
+  store.load(Comment, { id: 1, body: "Kthx" });
+  store.load(Post, { id: 1, title: "Ohai", body: "FIRST POST ZOMG" });
+
+  var post = store.find(Post, 1);
+  var comment = store.find(Comment, 1);
+
+  var transaction = store.transaction();
+
+  transaction.add(post);
+  transaction.add(comment);
+
+  comment.set('post', post);
+  comment.set('post', null);
+
+  var relationships = transaction.dirtyRelationships;
+
+  deepEqual(relationships.byChild.get(comment), [ ]);
+  deepEqual(relationships.byOldParent.get(post), [ ]);
+});
+
+test("If a child was added to one parent, and then another, the changes coalesce. A->B, B->C", function() {
+  store.load(Comment, { id: 1, body: "Kthx", post: 1 });
   store.load(Post, { id: 1, title: "Ohai", body: "FIRST POST ZOMG", comments: [ 1 ] });
   store.load(Post, { id: 2, title: "ZOMG", body: "SECOND POST WAT" });
   store.load(Post, { id: 3, title: "ORLY?", body: "Why am I still here?" });
@@ -417,10 +492,8 @@ test("If a child was added to one parent, and then another, the changes coalesce
   transaction.add(post);
   transaction.add(comment);
 
-  post.get('comments').removeObject(comment);
-  post2.get('comments').pushObject(comment);
-  post2.get('comments').removeObject(comment);
-  post3.get('comments').pushObject(comment);
+  comment.set('post', post2);
+  comment.set('post', post3);
 
   var relationships = transaction.dirtyRelationships;
 
@@ -428,4 +501,3 @@ test("If a child was added to one parent, and then another, the changes coalesce
   deepEqual(relationships.byOldParent.get(post), [ { child: comment, oldParent: post, newParent: post3 } ]);
   deepEqual(relationships.byNewParent.get(post3), [ { child: comment, oldParent: post, newParent: post3 } ]);
 });
-


### PR DESCRIPTION
Here's a first pass at this, base on my conversation with @wycats today.

In our app, this change (in combination with implementing shouldCommit on our adapter) makes setting a belongsTo attribute work as expected, except... the record that gets updated via the API never gets removed from the transaction. That results in an error the next time I try to add it to a transaction, since a record can only be a member of one transaction at a time.
