### PR TITLE
Move createSerializedForm to DS.Serializer

### DIFF
--- a/packages/ember-data/lib/serializers/fixture_serializer.js
+++ b/packages/ember-data/lib/serializers/fixture_serializer.js
@@ -32,18 +32,6 @@ DS.FixtureSerializer = DS.Serializer.extend({
     hash[relationship.key] = ids;
   },
 
-  /**
-    @private
-
-    Creates an empty hash that will be filled in by the hooks called from the
-    `serialize()` method.
-
-    @return {Object}
-  */
-  createSerializedForm: function() {
-    return {};
-  },
-
   extract: function(loader, fixture, type, record) {
     if (record) { loader.updateId(record, fixture); }
     this.extractRecordRepresentation(loader, type, fixture);

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -59,18 +59,6 @@ DS.JSONSerializer = DS.Serializer.extend({
     hash[key] = value;
   },
 
-  /**
-    @private
-
-    Creates an empty hash that will be filled in by the hooks called from the
-    `serialize()` method.
-
-    @return {Object}
-  */
-  createSerializedForm: function() {
-    return {};
-  },
-
   extractAttribute: function(type, hash, attributeName) {
     var key = this._keyForAttributeName(type, attributeName);
     return hash[key];

--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -394,6 +394,16 @@ DS.Serializer = Ember.Object.extend({
   addId: Ember.K,
 
   /**
+    Creates an empty hash that will be filled in by the hooks called from the
+    `serialize()` method.
+
+    @return {Object}
+  */
+  createSerializedForm: function() {
+    return {};
+  },
+
+  /**
     A hook you can use to change how relationships are added to the serialized
     representation of a record.
 


### PR DESCRIPTION
Move createSerializedForm to DS.Serializer. DS.Serializer calls the routine directly, but it's only defined in the JSON and Fixture implementations.

Passes "rake test[all]".
