### PR TITLE
Use _reference instead of reference for DS.Model

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -71,7 +71,7 @@ DS.RESTAdapter = DS.Adapter.extend({
   },
 
   shouldSave: function(record) {
-    var reference = get(record, 'reference');
+    var reference = get(record, '_reference');
 
     return !reference.parent;
   },
@@ -105,7 +105,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       this.dirtyRecordsForRecordChange(dirtySet, embeddedRecord);
     }, this);
 
-    var reference = record.get('reference');
+    var reference = record.get('_reference');
 
     if (reference.parent) {
       var store = get(record, 'store');

--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -9,7 +9,6 @@ DS.Model.reopenClass({
     this.eachComputedProperty(function(name, meta) {
       if (meta.isAttribute) {
         Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.toString(), name !== 'id');
-        Ember.assert("The attribute name `reference` is reserved for internal use for now " + this.toString(), name !== 'reference');
 
         meta.name = name;
         map.set(name, meta);
@@ -52,7 +51,7 @@ DS.Model.reopen({
   },
 
   attributeWillChange: Ember.beforeObserver(function(record, key) {
-    var reference = get(record, 'reference'),
+    var reference = get(record, '_reference'),
         store = get(record, 'store');
 
     record.send('willSetProperty', { reference: reference, store: store, name: key });
@@ -88,7 +87,6 @@ DS.attr = function(type, options) {
 
     if (arguments.length > 1) {
       Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.constructor.toString(), key !== 'id');
-      Ember.assert("The attribute name `reference` is reserved for internal use for now " + this.constructor.toString(), key !== 'reference');
     } else {
       value = getAttr(this, options, key);
     }

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -301,7 +301,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, LoadPromise, {
     this.updateRecordArraysLater();
   },
 
-  reference: Ember.computed(function() {
+  _reference: Ember.computed(function() {
     return get(this, 'store').referenceForClientId(get(this, 'clientId'));
   }),
 

--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -76,7 +76,7 @@ DS.ManyArray = DS.RecordArray.extend({
     // Map the array of record objects into an array of  client ids.
     added = added.map(function(record) {
       Ember.assert("You can only add records of " + (get(this, 'type') && get(this, 'type').toString()) + " to this relationship.", !get(this, 'type') || (get(this, 'type') === record.constructor));
-      return get(record, 'reference');
+      return get(record, '_reference');
     }, this);
 
     this._super(index, removed, added);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1424,7 +1424,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     @param {DS.Model} record
   */
   removeFromRecordArrays: function(record) {
-    var reference = get(record, 'reference');
+    var reference = get(record, '_reference');
     var recordArrays = this.recordArraysForClientId(reference.clientId);
 
     recordArrays.forEach(function(array) {


### PR DESCRIPTION
Models using `reference: DS.attr('string')`, and the error is kind of hard to debug (happens later, when using the model instance).

Since `_reference` is internal it makes sense to prepend it with an underscore. Hopefully I've made the correct changes.

Action plan:
1. If this sounds good, squash the two commits (or ask me to do it) and merge.
2. If you want to keep the current attribute name, keep the first commit (which adds a warning), throw away the second and merge. 

_I think option 2 is less desirable, but better than the current situation where there is no warning when using `reference` in your models._
