### PR TITLE
DS.FixtureAdapter.findQuery takes type

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -19,7 +19,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
   /*
     Implement this method in order to query fixtures data
   */
-  queryFixtures: function(fixtures, query) {
+  queryFixtures: function(fixtures, query, type) {
     return fixtures;
   },
 
@@ -86,7 +86,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
 
     Ember.assert("Unable to find fixtures for model type "+type.toString(), !!fixtures);
 
-    fixtures = this.queryFixtures(fixtures, query);
+    fixtures = this.queryFixtures(fixtures, query, type);
 
     if (fixtures) {
       this.simulateRemoteCall(function() {


### PR DESCRIPTION
Pass type into findQuery. This allows you to do custom query logic based
on what kind of fixtures are requested. Now you can switch your query
logic if Todo or Message is queried. This logic would normally be done
on the server, but you can implement it here for development purposes.
