### PR TITLE
Bug fix: hasMany loaded as null is throwing exception

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -673,7 +673,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
       if (adapter && adapter.findHasMany) {
         adapter.findHasMany(this, record, relationship, idsOrReferencesOrOpaque);
-      } else if (idsOrReferencesOrOpaque !== undefined) {
+      } else if (!isNone(idsOrReferencesOrOpaque)) {
         Ember.assert("You tried to load many records but you have no adapter (for " + type + ")", adapter);
         Ember.assert("You tried to load many records but your adapter does not implement `findHasMany`", adapter.findHasMany);
       }

--- a/packages/ember-data/tests/integration/relationships/one_to_many_relationships_test.js
+++ b/packages/ember-data/tests/integration/relationships/one_to_many_relationships_test.js
@@ -48,6 +48,22 @@ test("Referencing a null belongsTo relationship returns null", function(){
   equal(comment.get('post'), null, "null belongsTo relationship returns null");
 });
 
+test("Referencing an undefined hasMany relationship returns empty array", function() {
+  store.load(App.Post, {id: 1, title: "parent with undefined children"});
+  var post = store.find(App.Post, 1);
+  ok(post.get('comments'), "able to get the post's comments");
+  equal(post.get('comments.length'), 0, "undefined hasMany relationship returns empty array");
+  deepEqual(post.get('comments').toArray(), [], "comments is empty array");
+});
+
+test("Referencing a null hasMany relationship returns empty array", function(){
+  store.load(App.Post, { id: 1, comments: null, title: "parent with children set to null" });
+  var post = store.find(App.Post, 1);
+  ok(post.get('comments'), "able to get the post's comments");
+  equal(post.get('comments.length'), 0, "null masMany relationship returns empty array");
+  deepEqual(post.get('comments').toArray(), [], "comments is an empty array");
+});
+
 test("When setting a record's belongsTo relationship to another record, that record should be added to the inverse hasMany array", function() {
   store.load(App.Post, { id: 1, title: "parent" });
   store.load(App.Comment, { id: 2, body: "child" });


### PR DESCRIPTION
If a hasMany relationship is loaded as `null`, don't throw `Adapter is either null or does not implement 'findHasMany' method`. I have written some failing tests for this situation. I also committed a proposed fix, but not sure if it is the right approach.

Change introduced at this commit https://github.com/emberjs/data/commit/81e6fdeef02e909c90b88da93d94c5cab7625baf for these files:
`system/relationships/has_many.js:20`
`system/store.js:679`
