### PR TITLE
Remove findByClientId() test sync

### DIFF
--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -102,7 +102,6 @@
       loadMany: syncForTest(),
       filter: syncForTest(),
       find: syncForTest(),
-      findByClientId: syncForTest(),
       findMany: syncForTest(),
       didSaveRecord: syncForTest(),
       didSaveRecords: syncForTest(),


### PR DESCRIPTION
Records are now looked up via recordForReference()
