### PR TITLE
Add date shim to fix cross browser issues with parsing ISO-8601 dates

### DIFF
--- a/packages/ember-data/lib/ext.js
+++ b/packages/ember-data/lib/ext.js
@@ -1,0 +1,1 @@
+require('ember-data/ext/date');

--- a/packages/ember-data/lib/ext/date.js
+++ b/packages/ember-data/lib/ext/date.js
@@ -1,0 +1,46 @@
+/**
+ * Date.parse with progressive enhancement for ISO 8601 <https://github.com/csnover/js-iso8601>
+ * © 2011 Colin Snover <http://zetafleet.com>
+ * Released under MIT license.
+ */
+
+Ember.Date = Ember.Date || {};
+
+var origParse = Date.parse, numericKeys = [ 1, 4, 5, 6, 7, 10, 11 ];
+Ember.Date.parse = function (date) {
+    var timestamp, struct, minutesOffset = 0;
+
+    // ES5 §15.9.4.2 states that the string should attempt to be parsed as a Date Time String Format string
+    // before falling back to any implementation-specific date parsing, so that’s what we do, even if native
+    // implementations could be faster
+    //              1 YYYY                2 MM       3 DD           4 HH    5 mm       6 ss        7 msec        8 Z 9 ±    10 tzHH    11 tzmm
+    if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/.exec(date))) {
+        // avoid NaN timestamps caused by “undefined” values being passed to Date.UTC
+        for (var i = 0, k; (k = numericKeys[i]); ++i) {
+            struct[k] = +struct[k] || 0;
+        }
+
+        // allow undefined days and months
+        struct[2] = (+struct[2] || 1) - 1;
+        struct[3] = +struct[3] || 1;
+
+        if (struct[8] !== 'Z' && struct[9] !== undefined) {
+            minutesOffset = struct[10] * 60 + struct[11];
+
+            if (struct[9] === '+') {
+                minutesOffset = 0 - minutesOffset;
+            }
+        }
+
+        timestamp = Date.UTC(struct[1], struct[2], struct[3], struct[4], struct[5] + minutesOffset, struct[6], struct[7]);
+    }
+    else {
+        timestamp = origParse ? origParse(date) : NaN;
+    }
+
+    return timestamp;
+};
+
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Date) {
+  Date.parse = Ember.Date.parse;
+}

--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -19,6 +19,7 @@
 //SOFTWARE.
 
 require("ember-data/core");
+require("ember-data/ext");
 require("ember-data/system/store");
 require("ember-data/system/record_arrays");
 require("ember-data/system/model");

--- a/packages/ember-data/lib/transforms/json_transforms.js
+++ b/packages/ember-data/lib/transforms/json_transforms.js
@@ -51,20 +51,10 @@ DS.JSONTransforms = {
       var type = typeof serialized;
       var date = null;
 
-      if (type === "string" || type === "number") {
-        // this is a fix for Safari 5.1.5 on Mac which does not accept timestamps as yyyy-mm-dd
-        if (type === "string" && serialized.search(/^\d{4}-\d{2}-\d{2}$/) !== -1) {
-          serialized += "T00:00:00Z";
-        }
-
-        date = new Date(serialized);
-
-        // this is a fix for IE8 which does not accept timestamps in ISO 8601 format
-        if (type === "string" && isNaN(date)) {
-          date = new Date(Date.parse(serialized.replace(/\-/ig, '/').replace(/Z$/, '').split('.')[0]));
-        }
-
-        return date;
+      if (type === "string") {
+        return new Date(Ember.Date.parse(serialized));
+      } else if (type === "number") {
+        return new Date(serialized);
       } else if (serialized === null || serialized === undefined) {
         // if the value is not present in the data,
         // return undefined, not null.

--- a/packages/ember-data/tests/integration/transform_test.js
+++ b/packages/ember-data/tests/integration/transform_test.js
@@ -117,6 +117,18 @@ test("the default date transform", function() {
   equal(person2.get('born').toString(), date2.toString(), "date.toString and transformed date.toString values match");
 });
 
+test("the date transform parses iso8601 dates", function() {
+  var expectDate = function(string, timestamp, message) {
+    equal(Ember.Date.parse(string), timestamp, message);
+  };
+
+  expectDate('2011-11-29T15:52:18.867', 1322581938867, "YYYY-MM-DDTHH:mm:ss.sss");
+  expectDate('2011-11-29T15:52:18.867Z', 1322581938867, "YYYY-MM-DDTHH:mm:ss.sssZ");
+  expectDate('2011-11-29T15:52:18.867-03:30', 1322594538867, "YYYY-MM-DDTHH:mm:ss.sss-HH:mm");
+  expectDate('2011-11-29', 1322524800000, "YYYY-MM-DD");
+  expectDate('2011-11', 1320105600000, "YYYY-MM");
+  expectDate('2011', 1293840000000, "YYYY");
+});
 
 module("Enum Transforms", {
   setup: function() {


### PR DESCRIPTION
It turns out that my fix for #538 doesn't correctly handle timezones in dates. This fixes that behavior by overriding Date.parse with a custom implementation taken from: https://github.com/csnover/js-iso8601
