### PR TITLE
Clear relationships before dematerializing

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -436,8 +436,8 @@ createdState.states.uncommitted.reopen({
       t.recordIsMoving('created', record);
     });
 
-    manager.transitionTo('deleted.saved');
     record.clearRelationships();
+    manager.transitionTo('deleted.saved');
   }
 });
 

--- a/packages/ember-data/tests/integration/associations_test.js
+++ b/packages/ember-data/tests/integration/associations_test.js
@@ -223,6 +223,25 @@ test("When adding a child to a parent, then commit, the parent should come back 
   //equal(person.get('stateManager.currentState.path'), "rootState.loaded.saved");
 });
 
+test("deleting a new record clears its relationships", function() {
+  var parent, child;
+
+  store.load(Comment, { id: 1, body: "Child" });
+
+  child = store.find(Comment, 1);
+  parent = store.createRecord(Comment);
+
+  equal(child.get('comment'), null, "the child should not yet belong to anyone");
+
+  parent.get('comments').addObject(child);
+
+  equal(child.get('comment'), parent, "the child should now belong to the parent");
+
+  parent.deleteRecord();
+
+  equal(child.get('comment'), null, "the child should no longer belong to anyone");
+});
+
 //test("When a record with a hasMany association is deleted, its associated record is materialized and its belongsTo is changed", function() {
   //expect(3);
 


### PR DESCRIPTION
The relationship change object needs to look up the record type in the
store (so it can find and unset inverse associations). Dematerialization
needs to occur after that happens, as it removes it from the store's type
lookup table.
