### PR TITLE
Add option to use HTTP PATCH method for updates

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -63,6 +63,7 @@ var get = Ember.get, set = Ember.set, merge = Ember.merge;
 DS.RESTAdapter = DS.Adapter.extend({
   bulkCommit: false,
   since: 'since',
+  updateViaPATCH: false,
 
   serializer: DS.RESTSerializer,
 
@@ -153,13 +154,15 @@ DS.RESTAdapter = DS.Adapter.extend({
   },
 
   updateRecord: function(store, type, record) {
-    var id = get(record, 'id');
-    var root = this.rootForType(type);
+    var id = get(record, 'id'),
+        root = this.rootForType(type),
+        requestMethod = get(this, 'updateViaPATCH') ? "PATCH" : "PUT";
+
 
     var data = {};
     data[root] = this.serialize(record);
 
-    this.ajax(this.buildURL(root, id), "PUT", {
+    this.ajax(this.buildURL(root, id), requestMethod, {
       data: data,
       context: this,
       success: function(json) {
@@ -179,7 +182,8 @@ DS.RESTAdapter = DS.Adapter.extend({
     }
 
     var root = this.rootForType(type),
-        plural = this.pluralize(root);
+        plural = this.pluralize(root),
+        requestMethod = get(this, 'updateViaPATCH') ? "PATCH" : "PUT";
 
     var data = {};
     data[plural] = [];
@@ -187,7 +191,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       data[plural].push(this.serialize(record, { includeId: true }));
     }, this);
 
-    this.ajax(this.buildURL(root, "bulk"), "PUT", {
+    this.ajax(this.buildURL(root, "bulk"), requestMethod, {
       data: data,
       context: this,
       success: function(json) {

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -172,6 +172,33 @@ test("updating a person makes a PUT to /people/:id with the data hash", function
   equal(get(person, 'name'), "Brohuda Brokatz", "the hash should be updated");
 });
 
+test("updates can optionally be made via the PATCH request method", function() {
+  set(adapter, 'updateViaPATCH', true);
+
+  store.load(Person, { id: 1, name: "Yehuda Katz" });
+
+  person = store.find(Person, 1);
+
+  expectState('new', false);
+  expectState('loaded');
+  expectState('dirty', false);
+
+  set(person, 'name', "Brohuda Brokatz");
+
+  expectState('dirty');
+  store.commit();
+  expectState('saving');
+
+  expectUrl("/people/1", "the plural of the model name with its ID");
+  expectType("PATCH");
+
+  ajaxHash.success({ person: { id: 1, name: "Brohuda Brokatz" } });
+  expectState('saving', false);
+
+  equal(person, store.find(Person, 1), "the same person is retrieved by the same ID");
+  equal(get(person, 'name'), "Brohuda Brokatz", "the hash should be updated");
+});
+
 test("updates are not required to return data", function() {
   store.load(Person, { id: 1, name: "Yehuda Katz" });
 
@@ -725,6 +752,46 @@ test("updating several people (with bulkCommit) makes a PUT to /people/bulk with
 
   expectUrl("/people/bulk", "the collection at the plural of the model name");
   expectType("PUT");
+  expectData({ people: [{ id: 1, name: "Brohuda Brokatz" }, { id: 2, name: "Brocarl Brolerche" }] });
+
+  ajaxHash.success({ people: [
+    { id: 1, name: "Brohuda Brokatz" },
+    { id: 2, name: "Brocarl Brolerche" }
+  ]});
+
+  expectStates('saving', false);
+
+  equal(yehuda, store.find(Person, 1), "the same person is retrieved by the same ID");
+  equal(carl, store.find(Person, 2), "the same person is retrieved by the same ID");
+});
+
+test("updating several people (with bulkCommit) can optionally use the PATCH request method", function() {
+  set(adapter, 'bulkCommit', true);
+  set(adapter, 'updateViaPATCH', true);
+
+  store.loadMany(Person, [
+    { id: 1, name: "Yehuda Katz" },
+    { id: 2, name: "Carl Lerche" }
+  ]);
+
+  var yehuda = store.find(Person, 1);
+  var carl = store.find(Person, 2);
+
+  people = [ yehuda, carl ];
+
+  expectStates('new', false);
+  expectStates('loaded');
+  expectStates('dirty', false);
+
+  set(yehuda, 'name', "Brohuda Brokatz");
+  set(carl, 'name', "Brocarl Brolerche");
+
+  expectStates('dirty');
+  store.commit();
+  expectStates('saving');
+
+  expectUrl("/people/bulk", "the collection at the plural of the model name");
+  expectType("PATCH");
   expectData({ people: [{ id: 1, name: "Brohuda Brokatz" }, { id: 2, name: "Brocarl Brolerche" }] });
 
   ajaxHash.success({ people: [


### PR DESCRIPTION
I'm not sure if this is the best way to accomplish this, but I think it'd be nice to allow this option. Especially considering that PATCH will be the primary update method for Rails 4.
