### PR TITLE
Test interaction between App.reset() and defaultStore

### DIFF
--- a/packages/ember-data/tests/integration/application_test.js
+++ b/packages/ember-data/tests/integration/application_test.js
@@ -37,6 +37,23 @@ if (Ember.Application.initializer) {
     var fooController = container.lookup('controller:foo');
     ok(fooController.get('store') instanceof DS.Store, "the store was injected");
   });
+
+  test("After App.reset(), App.MyModel.find(...) still works", function () {
+    app.Person = DS.Model.extend({ name: DS.attr('string') });
+    app.Person.find('1');
+    Ember.run(function () { app.reset(); });
+    app.Person.find('2');
+    ok(true, "did not crash");
+  });
+
+  test("After App.reset(), there is a new, valid defaultStore", function () {
+    var oldStore = DS.get("defaultStore");
+    ok(oldStore instanceof DS.Store, "defaultStore is present before reset");
+    Ember.run(function () { app.reset(); });
+    var newStore = DS.get("defaultStore");
+    ok(newStore instanceof DS.Store, "defaultStore is present after reset");
+    ok(newStore !== oldStore, "defaultStore has changed");
+  });
 }
 
 if (Ember.Application.registerInjection) {
@@ -84,6 +101,25 @@ if (Ember.Application.registerInjection) {
     Ember.run(function() { app.initialize(); });
 
     equal(app.get('router.bazController.store'), undefined, "the function was not injected");
+  });
+
+  test("After App.reset(), App.MyModel.find(...) still works", function () {
+    app.Person = DS.Model.extend({ name: DS.attr('string') });
+    Ember.run(function () { app.initialize(); });
+    app.Person.find('1');
+    Ember.run(function () { app.reset(); });
+    app.Person.find('2');
+    ok(true, "did not crash");
+  });
+
+  test("After App.reset(), there is a new, valid defaultStore", function () {
+    Ember.run(function () { app.initialize(); });
+    var oldStore = DS.get("defaultStore");
+    ok(oldStore instanceof DS.Store, "defaultStore is present before reset");
+    Ember.run(function () { app.reset(); });
+    var newStore = DS.get("defaultStore");
+    ok(newStore instanceof DS.Store, "defaultStore is present after reset");
+    ok(newStore !== oldStore, "defaultStore has changed");
   });
 }
 


### PR DESCRIPTION
As discussed in https://github.com/emberjs/data/issues/847 , there are interactions between App.reset() and DS.get("defaultStore") in certain versions of Ember.js.  In Ember 1.0.0-rc.1, App.reset() didn't need to be wrapped in Ember.run.  In Ember 1.0.0-rc.2, it did.  As of Ember commit 604753e99bb9a24d12aba96f87f827b4365a47f0, it appeared that App.reset() might be leaving DS.get("defaultStore") uninitialized.

In order to keep this API stable, this patch adds tests for both:
- App.MyModel.find(...), which is the high-level API that tends to
  break.
- DS.get("defaultStore"), which is the lower-level API where the
  problem occurs.

These new tests pass against Ember 1.0.0-rc.2.

**Pull Request Notes**
- I've tried testing this against Ember `master`, but I can't get it to fail, so I'm probably not understanding how to run QUnit against another version of Ember. Could somebody please help? Either that, or the bug has been fixed since @joliss reported it.
- `App.reset()` is necessary for writing Ember integration tests, and several people want to work on a testing guide.
- There's two slightly different versions of the test cases because of the differences between `registerInjection` and `initializer`. All the other tests in this file are duplicated as well.

Please let me know if there's anything I can improve here.
