### PR TITLE
Fixed sometimes-incorrect error message in DS.StateManager

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -728,7 +728,7 @@ DS.StateManager = Ember.StateManager.extend({
         errorMessage;
     errorMessage  = "Attempted to handle event `" + originalEvent + "` ";
     errorMessage += "on " + record.toString() + " while in state ";
-    errorMessage += get(this, 'currentState.path') + ". Called with ";
+    errorMessage += get(manager, 'currentState.path') + ". Called with ";
     errorMessage += arrayMap.call(contexts, function(context){
                       return Ember.inspect(context);
                     }).join(', ');


### PR DESCRIPTION
When reporting an unhandledEvent in DS.StateManager, use the passed in/originating `manager` rather than `this` (catching statemanager) to determine the correct `currentState` to report in the error message.
