### PR TITLE
Make json serializer set singular alias on belongsTo

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -397,6 +397,6 @@ DS.JSONSerializer = DS.Serializer.extend({
     @return {String} name of the root element
   */
   defaultSideloadRootForType: function(type) {
-    return this.pluralize(this.rootForType(type));
+    return this.rootForType(type);
   }
 });


### PR DESCRIPTION
The aliases generated for the belongsTo associations are being set as plural and plural + 's' so if you have a model called 'post' it and do a belongsTo association to that model, it will create the aliases for 'posts' and 'postss' - which doesn't make much sense.

This change makes the alias be set to the singular on the association (changing `defaultSideloadRootForType`, so when all the aliases are pluralized later it will define the pluralized alias.

I'm having issues with this as it is not_defining aliases for the singular version of some models I need, and defining the singular alias manually results on an error when it tries to pluralize the singular, as there is a key for that already.
