### PR TITLE
Fixed embedded belongsTo relationships

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -145,6 +145,22 @@ DS.RESTAdapter = DS.Adapter.extend({
   },
 
   /**
+    @method dirtyRecordsForBelongsToChange
+    @param {Ember.OrderedSet} dirtySet
+    @param {DS.Model} record
+    @param {DS.RelationshipChange} relationship
+  */
+  dirtyRecordsForBelongsToChange: function(dirtySet, record, relationship) {
+    var serializer = get(this, 'serializer');
+    var embeddedType = get(this, 'serializer').embeddedType(relationship.childReference.record.constructor, relationship.firstRecordName);
+
+    if (embeddedType === 'always') {
+      relationship.parentReference.parent = relationship.childReference;
+    }
+    this._dirtyTree(dirtySet, record);
+  },
+
+  /**
     @method dirtyRecordsForHasManyChange
     @param {Ember.OrderedSet} dirtySet
     @param {DS.Model} record

--- a/packages/ember-data/tests/unit/relationships_test.js
+++ b/packages/ember-data/tests/unit/relationships_test.js
@@ -502,6 +502,25 @@ test("calling createRecord and passing in an undefined value for a relationship 
   strictEqual(person.get('tag'), null, "undefined values should return null relationships");
 });
 
+test("calling createRecord and passing in a record creates the relationship record", function () {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tag: DS.belongsTo(Tag),
+  });
+
+  var store = DS.Store.create();
+
+  store.createRecord(Person, { id: 1, tag: store.createRecord(Tag, { name: 'Ember.js' }) });
+
+  var person = store.find(Person, 1);
+
+  strictEqual(person.get('tag.name'), 'Ember.js', "the relationship record was created");
+});
+
 test("findMany is passed the owner record for adapters when some of the object graph is already loaded", function() {
   var Occupation = DS.Model.extend({
     description: DS.attr('string')


### PR DESCRIPTION
This fixes an an error where the code

```
Person = DS.Model.extend({
  name: DS.attr('string')
});
Group = DS.Model.extend({
  name: DS.attr('string'),
  people: DS.hasMany(Person)
});
Person.reopen({
  group: DS.belongsTo(Group)
});
Adapter.map(Person, {
  group: { embedded: 'always' }
});

store.createRecord(Person, { name: "Tom Dale", group: store.createRecord(Group, { name: "Ember.js Group" }) });
store.commit();
```

would trigger 2 POST requests (1 to /people, 1 to /groups) where you would only expect 1 (because of group being embedded in person).
