### PR TITLE
Fix all records array load state

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -382,6 +382,10 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     var loader = DS.loaderFor(store),
         serializer = get(this, 'serializer');
 
+    loader.populateArray = function(data) {
+      store.didLoadAll(type);
+    };
+
     store.didUpdateAll(type);
 
     serializer.extractMany(loader, payload, type);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -792,6 +792,14 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     set(findAllCache, 'isUpdating', false);
   },
 
+  didLoadAll: function(type) {
+    var findAllCache = this.typeMapFor(type).findAllCache;
+    set(findAllCache, 'isLoaded', true);
+    Ember.run.once(function() {
+      findAllCache.trigger('didLoad');
+    });
+  },
+
   /**
     This method returns a filtered array that contains all of the known records
     for a given type.
@@ -811,7 +819,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     if (findAllCache) { return findAllCache; }
 
-    var array = DS.RecordArray.create({ type: type, content: Ember.A([]), store: this, isLoaded: true });
+    var array = DS.RecordArray.create({ type: type, content: Ember.A([]), store: this, isLoaded: false });
     this.registerRecordArray(array, type);
 
     typeMap.findAllCache = array;

--- a/packages/ember-data/tests/integration/find_all_test.js
+++ b/packages/ember-data/tests/integration/find_all_test.js
@@ -4,7 +4,9 @@ var Person, adapter, store, allRecords;
 
 module("Finding All Records of a Type", {
   setup: function() {
-    Person = DS.Model.extend({
+    var App = Ember.Namespace.create({ name: "App" });
+
+    Person = App.Person = DS.Model.extend({
       updatedAt: DS.attr('string'),
       name: DS.attr('string'),
       firstName: DS.attr('string'),
@@ -43,6 +45,32 @@ test("When all records for a type are requested, the store should call the adapt
 
   allRecords = store.find(Person);
   equal(get(allRecords, 'length'), 0, "the record array's length is zero before any records are loaded");
+});
+
+test("When all records for a type are requested, the record array should be populate with the query result.", function() {
+  expect(3);
+
+  adapter.findAll = function(store, type, since) {
+    stop();
+    var self = this;
+    setTimeout(function() {
+      Ember.run(function() {
+        self.didFindAll(store, type, { persons: [{id: 1, name: 'Tom Dale'}] });
+      });
+    }, 100);
+  };
+
+  var allRecords = store.find(Person);
+  equal(get(allRecords, 'isLoaded'), false, "the record array's `isLoaded` property is false");
+
+  allRecords.one('didLoad', function() {
+    equal(get(allRecords, 'isLoaded'), true, "the record array's `isLoaded` property is true");
+  });
+
+  allRecords.then(function(resolvedValue) {
+    start();
+    equal(resolvedValue, allRecords, "The promise was resolved with the allRecords");
+  });
 });
 
 test("When all records for a type are requested, records that are already loaded should be returned immediately.", function() {


### PR DESCRIPTION
With this, the all record array which is returned by `App.Model.find()` will
not be flagged as loaded before the adapter populate the array with the
query result

This will fix #720 and part of #587

The `isLoaded` property of relationship array still need to be fixed.
