### PR TITLE
Rest Adapter ajax error fix

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -23,7 +23,7 @@ DS.RESTAdapter = DS.Adapter.extend({
         this.didCreateRecord(store, type, record, json);
       },
       error: function(xhr) {
-        this.context.didError(store, type, record, xhr);
+        this.didError(store, type, record, xhr);
       }
     });
   },
@@ -99,7 +99,7 @@ DS.RESTAdapter = DS.Adapter.extend({
         this.didUpdateRecord(store, type, record, json);
       },
       error: function(xhr) {
-        this.context.didError(store, type, record, xhr);
+        this.didError(store, type, record, xhr);
       }
     });
   },

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -13,7 +13,9 @@ module("the REST adapter", {
 
     adapter = DS.RESTAdapter.create({
       ajax: function(url, type, hash) {
-        var success = hash.success, self = this;
+        var success = hash.success,
+            error = hash.error,
+            self = this;
 
         ajaxUrl = url;
         ajaxType = type;
@@ -22,6 +24,12 @@ module("the REST adapter", {
         if (success) {
           hash.success = function(json) {
             success.call(self, json);
+          };
+        }
+
+        if (error) {
+          hash.error = function() {
+            error.apply(self, arguments);
           };
         }
       },


### PR DESCRIPTION
Change rest adapter test to execute error function in context of the adapter. Change rest adapter error function to call this.didError and not this.context
