### PR TITLE
JSON serializer augments hash with null value for null belongsTo relatio...

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -105,7 +105,7 @@ DS.JSONSerializer = DS.Serializer.extend({
       hash[key] = value;
     } else {
       var id = get(record, relationship.key+'.id');
-      if (!Ember.isNone(id)) { hash[key] = id; }
+      hash[key] = id;
     }
   },
 

--- a/packages/ember-data/tests/unit/json_serializer_test.js
+++ b/packages/ember-data/tests/unit/json_serializer_test.js
@@ -151,6 +151,27 @@ test("Mapped relationships should be used when serializing a record to JSON.", f
   serializer.serialize(address);
 });
 
+test("BelongsTo relationships augment hash based on the related model when serializing to JSON", function() {
+
+  var hash = {},
+      relatedRecord = Ember.Object.createWithMixins({id: 1}),
+      record = Ember.Object.createWithMixins({relatedRecord: relatedRecord}),
+      key = 'related_record_id',
+      relationship = {key: 'relatedRecord'};
+
+
+  serializer.addBelongsTo(hash, record, key, relationship);
+  equal(hash[key], relatedRecord.get('id'));
+
+  hash = {};
+
+  record.set('relatedRecord', null);
+  serializer.addBelongsTo(hash, record, key, relationship);
+  strictEqual(hash[key], null);
+
+});
+
+
 test("mapped relationships are respected when materializing a record from JSON", function() {
   Person.relationships = { addresses: 'hasMany' };
   window.Address.relationships = { person: 'belongsTo' };

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -119,7 +119,7 @@ test("creating a person makes a POST to /people, with the data hash", function()
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ person: { name: "Tom Dale" } });
+  expectData({ person: { name: "Tom Dale", group_id: null } });
 
   ajaxHash.success({ person: { id: 1, name: "Tom Dale" } });
   expectState('saving', false);
@@ -140,7 +140,7 @@ test("singular creations can sideload data", function() {
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ person: { name: "Tom Dale" } });
+  expectData({ person: { name: "Tom Dale", group_id: null } });
 
   ajaxHash.success({
     person: { id: 1, name: "Tom Dale" },
@@ -666,7 +666,7 @@ test("creating several people (with bulkCommit) makes a POST to /people, with a 
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ people: [ { name: "Tom Dale" }, { name: "Yehuda Katz" } ] });
+  expectData({ people: [ { name: "Tom Dale", group_id: null }, { name: "Yehuda Katz", group_id: null } ] });
 
   ajaxHash.success({ people: [ { id: 1, name: "Tom Dale" }, { id: 2, name: "Yehuda Katz" } ] });
   expectStates('saving', false);
@@ -691,7 +691,7 @@ test("bulk commits can sideload data", function() {
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ people: [ { name: "Tom Dale" }, { name: "Yehuda Katz" } ] });
+  expectData({ people: [ { name: "Tom Dale", group_id: null }, { name: "Yehuda Katz", group_id: null } ] });
 
   ajaxHash.success({
     people: [ { id: 1, name: "Tom Dale" }, { id: 2, name: "Yehuda Katz" } ],
@@ -733,7 +733,7 @@ test("updating several people (with bulkCommit) makes a PUT to /people/bulk with
 
   expectUrl("/people/bulk", "the collection at the plural of the model name");
   expectType("PUT");
-  expectData({ people: [{ id: 1, name: "Brohuda Brokatz" }, { id: 2, name: "Brocarl Brolerche" }] });
+  expectData({ people: [{ id: 1, name: "Brohuda Brokatz", group_id: null }, { id: 2, name: "Brocarl Brolerche", group_id: null }] });
 
   ajaxHash.success({ people: [
     { id: 1, name: "Brohuda Brokatz" },
@@ -774,7 +774,7 @@ test("bulk updates can sideload data", function() {
 
   expectUrl("/people/bulk", "the collection at the plural of the model name");
   expectType("PUT");
-  expectData({ people: [{ id: 1, name: "Brohuda Brokatz" }, { id: 2, name: "Brocarl Brolerche" }] });
+  expectData({ people: [{ id: 1, name: "Brohuda Brokatz", group_id: null }, { id: 2, name: "Brocarl Brolerche", group_id: null }] });
 
   ajaxHash.success({
     people: [
@@ -943,7 +943,7 @@ test("data loaded from the server is converted from underscores to camelcase", f
   equal(person.get('lastName'), "Dale", "the attribute name was camelized");
 });
 
-test("When a record with a belongsTo is saved the foreign key should be sent.", function () {
+test("When a record with a belongsTo is saved the foreign key should be sent as the id or null.", function () {
   var PersonType = DS.Model.extend({
     title: DS.attr("string"),
     people: DS.hasMany(Person)
@@ -965,8 +965,8 @@ test("When a record with a belongsTo is saved the foreign key should be sent.", 
 
   expectUrl('/people');
   expectType("POST");
-  expectData({ person: { name: "Sam Woodard", person_type_id: "1" } });
-  ajaxHash.success({ person: { name: 'Sam Woodard', person_type_id: 1}});
+  expectData({ person: { name: "Sam Woodard", person_type_id: "1", group_id: null } });
+  ajaxHash.success({ person: { name: 'Sam Woodard', person_type_id: 1, group_id: null}});
 });
 
 test("creating a record with a 422 error marks the records as invalid", function(){


### PR DESCRIPTION
...nships to ensure that the value is transmitted by the adapter.

I was finding that when nulling belongsTo relationships and committing the store, that the resulting hash used in PUT requests did not contain the nulled value against the key for the relationship. This meant that the server was never aware that it needed to null the value.

This change ensures that belongsTo keys are always present with either an id or null value depending on the presence of the related model.
