### PR TITLE
Allow to define integer ids in the fixtures, as well as string

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -13,7 +13,14 @@ DS.FixtureAdapter = DS.Adapter.extend({
     Implement this method in order to provide data associated with a type
   */
   fixturesForType: function(type) {
-    return type.FIXTURES ? Ember.A(type.FIXTURES) : null;
+    if (type.FIXTURES) {
+      var fixtures = Ember.A(type.FIXTURES);
+      return fixtures.map(function(fixture){
+        fixture.id = fixture.id + '';
+        return fixture;
+      });
+    }
+    return null;
   },
 
   /*

--- a/packages/ember-data/tests/unit/fixture_adapter_test.js
+++ b/packages/ember-data/tests/unit/fixture_adapter_test.js
@@ -168,3 +168,28 @@ test("should follow isUpdating semantics", function() {
     ok(false, "timeout exceeded waiting for fixture data");
   }, 1000);
 });
+
+test("should coerce integer ids into string", function() {
+  stop();
+
+  Person.FIXTURES = [{
+    id: 1,
+    firstName: "Adam",
+    lastName: "Hawkins",
+    height: 65
+  }];
+
+  var result = Person.find("1");
+
+  result.then(function() {
+    clearTimeout(timer);
+    start();
+    clearTimeout(timer);
+    equal(get(result, 'id'), "1", "should load integer model id");
+  });
+
+  var timer = setTimeout(function() {
+    start();
+    ok(false, "timeout exceeded waiting for fixture data");
+  }, 1000);
+});


### PR DESCRIPTION
fixes  #591 
Clearly not optimal since it goes through fiextures each time it's requested and coerce id as string
