### PR TITLE
A serializer implements `extractEmbeddedData` to retrieve embedded associations data

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -81,6 +81,10 @@ DS.JSONSerializer = DS.Serializer.extend({
     }
   },
 
+  extractEmbeddedData: function(hash, key) {
+    return hash[key];
+  },
+
   extractHasMany: function(type, hash, key) {
     return hash[key];
   },

--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -215,24 +215,24 @@ DS.Serializer = Ember.Object.extend({
   extractHasMany: mustImplement('extractHasMany'),
   extractBelongsTo: mustImplement('extractBelongsTo'),
 
-  extractRecordRepresentation: function(loader, type, json, shouldSideload) {
+  extractRecordRepresentation: function(loader, type, data, shouldSideload) {
     var prematerialized = {}, reference;
 
     if (shouldSideload) {
-      reference = loader.sideload(type, json);
+      reference = loader.sideload(type, data);
     } else {
-      reference = loader.load(type, json);
+      reference = loader.load(type, data);
     }
 
     this.eachEmbeddedHasMany(type, function(name, relationship) {
-      var embeddedData = json[this.keyFor(relationship)];
+      var embeddedData = this.extractEmbeddedData(data, this.keyFor(relationship));
       if (!isNone(embeddedData)) {
         this.extractEmbeddedHasMany(loader, relationship, embeddedData, reference, prematerialized);
       }
     }, this);
 
     this.eachEmbeddedBelongsTo(type, function(name, relationship) {
-      var embeddedData = json[this.keyFor(relationship)];
+      var embeddedData = this.extractEmbeddedData(data, this.keyFor(relationship));
       if (!isNone(embeddedData)) {
         this.extractEmbeddedBelongsTo(loader, relationship, embeddedData, reference, prematerialized);
       }
@@ -282,17 +282,26 @@ DS.Serializer = Ember.Object.extend({
 
     The `extractEmbeddedType` hook is called with:
 
-    * the serialized representation being built
-    * the serialized id (after calling the `serializeId` hook)
+    * the relationship
+    * the serialized representation of the record
 
     By default, it returns the type of the relationship.
 
     @param {Object} relationship an object representing the relationship
-    @param {any} data the serialized representation that is being built
+    @param {any} data the serialized representation of the record
   */
   extractEmbeddedType: function(relationship, data) {
     return relationship.type;
   },
+
+  /**
+    A hook you need to implement in order to extract
+    the data associated with an embedded record.
+
+    @param {any} data the serialized representation of the record
+    @param {String} key the key that represents the embedded record
+   */
+  extractEmbeddedData: mustImplement(),
 
   //.......................
   //. SERIALIZATION HOOKS

--- a/packages/ember-data/tests/unit/serializer_test.js
+++ b/packages/ember-data/tests/unit/serializer_test.js
@@ -1,12 +1,65 @@
-var serializer;
+var serializer, originalLookup = Ember.lookup, lookup;
+
+var Group = DS.Model.extend();
+var Comment = DS.Model.extend();
+
+var Person = DS.Model.extend({
+  group: DS.belongsTo(Group),
+  comments: DS.hasMany(Comment)
+});
 
 module("DS.Serializer", {
   setup: function() {
+    lookup = Ember.lookup = {};
+
+    lookup.Comment = Comment;
+    lookup.Group = Group;
+    lookup.Person = Person;
+
     serializer = DS.Serializer.create();
   },
 
   teardown: function() {
     serializer.destroy();
+
+    Ember.lookup = originalLookup;
   }
 });
 
+test("extractEmbeddedData is called to retrieve the data associated with an embedded hasMany relationship", function() {
+  expect(1);
+
+  var loader = {
+    load: function() {},
+    prematerialize: function() {}
+  };
+
+  serializer.map( 'Person', {
+    comments: {embedded: 'load'}
+  });
+
+  serializer.extractEmbeddedData = function(data, key) {
+    equal(key, 'comments', "The serializer can extract embedded hasMany relationship");
+  };
+
+  serializer.extractRecordRepresentation( loader, Person, {comments: [1, 2, 3]}, false);
+});
+
+test("extractEmbeddedData is called to retrieve the data associated with an embedded belongsTo relationship", function() {
+  expect(1);
+
+  var loader = {
+    load: function() {},
+    prematerialize: function() {}
+  };
+
+  serializer.map( 'Person', {
+    group: {embedded: 'load'}
+  });
+
+  serializer.extractEmbeddedData = function(data, key) {
+    equal(key, 'group', "The serializer can extract embedded belongTo relationship");
+  };
+
+  serializer.extractRecordRepresentation( loader, Person, {group: {id: 1}}, false);
+});


### PR DESCRIPTION
Remove references to `json` in `DS.Serializer`
