### PR TITLE
Rename setup() method to _setup() on DS.Model

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -67,12 +67,12 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
     var stateManager = DS.StateManager.create({ record: this });
     set(this, 'stateManager', stateManager);
 
-    this.setup();
+    this._setup();
 
     stateManager.goToState('empty');
   },
 
-  setup: function() {
+  _setup: function() {
     this._relationshipChanges = {};
   },
 
@@ -212,7 +212,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   rollback: function() {
-    this.setup();
+    this._setup();
     this.send('becameClean');
 
     this.suspendAssociationObservers(function() {


### PR DESCRIPTION
It is pretty common to find a DB column named 'setup'.
Previously I would do something like this to map around the problem.
App.Adapter.map('App.SomeModel', {
    // setup is reserved, so we have to map around it.
    _setup: { key: 'setup' }
});
