### PR TITLE
Fix hasMany access within init

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -53,7 +53,6 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   }).property(),
 
   materializeData: function() {
-    this.setupData();
     get(this, 'store').materializeData(this);
 
     this.suspendAssociationObservers(function() {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -148,6 +148,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
         adapter = this.adapterForType(record.constructor),
         data = cidToData[clientId];
 
+    if (data === MATERIALIZED) { return; }
+
     cidToData[clientId] = MATERIALIZED;
 
     // Ensures the record's data structures are setup

--- a/packages/ember-data/tests/unit/store_test.js
+++ b/packages/ember-data/tests/unit/store_test.js
@@ -237,6 +237,26 @@ test("DS.Store loads individual records without explicit IDs", function() {
   equal(get(tom, 'name'), "Tom Dale", "the person was successfully loaded for the given ID");
 });
 
+test("DS.Store loads individual records that access associations during initialization", function() {
+  var store = DS.Store.create();
+  var Person = DS.Model.extend();
+
+  Person.reopen({
+    init: function() {
+      this._super.apply(this, arguments);
+      this.get('children');
+    },
+    name: DS.attr('string'),
+    children: DS.hasMany(Person)
+  });
+
+  store.load(Person, { id: 1, name: "John Doe" });
+
+  var person = store.find(Person, 1);
+
+  equal(get(person, 'name'), "John Doe", "person attributes are properly set up");
+});
+
 test("can load data for the same record if it is not dirty", function() {
   var store = DS.Store.create();
   var Person = DS.Model.extend({


### PR DESCRIPTION
This commit fixes a bug in materialization when accessing a has many association within the initializer method of a record.
