### PR TITLE
Bug: Multiple belongsTo relationships to the same model cannot be set independently

### DIFF
--- a/packages/ember-data/tests/integration/associations_test.js
+++ b/packages/ember-data/tests/integration/associations_test.js
@@ -45,7 +45,7 @@ test("If a model has 2 belongsTo relationships to the same model it should be po
     });
 
     equal(comment3.get('comment'), comment1, 'The comment is set correctly');
-    equal(comment3.get('referenceComment', comment2, 'The reference comment is set correctly'));
+    equal(comment3.get('referenceComment'), comment2, 'The reference comment is set correctly');
 });
 
 test("when modifying a child record's belongsTo relationship, its parent hasMany relationships should be updated", function() {


### PR DESCRIPTION
If a model has two belongsTo relationships defined to the same model, they will always be set to the same value even when attempting to set them to two different values.

This commit includes a failing test demonstrating this issue.
