### PR TITLE
The DATE data type (passthrough) was missing.

### DIFF
--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -16,7 +16,8 @@ DS.Serializer = Ember.Object.extend({
     this.transforms = {
       'string': passthrough,
       'number': passthrough,
-      'boolean': passthrough
+      'boolean': passthrough,
+      'date': passthrough
     };
 
     this.mappings = Ember.Map.create();


### PR DESCRIPTION
The docs say that date is part of the base data types that are supported by ember-data... added that transform so the error : "You tried to use a attribute type (date) that has not been registered"
