### PR TITLE
Implement extractHasMany and extractBelongsTo on FixtureAdapter

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -4,6 +4,16 @@ require('ember-data/serializers/fixture_serializer');
 
 var get = Ember.get;
 
+/**
+  `DS.FixtureAdapter` is an adapter that loads records from memory.
+  Its primarily used for development and testing. You can also use
+  `DS.FixtureAdapter` while working on the API but are not ready to
+  integrate yet. It is a fully functioning adapter. All CRUD methods
+  are implemented. You can also implement query logic that a remote
+  system would do. Its possible to do develop your entire application
+  with `DS.FixtureAdapter`.
+
+*/
 DS.FixtureAdapter = DS.Adapter.extend({
 
   simulateRemoteResponse: true,

--- a/packages/ember-data/lib/serializers/fixture_serializer.js
+++ b/packages/ember-data/lib/serializers/fixture_serializer.js
@@ -3,24 +3,6 @@ require('ember-data/system/serializer');
 var get = Ember.get, set = Ember.set;
 
 DS.FixtureSerializer = DS.Serializer.extend({
-  extract: function(loader, fixture, type, record) {
-    if (record) { loader.updateId(record, fixture); }
-    this.extractRecordRepresentation(loader, type, fixture);
-  },
-
-  extractMany: function(loader, fixtures, type, records) {
-    var objects = fixtures, references = [];
-    if (records) { records = records.toArray(); }
-
-    for (var i = 0; i < objects.length; i++) {
-      if (records) { loader.updateId(records[i], objects[i]); }
-      var reference = this.extractRecordRepresentation(loader, type, objects[i]);
-      references.push(reference);
-    }
-
-    loader.populateArray(references);
-  },
-
   deserializeValue: function(value, attributeType) {
     return value;
   },
@@ -41,9 +23,22 @@ DS.FixtureSerializer = DS.Serializer.extend({
     return {};
   },
 
-  extractAttribute: function(type, hash, attributeName) {
-    var key = this._keyForAttributeName(type, attributeName);
-    return hash[key];
+  extract: function(loader, fixture, type, record) {
+    if (record) { loader.updateId(record, fixture); }
+    this.extractRecordRepresentation(loader, type, fixture);
+  },
+
+  extractMany: function(loader, fixtures, type, records) {
+    var objects = fixtures, references = [];
+    if (records) { records = records.toArray(); }
+
+    for (var i = 0; i < objects.length; i++) {
+      if (records) { loader.updateId(records[i], objects[i]); }
+      var reference = this.extractRecordRepresentation(loader, type, objects[i]);
+      references.push(reference);
+    }
+
+    loader.populateArray(references);
   },
 
   extractId: function(type, hash) {
@@ -58,5 +53,18 @@ DS.FixtureSerializer = DS.Serializer.extend({
     } else {
       return null;
     }
+  },
+
+  extractAttribute: function(type, hash, attributeName) {
+    var key = this._keyForAttributeName(type, attributeName);
+    return hash[key];
+  },
+
+  extractHasMany: function(type, hash, key) {
+    return hash[key];
+  },
+
+  extractBelongsTo: function(type, hash, key) {
+    return hash[key];
   }
 });

--- a/packages/ember-data/tests/unit/fixture_adapter_test.js
+++ b/packages/ember-data/tests/unit/fixture_adapter_test.js
@@ -1,5 +1,5 @@
 var get = Ember.get, set = Ember.set;
-var store, Person;
+var store, Person, Phone, App;
 
 module("DS.FixtureAdapter", {
   setup: function() {
@@ -11,15 +11,28 @@ module("DS.FixtureAdapter", {
       firstName: DS.attr('string'),
       lastName: DS.attr('string'),
 
-      height: DS.attr('number')
+      height: DS.attr('number'),
+
+      phones: DS.hasMany('App.Phone')
     });
+
+    Phone = DS.Model.extend({
+      person: DS.belongsTo('App.Person')
+    });
+
+    App = Ember.Namespace.create();
+    App.Person = Person;
+    App.Phone = Phone;
+    Ember.lookup.App = App;
   },
   teardown: function() {
     Ember.run(function() {
       store.destroy();
+      App.destroy();
     });
     store = null;
     Person = null;
+    Phone = null;
   }
 });
 
@@ -37,7 +50,16 @@ test("should load data for a type asynchronously when it is requested", function
     firstName: "Erik",
     lastName: "Brynjolffsosysdfon",
 
-    height: 70
+    height: 70,
+    phones: [1, 2]
+  }];
+
+  Phone.FIXTURES = [{
+    id: 1,
+    person: 'ebryn'
+  }, {
+    id: 2,
+    person: 'ebryn'
   }];
 
   stop();
@@ -52,6 +74,7 @@ test("should load data for a type asynchronously when it is requested", function
 
     ok(get(ebryn, 'isLoaded'), "data loads asynchronously");
     equal(get(ebryn, 'height'), 70, "data from fixtures is loaded correctly");
+    equal(get(ebryn, 'phones.length'), 2, "relationships from fixtures is loaded correctly");
 
     stop();
 


### PR DESCRIPTION
Enable fixtures to load relationships. It was omitted in 96de4d5b88d1156ee9ee743dad39b2be5b1da90e. This PR add a test and fix it.

I made another PR to enforce more methods on the serializer (#717) in order to prevent this kind of problems in the future
