### PR TITLE
DS.RESTAdapter can findMany in size-limited batches

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -3,8 +3,7 @@ require('ember-data/system/adapter');
 require('ember-data/serializers/rest_serializer');
 /*global jQuery*/
 
-var get = Ember.get, set = Ember.set, merge = Ember.merge;
-var get = Ember.get, set = Ember.set, getWithDefault = Ember.getWithDefault;
+var get = Ember.get, set = Ember.set, merge = Ember.merge, getWithDefault = Ember.getWithDefault;
 
 /**
   The REST adapter allows your store to communicate with an HTTP server by
@@ -64,6 +63,7 @@ var get = Ember.get, set = Ember.set, getWithDefault = Ember.getWithDefault;
 DS.RESTAdapter = DS.Adapter.extend({
   bulkCommit: false,
   since: 'since',
+  fetchBatchSize: undefined,
 
   serializer: DS.RESTSerializer,
 
@@ -76,8 +76,6 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     return !reference.parent;
   },
-
-  fetchBatchSize: undefined,
 
   createRecord: function(store, type, record) {
     var root = this.rootForType(type);

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -20,9 +20,9 @@ module("the REST adapter", {
       ajax: function(url, type, hash) {
         var success = hash.success, self = this;
 
-        ajaxUrl = url;
-        ajaxType = type;
-        ajaxHash = hash;
+        ajaxUrl = setOrPush(ajaxUrl, url);
+        ajaxType = setOrPush(ajaxType, type);
+        ajaxHash = setOrPush(ajaxHash, hash);
 
         if (success) {
           hash.success = function(json) {
@@ -83,16 +83,61 @@ module("the REST adapter", {
   }
 });
 
+var setOrPush = function(current, next){
+  if (Ember.isArray(current)){
+    current.push(next);
+    return current;
+  } else {
+    return next;
+  }
+};
+
 var expectUrl = function(url, desc) {
-  equal(ajaxUrl, url, "the URL is " + desc);
+  var actualUrl;
+  if (Ember.isArray(ajaxUrl)) {
+    actualUrl = ajaxUrl[0];
+  } else {
+    actualUrl = ajaxUrl;
+  }
+  equal(actualUrl, url, "the URL is " + desc);
 };
 
 var expectType = function(type) {
-  equal(type, ajaxType, "the HTTP method is " + type);
+  var actualType;
+  if (Ember.isArray(ajaxType)) {
+    actualType = ajaxType[0];
+  } else {
+    actualType = ajaxType;
+  }
+  equal(type, actualType, "the HTTP method is " + type);
 };
 
 var expectData = function(hash) {
-  deepEqual(hash, ajaxHash.data, "the hash was passed along");
+  var actualHash;
+  if (Ember.isArray(ajaxHash)) {
+    actualHash = ajaxHash[0];
+  } else {
+    actualHash = ajaxHash;
+  }
+  deepEqual(hash, actualHash.data, "the hash was passed along");
+};
+
+var accumulateAjaxRequests = function(){
+  ajaxUrl = [];
+  ajaxType = [];
+  ajaxHash = [];
+};
+
+var nextRequest = function(){
+  if (Ember.isArray(ajaxUrl)){
+    ajaxUrl.shift();
+  }
+  if (Ember.isArray(ajaxType)){
+    ajaxType.shift();
+  }
+  if (Ember.isArray(ajaxHash)){
+    ajaxHash.shift();
+  }
 };
 
 var expectState = function(state, value, p) {
@@ -579,30 +624,42 @@ test("the number of records fetched by findMany can be limited by fetchBatchSize
 
   set(adapter, 'fetchBatchSize', 2);
 
+  accumulateAjaxRequests();
+
   var people = store.findMany(Person, [ 1, 2, 3 ]);
 
-  // Uses a while loop to fire off multiple ajax requests, so we will
-  // only see the last one. TODO: make it capture a list of requests
-  // made within the test.
+  equal(2, ajaxUrl.length, "two Ajax requests have been made");
+
+  expectUrl("/people");
+  expectType("GET");
+  expectData({ ids: [ 1, 2 ] });
+
+  ajaxHash[0].success({
+    people: [
+      { id: 1, name: "Rein Heinrichs" },
+      { id: 2, name: "Tom Dale" }
+    ]
+  });
+
+  nextRequest();
+
   expectUrl("/people");
   expectType("GET");
   expectData({ ids: [ 3 ] });
 
-  ajaxHash.success({
+  ajaxHash[0].success({
     people: [
-      // { id: 1, name: "Rein Heinrichs" },
-      // { id: 2, name: "Tom Dale" },
       { id: 3, name: "Yehuda Katz" }
     ]
   });
 
-  // var rein = people.objectAt(0);
-  // equal(get(rein, 'name'), "Rein Heinrichs");
-  // equal(get(rein, 'id'), 1);
+  var rein = people.objectAt(0);
+  equal(get(rein, 'name'), "Rein Heinrichs");
+  equal(get(rein, 'id'), 1);
 
-  // var tom = people.objectAt(1);
-  // equal(get(tom, 'name'), "Tom Dale");
-  // equal(get(tom, 'id'), 2);
+  var tom = people.objectAt(1);
+  equal(get(tom, 'name'), "Tom Dale");
+  equal(get(tom, 'id'), 2);
 
   var yehuda = people.objectAt(2);
   equal(get(yehuda, 'name'), "Yehuda Katz");


### PR DESCRIPTION
Especially in the case where `hasMany` associations have high-cardinality, sometimes the Ajax request to fetch many records at once will generate a URL that is longer than supported by the browser.

This pull-request adds a `'fetchBatchSize'` property to `DS.RESTAdapter` that allows large collections to be fetched in fixed-size chunks. If left unset, the default behavior is essentially unchanged.
