### PR TITLE
Typo in Bulk DELETE test

### DIFF
--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -826,7 +826,7 @@ test("bulk updates can sideload data", function() {
   equal(get(group, 'name'), "Group 1", "the data sideloaded successfully");
 });
 
-test("deleting several people (with bulkCommit) makes a PUT to /people/bulk", function() {
+test("deleting several people (with bulkCommit) makes a DELETE to /people/bulk", function() {
   set(adapter, 'bulkCommit', true);
 
   store.loadMany(Person, [


### PR DESCRIPTION
This test labeled as issuing a `PUT` instead of a `DELETE`

The actual test code does make a `DELETE` request
