### PR TITLE
RESTAdapter : Convert errors object returned with a 422 in an Ember Object

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -308,7 +308,7 @@ DS.RESTAdapter = DS.Adapter.extend({
   didError: function(store, type, record, xhr) {
     if (xhr.status === 422) {
       var data = JSON.parse(xhr.responseText);
-      store.recordWasInvalid(record, data['errors']);
+      store.recordWasInvalid(record, Ember.Object.create(data['errors']));
     } else {
       this._super.apply(this, arguments);
     }

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -973,15 +973,16 @@ test("creating a record with a 422 error marks the records as invalid", function
   person = store.createRecord(Person, { name: "" });
   store.commit();
 
+  var errors = { name: ["can't be blank"]};
+
   var mockXHR = {
     status:       422,
-    responseText: JSON.stringify({ errors: { name: ["can't be blank"]} })
+    responseText: JSON.stringify({ errors: errors })
   };
-
   ajaxHash.error.call(ajaxHash.context, mockXHR);
 
   expectState('valid', false);
-  deepEqual(person.get('errors'), { name: ["can't be blank"]}, "the person has the errors");
+  deepEqual(person.get('errors'), Ember.Object.create(errors), "the person has the errors");
 });
 
 test("updating a record with a 422 error marks the records as invalid", function(){
@@ -990,15 +991,17 @@ test("updating a record with a 422 error marks the records as invalid", function
   person.set('name', '');
   store.commit();
 
+  var errors = { name: ["can't be blank"]};
+
   var mockXHR = {
     status:       422,
-    responseText: JSON.stringify({ errors: { name: ["can't be blank"]} })
+    responseText: JSON.stringify({ errors: errors })
   };
 
   ajaxHash.error.call(ajaxHash.context, mockXHR);
 
   expectState('valid', false);
-  deepEqual(person.get('errors'), { name: ["can't be blank"]}, "the person has the errors");
+  deepEqual(person.get('errors'), Ember.Object.create(errors), "the person has the errors");
 });
 
 test("creating a record with a 500 error marks the record as error", function() {


### PR DESCRIPTION
Without this, after an error 422, the errors on the record are not an Ember Object. I believe the wanted behavior is to convert it to an Ember Object as [it](https://github.com/emberjs/data/blob/master/packages/ember-data/lib/system/model/states.js#L396) [is](https://github.com/emberjs/data/blob/master/packages/ember-data/tests/integration/store_adapter_test.js#L291) use like one.

I would love any feedback on this if it is not relevant.
