### PR TITLE
Add assertion in `relatedTypes` to catch undefined relations

### DIFF
--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -208,6 +208,8 @@ DS.Model.reopenClass({
           type = get(this, type, false) || get(Ember.lookup, type);
         }
 
+        Ember.assert("You specified a hasMany (" + meta.type + ") on " + meta.parentType + " but " + meta.type + " was not found.",  type);
+
         if (!types.contains(type)) {
           types.push(type);
         }


### PR DESCRIPTION
If you define a relation on a model with a String identifier of an undefined object (`"App.Usre"`, perchance) your application might appear functional until ember-data tries to sideload responses for that model. Eventually an exception is raised in the serializer's `rootForType` method, but its not immediately apparent why.

This seems like the kind of thing ember-data should have an assertion for – catching a mistake early as in `DS.JSONSerializer#sideload`.
