### PR TITLE
Include the version number in the javascript.

### DIFF
--- a/packages/ember-data/lib/core.js
+++ b/packages/ember-data/lib/core.js
@@ -10,4 +10,6 @@
   @static
 */
 
-window.DS = Ember.Namespace.create();
+window.DS = Ember.Namespace.create({
+  VERSION: '0.13'
+});


### PR DESCRIPTION
For #1029 - expose the version number for debugging. Ember should be able to print it like so:

``` javascript
Ember.debug('-------------------------------');
Ember.debug('Ember.VERSION : ' + Ember.VERSION);
if (window.DS && DS.VERSION) {
  Ember.debug('DS.VERSION : ' + DS.VERSION);
} //...
```
