### PR TITLE
Better support for model urls

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -322,30 +322,37 @@ DS.RESTAdapter = DS.Adapter.extend({
     return this.plurals[name] || name + "s";
   },
 
-  // extracts the root from an embedded url:
-  //   "blah/blah/posts"   => "posts"
-  //   "posts"             => "posts"
+  singularize: function(name) {
+    var singlular;
+    for (singlular in this.plurals) {
+      if (this.plurals[singlular] === name) {
+        return singlular;
+      }
+    }
+    return name.replace(/s$/, "");
+  },
+
   rootForType: function(type) {
-    return this.urlForType(type).replace(/.*\//, "");
+    return this.singularize(this.pluralizedRootForType(type));
   },
 
   pluralizedRootForType: function(type) {
-    // if the user has typed in a url, it is safe to assume they
-    // already pluralized it
     if (type.url) {
-      return this.rootForType(type);
+      return this.urlForType(type).replace(/.*\//, "");
     } else {
-      return this.pluralize(this.rootForType(type));
+      return this.urlForType(type);
     }
   },
 
+  // the url is always pluralized by default
   urlForType: function(type) {
     if (type.url) { return type.url; }
 
     // use the last part of the name as the URL
     var parts = type.toString().split(".");
     var name = parts[parts.length - 1];
-    return name.replace(/([A-Z])/g, '_$1').toLowerCase().slice(1);
+    name = name.replace(/([A-Z])/g, '_$1').toLowerCase().slice(1);
+    return this.pluralize(name);
   },
 
   ajax: function(url, type, hash) {
@@ -428,13 +435,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       url.push(this.namespace);
     }
 
-    // don't pluralize if the record is an embedded url, the user will have
-    // already done it when defining it
-    if (/\//.test(record)) {
-      url.push(record);
-    } else {
-      url.push(this.pluralize(record));
-    }
+    url.push(record);
 
     if (suffix !== undefined) {
       url.push(suffix);

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -452,6 +452,26 @@ test("finding a person by ID makes a GET to /people/:id", function() {
   equal(person, store.find(Person, 1), "the record is now in the store, and can be looked up by ID without another Ajax request");
 });
 
+test("finding a person by via an embedded url works", function() {
+
+  Person.reopenClass({
+    url: "some/path/to/people"
+  });
+
+  person = store.find(Person, 1);
+
+  expectState('loaded', false);
+  expectUrl("/some/path/to/people/1", "the plural of the model name with the ID requested");
+  expectType("GET");
+
+  ajaxHash.success({ person: { id: 1, name: "Yehuda Katz" } });
+
+  expectState('loaded');
+  expectState('dirty', false);
+
+  equal(person, store.find(Person, 1), "the record is now in the store, and can be looked up by ID without another Ajax request");
+});
+
 test("finding a person by an ID-alias populates the store", function() {
   person = store.find(Person, 'me');
 
@@ -1062,4 +1082,9 @@ test("updating a record with a 500 error marks the record as error", function() 
   ajaxHash.error.call(ajaxHash.context, mockXHR);
 
   expectState('error');
+});
+
+test ("singularize works", function() {
+  equal(adapter.singularize('posts'), "post", "singularize doesn't handle regular plurals");
+  equal(adapter.singularize('people'), "person", "singularize doesn't handle special plurals");
 });


### PR DESCRIPTION
Hi,

Ember-data automatically builds models on the client side when consuming a REST API, however when a url is defined such as:

App.Person.reopenClass {
  url: "some/path/to/people"
}

then it starts complaining that no mapping is defined to help it build the models.

This update makes the rest adapter work better in such situations and to automatically infer the json root based on the url.

Cheers,
Stephen
