### PR TITLE
moved the DS.RecordArray creation of Store#all(type) into a separate function

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -722,7 +722,7 @@ DS.Store = Ember.Object.extend(DS.Mappable, {
 
     if (findAllCache) { return findAllCache; }
 
-    var array = this.newRecordArray(type);
+    var array = this.createRecordArray(type);
     Ember.assert("You can only register an instance or subclass of DS.RecordArray", array instanceof DS.RecordArray);
 
     this.registerRecordArray(array, type);
@@ -736,7 +736,7 @@ DS.Store = Ember.Object.extend(DS.Mappable, {
     @param {Class} type
     @return {DS.RecordArray}
   **/
-  newRecordArray: function(type){
+  createRecordArray: function(type){
     return DS.RecordArray.create({ type: type, content: Ember.A([]), store: this, isLoaded: true });
   },
 

--- a/packages/ember-data/tests/unit/store_test.js
+++ b/packages/ember-data/tests/unit/store_test.js
@@ -397,7 +397,7 @@ test("all(type) can return a subclass of RecordArray", function(){
 
   var store = DS.Store.create({ 
     adapter: DS.Adapter.create(),
-    newRecordArray: function(type){
+    createRecordArray: function(type){
       return DerivedRecordArray.create({type: type, content: Ember.A([]), store: this});
     }
   });


### PR DESCRIPTION
Previously Store#all had the creation of the returned DS.RecordArray hard coded into the function:

```
var array = DS.RecordArray.create({ type: type, content: Ember.A([]), store: this, isLoaded: true });
this.registerRecordArray(array, type);
```

This pull request gives the user an opportunity to supply a derived type:

```
    //Store#all
    var array = this.newRecordArray(type);

    this.registerRecordArray(array, type);
```

```
  newRecordArray: function(type){
    return DS.RecordArray.create({ type: type, content: Ember.A([]), store: this, isLoaded: true });
  },
```

For example,  I might want to supply a PagedRecordArray that provides paging functionality.
