### PR TITLE
Add failing test, can record array promise be resolved multiple times?

### DIFF
--- a/packages/ember-data/tests/integration/queries_test.js
+++ b/packages/ember-data/tests/integration/queries_test.js
@@ -59,3 +59,32 @@ test("When a query is made, the adapter should receive a record array it can pop
     equal(resolvedValue, queryResults, "The promise was resolved with the query results");
   });
 });
+
+
+test("When a query is made, the record array promise can be resolved multiple times.", function() {
+  expect(1);
+
+  adapter.findQuery = function(store, type, query, recordArray) {
+
+    stop();
+
+    var self = this;
+
+    // Simulate latency to ensure correct behavior in asynchronous conditions.
+    // Once 100ms has passed, load the results of the query into the record array.
+    setTimeout(function() {
+      Ember.run(function() {
+        self.didFindQuery(store, type, { persons: [{ id: 1, name: "Peter Wagenet" }, { id: 2, name: "Brohuda Katz" }] }, recordArray);
+      });
+    }, 100);
+  };
+
+  var queryResults = store.find(Person, { page: 1 });
+
+  queryResults.then(function(resolvedValue) {
+    queryResults.then(function(resolvedValue) {
+      start();
+      equal(resolvedValue, queryResults, "The promise was resolved with the query results");
+    });
+  });
+});


### PR DESCRIPTION
I realized that the `DS.Model` `promise` can be resolved multiple times, however `DS.RecordArray` does not work in the same way.

I PR a failing test to show the behaviour. 

I don't still know which is the expected behaviour, because i got a little confused with some tests i made with `Em.DeferredMixin`. The following test didn't also work:

``` js
asyncTest("Can re-resolve a promise", function() {
  var value = { value: true };

  var promise = Ember.Deferred.promise(function(deferred) {
    setTimeout(function() {
      Ember.run(function() { deferred.resolve(value); });
    });
  });

  promise.then(function(resolveValue) {
    equal(resolveValue, value, "The resolved value should be correct");

    promise.then(function(resolveValue) {
      start();
    });

});
```

Maybe, i didn't understand well something obvious.
