### PR TITLE
cover null case for belongsTo relationship

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -22,10 +22,13 @@ DS.belongsTo = function(type, options) {
 
     id = data[key];
 
-    if (typeof id === 'object') {
+    if(!id) {
+      return null;
+    }
+    else if (typeof id === 'object') {
       return store.findByClientId(type, id.clientId);
     } else {
-      return id ? store.find(type, id) : null;
+      return store.find(type, id);
     }
   }).property('data').meta(meta);
 };

--- a/packages/ember-data/tests/integration/relationships/one_to_many_relationships_test.js
+++ b/packages/ember-data/tests/integration/relationships/one_to_many_relationships_test.js
@@ -42,6 +42,12 @@ function verifySynchronizedOneToMany(post, comment, expectedHasMany) {
   deepEqual(post.get('comments').toArray(), expectedHasMany);
 }
 
+test("Referencing a null belongsTo relationship returns null", function(){
+  store.load(App.Comment, { id: 1, post: null, body: "child with intentionally null parent" });
+  var comment = store.find(App.Comment, 1);
+  equal(comment.get('post'), null, "null belongsTo relationship returns null");
+});
+
 test("When setting a record's belongsTo relationship to another record, that record should be added to the inverse hasMany array", function() {
   store.load(App.Post, { id: 1, title: "parent" });
   store.load(App.Comment, { id: 2, body: "child" });


### PR DESCRIPTION
I was getting an error:

```
TypeError: Cannot read property 'clientId' of null
```

The error was caused by the fact that this statement doesn't protect against a `null` id:

```
if (typeof id === 'object') {
  return store.findByClientId(type, id.clientId);
}
```

This pull request adds the null check, and also a test.
