### PR TITLE
Fixture serializer coerces belongsTo ids to string

### DIFF
--- a/packages/ember-data/lib/serializers/fixture_serializer.js
+++ b/packages/ember-data/lib/serializers/fixture_serializer.js
@@ -86,7 +86,7 @@ DS.FixtureSerializer = DS.Serializer.extend({
   },
 
   extractBelongsTo: function(type, hash, key) {
-    return hash[key];
+    return hash[key]+'';
   },
 
   extractBelongsToPolymorphic: function(type, hash, key) {

--- a/packages/ember-data/tests/unit/fixture_adapter_test.js
+++ b/packages/ember-data/tests/unit/fixture_adapter_test.js
@@ -265,7 +265,40 @@ test("should coerce integer ids into string", function() {
     clearTimeout(timer);
     start();
     clearTimeout(timer);
-    equal(get(result, 'id'), "1", "should load integer model id");
+    strictEqual(get(result, 'id'), "1", "should load integer model id as string");
+  });
+
+  var timer = setTimeout(function() {
+    start();
+    ok(false, "timeout exceeded waiting for fixture data");
+  }, 1000);
+});
+
+test("should coerce belongsTo ids into string", function() {
+  stop();
+
+  Person.FIXTURES = [{
+    id: 1,
+    firstName: "Adam",
+    lastName: "Hawkins",
+
+    phones: [1]
+  }];
+  Phone.FIXTURES = [{
+    id: 1,
+    person: 1
+  }];
+
+  var result = Phone.find("1");
+  
+  result.then(function() {
+    var person = get(result, 'person');
+    person.on('didLoad', function() {
+      clearTimeout(timer);
+      start();
+      strictEqual(get(result, 'person.id'), "1", "should load integer belongsTo id as string");
+      strictEqual(get(result, 'person.firstName'), "Adam", "resolved relationship with an integer belongsTo id");
+    });
   });
 
   var timer = setTimeout(function() {


### PR DESCRIPTION
Previous, broken behavior: http://jsfiddle.net/p4z6F/1/ (compare to http://jsfiddle.net/p4z6F/2/)
