### PR TITLE
Fix belongsTo relationships to models with id 0

### DIFF
--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -760,7 +760,7 @@ DS.Serializer = Ember.Object.extend({
       idOrTuple = this.extractBelongsTo(type, hash, key);
     }
 
-    if(idOrTuple) {
+    if(!isNone(idOrTuple)) {
       tuple = this._convertTuple(relationship.type, idOrTuple);
     }
 


### PR DESCRIPTION
I fixed the following failing test:

```
Module Failed: DS.belongsTo
  Test Failed: belongsTo supports relationships to models with id 0
    Assertion Failed: the tag property should return a tag
      Expected: true, Actual: false   
    Assertion Failed: the tag shuld have name
      Expected: friendly, Actual: null   
    Assertion Failed: relationship object is the same as object retrieved directly
      Expected: <Tag:ember8891:0>, Actual: null
```
