### PR TITLE
failing test of embedded records in a filter

### DIFF
--- a/packages/ember-data/tests/integration/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/store_adapter_test.js
@@ -12,7 +12,7 @@
 */
 
 var get = Ember.get, set = Ember.set;
-var Person, store, adapter;
+var Person, Dog, store, adapter;
 
 module("DS.Store and DS.Adapter integration test", {
   setup: function() {
@@ -355,6 +355,40 @@ test("the filter method can optionally take a server query as well", function() 
 
   equal(get(filter, 'length'), 1, "The filter has an item in it");
   deepEqual(filter.toArray(), [ tom ], "The filter has a single entry in it");
+});
+
+test("the filter method with server query works with embedded records", function() {
+  Dog = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  Person.reopen({
+    dogs: DS.hasMany(Dog)
+  });
+
+  DS.Adapter.map(Person, {
+    dogs: { embedded: 'always' }
+  });
+
+  adapter.findQuery = function(store, type, query, array) {
+    array.load([
+      {
+        id: 1,
+        name: "Tom Dale",
+        dogs: [ { name: "Tank" }, { name: "Fluffy" } ]
+      }
+    ]);
+  };
+
+  var filter = store.filter(Person, { name: "Tom Dale" }, function(data) {
+    return data.get('name') === "Tom Dale";
+  });
+
+  equal(get(filter, 'length'), 1, "The filter has an item in it");
+
+  var tom = filter.objectAt(0);
+  equal(tom.get('dogs.length'), 2, "loads embedded records");
+  equal(tom.get('dogs').objectAt(0).get('name'), 'Tank', "loads embedded record attributes");
 });
 
 test("can rollback after sucessives updates", function() {


### PR DESCRIPTION
I get the following error when using a `filter` with a server query for embedded records:

```
TypeError: Cannot call method 'hasOwnProperty' of undefined
```

I don't get the same error with a normal `find`, so I assume the error is in the filter logic somewhere.

This pull request contains a failing test to demonstrate the problem.
