### PR TITLE
Adds corsWithCredentials option to DS.RESTAdapter

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -59,6 +59,19 @@ var get = Ember.get, set = Ember.set, merge = Ember.merge;
     }
   }
   ```
+
+  ## Customization
+
+  ### Enable CORS with credentials
+
+  If your API is running on another domain and requires cookies to be included in every request
+  you have to enable this:
+
+  ```js
+  DS.RESTAdapter.reopen({ 
+    corsWithCredentials: true
+  });
+  ```
 */
 DS.RESTAdapter = DS.Adapter.extend({
   bulkCommit: false,
@@ -324,6 +337,11 @@ DS.RESTAdapter = DS.Adapter.extend({
     if (hash.data && type !== 'GET') {
       hash.data = JSON.stringify(hash.data);
     }
+    if (this.corsWithCredentials) {
+      hash.xhrFields = {
+        withCredentials: true
+      };
+    } 
 
     jQuery.ajax(hash);
   },
@@ -365,4 +383,3 @@ DS.RESTAdapter = DS.Adapter.extend({
     return since ? query : null;
   }
 });
-

--- a/packages/ember-data/tests/integration/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/rest_adapter_test.js
@@ -1,6 +1,42 @@
+var get = Ember.get, set = Ember.set;
 var store, adapter, Post, Comment;
 
-module("REST Adapter") ;
+module("REST Adapter", {
+  setup: function() {
+    adapter = DS.RESTAdapter.create();
+    store = DS.Store.create({
+      adapter: adapter
+    });
+
+    var attr = DS.attr;
+    Post = DS.Model.extend({
+      title: attr('string')
+    });
+    Post.toString = function() { return "Post"; };
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      store.destroy();
+      adapter.destroy();
+    });
+  }
+});
+
+test("if you specify corsWithCredentials then the withCredentials is passed to jquery", function() {
+  var hash;
+  window.jQuery._ajax = window.jQuery.ajax;
+  window.jQuery.ajax = function(ajaxHash) {
+    hash = ajaxHash;
+  };
+
+  set(adapter, 'corsWithCredentials', true);
+  var post = store.find(Post, 1);
+  deepEqual(hash.xhrFields, {withCredentials: true}, "xhrFields has withCredentials set to true.");
+  store.load(Post, { id: 1 });
+  
+  window.jQuery.ajax = window.jQuery._ajax;
+});
 
 //test("changing A=>null=>A should clean up the record", function() {
   //var store = DS.Store.create({


### PR DESCRIPTION
This PR adds an option to use cross-domain requests with credentials. Usage:

``` javascript
DS.RESTAdapter.reopen({
  corsWithCredentials: true
});
```

I didn't know, where to put the tests as the ajax function is mocked for unit testing and the integration tests were commented out.
