### PR TITLE
Embedded ids for hasMany associations

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -171,14 +171,20 @@ DS.JSONSerializer = DS.Serializer.extend({
 
     // If the has-many is not embedded, there is nothing to do.
     embeddedType = this.embeddedType(type, name);
-    if (embeddedType !== 'always') { return; }
+    if (['always', 'refs'].indexOf(embeddedType) < 0) { return; }
 
     // Get the DS.ManyArray for the relationship off the record
     manyArray = get(record, name);
 
     // Build up the array of serialized records
     manyArray.forEach(function (record) {
-      serializedHasMany.push(this.serialize(record, { includeId: true, includeType: includeType }));
+      var pushed;
+      if (embeddedType === 'always') {
+        pushed = this.serialize(record, { includeId: true, includeType: includeType });
+      } else {
+        pushed = record.id;
+      }
+      serializedHasMany.push(pushed);
     }, this);
 
     // Set the appropriate property of the serialized JSON to the

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -32,7 +32,8 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
   keyForHasMany: function(type, name) {
     var key = this.keyForAttributeName(type, name);
 
-    if (this.embeddedType(type, name)) {
+    var embeddedType = this.embeddedType(type, name);
+    if (embeddedType && embeddedType !== 'refs') {
       return key;
     }
 

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -238,7 +238,7 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     var serializer = get(this, 'serializer');
 
     serializer.eachEmbeddedRecord(record, function(embeddedRecord, embeddedType) {
-      if (embeddedType === 'load') { return; }
+      if (['load', 'refs'].indexOf(embeddedType) > -1) { return; }
 
       this.didSaveRecord(store, embeddedRecord.constructor, embeddedRecord);
     }, this);

--- a/packages/ember-data/tests/integration/embedded/embedded_only_ids_test.js
+++ b/packages/ember-data/tests/integration/embedded/embedded_only_ids_test.js
@@ -1,0 +1,68 @@
+var store, Adapter, adapter, post;
+var Post, Comment, User, App;
+var attr = DS.attr;
+
+var get = Ember.get, set = Ember.set;
+
+var originalLookup = Ember.lookup;
+
+module("Embedded Saving with only IDs", {
+  setup: function() {
+    App = Ember.lookup = Ember.Namespace.create({ name: "App" });
+
+    Post = App.Post = DS.Model.extend({
+      title: attr('string'),
+      relateds: DS.hasMany('Post')
+    });
+
+    Adapter = DS.RESTAdapter.extend();
+
+    Adapter.map(Post, {
+      relateds: { embedded: 'refs' }
+    });
+
+    adapter = Adapter.create();
+
+    store = DS.Store.create({
+      adapter: adapter
+    });
+
+    adapter.load(store, Post, {
+      id: 1,
+      title: "A New MVC Framework in Under 100 Lines of Code",
+    });
+
+    post = store.find(Post, 1);
+  },
+
+  teardown: function() {
+    store.destroy();
+    App.destroy();
+    Ember.lookup = originalLookup;
+  }
+});
+
+asyncTest("Reference to an pre-existing record should persist.", function() {
+  adapter.ajax = function(url, type, hash) {
+    equal(url, '/posts');
+    equal(type, 'POST');
+    equal(hash.data.post.related_ids.length, 1);
+
+    return new Ember.RSVP.Promise(function(resolve, reject){
+      Ember.run.later(function(){
+        start();
+        resolve(hash.data);
+      },0);
+    });
+
+  };
+
+  var transaction = store.transaction();
+  var new_post = transaction.createRecord(Post, {
+    title: 'This post is unsaved'
+  });
+
+  new_post.get('relateds').pushObject(post);
+
+  transaction.commit();
+});


### PR DESCRIPTION
## Use Case

My use case is to implement a reflexive many-to-many association (p.e. user has-many coworkers), rather than exposing the boilerplate 'coworkers' model to Ember. On the server I would implement a User's serializer that sends a list of ids in a coworkers field. This part already works well with ember data until I want to mutate the association.

When I try to save the record, the association is not saved by Ember Data. After investigation I found that this is the expected behavior, but I did not found any parameter to embed the association without embedding the whole records.
## Current State

The ember data docs contains the following statement: 

The default REST semantics are to only add a has-many relationship if it is embedded. If the relationship was initially loaded by ID, we assume that that was done as a performance optimization, and that changes to the as-many should be saved as foreign key changes on the child's belongs-to relationship.

I assume this might be valid for many use-cases, but I suggest to make embedding ids rather than the whole record available as an option as well.
## Proposal and discussion

I intend to implement this but I would first like to have your opinion whether this is the right way to solve this. If it's not what would be the right way.

If you believe as well that is the right way, I would like your opinion about the way I intend to do it. I suggest adding a new embedding type that could be called 'refs' alongside to 'always' and 'load'. This means adding support in RESTAdapter#addHasMany and RESTAdapter#serialize or JSONAdapter#serialize. Then adding conditions to skip record loading in DS.Adapter#didSaveRecord callback.

Thanks by advance for your interest and your comments. 
