### PR TITLE
Avoid unecessarily removing and adding children from the same parent

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -35,7 +35,7 @@ var get = Ember.get, set = Ember.set;
 DS.ManyArray = DS.RecordArray.extend({
   init: function() {
     this._super.apply(this, arguments);
-    this._changesToSync = Ember.OrderedSet.create();
+    this._changesToSync = DS.ChangeSet.create();
   },
 
   /**
@@ -149,9 +149,8 @@ DS.ManyArray = DS.RecordArray.extend({
       // in arrayContentWillChange, so that the array
       // membership test in the sync() logic operates
       // on the final results.
-      this._changesToSync.forEach(function(change) {
-        change.sync();
-      });
+      this._changesToSync.sync();
+
       DS.OneToManyChange.ensureSameTransaction(this._changesToSync, store);
       this._changesToSync.clear();
     }

--- a/packages/ember-data/lib/system/relationships.js
+++ b/packages/ember-data/lib/system/relationships.js
@@ -2,3 +2,4 @@ require("ember-data/system/relationships/belongs_to");
 require("ember-data/system/relationships/has_many");
 require("ember-data/system/relationships/ext");
 require("ember-data/system/relationships/one_to_many_change");
+require("ember-data/system/relationships/change_set");

--- a/packages/ember-data/lib/system/relationships/change_set.js
+++ b/packages/ember-data/lib/system/relationships/change_set.js
@@ -1,0 +1,60 @@
+var get = Ember.get, set = Ember.set;
+
+/**
+  Used to manage a set of changes for a particular relationship.
+ */
+
+DS.ChangeSet = Ember.Object.extend({
+  init: function() {
+    this._changes = Ember.OrderedSet.create();
+    this._super.apply(this, arguments);
+  },
+
+  add: function(obj) {
+    this._changes.add(obj);
+  },
+
+  remove: function(obj) {
+    this._changes.remove(obj);
+  },
+
+  forEach: function() {
+    this._changes.forEach.apply(this._changes, arguments);
+  },
+
+  /**
+    Removes pairs of changes that would cancel each other out.
+   */
+  coalesce: function() {
+    this.forEach(function(change, index) {
+      var reverseChangeType = change.changeType === 'add' ? 'remove' : 'add',
+          reverseChange;
+
+      reverseChange = Ember.A(this._changes.list.slice(index + 1)).find(function(possibleChange) {
+        return possibleChange.parentReference === change.parentReference &&
+          possibleChange.childReference === change.childReference &&
+          possibleChange.changeType === reverseChangeType;
+      });
+
+      if (reverseChange) {
+        this.remove(change);
+        this.remove(reverseChange);
+      }
+    }, this);
+  },
+
+  /**
+    Syncs only those changes that would have a net effect on the relationship.
+   */
+  sync: function() {
+    this.coalesce();
+
+    this.forEach(function(change) {
+      change.sync();
+    });
+  },
+
+  clear: function() {
+    this._changes.clear();
+  }
+});

--- a/packages/ember-data/lib/system/relationships/one_to_many_change.js
+++ b/packages/ember-data/lib/system/relationships/one_to_many_change.js
@@ -235,7 +235,7 @@ DS.OneToManyChange.createChange = function(childReference, parentReference, stor
   // definition.
   if (options.parentType) {
     key = inverseBelongsToName(options.parentType, childType, options.key);
-    DS.OneToManyChange.maintainInvariant( options, store, childReference, key );
+    DS.OneToManyChange.maintainInvariant( options, store, childReference, parentReference, key );
   } else if (options.key) {
     key = options.key;
   } else {
@@ -261,11 +261,13 @@ DS.OneToManyChange.createChange = function(childReference, parentReference, stor
 };
 
 
-DS.OneToManyChange.maintainInvariant = function(options, store, childReference, key){
+DS.OneToManyChange.maintainInvariant = function(options, store, childReference, parentReference, key){
   if (options.changeType === "add" && store.recordIsMaterialized(childReference)) {
-    var child = store.recordForReference(childReference);
-    var oldParent = get(child, key);
-    if (oldParent){
+    var child = store.recordForReference(childReference),
+        oldParent = get(child, key),
+        newParent = store.recordForReference(parentReference);
+
+    if (oldParent && oldParent !== newParent) {
       var correspondingChange = DS.OneToManyChange.createChange(childReference, oldParent.get('_reference'), store, {
           parentType: options.parentType,
           hasManyName: options.hasManyName,

--- a/packages/ember-data/tests/integration/relationships/one_to_many_relationships_test.js
+++ b/packages/ember-data/tests/integration/relationships/one_to_many_relationships_test.js
@@ -142,6 +142,28 @@ test("When changing a record's belongsTo, it should be removed from its old inve
   verifySynchronizedOneToMany(newParent, child);
 });
 
+test("Records can be reordered with Array#replace", function() {
+  var post, comments, comment2, comment3;
+
+  store.load(App.Post, { id: 1, comments: [ 1, 2, 3, 4 ] });
+  store.loadMany(App.Comment, [
+    { id: 1, post: 1 },
+    { id: 2, post: 1 },
+    { id: 3, post: 1 },
+    { id: 4, post: 1 }
+  ]);
+
+  post = store.find(App.Post, 1);
+  comment2 = store.find(App.Comment, 2);
+  comment3 = store.find(App.Comment, 3);
+
+  comments = post.get('comments');
+  deepEqual(comments.mapProperty('id'), [ '1', '2', '3', '4' ], 'Comments are in their original order');
+
+  comments.replace(1, 2, [ comment3, comment2 ]);
+  deepEqual(comments.mapProperty('id'), [ '1', '3', '2', '4' ], 'Comments 2 and 3 have swapped places');
+});
+
 test("Deleting a record removes it from any inverse hasMany arrays to which it belongs.", function() {
   var post, comment;
 


### PR DESCRIPTION
This change allows you to perform in-place array modifications on a has-many association:

``` javascript
store.load(App.Post, { id: 1, comments: [ 1, 2, 3, 4 ] });
store.loadMany(App.Comment, [
  { id: 1, post: 1 },
  { id: 2, post: 1 },
  { id: 3, post: 1 },
  { id: 4, post: 1 }
]);

post = store.find(App.Post, 1);
comment2 = store.find(App.Comment, 2);
comment3 = store.find(App.Comment, 3);

post.get('comments'); //=> [1, 2, 3, 4]
post.get('comments').replace(1, 2, [ comment3, comment2 ]);
post.get('comments'); //=> [1, 3, 2, 4]
```
