### PR TITLE
`sideloadAssociations` being called more than once per association

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -371,6 +371,7 @@ DS.RESTAdapter = DS.Adapter.extend({
   },
 
   sideloadAssociations: function(store, type, json, prop, loaded) {
+    if (loaded[prop]) { return; }
     loaded[prop] = true;
 
     get(type, 'associationsByName').forEach(function(key, meta) {


### PR DESCRIPTION
If you have complex relationships, where you're loading multiple types with relations in common, the current code leaves it open for sideloadAssociations to be called twice with the same params and the same json hash, despite the best efforts of a `loaded` hash to prevent it.

This commit adds one more check to `loaded`, and a test that is _not_ commented out.
