### PR TITLE
Adds support for configuring multiple aliases on the adapter

### DIFF
--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -1097,6 +1097,16 @@ DS.Serializer = Ember.Object.extend({
       delete configuration.alias;
     }
 
+    if (configuration.aliases && Ember.isArray(configuration.aliases)) {
+      var aliases = configuration.aliases;
+
+      for (var i = 0, len = aliases.length; i < len; i++) {
+        this.aliases.set(aliases[i], type);
+      }
+
+      delete configuration.aliases;
+    }
+
     config = Ember.create(this.globalConfigurations);
     Ember.merge(config, configuration);
 
@@ -1301,4 +1311,3 @@ DS.Serializer = Ember.Object.extend({
     }
   }
 });
-

--- a/packages/ember-data/tests/unit/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/unit/serializers/rest_serializer_test.js
@@ -141,3 +141,53 @@ test("Sideloading can be done by specifying only an alias", function() {
   equal(loadMainCallCount, 1, "one main record was loaded from a single payload");
   equal(loadCallCount, 1, "one secondary record was loaded from a single payload");
 });
+
+test("Sideloading can be done by specifying multiple aliases", function() {
+  var App = Ember.Namespace.create({
+    toString: function() { return "App"; }
+  });
+
+  App.Group = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  App.Post = DS.Model.extend({
+    title: DS.attr('string')
+  });
+
+  serializer.configure(App.Group, {
+    aliases: ['group', 'collectives']
+  });
+
+  var payload = {
+    post: {
+      id: 1,
+      title: "Fifty Ways to Bereave Your Lover"
+    },
+
+    groups: [{ id: 1, name: "Trolls" }],
+    collectives: [{ id: 2, name: "Elves" }]
+  };
+
+  var loadCallCount = 0,
+      loadMainCallCount = 0;
+
+  var loader = {
+    sideload: function(type, data, prematerialized) {
+      if(type === App.Group) {
+        loadCallCount++;
+      }
+    },
+
+    load: function(type, data, prematerialized) {
+      loadMainCallCount++;
+    },
+
+    prematerialize: Ember.K
+  };
+
+  serializer.extract(loader, payload, App.Post);
+
+  equal(loadMainCallCount, 1, "one main record was loaded from a single payload");
+  equal(loadCallCount, 2, "two secondary records were loaded from a single payload");
+});


### PR DESCRIPTION
I need support for multiple aliases for the same record on the adapter, as I have some models that are loaded with different names both from the same 'parent' and from different 'parent' models. This is partially supported, as you can set the `inverse` option on an association, but it there is no support for multiple aliases, so I find it lacking.

This adds a new key on the model configure `aliases` which takes an array of aliases and sets them the same way as the `alias` is set.
