### PR TITLE
Fixing primary key problem for FixtureAdapter when the key normaly is generated on the server.

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -65,13 +65,6 @@ DS.FixtureAdapter = DS.Adapter.extend({
     return this.serialize(record, { includeId: true });
   },
 
-  /*
-    Adapter methods
-  */
-  generateIdForRecord: function(store, record) {
-    return Ember.guidFor(record);
-  },
-
   find: function(store, type, id) {
     var fixtures = this.fixturesForType(type),
         fixture;
@@ -134,7 +127,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
   createRecord: function(store, type, record) {
     var fixture = this.mockJSON(type, record);
 
-    fixture.id = this.generateIdForRecord(store, record);
+    fixture.id = Ember.guidFor(record);
 
     this.updateFixtures(type, fixture);
 


### PR DESCRIPTION
There where an error that could trigger if you created a record and then commited it.
You also needed to define a primaryKey field. And not set the primary key when the 
record was created. This worked fine with the RESTAdepter, since the primaryKey was 
set by the server.

"""
 assertion failed: An adapter cannot assign a new id to a record that 
 already has an id. Models.MyModel:ember2545 had id: ember2545 and you
 tried to update it with undefined. This likely happened because your
 server returned a data hash in response to a find or update that had a
 different id than the one you sent.
"""
