### PR TITLE
Notify that a default adapter type has been selected

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -234,7 +234,11 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     @property {DS.Adapter|String}
   */
-  adapter: 'DS.RESTAdapter',
+  adapter: Ember.computed(function(){
+    Ember.debug("A custom DS.Adapter was not provided as the 'Adapter' property of your application's Store. The default (DS.RESTAdapter) will be used.");
+    return 'DS.RESTAdapter';
+  }).property(),
+
 
   /**
     @private

--- a/packages/ember-data/tests/integration/transactions/basic_test.js
+++ b/packages/ember-data/tests/integration/transactions/basic_test.js
@@ -30,11 +30,11 @@ test("Stores can create a new transaction", function() {
 test("If a record is created from a transaction, it is not committed when store.commit() is called but is committed when transaction.commit() is called", function() {
   var commitCalls = 0;
 
-  store.adapter = DS.Adapter.create({
+  set(store, 'adapter', DS.Adapter.create({
     createRecords: function() {
       commitCalls++;
     }
-  });
+  }));
 
   transaction = store.transaction();
   transaction.createRecord(Person, {});
@@ -49,11 +49,11 @@ test("If a record is created from a transaction, it is not committed when store.
 test("If a record is added to a transaction then updated, it is not committed when store.commit() is called but is committed when transaction.commit() is called", function() {
   var commitCalls = 0;
 
-  store.adapter = DS.Adapter.create({
+  set(store, 'adapter', DS.Adapter.create({
     updateRecords: function() {
       commitCalls++;
     }
-  });
+  }));
 
   store.load(Person, { id: 1, name: "Yehuda Katz" });
 


### PR DESCRIPTION
This will notify that in the absence of custom adapter a default has been selected.

_NOTE:_ This PR assume latest Ember with Ember.debug available, so maybe don't accept yet.
