### PR TITLE
Make belongsTo recognize id 0

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -22,7 +22,7 @@ DS.belongsTo = function(type, options) {
 
     id = data[key];
 
-    if(!id) {
+    if(none(id)) {
       return null;
     } else if (typeof id === 'object') {
       return store.recordForReference(id);


### PR DESCRIPTION
Using !id to check for a null belongsTo id was causing relationships to be treated as missing.

I'm using Ember.isNone to check for null or undefined instead of ! for falsiness.

I've also added a test to check for this case.
