### PR TITLE
prevent additional post and puts for bulk commits with embedded types

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -776,11 +776,19 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     }
 
     this.groupByType(commitDetails.created).forEach(function(type, set) {
-      this.createRecords(store, type, filter(set));
+      var records = filter(set);
+
+      if(records.list.length){
+        this.createRecords(store, type, records);
+      }
     }, this);
 
     this.groupByType(commitDetails.updated).forEach(function(type, set) {
-      this.updateRecords(store, type, filter(set));
+      var records = filter(set);
+
+      if(records.list.length){
+        this.updateRecords(store, type, records);
+      }
     }, this);
 
     this.groupByType(commitDetails.deleted).forEach(function(type, set) {


### PR DESCRIPTION
This is a fix for #1070.
