### PR TITLE
Allow a path as the return value of the keyForXXX.

### DIFF
--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -212,14 +212,14 @@ DS.Serializer = Ember.Object.extend({
     }
 
     this.eachEmbeddedHasMany(type, function(name, relationship) {
-      var embeddedData = json[this.keyFor(relationship)];
+      var embeddedData = get(json, this.keyFor(relationship));
       if (!isNone(embeddedData)) {
         this.extractEmbeddedHasMany(loader, relationship, embeddedData, reference, prematerialized);
       }
     }, this);
 
     this.eachEmbeddedBelongsTo(type, function(name, relationship) {
-      var embeddedData = json[this.keyFor(relationship)];
+      var embeddedData = get(json, this.keyFor(relationship));
       if (!isNone(embeddedData)) {
         this.extractEmbeddedBelongsTo(loader, relationship, embeddedData, reference, prematerialized);
       }


### PR DESCRIPTION
Consider the following JSON: `{ dashboard: { content: { tabs: [] } } }`

``` javascript
App.Dashboard.reopen({
    tabs: DS.hasMany(App.Tab)
});
App.DashboardAdapter.map('App.Dashboard', {
    tabs: { embedded: "always" }
});

App.DashboardSerializer = DS.JSONSerializer.extend({
    keyForHasMany: function(type, name) {
        return 'content.'+name;
    }
});
```
