### PR TITLE
Log the error message, not the error class

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -11,7 +11,7 @@ require('ember-data/serializers/rest_serializer');
 var get = Ember.get, set = Ember.set;
 
 function rejectionHandler(reason) {
-  Ember.Logger.error(reason);
+  Ember.Logger.error(reason, reason.message);
   throw reason;
 }
 

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -1394,7 +1394,7 @@ test("promise errors are sent to the ember error logger", function() {
   store = DS.Store.create({
     adapter: Adapter.extend({
       didFindRecord: function() {
-        throw new TestError();
+        throw new TestError('TestError');
       },
 
       ajax: function(url, type, hash) {
@@ -1407,10 +1407,11 @@ test("promise errors are sent to the ember error logger", function() {
     })
   });
 
-  expect(1);
+  expect(2);
 
-  Ember.Logger.error = function(error) {
-    ok(error instanceof TestError, "Promise chains should dump exceptions to the logger");
+  Ember.Logger.error = function(error, message) {
+    ok(error instanceof TestError, "Promise chains should dump exception classes to the logger");
+    equal(message, 'TestError', "Promise chains should dump exception messages to the logger");
   };
 
   store.find(Person, 1);


### PR DESCRIPTION
This actually provides useful error messages. Previously you'd see
"TypeError" on the console. This is not useful. Now you'll see "fooBar()
is not a method". This lets you track down exceptions.

@stefanpenner: This is an iteration from our work yesterday. We need to log the error message and simply rethrow the error itself. It seems the errors do not have a meaningful `toString()` method.
