### PR TITLE
loadMany 40X performance improvement, array observer notifications only on load completion.

### DIFF
--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -108,7 +108,9 @@
       didUpdateAttribute: syncForTest(),
       didUpdateAttributes: syncForTest(),
       didUpdateRelationship: syncForTest(),
-      didUpdateRelationships: syncForTest()
+      didUpdateRelationships: syncForTest(),
+      updateRecordArrays: syncForTest(),
+      updateRecordArraysLater: syncForTest()
     });
 
     DS.Model.reopen({


### PR DESCRIPTION
So, this started as an attempt to improve load performance, which it does, however it also solves another annoying bug, namely that observers fire for every single record loaded into a store.

The performance is way better in this version, for a large number of records (~10,000) load time is about ~500ms vs ~20s in chrome on a recent MacBook Pro. It also solves a really annoying problem of computed properties / observers, namely that when they observe an array that is loaded from ember data they fire for every object loaded into the store, not just when all the objects are loaded.

This problem can be demonstrated here in these jsFiddles.

[Fiddle with ember-data master version](http://jsfiddle.net/alexspeller/UdybQ/)

[Fiddle with this version of ember-data](http://jsfiddle.net/alexspeller/VCSE3/)

As you can see in the fiddles, my version only logs a property change when all models are loaded into the store, wheras for the current master there is a log for each individual object loaded into the store. When there are a large number of models this quickly becomes a problem (even for smaller numbers of models it is a pain, as if you have processing that takes e.g. 500ms in an array observer, and you then load 10 objects into that array, the app will freeze for 5 seconds).

There are failing tests in this pull request - I have not been able to fix them and they seem to run fine individually with rackup but not together. I don't have more time to work on fixing the tests at the moment and am using a different approach now, however these performance improvements and bugfix work great apart from the tests, so I'm filing this pull request in the hope that someone more experienced with the tests can take a look.
