### PR TITLE
Handle 422 errors when committing new objects

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -27,8 +27,18 @@ DS.RESTAdapter = DS.Adapter.extend({
       context: this,
       success: function(json) {
         this.didCreateRecord(store, type, record, json);
+      },
+      statusCode: {
+        422: function(jqXHR, textStatus, errorThrown) {
+          var json = jQuery.parseJSON(jqXHR.responseText);
+          this.recordWasInvalid(store, type, record, json);
+        }
       }
     });
+  },
+
+  recordWasInvalid: function(store, type, record, json) {
+    store.recordWasInvalid(record, json); 
   },
 
   didCreateRecord: function(store, type, record, json) {
@@ -274,6 +284,12 @@ DS.RESTAdapter = DS.Adapter.extend({
     if (hash.data && type !== 'GET') {
       hash.data = JSON.stringify(hash.data);
     }
+
+    // Add callbacks for error statuses
+    if (hash.statusCode === undefined) { hash.statusCode = {}; }
+    hash.statusCode['404'] = function() {
+      if (this.error404 !== undefined) this.error404();
+    };
 
     jQuery.ajax(hash);
   },


### PR DESCRIPTION
Right now Ember Data only accepts successful responses from ajax calls. 

``` javascript
this.ajax(this.buildURL(root), "POST", {
  data: data,
  context: this,
  success: function(json) {
    this.didCreateRecord(store, type, record, json);
  }
});
```

The default behaviour in Rails is to return a 422 (Unprocessable Entity) so it seems like Ember Data should digest the errors returned when committing that record and switch states.

``` javascript
this.ajax(this.buildURL(root), "POST", {
  data: data,
  context: this,
  success: function(json) {
    this.didCreateRecord(store, type, record, json);
  },
  statusCode: {
    422: function(jqXHR, textStatus, errorThrown) {
      var json = $.parseJSON(jqXHR.responseText)
      this.recordWasInvalid(store, type, record, json);
    }
  }
});
```

I did notice that there are a few issues for errors open already, but they seem more broad and none of those solutions have been updated or merged.
