### PR TITLE
Capture and log errors from promise chains

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -10,6 +10,11 @@ require('ember-data/serializers/rest_serializer');
 
 var get = Ember.get, set = Ember.set;
 
+var rejectionHandler = function(error) {
+  Ember.Logger.error(error);
+  throw error;
+};
+
 /**
   The REST adapter allows your store to communicate with an HTTP server by
   transmitting JSON via XHR. Most Ember.js apps that consume a JSON API
@@ -132,7 +137,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     }, function(xhr) {
       adapter.didError(store, type, record, xhr);
       throw xhr;
-    });
+    }).then(null, rejectionHandler);
   },
 
   createRecords: function(store, type, records) {
@@ -155,7 +160,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       data: data
     }).then(function(json) {
       Ember.run(adapter, 'didCreateRecords', store, type, records, json);
-    });
+    }).then(null, rejectionHandler);
   },
 
   updateRecord: function(store, type, record) {
@@ -175,7 +180,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     }, function(xhr) {
       adapter.didError(store, type, record, xhr);
       throw xhr;
-    });
+    }).then(null, rejectionHandler);
   },
 
   updateRecords: function(store, type, records) {
@@ -201,7 +206,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       data: data
     }).then(function(json) {
       Ember.run(adapter, 'didUpdateRecords', store, type, records, json);
-    });
+    }).then(null, rejectionHandler);
   },
 
   deleteRecord: function(store, type, record) {
@@ -216,7 +221,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     }, function(xhr){
       adapter.didError(store, type, record, xhr);
       throw xhr;
-    });
+    }).then(null, rejectionHandler);
   },
 
   deleteRecords: function(store, type, records) {
@@ -240,7 +245,7 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     return this.ajax(this.buildURL(root, 'bulk'), "DELETE", { data: data }).then(function(json){
       Ember.run(adapter, 'didDeleteRecords', store, type, records, json);
-    });
+    }).then(null, rejectionHandler);
   },
 
   find: function(store, type, id) {
@@ -248,7 +253,7 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     return this.ajax(this.buildURL(root, id), "GET").then(function(json){
       return Ember.run(adapter,'didFindRecord', store, type, json, id);
-    });
+    }).then(null, rejectionHandler);
   },
 
   findAll: function(store, type, since) {
@@ -261,7 +266,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       data: this.sinceQuery(since)
     }).then(function(json) {
       Ember.run(adapter,'didFindAll', store, type, json);
-    });
+    }).then(null, rejectionHandler);
   },
 
   findQuery: function(store, type, query, recordArray) {
@@ -274,7 +279,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       Ember.run(adapter, function(){
         this.didFindQuery(store, type, json, recordArray);
       });
-    });
+    }).then(null, rejectionHandler);
   },
 
   findMany: function(store, type, ids, owner) {
@@ -287,7 +292,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       data: {ids: ids}
     }).then(function(json) {
       return Ember.run(adapter,'didFindMany', store, type, json);
-    });
+    }).then(null, rejectionHandler);
   },
 
   /**

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -1364,3 +1364,54 @@ test("updating a record with a 500 error marks the record as error", function() 
   stateEquals(person, 'error');
   enabledFlags(person, ['isError', 'isValid']);
 });
+
+var TestError = function(message) {
+  this.message = message;
+};
+
+var originalLogger = Ember.Logger.error;
+
+module('The REST adapter - error handling', {
+  setup: function() {
+    Adapter = DS.RESTAdapter.extend();
+
+    Person = DS.Model.extend({
+      name: DS.attr('string')
+    });
+
+    Person.toString = function() {
+      return "App.Person";
+    };
+  },
+
+  teardown: function() {
+    Ember.Logger.error = originalLogger;
+  }
+});
+
+test("promise errors are sent to the ember error logger", function() {
+  // setup
+  store = DS.Store.create({
+    adapter: Adapter.extend({
+      didFindRecord: function() {
+        throw new TestError();
+      },
+
+      ajax: function(url, type, hash) {
+        return new Ember.RSVP.Promise(function(resolve, reject){
+          Ember.run(function(){
+            resolve({ person: [{ id: 1, name: "Adam Hawkins" }] });
+          });
+        });
+      }
+    })
+  });
+
+  expect(1);
+
+  Ember.Logger.error = function(error) {
+    ok(error instanceof TestError, "Promise chains should dump exceptions to the logger");
+  };
+
+  store.find(Person, 1);
+});


### PR DESCRIPTION
This fixes this problem:

``` js
promise.then(function() {
  throw "Fail here for whatever reason"
});
```

The thrown error never sees the light of day because it's treated as
promise rejection and **not** a failure. I encournted this problem when
ED was erroring _internally_ trying to sideload association. The
serializer raised an exception (inside a then callback) that was
swallowed and ruined my god damn day. Here's the offending code:

``` js
return this.ajax(this.buildURL(root), "GET",{
      data: this.sinceQuery(since)
    }).then(function(json) {
      // errrors from `didFindAll` are ignored. This is horrible.
      Ember.run(adapter,'didFindAll', store, type, json);
    })
```

EDIT: I want to make something clear. It's these sort of issues that prevent me recommending ember-data to anyone. This seriously crippled @dagda1's and I's brains. The time required to simply figure out what is wrong with JSON parsing is unacceptable. Seriously, who can use this library? /rant.
