### PR TITLE
Add warning when load request, but not data given

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -206,6 +206,8 @@ DS.JSONSerializer = DS.Serializer.extend({
     if (json[root]) {
       if (record) { loader.updateId(record, json[root]); }
       this.extractRecordRepresentation(loader, type, json[root]);
+    } else {
+      Ember.Logger.warn("Extract requested, but no data given for " + type + ". This may cause weird problems.");
     }
   },
 


### PR DESCRIPTION
This can cause some really weird things to happen. For example, if you do a post and the sever simply returns `{}` or `{"model": null}` this will keep records dirty forever. In general this can really just mess stuff up. I made it a warning because it's not exactly a problem, but an unexpected case. I can make it an assertion if needed.
