### PR TITLE
Add docs directory with package.json and yuidoc.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ember-docs",
+  "version": "0.0.1",
+  "dependencies": {
+    "yuidoc": "git://github.com/wagenet/yuidoc.git"
+  }
+}

--- a/docs/yuidoc.json
+++ b/docs/yuidoc.json
@@ -1,0 +1,13 @@
+{
+  "name": "The ember-data API",
+  "description": "The ember-data API: a data persistence library for Ember.js",
+  "version": "1.0 pre",
+  "url": "https://github.com/emberjs/data",
+  "options": {
+    "paths": [
+      "../packages/ember-data/lib"
+    ],
+    "exclude": "vendor",
+    "outdir":   "./build"
+  }
+}


### PR DESCRIPTION
`EMBER_PATH=../ember-data rake preview` in ember-website does not quite
work yet. I don't have time at the moment to get it working completely,
but let's have the docs directory as a starting point.
