### PR TITLE
Extract embedded `belongsTo` records properly

### DIFF
--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -250,7 +250,7 @@ DS.Serializer = Ember.Object.extend({
   },
 
   extractEmbeddedBelongsTo: function(loader, relationship, data, parent, prematerialized) {
-    var reference = loader.sideload(relationship.type, data);
+    var reference = this.extractRecordRepresentation(loader, relationship.type, data, true);
     prematerialized[relationship.key] = reference;
 
     // If the embedded record should also be saved back when serializing the parent,


### PR DESCRIPTION
Fix a bug where embedded records two levels (or more) aren't properly materialised under some circumstances. The problem occurs when records are embedded within a `belongsTo` relationship.

The `sideload` method doesn't consider relationships/embedded records, by using
`extractRecordRepresentation` we'll recurse into the record (similarly
to `extractEmbeddedHasMany`).

Credits to @rykov for the test.
