### PR TITLE
Add tests for calling jQuery.ajax from DS.RESTAdapter

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -24,7 +24,8 @@
         "expect",
         "minispade",
         "async",
-        "invokeAsync"
+        "invokeAsync",
+        "jQuery"
     ],
 
     "node" : false,


### PR DESCRIPTION
There was no test coverage for RESTAdapter#ajax thus Ember Data could not guarantee that jQuery.ajax was being called.

We have added test coverage for most scenarios.
