### PR TITLE
Added failing test for findHasMany behavior

### DIFF
--- a/packages/ember-data/tests/integration/has_many_test.js
+++ b/packages/ember-data/tests/integration/has_many_test.js
@@ -182,6 +182,7 @@ asyncTest("A serializer can materialize a hasMany as an opaque token that can be
     start();
     equal(comments.get('isLoaded'), true);
     equal(comments.get('length'), 2);
+    equal(comments.objectAtContent(0).get('currentState.stateName'), 'root.loaded.saved');
   }
 });
 


### PR DESCRIPTION
Using findHasMany in the pattern indicated by the has_many test will result in all HasMany in a `uncommitted` state, rather than `saved`.
