### PR TITLE
Add HTTP headers to RESTAdapter ajax calls

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -59,6 +59,44 @@ var get = Ember.get, set = Ember.set, merge = Ember.merge;
     }
   }
   ```
+
+  ## Customization
+
+  ### Endpoint path customization
+
+  Endpoint paths can be prefixed with a `namespace` by setting the namespace 
+  property on the adapter:
+
+  ```js
+  DS.RESTAdapter.reopen({
+    namespace: 'api/1'
+  });
+  ```
+  Requests for `App.Person` would now target `/api/1/people/1`.
+
+  ### Host customization
+
+  An adapter can target other hosts by setting the `url` property.
+
+  ```js
+  DS.RESTAdapter.reopen({
+    url: 'https://api.example.com'
+  });
+  ```
+  
+  ### Headers customization
+
+  Some APIs require HTTP headers, eg to provide an API key. An array of 
+  headers can be added to the adapter which are passed with every request:
+
+  ```js
+  DS.RESTAdapter.reopen({ 
+    headers: { 
+      "API_KEY": "secret key", 
+      "ANOTHER_HEADER": "asdsada"
+    }
+  });
+  ```
 */
 DS.RESTAdapter = DS.Adapter.extend({
   bulkCommit: false,
@@ -323,6 +361,15 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     if (hash.data && type !== 'GET') {
       hash.data = JSON.stringify(hash.data);
+    }
+
+    if (this.headers !== undefined) {
+      var headers = this.headers;
+      hash.beforeSend = function (xhr) {
+        Ember.keys(headers).forEach(function(key) {
+          xhr.setRequestHeader(key, headers[key]);
+        });
+      };   
     }
 
     jQuery.ajax(hash);


### PR DESCRIPTION
Some APIs require additional HTTP headers, for example an API_KEY so have added the ability for this.

Followed the same pattern as used for `namespace` by checking for an `apiHeaders` property on the adapter. 

Example configuration.

``` javascript
DS.RESTAdapter.reopen({ 
  apiHeaders: [[ "API_KEY", "secret key"], ["ANOTHER_HEADER", "asdsada"]]
});
```

I couldn't find tests for constructing the ajax hash so was unsure where to start. Would appreciate any guidance.
