### PR TITLE
Update the gemspec so it follows the revision number

### DIFF
--- a/ember-data-source.gemspec
+++ b/ember-data-source.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{ember-data source code wrapper.}
   gem.description   = %q{ember-data source code wrapper for use with Ruby libs.}
   gem.homepage      = "https://github.com/emberjs/data"
-  gem.version       = "0.0.5"
+  gem.version       = "0.0.12"
 
   gem.add_dependency "ember-source"
 


### PR DESCRIPTION
Update the gemspec so it follows the revision number listed in the breaking changes file.

``` cucumber
Given I want to know the latest revision of data I can reference in Store while using ember-rails
When I look my Gemfile.lock
Then I would like to see the same number used for the gem version that is used in the breaking changes file.
```

Perhaps here is a reason that this is not the case but just in case it was a time vs priority thing I though I would offer it as a PR. Cheers.
