### PR TITLE
added jsonp for custom url

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -321,7 +321,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     hash.contentType = 'application/json; charset=utf-8';
     hash.context = this;
 
-    if (this.url !== '') {
+    if (this.url !== '' && type === 'GET') {
       hash.dataType = 'jsonp';
       hash.jsonp = false;
     }

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -24,7 +24,7 @@ module("the REST adapter", {
         ajaxType = type;
         ajaxHash = hash;
 
-        if (this.url !== '') {
+        if (this.url !== '' && type === 'GET') {
           ajaxHash.dataType = 'jsonp';
           ajaxHash.jsonp = false;
         }
@@ -897,9 +897,11 @@ test("if you specify a url then that custom url is used", function() {
   store.load(Person, { id: 1 });
 });
 
-test("if you specify a url then that custom url is used and jsonp dataType is used", function() {
+test("if you specify a url then that custom url is used and jsonp dataType is used on GET requests", function() {
   set(adapter, 'url', 'http://api.ember.dev');
   person = store.find(Person, 1);
+
+  expectType("GET");
   expectDataType("jsonp", "the custom url, results in dataType of jsonp");
 
   store.load(Person, { id: 1 });


### PR DESCRIPTION
I noticed this pull request adding the ability to have a custom url: https://github.com/emberjs/data/commit/35f66f12781af18187569ae1f70651754136f8ac to your RESTAdapter. In using this, I noticed that the dataType of json was still being used, but when a custom URL is used, it should be using jsonp for CORS support.

I added dataType of jsonp when a custom url is used.
