### PR TITLE
Ensure that '_reference' key is used to store the reference

### DIFF
--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -74,6 +74,13 @@ test("trying to set an `id` attribute should raise", function() {
   }, /You may not set `id`/);
 });
 
+test("it should use `_reference` and not `reference` to store its reference", function() {
+  store.load(Person, { id: 1 });
+
+  var record = store.find(Person, 1);
+  equal(record.get('reference'), undefined, "doesn't shadow reference key");
+});
+
 test("it should cache attributes", function() {
   var store = DS.Store.create();
 


### PR DESCRIPTION
https://github.com/emberjs/data/pull/596 ensured that reference wasn't a reserved attribute, and https://github.com/emberjs/data/issues/929 fixed it again (thanks @bradleypriest).

This test ensures that reference isn't reserved.
