### PR TITLE
fix fixture adapter id generator

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -134,8 +134,6 @@ DS.FixtureAdapter = DS.Adapter.extend({
   createRecord: function(store, type, record) {
     var fixture = this.mockJSON(type, record);
 
-    fixture.id = this.generateIdForRecord(store, record);
-
     this.updateFixtures(type, fixture);
 
     this.simulateRemoteCall(function() {

--- a/packages/ember-data/tests/unit/fixture_adapter_test.js
+++ b/packages/ember-data/tests/unit/fixture_adapter_test.js
@@ -150,6 +150,7 @@ test("should create record asynchronously when it is committed", function() {
 
     var fixture = Person.FIXTURES[0];
 
+    equal(fixture.id, Ember.guidFor(paul));
     equal(fixture.firstName, 'Paul');
     equal(fixture.lastName, 'Chavard');
     equal(fixture.height, 70);


### PR DESCRIPTION
`generateIdForRecord` is called internally by ember on create if it is implemented on the adapter. Calling it again in the adapter can lad to unexpected behavior.

Currently in some cases creation will fail with :

```
assertion failed: An adapter cannot assign a new id to a record that 
 already has an id. Models.MyModel:ember2545 had id: ember2545 and you
 tried to update it with undefined. This likely happened because your
 server returned a data hash in response to a find or update that had a
 different id than the one you sent.
```
