### PR TITLE
Fix to deep recursion with embedded always records.

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -119,7 +119,9 @@ DS.RESTAdapter = DS.Adapter.extend({
     if (reference.parent) {
       var store = get(record, 'store');
       var parent = store.recordForReference(reference.parent);
-      this._dirtyTree(dirtySet, parent);
+      if (!dirtySet.has(parent)) {
+        this._dirtyTree(dirtySet, parent);
+      }
     }
   },
 


### PR DESCRIPTION
This is a fix for an issue where a large number of embedded always
records will cause a very deep call stack, that can overflow if the
collections are too large.

In my case it was a ImporteFile that has embedded a list of
ImportedPersons, that had embedded a list of Addresses. For each record
in the imported persons, the parent would be added again, and for each
record in addresses, the person would be added again, and again the file
would be added to the dirty set.

If the parent is already in the dirtySet, nothing is gained by adding
the parent again.

Alternativly the test could be even earlier, at the first line in the
_dirtyTree method.
