### PR TITLE
Update Readme Unit Test section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,36 @@ Currently you must build ember-data.js yourself.  Clone the repository, run `bun
   [`active_model_serializers`](https://github.com/rails-api/active_model_serializers) gem's conventions.
 * Handle partially-loaded records
 
-## Unit Tests
+## How to Run Unit Tests
 
-To run unit tests, run `bundle exec rackup` from the root directory and visit
-`http://localhost:9292/tests/index.html?package=ember-data`.
+### Setup
+
+1. Install Ruby 1.9.2+. There are many resources on the web can help; one of the best is [rvm](https://rvm.io/).
+
+2. Install Bundler: `gem install bundler`
+
+3. Run `bundle` inside the project root to install the gem dependencies.
+
+### In Your Browser
+
+1. To start the development server, run `rackup`.
+
+2. Then visit: `http://localhost:9292/?package=PACKAGE_NAME`.  Replace `PACKAGE_NAME` with the name of the package you want to run.  For example:
+
+  * [Ember.js Data](http://localhost:9292/?package=ember-data)
+
+To run multiple packages, you can separate them with commas. You can run all the tests using the `all` package:
+
+<http://localhost:9292/?package=all>
+
+You can also pass `jquery=VERSION` in the test URL to test different versions of jQuery. Default is 1.9.0.
+
+### From the CLI
+
+1. Install phantomjs from http://phantomjs.org
+
+2. Run `rake test` to run a basic test suite or run `rake test[all]` to
+   run a more comprehensive suite.
+
+3. (Mac OS X Only) Run `rake autotest` to automatically re-run tests
+   when any files are changed.


### PR DESCRIPTION
1. Corrected test URL from `http://localhost:9292/tests/index.html?package=ember-data` to `http://localhost:9292/?package=ember-data`.
2. Added setup procedure and CLI instructions based on the readme for Ember.
