### PR TITLE
Adding a child then commit, the owner should become in a clean state

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -862,10 +862,8 @@ DS.Store = Ember.Object.extend({
       this.didDeleteRecord(record);
     }
 
+    record.removeInFlightDirtyFactors();
     if (hash) {
-      // We're about to clobber the entire data hash with new
-      // data, so clear out any remaining unacknowledged changes
-      record.removeInFlightDirtyFactors();
       this.updateId(record, hash);
       this.updateRecordHash(record, hash);
     } else {

--- a/packages/ember-data/tests/integration/associations_test.js
+++ b/packages/ember-data/tests/integration/associations_test.js
@@ -106,6 +106,45 @@ test("When a hasMany association is accessed, the adapter's findMany method shou
   store.load(Person, { id: 1, comments: [ 1 ] });
 });
 
+test("When adding a child to a parent, then commit, the parent should come back to a clean state", function() {
+  expect(1);
+
+  adapter.shouldCommit = function(record) {
+    //behaves like DS.RESTAdapter, a parent record should not be commited when adding a child
+    if (record.isCommittingBecause('attribute') || record.isCommittingBecause('belongsTo')) {
+      return true;
+    }
+  };
+
+  adapter.createRecord = function(store, type, record) {
+    store.didSaveRecord(record, this.toJSON(record));
+  };
+
+  adapter.updateRecord = function(store, type, record) {
+    store.didSaveRecord(record, this.toJSON(record));
+  };
+
+  Person = DS.Model.extend({
+    updatedAt: DS.attr('string'),
+    name: DS.attr('string')
+  });
+
+  Comment = DS.Model.extend({
+    person: DS.belongsTo(Person)
+  });
+
+  Person.reopen({
+    comments: DS.hasMany(Comment)
+  });
+
+  store.load(Person, { id: 1});
+  var person = store.find(Person, 1);
+
+  person.get('comments').createRecord(Comment);
+  store.commit();
+  equal(person.get('stateManager.currentState.path'), "rootState.loaded.saved");
+});
+
 test("An adapter can materialize a hash and get it back later in a findAssociation hook", function() {
   expect(8);
 


### PR DESCRIPTION
Using the RESTAdapter, when creating a child record, then commit, the parent is not commited (which is ok), but its state remains in updated.inFlight.
As a result no other modifications on this parent record is possible.

NB: This issue was tracked with @tomdale, I hope he has not wasted his time tracking an imaginary bug...
