### PR TITLE
Add note about upading data with store.load

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,10 @@ App.store.loadMany(App.Person, [{
 }]);
 ```
 
+This can also become useful when you're changing the data outside of Ember Data,
+such as by doing a custom AJAX request. You can then use `App.store.load` to update
+the loaded data.
+
 ## Adapter API
 
 An adapter is an object that receives requests from a store and translates


### PR DESCRIPTION
The README specifies that `store.load` is meant to be used for pre-loading the data, but this isn't the only use case. Especially since it is one of the few ways to update the data once it has been fetched.
