### PR TITLE
RESTAdapter dirty parent record on embedded create.

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -113,9 +113,9 @@ DS.RESTAdapter = DS.Adapter.extend({
       this.dirtyRecordsForRecordChange(dirtySet, parent);
     }
   },
-
-  dirtyRecordsForHasManyChange: Ember.K,
-
+  dirtyRecordsForHasManyChange: function(dirtySet, parent) {
+    this.dirtyRecordsForRecordChange(dirtySet, parent);
+  },
   createRecords: function(store, type, records) {
     if (get(this, 'bulkCommit') === false) {
       return this._super(store, type, records);


### PR DESCRIPTION
This fixes an issue where a parent record is not marked as dirty when a new has many embedded record is added.
