### PR TITLE
Added support for polymorphic associations.

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -23,5 +23,13 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
     }
 
     return this.singularize(key) + "_ids";
+  },
+
+  keyForPolymorphicId: function(key) {
+    return key;
+  },
+
+  keyForPolymorphicType: function(key) {
+    return key.replace(/_id$/, '_type');
   }
 });

--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -47,6 +47,15 @@ DS.ManyArray = DS.RecordArray.extend({
   */
   owner: null,
 
+  /**
+    @private
+
+    `true` if the relationship is polymorphic, `false` otherwise.
+
+    @property {Boolean}
+  */
+  isPolymorphic: false,
+
   // LOADING STATE
 
   isLoaded: false,
@@ -66,17 +75,16 @@ DS.ManyArray = DS.RecordArray.extend({
   fetch: function() {
     var references = get(this, 'content'),
         store = get(this, 'store'),
-        type = get(this, 'type'),
         owner = get(this, 'owner');
 
-    store.fetchUnloadedReferences(type, references, owner);
+    store.fetchUnloadedReferences(references, owner);
   },
 
   // Overrides Ember.Array's replace method to implement
   replaceContent: function(index, removed, added) {
     // Map the array of record objects into an array of  client ids.
     added = added.map(function(record) {
-      Ember.assert("You can only add records of " + (get(this, 'type') && get(this, 'type').toString()) + " to this relationship.", !get(this, 'type') || (get(this, 'type') === record.constructor));
+      Ember.assert("You can only add records of " + (get(this, 'type') && get(this, 'type').toString()) + " to this relationship.", !get(this, 'type') || (get(this, 'type').detectInstance(record)) );
       return get(record, '_reference');
     }, this);
 
@@ -163,6 +171,8 @@ DS.ManyArray = DS.RecordArray.extend({
         store = get(owner, 'store'),
         type = get(this, 'type'),
         record;
+
+    Ember.assert("You can not create records of " + (get(this, 'type') && get(this, 'type').toString()) + " on this polymorphic relationship.", !get(this, 'isPolymorphic'));
 
     transaction = transaction || get(owner, 'transaction');
 

--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -9,25 +9,26 @@ DS.belongsTo = function(type, options) {
   var meta = { type: type, isRelationship: true, options: options, kind: 'belongsTo' };
 
   return Ember.computed(function(key, value) {
+    if (typeof type === 'string') {
+      type = get(this, type, false) || get(Ember.lookup, type);
+    }
+
     if (arguments.length === 2) {
+      Ember.assert("You can only add a record of " + type.toString() + " to this relationship", !value || type.detectInstance(value));
       return value === undefined ? null : value;
     }
 
     var data = get(this, 'data').belongsTo,
         store = get(this, 'store'), id;
 
-    if (typeof type === 'string') {
-      type = get(this, type, false) || get(Ember.lookup, type);
-    }
-
     id = data[key];
 
     if(!id) {
       return null;
-    } else if (typeof id === 'object') {
+    } else if (id.clientId) {
       return store.recordForReference(id);
     } else {
-      return store.find(type, id);
+      return store.findById(id.type, id.id);
     }
   }).property('data').meta(meta);
 };

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -104,7 +104,7 @@ DS.Model.reopenClass({
     relationships, like this:
 
         var relationships = Ember.get(App.Blog, 'relationships');
-        associatons.get(App.User);
+        relationships.get(App.User);
         //=> [ { name: 'users', kind: 'hasMany' },
         //     { name: 'owner', kind: 'belongsTo' } ]
         relationships.get(App.Post);
@@ -389,6 +389,9 @@ DS._inverseRelationshipFor = function(modelType, inverseModelType) {
 
   if (!possibleRelationships) { return; }
   if (possibleRelationships.length > 1) { return; }
+  if (possibleRelationships.length === 0 && inverseModelType.superclass) {
+    return DS._inverseRelationshipFor(modelType, inverseModelType.superclass);
+  }
   return possibleRelationships[0];
 };
 

--- a/packages/ember-data/lib/system/relationships/has_many.js
+++ b/packages/ember-data/lib/system/relationships/has_many.js
@@ -16,10 +16,14 @@ var hasRelationship = function(type, options) {
       type = get(this, type, false) || get(Ember.lookup, type);
     }
 
+    //ids can be references or opaque token
+    //(e.g. `{url: '/relationship'}`) that will be passed to the adapter
     ids = data[key];
+
     relationship = store.findMany(type, ids, this, meta);
     set(relationship, 'owner', this);
     set(relationship, 'name', key);
+    set(relationship, 'isPolymorphic', options.polymorphic);
 
     return relationship;
   }).property().meta(meta);

--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -203,6 +203,7 @@ function mustImplement(name) {
 DS.Serializer = Ember.Object.extend({
   init: function() {
     this.mappings = Ember.Map.create();
+    this.aliases = Ember.Map.create();
     this.configurations = Ember.Map.create();
     this.globalConfigurations = {};
   },
@@ -211,8 +212,7 @@ DS.Serializer = Ember.Object.extend({
   extractMany: mustImplement('extractMany'),
 
   extractRecordRepresentation: function(loader, type, json, shouldSideload) {
-    var mapping = this.mappingForType(type);
-    var embeddedData, prematerialized = {}, reference;
+    var prematerialized = {}, reference;
 
     if (shouldSideload) {
       reference = loader.sideload(type, json);
@@ -243,7 +243,8 @@ DS.Serializer = Ember.Object.extend({
     var references = map.call(array, function(item) {
       if (!item) { return; }
 
-      var reference = this.extractRecordRepresentation(loader, relationship.type, item, true);
+      var foundType = this.extractEmbeddedType(relationship, item),
+          reference = this.extractRecordRepresentation(loader, foundType, item, true);
 
       // If the embedded record should also be saved back when serializing the parent,
       // make sure we set its parent since it will not have an ID.
@@ -259,7 +260,8 @@ DS.Serializer = Ember.Object.extend({
   },
 
   extractEmbeddedBelongsTo: function(loader, relationship, data, parent, prematerialized) {
-    var reference = this.extractRecordRepresentation(loader, relationship.type, data, true);
+    var foundType = this.extractEmbeddedType(relationship, data),
+        reference = this.extractRecordRepresentation(loader, foundType, data, true);
     prematerialized[relationship.key] = reference;
 
     // If the embedded record should also be saved back when serializing the parent,
@@ -268,6 +270,24 @@ DS.Serializer = Ember.Object.extend({
     if (embeddedType === 'always') {
       reference.parent = parent;
     }
+  },
+
+  /**
+    A hook you can use to customize how the record's type is extracted from
+    the serialized data.
+
+    The `extractEmbeddedType` hook is called with:
+
+    * the serialized representation being built
+    * the serialized id (after calling the `serializeId` hook)
+
+    By default, it returns the type of the relationship.
+
+    @param {Object} relationship an object representing the relationship
+    @param {any} data the serialized representation that is being built
+  */
+  extractEmbeddedType: function(relationship, data) {
+    return relationship.type;
   },
 
   //.......................
@@ -285,6 +305,7 @@ DS.Serializer = Ember.Object.extend({
 
     * If the option hash contains `includeId`, add the record's ID to the serialized form.
       By default, `serialize` calls `addId` if appropriate.
+    * If the option hash contains `includeType`, add the record's type to the serialized form.
     * Add the record's attributes to the serialized form. By default, `serialize` calls
       `addAttributes`.
     * Add the record's relationships to the serialized form. By default, `serialize` calls
@@ -303,6 +324,10 @@ DS.Serializer = Ember.Object.extend({
       if (id = get(record, 'id')) {
         this._addId(serialized, record.constructor, id);
       }
+    }
+
+    if (options.includeType) {
+      this.addType(serialized, record.constructor);
     }
 
     this.addAttributes(serialized, record);
@@ -392,6 +417,20 @@ DS.Serializer = Ember.Object.extend({
     @param {id} id the serialized id
   */
   addId: Ember.K,
+
+  /**
+    A hook you can use to customize how the record's type is added to
+    the serialized data.
+
+    The `addType` hook is called with:
+
+    * the serialized representation being built
+    * the serialized id (after calling the `serializeId` hook)
+
+    @param {any} data the serialized representation that is being built
+    @param {DS.Model subclass} type the type of the record
+  */
+  addType: Ember.K,
 
   /**
     A hook you can use to change how relationships are added to the serialized
@@ -675,13 +714,15 @@ DS.Serializer = Ember.Object.extend({
     record.eachRelationship(function(name, relationship) {
       if (relationship.kind === 'hasMany') {
         if (prematerialized && prematerialized.hasOwnProperty(name)) {
-          record.materializeHasMany(name, prematerialized[name]);
+          var tuplesOrReferencesOrOpaque = this._convertPrematerializedHasMany(relationship.type, prematerialized[name]);
+          record.materializeHasMany(name, tuplesOrReferencesOrOpaque);
         } else {
           this.materializeHasMany(name, record, hash, relationship, prematerialized);
         }
       } else if (relationship.kind === 'belongsTo') {
         if (prematerialized && prematerialized.hasOwnProperty(name)) {
-          record.materializeBelongsTo(name, prematerialized[name]);
+          var tupleOrReference = this._convertTuple(relationship.type, prematerialized[name]);
+          record.materializeBelongsTo(name, tupleOrReference);
         } else {
           this.materializeBelongsTo(name, record, hash, relationship, prematerialized);
         }
@@ -690,13 +731,35 @@ DS.Serializer = Ember.Object.extend({
   },
 
   materializeHasMany: function(name, record, hash, relationship) {
-    var key = this._keyForHasMany(record.constructor, relationship.key);
-    record.materializeHasMany(name, this.extractHasMany(record.constructor, hash, key));
+    var type = record.constructor,
+        key = this._keyForHasMany(type, relationship.key),
+        idsOrTuples = this.extractHasMany(type, hash, key),
+        tuples = idsOrTuples;
+
+    if(idsOrTuples && Ember.isArray(idsOrTuples)) {
+      tuples = this._convertTuples(relationship.type, idsOrTuples);
+    }
+
+    record.materializeHasMany(name, tuples);
   },
 
   materializeBelongsTo: function(name, record, hash, relationship) {
-    var key = this._keyForBelongsTo(record.constructor, relationship.key);
-    record.materializeBelongsTo(name, this.extractBelongsTo(record.constructor, hash, key));
+    var type = record.constructor,
+        key = this._keyForBelongsTo(type, relationship.key),
+        idOrTuple,
+        tuple = null;
+
+    if(relationship.options && relationship.options.polymorphic) {
+      idOrTuple = this.extractBelongsToPolymorphic(type, hash, key);
+    } else {
+      idOrTuple = this.extractBelongsTo(type, hash, key);
+    }
+
+    if(idOrTuple) {
+      tuple = this._convertTuple(relationship.type, idOrTuple);
+    }
+
+    record.materializeBelongsTo(name, tuple);
   },
 
   _extractEmbeddedRelationship: function(type, hash, name, relationshipType) {
@@ -713,6 +776,38 @@ DS.Serializer = Ember.Object.extend({
 
   _extractEmbeddedHasMany: function(type, hash, name) {
     return this._extractEmbeddedRelationship(type, hash, name, 'HasMany');
+  },
+
+  _convertPrematerializedHasMany: function(type, prematerializedHasMany) {
+    var tuplesOrReferencesOrOpaque;
+    if( typeof prematerializedHasMany === 'string' ) {
+      tuplesOrReferencesOrOpaque = prematerializedHasMany;
+    } else {
+      tuplesOrReferencesOrOpaque = this._convertTuples(type, prematerializedHasMany);
+    }
+    return tuplesOrReferencesOrOpaque;
+  },
+
+  _convertTuples: function(type, idsOrTuples) {
+    return map.call(idsOrTuples, function(idOrTuple) {
+      return this._convertTuple(type, idOrTuple);
+    }, this);
+  },
+
+  _convertTuple: function(type, idOrTuple) {
+    var foundType;
+
+    if (typeof idOrTuple === 'object') {
+      if (DS.Model.detect(idOrTuple.type)) {
+        return idOrTuple;
+      } else {
+        foundType = this.typeFromAlias(idOrTuple.type);
+        Ember.assert("Unable to resolve type " + idOrTuple.type + ".  You may need to configure your serializer aliases.", !!foundType);
+
+        return {id: idOrTuple.id, type: foundType};
+      }
+    }
+    return {id: idOrTuple, type: type};
   },
 
   /**
@@ -943,10 +1038,23 @@ DS.Serializer = Ember.Object.extend({
       return;
     }
 
-    var config = Ember.create(this.globalConfigurations);
+    var config, alias;
+
+    if (configuration.alias) {
+      alias = configuration.alias;
+      this.aliases.set(alias, type);
+      delete configuration.alias;
+    }
+
+    config = Ember.create(this.globalConfigurations);
     Ember.merge(config, configuration);
 
     this.configurations.set(type, config);
+  },
+
+  typeFromAlias: function(alias) {
+    this._completeAliases();
+    return this.aliases.get(alias);
   },
 
   mappingForType: function(type) {
@@ -957,6 +1065,59 @@ DS.Serializer = Ember.Object.extend({
   configurationForType: function(type) {
     this._reifyConfigurations();
     return this.configurations.get(type) || this.globalConfigurations;
+  },
+
+  _completeAliases: function() {
+    this._pluralizeAliases();
+    this._reifyAliases();
+  },
+
+  _pluralizeAliases: function() {
+    if (this._didPluralizeAliases) { return; }
+
+    var aliases = this.aliases,
+        sideloadMapping = this.aliases.sideloadMapping,
+        plural,
+        self = this;
+
+    aliases.forEach(function(key, type) {
+      plural = self.pluralize(key);
+      Ember.assert("The '" + key + "' alias has already been defined", !aliases.get(plural));
+      aliases.set(plural, type);
+    });
+
+    // This map is only for backward compatibility with the `sideloadAs` option.
+    if (sideloadMapping) {
+      sideloadMapping.forEach(function(key, type) {
+        Ember.assert("The '" + key + "' alias has already been defined", !aliases.get(key) || (aliases.get(key)===type) );
+        aliases.set(key, type);
+      });
+      delete this.aliases.sideloadMapping;
+    }
+
+    this._didPluralizeAliases = true;
+  },
+
+  _reifyAliases: function() {
+    if (this._didReifyAliases) { return; }
+
+    var aliases = this.aliases,
+        reifiedAliases = Ember.Map.create(),
+        foundType;
+
+    aliases.forEach(function(key, type) {
+      if (typeof type === 'string') {
+        foundType = Ember.get(Ember.lookup, type);
+        Ember.assert("Could not find model at path " + key, type);
+
+        reifiedAliases.set(key, foundType);
+      } else {
+        reifiedAliases.set(key, type);
+      }
+    });
+
+    this.aliases = reifiedAliases;
+    this._didReifyAliases = true;
   },
 
   _reifyMappings: function() {
@@ -1064,6 +1225,33 @@ DS.Serializer = Ember.Object.extend({
         }
       }
     }, this);
-  }
+  },
+
+  // HELPERS
+
+  // define a plurals hash in your subclass to define
+  // special-case pluralization
+  pluralize: function(name) {
+    var plurals = this.configurations.get('plurals');
+    return (plurals && plurals[name]) || name + "s";
+  },
+
+  // use the same plurals hash to determine
+  // special-case singularization
+  singularize: function(name) {
+    var plurals = this.configurations.get('plurals');
+    if (plurals) {
+      for (var i in plurals) {
+        if (plurals[i] === name) {
+          return i;
+        }
+      }
+    }
+    if (name.lastIndexOf('s') === name.length - 1) {
+      return name.substring(0, name.length - 1);
+    } else {
+      return name;
+    }
+  },
 });
 

--- a/packages/ember-data/tests/integration/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/belongs_to_test.js
@@ -1,0 +1,166 @@
+var Adapter, adapter, serializer, store, App;
+var originalLookup = Ember.lookup, lookup;
+var get = Ember.get, set = Ember.set;
+
+module("Belongs-To Relationships", {
+  setup: function() {
+    lookup = Ember.lookup = {};
+
+    serializer = DS.RESTSerializer.create();
+    Adapter = DS.RESTAdapter.extend({
+      serializer: serializer
+    });
+    Adapter.configure('App.Comment', {
+      alias: 'comment'
+    });
+    Adapter.configure('App.Post', {
+      alias: 'post'
+    });
+
+    App = Ember.Namespace.create({
+      name: 'App'
+    });
+
+    App.User = DS.Model.extend({
+      name: DS.attr('string'),
+      messages: DS.hasMany('App.Message', {polymorphic: true}),
+      favouriteMessage: DS.belongsTo('App.Message', {polymorphic: true})
+    });
+
+    App.Message = DS.Model.extend({
+      user: DS.belongsTo('App.User'),
+      created_at: DS.attr('date')
+    });
+
+    App.Post = App.Message.extend({
+      title: DS.attr('string'),
+      comments: DS.hasMany('App.Comment')
+    });
+
+    App.Comment = App.Message.extend({
+      body: DS.attr('string'),
+      message: DS.belongsTo('App.Message', {polymorphic: true})
+    });
+
+    Adapter.map(App.User, {
+      favouriteMessage: {embedded: 'always'}
+    });
+
+    adapter = Adapter.create();
+    store = DS.Store.create({
+      adapter: adapter
+    });
+
+    lookup.App = {
+      User: App.User,
+      Post: App.Post,
+      Comment: App.Comment,
+      Message: App.Message
+    };
+  },
+
+  teardown: function() {
+    serializer.destroy();
+    adapter.destroy();
+    store.destroy();
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("The store can materialize a non loaded monomorphic belongsTo association", function() {
+  expect(1);
+  store.load(App.Post, { id: 1, user_id: 2});
+  var post = store.find(App.Post, 1);
+
+  adapter.find = function(store, type, id) {
+    ok(true, "The adapter's find method should be called");
+  };
+
+  post.get('user');
+});
+
+test("Only a record of the same type can be used with a monomorphic belongsTo relationship", function() {
+  expect(1);
+  store.load(App.Post, { id: 1 });
+  store.load(App.Comment, { id: 2 });
+  var post = store.find(App.Post, 1),
+      comment = store.find(App.Comment, 2);
+
+  raises(
+    function() { post.set('user', comment); },
+    /You can only add a record of App.User to this relationship/,
+    "Adding a record of a different type on a monomorphic belongsTo is disallowed"
+  );
+});
+
+test("Only a record of the same base type can be used with a polymorphic belongsTo relationship", function() {
+  expect(1);
+  store.load(App.Comment, { id: 1 });
+  store.load(App.Comment, { id: 2 });
+  store.load(App.Post, { id: 1 });
+  store.load(App.User, { id: 3 });
+
+  var user = store.find(App.User, 3),
+      post = store.find(App.Post, 1),
+      comment = store.find(App.Comment, 1),
+      anotherComment = store.find(App.Comment, 2);
+
+  comment.set('message', anotherComment);
+  comment.set('message', post);
+  comment.set('message', null);
+
+  raises(
+    function() { comment.set('message', user); },
+    /You can only add a record of App.Message to this relationship/,
+    "Adding a record of a different base type on a polymorphic belongsTo is disallowed"
+  );
+});
+
+test("The store can load a polymorphic belongsTo association", function() {
+  store.load(App.Post, { id: 1 });
+  store.load(App.Comment, { id: 2, message_id: 1, message_type: 'post' });
+
+  var message = store.find(App.Post, 1),
+      comment = store.find(App.Comment, 2);
+
+  equal(comment.get('message'), message);
+});
+
+test("The store can serialize a polymorphic belongsTo association", function() {
+  store.load(App.Post, { id: 1 });
+  store.load(App.Comment, { id: 2, message_id: 1, message_type: 'post' });
+
+  var comment = store.find(App.Comment, 2);
+
+  var serialized = store.serialize(comment, {includeId: true});
+  equal(serialized.hasOwnProperty('message'), false);
+  equal(serialized['message_id'], 1);
+  equal(serialized['message_type'], 'post');
+});
+
+test("The store can load an embedded polymorphic belongsTo association", function() {
+  serializer.keyForEmbeddedType = function() {
+    return 'embeddedType';
+  };
+
+  adapter.load(store, App.User, { id: 2, favourite_message: { id: 1, embeddedType: 'comment'}});
+
+  var user = store.find(App.User, 2),
+      message = store.find(App.Comment, 1);
+
+  equal(user.get('favouriteMessage'), message);
+});
+
+test("The store can serialize an embedded polymorphic belongsTo association", function() {
+  serializer.keyForEmbeddedType = function() {
+    return 'embeddedType';
+  };
+  adapter.load(store, App.User, { id: 2, favourite_message: { id: 1, embeddedType: 'comment'}});
+
+  var user = store.find(App.User, 2),
+      serialized = store.serialize(user, {includeId: true});
+
+  ok(serialized.hasOwnProperty('favourite_message'));
+  equal(serialized.favourite_message.id, 1);
+  equal(serialized.favourite_message.embeddedType, 'comment');
+});

--- a/packages/ember-data/tests/integration/find_test.js
+++ b/packages/ember-data/tests/integration/find_test.js
@@ -45,17 +45,6 @@ test("When a record is requested but has not yet been loaded, its `id` property 
   equal(get(record, 'id'), 1, "should report its id while loading");
 });
 
-test("When multiple records are requested, the adapter's `findMany` method should be called.", function() {
-  expect(1);
-
-  adapter.findMany = function(store, type, ids) {
-    deepEqual(ids, ['1','2','3'], "ids are passed");
-  };
-
-  store.findMany(Person, [1,2,3]);
-  store.findMany(Person, [1,2,3]);
-});
-
 test("When multiple records are requested, the default adapter should call the `find` method once per record if findMany is not implemented", function() {
   expect(3);
 
@@ -68,15 +57,4 @@ test("When multiple records are requested, the default adapter should call the `
 
   store.findMany(Person, [1,2,3]);
   store.findMany(Person, [1,2,3]);
-});
-
-test("When multiple records are requested, the store should not call findMany on the adapter if all the requested records are already loaded.", function() {
-  expect(0);
-
-  adapter.find = function(store, type, id) {
-    ok(false, "This should not be called");
-  };
-
-  store.load(Person, { id: 1 });
-  store.findMany(Person, [ 1 ]);
 });

--- a/packages/ember-data/tests/integration/has_many_test.js
+++ b/packages/ember-data/tests/integration/has_many_test.js
@@ -1,8 +1,10 @@
 var get = Ember.get, set = Ember.set;
+var originalLookup = Ember.lookup, lookup;
 var adapter, serializer, store, App;
 
 module("Has-Many Relationships", {
   setup: function() {
+    lookup = Ember.lookup = {};
     adapter = DS.Adapter.create();
     store = DS.Store.create({
       adapter: adapter
@@ -10,15 +12,32 @@ module("Has-Many Relationships", {
 
     serializer = get(adapter, 'serializer');
 
+    serializer.configure('App.Comment', {
+      alias: 'comment'
+    });
+
+    serializer.configure('App.Post', {
+      alias: 'post'
+    });
+
     App = Ember.Namespace.create({
       name: 'App'
     });
 
-    App.Post = DS.Model.extend({
+    App.User = DS.Model.extend({
+      name: DS.attr('string')
+    });
+
+    App.Message = DS.Model.extend({
+      user: DS.belongsTo(App.User),
+      created_at: DS.attr('date')
+    });
+
+    App.Post = App.Message.extend({
       title: DS.attr('string')
     });
 
-    App.Comment = DS.Model.extend({
+    App.Comment = App.Message.extend({
       body: DS.attr('string'),
       post: DS.belongsTo(App.Post)
     });
@@ -26,11 +45,21 @@ module("Has-Many Relationships", {
     App.Post.reopen({
       comments: DS.hasMany(App.Comment)
     });
+
+    App.User.reopen({
+      messages: DS.hasMany(App.Message, {polymorphic: true})
+    });
+
+    lookup.App = {
+      Post: App.Post,
+      Comment: App.Comment
+    };
   },
 
   teardown: function() {
     adapter.destroy();
     store.destroy();
+    Ember.lookup = originalLookup;
   }
 });
 
@@ -41,7 +70,7 @@ test("A hasMany relationship has an isLoaded flag that indicates whether the Man
 
   adapter.find = function(store, type, id) {
     setTimeout(async(function() {
-      equal(array.get('isLoaded'), false, "Before loading, the array isn't isLoaded");
+      equal(get(array, 'isLoaded'), false, "Before loading, the array isn't isLoaded");
       store.load(type, { id: id });
 
       // The isLoaded flag change is deferred, so this should be `false`
@@ -78,15 +107,13 @@ test("When a hasMany relationship is accessed, the adapter's findMany method sho
   var post = store.find(App.Post, 1);
 
   post.get('comments');
-
-  store.load(App.Post, { id: 1, comments: [ 1 ] });
 });
 
 // This tests the case where a serializer materializes a has-many
 // relationship as a reference that it can fetch lazily. The most
 // common use case of this is to provide a URL to a collection that
 // is loaded later.
-asyncTest("An serializer can materialize a hasMany as an opaque token that can be lazily fetched via the adapter's findHasMany hook", function() {
+asyncTest("A serializer can materialize a hasMany as an opaque token that can be lazily fetched via the adapter's findHasMany hook", function() {
   expect(8);
 
   // When a payload comes in from the server, replace the string
@@ -151,4 +178,106 @@ asyncTest("An serializer can materialize a hasMany as an opaque token that can b
     equal(comments.get('isLoaded'), true);
     equal(comments.get('length'), 2);
   }
+});
+
+test("When a polymorphic hasMany relationship is accessed, the adapter's findMany method should not be called if all the records in the relationship are already loaded", function() {
+  expect(1);
+
+  adapter.findMany = function() {
+    ok(false, "The adapter's find method should not be called");
+  };
+
+  store.load(App.User, { id: 1, messages: [ {id: 1, type: 'post'}, {id: 3, type: 'comment'} ] });
+  store.load(App.Post, { id: 1 });
+  store.load(App.Comment, { id: 3 });
+
+  var user = store.find(App.User, 1),
+      messages = user.get('messages');
+
+  equal(messages.get('length'), 2, "The messages are correctly loaded");
+});
+
+test("When a polymorphic hasMany relationship is accessed, the store can call multiple adapters' findMany method if the records are not loaded", function() {
+  expect(3);
+
+  adapter.findMany = function() {
+    ok(true, "The adapter's find method should be called");
+  };
+
+  store.load(App.User, { id: 1, messages: [ {id: 1, type: 'post'}, {id: 3, type: 'comment'} ] });
+
+  var user = store.find(App.User, 1),
+      messages = user.get('messages');
+
+  equal(messages.get('length'), 2, "The messages are correctly loaded");
+});
+
+test("A record can't be created from a polymorphic hasMany relationship", function() {
+  expect(1);
+  store.load(App.User, { id: 1, messages: [] });
+  var user = store.find(App.User, 1),
+      messages = user.get('messages');
+
+  raises(
+    function() { messages.createRecord(); },
+    /You can not create records of App.Message on this polymorphic relationship/,
+    "Creating records directly on a polymorphic hasMany is disallowed"
+  );
+});
+
+test("Only records of the same type can be added to a monomorphic hasMany relationship", function() {
+  expect(1);
+  store.load(App.Post, { id: 1 });
+  store.load(App.Post, { id: 2 });
+  var post = store.find(App.Post, 1),
+      message = store.find(App.Post, 2);
+
+  raises(
+    function() { post.get('comments').pushObject(message); },
+    /You can only add records of App.Comment to this relationship/,
+    "Adding records of a different type on a monomorphic hasMany is disallowed"
+  );
+});
+
+test("Only records of the same base type can be added to a polymorphic hasMany relationship", function() {
+  expect(2);
+  store.load(App.User, { id: 1 });
+  store.load(App.User, { id: 2 });
+  store.load(App.Post, { id: 1 });
+  store.load(App.Comment, { id: 3 });
+
+  var user = store.find(App.User, 1),
+      anotherUser = store.find(App.User, 2),
+      messages = user.get('messages'),
+      post = store.find(App.Post, 1),
+      comment = store.find(App.Comment, 3);
+
+  messages.pushObject(post);
+  messages.pushObject(comment);
+
+  equal(messages.get('length'), 2, "The messages are correctly added");
+
+  raises(
+    function() { messages.pushObject(anotherUser); },
+    /You can only add records of App.Message to this relationship/,
+    "Adding records of a different base type on a polymorphic hasMany is disallowed"
+  );
+});
+
+test("A record can be removed from a polymorphic association", function() {
+  expect(3);
+
+  store.load(App.User, { id: 1 , messages: [{id: 3, type: 'comment'}]});
+  store.load(App.Comment, { id: 3 });
+
+  var user = store.find(App.User, 1),
+      comment = store.find(App.Comment, 3),
+      messages = user.get('messages');
+
+  equal(messages.get('length'), 1, "The user has 1 message");
+
+  var removedObject = messages.popObject();
+
+  equal(removedObject, comment, "The message is correctly removed");
+  equal(messages.get('length'), 0, "The user does not have any messages");
 });

--- a/packages/ember-data/tests/integration/inverse_relationships_test.js
+++ b/packages/ember-data/tests/integration/inverse_relationships_test.js
@@ -1,4 +1,4 @@
-var Post, Comment, store;
+var Post, Comment, Message, User, store;
 
 module('Inverse Relationships', {
   setup: function() {
@@ -89,4 +89,120 @@ test("When a record's belongsTo relationship is set, it can specify the inverse 
   equal(post.get('meComments.length'), 0, "meComments has no posts");
   equal(post.get('youComments.length'), 1, "youComments had the post added");
   equal(post.get('everyoneWeKnowComments.length'), 0, "everyoneWeKnowComments has no posts");
+});
+
+test("When a record is added to or removed from a polymorphic has-many relationship, the inverse belongsTo can be set explicitly", function() {
+  User = DS.Model.extend();
+
+  Message = DS.Model.extend({
+    oneUser: DS.belongsTo(User),
+    twoUser: DS.belongsTo(User),
+    redUser: DS.belongsTo(User),
+    blueUser: DS.belongsTo(User)
+  });
+
+  Post = Message.extend();
+
+  User.reopen({
+    messages: DS.hasMany(Message, {
+      inverse: 'redUser',
+      polymorphic: true
+    })
+  });
+
+  var post = store.createRecord(Post);
+  var user = store.createRecord(User);
+
+  equal(post.get('oneUser'), null, "oneUser has not been set on the user");
+  equal(post.get('twoUser'), null, "twoUser has not been set on the user");
+  equal(post.get('redUser'), null, "redUser has not been set on the user");
+  equal(post.get('blueUser'), null, "blueUser has not been set on the user");
+
+  user.get('messages').pushObject(post);
+
+  equal(post.get('oneUser'), null, "oneUser has not been set on the user");
+  equal(post.get('twoUser'), null, "twoUser has not been set on the user");
+  equal(post.get('redUser'), user, "redUser has been set on the user");
+  equal(post.get('blueUser'), null, "blueUser has not been set on the user");
+
+  user.get('messages').popObject();
+
+  equal(post.get('oneUser'), null, "oneUser has not been set on the user");
+  equal(post.get('twoUser'), null, "twoUser has not been set on the user");
+  equal(post.get('redUser'), null, "redUser has bot been set on the user");
+  equal(post.get('blueUser'), null, "blueUser has not been set on the user");
+});
+
+test("When a record's belongsTo relationship is set, it can specify the inverse polymorphic hasMany to which the new child should be added or removed", function() {
+  User = DS.Model.extend();
+
+  Message = DS.Model.extend({
+    user: DS.belongsTo(User, {
+      inverse: 'youMessages'
+    })
+  });
+
+  Post = Message.extend();
+
+  User.reopen({
+    meMessages: DS.hasMany(Message, { polymorphic: true }),
+    youMessages: DS.hasMany(Message, { polymorphic: true }),
+    everyoneWeKnowMessages: DS.hasMany(Message, { polymorphic: true }),
+  });
+
+  var user = store.createRecord(User);
+  var post = store.createRecord(Post);
+
+  equal(user.get('meMessages.length'), 0, "meMessages has no posts");
+  equal(user.get('youMessages.length'), 0, "youMessages has no posts");
+  equal(user.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
+
+  post.set('user', user);
+
+  equal(user.get('meMessages.length'), 0, "meMessages has no posts");
+  equal(user.get('youMessages.length'), 1, "youMessages had the post added");
+  equal(user.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
+
+  post.set('user', null);
+
+  equal(user.get('meMessages.length'), 0, "meMessages has no posts");
+  equal(user.get('youMessages.length'), 0, "youMessages has no posts");
+  equal(user.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
+});
+
+test("When a record's polymorphic belongsTo relationship is set, it can specify the inverse hasMany to which the new child should be added", function() {
+  Message = DS.Model.extend();
+  Post = Message.extend();
+
+  Comment = Message.extend({
+    message: DS.belongsTo(Message, {
+      polymorphic: true,
+      inverse: 'youMessages'
+    }),
+  });
+
+  Message.reopen({
+    meMessages: DS.hasMany(Comment),
+    youMessages: DS.hasMany(Comment),
+    everyoneWeKnowMessages: DS.hasMany(Comment)
+  });
+
+  var comment = store.createRecord(Comment);
+  var post = store.createRecord(Post);
+
+  equal(post.get('meMessages.length'), 0, "meMessages has no posts");
+  equal(post.get('youMessages.length'), 0, "youMessages has no posts");
+  equal(post.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
+
+  comment.set('message', post);
+
+  equal(post.get('meMessages.length'), 0, "meMessages has no posts");
+  equal(post.get('youMessages.length'), 1, "youMessages had the post added");
+  equal(post.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
+
+  comment.set('message', null);
+
+  equal(post.get('meMessages.length'), 0, "meMessages has no posts");
+  equal(post.get('youMessages.length'), 0, "youMessages has no posts");
+  equal(post.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
 });

--- a/packages/ember-data/tests/integration/prematerialized_data_test.js
+++ b/packages/ember-data/tests/integration/prematerialized_data_test.js
@@ -26,6 +26,7 @@ module("Prematerialized Data", {
   },
 
   teardown: function() {
+    adapter.destroy();
     store.destroy();
   }
 });

--- a/packages/ember-data/tests/integration/relationships/embedded_polymorphic_has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/embedded_polymorphic_has_many_test.js
@@ -1,0 +1,154 @@
+var get = Ember.get, set = Ember.set;
+var originalLookup = Ember.lookup, lookup;
+var Adapter, adapter, serializer, store, App;
+
+module("Has-Many Polymorphic Relationships", {
+  setup: function() {
+    lookup = Ember.lookup = {};
+    serializer = DS.RESTSerializer.create();
+    Adapter = DS.RESTAdapter.extend({
+      serializer: serializer
+    });
+    Adapter.configure('App.Comment', {
+      alias: 'comment'
+    });
+
+    Adapter.map('App.User', {
+      messages: { embedded: 'always' }
+    });
+    Adapter.configure('App.Post', {
+      alias: 'post'
+    });
+    Adapter.configure('App.Comment', {
+      alias: 'comment'
+    });
+
+    adapter = Adapter.create();
+    store = DS.Store.create({
+      adapter: adapter
+    });
+
+    App = Ember.Namespace.create({
+      name: 'App'
+    });
+
+    App.User = DS.Model.extend({
+      name: DS.attr('string'),
+      messages: DS.hasMany('App.Message', {polymorphic: true})
+    });
+
+    App.Message = DS.Model.extend({
+      user: DS.belongsTo('App.User'),
+      created_at: DS.attr('date')
+    });
+
+    App.Post = App.Message.extend({
+      title: DS.attr('string'),
+      comments: DS.hasMany('App.Comment')
+    });
+
+    App.Comment = App.Message.extend({
+      body: DS.attr('string'),
+      post: DS.belongsTo('App.Post')
+    });
+
+    lookup.App = {
+      Post: App.Post,
+      Comment: App.Comment,
+      User: App.User,
+      Message: App.Message
+    };
+  },
+
+  teardown: function() {
+    serializer.destroy();
+    adapter.destroy();
+    store.destroy();
+    Ember.lookup = originalLookup;
+  }
+});
+
+
+test("A record can't be created from an embedded polymorphic hasMany relationship", function() {
+  expect(1);
+  store.load(App.User, { id: 1, messages: [] });
+  var user = store.find(App.User, 1),
+      messages = user.get('messages');
+
+  raises(
+    function() { messages.createRecord(); },
+    /You can not create records of App.Message on this polymorphic relationship/,
+    "Creating records directly on a polymorphic hasMany is disallowed"
+  );
+});
+
+test("Only records of the same base type can be added to an embedded polymorphic hasMany relationship", function() {
+  expect(2);
+  store.load(App.User, { id: 1 });
+  store.load(App.User, { id: 2 });
+  store.load(App.Post, { id: 1 });
+  store.load(App.Comment, { id: 3 });
+
+  var user = store.find(App.User, 1),
+      anotherUser = store.find(App.User, 2),
+      messages = user.get('messages'),
+      post = store.find(App.Post, 1),
+      comment = store.find(App.Comment, 3);
+
+  messages.pushObject(post);
+  messages.pushObject(comment);
+
+  equal(messages.get('length'), 2, "The messages are correctly added");
+
+  raises(
+    function() { messages.pushObject(anotherUser); },
+    /You can only add records of App.Message to this relationship/,
+    "Adding records of a different base type on a polymorphic hasMany is disallowed"
+  );
+});
+
+test("A record can be removed from an embedded polymorphic association", function() {
+  expect(3);
+
+  store.load(App.User, { id: 1 , messages: [{id: 3, type: 'comment'}]});
+  store.load(App.Comment, { id: 3 });
+
+  var user = store.find(App.User, 1),
+      comment = store.find(App.Comment, 3),
+      messages = user.get('messages');
+
+  equal(messages.get('length'), 1, "The user has 1 message");
+
+  var removedObject = messages.popObject();
+
+  equal(removedObject, comment, "The message is correctly removed");
+  equal(messages.get('length'), 0, "The user does not have any messages");
+});
+
+test("The store can load an embedded polymorphic hasMany association", function() {
+  serializer.keyForEmbeddedType = function() {
+    return 'embeddedType';
+  };
+
+  adapter.load(store, App.User, { id: 2, messages: [{ id: 1, embeddedType: 'comment'}]});
+
+  var user = store.find(App.User, 2),
+      message = store.find(App.Comment, 1);
+
+  deepEqual(user.get('messages').toArray(), [message]);
+});
+
+test("The store can serialize an embedded polymorphic belongsTo association", function() {
+  serializer.keyForEmbeddedType = function() {
+    return 'embeddedType';
+  };
+  adapter.load(store, App.User, { id: 2, messages: [{ id: 1, embeddedType: 'comment'}]});
+
+  var user = store.find(App.User, 2),
+      serialized = store.serialize(user, {includeId: true});
+
+  ok(serialized.hasOwnProperty('messages'));
+  equal(serialized.messages.length, 1, "The messages are serialized");
+  equal(serialized.messages[0].id, 1);
+  equal(serialized.messages[0].embeddedType, 'comment');
+});

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -54,7 +54,7 @@ test("a record reports its unique id via the `id` property", function() {
   equal(get(record, 'id'), 1, "reports id as id by default");
 });
 
-test("a record's id is included in its toString represenation", function() {
+test("a record's id is included in its toString representation", function() {
   store.load(Person, { id: 1 });
 
   var record = store.find(Person, 1);

--- a/packages/ember-data/tests/unit/relationships_test.js
+++ b/packages/ember-data/tests/unit/relationships_test.js
@@ -189,7 +189,7 @@ test("relationships work when declared with a string path", function() {
   equal(get(person, 'tags.length'), 2, "the list of tags should have the correct length");
 });
 
-test("relationships work when the data hash has not been loaded", function() {
+test("hasMany relationships work when the data hash has not been loaded", function() {
   expect(13);
 
   var Tag = DS.Model.extend({
@@ -425,7 +425,7 @@ test("belongsTo lazily loads relationships as needed", function() {
   strictEqual(get(person, 'tag'), store.find(Tag, 5), "relationship object is the same as object retrieved directly");
 });
 
-test("relationships work when the data hash has not been loaded", function() {
+test("belongsTo relationships work when the data hash has not been loaded", function() {
   expect(12);
 
   var Tag = DS.Model.extend({


### PR DESCRIPTION
``` js
App.User = DS.Model.extend({
 messages: DS.hasMany(App.Message, {polymorphic: true})
});

App.Message = DS.Model.extend({
  created_at: DS.attr('date'),
  user: DS.belongsTo(App.User)
});

App.Post = App.Message.extend({
  title: DS.attr('string')
});

App.Comment = App.Message.extend({
  body: DS.attr('string'),
  message: DS.belongsTo(App.Message, {polymorphic: true})
});
```

You need to configure the serializer to map to the correct type:

``` js
DS.RESTAdapter.configure('App.Post' {
  alias: 'post'
});
DS.RESTAdapter.configure('App.Comment' {
  alias: 'comment'
});
```

The expected payload for a polymorphic association with the REST adapter/serializer should contain the type:

```
{
    user: {
        id: 3,
        // For a polymorphic hasMany
        messages: [
            {id: 1, type:"post"},
            {id:1, type: "comment"}
        ]
    },

    comment: {
        id: 1,
        // For a polymorphic belongsTo
        message_id: 1,
        message_type: "post"
    }
}
```

Initializing an alias will automatically allow you to sideload this
type. The support for `sideloadAs` is only for backward compatibility.

Two hooks exist for the serialization and materialization of an embedded
polymorphic association:
- `addType` that adds the record's type to the serialized data
- `extractEmbeddedType` that retrieves the record's type from the
  payload.

Both hooks rely in the JSONSerializer on `keyForEmbeddedType`, which returns the string used to
represent the record's type in the payload. The default value is `'type'`
