### PR TITLE
Stop using extended method

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -2,7 +2,7 @@ require("ember-data/core");
 require("ember-data/system/adapter");
 require('ember-data/serializers/fixture_serializer');
 
-var get = Ember.get;
+var get = Ember.get, fmt = Ember.String.fmt;
 
 /**
   `DS.FixtureAdapter` is an adapter that loads records from memory.
@@ -30,7 +30,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
       var fixtures = Ember.A(type.FIXTURES);
       return fixtures.map(function(fixture){
         if(!fixture.id){
-          throw new Error('the id property must be defined for fixture %@'.fmt(fixture));
+          throw new Error(fmt('the id property must be defined for fixture %@', [fixture]));
         }
         fixture.id = fixture.id + '';
         return fixture;


### PR DESCRIPTION
I used `Ember.String.fmt` instead of `String#fmt`.
Because the latter may be undefined.
