### PR TITLE
deleteRecord, rollback, commit issues

### DIFF
--- a/packages/ember-data/tests/integration/rollback_test.js
+++ b/packages/ember-data/tests/integration/rollback_test.js
@@ -682,7 +682,8 @@ test("A deleted record should remove itself from the hasMany relationship after 
   comment2.deleteRecord();
   post.get('transaction').rollback();
 
-  equal(comment2.get('isDirty'), true, "deleted record should rollback correctly");
+  equal(comment2.get('isDirty'), false, "deleted record should rollback correctly");
+  equal(post.get('comments.length'), 1, "deleted record should be restored to the hasMany relationship");
 });
 
 //test("A deleted record in a transaction with changed attributes should revert to the old attributes when the transaction is rolled back.");


### PR DESCRIPTION
ember-data has a bug where deleting records and rolling back is not working as it should. 

Suppose there is Post model that `hasMany` Comments. Also suppose we have a post with 2 comments. When deleting comment1 and rolling back, things work fine. But then deleting the comment1 again and then committing doesn't seem to update the hasMany association.

The association then gets in a bad state such that trying to delete comment2 and rolling back doesn't work like it should as comment2 stays in a dirty state.

This pull request contains a failing test that exposes this issue.
