### PR TITLE
Trigger didLoad event in the `AdapterPopulatedRecordArray` at the end of the runloop

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -18,6 +18,10 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
     set(this, 'isLoaded', true);
     this.endPropertyChanges();
 
-    this.trigger('didLoad');
+    var self = this; 
+    // TODO: does triggering didLoad event should be the last action of the runLoop?
+    Ember.run.once(function() {
+      self.trigger('didLoad');
+    });
   }
 });

--- a/packages/ember-data/tests/integration/queries_test.js
+++ b/packages/ember-data/tests/integration/queries_test.js
@@ -35,7 +35,9 @@ test("When a query is made, the adapter should receive a record array it can pop
     // Simulate latency to ensure correct behavior in asynchronous conditions.
     // Once 100ms has passed, load the results of the query into the record array.
     setTimeout(function() {
-      self.didFindQuery(store, type, { persons: [{ id: 1, name: "Peter Wagenet" }, { id: 2, name: "Brohuda Katz" }] }, recordArray);
+      Ember.run(function() {
+        self.didFindQuery(store, type, { persons: [{ id: 1, name: "Peter Wagenet" }, { id: 2, name: "Brohuda Katz" }] }, recordArray);
+      });
     }, 100);
   };
 

--- a/packages/ember-data/tests/integration/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/store_adapter_test.js
@@ -63,7 +63,6 @@ asyncTest("Records loaded multiple times and retrieved in recordArray are ready 
   };
 
   var people, people2;
-
   people = store.findQuery(Person, {q: 'bla'});
   people.one('didLoad', function() {
 
@@ -78,12 +77,11 @@ asyncTest("Records loaded multiple times and retrieved in recordArray are ready 
 
       var person = people.objectAt(0);
       ok( person.get('isLoaded'), 'record is loaded' );
+      // delete record will not throw exception
       person.deleteRecord();
 
 
     });
-
-
   });
 
 });

--- a/packages/ember-data/tests/unit/record_array_test.js
+++ b/packages/ember-data/tests/unit/record_array_test.js
@@ -131,16 +131,17 @@ test("an AdapterPopulatedRecordArray knows if it's loaded or not", function() {
         var self = this;
 
         setTimeout(function() {
-          self.didFindQuery(store, type, { persons: array }, recordArray);
-          equal(get(people, 'isLoaded'), true, "The array is now loaded");
-          start();
+          Ember.run(function() {
+            self.didFindQuery(store, type, { persons: array }, recordArray);
+            equal(get(people, 'isLoaded'), true, "The array is now loaded");
+            start();
+          });
         }, 100);
       }
     })
   });
 
   var people = store.find(Person, { page: 1 });
-
   equal(get(people, 'isLoaded'), false, "The array is not yet loaded");
 });
 


### PR DESCRIPTION
Include an integration test to show the expected behaviour.

Currently, some events in the models have been delayed with `Em.run.once`, however the events in the recordArray has  has not been delayed, so records and recordArray could be in an inconsistent state, which originates the following exception:

**Uncaught Error: Attempted to handle event loadedData on App.Person:ember244:1 while in state rootState.deleted.uncommitted. Called with {}**

Triggering the `didLoad` event of the `AdapterPopulatedRecordArray` at the end of the runLoop fixed this case.
