### PR TITLE
point `source` to `https://rubygems.org`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "rake-pipeline", :git => "https://github.com/livingsocial/rake-pipeline.git"
 gem "ember-dev", :git => "https://github.com/emberjs/ember-dev.git", :branch => "master"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: d0cd62116bce700680393badbf18278b84f31785
+  revision: 9e2b101001e417cf762ebccb13413515d2788705
   branch: master
   specs:
     ember-dev (0.1)
       colored
       execjs
       grit
+      handlebars-source
       kicker
       rack
       rake-pipeline (~> 0.8.0)
@@ -23,24 +24,25 @@ GIT
       thor
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     colored (1.2)
-    diff-lcs (1.2.0)
+    diff-lcs (1.2.1)
     execjs (1.4.0)
       multi_json (~> 1.0)
     grit (2.5.0)
       diff-lcs (~> 1.1)
       mime-types (~> 1.15)
       posix-spawn (~> 0.3.6)
-    json (1.7.6)
+    handlebars-source (1.0.9)
+    json (1.7.7)
     kicker (2.6.1)
       listen
     listen (0.7.2)
-    mime-types (1.20.1)
-    multi_json (1.5.0)
+    mime-types (1.21)
+    multi_json (1.6.1)
     posix-spawn (0.3.6)
-    rack (1.5.1)
+    rack (1.5.2)
     rake (10.0.3)
     rake-pipeline-web-filters (0.7.0)
       rack


### PR DESCRIPTION
Since the recent rubygems.org exploit the rubygems team have been recommending that everyone update their Gemfiles to have `source` point to `https://rubygems.org`

From the Rubygems chatroom on Freenode

> over http, a man in the middle could provide you a malicious gem

I'm closing [Pull Request 755](https://github.com/emberjs/data/pull/755) (because I believe the Travis build was failing due to my having been using Ruby 1.8.7 on my localhost when I ran `bundle update`) and issuing a new pull request here.
