### PR TITLE
Add a hash argument to this.ajax call in find()

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -246,7 +246,7 @@ DS.RESTAdapter = DS.Adapter.extend({
   find: function(store, type, id) {
     var root = this.rootForType(type), adapter = this;
 
-    return this.ajax(this.buildURL(root, id), "GET").then(function(json){
+    return this.ajax(this.buildURL(root, id), "GET", {}).then(function(json){
       return Ember.run(adapter,'didFindRecord', store, type, json, id);
     });
   },


### PR DESCRIPTION
this.ajax inside of the adapter expects three args.. the last one being the hash of jQuery options to send with the request.

Find is not including this, so users who were expecting a hash to add onto may encounter issues
