### PR TITLE
Allow options.defaultValue of DS.attr to be a function

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -67,7 +67,11 @@ function getAttr(record, options, key) {
   var value = attributes[key];
 
   if (value === undefined) {
-    value = options.defaultValue;
+    if (typeof options.defaultValue === "function") {
+      value = options.defaultValue();
+    } else {
+      value = options.defaultValue;
+    }
   }
 
   return value;

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -128,6 +128,19 @@ test("a DS.Model can have a defaultValue", function() {
   equal(get(tag, 'name'), null, "null doesn't shadow defaultValue");
 });
 
+test("a defaultValue for an attribite can be a function", function() {
+  var Tag = DS.Model.extend({
+    createdAt: DS.attr('string', {
+      defaultValue: function() {
+        return "le default value";
+      }
+    })
+  });
+
+  var tag = Tag.createRecord();
+  equal(get(tag, 'createdAt'), "le default value", "the defaultValue function is evaluated");
+});
+
 test("when a DS.Model updates its attributes, its changes affect its filtered Array membership", function() {
   var people = store.filter(Person, function(hash) {
     if (hash.get('name').match(/Katz$/)) { return true; }


### PR DESCRIPTION
This change allows the defaultValue defined for a DS.attr to be a
function, so it is possible to do something like this:

``` javascript
User = DS.Model.extend({
  createdAt: DS.attr("date", {
    defaultValue: function() {
      return (new Date());
    }
  })
});
```
