### PR TITLE
make transaction.isDefault volatile

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,6 +12,7 @@
         "ember_deprecateFunc",
         "require",
         "equal",
+        "notEqual",
         "asyncTest",
         "test",
         "raises",

--- a/packages/ember-data/lib/system/transaction.js
+++ b/packages/ember-data/lib/system/transaction.js
@@ -120,7 +120,7 @@ DS.Transaction = Ember.Object.extend({
 
   isDefault: Ember.computed(function() {
     return this === get(this, 'store.defaultTransaction');
-  }),
+  }).volatile(),
 
   /**
     Adds an existing record to this transaction. Only records without
@@ -155,9 +155,8 @@ DS.Transaction = Ember.Object.extend({
   commit: function() {
     var store = get(this, 'store');
     var adapter = get(store, '_adapter');
-    var defaultTransaction = get(store, 'defaultTransaction');
 
-    if (this === defaultTransaction) {
+    if (get(this, 'isDefault')) {
       set(store, 'defaultTransaction', store.transaction());
     }
 

--- a/packages/ember-data/tests/integration/transactions/basic_test.js
+++ b/packages/ember-data/tests/integration/transactions/basic_test.js
@@ -172,6 +172,24 @@ test("a record that is in the clean state is moved back to the default transacti
   equal(get(person, 'transaction'), get(store, 'defaultTransaction'), "record should have been moved back to the default transaction");
 });
 
+test("isDefault should return false when no longer the default transaction", function() {
+  var store = DS.Store.create();
+
+  store.load(Person, { id: 1 });
+
+  var person = store.find(Person, 1);
+
+  var transaction = get(person, 'transaction');
+  equal(transaction, get(store, 'defaultTransaction'));
+  ok(get(transaction, 'isDefault'));
+
+  transaction.commit();
+
+  notEqual(transaction, get(store, 'defaultTransaction'));
+  ok(!get(transaction, 'isDefault'));
+});
+
+
 test("modified records are reset when their transaction is rolled back", function() {
 
   var store = DS.Store.create({


### PR DESCRIPTION
transaction.isDefault is currently cached and remains true after the default transaction has changed.
