### PR TITLE
Add a note about the removed embedded option to BREAKING_CHANGES

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -121,6 +121,10 @@ DS.RESTAdapter.map('App.Post', {
 });
 ```
 
+### Embedded relationships
+
+Using `{ embedded: true }` for nesting the concrete objects of a relationship into the parents JSON is no longer supported.
+
 ### ID as an Attribute
 
 Some applications were erroneously declaring `id` as an attribute on


### PR DESCRIPTION
I guess this will break a lot of projects and currently it is not mentioned in BREAKING_CHANGES.
