### PR TITLE
Add a reset method for testing

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -128,7 +128,6 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
   */
   registerSerializerMappings: function(serializer) {
     var mappings = this._attributesMap;
-
     mappings.forEach(function(type, mapping) {
       serializer.map(type, mapping);
     }, this);
@@ -156,6 +155,12 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
       }
   */
   find: null,
+
+  /**
+    Implement this method if you need to reset internal bookkeeping
+    when the store is reset.
+  */
+  reset: Ember.K,
 
   serializer: DS.JSONSerializer,
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -85,6 +85,16 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
       set(DS, 'defaultStore', this);
     }
 
+    this.reset();
+  },
+
+  /**
+    Reset the internal bookkeeping. Call this when you don't
+    want to `destroy()` the store. This is primarily used
+    for testings. This will also call the adapter's reset
+    method.
+  */
+  reset: function() {
     // internal bookkeeping; not observable
     this.typeMaps = {};
     this.recordCache = [];
@@ -102,6 +112,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     this.loadingRecordArrays = {};
 
     set(this, 'defaultTransaction', this.transaction());
+
+    get(this, '_adapter').reset();
   },
 
   /**

--- a/packages/ember-data/tests/integration/embedded_load_test.js
+++ b/packages/ember-data/tests/integration/embedded_load_test.js
@@ -21,11 +21,8 @@ module("Embedded Load", {
     lookup.Comment = Comment;
 
     Adapter = DS.Adapter.extend();
-
-    store = DS.Store.create({
-      adapter: Adapter
-    });
   },
+
   teardown: function() {
     Ember.lookup = originalLookup;
   }
@@ -36,6 +33,10 @@ Ember.ArrayPolyfills.forEach.call([[Comment, "as a type"], ["Comment", "as a str
   test("A belongsTo association can be marked as embedded via the `map` API (" + testString + ")", function() {
     Adapter.map(mapping, {
       user: { embedded: 'load' }
+    });
+
+    store = DS.Store.create({
+      adapter: Adapter
     });
 
     store.load(Comment, {
@@ -69,6 +70,10 @@ Ember.ArrayPolyfills.forEach.call([Person, "Person"], function(mapping) {
   test("A hasMany association can be marked as embedded via the `map` API", function() {
     Adapter.map(mapping, {
       comments: { embedded: 'load' }
+    });
+
+    store = DS.Store.create({
+      adapter: Adapter
     });
 
     store.load(Person, {

--- a/packages/ember-data/tests/unit/store_test.js
+++ b/packages/ember-data/tests/unit/store_test.js
@@ -722,3 +722,25 @@ test("unload a record", function() {
   store.find(Record, 1);
   equal(tryToFind, true, "not found record with id 1");
 });
+
+module("DS.Store - reset", {
+  setup: function() {
+    store = DS.Store.create({
+      adapter: DS.Adapter.create()
+    });
+  },
+
+  teardown: function() {
+    store.destroy();
+  }
+});
+
+test("reset also calls the adapter's reset method", function() {
+  expect(1);
+
+  store.get('_adapter').reset = function() {
+    ok("Adapter's reset method called");
+  };
+
+  store.reset();
+});


### PR DESCRIPTION
This method is primarily used in tests. The reset method undos everything internally and goes back to how it was when it was initialized. This does not undo anything committed. It also call's the adapter's reset method. You can use this with the fixture adapter to reset the store between tests. 

I simply moved the initialization code from `init` into it's own method. **I'm not sure if this is enough.** I hope that it is. If it's not then there are problems somewhere. @tomdale and @wycats know more about this than I do. 

EDIT: This is the perfect compliment to #512. The combination of these two PR's will actually make ember apps much more testable.
