### PR TITLE
properly set isUpdating flag and trigger didUpdate event

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -401,9 +401,9 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     var loader = DS.loaderFor(store),
         serializer = get(this, 'serializer');
 
-    store.didUpdateAll(type);
-
     serializer.extractMany(loader, payload, type);
+
+    store.didUpdateAll(type);
   },
 
   /**

--- a/packages/ember-data/lib/system/record_arrays/record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/record_array.js
@@ -45,6 +45,14 @@ DS.RecordArray = Ember.ArrayProxy.extend(LoadPromise, {
   // The store that created this record array.
   store: null,
 
+  init: function() {
+    this._super();
+
+    this.on('didUpdate', this, function() {
+      set(this, 'isUpdating', false);
+    });
+  },
+
   objectAtContent: function(index) {
     var content = get(this, 'content'),
         reference = content.objectAt(index),

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -784,7 +784,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
   */
   didUpdateAll: function(type) {
     var findAllCache = this.typeMapFor(type).findAllCache;
-    set(findAllCache, 'isUpdating', false);
+
+    Ember.run.once(findAllCache, 'trigger', 'didUpdate');
   },
 
   /**

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -4,7 +4,7 @@ var Adapter, Person, Group, Role, adapter, serializer, store, ajaxUrl, ajaxType,
 var forEach = Ember.EnumerableUtils.forEach;
 
 // Note: You will need to ensure that you do not attempt to assert against flags that do not exist in this array (or else they will show positive).
-recordArrayFlags = ['isLoaded'];
+recordArrayFlags = ['isLoaded', 'isUpdating'];
 manyArrayFlags = ['isLoaded'];
 
 // Used for testing the adapter state path on a single entity
@@ -433,7 +433,7 @@ test("finding all people makes a GET to /people", function() {
   people = store.find(Person);
 
   // test
-  enabledFlags(people, ['isLoaded', 'isValid'], recordArrayFlags);
+  enabledFlags(people, ['isLoaded', 'isUpdating'], recordArrayFlags);
   expectUrl("/people", "the plural of the model name");
   expectType("GET");
 
@@ -455,7 +455,7 @@ test("finding all can sideload data", function() {
   groups = store.find(Group);
 
   // test
-  enabledFlags(groups, ['isLoaded'], recordArrayFlags);
+  enabledFlags(groups, ['isLoaded', 'isUpdating'], recordArrayFlags);
   expectUrl("/groups", "the plural of the model name");
   expectType("GET");
 
@@ -476,12 +476,22 @@ test("finding all can sideload data", function() {
 });
 
 test("finding all people with since makes a GET to /people", function() {
+  expect(59);
+
+  function didUpdate() {
+    enabledFlags(people, ['isLoaded'], recordArrayFlags);
+    equal(people.get('length'), size, 'record array should be filled');
+    people.removeObserver('isUpdating', didUpdate);
+  }
+
   // setup
-  var people, person;
+  var people, person, size = 1;
   people = store.find(Person);
 
+  people.addObserver('isUpdating', didUpdate);
+
   // test
-  enabledFlags(people, ['isLoaded'], recordArrayFlags);
+  enabledFlags(people, ['isLoaded', 'isUpdating'], recordArrayFlags);
   expectUrl("/people", "the plural of the model name");
   expectType("GET");
 
@@ -489,8 +499,11 @@ test("finding all people with since makes a GET to /people", function() {
   ajaxHash.success({ meta: { since: '123'}, people: [{ id: 1, name: "Yehuda Katz" }] });
   people = store.find(Person);
 
+  size = 2;
+  people.addObserver('isUpdating', didUpdate);
+
   // test
-  enabledFlags(people, ['isLoaded'], recordArrayFlags);
+  enabledFlags(people, ['isLoaded', 'isUpdating'], recordArrayFlags);
   expectUrl("/people", "the plural of the model name");
   expectType("GET");
   expectData({since: '123'});
@@ -508,9 +521,12 @@ test("finding all people with since makes a GET to /people", function() {
   // setup
   people.update();
 
+  size = 3;
+  people.addObserver('isUpdating', didUpdate);
+
   // test
   stateEquals(person, 'loaded.saved');
-  enabledFlags(people, ['isLoaded'], recordArrayFlags);
+  enabledFlags(people, ['isLoaded', 'isUpdating'], recordArrayFlags);
   enabledFlags(person, ['isLoaded', 'isValid']);
   expectUrl("/people", "the plural of the model name");
   expectType("GET");
@@ -537,7 +553,7 @@ test("meta and since are configurable", function() {
   people = store.find(Person);
 
   // test
-  enabledFlags(people, ['isLoaded'], recordArrayFlags);
+  enabledFlags(people, ['isLoaded', 'isUpdating'], recordArrayFlags);
   expectUrl("/people", "the plural of the model name");
   expectType("GET");
 
@@ -551,7 +567,7 @@ test("meta and since are configurable", function() {
   people.update();
 
   // test
-  enabledFlags(people, ['isLoaded'], recordArrayFlags);
+  enabledFlags(people, ['isLoaded', 'isUpdating'], recordArrayFlags);
   expectUrl("/people", "the plural of the model name");
   expectType("GET");
   expectData({lastToken: '123'});
@@ -791,7 +807,7 @@ test("finding people by a query", function() {
   // test
   statesEqual([rein, tom, yehuda], 'loaded.saved');
   enabledFlags(people, ['isLoaded'], recordArrayFlags);
-  enabledFlagsForArray([rein, tom, yehuda], ['isLoaded'], recordArrayFlags);
+  enabledFlagsForArray([rein, tom, yehuda], ['isLoaded', 'isValid']);
   equal(get(people, 'length'), 3, "the people are now loaded");
   equal(get(rein, 'name'), "Rein Heinrichs");
   equal(get(tom, 'name'), "Tom Dale");


### PR DESCRIPTION
Previously isUpdating flag was set to false before the record array was populated with new records from the adapter. We defer didUpdate event to the end of the run loop in the same manner we do with findQuery didLoad event.
