### PR TITLE
automatically publish passing master branch builds to s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,10 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - "rake clean"
 script: "rake test[all]"
+after_success: 'bundle exec rake publish_build'
 notifications:
   webhooks: http://emberjs-master-builds.herokuapp.com/upload/data
+env:
+  global:
+    - S3_BUCKET_NAME=yourbucketname
+

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,6 @@ gem "rake-pipeline", :git => "https://github.com/livingsocial/rake-pipeline.git"
 gem "ember-dev", :git => "https://github.com/emberjs/ember-dev.git", :branch => "master"
 
 gem "ember-source", "1.0.0.rc1.4"
+
+gem "aws-sdk", "1.8.5"
+

--- a/Rakefile
+++ b/Rakefile
@@ -32,3 +32,33 @@ task :clean => "ember:clean"
 task :dist => "ember:dist"
 task :test, [:suite] => "ember:test"
 task :default => :dist
+
+task :publish_build do
+  require 'date'
+  require 'aws-sdk'
+  access_key_id = ENV['S3_ACCESS_KEY_ID']
+  secret_access_key = ENV['S3_SECRET_ACCESS_KEY']
+  bucket_name = ENV['S3_BUCKET_NAME']
+  rev=`git rev-list HEAD -n 1`.to_s.strip
+  master_rev = `git rev-list origin/master -n 1`.to_s.strip
+  return unless rev == master_rev
+  return unless access_key_id && secret_access_key && bucket_name
+  s3 = AWS::S3.new(
+    :access_key_id => access_key_id,
+    :secret_access_key => secret_access_key
+  )
+  bucket = s3.buckets[bucket_name]
+  ember_data_latest = bucket.objects['ember-data-latest.js']
+  ember_data_latest_min = bucket.objects['ember-data-latest.min.js']
+  ember_data_dev = bucket.objects["ember-data-#{rev}.js"]
+  ember_data_min = bucket.objects["ember-data-#{rev}.min.js"]
+  dist = File.dirname(__FILE__) + '/dist/'
+  data_path = Pathname.new dist + 'ember-data.js'
+  min_path = Pathname.new dist + 'ember-data.min.js'
+  ember_data_dev.write data_path
+  ember_data_latest.write data_path
+  ember_data_latest_min.write min_path
+  ember_data_min.write min_path
+  puts "Published ember-data for #{rev}"
+end
+


### PR DESCRIPTION
This commit will publish passing builds of the master branch to s3 for
convenient downloading.

Files created if the build is successful:
ember-data-latest.js
ember-data-latest.min.js
ember-data-<revision>.js
ember-data-<revision>.min.js

Any _-latest_.js files will be overwritten to the build that passes and
runs `rake publish_build`.

To add credentials to your travis instance:

gem install travis
travis encrypt S3_ACCESS_KEY_ID=yourkey --add
travis encrypt S3_SECRET_ACCESS_KEY=yourkey --add

You'll also need to update the S3_BUCKET_NAME=yourbucketname in
.travis.yml
