### PR TITLE
make sure to read all files in UTF-8 encoding

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -1,3 +1,5 @@
+Encoding.default_external = "UTF-8" if defined?(Encoding)
+
 require "rake-pipeline-web-filters"
 require "json"
 require "uglifier"


### PR DESCRIPTION
This fixes an encoding issue where "rake" fails because of some encoding issue:

$ rake
Building Ember Data...
rake aborted!
"\xC3" on US-ASCII

This is basically the same as https://github.com/emberjs-addons/ember-bootstrap/issues/55 / https://github.com/emberjs-addons/ember-bootstrap/issues/56
