### PR TITLE
Increase loadMany performance by 10% by removing dead code

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1402,7 +1402,6 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     }
 
     var content = get(array, 'content');
-    var alreadyInArray = content.indexOf(clientId) !== -1;
 
     var recordArrays = this.recordArraysForClientId(clientId);
     var reference = this.referenceForClientId(clientId);


### PR DESCRIPTION
I'm working on performance improvements to loadMany. This indexOf function call assigns a variable that is never used. Removing this increases loadMany speed approximately 10% for loading large numbers of objects (~10000).

All tests are passing after making this change.
