### PR TITLE
Test registerEnumTransform on Adapter class instead of adapter instance

### DIFF
--- a/packages/ember-data/tests/integration/transform_test.js
+++ b/packages/ember-data/tests/integration/transform_test.js
@@ -120,9 +120,11 @@ test("the default date transform", function() {
 
 module("Enum Transforms", {
   setup: function() {
-    adapter = DS.Adapter.create();
-    adapter.registerEnumTransform('materials', ['unobtainium', 'kindaobtainium', 'veryobtainium']);
-  
+    Adapter = DS.Adapter.extend();
+
+    Adapter.registerEnumTransform('materials', ['unobtainium', 'kindaobtainium', 'veryobtainium']);
+
+    adapter = Adapter.create();
     store = DS.Store.create({
       adapter: adapter
     });


### PR DESCRIPTION
I believe `registerTransform` should be use on the Adapter class, the `registerEnumTransform` should operate on the class as well.

Here is the actual test updated to reflect this behavior, it's failing for now.

Related to #581
cc @leepfrog
