### PR TITLE
Add sensible defaults for polymorphic keys

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -331,7 +331,9 @@ DS.JSONSerializer = DS.Serializer.extend({
 
     @returns {String} the key
   */
-  keyForPolymorphicId: Ember.K,
+  keyForPolymorphicId: function(key){
+    return key;
+  },
 
   /**
     A hook you can use in your serializer subclass to customize
@@ -341,7 +343,9 @@ DS.JSONSerializer = DS.Serializer.extend({
 
     @returns {String} the key
   */
-  keyForPolymorphicType: Ember.K,
+  keyForPolymorphicType: function(key){
+    return this.keyForPolymorphicId(key) + '_type';
+  },
 
   /**
     A hook you can use in your serializer subclass to customize


### PR DESCRIPTION
Current implementation is `Ember.K`, which returns `this`, which conflicts with the function spec to return a string. Fixes stored objects like this:

```
{
   "id": "foo"
   "name": "App",
   "<DS.CouchDBSerializer:ember12963>": "Reflect.Class"
}
```
