### PR TITLE
Fixtures must have ids

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -17,7 +17,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
       var fixtures = Ember.A(type.FIXTURES);
       return fixtures.map(function(fixture){
         if(!fixture.id){
-          throw new Error('ids must be defined in FIXTURES');
+          throw new Error('the id property must be defined for fixture %@'.fmt(fixture));
         }
         fixture.id = fixture.id + '';
         return fixture;

--- a/packages/ember-data/tests/unit/fixture_adapter_test.js
+++ b/packages/ember-data/tests/unit/fixture_adapter_test.js
@@ -204,7 +204,7 @@ test("should throw if ids are not defined in the FIXTURES", function() {
 
   raises(function(){
     Person.find("1");
-  }, /ids must be defined in FIXTURES/);
+  }, /the id property must be defined for fixture/);
 
   
 });


### PR DESCRIPTION
Using the FixtureAdapter, some users feel puzzled when having not understandable errors when forgetting to define ids in the FIXTURES;
