### PR TITLE
Resolve hasMany Relationships On-Demand

### DIFF
--- a/packages/ember-data/lib/system/changes/relationship_change.js
+++ b/packages/ember-data/lib/system/changes/relationship_change.js
@@ -46,6 +46,7 @@ DS.RelationshipChangeRemove = function(options){
   DS.RelationshipChange.call(this, options);
 };
 
+/** @private */
 DS.RelationshipChange.create = function(options) {
   return new DS.RelationshipChange(options);
 };
@@ -447,13 +448,15 @@ DS.RelationshipChangeAdd.prototype.sync = function() {
 
      }
      else if(this.secondRecordKind === "hasMany"){
-      secondRecord.suspendRelationshipObservers(function(){
-        get(secondRecord, secondRecordName).addObject(firstRecord);
-      });
-    }
+       if (!secondRecord.get('store').adapterForType(secondRecord).findHasMany || (get(secondRecord, 'isNew') || get(secondRecord, 'data')[this.secondRecordKind][secondRecordName] !== undefined)) {
+         secondRecord.suspendRelationshipObservers(function () {
+           get(secondRecord, secondRecordName).addObject(firstRecord);
+         });
+       }
+     }
   }
 
-  if (firstRecord && secondRecord && get(firstRecord, firstRecordName) !== secondRecord) {
+  if (firstRecord && secondRecord && (!firstRecord.get('store').adapterForType(firstRecord).findHasMany || (get(firstRecord, 'isNew') || get(firstRecord, 'data')[this.firstRecordKind][firstRecordName])) && get(firstRecord, firstRecordName) !== secondRecord) {
     if(this.firstRecordKind === "belongsTo"){
       firstRecord.suspendRelationshipObservers(function(){
         set(firstRecord, firstRecordName, secondRecord);
@@ -488,15 +491,17 @@ DS.RelationshipChangeRemove.prototype.sync = function() {
       secondRecord.suspendRelationshipObservers(function(){
         set(secondRecord, secondRecordName, null);
       });
-    }
-    else if(this.secondRecordKind === "hasMany"){
-      secondRecord.suspendRelationshipObservers(function(){
-        get(secondRecord, secondRecordName).removeObject(firstRecord);
-      });
-    }
+     }
+     else if(this.secondRecordKind === "hasMany"){
+       if (!secondRecord.get('store').adapterForType(secondRecord).findHasMany || (get(secondRecord, 'isNew') || get(secondRecord, 'data')[this.secondRecordKind][secondRecordName] !== undefined)) {
+         secondRecord.suspendRelationshipObservers(function () {
+           get(secondRecord, secondRecordName).removeObject(firstRecord);
+         });
+       }
+     }
   }
 
-  if (firstRecord && get(firstRecord, firstRecordName)) {
+  if (firstRecord && (!firstRecord.get('store').adapterForType(firstRecord).findHasMany || (get(firstRecord, 'isNew') || get(firstRecord, 'data')[this.firstRecordKind][firstRecordName] !== undefined)) && get(firstRecord, firstRecordName)) {
     if(this.firstRecordKind === "belongsTo"){
       firstRecord.suspendRelationshipObservers(function(){
         set(firstRecord, firstRecordName, null);

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -321,6 +321,11 @@ DS.Model = Ember.Object.extend(Ember.Evented, LoadPromise, {
         return store.referenceForId(type, id);
       });
 
+      references.forEach(function (reference) {
+        var recordArrays = store.recordArrayManager.recordArraysForReference(reference);
+        recordArrays.add(cachedValue);
+      });
+
       set(cachedValue, 'content', Ember.A(references));
     }
   },

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -416,6 +416,10 @@ createdState.uncommitted.deleteRecord = function(record) {
 };
 
 createdState.uncommitted.rollback = function(record) {
+  //HACK Rollback puts record into a loaded.saved state which then transitions to loaded.materializing... this is not correct for a new record.
+  if (get(record, 'isNew')) {
+    record.clearRelationships();
+  }
   DirtyState.uncommitted.rollback.apply(this, arguments);
   record.transitionTo('deleted.saved');
 };

--- a/packages/ember-data/lib/system/record_array_manager.js
+++ b/packages/ember-data/lib/system/record_array_manager.js
@@ -188,7 +188,7 @@ DS.RecordArrayManager = Ember.Object.extend({
     @method registerFilteredRecordArray
     @param {DS.RecordArray} array
     @param {Class} type
-    @param {Function} filter
+    @param {Function} [filter]
   */
   registerFilteredRecordArray: function(array, type, filter) {
     var recordArrays = this.filteredRecordArrays.get(type);

--- a/packages/ember-data/lib/system/relationships/has_many.js
+++ b/packages/ember-data/lib/system/relationships/has_many.js
@@ -27,6 +27,7 @@ var hasRelationship = function(type, options) {
     //ids can be references or opaque token
     //(e.g. `{url: '/relationship'}`) that will be passed to the adapter
     ids = data[key];
+    meta.key = key;
 
     relationship = store.findMany(type, ids, this, meta);
     set(relationship, 'owner', this);


### PR DESCRIPTION
This allows one to implement a `findHasMany` hook on a custom adapter to resolve hasMany relationships on demand (IOW, not needing a list of related ids upfront). 

Currently, the expectation is that there is a list of related ids for any unresolved hasMany relationships. Then, when the relationship is needed, that list of ids will be used to resolve the related records by passing them along to the store's `findMany`. The workflow is essentially:

DS.Model.get('aHasManyRelationship') -> DS.hasMany -> DS.Store.findMany -> DS.Adapter.findMany -> ... request to server ... -> DS.Adapter.didFindMany -> DS.Serializer.extractMany -> DS.Store.loadMany

There has been a lot of discussion online about trying to do this without the need to provide any related ids upfront. Given a record and name of a hasMany relationship, one would presume to have everything they would need to resolve that relationship server-side without needing any ids. The DS.Adapter could, for example, introspect the record to obtain its type and id. Then pass a record type, unique id and relationship name to the server. With that information a server could then grab the record for the given type and id and then ask for the realted records using the name of the hasMany relationship.

I notice in reading through some of ember-data's more recent revisions that the initial plumbing seems to be in place for this. The store implements a `loadHasMany` and contains code in `findMany` to fire off a call to the adapter's `findHasMany` hook if the expected array of related ids is undefined and call `didFindHasMany` in a success callback when the server returns the requested payload. 

So, I teaked things in a couple places. This pull request assumes that if a hasMany relationship is undefined on an existing record, it should be resolved with a request to the server. The workflow becomes:

DS.Model.get('aHasManyRelationship') -> DS.hasMany -> DS.Store.findMany -> <b>DS.Adapter.findHasMany</b> -> ... request to server ... -> <b>DS.Adapter.didFindHasMany</b> -> DS.Serializer.extractMany -> <b>DS.Store.loadHasMany</b>

All one needs to do is implement a `Adapter.findHasMany(store, record, relationship)` and call `adapter.didFindHasMany(store, type, payload, record, key)` in a success callback.

I have been using this for that last few days without issue. I also believe that these changes are non-breaking to existing symantics but haven't had the time to extensively test that.
