### PR TITLE
relationship-improvements branch: delete owner of hasMany-belongsTo relation

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -109,7 +109,7 @@ DS.ManyArray = DS.RecordArray.extend({
         var change = DS.OneToManyChange.forChildAndParent(clientId, get(this, 'store'), { parentType: owner.constructor });
         change.hasManyName = name;
 
-        if (change.oldParent === undefined) { change.oldParent = get(owner, 'clientId'); }
+        if (change.oldParent === undefined || change.oldParent === null) { change.oldParent = get(owner, 'clientId'); }
         change.newParent = null;
         this._changesToSync.add(change);
       }

--- a/packages/ember-data/tests/unit/associations_test.js
+++ b/packages/ember-data/tests/unit/associations_test.js
@@ -311,6 +311,65 @@ test("it is possible to remove an item from an association", function() {
   equal(get(person, 'tags.length'), 0, "object is removed from the association");
 });
 
+test("loading an association then deleting the owner", function() {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tags: DS.hasMany(Tag)
+  });
+
+  Tag.reopen({
+    person: DS.belongsTo(Person)
+  });
+
+  var store = DS.Store.create();
+
+  store.load(Person, { id: 1, name: "Tom Dale", tags: [1] });
+  store.load(Tag, { id: 1, name: "ember", person: 1 });
+
+  var person = store.find(Person, 1);
+  var tag = person.get('tags').objectAt(0);
+
+  equal(get(tag, 'name'), "ember", "precond - associations work");
+  person.deleteRecord();
+  strictEqual(tag.get('person'), null, "deleting the owner should nullify it in the child");
+  tag.deleteRecord();
+  
+});
+
+test("adding a child then deleting the owner", function() {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tags: DS.hasMany(Tag)
+  });
+
+  Tag.reopen({
+    person: DS.belongsTo(Person)
+  });
+
+  var store = DS.Store.create();
+
+  store.load(Person, { id: 1, name: "Tom Dale", tags: [] });
+  store.load(Tag, { id: 1, name: "ember", person: 1 });
+
+  var person = store.find(Person, 1);
+  var tag = store.find(Tag, 1);
+  person.get('tags').pushObject(tag);
+
+  equal(person.get('tags').objectAt(0).get('name'), "ember", "precond - associations work");
+  person.deleteRecord();
+  strictEqual(tag.get('person'), null, "deleting the owner should nullify it in the child");
+  tag.deleteRecord();
+  
+});
+
 test("it is possible to add an item to an association, remove it, then add it again", function() {
   var Tag = DS.Model.extend({
     name: DS.attr('string')
@@ -481,7 +540,7 @@ test("calling createRecord and passing in an undefined value for an association 
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
-    tag: DS.belongsTo(Tag),
+    tag: DS.belongsTo(Tag)
   });
 
   Tag.reopen({


### PR DESCRIPTION
Deleting a owner of a hasMany-belongsTo association should "nullify" the owner reference in the child.

Without the modification, the first test passed, but the second one failed.
