### PR TITLE
RESTAdapter learned side-deleting.

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -660,6 +660,16 @@ var states = {
           });
 
           manager.transitionTo('loaded.saved');
+        },
+
+        removeRecord: function(manager) {
+          var record = get(manager, 'record');
+
+          record.withTransaction(function(t) {
+            t.recordBecameClean('deleted', record);
+          });
+
+          manager.goToState('saved');
         }
       }),
 
@@ -707,7 +717,10 @@ var states = {
         invokeLifecycleCallbacks: function(manager) {
           var record = get(manager, 'record');
           record.trigger('didDelete', record);
-        }
+        },
+
+        // EVENTS
+        removeRecord: Ember.K
       })
     }),
 


### PR DESCRIPTION
If the adapter has a deleteMapping property, records can be side deleted as
well as sideloaded when responses set this property to a hash of type names
to list of ids.  For example:

``` javascript
  store.adapter.deleteMapping = '_deleted';

  // POST /people
 {
   person: { id: 1, name: "David" },
   groups: [{ id: 1, name: "Coffee Addicts" }],  //sideloading
   _deleted: {                                   // side deleting
     groups: [ 3, 4, 5 ],
     people: [ 6 ]
   }
 }
```
