### PR TITLE
Handle some create and update errors in the REST adapter.

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -27,6 +27,9 @@ DS.RESTAdapter = DS.Adapter.extend({
       context: this,
       success: function(json) {
         this.didCreateRecord(store, type, record, json);
+      },
+      error: function(xhr) {
+        this.context.didError(store, type, record, xhr);
       }
     });
   },
@@ -98,6 +101,9 @@ DS.RESTAdapter = DS.Adapter.extend({
       context: this,
       success: function(json) {
         this.didUpdateRecord(store, type, record, json);
+      },
+      error: function(xhr) {
+        this.context.didError(store, type, record, xhr);
       }
     });
   },
@@ -262,6 +268,15 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     this.sideload(store, type, json, root);
     store.loadMany(type, json[root]);
+  },
+
+  didError: function(store, type, record, xhr) {
+    if (xhr.status === 422) {
+      var data = JSON.parse(xhr.responseText);
+      store.recordWasInvalid(record, data['errors']);
+    } else {
+      store.recordWasError(record);
+    }
   },
 
   // HELPERS

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -421,6 +421,10 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
     this.send('becameInvalid', errors);
   },
 
+  adapterDidError: function() {
+    this.send('becameError');
+  },
+
   /**
     @private
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -954,6 +954,17 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
   },
 
   /**
+     This method allows the adapter to specify that a record
+     could not be saved because the server returned an unhandled
+     error.
+
+     @param {DS.Model} record
+  */
+  recordWasError: function(record) {
+    record.adapterDidError();
+  },
+
+  /**
     This is a lower-level API than `didSaveRecord` that allows an
     adapter to acknowledge the persistence of a single attribute.
 

--- a/packages/ember-data/tests/integration/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/store_adapter_test.js
@@ -264,6 +264,18 @@ test("if a created record is marked as invalid by the server, it enters an error
   Ember.removeObserver(yehuda, 'errors.name', observer);
 });
 
+test("if a created record is marked as erred by the server, it enters an error state", function() {
+  adapter.createRecord = function(store, type, record) {
+    store.recordWasError(record);
+  };
+
+  var person = store.createRecord(Person, { id: 1, name: "John Doe" });
+
+  store.commit();
+
+  ok(get(person, 'isError'), "the record is in the error state");
+});
+
 test("if an updated record is marked as invalid by the server, it enters an error state", function() {
   adapter.updateRecord = function(store, type, record) {
     equal(type, Person, "the type is correct");
@@ -299,6 +311,20 @@ test("if an updated record is marked as invalid by the server, it enters an erro
   equal(get(yehuda, 'isDirty'), false, "record is no longer new");
 
   // Test key mapping
+});
+
+test("if a created record is marked as erred by the server, it enters an error state", function() {
+  adapter.updateRecord = function(store, type, record) {
+    store.recordWasError(record);
+  };
+
+  store.load(Person, { id: 1, name: "John Doe" });
+  var person = store.find(Person, 1);
+  person.set('name', "Jonathan Doe");
+
+  store.commit();
+
+  ok(get(person, 'isError'), "the record is in the error state");
 });
 
 test("can be created after the DS.Store", function() {


### PR DESCRIPTION
- 422 Unprocessable Entity
  
  Transitions the record to the invalid state. Assumes
  the server has responded with `{errors: {...}}` and
  sets them on the record.
- All other status codes
  
  Transitions the record to the error state.

This is limited to only single, non-bulk creates/updates.
