### PR TITLE
Assert root is dirty in embedded tests

### DIFF
--- a/packages/ember-data/tests/integration/embedded/embedded_dirtying_test.js
+++ b/packages/ember-data/tests/integration/embedded/embedded_dirtying_test.js
@@ -106,6 +106,7 @@ function assertEmbeddedLoadNotDirtied() {
 }
 
 function assertTreeIs(state) {
+  assertRecordIs(post, state);
   post.get('comments').forEach(function(comment) {
     assertRecordIs(comment, state);
     if (comment.get('user')) {


### PR DESCRIPTION
Add a missing assertion. Now the assertion actually covers the entire tree.
