### PR TITLE
Fix RestAdapter#ajax to account for empty hash

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -319,6 +319,7 @@ DS.RESTAdapter = DS.Adapter.extend({
 
   ajax: function(url, type, hash) {
     try {
+      hash = hash || {};
       hash.url = url;
       hash.type = type;
       hash.dataType = 'json';


### PR DESCRIPTION
`findById` does not pass a hash, which causes an exception.
