### PR TITLE
Creating and deleting associations doesn't remove the record from the ManyArray

### DIFF
--- a/packages/ember-data/tests/unit/record_array_test.js
+++ b/packages/ember-data/tests/unit/record_array_test.js
@@ -98,6 +98,60 @@ test("a record array returns undefined when asking for a member outside of its c
   strictEqual(recordArray.objectAt(20), undefined, "objects outside of the range just return undefined");
 });
 
+test("if an association record is deleted, it is removed from the association", function() {
+  var store = DS.Store.create();
+
+  var Tag = DS.Model.extend({
+    people: DS.hasMany(Person)
+  });
+
+  Person.reopen({
+    tag: DS.belongsTo(Tag)
+  });
+
+  store.load(Person, {id: '1'} );
+  store.load(Tag, { id: '1', people: ['1'] });
+
+  var tag = store.find(Tag, 1);
+  var people = get(tag, 'people');
+  var person1 = store.find(Person, 1);
+
+  equal( get(people,'length'), 1, "the record exists in the association");
+
+  person1.deleteRecord();
+
+  equal( get(people,'length'), 0, "the record is removed from the association");
+});
+
+test("if an association record is created and then deleted, it is removed from the association", function() {
+  var store = DS.Store.create();
+
+  var Tag = DS.Model.extend({
+    people: DS.hasMany(Person)
+  });
+
+  Person.reopen({
+    tag: DS.belongsTo(Tag)
+  });
+
+  store.load(Tag, { id: '1', people: [] });
+
+  var tag = store.find(Tag, 1);
+  var people = get(tag, 'people');
+  var person = store.createRecord(Person, {});
+
+  equal( get(people,'length'), 0, "there are no associations");
+
+  people.pushObject(person);
+
+  equal( get(people,'length'), 1, "the record exists in the association");
+
+  person.deleteRecord();
+
+  equal( get(people,'length'), 0, "the record is removed from the association");
+});
+
+
 // This tests for a bug in the recordCache, where the records were being cached in the incorrect order.
 test("a record array should be able to be enumerated in any order", function() {
   var store = DS.Store.create();
@@ -176,4 +230,3 @@ test("a record array that backs a collection view functions properly", function(
   container.destroy();
 
 });
-


### PR DESCRIPTION
Here are two tests involving associations.  The first one passes and the second one is failing.  Both of these tests can be added to `packages/ember-data/tests/unit/many_array_test.js`

If an association exists, when it is loaded and then deleted using `deleteRecord()` it is removed from the association.  This is demonstrated in the first test which currently passes.

``` javascript
test("if an association record is deleted, it is removed from the association", function() {
  store.load(Group, { id: 1, people: [ 1 ] });
  store.loadMany(Person, [{ id: 1 }]);

  var group = store.find(Group, 1);
  var people = get(group, 'people');
  var person1 = store.find(Person, 1);

  equal( get(people,'length'), 1, "the record exists in the association");

  person1.deleteRecord();

  equal( get(people,'length'), 0, "the record is removed from the association");
});

```

However, if the record is created, added to the association and then deleted, it doesn't get removed from the association.  This is shown in the following test which currently fails.

``` javascript
test("if an association record is created and then deleted, it is removed from the association", function() {
  store.load(Group, { id: 1, people: [] });
  var group = store.find(Group, 1);
  var people = get(group, 'people');
  var person = store.createRecord(Person, {});

  equal( get(people,'length'), 0, "there are no associations");

  people.pushObject(person);

  equal( get(people,'length'), 1, "the record is added to the association");

  person.deleteRecord();

  equal( get(people,'length'), 0, "the record is removed from the association");
});

```
