### PR TITLE
A new proposition for error handling

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -27,7 +27,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
     Implement this method in order to provide provide json for CRUD methods
   */
   mockJSON: function(type, record) {
-    return record.toJSON({associations: true});
+    return this.toJSON(record, { includeId: true });
   },
 
   /*
@@ -69,16 +69,6 @@ DS.FixtureAdapter = DS.Adapter.extend({
         store.loadMany(type, fixtures);
       }, store, type);
     }
-  },
-
-  findAll: function(store, type) {
-    var fixtures = this.fixturesForType(type);
-
-    Ember.assert("Unable to find fixtures for model type "+type.toString(), !!fixtures);
-
-    this.simulateRemoteCall(function() {
-      store.loadMany(type, fixtures);
-    }, store, type);
   },
 
   findQuery: function(store, type, query, array) {

--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -20,6 +20,7 @@
 
 require("ember-data/core");
 require("ember-data/system/store");
+require("ember-data/system/errors");
 require("ember-data/system/record_arrays");
 require("ember-data/system/model");
 require("ember-data/system/associations");

--- a/packages/ember-data/lib/system/error.js
+++ b/packages/ember-data/lib/system/error.js
@@ -1,0 +1,15 @@
+DS.Error = Ember.Object.extend({
+  message: null
+});
+
+DS.ValidationError = DS.Error.extend({
+  attribute: null,
+});
+
+DS.ClientValidationError = DS.ValidationError.extend();
+DS.ServerValidationError = DS.ValidationError.extend();
+
+DS.ServerError = DS.Error.extend({
+  code: null,
+  isFatal: false
+});

--- a/packages/ember-data/lib/system/errors.js
+++ b/packages/ember-data/lib/system/errors.js
@@ -1,0 +1,83 @@
+require("ember-data/system/error");
+
+var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach;
+
+DS.Errors = Ember.Object.extend(Ember.Enumerable, {
+  errorsByType: Ember.computed(function() {
+    return Ember.MapWithDefault.create({
+      defaultValue: function() { return Ember.A(); }
+    });
+  }).cacheable(),
+
+  all: Ember.computed(function() {
+    return Ember.A();
+  }).cacheable(),
+
+  nextObject: function(index, previousObject, context) {
+    return get(this, 'all').objectAt(index);
+  },
+
+  length: Ember.computed('all.length', function() {
+    return get(this, 'all.length');
+  }).cacheable(),
+
+  isEmpty: Ember.computed.not('length'),
+
+  add: function(errors) {
+    var errorsByType = get(this, 'errorsByType');
+
+    errors = Ember.makeArray(errors);
+
+    forEach(errors, function(error) {
+      errorsByType.get(error.constructor).pushObject(error);
+    });
+
+    get(this, 'all').addObjects(errors);
+  },
+
+  remove: function(errors) {
+    var errorsByType = get(this, 'errorsByType');
+
+    if (Ember.typeOf(errors) === 'string') {
+      errors = this.findByAttributeName(errors);
+    } else {
+      errors = Ember.makeArray(errors);
+    }
+
+    forEach(errors, function(error) {
+      errorsByType.get(error.constructor).removeObject(error);
+    });
+
+    get(this, 'all').removeObjects(errors);
+  },
+
+  clear: function() {
+    get(this, 'errorsByType').forEach(function(type, errors) {
+      errors.clear();
+    });
+
+    get(this, 'all').clear();
+  },
+
+  findByAttributeName: function(key) {
+    var errorsByType = Ember.A();
+
+    get(this, 'errorsByType').forEach(function(type, errors) {
+      if (DS.ValidationError.detect(type)) {
+        errorsByType.pushObjects(errors.filterProperty('attribute', key));
+      }
+    });
+
+    return errorsByType;
+  },
+
+  hasErrorsOfType: function(errorType) {
+    get(this, 'errorsByType').forEach(function(type, errors) {
+      if (errorType.detect(type) && get(errors, 'length')) {
+        return true;
+      }
+    });
+
+    return false;
+  }
+});

--- a/packages/ember-data/lib/system/model.js
+++ b/packages/ember-data/lib/system/model.js
@@ -1,3 +1,4 @@
 require("ember-data/system/model/model");
 require("ember-data/system/model/states");
 require("ember-data/system/model/attributes");
+require("ember-data/system/model/validations");

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -41,8 +41,8 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   didUpdate: Ember.K,
   didCreate: Ember.K,
   didDelete: Ember.K,
+  didError: Ember.K,
   becameInvalid: Ember.K,
-  becameError: Ember.K,
 
   data: Ember.computed(function() {
     if (!this._data) {
@@ -68,6 +68,9 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
     set(this, 'stateManager', stateManager);
 
     this.setup();
+
+    var errors = DS.Errors.create();
+    set(this, 'errors', errors);
 
     stateManager.goToState('empty');
   },
@@ -258,6 +261,8 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
     this.suspendAssociationObservers(function() {
       this.notifyPropertyChange('data');
     });
+
+    get(this, 'errors').clear();
   },
 
   isDirtyBecause: function(reason) {
@@ -393,6 +398,7 @@ var storeAlias = function(methodName) {
 DS.Model.reopenClass({
   isLoaded: storeAlias('recordIsLoaded'),
   find: storeAlias('find'),
+  all: storeAlias('all'),
   filter: storeAlias('filter'),
 
   _create: DS.Model.create,

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -299,15 +299,18 @@ var DirtyState = DS.State.extend({
       manager.transitionTo('loaded.saved');
     },
 
-    becameInvalid: function(manager) {
+    becameInvalid: function(manager, errors) {
       var dirtyType = get(this, 'dirtyType'),
           record = get(manager, 'record');
+
+      get(record, 'errors').add(errors);
 
       record.withTransaction(function (t) {
         t.recordBecameInFlight(dirtyType, record);
       });
 
       manager.transitionTo('invalid');
+      manager.send('invokeLifecycleCallbacks');
     },
 
     rollback: function(manager) {
@@ -351,7 +354,7 @@ var DirtyState = DS.State.extend({
     becameInvalid: function(manager, errors) {
       var record = get(manager, 'record');
 
-      set(record, 'errors', errors);
+      get(record, 'errors').add(errors);
 
       record.restoreDirtyFactors();
 
@@ -359,9 +362,18 @@ var DirtyState = DS.State.extend({
       manager.send('invokeLifecycleCallbacks');
     },
 
-    becameError: function(manager) {
-      manager.transitionTo('error');
-      manager.send('invokeLifecycleCallbacks');
+    didError: function(manager, error) {
+      var record = get(manager, 'record');
+
+      get(record, 'errors').add(error);
+
+      if (get(error, 'isFatal')) {
+        manager.transitionTo('error');
+        manager.send('invokeLifecycleCallbacks');
+      } else {
+        manager.transitionTo('uncommitted');
+        record.trigger('didError', record);
+      }
     }
   }),
 
@@ -391,9 +403,9 @@ var DirtyState = DS.State.extend({
           errors = get(record, 'errors'),
           key = context.key;
 
-      set(errors, key, null);
+      errors.remove(key);
 
-      if (!hasDefinedProperties(errors)) {
+      if (!errors.hasErrorsOfType(DS.ValidationError)) {
         manager.send('becameValid');
       }
 
@@ -695,6 +707,20 @@ var states = {
           manager.transitionTo('saved');
 
           manager.send('invokeLifecycleCallbacks');
+        },
+
+        didError: function(manager, error) {
+          var record = get(manager, 'record');
+
+          get(record, 'errors').add(error);
+
+          if (get(error, 'isFatal')) {
+            manager.transitionTo('error');
+            manager.send('invokeLifecycleCallbacks');
+          } else {
+            manager.transitionTo('uncommitted');
+            record.trigger('didError', record);
+          }
         }
       }),
 
@@ -722,7 +748,7 @@ var states = {
 
       invokeLifecycleCallbacks: function(manager) {
         var record = get(manager, 'record');
-        record.trigger('becameError', record);
+        record.trigger('didError', record);
       }
     })
   })

--- a/packages/ember-data/lib/system/model/validations.js
+++ b/packages/ember-data/lib/system/model/validations.js
@@ -1,0 +1,5 @@
+DS.Model.reopen({
+  validate: function() {
+    return [];
+  }
+});

--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -4,6 +4,14 @@ var get = Ember.get, set = Ember.set;
 
 DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
   query: null,
+  isError: Ember.computed.not('errors.isEmpty'),
+
+  init: function() {
+    this._super();
+
+    var errors = DS.Errors.create();
+    set(this, 'errors', errors);
+  },
 
   replace: function() {
     var type = get(this, 'type').toString();

--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -35,6 +35,9 @@ var get = Ember.get, set = Ember.set;
 */
 DS.ManyArray = DS.RecordArray.extend({
   init: function() {
+    var errors = DS.Errors.create();
+    set(this, 'errors', errors);
+
     this._super.apply(this, arguments);
     this._changesToSync = Ember.OrderedSet.create();
   },
@@ -51,6 +54,7 @@ DS.ManyArray = DS.RecordArray.extend({
   // LOADING STATE
 
   isLoaded: false,
+  isError: Ember.computed.not('errors.isEmpty'),
 
   loadingRecordsCount: function(count) {
     this.loadingRecordsCount = count;
@@ -69,7 +73,7 @@ DS.ManyArray = DS.RecordArray.extend({
         store = get(this, 'store'),
         type = get(this, 'type');
 
-    store.fetchUnloadedClientIds(type, clientIds);
+    store.fetchUnloadedClientIds(type, clientIds, this);
   },
 
   // Overrides Ember.Array's replace method to implement
@@ -198,6 +202,14 @@ DS.ManyArray = DS.RecordArray.extend({
     this.pushObject(record);
 
     return record;
+  },
+
+  load: function(array) {
+    var owner = get(this, 'owner'),
+        store = get(owner, 'store') || get(this, 'store'),
+        type = get(this, 'type');
+
+    store.loadMany(type, array);
   },
 
   /**

--- a/packages/ember-data/tests/integration/find_all_test.js
+++ b/packages/ember-data/tests/integration/find_all_test.js
@@ -23,10 +23,10 @@ module("Finding All Records of a Type", {
   }
 });
 
-test("When all records for a type are requested, the store should call the adapter's `findAll` method.", function() {
+test("When all records for a type are requested, the store should call the adapter's `findQuery` method.", function() {
   expect(5);
 
-  adapter.findAll = function(store, type) {
+  adapter.findQuery = function(store, type) {
     ok(true, "the adapter's findAll method should be invoked");
 
     // Simulate latency to ensure correct behavior in asynchronous conditions.
@@ -37,11 +37,11 @@ test("When all records for a type are requested, the store should call the adapt
       equal(allRecords.objectAt(0).get('name'), "Braaaahm Dale", "the first item in the record array is Braaaahm Dale");
 
       // Only one record array per type should ever be created (identity map)
-      strictEqual(allRecords, store.find(Person), "the same record array is returned every time all records of a type are requested");
+      strictEqual(allRecords, store.all(Person), "the same record array is returned every time all records of a type are requested");
     });
   };
 
-  allRecords = store.find(Person);
+  allRecords = store.find(Person, true);
   equal(get(allRecords, 'length'), 0, "the record array's length is zero before any records are loaded");
 });
 

--- a/packages/ember-data/tests/integration/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/store_adapter_test.js
@@ -224,7 +224,13 @@ test("if a created record is marked as invalid by the server, it enters an error
     equal(type, Person, "the type is correct");
 
     if (get(record, 'name').indexOf('Bro') === -1) {
-      store.recordWasInvalid(record, { name: ['common... name requires a "bro"'] });
+      var errors = [
+        DS.ServerValidationError.create({
+          message: 'common... name requires a "bro"',
+          attribute: 'name'
+        })
+      ];
+      store.recordWasInvalid(record, errors);
     } else {
       store.didSaveRecord(record);
     }
@@ -233,22 +239,18 @@ test("if a created record is marked as invalid by the server, it enters an error
   var yehuda = store.createRecord(Person, { id: 1, name: "Yehuda Katz" });
 
   var hasNameError,
-      observer = function() { hasNameError = yehuda.get('errors.name'); };
+      observer = function() { hasNameError = yehuda.get('errors').findByAttributeName('name')[0]; };
 
-  Ember.addObserver(yehuda, 'errors.name', observer);
+  Ember.addObserver(yehuda, 'errors.isValid', observer);
 
   store.commit();
 
   equal(get(yehuda, 'isValid'), false, "the record is invalid");
-  ok(hasNameError, "should trigger errors.name observer on invalidation");
+  ok(hasNameError, "should trigger errors.isValid observer on invalidation");
 
   set(yehuda, 'updatedAt', true);
   equal(get(yehuda, 'isValid'), false, "the record is still invalid");
 
-  // This tests that we handle undefined values without blowing up
-  var errors = get(yehuda, 'errors');
-  set(errors, 'other_bound_property', undefined);
-  set(yehuda, 'errors', errors);
   set(yehuda, 'name', "Brohuda Brokatz");
 
   equal(get(yehuda, 'isValid'), true, "the record is no longer invalid after changing");
@@ -269,7 +271,13 @@ test("if an updated record is marked as invalid by the server, it enters an erro
     equal(type, Person, "the type is correct");
 
     if (get(record, 'name').indexOf('Bro') === -1) {
-      store.recordWasInvalid(record, { name: ['common... name requires a "bro"'] });
+      var errors = [
+        DS.ServerValidationError.create({
+          message: 'common... name requires a "bro"',
+          attribute: 'name'
+        })
+      ];
+      store.recordWasInvalid(record, errors);
     } else {
       store.didSaveRecord(record);
     }

--- a/packages/ember-data/tests/unit/record_array_test.js
+++ b/packages/ember-data/tests/unit/record_array_test.js
@@ -147,7 +147,7 @@ test("a record array that backs a collection view functions properly", function(
   store.load(Person, 5, { name: "Other Katz" });
 
   var container = Ember.CollectionView.create({
-    content: store.findAll(Person)
+    content: store.all(Person)
   });
 
   container.appendTo('#qunit-fixture');

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -320,7 +320,7 @@ test("deleting a record with custom primaryKey", function() {
 */
 
 test("finding all people makes a GET to /people", function() {
-  people = store.find(Person);
+  people = store.findAll(Person);
 
   expectUrl("/people", "the plural of the model name");
   expectType("GET");
@@ -336,7 +336,7 @@ test("finding all people makes a GET to /people", function() {
 });
 
 test("finding all can sideload data", function() {
-  var groups = store.find(Group);
+  var groups = store.findAll(Group);
 
   expectUrl("/groups", "the plural of the model name");
   expectType("GET");

--- a/packages/ember-data/tests/unit/store_test.js
+++ b/packages/ember-data/tests/unit/store_test.js
@@ -65,7 +65,6 @@ test("the empty state", function() {
   isFalse("isDirty");
   isFalse("isSaving");
   isFalse("isDeleted");
-  isFalse("isError");
 });
 
 test("the loading state", function() {
@@ -74,7 +73,6 @@ test("the loading state", function() {
   isFalse("isDirty");
   isFalse("isSaving");
   isFalse("isDeleted");
-  isFalse("isError");
 });
 
 test("the loaded state", function() {
@@ -83,7 +81,6 @@ test("the loaded state", function() {
   isFalse("isDirty");
   isFalse("isSaving");
   isFalse("isDeleted");
-  isFalse("isError");
 });
 
 test("the updated state", function() {
@@ -92,7 +89,6 @@ test("the updated state", function() {
   isTrue("isDirty");
   isFalse("isSaving");
   isFalse("isDeleted");
-  isFalse("isError");
 });
 
 test("the saving state", function() {
@@ -101,7 +97,6 @@ test("the saving state", function() {
   isTrue("isDirty");
   isTrue("isSaving");
   isFalse("isDeleted");
-  isFalse("isError");
 });
 
 test("the deleted state", function() {
@@ -110,7 +105,6 @@ test("the deleted state", function() {
   isTrue("isDirty");
   isFalse("isSaving");
   isTrue("isDeleted");
-  isFalse("isError");
 });
 
 test("the deleted.saving state", function() {
@@ -119,7 +113,6 @@ test("the deleted.saving state", function() {
   isTrue("isDirty");
   isTrue("isSaving");
   isTrue("isDeleted");
-  isFalse("isError");
 });
 
 test("the deleted.saved state", function() {
@@ -128,17 +121,6 @@ test("the deleted.saved state", function() {
   isFalse("isDirty");
   isFalse("isSaving");
   isTrue("isDeleted");
-  isFalse("isError");
-});
-
-
-test("the error state", function() {
-  stateName = "error";
-  isFalse("isLoaded");
-  isFalse("isDirty");
-  isFalse("isSaving");
-  isFalse("isDeleted");
-  isTrue("isError");
 });
 
 module("DS.Store working with a DS.Adapter");
@@ -322,7 +304,7 @@ test("loadMany takes an optional Object and passes it on to the Adapter", functi
   store.find(Person, passedQuery);
 });
 
-test("findAll(type) returns a record array of all records of a specific type", function() {
+test("all(type) returns a record array of all records of a specific type", function() {
   var store = DS.Store.create({ adapter: DS.Adapter.create() });
   var Person = DS.Model.extend({
     name: DS.attr('string')
@@ -330,7 +312,7 @@ test("findAll(type) returns a record array of all records of a specific type", f
 
   store.load(Person, 1, { id: 1, name: "Tom Dale" });
 
-  var results = store.findAll(Person);
+  var results = store.all(Person);
   equal(get(results, 'length'), 1, "record array should have the original object");
   equal(get(results.objectAt(0), 'name'), "Tom Dale", "record has the correct information");
 
@@ -338,7 +320,7 @@ test("findAll(type) returns a record array of all records of a specific type", f
   equal(get(results, 'length'), 2, "record array should have the new object");
   equal(get(results.objectAt(1), 'name'), "Yehuda Katz", "record has the correct information");
 
-  strictEqual(results, store.findAll(Person), "subsequent calls to findAll return the same recordArray)");
+  strictEqual(results, store.all(Person), "subsequent calls to all return the same recordArray)");
 });
 
 test("a new record of a particular type is created via store.createRecord(type)", function() {
@@ -596,7 +578,7 @@ test("an ID of 0 is allowed", function() {
   });
 
   store.load(Person, { id: 0, name: "Tom Dale" });
-  equal(store.findAll(Person).objectAt(0).get('name'), "Tom Dale", "found record with id 0");
+  equal(store.all(Person).objectAt(0).get('name'), "Tom Dale", "found record with id 0");
 });
 
 var stubAdapter, store;


### PR DESCRIPTION
I wanted to try a new approach.

The error state is now used only for fatal errors.

Validation errors deserve they own state, because validation error has something
to do with actual data.

Other type of errors have no effect on data. They just say "I can not save now, try later"

This is why, non fatal errors, act as a decorator, independent of record state.

This is not a final proposition. I need to port tests from my earlier propositions.
But before I put more work in to it, I would like some feedback from @tomdale and @wycats
