### PR TITLE
FixtureAdapter calls store.didUpdateAll for findAll

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -78,6 +78,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
 
     this.simulateRemoteCall(function() {
       store.loadMany(type, fixtures);
+      store.didUpdateAll(type);
     }, store, type);
   },
 

--- a/packages/ember-data/tests/unit/fixture_adapter_test.js
+++ b/packages/ember-data/tests/unit/fixture_adapter_test.js
@@ -143,3 +143,26 @@ test("should delete record asynchronously when it is committed", function() {
     ok(false, "timeout exceeded waiting for fixture data");
   }, 1000);
 });
+
+test("should follow isUpdating semantics", function() {
+  stop();
+
+  Person.FIXTURES = [{
+    id: "twinturbo",
+    firstName: "Adam",
+    lastName: "Hawkins",
+    height: 65
+  }];
+
+  var result = store.findAll(Person);
+
+  result.addObserver('isUpdating', function() {
+    start();
+    equal(get(result, 'isUpdating'), false, "isUpdating is set when it shouldn't be");
+  });
+
+  var timer = setTimeout(function() {
+    start();
+    ok(false, "timeout exceeded waiting for fixture data");
+  }, 1000);
+});


### PR DESCRIPTION
This commit ensures the FixtureAdapter correctly calls `store.didUpdateAll` when `findAll` is called. This ensures that result's `isUpdating` property is correctly set back to `false` after hitting the adapter. Previously results from the FixtureAdapter would be `isUpdating` forever.
