### PR TITLE
Always include belongsTo relationships in JSON

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -101,12 +101,11 @@ DS.JSONSerializer = DS.Serializer.extend({
       if (embeddedChild = get(record, name)) {
         value = this.serialize(embeddedChild, { includeId: true });
       }
-
-      hash[key] = value;
     } else {
-      var id = get(record, relationship.key+'.id');
-      if (!Ember.isNone(id)) { hash[key] = id; }
+      value = get(record, relationship.key+'.id');
     }
+
+    hash[key] = value;
   },
 
   /**

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -92,7 +92,7 @@ var expectType = function(type) {
 };
 
 var expectData = function(hash) {
-  deepEqual(hash, ajaxHash.data, "the hash was passed along");
+  deepEqual(ajaxHash.data, hash, "the hash was passed along");
 };
 
 var expectState = function(state, value, p) {
@@ -119,7 +119,7 @@ test("creating a person makes a POST to /people, with the data hash", function()
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ person: { name: "Tom Dale" } });
+  expectData({ person: { name: "Tom Dale", group_id: null } });
 
   ajaxHash.success({ person: { id: 1, name: "Tom Dale" } });
   expectState('saving', false);
@@ -140,7 +140,7 @@ test("singular creations can sideload data", function() {
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ person: { name: "Tom Dale" } });
+  expectData({ person: { name: "Tom Dale", group_id: null } });
 
   ajaxHash.success({
     person: { id: 1, name: "Tom Dale" },
@@ -666,7 +666,7 @@ test("creating several people (with bulkCommit) makes a POST to /people, with a 
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ people: [ { name: "Tom Dale" }, { name: "Yehuda Katz" } ] });
+  expectData({ people: [ { group_id: null, name: "Tom Dale" }, { group_id: null, name: "Yehuda Katz" } ] });
 
   ajaxHash.success({ people: [ { id: 1, name: "Tom Dale" }, { id: 2, name: "Yehuda Katz" } ] });
   expectStates('saving', false);
@@ -691,7 +691,7 @@ test("bulk commits can sideload data", function() {
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ people: [ { name: "Tom Dale" }, { name: "Yehuda Katz" } ] });
+  expectData({ people: [ { group_id: null, name: "Tom Dale" }, { group_id: null, name: "Yehuda Katz" } ] });
 
   ajaxHash.success({
     people: [ { id: 1, name: "Tom Dale" }, { id: 2, name: "Yehuda Katz" } ],
@@ -733,7 +733,7 @@ test("updating several people (with bulkCommit) makes a PUT to /people/bulk with
 
   expectUrl("/people/bulk", "the collection at the plural of the model name");
   expectType("PUT");
-  expectData({ people: [{ id: 1, name: "Brohuda Brokatz" }, { id: 2, name: "Brocarl Brolerche" }] });
+  expectData({ people: [{ group_id: null, id: 1, name: "Brohuda Brokatz" }, { group_id: null, id: 2, name: "Brocarl Brolerche" }] });
 
   ajaxHash.success({ people: [
     { id: 1, name: "Brohuda Brokatz" },
@@ -774,7 +774,7 @@ test("bulk updates can sideload data", function() {
 
   expectUrl("/people/bulk", "the collection at the plural of the model name");
   expectType("PUT");
-  expectData({ people: [{ id: 1, name: "Brohuda Brokatz" }, { id: 2, name: "Brocarl Brolerche" }] });
+  expectData({ people: [{ group_id: null, id: 1, name: "Brohuda Brokatz" }, { group_id: null, id: 2, name: "Brocarl Brolerche" }] });
 
   ajaxHash.success({
     people: [
@@ -965,7 +965,7 @@ test("When a record with a belongsTo is saved the foreign key should be sent.", 
 
   expectUrl('/people');
   expectType("POST");
-  expectData({ person: { name: "Sam Woodard", person_type_id: "1" } });
+  expectData({ person: { group_id: null, name: "Sam Woodard", person_type_id: "1" } });
   ajaxHash.success({ person: { name: 'Sam Woodard', person_type_id: 1}});
 });
 


### PR DESCRIPTION
APIs will commonly ignore keys that are not included in the request. If
the belongsTo relationship has been unset, we need to include the key to
ensure the server knows it should unset the relationship.

— Ian (@elliterate)
