### PR TITLE
Advanced errors handling

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -132,7 +132,7 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     return this.ajax(this.buildURL(root), "POST", {
       data: data
-    }).then(function(json){
+    }).then(function(json) {
       adapter.didCreateRecord(store, type, record, json);
     }, function(xhr) {
       adapter.didError(store, type, record, xhr);
@@ -175,7 +175,7 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     return this.ajax(this.buildURL(root, id), "PUT",{
       data: data
-    }).then(function(json){
+    }).then(function(json) {
       adapter.didUpdateRecord(store, type, record, json);
     }, function(xhr) {
       adapter.didError(store, type, record, xhr);
@@ -245,7 +245,7 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     return this.ajax(this.buildURL(root, 'bulk'), "DELETE", {
       data: data
-    }).then(function(json){
+    }).then(function(json) {
       adapter.didDeleteRecords(store, type, records, json);
     }).then(null, DS.rejectionHandler);
   },
@@ -254,7 +254,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     var root = this.rootForType(type), adapter = this;
 
     return this.ajax(this.buildURL(root, id), "GET").
-      then(function(json){
+      then(function(json) {
         adapter.didFindRecord(store, type, json, id);
     }).then(null, DS.rejectionHandler);
   },
@@ -265,7 +265,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     root = this.rootForType(type);
     adapter = this;
 
-    return this.ajax(this.buildURL(root), "GET",{
+    return this.ajax(this.buildURL(root), "GET", {
       data: this.sinceQuery(since)
     }).then(function(json) {
       adapter.didFindAll(store, type, json);
@@ -319,8 +319,19 @@ DS.RESTAdapter = DS.Adapter.extend({
 
       store.recordWasInvalid(record, errors);
     } else {
-      this._super.apply(this, arguments);
+      var error = this.errorFromStatus(xhr.statusText, xhr);
+      this._super(store, type, record, error);
     }
+  },
+
+  errorFromStatus: function(statusText, xhr) {
+    var error = xhr;
+
+    if (statusText === 'timeout') {
+      error = DS.AdapterTimeoutError.create({thrown: xhr});
+    }
+
+    return error;
   },
 
   ajax: function(url, type, hash) {

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -457,8 +457,8 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     @param {subclass of DS.Model} type
     @param {DS.Model} record
   */
-  didError: function(store, type, record) {
-    store.recordWasError(record);
+  didError: function(store, type, record, error) {
+    store.recordWasError(record, error);
   },
 
   dirtyRecordsForAttributeChange: function(dirtySet, record, attributeName, newValue, oldValue) {

--- a/packages/ember-data/lib/system/error.js
+++ b/packages/ember-data/lib/system/error.js
@@ -1,0 +1,7 @@
+DS.Error = Ember.Object.extend({
+  thrown: null
+});
+
+DS.NotFoundError = DS.Error.extend();
+DS.AdapterError = DS.Error.extend();
+DS.AdapterTimeoutError = DS.AdapterError.extend();

--- a/packages/ember-data/lib/system/model.js
+++ b/packages/ember-data/lib/system/model.js
@@ -6,3 +6,4 @@
 require("ember-data/system/model/model");
 require("ember-data/system/model/states");
 require("ember-data/system/model/attributes");
+require("ember-data/system/validation_error");

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -480,7 +480,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
       if (thenable && thenable.then) {
         thenable.then(null /* for future use */, function(error) {
-          store.recordWasError(record);
+          error = DS.NotFoundError.create({thrown: error});
+          store.recordWasError(record, error);
         });
       }
     }
@@ -502,7 +503,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     if (thenable && thenable.then) {
       thenable.then(null /* for future use */, function(error) {
-        store.recordWasError(record);
+        error = DS.NotFoundError.create({thrown: error});
+        store.recordWasError(record, error);
       });
     }
   },
@@ -1045,8 +1047,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
      @param {DS.Model} record
   */
-  recordWasError: function(record) {
-    record.adapterDidError();
+  recordWasError: function(record, error) {
+    record.adapterDidError(error);
   },
 
   /**

--- a/packages/ember-data/lib/system/validation_error.js
+++ b/packages/ember-data/lib/system/validation_error.js
@@ -1,0 +1,69 @@
+require("ember-data/system/error");
+
+var get = Ember.get, set = Ember.set;
+
+DS.ValidationError = DS.Error.extend(Ember.Enumerable, Ember.Evented, {
+  errorsByAttributeName: Ember.computed(function() {
+    return Ember.MapWithDefault.create({
+      defaultValue: function() { return Ember.A(); }
+    });
+  }),
+
+  content: Ember.computed(function() {
+    return Ember.A();
+  }),
+
+  unknownProperty: function(name) {
+    var errors = get(this, 'errorsByAttributeName').get(name);
+    if (!errors.length) { return null; }
+    return errors;
+  },
+
+  nextObject: function(index, previousObject, context) {
+    return get(this, 'content').objectAt(index);
+  },
+
+  length: Ember.computed.alias('content.length'),
+  isEmpty: Ember.computed.not('length'),
+
+  add: function(name, messages) {
+    var errorsByAttributeName = get(this, 'errorsByAttributeName'),
+        errors = errorsByAttributeName.get(name);
+
+    messages = Ember.makeArray(messages);
+
+    errors.addObjects(messages);
+    get(this, 'content').addObjects(messages);
+    this.notifyPropertyChange(name);
+
+    if (!get(this, 'isEmpty')) {
+      this.trigger('becameInvalid');
+    }
+  },
+
+  remove: function(name) {
+    var errorsByAttributeName = get(this, 'errorsByAttributeName'),
+        errors = errorsByAttributeName.get(name);
+
+    errorsByAttributeName.set(name, Ember.A());
+    get(this, 'content').removeObjects(errors);
+    this.notifyPropertyChange(name);
+
+    if (get(this, 'isEmpty')) {
+      this.trigger('becameValid');
+    }
+  },
+
+  clear: function() {
+    this.notifyPropertyChange('errorsByAttributeName');
+    this.notifyPropertyChange('content');
+
+    this.trigger('becameValid');
+  },
+
+  has: function(name) {
+    return get(this, 'errorsByAttributeName').get(name).length > 0;
+  }
+});
+
+DS.AdapterValidationError = DS.ValidationError.extend();

--- a/packages/ember-data/tests/integration/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/store_adapter_test.js
@@ -302,10 +302,6 @@ test("if a created record is marked as invalid by the server, it enters an error
   set(yehuda, 'updatedAt', true);
   equal(get(yehuda, 'isValid'), false, "the record is still invalid");
 
-  // This tests that we handle undefined values without blowing up
-  var errors = get(yehuda, 'errors');
-  set(errors, 'other_bound_property', undefined);
-  set(yehuda, 'errors', errors);
   set(yehuda, 'name', "Brohuda Brokatz");
 
   equal(get(yehuda, 'isValid'), true, "the record is no longer invalid after changing");

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -1262,7 +1262,7 @@ test("creating a record with a 422 error marks the records as invalid", function
   // test
   stateEquals(person, 'loaded.created.invalid');
   enabledFlags(person, ['isLoaded', 'isDirty', 'isNew']);
-  deepEqual(person.get('errors'), { name: ["can't be blank"]}, "the person has the errors");
+  deepEqual(person.get('errors.name'), ["can't be blank"], "the person has the errors");
 });
 
 test("updating a record with a 422 error marks the records as invalid", function(){
@@ -1302,7 +1302,8 @@ test("updating a record with a 422 error marks the records as invalid", function
   // test
   stateEquals(person, 'loaded.updated.invalid');
   enabledFlags(person, ['isLoaded', 'isDirty']);
-  deepEqual(person.get('errors'), { name: ["can't be blank"], updatedAt: ["can't be blank"] }, "the person has the errors");
+  deepEqual(person.get('errors.name'), ["can't be blank"], "the person has the errors");
+  deepEqual(person.get('errors.updatedAt'), ["can't be blank"], "the person has the errors");
 });
 
 test("creating a record with a 500 error marks the record as error", function() {


### PR DESCRIPTION
This PR adds a few error classes to ember-data and a way to manage them.

`DS.Error`
`DS.AdapterError`

`DS.ValidationError`
`DS.AdapterValidationError`

At some point we will probably want a `DS.ClientValidationError` (probably not the right name)

`DS.ValidationError` is an enumerable that exposes also per attribute errors.

```
{{#each errors}}
  {{this}}
{{/each}}

{{#each errors.firstName}}
  {{this}}
{{/each}}
```

A record have an `error` property, and in case of validation errors, `error` is aliased to `errors`.
`DS.ValidationError` is responsable to manage record state based on presence absence of attribute error messages on it.

```
record.get('errors').add('firstName', 'is invalid');
record.get('errors').add('lastName', 'is invalid');
record.get('isValid') //=> false
record.get('errors').remove('lastName');
record.get('isValid') //=> false
record.get('errors').clear();
record.get('isValid') //=> true
```
