### PR TITLE
Advanced errors handling

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -50,11 +50,25 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
   extractValidationErrors: function(type, json) {
     var errors = {};
 
-    get(type, 'attributes').forEach(function(name) {
-      var key = this._keyForAttributeName(type, name);
+    function addError(name, key) {
       if (json['errors'].hasOwnProperty(key)) {
         errors[name] = json['errors'][key];
       }
+    }
+
+    type.eachAttribute(function(name) {
+      var key = this._keyForAttributeName(type, name);
+      addError(name, key);
+    }, this);
+
+    type.eachRelationship(function(name, meta) {
+      var key;
+      if (meta.kind === 'belongsTo') {
+        key = this._keyForBelongsTo(type, name);
+      } else if (meta.kind === 'hasMany') {
+        key = this._keyForHasMany(type, name);
+      }
+      addError(name, key);
     }, this);
 
     return errors;

--- a/packages/ember-data/lib/system/errors.js
+++ b/packages/ember-data/lib/system/errors.js
@@ -1,0 +1,65 @@
+var get = Ember.get, set = Ember.set;
+
+DS.Errors = Ember.Object.extend(Ember.Enumerable, Ember.Evented, {
+  errorsByAttributeName: Ember.computed(function() {
+    return Ember.MapWithDefault.create({
+      defaultValue: function() { return Ember.A(); }
+    });
+  }),
+
+  content: Ember.computed(function() {
+    return Ember.A();
+  }),
+
+  unknownProperty: function(name) {
+    var errors = get(this, 'errorsByAttributeName').get(name);
+    if (!errors.length) { return null; }
+    return errors;
+  },
+
+  nextObject: function(index, previousObject, context) {
+    return get(this, 'content').objectAt(index);
+  },
+
+  length: Ember.computed.alias('content.length'),
+  isEmpty: Ember.computed.not('length'),
+
+  add: function(name, messages) {
+    var errorsByAttributeName = get(this, 'errorsByAttributeName'),
+        errors = errorsByAttributeName.get(name);
+
+    messages = Ember.makeArray(messages);
+
+    errors.addObjects(messages);
+    get(this, 'content').addObjects(messages);
+    this.notifyPropertyChange(name);
+
+    if (!get(this, 'isEmpty')) {
+      this.trigger('becameInvalid');
+    }
+  },
+
+  remove: function(name) {
+    var errorsByAttributeName = get(this, 'errorsByAttributeName'),
+        errors = errorsByAttributeName.get(name);
+
+    errorsByAttributeName.set(name, Ember.A());
+    get(this, 'content').removeObjects(errors);
+    this.notifyPropertyChange(name);
+
+    if (get(this, 'isEmpty')) {
+      this.trigger('becameValid');
+    }
+  },
+
+  clear: function() {
+    this.notifyPropertyChange('errorsByAttributeName');
+    this.notifyPropertyChange('content');
+
+    this.trigger('becameValid');
+  },
+
+  has: function(name) {
+    return get(this, 'errorsByAttributeName').get(name).length > 0;
+  }
+});

--- a/packages/ember-data/lib/system/model.js
+++ b/packages/ember-data/lib/system/model.js
@@ -6,3 +6,4 @@
 require("ember-data/system/model/model");
 require("ember-data/system/model/states");
 require("ember-data/system/model/attributes");
+require("ember-data/system/errors");

--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -21,15 +21,19 @@ DS.Model.reopenClass({
     });
 
     return map;
-  })
+  }),
+
+  eachAttribute: function(callback, binding) {
+    get(this, 'attributes').forEach(function(name, meta) {
+      callback.call(binding, name, meta);
+    });
+  }
 });
 
 
 DS.Model.reopen({
   eachAttribute: function(callback, binding) {
-    get(this.constructor, 'attributes').forEach(function(name, meta) {
-      callback.call(binding, name, meta);
-    }, binding);
+    this.constructor.eachAttribute(callback, binding);
   },
 
   attributeWillChange: Ember.beforeObserver(function(record, key) {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1045,8 +1045,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
      @param {DS.Model} record
   */
-  recordWasError: function(record) {
-    record.adapterDidError();
+  recordWasError: function(record, error) {
+    record.adapterDidError(error);
   },
 
   /**

--- a/packages/ember-data/tests/integration/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/store_adapter_test.js
@@ -302,10 +302,6 @@ test("if a created record is marked as invalid by the server, it enters an error
   set(yehuda, 'updatedAt', true);
   equal(get(yehuda, 'isValid'), false, "the record is still invalid");
 
-  // This tests that we handle undefined values without blowing up
-  var errors = get(yehuda, 'errors');
-  set(errors, 'other_bound_property', undefined);
-  set(yehuda, 'errors', errors);
   set(yehuda, 'name', "Brohuda Brokatz");
 
   equal(get(yehuda, 'isValid'), true, "the record is no longer invalid after changing");

--- a/packages/ember-data/tests/unit/rest_adapter_test.js
+++ b/packages/ember-data/tests/unit/rest_adapter_test.js
@@ -1262,7 +1262,7 @@ test("creating a record with a 422 error marks the records as invalid", function
   // test
   stateEquals(person, 'loaded.created.invalid');
   enabledFlags(person, ['isLoaded', 'isDirty', 'isNew']);
-  deepEqual(person.get('errors'), { name: ["can't be blank"]}, "the person has the errors");
+  deepEqual(person.get('errors.name'), ["can't be blank"], "the person has the errors");
 });
 
 test("updating a record with a 422 error marks the records as invalid", function(){
@@ -1302,7 +1302,8 @@ test("updating a record with a 422 error marks the records as invalid", function
   // test
   stateEquals(person, 'loaded.updated.invalid');
   enabledFlags(person, ['isLoaded', 'isDirty']);
-  deepEqual(person.get('errors'), { name: ["can't be blank"], updatedAt: ["can't be blank"] }, "the person has the errors");
+  deepEqual(person.get('errors.name'), ["can't be blank"], "the person has the errors");
+  deepEqual(person.get('errors.updatedAt'), ["can't be blank"], "the person has the errors");
 });
 
 test("creating a record with a 500 error marks the record as error", function() {


### PR DESCRIPTION
This is part 2/2 of error handling. (split of #958)

In this PR I implement `DS.Errors` an errors messages per attribute store. After more thoughts I think it is better too keep it separate from `DS.Error` implementation.
This PR also include in validation messages errors on relationships.

More tests soon.
