### PR TITLE
belongsTo relationship should return null when the id is null.

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -22,7 +22,7 @@ DS.belongsTo = function(type, options) {
 
     id = data[key];
 
-    if (typeof id === 'object') {
+    if (id !== null && typeof id === 'object') {
       return store.findByClientId(type, id.clientId);
     } else {
       return id ? store.find(type, id) : null;

--- a/packages/ember-data/tests/unit/relationships_test.js
+++ b/packages/ember-data/tests/unit/relationships_test.js
@@ -425,6 +425,29 @@ test("belongsTo lazily loads relationships as needed", function() {
   strictEqual(get(person, 'tag'), store.find(Tag, 5), "relationship object is the same as object retrieved directly");
 });
 
+test("belongsTo returns null when the id is not available", function() {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+  Tag.toString = function() { return "Tag"; };
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tag: DS.belongsTo(Tag)
+  });
+  Person.toString = function() { return "Person"; };
+
+  Tag.reopen({
+    people: DS.hasMany(Person)
+  });
+
+  var store = DS.Store.create();
+  store.load(Person, 1, { id: 1, name: "Tom Dale", tag: null });
+
+  var person = store.find(Person, 1);
+  equal(get(person, 'tag'), null, "the tag property should return a null");
+});
+
 test("relationships work when the data hash has not been loaded", function() {
   expect(12);
 


### PR DESCRIPTION
**Problem**
id typeof "object" is true when id is null which leads to an exception.

**Solution**
Check if the id is null before the typeof check.
