### PR TITLE
Multistage commits for transactions 

### DIFF
--- a/packages/ember-data/lib/system/transaction.js
+++ b/packages/ember-data/lib/system/transaction.js
@@ -196,7 +196,7 @@ DS.Transaction = Ember.Object.extend({
           return createdParents.list[i];
         }
       }
-    }
+    };
 
     relationships.forEach(function (relationship) {
      var parent = findCreatedParentByRef(relationship.parentReference);
@@ -233,10 +233,10 @@ DS.Transaction = Ember.Object.extend({
 
 
     var commitStage = function (commitDetails) {
-      if (!commitDetails.created.isEmpty()
-          || !commitDetails.updated.isEmpty()
-          || !commitDetails.deleted.isEmpty()
-          || !relationships.isEmpty()) {
+      if (!commitDetails.created.isEmpty() ||
+          !commitDetails.updated.isEmpty() ||
+          !commitDetails.deleted.isEmpty() ||
+          !relationships.isEmpty()) {
         Ember.assert("You tried to commit records but you have no adapter", adapter);
         Ember.assert("You tried to commit records but your adapter does not implement `commit`", adapter.commit);
 
@@ -245,11 +245,11 @@ DS.Transaction = Ember.Object.extend({
     };
 
     var parentCreated = function (record) {
-        createdParentsCount--;
-        if (createdParentsCount === 0) {
-          commitStage(childrenCommitStage);
-        }
+      createdParentsCount--;
+      if (createdParentsCount === 0) {
+        commitStage(childrenCommitStage);
       }
+    };
 
     var createdParentsCount = 0;
     parentsCommitStage.created.forEach(function (record) {

--- a/packages/ember-data/tests/integration/transactions/multistage_commit_test.js
+++ b/packages/ember-data/tests/integration/transactions/multistage_commit_test.js
@@ -42,8 +42,8 @@ test("Commits new record with relations in stages", function() {
   adapter.createRecord = function(store, type, record) {
     var json = this.serialize(record, { includeId: true });
     record.createRecordTestCallback(json);
-    var jsonWithRoot = {}
-    jsonWithRoot[this.serializer.rootForType(type)] = json
+    var jsonWithRoot = {};
+    jsonWithRoot[this.serializer.rootForType(type)] = json;
     Ember.run.later(this, function(){
       this.didCreateRecord(store, type, record, jsonWithRoot);
     }, 1);
@@ -72,13 +72,13 @@ test("Commits new record with relations in stages", function() {
 
   var postSaved, commentSaved;
   post.one('didCreate', function () {
-    ok(true, 'post is saved')
+    ok(true, 'post is saved');
     postSaved = true;
     if (postSaved && commentSaved) start();
   });
 
   comment.one('didCreate', function () {
-    ok(true, 'comment is saved')
+    ok(true, 'comment is saved');
     commentSaved = true;
     if (postSaved && commentSaved) start();
   });


### PR DESCRIPTION
This is a very basic fix for #844.

When transaction is committed it does this:
1. Splits new records and their relations in transaction into two stages: "parents" and "children"
2. Commits "parents" to the adapter
3. Waits until all parents' ids are materialized
4. Commits "children" and all other updated and deleted records

I see several problems with this code:
- Only two stages. Ideally this should handle arbitrary complex relations but it would require topological sorting and breaking cycles.
- Waiting for ids. #858 could help this, but from my tests it looks like promises will be resolved before record ids are materialized. I'm not sure.
- Documentation and refactoring for the whole thing.

Could someone please provide feedback on this? Is this the right direction to go or there is some other solution? What else needs to be done?
