### PR TITLE
Improve error message

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -2,7 +2,8 @@ require("ember-data/core");
 require("ember-data/system/adapter");
 require('ember-data/serializers/fixture_serializer');
 
-var get = Ember.get, fmt = Ember.String.fmt;
+var get = Ember.get, fmt = Ember.String.fmt,
+    dump = Ember.get(window, 'JSON.stringify') || function(object) { return object.toString(); };
 
 /**
   `DS.FixtureAdapter` is an adapter that loads records from memory.
@@ -30,7 +31,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
       var fixtures = Ember.A(type.FIXTURES);
       return fixtures.map(function(fixture){
         if(!fixture.id){
-          throw new Error(fmt('the id property must be defined for fixture %@', [JSON.stringify(fixture)]));
+          throw new Error(fmt('the id property must be defined for fixture %@', [dump(fixture)]));
         }
         fixture.id = fixture.id + '';
         return fixture;


### PR DESCRIPTION
`fixture` is an instance of `Object`.

Before:

```
the id property must be defined for fixture [Object object]
```

After:

```
the id property must be defined for fixture {"foo": "bar"}
```
