### PR TITLE
Only coerce belongsTo ids to string if id is defined

### DIFF
--- a/packages/ember-data/lib/serializers/fixture_serializer.js
+++ b/packages/ember-data/lib/serializers/fixture_serializer.js
@@ -86,7 +86,11 @@ DS.FixtureSerializer = DS.Serializer.extend({
   },
 
   extractBelongsTo: function(type, hash, key) {
-    return hash[key]+'';
+    var val = hash[key];
+    if (val !== null && val !== undefined) {
+      val = val + '';
+    }
+    return val;
   },
 
   extractBelongsToPolymorphic: function(type, hash, key) {

--- a/packages/ember-data/tests/unit/fixture_adapter_test.js
+++ b/packages/ember-data/tests/unit/fixture_adapter_test.js
@@ -290,7 +290,7 @@ test("should coerce belongsTo ids into string", function() {
   }];
 
   var result = Phone.find("1");
-  
+
   result.then(function() {
     var person = get(result, 'person');
     person.on('didLoad', function() {
@@ -299,6 +299,27 @@ test("should coerce belongsTo ids into string", function() {
       strictEqual(get(result, 'person.id'), "1", "should load integer belongsTo id as string");
       strictEqual(get(result, 'person.firstName'), "Adam", "resolved relationship with an integer belongsTo id");
     });
+  });
+
+  var timer = setTimeout(function() {
+    start();
+    ok(false, "timeout exceeded waiting for fixture data");
+  }, 1000);
+});
+
+test("only coerce belongsTo ids to string if id is defined and not null", function() {
+  stop();
+
+  Person.FIXTURES = [];
+
+  Phone.FIXTURES = [{
+    id: 1
+  }];
+
+  Phone.find(1).then(function(phone) {
+    clearTimeout(timer);
+    start();
+    equal(phone.get('person'), null);
   });
 
   var timer = setTimeout(function() {


### PR DESCRIPTION
#918 forced coercion of belongTo ids into `String`.  It did not take into account `null` or `undefined` foreign keys (when belongsTo is optional / does not exist).
