### PR TITLE
Extract validation errors with correct relationship names

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -48,9 +48,12 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
   },
 
   extractValidationErrors: function(type, json) {
-    var errors = {};
+    var errors = {},
+        attributeNames = get(type, 'attributes.keys.list'),
+        relationshipNames = get(type, 'relationshipNames').belongsTo,
+        allowedKeys = attributeNames.concat(relationshipNames);
 
-    get(type, 'attributes').forEach(function(name) {
+    allowedKeys.forEach(function(name) {
       var key = this._keyForAttributeName(type, name);
       if (json['errors'].hasOwnProperty(key)) {
         errors[name] = json['errors'][key];

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -1267,9 +1267,18 @@ test("creating a record with a 422 error marks the records as invalid", function
 
 test("updating a record with a 422 error marks the records as invalid", function(){
   // setup
-  var person, mockXHR;
+  var person, mockXHR, PersonType, personType;
+  PersonType = DS.Model.extend({
+    title: DS.attr("string"),
+    people: DS.hasMany(Person)
+  });
+  PersonType.toString = function() {
+      return "App.PersonType";
+  };
+
   Person.reopen({
-    updatedAt: DS.attr('date')
+    updatedAt: DS.attr('date'),
+    personType: DS.belongsTo(PersonType)
   });
   store.load(Person, { id: 1, name: "John Doe" });
   person = store.find(Person, 1);
@@ -1295,14 +1304,14 @@ test("updating a record with a 422 error marks the records as invalid", function
   // setup
   mockXHR = {
     status:       422,
-    responseText: JSON.stringify({ errors: { name: ["can't be blank"], updated_at: ["can't be blank"] } })
+    responseText: JSON.stringify({ errors: { name: ["can't be blank"], updated_at: ["can't be blank"], person_type: ["can't be blank"] } })
   };
   ajaxHash.error.call(ajaxHash.context, mockXHR);
 
   // test
   stateEquals(person, 'loaded.updated.invalid');
   enabledFlags(person, ['isLoaded', 'isDirty']);
-  deepEqual(person.get('errors'), { name: ["can't be blank"], updatedAt: ["can't be blank"] }, "the person has the errors");
+  deepEqual(person.get('errors'), { name: ["can't be blank"], updatedAt: ["can't be blank"], personType: ["can't be blank"] }, "the person has the errors");
 });
 
 test("creating a record with a 500 error marks the record as error", function() {


### PR DESCRIPTION
With #831 in place it's impossible to get validation errors for related objects, such as those values assigned through a `<select>` element.

With this modification both the errors from attributes and from `belongsTo` associations would be allowed.

@tchak mentions this could be dangerous in #909, but there hasn't been any solution proposed.

If this is a no-go, we should figure out different approach. Whitelisting attributes on model level wouldn't work since error extraction is an adapter/serializer concern. Or maybe revisit #910 — if I understood correctly, with the PR merged in, #831 could be rolled back.
