### PR TITLE
Add notDirty mapping option

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -442,7 +442,8 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
   },
 
   dirtyRecordsForAttributeChange: function(dirtySet, record, attributeName, newValue, oldValue) {
-    if (newValue !== oldValue) {
+    var notDirty = get(this, 'serializer').mappingOption(record.constructor, attributeName, 'notDirty');
+    if (!notDirty && newValue !== oldValue) {
       // If this record is embedded, add its parent
       // to the dirty set.
       this.dirtyRecordsForRecordChange(dirtySet, record);
@@ -453,12 +454,18 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     dirtySet.add(record);
   },
 
-  dirtyRecordsForBelongsToChange: function(dirtySet, child) {
-    this.dirtyRecordsForRecordChange(dirtySet, child);
+  dirtyRecordsForBelongsToChange: function(dirtySet, child, attributeName) {
+    var notDirty = get(this, 'serializer').mappingOption(child.constructor, attributeName, 'notDirty');
+    if (!notDirty ) {
+      this.dirtyRecordsForRecordChange(dirtySet, child);
+    }
   },
 
-  dirtyRecordsForHasManyChange: function(dirtySet, parent) {
-    this.dirtyRecordsForRecordChange(dirtySet, parent);
+  dirtyRecordsForHasManyChange: function(dirtySet, parent, attributeName) {
+    var notDirty = get(this, 'serializer').mappingOption(parent.constructor, attributeName, 'notDirty');
+    if (!notDirty ) {
+      this.dirtyRecordsForRecordChange(dirtySet, parent);
+    }
   },
 
   /**

--- a/packages/ember-data/lib/system/relationships/one_to_many_change.js
+++ b/packages/ember-data/lib/system/relationships/one_to_many_change.js
@@ -408,11 +408,11 @@ DS.RelationshipChange.prototype = {
     // of ember-data, and should be done as new infrastructure, not
     // a one-off hack. [tomhuda]
     if (parentRecord && get(parentRecord, 'isLoaded')) {
-      this.store.recordHasManyDidChange(dirtySet, parentRecord, this);
+      this.store.recordHasManyDidChange(dirtySet, parentRecord, hasManyName);
     }
 
     if (child) {
-      this.store.recordBelongsToDidChange(dirtySet, child, this);
+      this.store.recordBelongsToDidChange(dirtySet, child, belongsToName);
     }
 
     dirtySet.forEach(function(record) {


### PR DESCRIPTION
Adding a notDirty property to a model property via the map API, it
allows the record property value be updated and cause the record does not
become dirty.

``` js
    Adapter.map(App.Person, {
      firstName: { notDirty: true }
    });
```

This feature can be used for example, whenever a client will not
update these model properties to the remote server, although it updates
its local copy to improve the application user experience.
