### PR TITLE
Simplify Transaction Implementation

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -32,6 +32,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, LoadPromise, {
   isError: retrieveFromCurrentState,
   isNew: retrieveFromCurrentState,
   isValid: retrieveFromCurrentState,
+  dirtyType: retrieveFromCurrentState,
 
   clientId: null,
   id: null,

--- a/packages/ember-data/tests/integration/transactions/basic_test.js
+++ b/packages/ember-data/tests/integration/transactions/basic_test.js
@@ -158,45 +158,6 @@ test("a record that is clean can be removed from a transaction", function() {
   equal(updateCalled, 1, "after removing from transaction it commits on the store");
 });
 
-test("a record that is in the created state cannot be moved into a new transaction", function() {
-  var store = DS.Store.create();
-
-  var person = store.createRecord(Person);
-  transaction = store.transaction();
-
-  raises(function() {
-    transaction.add(person);
-  }, Error);
-});
-
-test("a record that is in the updated state cannot be moved into a new transaction", function() {
-  var store = DS.Store.create();
-
-  store.load(Person, { id: 1 });
-  var person = store.find(Person, 1);
-
-  person.set('name', "Scumdale");
-  transaction = store.transaction();
-
-  raises(function() {
-    transaction.add(person);
-  }, Error);
-});
-
-test("a record that is in the deleted state cannot be moved into a new transaction", function() {
-  var store = DS.Store.create();
-
-  store.load(Person, { id: 1 });
-  var person = store.find(Person, 1);
-
-  person.deleteRecord();
-  transaction = store.transaction();
-
-  raises(function() {
-    transaction.add(person);
-  }, Error);
-});
-
 test("a record that is in the clean state is moved back to the default transaction after its transaction is committed", function() {
   var store = DS.Store.create();
 


### PR DESCRIPTION
Currently, model states are tracked twice: once on the model and once in the transaction "buckets". This results in un-necessary coupling between the model and it's transaction and adds a lot of complexity to the implementation. This PR simplifies things by calculating the commit details based on model state.

@wycats worried this would result in worse performance, however I don't believe that to be the case, as we already iterate over all records during commit (not to mention the number of models in a transaction is low-cardinality).

I expect this to make things simpler down the line, e.g. #539. It should also be noted that this makes transactions a little more flexible by allowing mutated records to be moved to a different transaction. Below is an actual use case for this behavior:

In our application, we have an `EditRoute` subclass that adds the model to a new transaction inside `setupControllers`. We would like to re-use the same logic when the model is newly created. To do this, however, we need to be able to move dirty records between transactions (specifically from the store's default transaction to the route's transaction).
