### PR TITLE
A record is found after loading its id through a hasMany relationship.

### DIFF
--- a/packages/ember-data/tests/integration/has_many_test.js
+++ b/packages/ember-data/tests/integration/has_many_test.js
@@ -281,3 +281,15 @@ test("A record can be removed from a polymorphic association", function() {
   equal(removedObject, comment, "The message is correctly removed");
   equal(messages.get('length'), 0, "The user does not have any messages");
 });
+
+test("A record can be found after loading its id through a hasMany relationship", function() {
+  expect(1);
+  store.load(App.Post, { id: 1, comments: [1, 2, 3] });
+
+  adapter.find = function(store, type, id) {
+    ok(true, "The adapter's find method should be called");
+  };
+
+  var post = store.find(App.Post, 1);
+  var comment = store.find(App.Comment, 2);
+});


### PR DESCRIPTION
As we have now a reference for records in a hasMany relationship,
we need to make sure we load them when accessed. If the record is
`UNLOADED`, we materialize the record.

[Fixes #869]
