### PR TITLE
Do not sideloads records twice

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -6,7 +6,7 @@ var get = Ember.get, set = Ember.set;
 
 DS.RESTAdapter = DS.Adapter.extend({
   bulkCommit: false,
-	
+
   createRecord: function(store, type, record) {
     var root = this.rootForType(type);
 
@@ -262,6 +262,7 @@ DS.RESTAdapter = DS.Adapter.extend({
   },
 
   sideloadAssociations: function(store, type, json, prop, loaded) {
+    if (loaded[prop]) { return; }
     loaded[prop] = true;
 
     get(type, 'associationsByName').forEach(function(key, meta) {
@@ -269,7 +270,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       if (meta.kind === 'belongsTo') {
         key = this.pluralize(key);
       }
-      if (json[key] && !loaded[key]) {
+      if (json[key]) {
         this.sideloadAssociations(store, meta.type, json, key, loaded);
       }
     }, this);


### PR DESCRIPTION
Only one of the two `sideloadAssociations` calls was guarded with
loaded[prop]. This could lead to records being sideloaded twice. E.g. if A
hasMany B, then sideload would load first A (which loads B and then
itself), and then load B. Now the guarding happens at the beginning of
sideloadAssociations, so this cannot happen anymore.

I haven't been able to write a concise test for this bug. I figure it's
better to keep the test suite readable, so I'm submitting this without a
test. It's been verified with copious console.log statements and my own
application models though.
