### PR TITLE
Fix: unload record with relationships

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -572,8 +572,15 @@ var states = {
         },
 
         unloadRecord: function(manager) {
+          var record = get(manager, 'record');
+
+          // clear relationships before moving to deleted state
+          // otherwise it fails
+          record.clearRelationships();
+          record.withTransaction(function(t) {
+            t.recordIsMoving('updated', record);
+          });
           manager.transitionTo('deleted.saved');
-          get(manager, 'record').clearRelationships();
         },
 
         willCommit: function(manager) {


### PR DESCRIPTION
- calling `clearRelationships` before changing record state,
  otherwise fails because properties try to update removed
  relationships
- Transaction commit failed when an unloaded record was in the
  `transaction.bucketForType.updated` array. Using recordIsMoving fixed
  this issue
