### PR TITLE
Clear test timer on observer execution

### DIFF
--- a/packages/ember-data/tests/unit/fixture_adapter_test.js
+++ b/packages/ember-data/tests/unit/fixture_adapter_test.js
@@ -157,6 +157,7 @@ test("should follow isUpdating semantics", function() {
   var result = store.findAll(Person);
 
   result.addObserver('isUpdating', function() {
+    clearTimeout(timer);
     start();
     equal(get(result, 'isUpdating'), false, "isUpdating is set when it shouldn't be");
   });


### PR DESCRIPTION
Fixes the build when run within the browser.
