### PR TITLE
Docs for DS namespace

### DIFF
--- a/packages/ember-data/lib/core.js
+++ b/packages/ember-data/lib/core.js
@@ -1,10 +1,23 @@
 /**
   @module data
-
   @main data
 */
 
+/**
+  All Ember Data methods and functions are defined inside of this namespace. 
+
+  @class DS
+  @static
+*/
+
 window.DS = Ember.Namespace.create({
-  // this one goes past 11
+  /**
+    Current API revision. See 
+    [BREAKING_CHANGES.md](https://github.com/emberjs/data/blob/master/BREAKING_CHANGES.md) 
+    for more information.
+
+    @property CURRENT_API_REVISION
+    @type Integer
+  */
   CURRENT_API_REVISION: 12
 });


### PR DESCRIPTION
Tiny little comments addition. Needed for https://github.com/emberjs/website/pull/457, as the index page for the docs should be the DS namespace's page.
