### PR TITLE
Errors object

### DIFF
--- a/packages/ember-data/lib/system/model.js
+++ b/packages/ember-data/lib/system/model.js
@@ -2,7 +2,7 @@
   @module data
   @submodule data-model
 */
-
+require("ember-data/system/model/errors");
 require("ember-data/system/model/model");
 require("ember-data/system/model/states");
 require("ember-data/system/model/attributes");

--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -1,0 +1,34 @@
+DS.Errors = Ember.Object.extend({
+  add: function(property, value) {
+    this.set(property, (this.get(property) || []).concat(value));
+  },
+  clear: function() {
+    var keys = Object.keys(this);
+    var only = null;
+    if ( arguments.length > 1 )
+    {
+      only = Array.prototype.slice.apply(arguments);
+    }
+    else
+    {
+      if (arguments.length === 1)
+      {
+        if ( arguments[0] instanceof Array )
+        {
+          only = arguments[0];
+        } else
+        {
+          only = [arguments[0]];
+        }
+      }
+    }
+    for(var i = 0; i < keys.length; i++) {
+      if ( only && only.indexOf(keys[i]) < 0 )
+      {
+        continue;
+      }
+      this.set(keys[i], undefined);
+      delete this[keys[i]];
+    }
+  }
+});

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -148,6 +148,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, LoadPromise, {
 
     var stateManager = DS.StateManager.create({ record: this });
     set(this, 'stateManager', stateManager);
+    set(this, 'errors', DS.Errors.create({}));
 
     this._setup();
 
@@ -387,6 +388,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, LoadPromise, {
   },
 
   becameInFlight: function() {
+    this.get("errors").clear();
   },
 
   // FOR USE BY THE BASIC ADAPTER

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -333,8 +333,11 @@ var DirtyState = DS.State.extend({
 
     becameInvalid: function(manager, errors) {
       var record = get(manager, 'record');
+      var prop;
 
-      set(record, 'errors', errors);
+      for(prop in errors) {
+        get(record, 'errors').add(prop, errors[prop]);
+      }
 
       manager.transitionTo('invalid');
       manager.send('invokeLifecycleCallbacks');

--- a/packages/ember-data/tests/unit/errors_test.js
+++ b/packages/ember-data/tests/unit/errors_test.js
@@ -1,0 +1,39 @@
+var errors;
+
+module('Errors test', {
+  setup: function() {
+    errors = DS.Errors.create();
+  }
+});
+
+test('adding a new error for a property', function() {
+  errors.add('firstName', "can't be blank");
+  deepEqual(errors.get('firstName'), ["can't be blank"]);
+  errors.add('firstName', "is invalid");
+  deepEqual(errors.get('firstName'), ["can't be blank", 'is invalid']);
+});
+
+test("adding an array of errors", function() {
+  errors.add('firstName', ["can't be blank"]);
+  errors.add('firstName', ["and this", "and that"]);
+  deepEqual(errors.get('firstName'), ["can't be blank", 'and this', 'and that']);
+});
+
+test('clears existing errors', function() {
+  errors.add('firstName', "can't be blank");
+  errors.add('lastName', "can't be blank");
+  deepEqual(Object.keys(errors), ['firstName', 'lastName']);
+  errors.clear();
+  deepEqual(Object.keys(errors), []);
+  errors.add('firstName', 'no good');
+  deepEqual(errors.get('firstName'), ["no good"]);
+});
+
+test('clear error on some attribute', function() {
+  errors.add('firstName', "can't be blank");
+  errors.add('lastName', "can't be blank");
+  errors.add('email', "can't be blank");
+  deepEqual(Object.keys(errors), ['firstName', 'lastName', 'email']);
+  errors.clear('firstName', 'email');
+  deepEqual(Object.keys(errors), ['lastName']);
+});

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -178,6 +178,19 @@ module("with a simple Person model", {
   }
 });
 
+test("it should have an errors object when created", function() {
+  var person = Person.createRecord({name: "Bob"});
+  ok(person.get("errors"));
+  ok(Ember.isEmpty(Ember.keys(person.get("errors"))), "The errors were not empty");
+});
+
+test("errors should be cleared when model becomes inFlight", function() {
+  var person = Person.createRecord({name: "Bob"});
+  person.set("errors.name", ["Bob is a terrible name"]);
+  person.becameInFlight();
+  ok(Ember.isEmpty(Ember.keys(person.get("errors"))), "The errors where not empty");
+});
+
 test("when a DS.Model updates its attributes, its changes affect its filtered Array membership", function() {
   var people = store.filter(Person, function(hash) {
     if (hash.get('name').match(/Katz$/)) { return true; }

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -1258,7 +1258,7 @@ test("creating a record with a 422 error marks the records as invalid", function
   // test
   stateEquals(person, 'loaded.created.invalid');
   enabledFlags(person, ['isLoaded', 'isDirty', 'isNew']);
-  deepEqual(person.get('errors'), { name: ["can't be blank"]}, "the person has the errors");
+  deepEqual(person.get('errors.name'), ["can't be blank"], "the person has the errors");
 });
 
 test("updating a record with a 422 error marks the records as invalid", function(){
@@ -1298,7 +1298,8 @@ test("updating a record with a 422 error marks the records as invalid", function
   // test
   stateEquals(person, 'loaded.updated.invalid');
   enabledFlags(person, ['isLoaded', 'isDirty']);
-  deepEqual(person.get('errors'), { name: ["can't be blank"], updatedAt: ["can't be blank"] }, "the person has the errors");
+  deepEqual(person.get('errors.name'), ["can't be blank"], "the person has the errors");
+  deepEqual(person.get('errors.updatedAt'), ["can't be blank"], "the person has the errors");
 });
 
 test("creating a record with a 500 error marks the record as error", function() {


### PR DESCRIPTION
Another attempt to fix #852. This time I brought in the errors object from ember-validations, which is created on init and cleared on inFlight. Errors are added to the object rather than cleared. cc /@bcardarella
