### PR TITLE
Introduce a custom `keyForHasMany()` for `DS.RESTSerializer`.

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -253,6 +253,24 @@ DS.JSONSerializer = DS.Serializer.extend({
     return (plurals && plurals[name]) || name + "s";
   },
 
+  // use the same plurals hash to determine
+  // special-case singularization
+  singularize: function(name) {
+    var plurals = this.configurations.get('plurals');
+    if (plurals) {
+      for (var i in plurals) {
+        if (plurals[i] === name) {
+          return i;
+        }
+      }
+    }
+    if (name.lastIndexOf('s') === name.length - 1) {
+      return name.substring(0, name.length - 1);
+    } else {
+      return name;
+    }
+  },
+
   rootForType: function(type) {
     var typeString = type.toString();
 

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -13,5 +13,15 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
     }
 
     return key + "_id";
+  },
+
+  keyForHasMany: function(type, name) {
+    var key = this.keyForAttributeName(type, name);
+
+    if (this.embeddedType(type, name)) {
+      return key;
+    }
+
+    return this.singularize(key) + "_ids";
   }
 });

--- a/packages/ember-data/tests/unit/relationships_test.js
+++ b/packages/ember-data/tests/unit/relationships_test.js
@@ -181,7 +181,7 @@ test("relationships work when declared with a string path", function() {
 
   var store = DS.Store.create();
   store.loadMany(App.Tag, [5, 2, 12], [{ id: 5, name: "friendly" }, { id: 2, name: "smarmy" }, { id: 12, name: "oohlala" }]);
-  store.load(App.Person, 1, { id: 1, name: "Tom Dale", tags: [5, 2] });
+  store.load(App.Person, 1, { id: 1, name: "Tom Dale", tag_ids: [5, 2] });
 
   var person = store.find(App.Person, 1);
   equal(get(person, 'name'), "Tom Dale", "precond - retrieves person record from store");
@@ -268,7 +268,7 @@ test("it is possible to add a new item to a relationship", function() {
 
   var store = DS.Store.create();
 
-  store.load(Person, { id: 1, name: "Tom Dale", tags: [ 1 ] });
+  store.load(Person, { id: 1, name: "Tom Dale", tag_ids: [ 1 ] });
   store.load(Tag, { id: 1, name: "ember" });
 
   var person = store.find(Person, 1);
@@ -298,7 +298,7 @@ test("it is possible to remove an item from a relationship", function() {
 
   var store = DS.Store.create();
 
-  store.load(Person, { id: 1, name: "Tom Dale", tags: [ 1 ] });
+  store.load(Person, { id: 1, name: "Tom Dale", tag_ids: [ 1 ] });
   store.load(Tag, { id: 1, name: "ember" });
 
   var person = store.find(Person, 1);

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -330,7 +330,7 @@ test("finding all can sideload data", function() {
   expectType("GET");
 
   ajaxHash.success({
-    groups: [{ id: 1, name: "Group 1", people: [ 1 ] }],
+    groups: [{ id: 1, name: "Group 1", person_ids: [ 1 ] }],
     people: [{ id: 1, name: "Yehuda Katz" }]
   });
 
@@ -443,7 +443,7 @@ test("additional data can be sideloaded in a GET", function() {
 
   ajaxHash.success({
     group: {
-      id: 1, name: "Group 1", people: [ 1 ]
+      id: 1, name: "Group 1", person_ids: [ 1 ]
     },
     people: [{
       id: 1, name: "Yehuda Katz"
@@ -455,7 +455,7 @@ test("additional data can be sideloaded in a GET", function() {
 });
 
 test("finding many people by a list of IDs", function() {
-  store.load(Group, { id: 1, people: [ 1, 2, 3 ] });
+  store.load(Group, { id: 1, person_ids: [ 1, 2, 3 ] });
 
   var group = store.find(Group, 1);
 
@@ -499,7 +499,7 @@ test("finding many people by a list of IDs", function() {
 });
 
 test("finding many people by a list of IDs doesn't rely on the returned array order matching the passed list of ids", function() {
-  store.load(Group, { id: 1, people: [ 1, 2, 3 ] });
+  store.load(Group, { id: 1, person_ids: [ 1, 2, 3 ] });
 
   var group = store.find(Group, 1);
 
@@ -545,7 +545,7 @@ test("additional data can be sideloaded in a GET with many IDs", function() {
 
   ajaxHash.success({
     groups: [
-      { id: 1, people: [ 1, 2, 3 ] }
+      { id: 1, person_ids: [ 1, 2, 3 ] }
     ],
     people: [
       { id: 1, name: "Rein Heinrichs" },
@@ -621,7 +621,7 @@ test("finding people by a query can sideload data", function() {
 
   ajaxHash.success({
     groups: [
-      { id: 1, name: "Group 1", people: [ 1, 2, 3 ] }
+      { id: 1, name: "Group 1", person_ids: [ 1, 2, 3 ] }
     ],
     people: [
       { id: 1, name: "Rein Heinrichs" },
@@ -900,7 +900,7 @@ test("sideloaded data is loaded prior to primary data (to ensure relationship co
     people: [
       { id: 1, name: "Tom Dale" }
     ],
-    group: { id: 1, name: "Tilde team", people: [1] }
+    group: { id: 1, name: "Tilde team", person_ids: [1] }
   });
 });
 

--- a/packages/ember-data/tests/unit/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/unit/serializers/rest_serializer_test.js
@@ -5,6 +5,9 @@ var serializer;
 module("DS.RESTSerializer", {
   setup: function() {
     serializer = DS.RESTSerializer.create();
+    serializer.configure('plurals', {
+      person: 'people'
+    });
   },
   teardown: function() {
     serializer.destroy();
@@ -18,7 +21,14 @@ test("keyForAttributeName returns decamelized property name", function() {
 
 test("keyForBelongsTo returns the key appended with '_id'", function() {
   equal(serializer.keyForBelongsTo(DS.Model, 'person'), 'person_id');
+  equal(serializer.keyForBelongsTo(DS.Model, 'town'), 'town_id');
   equal(serializer.keyForBelongsTo(DS.Model, 'homeTown'), 'home_town_id');
+});
+
+test("keyForHasMany returns the singularized key appended with '_ids'", function() {
+  equal(serializer.keyForHasMany(DS.Model, 'people'), 'person_ids');
+  equal(serializer.keyForHasMany(DS.Model, 'towns'), 'town_ids');
+  equal(serializer.keyForHasMany(DS.Model, 'homeTowns'), 'home_town_ids');
 });
 
 test("Calling extract on a JSON payload with multiple records will tear them apart and call loader", function() {


### PR DESCRIPTION
As discussed by @leepfrog in #710, `DS.RESTSerializer` is currently inconsistent with the data served up by active_model_serializers as of [this commit](https://github.com/rails-api/active_model_serializers/commit/3b1d2faf51b16446e1df26bc7d1b620741936da3). As the person responsible, I thought I should bring some consistency to AMS and ember-data, especially since I'm preparing a talk about that very topic ;)

This change introduces `keyForHasMany()` for `DS.RESTSerializer`, which returns the singularized key appended with `_ids`. It uses the same plurals hash on the serializer to determine singular versions of keys. This brings consistency to singularization and pluralization logic, and accounts for cases in which the key does not match the model name (for instance, consider `authors: DS.hasMany('App.User')`). In other words, there's a good reason to have a `singularize()` method instead of just relying on the model class.

//cc @wycats @tomdale
