### PR TITLE
Add a failing spec for data issue #506

### DIFF
--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -1043,7 +1043,7 @@ test("updating a record with a 500 error marks the record as error", function() 
   expectState('error');
 });
 
-test("When adding a chile to a parent, then commit, then edit the parent then revert, the child should still be associated to the parent", function () {
+test("When adding a child to a parent, then commit, then edit the parent then revert, the child should still be associated to the parent", function () {
   var Comment = DS.Model.extend({
     person: DS.belongsTo(Person)
   });


### PR DESCRIPTION
Data is removing a saved record from the hasMany collection when rollback

This is a failing spec for https://github.com/emberjs/data/issues/506.
