### PR TITLE
Failing test for finding one record whose id was loaded in hasMany

### DIFF
--- a/packages/ember-data/tests/integration/has_many_test.js
+++ b/packages/ember-data/tests/integration/has_many_test.js
@@ -281,3 +281,15 @@ test("A record can be removed from a polymorphic association", function() {
   equal(removedObject, comment, "The message is correctly removed");
   equal(messages.get('length'), 0, "The user does not have any messages");
 });
+
+test("Finding single record after loading its id through hasMany", function() {
+  expect(1);
+  store.load(App.Post, { id: 1, comments: [1, 2, 3] });
+
+  adapter.find = function(store, type, id) {
+    ok(true, "The find method should be called for comment");
+  };
+
+  var post = store.find(App.Post, 1);
+  var comment = store.find(App.Comment, 2);
+});


### PR DESCRIPTION
Failing test for the following bug:

When an id of a record is already loaded through a `hasMany` relationship, `findById` on this record no longer triggers the adapter's `find` method.

Example:

``` javascript
App.Post = DS.Model.extend({
   comments: DS.hasMany('App.Comment')
});
```

if `post = App.Post.find(1)` returns:

``` json
"post": {
  "id": 1,
  "comment_ids": [1, 2]
}
```

When we later call `App.Comment.find(1)` or `App.Comment.find(2)` the store assumes they are already loaded and doesn't call `Adapter#find` and the records get stuck in the `loading` state.

The only way to fetch these records from the server is to use `post.get('comments')`.

I did a git bisect and it seems the issue started after this: 6f7c13dc50823028e3ee9c2907af4cc5328131ff
