### PR TITLE
Better handling of http requests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,6 +26,9 @@
         "minispade",
         "async",
         "invokeAsync",
+        "mockAjax",
+        "restoreAjax",
+        "mockXHR",
         "jQuery",
         "expectAssertion"
     ],

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -1,6 +1,7 @@
 require("ember-data/core");
 require('ember-data/system/adapter');
 require('ember-data/serializers/rest_serializer');
+require('ember-data/system/error');
 
 /**
   @module data
@@ -13,6 +14,16 @@ DS.rejectionHandler = function(reason) {
   Ember.Logger.assert([reason, reason.message, reason.stack]);
 
   throw reason;
+};
+
+DS.HttpResponse = function(xhr, textStatus, content) {
+  this.status = xhr.status;
+  this.textStatus = textStatus;
+  this.content = content || xhr.responseText;
+  this.header = function(header) {
+    return xhr.getResponseHeader(header);
+  };
+  this.isSuccess = (xhr.status >= 200 && xhr.status < 400);
 };
 
 /**
@@ -82,10 +93,6 @@ DS.RESTAdapter = DS.Adapter.extend({
 
   serializer: DS.RESTSerializer,
 
-  init: function() {
-    this._super.apply(this, arguments);
-  },
-
   shouldSave: function(record) {
     var reference = get(record, '_reference');
 
@@ -130,14 +137,13 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     data[root] = this.serialize(record, { includeId: true });
 
-    return this.ajax(this.buildURL(root), "POST", {
-      data: data
-    }).then(function(json){
-      adapter.didCreateRecord(store, type, record, json);
-    }, function(xhr) {
-      adapter.didError(store, type, record, xhr);
-      throw xhr;
-    }).then(null, DS.rejectionHandler);
+    return this.request(type, this.buildURL(root), {
+      method: "POST",
+      data: data,
+      success: function(payload) {
+        this.didCreateRecord(store, type, record, payload);
+      }
+    });
   },
 
   createRecords: function(store, type, records) {
@@ -156,11 +162,20 @@ DS.RESTAdapter = DS.Adapter.extend({
       data[plural].push(this.serialize(record, { includeId: true }));
     }, this);
 
-    return this.ajax(this.buildURL(root), "POST", {
-      data: data
-    }).then(function(json) {
-      adapter.didCreateRecords(store, type, records, json);
-    }).then(null, DS.rejectionHandler);
+    return this.request(type, this.buildURL(root), {
+      method: "POST",
+      data: data,
+      success: function(payload) {
+        this.didCreateRecords(store, type, records, payload);
+      },
+      error: function(response) {
+        var error = this.extractError(response, type),
+            thenable = Ember.RSVP.reject(error);
+        records.forEach(function(record) {
+          store.resolveWith(thenable, record);
+        });
+      }
+    });
   },
 
   updateRecord: function(store, type, record) {
@@ -173,14 +188,13 @@ DS.RESTAdapter = DS.Adapter.extend({
     data = {};
     data[root] = this.serialize(record);
 
-    return this.ajax(this.buildURL(root, id, record), "PUT",{
-      data: data
-    }).then(function(json){
-      adapter.didUpdateRecord(store, type, record, json);
-    }, function(xhr) {
-      adapter.didError(store, type, record, xhr);
-      throw xhr;
-    }).then(null, DS.rejectionHandler);
+    return this.request(type, this.buildURL(root, id, record), {
+      method: "PUT",
+      data: data,
+      success: function(payload) {
+        this.didUpdateRecord(store, type, record, payload);
+      }
+    });
   },
 
   updateRecords: function(store, type, records) {
@@ -202,11 +216,20 @@ DS.RESTAdapter = DS.Adapter.extend({
       data[plural].push(this.serialize(record, { includeId: true }));
     }, this);
 
-    return this.ajax(this.buildURL(root, "bulk"), "PUT", {
-      data: data
-    }).then(function(json) {
-      adapter.didUpdateRecords(store, type, records, json);
-    }).then(null, DS.rejectionHandler);
+    return this.request(type, this.buildURL(root, "bulk"), {
+      method: "PUT",
+      data: data,
+      success: function(payload) {
+        this.didUpdateRecords(store, type, records, payload);
+      },
+      error: function(response) {
+        var error = this.extractError(response, type),
+            thenable = Ember.RSVP.reject(error);
+        records.forEach(function(record) {
+          store.resolveWith(thenable, record);
+        });
+      }
+    });
   },
 
   deleteRecord: function(store, type, record) {
@@ -216,12 +239,12 @@ DS.RESTAdapter = DS.Adapter.extend({
     root = this.rootForType(type);
     adapter = this;
 
-    return this.ajax(this.buildURL(root, id, record), "DELETE").then(function(json){
-      adapter.didDeleteRecord(store, type, record, json);
-    }, function(xhr){
-      adapter.didError(store, type, record, xhr);
-      throw xhr;
-    }).then(null, DS.rejectionHandler);
+    return this.request(type, this.buildURL(root, id, record), {
+      method: "DELETE",
+      success: function(payload) {
+        this.didDeleteRecord(store, type, record, payload);
+      }
+    });
   },
 
   deleteRecords: function(store, type, records) {
@@ -243,57 +266,69 @@ DS.RESTAdapter = DS.Adapter.extend({
       data[plural].push(serializer.serializeId( get(record, 'id') ));
     });
 
-    return this.ajax(this.buildURL(root, 'bulk'), "DELETE", {
-      data: data
-    }).then(function(json){
-      adapter.didDeleteRecords(store, type, records, json);
-    }).then(null, DS.rejectionHandler);
+    return this.request(type, this.buildURL(root, 'bulk'), {
+      method: "DELETE",
+      data: data,
+      success: function(payload) {
+        this.didDeleteRecords(store, type, records, payload);
+      },
+      error: function(response) {
+        var error = this.extractError(response, type),
+            thenable = Ember.RSVP.reject(error);
+        records.forEach(function(record) {
+          store.resolveWith(thenable, record);
+        });
+      }
+    });
   },
 
   find: function(store, type, id) {
-    var root = this.rootForType(type), adapter = this;
+    var root = this.rootForType(type);
 
-    return this.ajax(this.buildURL(root, id), "GET").
-      then(function(json){
-        adapter.didFindRecord(store, type, json, id);
-    }).then(null, DS.rejectionHandler);
+    return this.request(type, this.buildURL(root, id), {
+      method: "GET",
+      success: function(payload) {
+        this.didFindRecord(store, type, payload, id);
+      }
+    });
   },
 
   findAll: function(store, type, since) {
-    var root, adapter;
+    var root = this.rootForType(type);
 
-    root = this.rootForType(type);
-    adapter = this;
-
-    return this.ajax(this.buildURL(root), "GET",{
-      data: this.sinceQuery(since)
-    }).then(function(json) {
-      adapter.didFindAll(store, type, json);
-    }).then(null, DS.rejectionHandler);
+    return this.request(type, this.buildURL(root), {
+      method: "GET",
+      data: this.sinceQuery(since),
+      success: function(payload) {
+        this.didFindAll(store, type, payload);
+      }
+    });
   },
 
   findQuery: function(store, type, query, recordArray) {
-    var root = this.rootForType(type),
-    adapter = this;
+    var root = this.rootForType(type);
 
-    return this.ajax(this.buildURL(root), "GET", {
-      data: query
-    }).then(function(json){
-      adapter.didFindQuery(store, type, json, recordArray);
-    }).then(null, DS.rejectionHandler);
+    return this.request(type, this.buildURL(root), {
+      method: "GET",
+      data: query,
+      success: function(payload) {
+        this.didFindQuery(store, type, payload, recordArray);
+      }
+    });
   },
 
   findMany: function(store, type, ids, owner) {
-    var root = this.rootForType(type),
-    adapter = this;
+    var root = this.rootForType(type);
 
     ids = this.serializeIds(ids);
 
-    return this.ajax(this.buildURL(root), "GET", {
-      data: {ids: ids}
-    }).then(function(json) {
-      adapter.didFindMany(store, type, json);
-    }).then(null, DS.rejectionHandler);
+    return this.request(type, this.buildURL(root), {
+      method: "GET",
+      data: {ids: ids},
+      success: function(payload) {
+        this.didFindMany(store, type, payload);
+      }
+    });
   },
 
   /**
@@ -311,42 +346,105 @@ DS.RESTAdapter = DS.Adapter.extend({
     });
   },
 
-  didError: function(store, type, record, xhr) {
-    if (xhr.status === 422) {
-      var json = JSON.parse(xhr.responseText),
-          serializer = get(this, 'serializer'),
-          errors = serializer.extractValidationErrors(type, json);
-
-      store.recordWasInvalid(record, errors);
+  didError: function(response, type) {
+    if (response.status === 422) {
+      return this.didValidationError(response, type);
     } else {
-      this._super.apply(this, arguments);
+      return this.didAdapterError(response, type);
     }
   },
 
-  ajax: function(url, type, hash) {
-    var adapter = this;
+  didAdapterError: function(response, type) {
+    switch (response.textStatus) {
+    case 'timeout':
+      return new DS.TimeoutError(response.textStatus);
+    case 'abort':
+      return new DS.AbortError(response.textStatus);
+    case 'parsererror':
+      return new DS.ParserError(response.textStatus);
+    default:
+      switch (response.status) {
+      case 401:
+        return new DS.UnauthorizedError(response.content);
+      case 403:
+        return new DS.ForbiddenError(response.content);
+      case 404:
+        return new DS.NotFoundError(response.content);
+      default:
+        return new DS.AdapterError(response.content);
+      }
+    }
+  },
 
+  didValidationError: function(response, type) {
+    var json = JSON.parse(response.content),
+        serializer = get(this, 'serializer'),
+        errors = serializer.extractValidationErrors(type, json),
+        error = new DS.AdapterValidationError(errors);
+
+    return error;
+  },
+
+  responseHandler: function(response, success, error) {
+    if (response.isSuccess) {
+      success.call(this, response.content);
+    } else {
+      throw error.call(this, response);
+    }
+  },
+
+  request: function(type, url, options) {
+    var adapter = this,
+        success = options.success,
+        error = options.error,
+        method = options.method;
+
+    error = error || function(response) {
+      return this.didError(response, type);
+    };
+
+    delete options.success;
+    delete options.error;
+    delete options.method;
+
+    return this.ajax(url, method, options)
+      .then(function(response) {
+        adapter.responseHandler(response, success, error);
+      }, function(response) {
+        throw error.call(adapter, response);
+      })
+      .then(null, DS.rejectionHandler);
+  },
+
+  ajax: function(url, method, options) {
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      hash = hash || {};
-      hash.url = url;
-      hash.type = type;
-      hash.dataType = 'json';
-      hash.context = adapter;
+      options = options || {};
+      options.url = url;
+      options.type = method;
+      options.dataType = 'json';
 
-      if (hash.data && type !== 'GET') {
-        hash.contentType = 'application/json; charset=utf-8';
-        hash.data = JSON.stringify(hash.data);
+      if (options.data && method !== 'GET') {
+        options.contentType = 'application/json; charset=utf-8';
+        options.data = JSON.stringify(options.data);
       }
 
-      hash.success = function(json) {
-        Ember.run(null, resolve, json);
+      options.success = function(json, textStatus, jqXHR) {
+        var response = new DS.HttpResponse(jqXHR, textStatus, json);
+
+        Ember.run(null, resolve, response);
       };
 
-      hash.error = function(jqXHR, textStatus, errorThrown) {
-        Ember.run(null, reject, jqXHR);
+      options.error = function(jqXHR, textStatus, errorThrown) {
+        var response = new DS.HttpResponse(jqXHR, textStatus);
+
+        if (textStatus !== 'error' || response.status >= 500) {
+          Ember.run(null, reject, response);
+        } else {
+          Ember.run(null, resolve, response);
+        }
       };
 
-      Ember.$.ajax(hash);
+      Ember.$.ajax(options);
     });
   },
 

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -445,22 +445,6 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     get(this, 'serializer').extractMany(loader, payload, type);
   },
 
-  /**
-    Notifies the store that a request to the backend returned
-    an error.
-
-    Your adapter should call this method to indicate that the
-    backend returned an error for a request.
-
-    @method didError
-    @param {DS.Store} store
-    @param {subclass of DS.Model} type
-    @param {DS.Model} record
-  */
-  didError: function(store, type, record) {
-    store.recordWasError(record);
-  },
-
   dirtyRecordsForAttributeChange: function(dirtySet, record, attributeName, newValue, oldValue) {
     if (newValue !== oldValue) {
       // If this record is embedded, add its parent
@@ -690,19 +674,22 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
 
   createRecords: function(store, type, records) {
     records.forEach(function(record) {
-      this.createRecord(store, type, record);
+      var thenable = this.createRecord(store, type, record);
+      store.resolveWith(thenable, record);
     }, this);
   },
 
   updateRecords: function(store, type, records) {
     records.forEach(function(record) {
-      this.updateRecord(store, type, record);
+      var thenable = this.updateRecord(store, type, record);
+      store.resolveWith(thenable, record);
     }, this);
   },
 
   deleteRecords: function(store, type, records) {
     records.forEach(function(record) {
-      this.deleteRecord(store, type, record);
+      var thenable = this.deleteRecord(store, type, record);
+      store.resolveWith(thenable, record);
     }, this);
   },
 

--- a/packages/ember-data/lib/system/error.js
+++ b/packages/ember-data/lib/system/error.js
@@ -1,0 +1,50 @@
+var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'number', 'stack'];
+
+var extendError = function(superError, constructor) {
+  var error = function() {
+    if (constructor) {
+      superError.apply(this);
+      constructor.apply(this, arguments);
+    } else {
+      var parent = superError.apply(this, arguments);
+
+      // Unfortunately errors are not enumerable in Chrome (at least), so `for prop in tmp` doesn't work.
+      for (var idx = 0; idx < errorProps.length; idx++) {
+        this[errorProps[idx]] = parent[errorProps[idx]];
+      }
+    }
+
+    return this;
+  };
+
+  error.prototype = Ember.create(superError.prototype);
+
+  error.extend = function(constructor) {
+    return extendError(this, constructor);
+  };
+
+  return error;
+};
+
+/**
+  A subclass of the JavaScript Error object for use in DS.
+
+  @class Error
+  @namespace DS
+  @extends Error
+  @constructor
+*/
+DS.Error = extendError(Error);
+
+DS.AdapterError = DS.Error.extend();
+DS.TimeoutError = DS.Error.extend();
+DS.AbortError = DS.Error.extend();
+DS.ParserError = DS.Error.extend();
+DS.NotFoundError = DS.Error.extend();
+DS.UnauthorizedError = DS.Error.extend();
+DS.ForbiddenError = DS.Error.extend();
+
+DS.ValidationError = DS.Error.extend(function(errors) {
+  this.errors = errors;
+});
+DS.AdapterValidationError = DS.ValidationError.extend();

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -478,11 +478,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
       var thenable = adapter.find(this, type, id);
 
-      if (thenable && thenable.then) {
-        thenable.then(null /* for future use */, function(error) {
-          store.recordWasError(record);
-        });
-      }
+      this.resolveWith(thenable, record);
     }
 
     return record;
