### PR TITLE
Improve errors handling for embedded records

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -100,6 +100,10 @@ DS.RESTAdapter = DS.Adapter.extend({
     this._invalidTree(invalidSet, record);
   },
 
+  validRecords: function(validSet, record) {
+    this._validTree(validSet, record);
+  },
+
   _invalidTree: function(invalidSet, record) {
     invalidSet.add(record);
 
@@ -108,6 +112,10 @@ DS.RESTAdapter = DS.Adapter.extend({
       if (invalidSet.has(embeddedRecord)) { return; }
       this._invalidTree(invalidSet, embeddedRecord);
     }, this);
+  },
+
+  _validTree: function(validSet, record) {
+    this._dirtyTree(validSet, record);
   },
 
   dirtyRecordsForRecordChange: function(dirtySet, record) {

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -463,6 +463,10 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     invalidSet.add(record);
   },
 
+  validRecords: function(validSet, record) {
+    validSet.add(record);
+  },
+
   /**
     @private
 

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -309,6 +309,10 @@ DS.Model = Ember.Object.extend(Ember.Evented, LoadPromise, {
     this.send('becameInvalid', errors);
   },
 
+  adapterDidValidate: function() {
+    this.send('becameValid');
+  },
+
   adapterDidError: function() {
     this.send('becameError');
   },

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -396,7 +396,8 @@ var DirtyState = DS.State.extend({
       set(errors, key, null);
 
       if (!hasDefinedProperties(errors)) {
-        manager.send('becameValid');
+        var store = get(record, 'store');
+        store.recordBecameValid(record);
       }
 
       didSetProperty(manager, context);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1008,7 +1008,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     invalid state and be ready to commit again.
     
     The embedded records which were sent with the request will
-    become invalid too.
+    become invalid too. If one of them is updated the record and
+    all of the embedded records will move out of the invalid state.
 
     TODO: We should probably automate the process of converting
     server names to attribute names using the existing serializer
@@ -1027,6 +1028,22 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     invalidSet.forEach(function(record) {
       record.adapterDidInvalidate({});
+    });
+  },
+
+  /**
+    This method allows the adapter to specify that an invalid record
+    became valid. The record, all of his parents and all objects embedded
+    in the parents will became Valid.
+  */
+  recordBecameValid: function(record) {
+    var validSet = new Ember.OrderedSet(),
+        adapter = this.adapterForType(record.constructor);
+
+    adapter.validRecords(validSet, record);
+
+    validSet.forEach(function(record) {
+      record.adapterDidValidate();
     });
   },
 


### PR DESCRIPTION
This is a first try to handle errors with embedded records. When talking about embedded records here, I will assume it's an `embedded: always` association.

As of now, when an _Error 422_ is returned from a commit, the record commited become _invalid_. We expect that the 422 returns a json object with an `errors` key, and from the doc :

>    The errors object must have keys that correspond to the
>    attribute names. Once each of the specified attributes have
>    changed, the record will automatically move out of the
>    invalid state and be ready to commit again.

This is great but it's not working for embedded records : they are not flagged as _invalid_, they stay _inFlight_ and never get out of this state. It avoid us to commit the record again.

What I did is ensure that all embedded records will go to the _invalid_ state and will become _uncommitted_ when needed (see below).

In case of embedded record modification, the JSON errors object returned is ignored and it will become _uncommited_ for any modification, the parent will be send to the _uncommitted_ state as well as all of his embedded records.

This could definitely be improved but it requires some works to manage the serialization of errors for embedded object. For now at least, this PR make it possible to use the 422 behavior of the `RESTAdapter` with embedded object.

If this one get a chance of merge, I will be happy to improve the code / architecture in any way and of course will write the needed tests.
