### PR TITLE
When saving records with null belongsTo relationships, the relationship ...

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -110,7 +110,9 @@ DS.JSONSerializer = DS.Serializer.extend({
         name = relationship.key,
         value = null,
         includeType = (relationship.options && relationship.options.polymorphic),
-        embeddedChild;
+        embeddedChild,
+        child,
+        id;
 
     if (this.embeddedType(type, name)) {
       if (embeddedChild = get(record, name)) {
@@ -119,14 +121,13 @@ DS.JSONSerializer = DS.Serializer.extend({
 
       hash[key] = value;
     } else {
-      var child = get(record, relationship.key),
-          id = get(child, 'id');
-      if (!Ember.isNone(id)) {
-        if (relationship.options && relationship.options.polymorphic) {
-          this.addBelongsToPolymorphic(hash, key, id, child.constructor);
-        } else {
-           hash[key] = id;
-        }
+      child = get(record, relationship.key);
+      id = get(child, 'id');
+
+      if (relationship.options && relationship.options.polymorphic && !Ember.isNone(id)) {
+        this.addBelongsToPolymorphic(hash, key, id, child.constructor);
+      } else {
+        hash[key] = id === undefined ? null : id;
       }
     }
   },

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -155,7 +155,7 @@ test("creating a person makes a POST to /people, with the data hash", function()
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ person: { name: "Tom Dale" } });
+  expectData({ person: { name: "Tom Dale", group_id: null } });
 
   ajaxHash.success({ person: { id: 1, name: "Tom Dale" } });
   expectState('saving', false);
@@ -172,7 +172,7 @@ test("singular creations can sideload data", function() {
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ person: { name: "Tom Dale" } });
+  expectData({ person: { name: "Tom Dale", group_id: null } });
 
   ajaxHash.success({
     person: { id: 1, name: "Tom Dale" },
@@ -698,7 +698,7 @@ test("creating several people (with bulkCommit) makes a POST to /people, with a 
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ people: [ { name: "Tom Dale" }, { name: "Yehuda Katz" } ] });
+  expectData({ people: [ { name: "Tom Dale", group_id: null }, { name: "Yehuda Katz", group_id: null } ] });
 
   ajaxHash.success({ people: [ { id: 1, name: "Tom Dale" }, { id: 2, name: "Yehuda Katz" } ] });
   expectStates('saving', false);
@@ -723,7 +723,7 @@ test("bulk commits can sideload data", function() {
 
   expectUrl("/people", "the collection at the plural of the model name");
   expectType("POST");
-  expectData({ people: [ { name: "Tom Dale" }, { name: "Yehuda Katz" } ] });
+  expectData({ people: [ { name: "Tom Dale", group_id: null }, { name: "Yehuda Katz", group_id: null } ] });
 
   ajaxHash.success({
     people: [ { id: 1, name: "Tom Dale" }, { id: 2, name: "Yehuda Katz" } ],
@@ -765,7 +765,7 @@ test("updating several people (with bulkCommit) makes a PUT to /people/bulk with
 
   expectUrl("/people/bulk", "the collection at the plural of the model name");
   expectType("PUT");
-  expectData({ people: [{ id: 1, name: "Brohuda Brokatz" }, { id: 2, name: "Brocarl Brolerche" }] });
+  expectData({ people: [{ id: 1, name: "Brohuda Brokatz", group_id: null }, { id: 2, name: "Brocarl Brolerche", group_id: null }] });
 
   ajaxHash.success({ people: [
     { id: 1, name: "Brohuda Brokatz" },
@@ -806,7 +806,7 @@ test("bulk updates can sideload data", function() {
 
   expectUrl("/people/bulk", "the collection at the plural of the model name");
   expectType("PUT");
-  expectData({ people: [{ id: 1, name: "Brohuda Brokatz" }, { id: 2, name: "Brocarl Brolerche" }] });
+  expectData({ people: [{ id: 1, name: "Brohuda Brokatz", group_id: null }, { id: 2, name: "Brocarl Brolerche", group_id: null }] });
 
   ajaxHash.success({
     people: [
@@ -998,7 +998,7 @@ test("When a record with a belongsTo is saved the foreign key should be sent.", 
 
   expectUrl('/people');
   expectType("POST");
-  expectData({ person: { name: "Sam Woodard", person_type_id: "1" } });
+  expectData({ person: { name: "Sam Woodard", person_type_id: "1", group_id: null } });
   ajaxHash.success({ person: { name: 'Sam Woodard', person_type_id: 1}});
 });
 


### PR DESCRIPTION
...is serialized with a null value.

This is an update to PR https://github.com/emberjs/data/pull/685 rebased against master and taking into account the recent addition of polymorphic associations.
