### PR TITLE
Add hasOne association

### DIFF
--- a/packages/ember-data/lib/serializers/fixture_serializer.js
+++ b/packages/ember-data/lib/serializers/fixture_serializer.js
@@ -66,5 +66,9 @@ DS.FixtureSerializer = DS.Serializer.extend({
 
   extractBelongsTo: function(type, hash, key) {
     return hash[key];
+  },
+
+  extractHasOne: function(type, hash, key) {
+    return hash[key];
   }
 });

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -91,11 +91,48 @@ DS.JSONSerializer = DS.Serializer.extend({
     return hash[key];
   },
 
+  extractHasOne: function(type, hash, key) {
+    return hash[key];
+  },
+
   addBelongsTo: function(hash, record, key, relationship) {
     var type = record.constructor,
         name = relationship.key,
         value = null,
-        embeddedChild;
+        embeddedParent;
+
+    if (this.embeddedType(type, name)) {
+      if (embeddedParent = get(record, name)) {
+        value = this.serialize(embeddedParent, { includeId: true });
+      }
+
+      hash[key] = value;
+    } else {
+      var id = get(record, relationship.key+'.id');
+      if (!Ember.isNone(id)) { hash[key] = id; }
+    }
+  },
+
+  /**
+    Adds a has-one relationship to the JSON hash being built.
+
+    The default REST semantics are to only add a has-one relationship if it
+    is embedded. If the relationship was initially loaded by ID, we assume that
+    that was done as a performance optimization, and that changes to the
+    has-one should be saved as foreign key changes on the child's belongs-to
+    relationship.
+
+    @param {Object} hash the JSON being built
+    @param {DS.Model} record the record being serialized
+    @param {String} key the JSON key into which the serialized relationship
+      should be saved
+    @param {Object} relationship metadata about the relationship being serialized
+  */
+  addHasOne: function(hash, record, key, relationship) {
+    var type = record.constructor,
+      name = relationship.key,
+      value = null,
+      embeddedChild;
 
     if (this.embeddedType(type, name)) {
       if (embeddedChild = get(record, name)) {
@@ -103,9 +140,6 @@ DS.JSONSerializer = DS.Serializer.extend({
       }
 
       hash[key] = value;
-    } else {
-      var id = get(record, relationship.key+'.id');
-      if (!Ember.isNone(id)) { hash[key] = id; }
     }
   },
 

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -15,6 +15,16 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
     return key + "_id";
   },
 
+  keyForHasOne: function(type, name) {
+    var key = this.keyForAttributeName(type, name);
+
+    if (this.embeddedType(type, name)) {
+      return key;
+    }
+
+    return key + "_id";
+  },
+
   keyForHasMany: function(type, name) {
     var key = this.keyForAttributeName(type, name);
 

--- a/packages/ember-data/lib/system/relationships.js
+++ b/packages/ember-data/lib/system/relationships.js
@@ -1,4 +1,5 @@
 require("ember-data/system/relationships/belongs_to");
+require("ember-data/system/relationships/has_one");
 require("ember-data/system/relationships/has_many");
 require("ember-data/system/relationships/ext");
 require("ember-data/system/relationships/one_to_many_change");

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -34,9 +34,14 @@ DS.Model.reopen({
       // the computed property.
       var meta = value.meta();
 
-      if (meta.isRelationship && meta.kind === 'belongsTo') {
-        Ember.addObserver(proto, key, null, 'belongsToDidChange');
-        Ember.addBeforeObserver(proto, key, null, 'belongsToWillChange');
+      if (meta.isRelationship) {
+        if (meta.kind === 'belongsTo') {
+          Ember.addObserver(proto, key, null, 'belongsToDidChange');
+          Ember.addBeforeObserver(proto, key, null, 'belongsToWillChange');
+        } else if (meta.kind === 'hasOne') {
+          Ember.addObserver(proto, key, null, 'hasOneDidChange');
+          Ember.addBeforeObserver(proto, key, null, 'hasOneWillChange');
+        }
       }
 
       if (meta.isAttribute) {
@@ -162,7 +167,7 @@ DS.Model.reopenClass({
     @readOnly
   */
   relationshipNames: Ember.computed(function() {
-    var names = { hasMany: [], belongsTo: [] };
+    var names = { hasMany: [], belongsTo: [], hasOne: [] };
 
     this.eachComputedProperty(function(name, meta) {
       if (meta.isRelationship) {

--- a/packages/ember-data/lib/system/relationships/has_one.js
+++ b/packages/ember-data/lib/system/relationships/has_one.js
@@ -1,0 +1,77 @@
+var get = Ember.get, set = Ember.set,
+  none = Ember.isNone;
+
+DS.hasOne = function(type, options) {
+  Ember.assert("The first argument DS.hasOne must be a model type or string, like DS.hasOne(App.Person)", !!type && (typeof type === 'string' || DS.Model.detect(type)));
+
+  options = options || {};
+
+  var meta = { type: type, isRelationship: true, options: options, kind: 'hasOne' };
+
+  return Ember.computed(function(key, value) {
+    if (arguments.length === 2) {
+      return value === undefined ? null : value;
+    }
+
+    var data = get(this, 'data').hasOne,
+      store = get(this, 'store'), id;
+
+    if (typeof type === 'string') {
+      type = get(this, type, false) || get(Ember.lookup, type);
+    }
+
+    id = data[key];
+
+    if (!id) {
+      return null;
+    } else if (typeof id === 'object') {
+      return store.recordForReference(id);
+    } else {
+      return store.find(type, id);
+    }
+  }).property('data').meta(meta);
+};
+
+/**
+ These observers observe all `hasOne` relationships on the record. See
+ `relationships/ext` to see how these observers get their dependencies.
+
+ */
+
+DS.Model.reopen({
+  /** @private */
+  hasOneWillChange: Ember.beforeObserver(function(record, key) {
+    if (get(record, 'isLoaded')) {
+      var oldChild = get(record, key),
+          parentReference = get(record, '_reference'),
+          store = get(record, 'store');
+
+      if (oldChild) {
+        var change = DS.RelationshipChange.createChange(parentReference, get(oldChild, '_reference'), store, { key: key, kind: "hasOne", changeType: "remove" });
+        change.sync();
+
+        this._changesToSync[key] = change;
+      }
+    }
+  }),
+
+  /** @private */
+  hasOneDidChange: Ember.immediateObserver(function(record, key) {
+    if (get(record, 'isLoaded')) {
+      var newChild = get(record, key);
+
+      if (newChild) {
+        var parentReference = get(record, '_reference'),
+            store = get(record, 'store');
+
+        var change = DS.RelationshipChange.createChange(parentReference, get(newChild, '_reference'), store, { key: key, kind: "hasOne", changeType: "add" });
+        change.sync();
+
+        if (this._changesToSync[key]) {
+          DS.OneToManyChange.ensureSameTransaction([change, this._changesToSync[key]], store);
+        }
+      }
+    }
+    delete this._changesToSync[key];
+  })
+});

--- a/packages/ember-data/lib/system/relationships/one_to_many_change.js
+++ b/packages/ember-data/lib/system/relationships/one_to_many_change.js
@@ -72,8 +72,8 @@ DS.RelationshipChange.determineRelationshipType = function(recordType, knownSide
     return knownContainerType === "belongsTo" ? "oneToNone" : "manyToNone";
   }
   else{
-    if(otherContainerType === "belongsTo"){
-      return knownContainerType === "belongsTo" ? "oneToOne" : "manyToOne";
+    if(otherContainerType === "belongsTo" || otherContainerType === "hasOne"){
+      return knownContainerType === "belongsTo" || knownContainerType === "hasOne" ? "oneToOne" : "manyToOne";
     }
     else{
       return knownContainerType === "belongsTo" ? "oneToMany" : "manyToMany";

--- a/packages/ember-data/tests/integration/dirtiness_test.js
+++ b/packages/ember-data/tests/integration/dirtiness_test.js
@@ -56,6 +56,52 @@ test("By default, changing the relationship between two records does not cause t
   ok(!comment.get('isDirty'), "comment should not be dirty");
 });
 
+test("By default, changing a one-to-one relationship from the child causes both records to become dirty", function() {
+  var Post = DS.Model.extend();
+
+  var Attachment = DS.Model.extend({
+    post: DS.belongsTo(Post)
+  });
+
+  Post.reopen({
+    attachment: DS.hasOne(Attachment)
+  });
+
+  store.load(Post, { id: 1, attachment: 1 });
+  store.load(Attachment, { id: 1, post: 1 });
+
+  var post = store.find(Post, 1);
+  var attachment = store.find(Attachment, 1);
+
+  attachment.set('post', null);
+
+  ok(post.get('isDirty'), "post should be dirty");
+  ok(attachment.get('isDirty'), "attachment should be dirty");
+});
+
+test("By default, changing a one-to-one relationship from the parent causes both records to become dirty", function() {
+  var Post = DS.Model.extend();
+
+  var Attachment = DS.Model.extend({
+    post: DS.belongsTo(Post)
+  });
+
+  Post.reopen({
+    attachment: DS.hasOne(Attachment)
+  });
+
+  store.load(Post, { id: 1, attachment: 1 });
+  store.load(Attachment, { id: 1, post: 1 });
+
+  var post = store.find(Post, 1);
+  var attachment = store.find(Attachment, 1);
+
+  post.set('attachment', null);
+
+  ok(post.get('isDirty'), "post should be dirty");
+  ok(attachment.get('isDirty'), "attachment should be dirty");
+});
+
 test("If dirtyRecordsForAttributeChange does not add the record to the dirtyRecords set, it does not become dirty", function() {
   store.load(Person, { id: 1, firstName: "Yehuda" });
   var wycats = store.find(Person, 1);

--- a/packages/ember-data/tests/integration/embedded/embedded_loading_test.js
+++ b/packages/ember-data/tests/integration/embedded/embedded_loading_test.js
@@ -8,6 +8,10 @@ var App = Ember.Namespace.create({
 
 var Person = App.Person = DS.Model.extend();
 
+var Avatar = App.Avatar = DS.Model.extend({
+  filename: DS.attr('string')
+});
+
 var Comment = App.Comment = DS.Model.extend({
   user: DS.belongsTo(Person)
 });
@@ -19,6 +23,7 @@ var Group = App.Group = DS.Model.extend({
 
 Person.reopen({
   name: DS.attr('string'),
+  avatar: DS.hasOne(Avatar),
   group: DS.belongsTo(Group),
   comments: DS.hasMany(Comment)
 });
@@ -37,6 +42,7 @@ module("Embedded Loading", {
 
   teardown: function() {
     Ember.lookup = originalLookup;
+    store.destroy();
   }
 });
 
@@ -296,3 +302,66 @@ test("updating a embedded record with a belongsTo relationship is serialize corr
     deepEqual(commentJSON, { id: 1, user: { id: 4, name: "Peter Pan", group: null }});
 });
 
+test("A nested hasOne relationship can be marked as embedded via the `map` API", function() {
+  Adapter.map(Comment, {
+    user: { embedded: 'load' }
+  });
+
+  Adapter.map(Person, {
+    avatar: { embedded: 'load' }
+  });
+
+  adapter = Adapter.create();
+  store.set('adapter', adapter);
+
+  adapter.load(store, Comment, {
+    id: 1,
+    user: {
+      id: 2,
+      name: "Yehuda Katz",
+      avatar: {
+        id: 3,
+        filename: "photo.jpg"
+      }
+    }
+  });
+
+  var comment = store.find(Comment, 1);
+  var avatar = store.find(Avatar, 3);
+
+  strictEqual(avatar.get('filename'), "photo.jpg", "Avatar is addressable by its ID despite being loaded via embedding");
+  strictEqual(comment.get('user.avatar'), avatar, "relationship references the globally addressable record");
+});
+
+test("An embedded hasOne relationship is serialized correctly on update", function() {
+  Adapter.map(Person, {
+    avatar: { embedded: 'load' }
+  });
+
+  adapter = Adapter.create();
+  serializer = adapter.get('serializer');
+  store.set('adapter', adapter);
+
+  adapter.load(store, Person, {
+    id: 1,
+    name: "Yehuda Katz",
+    avatar: {
+      id: 2,
+      filename: "photo.jpg"
+    }
+  });
+  adapter.load(store, Avatar, {
+    id: 3,
+    filename: "photo2.jpg"
+  });
+
+  var person = store.find(Person, 1);
+  var avatar1 = store.find(Avatar, 2);
+  var avatar2 = store.find(Avatar, 3);
+
+  person.set('avatar', avatar2);
+  strictEqual(person.get('avatar'), avatar2, "updated relationship references the globally addressable record");
+
+  var personJSON = serializer.serialize(person, { includeId: true });
+  deepEqual(personJSON, { avatar: { id: 3, filename: "photo2.jpg" }, id: 1, name: "Yehuda Katz"});
+});

--- a/packages/ember-data/tests/integration/inverse_relationships_test.js
+++ b/packages/ember-data/tests/integration/inverse_relationships_test.js
@@ -90,3 +90,46 @@ test("When a record's belongsTo relationship is set, it can specify the inverse 
   equal(post.get('youComments.length'), 1, "youComments had the post added");
   equal(post.get('everyoneWeKnowComments.length'), 0, "everyoneWeKnowComments has no posts");
 });
+
+test("When a record is added to a has-one relationship, the inverse belongsTo is determined automatically", function() {
+  var Person = DS.Model.extend(),
+      Address = DS.Model.extend();
+
+  Person.reopen({
+    address: DS.hasOne(Address)
+  });
+  Address.reopen({
+    person: DS.belongsTo(Person)
+  });
+
+  var person = store.createRecord(Person),
+      address = store.createRecord(Address);
+
+  equal(address.get('person'), null, "no person has been set on the address");
+
+  person.set('address', address);
+  equal(address.get('person'), person, "person was set on the address");
+});
+
+test("When a record is added to a has-one relationship, the inverse belongsTo can be set explicitly", function() {
+  var Person = DS.Model.extend(),
+      Address = DS.Model.extend();
+
+  Person.reopen({
+    address: DS.hasOne(Address, { inverse: 'tenant' })
+  });
+  Address.reopen({
+    landlord: DS.belongsTo(Person),
+    tenant: DS.belongsTo(Person)
+  });
+
+  var person = store.createRecord(Person),
+      address = store.createRecord(Address);
+
+  equal(address.get('landlord'), null, "landlord is initially null");
+  equal(address.get('tenant'), null, "tenant is initially null");
+
+  person.set('address', address);
+  equal(address.get('landlord'), null, "no landlord was set on the address");
+  equal(address.get('tenant'), person, "tenant was set on the address");
+});

--- a/packages/ember-data/tests/integration/json_serialization_test.js
+++ b/packages/ember-data/tests/integration/json_serialization_test.js
@@ -109,7 +109,7 @@ test("by default, addId calls primaryKey", function() {
   deepEqual(json, { __key__: "EWOT" });
 });
 
-var Comment, comment;
+var Attachment, Comment, attachment, comment;
 
 module("Adapter serialization with relationships", {
   setup: function() {
@@ -117,20 +117,27 @@ module("Adapter serialization with relationships", {
 
     Post = DS.Model.extend();
 
+    Attachment = DS.Model.extend({
+      post: DS.belongsTo(Post)
+    });
+
     Comment = DS.Model.extend({
       post: DS.belongsTo(Post)
     });
 
     Post.reopen({
-      comments: DS.hasMany(Comment)
+      comments: DS.hasMany(Comment),
+      attachment: DS.hasOne(Attachment)
     });
 
     serializer = DS.JSONSerializer.create();
 
     post = store.createRecord(Post);
     comment = store.createRecord(Comment);
+    attachment = store.createRecord(Attachment);
 
     post.get('comments').pushObject(comment);
+    post.set('attachment', attachment);
   },
 
   teardown: function() {
@@ -152,6 +159,8 @@ test("calling serialize with a record with relationships invokes addRelationship
 });
 
 test("the default addRelationships calls addBelongsTo", function() {
+  expect(3);
+
   serializer.addBelongsTo = function(hash, record, key, relationship) {
     equal(relationship.kind, "belongsTo");
     equal(key, 'post');
@@ -162,9 +171,23 @@ test("the default addRelationships calls addBelongsTo", function() {
 });
 
 test("the default addRelationships calls addHasMany", function() {
+  expect(3);
+
   serializer.addHasMany = function(hash, record, key, relationship) {
     equal(relationship.kind, "hasMany");
     equal(key, 'comments');
+    equal(record, post);
+  };
+
+  serializer.serialize(post);
+});
+
+test("the default addRelationships calls addHasOne", function() {
+  expect(3);
+
+  serializer.addHasOne = function(hash, record, key, relationship) {
+    equal(relationship.kind, "hasOne");
+    equal(key, 'attachment');
     equal(record, post);
   };
 

--- a/packages/ember-data/tests/integration/materialization_tests.js
+++ b/packages/ember-data/tests/integration/materialization_tests.js
@@ -151,6 +151,27 @@ test("when materializing a record, the serializer's extractHasMany method should
   var person = store.find(Person, 1);
 });
 
+test("when materializing a record, the serializer's extractHasOne method should be invoked", function() {
+  expect(3);
+
+  Person.reopen({
+    protege: DS.hasOne(Person)
+  });
+
+  store.load(Person, { id: 1, protege: 2 });
+
+  serializer.extractHasOne = function(type, hash, name) {
+    equal(type, Person);
+    deepEqual(hash, {
+      id: 1,
+      protege: 2
+    });
+    equal(name, 'protege');
+  };
+
+  var person = store.find(Person, 1);
+});
+
 test("when materializing a record, the serializer's extractBelongsTo method should be invoked", function() {
   expect(3);
 

--- a/packages/ember-data/tests/integration/relationships/introspection_test.js
+++ b/packages/ember-data/tests/integration/relationships/introspection_test.js
@@ -1,4 +1,4 @@
-var Blog, User, Post;
+var Blog, User, Post, Config;
 var lookup, oldLookup;
 
 module("Relationship Introspection", {
@@ -8,10 +8,11 @@ module("Relationship Introspection", {
 
     User = DS.Model.extend();
     Post = DS.Model.extend();
+    Config = DS.Model.extend();
     Blog = DS.Model.extend({
       admins: DS.hasMany(User),
       owner: DS.belongsTo(User),
-
+      config: DS.hasOne(Config),
       posts: DS.hasMany(Post)
     });
   },
@@ -29,19 +30,23 @@ test("DS.Model class computed property `relationships` returns a map keyed on ty
 
   expected = [{ name: 'posts', kind: 'hasMany' }];
   deepEqual(relationships.get(Post), expected, "post relationships returns expected array");
+
+  expected = [{ name: 'config', kind: 'hasOne' }];
+  deepEqual(relationships.get(Config), expected, "config relationships returns expected array");
 });
 
 test("DS.Model class computed property `relationships` returns a map keyed on types when types are specified as strings", function() {
   Blog = DS.Model.extend({
     admins: DS.hasMany('User'),
     owner: DS.belongsTo('User'),
-
+    config: DS.hasOne('Config'),
     posts: DS.hasMany('Post')
   });
 
   Ember.lookup = {
     User: DS.Model.extend(),
-    Post: DS.Model.extend()
+    Post: DS.Model.extend(),
+    Config: DS.Model.extend()
   };
 
   var relationships = Ember.get(Blog, 'relationships');
@@ -51,4 +56,7 @@ test("DS.Model class computed property `relationships` returns a map keyed on ty
 
   expected = [{ name: 'posts', kind: 'hasMany' }];
   deepEqual(relationships.get(Ember.lookup.Post), expected, "post relationships returns expected array");
+
+  expected = [{ name: 'config', kind: 'hasOne' }];
+  deepEqual(relationships.get(Ember.lookup.Config), expected, "config relationships returns expected array");
 });

--- a/packages/ember-data/tests/integration/relationships/inverse_test.js
+++ b/packages/ember-data/tests/integration/relationships/inverse_test.js
@@ -24,6 +24,7 @@ module("Inverse test", {
 });
 
 test("One to one relationships should be identified correctly", function() {
+  var type;
 
   App.Post = DS.Model.extend({
     title: DS.attr('string')
@@ -35,11 +36,13 @@ test("One to one relationships should be identified correctly", function() {
   }); 
 
   App.Post.reopen({
-    comment: DS.belongsTo(App.Comment)
+    comment: DS.hasOne(App.Comment)
   });
 
-  var type = DS.RelationshipChange.determineRelationshipType(App.Post, {key: "comment", kind: "belongsTo"});
- 
+  type = DS.RelationshipChange.determineRelationshipType(App.Post, {key: "comment", kind: "hasOne"});
+  equal(type, "oneToOne", "Relationship type is oneToOne");
+
+  type = DS.RelationshipChange.determineRelationshipType(App.Comment, {key: "post", kind: "belongsTo"});
   equal(type, "oneToOne", "Relationship type is oneToOne");
 });
 

--- a/packages/ember-data/tests/integration/relationships/one_to_none_relationships_test.js
+++ b/packages/ember-data/tests/integration/relationships/one_to_none_relationships_test.js
@@ -15,8 +15,13 @@ module("One-to-None Relationships", {
       toString: function() { return "App"; }
     });
 
+    App.Attachment = DS.Model.extend({
+      filename: DS.attr('string')
+    });
+
     App.Post = DS.Model.extend({
-      title: DS.attr('string')
+      title: DS.attr('string'),
+      attachment: DS.hasOne(App.Attachment)
     });
 
     App.Comment = DS.Model.extend({
@@ -51,7 +56,7 @@ test("Setting a record's belongsTo relationship to another record, should work",
 });
 
 test("Setting a record's belongsTo relationship to null should work", function() {
-  store.load(App.Post, { id: 1, title: "parent", comments: [2, 3] });
+  store.load(App.Post, { id: 1, title: "parent" });
   store.load(App.Comment, { id: 2, body: "child", post: 1 });
   store.load(App.Comment, { id: 3, body: "child", post: 1 });
 
@@ -61,4 +66,26 @@ test("Setting a record's belongsTo relationship to null should work", function()
 
   comment1.set('post', null);
   equal(comment1.get('post'), null, "belongsTo relationship has been set to null");
+});
+
+test("Setting a record's hasOne relationship to another record, should work", function() {
+  store.load(App.Post, { id: 1, title: "parent" });
+  store.load(App.Attachment, { id: 2, filename: "episode.mp3" });
+
+  var post = store.find(App.Post, 1),
+      attachment = store.find(App.Attachment, 2);
+
+  post.set('attachment', attachment);
+  deepEqual(post.get('attachment'), attachment, "post should have the correct attachment set");
+});
+
+test("Setting a record's hasOne relationship to null should work", function() {
+  store.load(App.Post, { id: 1, title: "parent", attachment: 2 });
+  store.load(App.Attachment, { id: 2, filename: "episode.mp3" });
+
+  var post = store.find(App.Post, 1),
+      attachment = store.find(App.Attachment, 2);
+
+  post.set('attachment', null);
+  equal(post.get('attachment'), null, "attachment has been set to null");
 });

--- a/packages/ember-data/tests/integration/relationships/one_to_one_relationships_test.js
+++ b/packages/ember-data/tests/integration/relationships/one_to_one_relationships_test.js
@@ -25,7 +25,7 @@ module("One-to-One Relationships", {
     });
 
     App.Post.reopen({
-      comment: DS.belongsTo(App.Comment)
+      comment: DS.hasOne(App.Comment)
     });
   },
 
@@ -41,7 +41,7 @@ function verifySynchronizedOneToOne(post, comment, expectedHasMany) {
   equal(post.get('comment'), comment);
 }
 
-test("When setting a record's belongsTo relationship to another record, that record should be added to the inverse belongsTo", function() {
+test("When setting a record's belongsTo relationship to another record, that record should be added to the inverse hasOne", function() {
   store.load(App.Post, { id: 1, title: "parent" });
   store.load(App.Comment, { id: 2, body: "child" });
 
@@ -51,6 +51,18 @@ test("When setting a record's belongsTo relationship to another record, that rec
   comment.set('post', post);
   verifySynchronizedOneToOne(post, comment);
 });
+
+test("When setting a record's hasOne relationship to another record, that record should be added to the inverse belongsTo", function() {
+  store.load(App.Post, { id: 1, title: "parent" });
+  store.load(App.Comment, { id: 2, body: "child" });
+
+  var post = store.find(App.Post, 1),
+      comment = store.find(App.Comment, 2);
+
+  post.set('comment', comment);
+  verifySynchronizedOneToOne(post, comment);
+});
+
 /*
 test("When setting a record's belongsTo relationship to null, that record should be removed from the inverse hasMany array", function() {
   store.load(App.Post, { id: 1, title: "parent", comments: [2, 3] });

--- a/packages/ember-data/tests/integration/rollback_test.js
+++ b/packages/ember-data/tests/integration/rollback_test.js
@@ -1,25 +1,31 @@
-var store, Comment, Post;
+var store, Comment, Post, Attachment;
 
 module("Transaction Rollback", {
   setup: function() {
     store = DS.Store.create({ adapter: 'DS.Adapter' });
 
-    Post = DS.Model.extend({
-      title: DS.attr('string')
-    });
+    Post = DS.Model.extend();
+    Attachment = DS.Model.extend();
+    Comment = DS.Model.extend();
 
+    Post.reopen({
+      title: DS.attr('string'),
+      comments: DS.hasMany(Comment),
+      attachment: DS.hasOne(Attachment)
+    });
     Post.toString = function() { return "Post"; };
 
-    Comment = DS.Model.extend({
+    Comment.reopen({
       title: DS.attr('string'),
       post: DS.belongsTo(Post)
     });
-
     Comment.toString = function() { return "Comment"; };
 
-    Post.reopen({
-      comments: DS.hasMany(Comment)
+    Attachment.reopen({
+      url: DS.attr('string'),
+      post: DS.belongsTo(Post)
     });
+    Attachment.toString = function() { return "Attachment"; };
   },
 
   teardown: function() {
@@ -75,9 +81,9 @@ test("A loaded record that is deleted and then rolled back is not dirty.", funct
   ok(!post.get('isDeleted'), "record is not deleted");
 });
 
-// UPDATED
+// UPDATED - belongsTo (for a hasMany)
 
-test("A loaded record in a transaction with a changed belongsTo should revert to the old relationship when the transaction is rolled back. (A=>null)", function() {
+test("A loaded record in a transaction with a changed belongsTo (for a hasMany) should revert to the old relationship when the transaction is rolled back. (A=>null)", function() {
   store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", comments: [ 1, 2 ] });
   store.load(Comment, { id: 1, title: "I don't see the appeal of Rails these days when Node.js and Django are both as mature and inherently more scalable than Rails", post: 1 });
   store.load(Comment, { id: 2, title: "I was skeptical about http://App.net before I paid the $$, but now I am all excited about it.", post: 1 });
@@ -111,7 +117,7 @@ test("A loaded record in a transaction with a changed belongsTo should revert to
   deepEqual(post.get('comments').toArray(), [ comment1, comment2 ], "property is rolled back to its original value");
 });
 
-test("A loaded record in a transaction with a changed belongsTo should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+test("A loaded record in a transaction with a changed belongsTo (for a hasMany) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
   store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies" });
   store.load(Comment, { id: 1, title: "I don't see the appeal of Rails these days when Node.js and Django are both as mature and inherently more scalable than Rails" });
   store.load(Comment, { id: 2, title: "I was skeptical about http://App.net before I paid the $$, but now I am all excited about it." });
@@ -148,7 +154,7 @@ test("A loaded record in a transaction with a changed belongsTo should revert to
   deepEqual(post.get('comments').toArray(), [ ], "property is rolled back to its original value");
 });
 
-test("A loaded record in a transaction with a changed belongsTo should revert to the old relationship when the transaction is rolled back. (A=>B)", function() {
+test("A loaded record in a transaction with a changed belongsTo (for a hasMany) should revert to the old relationship when the transaction is rolled back. (A=>B)", function() {
   store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", comments: [ 1, 2 ] });
   store.load(Post, { id: 2, title: "VIM for iPad Best Practices" });
   store.load(Comment, { id: 1, title: "I don't see the appeal of Rails these days when Node.js and Django are both as mature and inherently more scalable than Rails", post: 1 });
@@ -189,6 +195,221 @@ test("A loaded record in a transaction with a changed belongsTo should revert to
   equal(comment1.get('post'), post, "property is rolled back to its original value");
   deepEqual(post.get('comments').toArray(), [ comment1, comment2 ], "property is rolled back to its original value");
 });
+
+// UPDATED - belongsTo (for a hasOne)
+
+test("A loaded record in a transaction with a changed belongsTo (for a hasOne) should revert to the old relationship when the transaction is rolled back. (A=>null)", function() {
+  store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", attachment: 1 });
+  store.load(Attachment, { id: 1, url: "http://www.example.com/podcast/ep1.mp3", post: 1 });
+
+  var post = store.find(Post, 1);
+  var attachment = store.find(Attachment, 1);
+
+  var transaction = store.transaction();
+  transaction.add(post);
+
+  ok(!post.get('isDirty'), "precond - record should not yet be dirty");
+  ok(!attachment.get('isDirty'), "precond - record should not yet be dirty");
+
+  attachment.set('post', null);
+
+  ok(post.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(post.get('attachment'), null, "precond - property reflects changed value");
+  equal(attachment.get('post'), null, "precond - property reflects changed value");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(post.get('attachment'), attachment, "property is rolled back to its original value");
+  equal(attachment.get('post'), post, "property is rolled back to its original value");
+});
+
+test("A loaded record in a transaction with a changed belongsTo (for a hasOne) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+  store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies" });
+  store.load(Attachment, { id: 1, url: "http://www.example.com/podcast/ep1.mp3" });
+
+  var post = store.find(Post, 1);
+  var attachment = store.find(Attachment, 1);
+
+  equal(post.get('attachment'), null, "precond - the original value is null");
+  equal(attachment.get('post'), null, "precond - the original value is null");
+
+  var transaction = store.transaction();
+  transaction.add(attachment);
+
+  ok(!post.get('isDirty'), "precond - record should not yet be dirty");
+  ok(!attachment.get('isDirty'), "precond - record should not yet be dirty");
+
+  attachment.set('post', post);
+
+  ok(post.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(post.get('attachment'), attachment, "precond - property reflects changed value");
+  equal(attachment.get('post'), post, "precond - property reflects changed value");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(post.get('attachment'), null, "property is rolled back to its original value");
+  equal(attachment.get('post'), null, "property is rolled back to its original value");
+});
+
+test("A loaded record in a transaction with a changed belongsTo (for a hasOne) should revert to the old relationship when the transaction is rolled back. (A=>B)", function() {
+  store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", attachment: 1 });
+  store.load(Post, { id: 2, title: "VIM for iPad Best Practices" });
+  store.load(Attachment, { id: 1, url: "http://www.example.com/podcast/ep1.mp3", post: 1 });
+
+  var post1 = store.find(Post, 1);
+  var post2 = store.find(Post, 2);
+  var attachment = store.find(Attachment, 1);
+
+  equal(post1.get('attachment'), attachment, "precond - the original value is the attachment");
+  equal(post2.get('attachment'), null, "precond - the original value is null");
+  equal(attachment.get('post'), post1, "precond - the original value is the first post");
+
+  var transaction = store.transaction();
+  transaction.add(attachment);
+
+  ok(!post1.get('isDirty'), "precond - record should not yet be dirty");
+  ok(!post2.get('isDirty'), "precond - record should not yet be dirty");
+  ok(!attachment.get('isDirty'), "precond - record should not yet be dirty");
+
+  attachment.set('post', post2);
+
+  ok(post1.get('isDirty'), "precond - record should be dirty after change");
+  ok(post2.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(post1.get('attachment'), null, "precond - property reflects changed value");
+  equal(post2.get('attachment'), attachment, "precond - property reflects changed value");
+  equal(attachment.get('post'), post2, "precond - property reflects changed value");
+
+  transaction.rollback();
+
+  ok(!post1.get('isDirty'), "record should not be dirty after rollback");
+  ok(!post2.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(post1.get('attachment'), attachment, "property is rolled back to its original value");
+  equal(post2.get('attachment'), null, "property is rolled back to its original value");
+  equal(attachment.get('post'), post1, "property is rolled back to its original value");
+});
+
+// UPDATED - hasOne
+
+test("A loaded record in a transaction with a changed hasOne should revert to the old relationship when the transaction is rolled back. (A=>null)", function() {
+  store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", attachment: 1 });
+  store.load(Attachment, { id: 1, url: "http://www.example.com/podcast/ep1.mp3", post: 1 });
+
+  var post = store.find(Post, 1);
+  var attachment = store.find(Attachment, 1);
+
+  var transaction = store.transaction();
+  transaction.add(post);
+
+  ok(!post.get('isDirty'), "precond - record should not yet be dirty");
+  ok(!attachment.get('isDirty'), "precond - record should not yet be dirty");
+
+  post.set('attachment', null);
+
+  ok(post.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(post.get('attachment'), null, "precond - property reflects changed value");
+  equal(attachment.get('post'), null, "precond - property reflects changed value");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(post.get('attachment'), attachment, "property is rolled back to its original value");
+  equal(attachment.get('post'), post, "property is rolled back to its original value");
+});
+
+test("A loaded record in a transaction with a changed hasOne should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+  store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies" });
+  store.load(Attachment, { id: 1, url: "http://www.example.com/podcast/ep1.mp3" });
+
+  var post = store.find(Post, 1);
+  var attachment = store.find(Attachment, 1);
+
+  equal(attachment.get('post'), null, "precond - the original value is null");
+  equal(post.get('attachment'), null, "precond - the original value is null");
+
+  var transaction = store.transaction();
+  transaction.add(post);
+
+  ok(!post.get('isDirty'), "precond - record should not yet be dirty");
+  ok(!attachment.get('isDirty'), "precond - record should not yet be dirty");
+
+  post.set('attachment', attachment);
+
+  ok(post.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(attachment.get('post'), post, "precond - property reflects changed value");
+  equal(post.get('attachment'), attachment, "precond - property reflects changed value");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(attachment.get('post'), null, "property is rolled back to its original value");
+  equal(post.get('attachment'), null, "property is rolled back to its original value");
+});
+
+test("A loaded record in a transaction with a changed hasOne should revert to the old relationship when the transaction is rolled back. (A=>B)", function() {
+  store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", attachment: 1 });
+
+  store.load(Attachment, { id: 1, url: "http://www.example.com/podcast/ep1.mp3", post: 1 });
+  store.load(Attachment, { id: 2, url: "http://www.example.com/podcast/ep2.mp3" });
+
+  var post = store.find(Post, 1);
+  var attachment1 = store.find(Attachment, 1);
+  var attachment2 = store.find(Attachment, 2);
+
+  equal(post.get('attachment'), attachment1, "precond - the original value is the first attachment");
+  equal(attachment1.get('post'), post, "precond - the original value is the post");
+  equal(attachment2.get('post'), null, "precond - the original value is null");
+
+  var transaction = store.transaction();
+  transaction.add(post);
+
+  ok(!post.get('isDirty'), "precond - record should not yet be dirty");
+  ok(!attachment1.get('isDirty'), "precond - record should not yet be dirty");
+  ok(!attachment2.get('isDirty'), "precond - record should not yet be dirty");
+
+  post.set('attachment', attachment2);
+
+  ok(post.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment1.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment2.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(post.get('attachment'), attachment2, "precond - property reflects changed value");
+  equal(attachment1.get('post'), null, "precond - property reflects changed value");
+  equal(attachment2.get('post'), post, "precond - property reflects changed value");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment1.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment2.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(post.get('attachment'), attachment1, "property is rolled back to its original value");
+  equal(attachment1.get('post'), post, "property is rolled back to its original value");
+  equal(attachment2.get('post'), null, "property is rolled back to its original value");
+});
+
+// UPDATED - hasMany
 
 test("A loaded record in a transaction with a changed hasMany should revert to the old relationship when the transaction is rolled back. (A=>null)", function() {
   store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", comments: [ 1, 2 ] });
@@ -346,9 +567,9 @@ test("A loaded record in a transaction with a changed hasMany (without first rem
   deepEqual(post.get('comments').toArray(), [ comment1, comment2 ], "property is rolled back to its original value");
 });
 
-// CREATED - Changing belongsTo
+// CREATED - Changing belongsTo (for a hasMany)
 
-test("A created record in a transaction with a changed belongsTo (child is newly created, but parent is not) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+test("A created record in a transaction with a changed belongsTo (for a hasMany) (child is newly created, but parent is not) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
   store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", comments: [ 2 ] });
   store.load(Comment, { id: 2, title: "I don't see the appeal of Rails these days when Node.js and Django are both as mature and inherently more scalable than Rails", post: 1 });
 
@@ -381,7 +602,7 @@ test("A created record in a transaction with a changed belongsTo (child is newly
   deepEqual(post.get('comments').toArray(), [ comment2 ], "property is rolled back to its original value");
 });
 
-test("A loaded record in a transaction with a changed belongsTo (parent is newly created, but child is not) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+test("A created record in a transaction with a changed belongsTo (for a hasMany) (parent is newly created, but child is not) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
   var transaction = store.transaction();
 
   store.load(Comment, { id: 1, title: "I don't see the appeal of Rails these days when Node.js and Django are both as mature and inherently more scalable than Rails" });
@@ -416,7 +637,7 @@ test("A loaded record in a transaction with a changed belongsTo (parent is newly
   deepEqual(post.get('comments').toArray(), [ ], "property is rolled back to its original value");
 });
 
-test("A loaded record in a transaction with a changed belongsTo (parent and child are both newly created) should revert to the old relationship when the transaction is rolled back. (A=>B)", function() {
+test("A created record in a transaction with a changed belongsTo (for a hasMany) (parent and child are both newly created) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
   var transaction = store.transaction();
 
   var post = transaction.createRecord(Post, { title: "My Darkest Node.js Fantasies" });
@@ -445,11 +666,103 @@ test("A loaded record in a transaction with a changed belongsTo (parent and chil
 
   equal(comment1.get('post'), null, "property is rolled back to its original value");
   deepEqual(post.get('comments').toArray(), [ ], "property is rolled back to its original value");
+});
+
+// CREATED - Changing belongsTo (for a hasOne)
+
+test("A created record in a transaction with a changed belongsTo (for a hasOne) (child is newly created, but parent is not) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+  store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies" });
+
+  var transaction = store.transaction();
+
+  var post = store.find(Post, 1);
+  var attachment = transaction.createRecord(Attachment, { url: "http://www.example.com/podcast/ep1.mpe" });
+
+  equal(post.get('attachment'), null, "precond - the original value is null");
+  equal(attachment.get('post'), null, "precond - the original value is null");
+
+  transaction.add(post);
+
+  attachment.set('post', post);
+
+  equal(post.get('attachment'), attachment, "precond - the new value is the attachment");
+  equal(attachment.get('post'), post, "precond - the new value is the post");
+
+  ok(post.get('isDirty'), "precond - record should be dirty");
+  ok(attachment.get('isDirty'), "precond - record should be dirty");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(post.get('attachment'), null, "property is rolled back to its original value");
+  equal(attachment.get('post'), null, "property is rolled back to its original value");
+});
+
+test("A created record in a transaction with a changed belongsTo (for a hasOne) (parent is newly created, but child is not) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+  var transaction = store.transaction();
+
+  store.load(Attachment, { id: 1, url: "http://www.example.com/podcast/ep1.mp3" });
+
+  var post = transaction.createRecord(Post, { title: "My Darkest Node.js Fantasies" });
+  var attachment = store.find(Attachment, 1);
+
+  equal(post.get('attachment'), null, "precond - the original value is null");
+  equal(attachment.get('post'), null, "precond - the original value is null");
+
+  ok(post.get('isDirty'), "precond - record should be dirty");
+  ok(!attachment.get('isDirty'), "precond - record should not yet be dirty");
+
+  attachment.set('post', post);
+
+  ok(post.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(attachment.get('post'), post, "precond - property reflects changed value");
+  equal(post.get('attachment'), attachment, "precond - property reflects changed value");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(attachment.get('post'), null, "property is rolled back to its original value");
+  equal(post.get('attachment'), null, "property is rolled back to its original value");
+});
+
+test("A created record in a transaction with a changed belongsTo (for a hasOne) (parent and child are both newly created) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+  var transaction = store.transaction();
+
+  var post = transaction.createRecord(Post, { title: "My Darkest Node.js Fantasies" });
+  var attachment = transaction.createRecord(Attachment, { url: "http://www.example.com/podcast/ep1.mp3" });
+
+  equal(post.get('attachment'), null, "precond - the original value is null");
+  equal(attachment.get('post'), null, "precond - the original value is null");
+
+  ok(post.get('isDirty'), "precond - record should be dirty");
+  ok(attachment.get('isDirty'), "precond - record should be dirty");
+
+  attachment.set('post', post);
+
+  ok(post.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(post.get('attachment'), attachment, "precond - property reflects changed value");
+  equal(attachment.get('post'), post, "precond - property reflects changed value");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(post.get('attachment'), null, "property is rolled back to its original value");
+  equal(attachment.get('post'), null, "property is rolled back to its original value");
 });
 
 // CREATED - Changing hasMany
 
-test("A created record in a transaction with a changed hasMany (child is newly created, but parent is not) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+test("A created record in a transaction with a changed hasMany (child is newly created, but parent is not) should revert to the old relationship when the transaction is rolled back. (A=>B)", function() {
   store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", comments: [ 2 ] });
   store.load(Comment, { id: 2, title: "I don't see the appeal of Rails these days when Node.js and Django are both as mature and inherently more scalable than Rails", post: 1 });
 
@@ -483,7 +796,7 @@ test("A created record in a transaction with a changed hasMany (child is newly c
   deepEqual(post.get('comments').toArray(), [ comment2 ], "property is rolled back to its original value");
 });
 
-test("A created record in a transaction with a changed belongsTo (parent is newly created, but child is not) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+test("A created record in a transaction with a changed hasMany (parent is newly created, but child is not) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
   var transaction = store.transaction();
 
   store.load(Comment, { id: 1, title: "I don't see the appeal of Rails these days when Node.js and Django are both as mature and inherently more scalable than Rails" });
@@ -518,7 +831,7 @@ test("A created record in a transaction with a changed belongsTo (parent is newl
   deepEqual(post.get('comments').toArray(), [ ], "property is rolled back to its original value");
 });
 
-test("A created record in a transaction with a changed belongsTo (parent and child are both newly created) should revert to the old relationship when the transaction is rolled back. (A=>B)", function() {
+test("A created record in a transaction with a changed hasMany (parent and child are both newly created) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
   var transaction = store.transaction();
 
   var post = transaction.createRecord(Post, { title: "My Darkest Node.js Fantasies" });
@@ -547,6 +860,105 @@ test("A created record in a transaction with a changed belongsTo (parent and chi
 
   equal(comment1.get('post'), null, "property is rolled back to its original value");
   deepEqual(post.get('comments').toArray(), [ ], "property is rolled back to its original value");
+});
+
+// CREATED - Changing hasOne
+
+test("A created record in a transaction with a changed hasOne (child is newly created, but parent is not) should revert to the old relationship when the transaction is rolled back. (A=>B)", function() {
+  store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", attachment: 2 });
+  store.load(Attachment, { id: 2, url: "http://www.example.com/podcast/ep1.mp3", post: 1 });
+
+  var transaction = store.transaction();
+
+  var post = store.find(Post, 1);
+  var attachment1 = store.find(Attachment, 2);
+  var attachment2 = transaction.createRecord(Attachment, { url: "http://www.example.com/podcast/ep2.mp3" });
+
+  equal(post.get('attachment'), attachment1, "precond - the original value is the existing attachment");
+  equal(attachment1.get('post'), post, "precond - the original value is the post");
+  equal(attachment2.get('post'), null, "precond - the original value is null");
+
+  transaction.add(post);
+
+  post.set('attachment', attachment2);
+
+  equal(post.get('attachment'), attachment2, "precond - the new value is the new attachment");
+  equal(attachment1.get('post'), null, "precond - the new value is null");
+  equal(attachment2.get('post'), post, "precond - the new value is the post");
+
+  ok(post.get('isDirty'), "precond - record should be dirty");
+  ok(attachment1.get('isDirty'), "precond - record should be dirty");
+  ok(attachment2.get('isDirty'), "precond - record should be dirty");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment1.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment2.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(post.get('attachment'), attachment1, "property is rolled back to its original value");
+  equal(attachment1.get('post'), post, "property is rolled back to its original value");
+  equal(attachment2.get('post'), null, "property is rolled back to its original value");
+});
+
+test("A created record in a transaction with a changed hasOne (parent is newly created, but child is not) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+  var transaction = store.transaction();
+
+  store.load(Attachment, { id: 1, url: "http://www.example.com/podcast/ep1.mp3" });
+
+  var post = transaction.createRecord(Post, { title: "My Darkest Node.js Fantasies" });
+  var attachment = store.find(Attachment, 1);
+
+  equal(post.get('attachment'), null, "precond - the original value is null");
+  equal(attachment.get('post'), null, "precond - the original value is null");
+
+  ok(post.get('isDirty'), "precond - record should be dirty");
+  ok(!attachment.get('isDirty'), "precond - record should not yet be dirty");
+
+  post.set('attachment', attachment);
+
+  ok(post.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(post.get('attachment'), attachment, "precond - property reflects changed value");
+  equal(attachment.get('post'), post, "precond - property reflects changed value");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(post.get('attachment'), null, "property is rolled back to its original value");
+  equal(attachment.get('post'), null, "property is rolled back to its original value");
+});
+
+test("A created record in a transaction with a changed hasOne (parent and child are both newly created) should revert to the old relationship when the transaction is rolled back. (null=>A)", function() {
+  var transaction = store.transaction();
+
+  var post = transaction.createRecord(Post, { title: "My Darkest Node.js Fantasies" });
+  var attachment = transaction.createRecord(Attachment, { url: "http://www.example.com/podcast/ep1.mp3" });
+
+  equal(post.get('attachment'), null, "precond - the original value is null");
+  equal(attachment.get('post'), null, "precond - the original value is null");
+
+  ok(post.get('isDirty'), "precond - record should be dirty");
+  ok(attachment.get('isDirty'), "precond - record should be dirty");
+
+  post.set('attachment', attachment);
+
+  ok(post.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(post.get('attachment'), attachment, "precond - property reflects changed value");
+  equal(attachment.get('post'), post, "precond - property reflects changed value");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(post.get('attachment'), null, "property is rolled back to its original value");
+  equal(attachment.get('post'), null, "property is rolled back to its original value");
 });
 
 // DELETED
@@ -584,6 +996,37 @@ test("A deleted record should be restored to a hasMany relationship if the trans
 
   equal(comment1.get('post'), post, "property is rolled back to its original value");
   deepEqual(post.get('comments').toArray(), [ comment1, comment2 ], "property is rolled back to its original value");
+});
+
+test("A deleted record should be restored to a hasOne relationship if the transaction is rolled back", function() {
+  store.load(Post, { id: 1, title: "My Darkest Node.js Fantasies", attachment: 1 });
+  store.load(Attachment, { id: 1, url: "http://www.example.com/podcast/ep1.mp3", post: 1 });
+
+  var post = store.find(Post, 1);
+  var attachment = store.find(Attachment, 1);
+
+  var transaction = store.transaction();
+  transaction.add(post);
+  transaction.add(attachment);
+
+  ok(!post.get('isDirty'), "precond - record should not yet be dirty");
+  ok(!attachment.get('isDirty'), "precond - record should not yet be dirty");
+
+  attachment.deleteRecord();
+
+  ok(post.get('isDirty'), "precond - record should be dirty after change");
+  ok(attachment.get('isDirty'), "precond - record should be dirty after change");
+
+  equal(attachment.get('post'), null, "precond - property reflects changed value");
+  equal(post.get('attachment'), null, "precond - deleted record is removed from parent's hasOne");
+
+  transaction.rollback();
+
+  ok(!post.get('isDirty'), "record should not be dirty after rollback");
+  ok(!attachment.get('isDirty'), "record should not be dirty after rollback");
+
+  equal(attachment.get('post'), post, "property is rolled back to its original value");
+  equal(post.get('attachment'), attachment, "property is rolled back to its original value");
 });
 
 test("A deleted record should be restored to a belongsTo relationship if the transaction is rolled back", function() {

--- a/packages/ember-data/tests/unit/json_serializer_test.js
+++ b/packages/ember-data/tests/unit/json_serializer_test.js
@@ -3,6 +3,7 @@ var MockModel = Ember.Object.extend({
     this.materializedAttributes = {};
     this.hasMany = {};
     this.belongsTo = {};
+    this.hasOne = {};
   },
 
   eachAttribute: function(callback, binding) {
@@ -37,6 +38,10 @@ var MockModel = Ember.Object.extend({
 
   materializeBelongsTo: function(name, id) {
     this.belongsTo[name] = id;
+  },
+
+  materializeHasOne: function(name, id) {
+    this.hasOne[name] = id;
   }
 });
 
@@ -107,13 +112,14 @@ test("Mapped attributes should be used when materializing a record from JSON.", 
 });
 
 test("Mapped relationships should be used when serializing a record to JSON.", function() {
-  expect(8);
+  expect(12);
 
-  Person.relationships = { addresses: 'hasMany' };
+  Person.relationships = { addresses: 'hasMany', heart: 'hasOne' };
   window.Address.relationships = { person: 'belongsTo' };
 
   serializer.map(Person, {
-    addresses: { key: 'ADDRESSES!' }
+    addresses: { key: 'ADDRESSES!' },
+    heart: { key: '<3' }
   });
 
   serializer.map('Address', {
@@ -147,16 +153,29 @@ test("Mapped relationships should be used when serializing a record to JSON.", f
     });
   };
 
+  serializer.addHasOne = function(hash, record, key, relationship) {
+    ok(typeof hash === 'object', "a hash to build is passed");
+    equal(record, person, "the record to serialize should be passed");
+    equal(key, '<3', "the key to add to the hash respects the mapping");
+
+    // The mocked record uses a simplified relationship description
+    deepEqual(relationship, {
+      kind: 'hasOne',
+      key: 'heart'
+    });
+  };
+
   serializer.serialize(person);
   serializer.serialize(address);
 });
 
 test("mapped relationships are respected when materializing a record from JSON", function() {
-  Person.relationships = { addresses: 'hasMany' };
+  Person.relationships = { addresses: 'hasMany', heart: 'hasOne' };
   window.Address.relationships = { person: 'belongsTo' };
 
   serializer.map(Person, {
-    addresses: { key: 'ADDRESSES!' }
+    addresses: { key: 'ADDRESSES!' },
+    heart: { key: '<3' }
   });
 
   serializer.map('Address', {
@@ -167,7 +186,8 @@ test("mapped relationships are respected when materializing a record from JSON",
   var address = window.Address.create();
 
   serializer.materialize(person, {
-    'ADDRESSES!': [ 1, 2, 3 ]
+    'ADDRESSES!': [ 1, 2, 3 ],
+    '<3': 1
   });
 
   serializer.materialize(address, {
@@ -176,6 +196,10 @@ test("mapped relationships are respected when materializing a record from JSON",
 
   deepEqual(person.hasMany, {
     addresses: [ 1, 2, 3 ]
+  });
+
+  deepEqual(person.hasOne, {
+    heart: 1
   });
 
   deepEqual(address.belongsTo, {

--- a/packages/ember-data/tests/unit/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/unit/serializers/rest_serializer_test.js
@@ -31,6 +31,11 @@ test("keyForHasMany returns the singularized key appended with '_ids'", function
   equal(serializer.keyForHasMany(DS.Model, 'homeTowns'), 'home_town_ids');
 });
 
+test("keyForHasOne returns the key appended with '_id'", function() {
+  equal(serializer.keyForHasOne(DS.Model, 'person'), 'person_id');
+  equal(serializer.keyForHasOne(DS.Model, 'homeTown'), 'home_town_id');
+});
+
 test("Calling extract on a JSON payload with multiple records will tear them apart and call loader", function() {
   var App = Ember.Namespace.create({
     toString: function() { return "App"; }
@@ -88,4 +93,3 @@ test("Calling extract on a JSON payload with multiple records will tear them apa
     //});
   //}
 });
-


### PR DESCRIPTION
Models can now define a hasOne association as the inverse of a belongsTo
association:

``` javascript
App.Person = DS.Model.extend({
  heart: DS.hasOne(App.Heart)
});

App.Heart = DS.Model.extend({
  person: DS.belongsTo(App.Person)
});
```

Includes updates for DS.RESTSerializer to parse hasOne information out
of incoming record data but not include it with outgoing data.
