### PR TITLE
Warn if an application lacks a Store property

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -335,6 +335,7 @@ var storeAlias = function(methodName) {
         args = [].slice.call(arguments);
 
     args.unshift(this);
+    Ember.assert("Your application does not have a 'Store' property defined. Attempts to call '" + methodName + "' on model classes will fail. Please provide one as with 'YourAppName.Store = DS.Store.extend()'", !!store);
     return store[methodName].apply(store, args);
   };
 };


### PR DESCRIPTION
Attempts to use model class related methods that alias
to the store currently throw
`TypeError: Cannot read property 'find' of undefined`

This commit improves the message and offers a suggested
solution.
