### PR TITLE
Don't trigger `findAll` when `Model.find()` is called with a `null` or `undefined` parameter

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -414,8 +414,12 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     its `isLoaded` property.
   */
   find: function(type, id) {
-    if (id === undefined) {
+    if (arguments.length === 1) {
       return this.findAll(type);
+    }
+
+    if ('undefined' === typeof id || id === null) {
+      throw new Ember.Error(fmt('Cannot find %@ for type %@.', [id + '', type]));
     }
 
     // We are passed a query instead of an id.

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -61,6 +61,16 @@ test("a record's id is included in its toString represenation", function() {
   equal(record.toString(), '<(subclass of DS.Model):'+Ember.guidFor(record)+':1>', "reports id in toString");
 });
 
+test("calling `find` with an `undefined` or `null` parameter should raise", function() {
+  raises(function() {
+    store.find(Person, undefined);
+  });
+
+  raises(function() {
+    store.find(Person, null);
+  });
+});
+
 test("trying to set an `id` attribute should raise", function() {
   Person = DS.Model.extend({
     id: DS.attr('number'),


### PR DESCRIPTION
Instead throw an error.  This is a much easier way to understand that you're passing a bad value to `Model.find`

so in the new behavior:

```
var postId = null;
Post.find(postId); // raises
```