@@ -500,11 +496,23 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     var thenable = adapter.find(this, type, id);
 
-    if (thenable && thenable.then) {
-      thenable.then(null /* for future use */, function(error) {
-        store.recordWasError(record);
-      });
-    }
+    this.resolveWith(thenable, record);
+  },
+
+  resolveWith: function(thenable, recordOrArray) {
+    var store = this;
+    return Ember.RSVP.resolve(thenable).then(function() {
+      return recordOrArray;
+    }, function(error) {
+      if (recordOrArray instanceof DS.Model) {
+        if (error instanceof DS.ValidationError) {
+          store.recordWasInvalid(recordOrArray, error.errors);
+        } else {
+          store.recordWasError(recordOrArray, error);
+        }
+      }
+      return Ember.RSVP.reject(error);
+    });
   },
 
   /**
@@ -1045,8 +1053,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
      @param {DS.Model} record
   */
-  recordWasError: function(record) {
-    record.adapterDidError();
+  recordWasError: function(record, error) {
+    record.adapterDidError(error);
   },
 
   /**

--- a/packages/ember-data/tests/integration/embedded/embedded_without_ids_test.js
+++ b/packages/ember-data/tests/integration/embedded/embedded_without_ids_test.js
@@ -2,10 +2,6 @@ var store, Adapter, adapter;
 var Post, Comment, User, Pingback, Like;
 var attr = DS.attr;
 
-function promise(fn){
-  return new Ember.RSVP.Promise(fn);
-}
-
 module("Embedded Relationships Without IDs", {
   setup: function() {
     var App = Ember.Namespace.create({ name: "App" });
@@ -92,26 +88,26 @@ asyncTest("Embedded belongsTo relationships can be saved when embedded: always i
     }
   });
 
-  adapter.ajax = function(url, type, hash) {
-    deepEqual(hash.data, {
-      comment: {
-        title: "Why not use a more lightweight solution?",
-        user: {
-          name: "mongodb_expert"
+  adapter.reopen({
+    ajax: function(url, type, hash) {
+      deepEqual(hash.data, {
+        comment: {
+          title: "Why not use a more lightweight solution?",
+          user: {
+            name: "mongodb_expert"
+          }
         }
-      }
-    });
-
-    return promise(function(resolve, reject) {
-      setTimeout(function() {
-        Ember.run(function() {
-          hash.data.comment.id = 1;
-          resolve(hash.data);
-        });
-        done();
       });
-    });
-  };
+
+      return this._super(url, type, hash);
+    }
+  });
+
+  mockAjax(function(hash) {
+    hash.data.comment.id = 1;
+    hash.success.call(adapter, hash.data, 'success', mockXHR());
+    done();
+  }, 1);
 
   var transaction = store.transaction();
 
@@ -130,6 +126,7 @@ asyncTest("Embedded belongsTo relationships can be saved when embedded: always i
     equal(user.get('isDirty'), false, "user becomes clean after commit");
     equal(comment.get('isDirty'), false, "comment becomes clean after commit");
     start();
+    restoreAjax();
   }
 });
 
@@ -178,34 +175,34 @@ asyncTest("Embedded hasMany relationships can be saved when embedded: always is 
     likes: [{ id: 1 }, { id: 2 }]
   });
 
-  adapter.ajax = function(url, type, hash) {
-    deepEqual(hash.data, {
-      post: {
-        title: "A New MVC Framework in Under 100 Lines of Code",
+  adapter.reopen({
+    ajax: function(url, type, hash) {
+      deepEqual(hash.data, {
+        post: {
+          title: "A New MVC Framework in Under 100 Lines of Code",
 
-        comments: [{
-          title: "Wouldn't a more lightweight solution be better? This feels very monolithic.",
-          user: null
-        },
-        {
-          title: "This does not seem to reflect the Unix philosophy haha",
-          user: null
-        }],
+          comments: [{
+            title: "Wouldn't a more lightweight solution be better? This feels very monolithic.",
+            user: null
+          },
+          {
+            title: "This does not seem to reflect the Unix philosophy haha",
+            user: null
+          }],
 
-        pingbacks: []
-      }
-    });
-
-    return promise(function(resolve, reject){
-      setTimeout(function() {
-        Ember.run(function() {
-          hash.data.post.id = 1;
-          resolve(hash.data);
-        });
-        done();
+          pingbacks: []
+        }
       });
-    });
-  };
+
+      return this._super(url, type, hash);
+    }
+  });
+
+  mockAjax(function(hash) {
+    hash.data.post.id = 1;
+    hash.success.call(adapter, hash.data, 'success', mockXHR());
+    done();
+  }, 1);
 
   var transaction = store.transaction();
 
@@ -229,6 +226,7 @@ asyncTest("Embedded hasMany relationships can be saved when embedded: always is 
     equal(comment1.get('isDirty'), false, "comment becomes clean after commit");
     equal(comment2.get('isDirty'), false, "comment becomes clean after commit");
     start();
+    restoreAjax();
   }
 });
 
@@ -279,38 +277,38 @@ asyncTest("Embedded records that contain embedded records can be saved", functio
     }]
   });
 
-  adapter.ajax = function(url, type, hash) {
-    deepEqual(hash.data, {
-      post: {
-        title: "A New MVC Framework in Under 100 Lines of Code",
+  adapter.reopen({
+    ajax: function(url, type, hash) {
+      deepEqual(hash.data, {
+        post: {
+          title: "A New MVC Framework in Under 100 Lines of Code",
 
-        comments: [{
-          title: "Wouldn't a more lightweight solution be better? This feels very monolithic.",
-          user: {
-            name: "mongodb_user"
-          }
-        },
-        {
-          title: "This does not seem to reflect the Unix philosophy haha",
-          user: {
-            name: "microuser"
-          }
-        }],
+          comments: [{
+            title: "Wouldn't a more lightweight solution be better? This feels very monolithic.",
+            user: {
+              name: "mongodb_user"
+            }
+          },
+          {
+            title: "This does not seem to reflect the Unix philosophy haha",
+            user: {
+              name: "microuser"
+            }
+          }],
 
-        pingbacks: []
-      }
-    });
-
-    return promise(function(resolve, reject){
-      setTimeout(function(){
-        Ember.run(function() {
-          hash.data.post.id = 1;
-          resolve(hash.data);
-        });
-        done();
+          pingbacks: []
+        }
       });
-    });
-  };
+
+      return this._super(url, type, hash);
+    }
+  });
+
+  mockAjax(function(hash) {
+    hash.data.post.id = 1;
+    hash.success.call(adapter, hash.data, 'success', mockXHR());
+    done();
+  }, 1);
 
   var transaction = store.transaction();
 
@@ -342,5 +340,6 @@ asyncTest("Embedded records that contain embedded records can be saved", functio
     equal(user1.get('isDirty'), false, "user becomes clean after commit");
     equal(user2.get('isDirty'), false, "user becomes clean after commit");
     start();
+    restoreAjax();
   }
 });

--- a/packages/ember-data/tests/integration/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/rest_adapter_test.js
@@ -1,10 +1,7 @@
 var store, adapter, Post, Comment;
-var originalAjax;
 
 module("REST Adapter", {
   setup: function() {
-    originalAjax = Ember.$.ajax;
-
     store = DS.Store.create({
       adapter: DS.RESTAdapter
     });
@@ -20,21 +17,18 @@ module("REST Adapter", {
 
   teardown: function() {
     store.destroy();
-    Ember.$.ajax = originalAjax;
+    restoreAjax();
   }
 });
 
 test("creating a record with a 422 error marks the records as invalid", function(){
   expect(1);
 
-  var mockXHR = {
-    status:       422,
-    responseText: JSON.stringify({ errors: { name: ["can't be blank"]} })
-  };
+  var xhr = mockXHR(422, JSON.stringify({ errors: { name: ["can't be blank"]} }), 'error');
 
-  jQuery.ajax = function(hash) {
-    hash.error.call(hash.context, mockXHR, "Unprocessable Entity");
-  };
+  mockAjax(function(hash) {
+    hash.error.call(adapter, xhr, 'error');
+  });
 
   var post = store.createRecord(Post, { name: "" });
 


### PR DESCRIPTION
This is part 1/2 of error handling. (split of #958)

In this PR I mostly unified the way we handle success/error for different adapter operations. I added a few hooks so a developer can customize how he interpret network/adapter errors. The only thing coming out of adapter is a promise that resolves or rejects with an error. I changed `DS.Error` to inherit from simple JS `Error` like we do it in ember core. Maybe we could inherit from `Ember.Error`? But anyways following @tomdale comment, errors are simple js object/errors now.

I think some part of it could be extracted in to core like `ember-http` and Error inheritance.

More tests soon.
