### PR TITLE
Keep errors after 422 response event if they do not match an attribute name

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -54,8 +54,13 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
       var key = this._keyForAttributeName(type, name);
       if (json['errors'].hasOwnProperty(key)) {
         errors[name] = json['errors'][key];
+        delete json['errors'][key];
       }
     }, this);
+
+    Ember.keys(json['errors']).forEach(function(errorKey)  {
+      errors[errorKey] = json['errors'][errorKey];
+    });
 
     return errors;
   }

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -1029,13 +1029,13 @@ test("updating a record with a 422 error marks the records as invalid", function
 
   var mockXHR = {
     status:       422,
-    responseText: JSON.stringify({ errors: { name: ["can't be blank"], updated_at: ["can't be blank"] } })
+    responseText: JSON.stringify({ errors: { name: ["can't be blank"], updated_at: ["can't be blank"], base: ["another error"] } })
   };
 
   ajaxHash.error.call(ajaxHash.context, mockXHR);
 
   expectState('valid', false);
-  deepEqual(person.get('errors'), { name: ["can't be blank"], updatedAt: ["can't be blank"] }, "the person has the errors");
+  deepEqual(person.get('errors'), { name: ["can't be blank"], updatedAt: ["can't be blank"], base: ["another error"] }, "the person has the errors");
 });
 
 test("creating a record with a 500 error marks the record as error", function() {


### PR DESCRIPTION
Since PR #831 was merged, all properties receive as error with a 422 response are lost if they do not match an attribute name. 

I would think we prefer to keep them in the `errors` property of the record then everyone would be able to deal with errors the way they wants.
