### PR TITLE
Allow HTTP Headers to be set in RESTAdapter

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -319,16 +319,7 @@ DS.RESTAdapter = DS.Adapter.extend({
 
   ajax: function(url, type, hash) {
     try {
-      hash = hash || {};
-      hash.url = url;
-      hash.type = type;
-      hash.dataType = 'json';
-      hash.context = this;
-
-      if (hash.data && type !== 'GET') {
-        hash.contentType = 'application/json; charset=utf-8';
-        hash.data = JSON.stringify(hash.data);
-      }
+      hash = this.getAjaxHash(url, type, hash);
 
       return Ember.RSVP.resolve(jQuery.ajax(hash));
     } catch (error) {
@@ -336,7 +327,23 @@ DS.RESTAdapter = DS.Adapter.extend({
     }
   },
 
+  getAjaxHash: function(url, type, hash) {
+    hash = jQuery.extend(this.ajaxHeaders, hash);
+    hash.url = url;
+    hash.type = type;
+    hash.dataType = 'json';
+    hash.context = this;
+
+    if (hash.data && type !== 'GET') {
+      hash.contentType = 'application/json; charset=utf-8';
+      hash.data = JSON.stringify(hash.data);
+    }
+
+    return hash;
+  },
+
   url: "",
+  ajaxHeaders: {},
 
   rootForType: function(type) {
     var serializer = get(this, 'serializer');


### PR DESCRIPTION
This allows optional HTTP headers to be sent in the RESTAdapter.

When creating your RESTAdapter, you can set a RESTAdapter.ajaxHeaders to the hash of information you would like to send.

This passes all tests and separates concern of setting headers to its own method instead of the RESTAdapter.Ajax method.

This a a resolution to issue #803
