### PR TITLE
Support DS.Store#all(DS.Model) and DS.Store#all(subclass of DS.Model)

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1226,6 +1226,12 @@ DS.Store = Ember.Object.extend({
 
       this.loadingRecordArrays[clientId] = null;
     }
+
+    // update all record arrays for superclass of this type
+    var superclass = type.superclass;
+    if (DS.Model.detect(superclass)) {
+      this.updateRecordArrays(superclass, clientId);
+    }
   },
 
   /**
@@ -1466,6 +1472,12 @@ DS.Store = Ember.Object.extend({
     }
 
     clientIds.push(clientId);
+
+    // add clientId to typeMap of superclass
+    while ((type = type.superclass) && DS.Model.detect(type)) {
+      typeMap = this.typeMapFor(type);
+      typeMap.clientIds.push(clientId);
+    }
 
     return clientId;
   },

--- a/packages/ember-data/tests/unit/store_test.js
+++ b/packages/ember-data/tests/unit/store_test.js
@@ -364,6 +364,49 @@ test("all(type) returns a record array of all records of a specific type", funct
   strictEqual(results, store.all(Person), "subsequent calls to all return the same recordArray)");
 });
 
+test("all(type) returns a record array of all child records of a generic type", function() {
+  var store = DS.Store.create();
+
+  var Lecture = DS.Model.extend();
+  var Person = DS.Model.extend({
+    name: DS.attr('string')
+  });
+  var Student = Person.extend();
+  var Teacher = Person.extend();
+
+  store.load(Student, 1, { id: 1, name: "Tobias Fünke" });
+  store.load(Teacher, 2, { id: 2, name: "Carl Weathers" });
+  store.load(Lecture, 3, { id: 3 });
+
+  var allLectures = store.all(Lecture);
+  var allPersons = store.all(Person);
+  var allStudents = store.all(Student);
+  var allTeachers = store.all(Teacher);
+  var allModels = store.all(DS.Model);
+
+  equal(get(allLectures, 'length'), 1, "precond - record array contains all lecture records");
+  equal(get(allPersons, 'length'), 2, "precond - record array contains all person records");
+  equal(get(allStudents, 'length'), 1, "precond - record array contains all student records");
+  equal(get(allTeachers, 'length'), 1, "precond - record array contains all teacher records");
+  equal(get(allModels, 'length'), 3, "precond - record array contains all model records");
+
+  store.load(Student, 4, { id: 4, name: "Buster Bluth" });
+
+  equal(get(allLectures, 'length'), 1, "adding a student - record array contains all lecture records");
+  equal(get(allPersons, 'length'), 3, "adding a student - record array contains all person records");
+  equal(get(allStudents, 'length'), 2, "adding a student - record array contains all student records");
+  equal(get(allTeachers, 'length'), 1, "adding a student - record array contains all teacher records");
+  equal(get(allModels, 'length'), 4, "adding a student - record array contains all model records");
+
+  store.find(Student, 4).deleteRecord();
+
+  equal(get(allLectures, 'length'), 1, "removing a student - record array contains all lecture records");
+  equal(get(allPersons, 'length'), 2, "removing a student - record array contains all person records");
+  equal(get(allStudents, 'length'), 1, "removing a student - record array contains all student records");
+  equal(get(allTeachers, 'length'), 1, "removing a student - record array contains all teacher records");
+  equal(get(allModels, 'length'), 3, "removing a student - record array contains all model records");
+});
+
 test("a new record of a particular type is created via store.createRecord(type)", function() {
   var store = DS.Store.create();
   var Person = DS.Model.extend({


### PR DESCRIPTION
This commit adds the possibility to get all models of a certain type, where sub-types are also included.

Let's say you have a `Person = DS.Model.extend()`, a `Student = Person.extend()` and a `Professor = Person.extend()`. To get all persons you can now do a `var allPersons = store.all(Person)`. If you additionally have for example a `Lecture = DS.Model.extend()` you can get all models of the store via `var allModels = store.all(DS.Model)`.

This PR is the rebased version of #339, on the recently merged `relationship-improvements` branch.
