### PR TITLE
Added support for polymorphic associations.

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -2,6 +2,7 @@ require('ember-data/system/serializer');
 require('ember-data/transforms/json_transforms');
 
 var get = Ember.get, set = Ember.set;
+var map = Ember.EnumerableUtils.map;
 
 var generatedId = 0;
 
@@ -83,7 +84,30 @@ DS.JSONSerializer = DS.Serializer.extend({
     }
   },
 
+  /**
+    Returns an array of id-type tuples based on the payload
+
+    @return {Array}
+  */
   extractHasMany: function(type, hash, key) {
+    var ids = hash[key];
+    if(!ids) {
+      return ids;
+    }
+
+    var hasManyType = type.typeForRelationship(key);
+
+    return map(ids, function(id) {
+      return {id: id, type: hasManyType};
+    });
+  },
+
+  /**
+    Returns an array of id-type tuples based on the payload
+
+    @return {Array}
+  */
+  extractHasManyPolymorphic: function(type, hash, key) {
     return hash[key];
   },
 

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -193,8 +193,14 @@ DS.Model = Ember.Object.extend(Ember.Evented, LoadPromise, {
       var ids = this._data.hasMany[key] || [];
 
       var references = map(ids, function(id) {
-        // if it was already a reference, return the reference
-        if (typeof id === 'object') { return id; }
+        if (typeof id === 'object') {
+          if( id.clientId ) {
+            // if it was already a reference, return the reference
+            return id;
+          } else {
+            return store.referenceForId(id.type, id.id);
+          }
+        }
         return store.referenceForId(type, id);
       });
 

--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -47,6 +47,15 @@ DS.ManyArray = DS.RecordArray.extend({
   */
   owner: null,
 
+  /**
+    @private
+
+    `true` if the relationship is polymorphic, `false` otherwise.
+
+    @property {Boolean}
+  */
+  isPolymorphic: false,
+
   // LOADING STATE
 
   isLoaded: false,
@@ -66,17 +75,16 @@ DS.ManyArray = DS.RecordArray.extend({
   fetch: function() {
     var references = get(this, 'content'),
         store = get(this, 'store'),
-        type = get(this, 'type'),
         owner = get(this, 'owner');
 
-    store.fetchUnloadedReferences(type, references, owner);
+    store.fetchUnloadedReferences(references, owner);
   },
 
   // Overrides Ember.Array's replace method to implement
   replaceContent: function(index, removed, added) {
     // Map the array of record objects into an array of  client ids.
     added = added.map(function(record) {
-      Ember.assert("You can only add records of " + (get(this, 'type') && get(this, 'type').toString()) + " to this relationship.", !get(this, 'type') || (get(this, 'type') === record.constructor));
+      Ember.assert("You can only add records of " + (get(this, 'type') && get(this, 'type').toString()) + " to this relationship.", !get(this, 'type') || (get(this, 'type').detectInstance(record)) );
       return get(record, '_reference');
     }, this);
 
@@ -163,6 +171,8 @@ DS.ManyArray = DS.RecordArray.extend({
         store = get(owner, 'store'),
         type = get(this, 'type'),
         record;
+
+    Ember.assert("You can not create records of " + (get(this, 'type') && get(this, 'type').toString()) + " on this polymorphic relationship.", !get(this, 'isPolymorphic'));
 
     transaction = transaction || get(owner, 'transaction');
 

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -329,6 +329,9 @@ DS._inverseRelationshipFor = function(modelType, inverseModelType) {
 
   if (!possibleRelationships) { return; }
   if (possibleRelationships.length > 1) { return; }
+  if (possibleRelationships.length === 0 && inverseModelType.superclass) {
+    return DS._inverseRelationshipFor(modelType, inverseModelType.superclass);
+  }
   return possibleRelationships[0];
 };
 

--- a/packages/ember-data/lib/system/relationships/has_many.js
+++ b/packages/ember-data/lib/system/relationships/has_many.js
@@ -2,6 +2,8 @@ var get = Ember.get, set = Ember.set;
 
 require("ember-data/system/model/model");
 
+var map = Ember.EnumerableUtils.map;
+
 var hasRelationship = function(type, options) {
   options = options || {};
 
@@ -10,16 +12,32 @@ var hasRelationship = function(type, options) {
   return Ember.computed(function(key, value) {
     var data = get(this, 'data').hasMany,
         store = get(this, 'store'),
-        ids, relationship;
+        ids, relationship, references;
 
     if (typeof type === 'string') {
       type = get(this, type, false) || get(Ember.lookup, type);
     }
 
-    ids = data[key];
-    relationship = store.findMany(type, ids || [], this, meta);
+    ids = data[key] || [];
+
+    if (Ember.isArray(ids)) {
+      // Coerce id-type tuples into Record Reference
+      references = map(ids, function(id) {
+        if (typeof id === 'object' && !id.clientId) {
+          return store.referenceForId(id.type, id.id);
+        }
+
+        return id;
+      }, this);
+    } else {
+      // custom, opaque token (e.g. `{url: '/relationship'}`) that will be passed to the adapter
+      references = ids;
+    }
+
+    relationship = store.findMany(type, references, this, meta);
     set(relationship, 'owner', this);
     set(relationship, 'name', key);
+    set(relationship, 'isPolymorphic', options.polymorphic);
 
     return relationship;
   }).property().meta(meta);

--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -681,8 +681,15 @@ DS.Serializer = Ember.Object.extend({
   },
 
   materializeHasMany: function(name, record, hash, relationship) {
-    var key = this._keyForHasMany(record.constructor, relationship.key);
-    record.materializeHasMany(name, this.extractHasMany(record.constructor, hash, key));
+    var key = this._keyForHasMany(record.constructor, relationship.key),
+        ids;
+    if(relationship.options && relationship.options.polymorphic) {
+      ids = this.extractHasManyPolymorphic(record.constructor, hash, key);
+    } else {
+      ids = this.extractHasMany(record.constructor, hash, key);
+    }
+
+    record.materializeHasMany(name, ids);
   },
 
   materializeBelongsTo: function(name, record, hash, relationship) {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -557,13 +557,13 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
   /**
     @private
 
-    Given a type and array of `clientId`s, determines which of those
+    Given an array of `reference`s, determines which of those
     `clientId`s has not yet been loaded.
 
     In preparation for loading, this method also marks any unloaded
     `clientId`s as loading.
   */
-  neededReferences: function(type, references) {
+  neededReferences: function(references) {
     var neededReferences = [],
         cidToData = this.clientIdToData,
         reference;
@@ -586,36 +586,46 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     This method is the entry point that relationships use to update
     themselves when their underlying data changes.
 
-    First, it determines which of its `clientId`s are still unloaded,
-    then converts the needed `clientId`s to IDs and invokes `findMany`
-    on the adapter.
+    First, it determines which of its `reference`s are still unloaded,
+    then invokes `findMany` on the adapter.
   */
-  fetchUnloadedReferences: function(type, references, owner) {
-    var neededReferences = this.neededReferences(type, references);
-    this.fetchMany(type, neededReferences, owner);
+  fetchUnloadedReferences: function(references, owner) {
+    var neededReferences = this.neededReferences(references);
+    this.fetchMany(neededReferences, owner);
   },
 
   /**
     @private
 
-    This method takes a type and list of `clientId`s, converts the
-    `clientId`s into IDs, and then invokes the adapter's `findMany`
+    This method takes a list of `reference`s, group the `reference`s by type,
+    converts the `reference`s into IDs, and then invokes the adapter's `findMany`
     method.
+    The `reference`s are grouped by type to invoke `findMany` on adapters
+    for each unique type in `reference`s.
 
     It is used both by a brand new relationship (via the `findMany`
     method) or when the data underlying an existing relationship
     changes (via the `fetchUnloadedReferences` method).
   */
-  fetchMany: function(type, references, owner) {
+  fetchMany: function(references, owner) {
     if (!references.length) { return; }
 
-    var ids = map(references, function(reference) {
-      return reference.id;
+    // Group By Type
+    var referencesByTypeMap = Ember.MapWithDefault.create({
+      defaultValue: function() { return Ember.A(); }
+    });
+    forEach(references, function(reference) {
+      referencesByTypeMap.get(reference.type).push(reference);
     });
 
-    var adapter = this.adapterForType(type);
-    if (adapter && adapter.findMany) { adapter.findMany(this, type, ids, owner); }
-    else { throw "Adapter is either null or does not implement `findMany` method"; }
+    forEach(referencesByTypeMap, function(type) {
+      var references = referencesByTypeMap.get(type),
+          ids = map(references, function(reference) { return reference.id; });
+
+      var adapter = this.adapterForType(type);
+      if (adapter && adapter.findMany) { adapter.findMany(this, type, ids, owner); }
+      else { throw "Adapter is either null or does not implement `findMany` method"; }
+    }, this);
   },
 
   referenceForId: function(type, id) {
@@ -663,26 +673,25 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     * ask the adapter to load the unloaded elements, by invoking
       findMany with the still-unloaded IDs.
   */
-  findMany: function(type, ids, record, relationship) {
-    // 1. Convert ids to client ids
-    // 2. Determine which of the client ids need to be loaded
-    // 3. Create a new ManyArray whose content is ALL of the clientIds
-    // 4. Decrement the ManyArray's counter by the number of loaded clientIds
-    // 5. Put the ManyArray into our bookkeeping data structure, keyed on
+  findMany: function(type, idsOrReferences, record, relationship) {
+    // 1. Determine which of the client ids need to be loaded
+    // 2. Create a new ManyArray whose content is ALL of the clientIds
+    // 3. Decrement the ManyArray's counter by the number of loaded clientIds
+    // 4. Put the ManyArray into our bookkeeping data structure, keyed on
     //    the needed clientIds
-    // 6. Ask the adapter to load the records for the unloaded clientIds (but
+    // 5. Ask the adapter to load the records for the unloaded clientIds (but
     //    convert them back to ids)
 
-    if (!Ember.isArray(ids)) {
+    if (!Ember.isArray(idsOrReferences)) {
       var adapter = this.adapterForType(type);
-      if (adapter && adapter.findHasMany) { adapter.findHasMany(this, record, relationship, ids); }
+      if (adapter && adapter.findHasMany) { adapter.findHasMany(this, record, relationship, idsOrReferences); }
       else { throw fmt("Adapter is either null or does not implement `findHasMany` method", this); }
 
       return this.createManyArray(type, Ember.A());
     }
 
     // Coerce server IDs into Record Reference
-    var references = map(ids, function(reference) {
+    var references = map(idsOrReferences, function(reference) {
       if (typeof reference !== 'object' && reference !== null) {
         return this.referenceForId(type, reference);
       }
@@ -690,7 +699,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
       return reference;
     }, this);
 
-    var neededReferences = this.neededReferences(type, references),
+    var neededReferences = this.neededReferences(references),
         manyArray = this.createManyArray(type, Ember.A(references)),
         loadingRecordArrays = this.loadingRecordArrays,
         reference, clientId, i, l;
@@ -715,7 +724,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
         }
       }
 
-      this.fetchMany(type, neededReferences, record);
+      this.fetchMany(neededReferences, record);
     } else {
       // all requested records are available
       manyArray.set('isLoaded', true);

--- a/packages/ember-data/tests/integration/find_test.js
+++ b/packages/ember-data/tests/integration/find_test.js
@@ -45,17 +45,6 @@ test("When a record is requested but has not yet been loaded, its `id` property 
   equal(get(record, 'id'), 1, "should report its id while loading");
 });
 
-test("When multiple records are requested, the adapter's `findMany` method should be called.", function() {
-  expect(1);
-
-  adapter.findMany = function(store, type, ids) {
-    deepEqual(ids, ['1','2','3'], "ids are passed");
-  };
-
-  store.findMany(Person, [1,2,3]);
-  store.findMany(Person, [1,2,3]);
-});
-
 test("When multiple records are requested, the default adapter should call the `find` method once per record if findMany is not implemented", function() {
   expect(3);
 
@@ -68,15 +57,4 @@ test("When multiple records are requested, the default adapter should call the `
 
   store.findMany(Person, [1,2,3]);
   store.findMany(Person, [1,2,3]);
-});
-
-test("When multiple records are requested, the store should not call findMany on the adapter if all the requested records are already loaded.", function() {
-  expect(0);
-
-  adapter.find = function(store, type, id) {
-    ok(false, "This should not be called");
-  };
-
-  store.load(Person, { id: 1 });
-  store.findMany(Person, [ 1 ]);
 });

--- a/packages/ember-data/tests/integration/has_many_test.js
+++ b/packages/ember-data/tests/integration/has_many_test.js
@@ -14,17 +14,30 @@ module("Has-Many Relationships", {
       name: 'App'
     });
 
-    App.Post = DS.Model.extend({
+    App.User = DS.Model.extend({
+      name: DS.attr('string')
+    });
+
+    App.Message = DS.Model.extend({
+      user: DS.belongsTo(App.User),
+      created_at: DS.attr('date')
+    });
+
+    App.Post = App.Message.extend({
       title: DS.attr('string')
     });
 
-    App.Comment = DS.Model.extend({
+    App.Comment = App.Message.extend({
       body: DS.attr('string'),
       post: DS.belongsTo(App.Post)
     });
 
     App.Post.reopen({
       comments: DS.hasMany(App.Comment)
+    });
+
+    App.User.reopen({
+      messages: DS.hasMany(App.Message, {polymorphic: true})
     });
   },
 
@@ -78,15 +91,13 @@ test("When a hasMany relationship is accessed, the adapter's findMany method sho
   var post = store.find(App.Post, 1);
 
   post.get('comments');
-
-  store.load(App.Post, { id: 1, comments: [ 1 ] });
 });
 
 // This tests the case where a serializer materializes a has-many
 // relationship as a reference that it can fetch lazily. The most
 // common use case of this is to provide a URL to a collection that
 // is loaded later.
-asyncTest("An serializer can materialize a hasMany as an opaque token that can be lazily fetched via the adapter's findHasMany hook", function() {
+asyncTest("A serializer can materialize a hasMany as an opaque token that can be lazily fetched via the adapter's findHasMany hook", function() {
   expect(8);
 
   // When a payload comes in from the server, replace the string
@@ -151,4 +162,125 @@ asyncTest("An serializer can materialize a hasMany as an opaque token that can b
     equal(comments.get('isLoaded'), true);
     equal(comments.get('length'), 2);
   }
+});
+
+test("When a polymorphic hasMany relationship is accessed, the adapter's findMany method should not be called if all the records in the relationship are already loaded", function() {
+  expect(4);
+
+  adapter.findMany = function() {
+    ok(false, "The adapter's find method should not be called");
+  };
+
+  serializer.extractHasManyPolymorphic = function( type, hash, key) {
+    equal(type, App.User, "We work on the user");
+    equal(key, "messages", "We load the messages polymorphic association");
+    deepEqual(hash[key], [{id: 1, type: "post"}, {id: 3, type: 'comment'}], "We load the two messages");
+    return [{id: 1, type: App.Post}, {id: 3, type: App.Comment}];
+  };
+
+  store.load(App.User, { id: 1, messages: [ {id: 1, type: 'post'}, {id: 3, type: 'comment'} ] });
+  store.load(App.Post, { id: 1 });
+  store.load(App.Comment, { id: 3 });
+
+  var user = store.find(App.User, 1);
+
+  var messages = user.get('messages');
+
+  equal(messages.get('length'), 2, "The messages are correctly loaded");
+});
+
+test("When a polymorphic hasMany relationship is accessed, the store can call multiple adapters' findMany method if the records are not loaded", function() {
+  expect(6);
+
+  adapter.findMany = function() {
+    ok(true, "The adapter's find method should be called");
+  };
+
+  serializer.extractHasManyPolymorphic = function( type, hash, key) {
+    equal(type, App.User, "We work on the user");
+    equal(key, "messages", "We load the messages polymorphic association");
+    deepEqual(hash[key], [{id: 1, type: "post"}, {id: 3, type: 'comment'}], "We load the two messages");
+    return [{id: 1, type: App.Post}, {id: 3, type: App.Comment}];
+  };
+
+  store.load(App.User, { id: 1, messages: [ {id: 1, type: 'post'}, {id: 3, type: 'comment'} ] });
+
+  var user = store.find(App.User, 1);
+
+  var messages = user.get('messages');
+
+  equal(messages.get('length'), 2, "The messages are correctly loaded");
+});
+
+test("A record can't be created from a polymorphic hasMany relationship", function() {
+  expect(1);
+  store.load(App.User, { id: 1, messages: [] });
+  var user = store.find(App.User, 1),
+      messages = user.get('messages');
+
+  raises(
+    function() { messages.createRecord(); },
+    /You can not create records of App.Message on this polymorphic relationship/,
+    "Creating records directly on a polymorphic hasMany is disallowed"
+  );
+});
+
+test("Only records of the same type can be added to a monomorphic hasMany relationship", function() {
+  expect(1);
+  store.load(App.Post, { id: 1 });
+  store.load(App.Post, { id: 2 });
+  var post = store.find(App.Post, 1),
+      message = store.find(App.Post, 2);
+
+  raises(
+    function() { post.get('comments').pushObject(message); },
+    /You can only add records of App.Comment to this relationship/,
+    "Adding records of a different type on a monomorphic hasMany is disallowed"
+  );
+});
+
+test("Only records of the same base type can be added to a polymorphic hasMany relationship", function() {
+  expect(2);
+  store.load(App.User, { id: 1 });
+  store.load(App.User, { id: 2 });
+  store.load(App.Post, { id: 1 });
+  store.load(App.Comment, { id: 3 });
+
+  var user = store.find(App.User, 1),
+      anotherUser = store.find(App.User, 2),
+      messages = user.get('messages'),
+      post = store.find(App.Post, 1),
+      comment = store.find(App.Comment, 3);
+
+  messages.pushObject(post);
+  messages.pushObject(comment);
+
+  equal(messages.get('length'), 2, "The messages are correctly added");
+
+  raises(
+    function() { messages.pushObject(anotherUser); },
+    /You can only add records of App.Message to this relationship/,
+    "Adding records of a different base type on a polymorphic hasMany is disallowed"
+  );
+});
+
+test("A record can be removed from a polymorphic association", function() {
+  expect(4);
+
+  serializer.extractHasManyPolymorphic = function( type, hash, key) {
+    equal(type, App.User, "We work on the user");
+    equal(key, "messages", "We load the messages polymorphic association");
+    deepEqual(hash[key], [{id: 3, type: 'comment'}], "We load the message");
+    return [{id: 3, type: App.Comment}];
+  };
+
+  store.load(App.User, { id: 1 , messages: [{id: 3, type: 'comment'}]});
+  store.load(App.Comment, { id: 3 });
+
+  var user = store.find(App.User, 1),
+      comment = store.find(App.Comment, 3),
+      messages = user.get('messages'),
+      removedObject = messages.popObject();
+
+  equal(removedObject, comment, "The message is correctly removed");
 });

--- a/packages/ember-data/tests/integration/inverse_relationships_test.js
+++ b/packages/ember-data/tests/integration/inverse_relationships_test.js
@@ -1,4 +1,4 @@
-var Post, Comment, store;
+var Post, Comment, Message, User, store;
 
 module('Inverse Relationships', {
   setup: function() {
@@ -89,4 +89,83 @@ test("When a record's belongsTo relationship is set, it can specify the inverse 
   equal(post.get('meComments.length'), 0, "meComments has no posts");
   equal(post.get('youComments.length'), 1, "youComments had the post added");
   equal(post.get('everyoneWeKnowComments.length'), 0, "everyoneWeKnowComments has no posts");
+});
+
+test("When a record is added to or removed from a polymorphic has-many relationship, the inverse belongsTo can be set explicitly", function() {
+  User = DS.Model.extend();
+
+  Message = DS.Model.extend({
+    oneUser: DS.belongsTo(User),
+    twoUser: DS.belongsTo(User),
+    redUser: DS.belongsTo(User),
+    blueUser: DS.belongsTo(User)
+  });
+
+  Post = Message.extend();
+
+  User.reopen({
+    messages: DS.hasMany(Message, {
+      inverse: 'redUser',
+      polymorphic: true
+    })
+  });
+
+  var post = store.createRecord(Post);
+  var user = store.createRecord(User);
+
+  equal(post.get('oneUser'), null, "oneUser has not been set on the user");
+  equal(post.get('twoUser'), null, "twoUser has not been set on the user");
+  equal(post.get('redUser'), null, "redUser has not been set on the user");
+  equal(post.get('blueUser'), null, "blueUser has not been set on the user");
+
+  user.get('messages').pushObject(post);
+
+  equal(post.get('oneUser'), null, "oneUser has not been set on the user");
+  equal(post.get('twoUser'), null, "twoUser has not been set on the user");
+  equal(post.get('redUser'), user, "redUser has been set on the user");
+  equal(post.get('blueUser'), null, "blueUser has not been set on the user");
+
+  user.get('messages').popObject();
+
+  equal(post.get('oneUser'), null, "oneUser has not been set on the user");
+  equal(post.get('twoUser'), null, "twoUser has not been set on the user");
+  equal(post.get('redUser'), null, "redUser has bot been set on the user");
+  equal(post.get('blueUser'), null, "blueUser has not been set on the user");
+});
+
+test("When a record's belongsTo relationship is set, it can specify the inverse polymorphic hasMany to which the new child should be added or removed", function() {
+  User = DS.Model.extend();
+
+  Message = DS.Model.extend({
+    user: DS.belongsTo(User, {
+      inverse: 'youMessages'
+    })
+  });
+
+  Post = Message.extend();
+
+  User.reopen({
+    meMessages: DS.hasMany(Message, { polymorphic: true }),
+    youMessages: DS.hasMany(Message, { polymorphic: true }),
+    everyoneWeKnowMessages: DS.hasMany(Message, { polymorphic: true }),
+  });
+
+  var user = store.createRecord(User);
+  var post = store.createRecord(Post);
+
+  equal(user.get('meMessages.length'), 0, "meMessages has no posts");
+  equal(user.get('youMessages.length'), 0, "youMessages has no posts");
+  equal(user.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
+
+  post.set('user', user);
+
+  equal(user.get('meMessages.length'), 0, "meMessages has no posts");
+  equal(user.get('youMessages.length'), 1, "youMessages had the post added");
+  equal(user.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
+
+  post.set('user', null);
+
+  equal(user.get('meMessages.length'), 0, "meMessages has no posts");
+  equal(user.get('youMessages.length'), 0, "youMessages has no posts");
+  equal(user.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
 });

--- a/packages/ember-data/tests/unit/json_serializer_test.js
+++ b/packages/ember-data/tests/unit/json_serializer_test.js
@@ -1,3 +1,5 @@
+var map = Ember.EnumerableUtils.map;
+
 var MockModel = Ember.Object.extend({
   init: function() {
     this.materializedAttributes = {};
@@ -153,6 +155,11 @@ test("Mapped relationships should be used when serializing a record to JSON.", f
 
 test("mapped relationships are respected when materializing a record from JSON", function() {
   Person.relationships = { addresses: 'hasMany' };
+  Person.reopenClass({
+    typeForRelationship: function( name ) {
+      return window.Address;
+    }
+  });
   window.Address.relationships = { person: 'belongsTo' };
 
   serializer.map(Person, {
@@ -175,7 +182,7 @@ test("mapped relationships are respected when materializing a record from JSON",
   });
 
   deepEqual(person.hasMany, {
-    addresses: [ 1, 2, 3 ]
+    addresses: map([ 1, 2, 3 ], function(id) { return {id: id, type: window.Address};})
   });
 
   deepEqual(address.belongsTo, {


### PR DESCRIPTION
``` javascript
App.User = DS.Model.extend({
 messages: DS.hasMany(App.Message, {polymorphic: true})
});

App.Message = DS.Model.extend({
  created_at: DS.attr('date'),
  user: DS.belongsTo(App.User)
});

App.Post = App.Message.extend({
  title: DS.attr('string')
});

App.Comment = App.Message.extend({
  body: DS.attr('string'),
  post: DS.belongsTo(App.Post)
});
```
- You can add support for embedded polymorphic associations by overriding`addHasMany` of the serializer.
- `BaseClass.find()` isn't supported yet and can be the subject of another PR.
