### PR TITLE
Fix issues with parsing ISO 8601 dates in IE8

### DIFF
--- a/packages/ember-data/lib/transforms/json_transforms.js
+++ b/packages/ember-data/lib/transforms/json_transforms.js
@@ -47,14 +47,22 @@ DS.JSONTransforms = {
   date: {
     deserialize: function(serialized) {
       var type = typeof serialized;
+      var date = null;
 
       if (type === "string" || type === "number") {
         // this is a fix for Safari 5.1.5 on Mac which does not accept timestamps as yyyy-mm-dd
-        if (type === "string" && serialized.search(/^\d{4}-\d{2}-\d{2}$/) !== -1){
+        if (type === "string" && serialized.search(/^\d{4}-\d{2}-\d{2}$/) !== -1) {
           serialized += "T00:00:00Z";
         }
 
-        return new Date(serialized);
+        date = new Date(serialized);
+
+        // this is a fix for IE8 which does not accept timestamps in ISO 8601 format
+        if (type === "string" && isNaN(date)) {
+          date = new Date(Date.parse(serialized.replace(/\-/ig, '/').replace(/Z$/, '').split('.')[0]));
+        }
+
+        return date;
       } else if (serialized === null || serialized === undefined) {
         // if the value is not present in the data,
         // return undefined, not null.


### PR DESCRIPTION
This is a dirty fix for IE8 not parsing [ISO 8601 dates](http://msdn.microsoft.com/en-us/library/ie/ff743760.aspx) properly.

Fix was taken from: 
http://stackoverflow.com/questions/3046459/ie-date-parse-method-returns-nan-for-date-with-time-string
