### PR TITLE
Maintain order in HasMany when removing and adding to the same collection

### DIFF
--- a/packages/ember-data/lib/system/associations/one_to_many_change.js
+++ b/packages/ember-data/lib/system/associations/one_to_many_change.js
@@ -279,14 +279,15 @@ DS.OneToManyChange.prototype = {
     // infinite loop.
 
 
-    // If there is an `oldParent`, use the idempotent `removeObject`
-    // to ensure that the record is no longer in its ManyArray. The
-    // `removeObject` method only has an effect if:
+    // If there is an `oldParent` and the `oldParent` is different to
+    // the `newParent`, use the idempotent `removeObject` to ensure
+    // that the record is no longer in its ManyArray. The `removeObject`
+    // method only has an effect if:
     //
     // 1. The change happened from the belongsTo side
     // 2. The record was moved to a new parent without explicitly
     //    removing it from the old parent first.
-    if (oldParent) {
+    if (oldParent && oldParent !== newParent) {
       get(oldParent, hasManyName).removeObject(child);
 
       if (get(oldParent, 'isLoaded')) {

--- a/packages/ember-data/tests/unit/associations_test.js
+++ b/packages/ember-data/tests/unit/associations_test.js
@@ -312,33 +312,40 @@ test("it is possible to remove an item from an association", function() {
 });
 
 test("it is possible to add an item to an association, remove it, then add it again", function() {
-  var Tag = DS.Model.extend({
-    name: DS.attr('string')
-  });
+  var Tag = DS.Model.extend();
+  var Person = DS.Model.extend();
 
-  var Person = DS.Model.extend({
+  Tag.reopen({
+    name: DS.attr('string'),
+    person: DS.belongsTo(Person)
+  });
+  Person.reopen({
     name: DS.attr('string'),
     tags: DS.hasMany(Tag)
   });
-
-  Tag.reopen({
-    person: DS.belongsTo(Person)
-  });
+  Tag.toString = function() { return "App.Tag"; };
+  Person.toString = function() { return "App.Person"; };
 
   var store = DS.Store.create();
 
   var person = store.createRecord(Person);
   var tag1 = store.createRecord(Tag);
   var tag2 = store.createRecord(Tag);
+  var tag3 = store.createRecord(Tag);
 
   var tags = get(person, 'tags');
 
-  tags.pushObject(tag1);
-  tags.pushObject(tag2);
-  tags.removeAt(0);
-  tags.pushObject(tag1);
-
+  tags.pushObjects([tag1, tag2, tag3]);
+  tags.removeObject(tag2);
+  equal(tags.objectAt(0), tag1);
+  equal(tags.objectAt(1), tag3);
   equal(get(person, 'tags.length'), 2, "object is removed from the association");
+
+  tags.insertAt(0, tag2);
+  equal(get(person, 'tags.length'), 3, "object is added back to the association");
+  equal(tags.objectAt(0), tag2);
+  equal(tags.objectAt(1), tag1);
+  equal(tags.objectAt(2), tag3);
 });
 
 module("RecordArray");


### PR DESCRIPTION
Fixes a bug where it adds the object to the end of the collection instead of the inserted position when removing and adding to the same collection.

As a side effect it also offers a small performance improvement as it no longer need to remove the object from the collection and re-add it while it's doing the sync.
