### PR TITLE
Do not allow setting to essentially read-only setters

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -5,7 +5,10 @@ var LoadPromise = DS.LoadPromise; // system/mixins/load_promise
 
 var get = Ember.get, set = Ember.set, none = Ember.isNone, map = Ember.EnumerableUtils.map;
 
-var retrieveFromCurrentState = Ember.computed(function(key) {
+var retrieveFromCurrentState = Ember.computed(function(key, value) {
+  if (arguments.length > 1) {
+    throw new Error('Cannot Set: ' + key + ' on: ' + this.toString() );
+  }
   return get(get(this, 'stateManager.currentState'), key);
 }).property('stateManager.currentState');
 

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -328,3 +328,13 @@ test("a DS.Model can describe Date attributes", function() {
   convertsWhenSet('date', date, dateString);
 });
 
+test("don't allow setting", function(){
+  var store = DS.Store.create();
+
+  var Person = DS.Model.extend();
+  var record = store.createRecord(Person);
+
+  raises(function(){
+    record.set('isLoaded', true);
+  }, "raised error when trying to set an unsettable record");
+});


### PR DESCRIPTION
If you set to any of the essentially read-only computed properties
such as: isLoaded, isReloading etc... on model, you are going to have
a really bad time.
