### PR TITLE
Fix for uncountable plural names.

### DIFF
--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -1124,7 +1124,11 @@ DS.Serializer = Ember.Object.extend({
   },
 
   _pluralizeAliases: function() {
-    if (this._didPluralizeAliases) { return; }
+    if (this._didPluralizeAliases) { 
+      return; 
+    } else {
+      this._didPluralizeAliases = true;
+    }
 
     var aliases = this.aliases,
         sideloadMapping = this.aliases.sideloadMapping,
@@ -1133,8 +1137,9 @@ DS.Serializer = Ember.Object.extend({
 
     aliases.forEach(function(key, type) {
       plural = self.pluralize(key);
-      Ember.assert("The '" + key + "' alias has already been defined", !aliases.get(plural));
-      aliases.set(plural, type);
+      if (!aliases.get(plural)) {
+        aliases.set(plural, type);
+      }
     });
 
     // This map is only for backward compatibility with the `sideloadAs` option.
@@ -1145,12 +1150,14 @@ DS.Serializer = Ember.Object.extend({
       });
       delete this.aliases.sideloadMapping;
     }
-
-    this._didPluralizeAliases = true;
   },
 
   _reifyAliases: function() {
-    if (this._didReifyAliases) { return; }
+    if (this._didReifyAliases) { 
+      return; 
+    } else {
+      this._didReifyAliases = true;
+    }
 
     var aliases = this.aliases,
         reifiedAliases = Ember.Map.create(),
@@ -1168,11 +1175,14 @@ DS.Serializer = Ember.Object.extend({
     });
 
     this.aliases = reifiedAliases;
-    this._didReifyAliases = true;
   },
 
   _reifyMappings: function() {
-    if (this._didReifyMappings) { return; }
+    if (this._didReifyMappings) { 
+      return; 
+    } else {
+      this._didReifyMappings = true;
+    }
 
     var mappings = this.mappings,
         reifiedMappings = Ember.Map.create();
@@ -1189,12 +1199,14 @@ DS.Serializer = Ember.Object.extend({
     });
 
     this.mappings = reifiedMappings;
-
-    this._didReifyMappings = true;
   },
 
   _reifyConfigurations: function() {
-    if (this._didReifyConfigurations) { return; }
+    if (this._didReifyConfigurations) { 
+      return; 
+    } else {
+      this._didReifyConfigurations = true;
+    }
 
     var configurations = this.configurations,
         reifiedConfigurations = Ember.Map.create();
@@ -1211,8 +1223,6 @@ DS.Serializer = Ember.Object.extend({
     });
 
     this.configurations = reifiedConfigurations;
-
-    this._didReifyConfigurations = true;
   },
 
   mappingOption: function(type, name, option) {

--- a/packages/ember-data/tests/unit/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/unit/serializers/rest_serializer_test.js
@@ -6,7 +6,8 @@ module("DS.RESTSerializer", {
   setup: function() {
     serializer = DS.RESTSerializer.create();
     serializer.configure('plurals', {
-      person: 'people'
+      person: 'people',
+      fish: 'fish'
     });
   },
   teardown: function() {
@@ -21,12 +22,14 @@ test("keyForAttributeName returns decamelized property name", function() {
 
 test("keyForBelongsTo returns the key appended with '_id'", function() {
   equal(serializer.keyForBelongsTo(DS.Model, 'person'), 'person_id');
+  equal(serializer.keyForBelongsTo(DS.Model, 'fish'), 'fish_id');
   equal(serializer.keyForBelongsTo(DS.Model, 'town'), 'town_id');
   equal(serializer.keyForBelongsTo(DS.Model, 'homeTown'), 'home_town_id');
 });
 
 test("keyForHasMany returns the singularized key appended with '_ids'", function() {
   equal(serializer.keyForHasMany(DS.Model, 'people'), 'person_ids');
+  equal(serializer.keyForHasMany(DS.Model, 'fish'), 'fish_ids');
   equal(serializer.keyForHasMany(DS.Model, 'towns'), 'town_ids');
   equal(serializer.keyForHasMany(DS.Model, 'homeTowns'), 'home_town_ids');
 });


### PR DESCRIPTION
The serializer complains if you try to use an uncountable plural name. E.g. "fish" is the same for both singular and plural.

This fix ensures the alias is only added once.

This PR also fixes the following issues: 
• https://github.com/emberjs/data/issues/928
• https://github.com/emberjs/data/issues/1003
