### PR TITLE
Clean up transaction relationship book-keeping

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -155,7 +155,6 @@ DS.Model = Ember.Object.extend(Ember.Evented, LoadPromise, {
   },
 
   _setup: function() {
-    this._relationshipChanges = {};
     this._changesToSync = {};
   },
 

--- a/packages/ember-data/lib/system/relationships/one_to_many_change.js
+++ b/packages/ember-data/lib/system/relationships/one_to_many_change.js
@@ -245,7 +245,7 @@ DS.OneToManyChange.createChange = function(childReference, parentReference, stor
       firstRecordName:  key
   });
 
-  store.addRelationshipChangeFor(childReference, key, parentReference, null, change);
+  store.addRelationshipChangeFor(childReference, key, parentReference, options.key, change);
 
 
   return change;
@@ -264,7 +264,7 @@ DS.OneToManyChange.maintainInvariant = function(options, store, childReference, 
           changeType: "remove",
           key: options.key
         });
-      store.addRelationshipChangeFor(childReference, key, options.parentReference , null, correspondingChange);
+      store.addRelationshipChangeFor(childReference, key, options.parentReference, options.key, correspondingChange);
       correspondingChange.sync();
     }
   }
@@ -277,10 +277,7 @@ DS.OneToManyChange.ensureSameTransaction = function(changes){
     records.addObject(change.getFirstRecord());
   });
 
-  var transaction = DS.Transaction.ensureSameTransaction(records);
-  forEach(changes, function(change){
-    change.transaction = transaction;
- });
+  return DS.Transaction.ensureSameTransaction(records);
 };
 
 DS.RelationshipChange.prototype = {
@@ -315,14 +312,9 @@ DS.RelationshipChange.prototype = {
     var childReference = this.childReference,
         belongsToName = this.getFirstRecordName(),
         hasManyName = this.getSecondRecordName(),
-        store = this.store,
-        transaction;
+        store = this.store;
 
     store.removeRelationshipChangeFor(childReference, belongsToName, this.parentReference, hasManyName, this.changeType);
-
-    if (transaction = this.transaction) {
-      transaction.relationshipBecameClean(this);
-    }
   },
 
   /** @private */
@@ -414,8 +406,7 @@ DS.RelationshipChangeAdd.prototype.sync = function() {
   //Ember.assert("You specified a hasMany (" + hasManyName + ") on " + (!belongsToName && (newParent || oldParent || this.lastParent).constructor) + " but did not specify an inverse belongsTo on " + child.constructor, belongsToName);
   //Ember.assert("You specified a belongsTo (" + belongsToName + ") on " + child.constructor + " but did not specify an inverse hasMany on " + (!hasManyName && (newParent || oldParent || this.lastParentRecord).constructor), hasManyName);
 
-  var transaction = this.ensureSameTransaction();
-  transaction.relationshipBecameDirty(this);
+  this.ensureSameTransaction();
 
   this.callChangeEvents();
 
@@ -459,8 +450,7 @@ DS.RelationshipChangeRemove.prototype.sync = function() {
   //Ember.assert("You specified a hasMany (" + hasManyName + ") on " + (!belongsToName && (newParent || oldParent || this.lastParent).constructor) + " but did not specify an inverse belongsTo on " + child.constructor, belongsToName);
   //Ember.assert("You specified a belongsTo (" + belongsToName + ") on " + child.constructor + " but did not specify an inverse hasMany on " + (!hasManyName && (newParent || oldParent || this.lastParentRecord).constructor), hasManyName);
 
-  var transaction = this.ensureSameTransaction(firstRecord, secondRecord, secondRecordName, firstRecordName);
-  transaction.relationshipBecameDirty(this);
+  this.ensureSameTransaction(firstRecord, secondRecord, secondRecordName, firstRecordName);
 
   this.callChangeEvents();
 

--- a/packages/ember-data/lib/system/transaction.js
+++ b/packages/ember-data/lib/system/transaction.js
@@ -92,8 +92,6 @@ DS.Transaction = Ember.Object.extend({
   */
   init: function() {
     set(this, 'records', Ember.OrderedSet.create());
-
-    set(this, 'relationships', Ember.OrderedSet.create());
   },
 
   /**
@@ -135,13 +133,21 @@ DS.Transaction = Ember.Object.extend({
     this.adoptRecord(record);
   },
 
-  relationshipBecameDirty: function(relationship) {
-    get(this, 'relationships').add(relationship);
-  },
+  relationships: Ember.computed(function() {
+    var relationships = Ember.OrderedSet.create(),
+        records = get(this, 'records'),
+        store = get(this, 'store');
 
-  relationshipBecameClean: function(relationship) {
-    get(this, 'relationships').remove(relationship);
-  },
+    records.forEach(function(record) {
+      var reference = get(record, '_reference');
+      var changes = store.relationshipChangesFor(reference);
+      for(var i = 0; i < changes.length; i++) {
+        relationships.add(changes[i]);
+      }
+    });
+
+    return relationships;
+  }).volatile(),
 
   /**
     Commits the transaction, which causes all of the modified records that


### PR DESCRIPTION
This is in the same vein as my previous transaction PR. Currently, we track relationships on both the store and the transaction. With this PR we only track on the store and compute the changes during transaction commit.

This PR is also important to allow moving dirty records between transactions. Currently this is allowed, but the relationship changes are left in the old transaction.
