### PR TITLE
reset `isError` when record successfully saved

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -416,6 +416,10 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   adapterDidCreate: function() {
+    if (get(this, 'isError')) {
+      set(this, 'isError', false);
+    }
+
     this.removeInFlightDirtyFactor('@created');
 
     this.updateRecordArraysLater();


### PR DESCRIPTION
Just starting a conversation here, if its something that seems acceptable I'll add some tests, etc.

When an attempt is made to save a record that fails, the record's `isError` property sticks around even when it is successfully saved later.

This may not be implemented in the right place, haven't had a chance to look much at the source of this project.
