### PR TITLE
RESTAdapter: call this.didSaveRecord on didDeleteRecord

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -153,7 +153,7 @@ DS.RESTAdapter = DS.Adapter.extend({
 
   didDeleteRecord: function(store, type, record, json) {
     if (json) { this.sideload(store, type, json); }
-    store.didSaveRecord(record);
+    this.didSaveRecord(store, record);
   },
 
   deleteRecords: function(store, type, records) {


### PR DESCRIPTION
This seems have been forgotten in the commit https://github.com/emberjs/data/commit/7ea66038d0f32668024860b1916e7596ad911ff1
As a result deleting a child did not result a clean parent :/
