### PR TITLE
Incorporate default transforms to RESTAdapter

### DIFF
--- a/packages/ember-data/lib/adapters/transforms.js
+++ b/packages/ember-data/lib/adapters/transforms.js
@@ -1,39 +1,56 @@
-var transforms = {
+DS.Transforms = Ember.Object.extend({
   string: {
-    from: function(serialized) {
+    fromJSON: function(serialized) {
       return Ember.none(serialized) ? null : String(serialized);
     },
 
-    to: function(deserialized) {
+    toJSON: function(deserialized) {
       return Ember.none(deserialized) ? null : String(deserialized);
     }
   },
 
   number: {
-    from: function(serialized) {
+    fromJSON: function(serialized) {
       return Ember.none(serialized) ? null : Number(serialized);
     },
 
-    to: function(deserialized) {
+    toJSON: function(deserialized) {
       return Ember.none(deserialized) ? null : Number(deserialized);
     }
   },
 
+  // Handles the following boolean inputs:
+  // "TrUe", "t", "f", "FALSE", 0, (non-zero), or boolean true/false
   'boolean': {
-    from: function(serialized) {
-      return Boolean(serialized);
+    fromJSON: function(serialized) {
+      var type = typeof serialized;
+
+      if (type === "boolean") {
+        return serialized;
+      } else if (type === "string") {
+        return serialized.match(/^true$|^t$|^1$/i) !== null;
+      } else if (type === "number") {
+        return serialized === 1;
+      } else {
+        return false;
+      }
     },
 
-    to: function(deserialized) {
+    toJSON: function(deserialized) {
       return Boolean(deserialized);
     }
   },
 
   date: {
-    from: function(serialized) {
+    fromJSON: function(serialized) {
       var type = typeof serialized;
 
       if (type === "string" || type === "number") {
+        // this is a fix for Safari 5.1.5 on Mac which does not accept timestamps as yyyy-mm-dd
+        if (serialized.search(/^\d{4}-\d{2}-\d{2}$/) !== -1){
+          serialized += "T00:00:00Z";
+        }
+
         return new Date(serialized);
       } else if (serialized === null || serialized === undefined) {
         // if the value is not present in the data,
@@ -44,7 +61,7 @@ var transforms = {
       }
     },
 
-    to: function(date) {
+    toJSON: function(date) {
       if (date instanceof Date) {
         var days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
@@ -75,6 +92,4 @@ var transforms = {
       }
     }
   }
-};
-
-
+});

--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -1,24 +1,11 @@
+require('ember-data/adapters/transforms');
+
 var get = Ember.get, set = Ember.set;
-
-var passthrough = {
-  fromJSON: function(value) {
-    return value;
-  },
-
-  toJSON: function(value) {
-    return value;
-  }
-};
 
 DS.Serializer = Ember.Object.extend({
   init: function() {
-    // By default, the JSON types are passthrough transforms
-    this.transforms = {
-      'string': passthrough,
-      'number': passthrough,
-      'boolean': passthrough
-    };
-
+    // By default, the JSON types are the transforms defined in DS.Transforms
+    this.transforms = DS.Transforms.create();
     this.mappings = Ember.Map.create();
   },
 

--- a/packages/ember-data/tests/integration/transform_test.js
+++ b/packages/ember-data/tests/integration/transform_test.js
@@ -1,4 +1,4 @@
-var Adapter, adapter, store, serializer;
+var Adapter, adapter, store, serializer, Person;
 
 module("Record Attribute Transforms", {
   setup: function() {
@@ -40,4 +40,69 @@ test("transformed values should be materialized on the record", function() {
 
   var json = adapter.toJSON(person);
   equal(json.name, "toJSON", "value of attribute in the JSON hash should be transformed");
+});
+
+module("Default DS.Transforms", {
+  setup: function() {
+    store = DS.Store.create();
+
+    Person = DS.Model.extend({
+      name: DS.attr('string'),
+      born: DS.attr('date'),
+      age: DS.attr('number'),
+      isGood: DS.attr('boolean')
+    });
+  },
+
+  teardown: function() {
+    store.destroy();
+  }
+});
+
+test("the default numeric transform", function() {
+  store.load(Person, {id: 1, age: "51"});
+  var person = store.find(Person, 1);
+
+  var result = (typeof person.get('age') === "number"); 
+  equal(result, true, "string is transformed into a number");
+  equal(person.get('age'),51, "string value and transformed numeric value match");
+});
+
+test("the default boolean transform", function() {
+  store.load(Person, {id: 1, isGood: "false"});
+  store.load(Person, {id: 2, isGood: "f"});
+  store.load(Person, {id: 3, isGood: 0});
+  store.load(Person, {id: 4, isGood: false});
+
+  var personOne = store.find(Person, 1);
+  var personTwo = store.find(Person, 2);
+  var personThree = store.find(Person, 3);
+  var personFour = store.find(Person, 4);
+
+  var result = (typeof personOne.get('isGood') === "boolean"); 
+  equal(result, true, "string is transformed into a boolean");
+
+  equal(personOne.get('isGood'), false, "string value and transformed boolean value match");
+  equal(personTwo.get('isGood'), false, "short string value and transformed boolean value match");
+  equal(personThree.get('isGood'), false, "numeric value and transformed boolean value match");
+  equal(personFour.get('isGood'), false, "boolean value and transformed boolean value match");
+});
+
+test("the default string transform", function() {
+  store.load(Person, {id: 1, name: 8675309});
+  var person = store.find(Person, 1);
+
+  var result = (typeof person.get('name') === "string"); 
+  equal(result, true, "number is transformed into a string");
+  equal(person.get('name'), "8675309", "numeric value and transformed string value match");
+});
+
+test("the default date transform", function() {
+  var date = new Date();
+  store.load(Person, {id: 1, born: date.toString()});
+  var person = store.find(Person, 1);
+
+  var result = (person.get('born') instanceof Date); 
+  equal(result, true, "string is transformed into a date");
+  equal(person.get('born').toString(), date.toString(), "date.toString and transformed date.toString values match");
 });


### PR DESCRIPTION
Fixes #386, Fixes #415, Fixes #404, Fixes #206
- Created integration test for default DS.Transforms
- Added unit test for models for default DS.Transforms (commented out some of the tests, see #421) from: 8a812c8
- Modified transforms.js to use DS.Transforms namespace
- Modified transforms.js to use fromJSON/toJSON instead of to/from
- Modified serializer to create an instance of DS.Transforms for it's default transformations instead of using the passthrough hack
- Modified transforms.js to have a little bit of logic in boolean transform
