### PR TITLE
Fix failing tests by running assertion in next run-loop

### DIFF
--- a/packages/ember-data/tests/integration/find_all_test.js
+++ b/packages/ember-data/tests/integration/find_all_test.js
@@ -33,11 +33,13 @@ test("When all records for a type are requested, the store should call the adapt
     invokeAsync(function() {
       store.loadMany(type, [{ id: 1, name: "Braaaahm Dale" }]);
 
-      equal(get(allRecords, 'length'), 1, "the record array's length is 1 after a record is loaded into it");
-      equal(allRecords.objectAt(0).get('name'), "Braaaahm Dale", "the first item in the record array is Braaaahm Dale");
+      Ember.run.next(function() {
+        equal(get(allRecords, 'length'), 1, "the record array's length is 1 after a record is loaded into it");
+        equal(allRecords.objectAt(0).get('name'), "Braaaahm Dale", "the first item in the record array is Braaaahm Dale");
 
-      // Only one record array per type should ever be created (identity map)
-      strictEqual(allRecords, store.all(Person), "the same record array is returned every time all records of a type are requested");
+        // Only one record array per type should ever be created (identity map)
+        strictEqual(allRecords, store.all(Person), "the same record array is returned every time all records of a type are requested");
+      });
     });
   };
 

--- a/packages/ember-data/tests/integration/has_many_test.js
+++ b/packages/ember-data/tests/integration/has_many_test.js
@@ -42,13 +42,16 @@ test("A hasMany relationship has an isLoaded flag that indicates whether the Man
   adapter.find = function(store, type, id) {
     setTimeout(async(function() {
       equal(array.get('isLoaded'), false, "Before loading, the array isn't isLoaded");
-      store.load(type, { id: id });
 
-      if (id === '3') {
-        equal(array.get('isLoaded'), true, "After loading all records, the array isLoaded");
-      } else {
-        equal(array.get('isLoaded'), false, "After loading some records, the array isn't isLoaded");
-      }
+      Ember.run.next(function() {
+        store.load(type, { id: id });
+
+        if (id === '3') {
+          equal(array.get('isLoaded'), true, "After loading all records, the array isLoaded");
+        } else {
+          equal(array.get('isLoaded'), false, "After loading some records, the array isn't isLoaded");
+        }
+      });
     }), 1);
   };
 


### PR DESCRIPTION
Some tests are failed in 2bcc7677.
This cause is that the timing for executing callback by `window.async` got later than as expectation.
- https://github.com/emberjs/data/commit/2bcc767755a03e985a7e26ec2eee41cc1f8dc177#L3R33

So I use `Ember.run.next` to adjust timing for assertion.
