### PR TITLE
Avoid touching the `window` object in case it is not defined.

### DIFF
--- a/packages/ember-data/lib/core.js
+++ b/packages/ember-data/lib/core.js
@@ -1,4 +1,22 @@
-window.DS = Ember.Namespace.create({
-  // this one goes past 11
-  CURRENT_API_REVISION: 12
-});
+/*global __fail__*/
+
+/**
+Ember Data Store Debug
+
+@module ember-data
+*/
+
+/**
+@class DS
+*/
+
+if ('undefined' === typeof DS) {
+    DS = Ember.Namespace.create({
+      // this one goes past 11
+      CURRENT_API_REVISION: 12
+    });
+}
+
+if ('undefined' !== typeof window) {
+    window.DS = DS;
+}


### PR DESCRIPTION
This makes the ember-data usable in node.js again.
