### PR TITLE
Serialize id of belongsTo relationship via serializeId

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -127,7 +127,7 @@ DS.JSONSerializer = DS.Serializer.extend({
       if (relationship.options && relationship.options.polymorphic && !Ember.isNone(id)) {
         this.addBelongsToPolymorphic(hash, key, id, child.constructor);
       } else {
-        hash[key] = id === undefined ? null : id;
+        hash[key] = id === undefined ? null : this.serializeId(id);
       }
     }
   },

--- a/packages/ember-data/tests/unit/json_serializer_test.js
+++ b/packages/ember-data/tests/unit/json_serializer_test.js
@@ -155,6 +155,24 @@ test("Mapped relationships should be used when serializing a record to JSON.", f
   serializer.serialize(address);
 });
 
+test("the id of a belongsTo relationship is serialized by using #serializeId", function() {
+  Person.relationships = { addresses: { key: 'addresses', kind: 'hasMany', type: window.Address }};
+  window.Address.relationships = { person: { key: 'person', kind: 'belongsTo', type: Person }};
+
+  var person = Person.create({ id: 1 });
+  var address = window.Address.create();
+
+  address.set('person', person);
+
+  serializer.serializeId = function(id) {
+    return 'serialized_' + id;
+  };
+
+  deepEqual(serializer.serialize(address), {
+    'person': 'serialized_1'
+  });
+});
+
 test("mapped relationships are respected when materializing a record from JSON", function() {
   Person.relationships = { addresses: { key: 'addresses', kind: 'hasMany', type: window.Address }};
   window.Address.relationships = { person: { key: 'person', kind: 'belongsTo', type: Person }};

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -204,7 +204,7 @@ test("updating a person makes a PUT to /people/:id with the data hash", function
 
   expectUrl("/people/1", "the plural of the model name with its ID");
   expectType("PUT");
-  expectData({ person: { name: "Brohuda Brokatz" } });
+  expectData({ person: { name: "Brohuda Brokatz", group_id: null } });
 
   ajaxHash.success({ person: { id: 1, name: "Brohuda Brokatz" } });
   expectState('saving', false);
@@ -999,7 +999,7 @@ test("When a record with a belongsTo is saved the foreign key should be sent.", 
 
   expectUrl('/people');
   expectType("POST");
-  expectData({ person: { name: "Sam Woodard", person_type_id: "1", group_id: null } });
+  expectData({ person: { name: "Sam Woodard", person_type_id: 1, group_id: null } });
   ajaxHash.success({ person: { name: 'Sam Woodard', person_type_id: 1}});
 });
 


### PR DESCRIPTION
This changes the serialization of a `belongsTo` relationship in `RESTSerializer`, so the id of the referenced model of the relationship is serialized via the adapters' `serializeId` method.

`Serializer#serializeId` is already used when creating the array of ids to delete in the `RESTAdapter#deleteRecords` (see https://github.com/pangratz/data/blob/master/packages/ember-data/lib/adapters/rest_adapter.js#L227) so this change makes this behavior consistent ...
