### PR TITLE
Fix double pluralizing aliases for polymorphic relations

### DIFF
--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -1136,8 +1136,10 @@ DS.Serializer = Ember.Object.extend({
 
     aliases.forEach(function(key, type) {
       plural = self.pluralize(key);
-      Ember.assert("The '" + key + "' alias has already been defined", !aliases.get(plural));
-      aliases.set(plural, type);
+      
+      if (!aliases.get(plural)) {
+        aliases.set(plural, type);
+      }
     });
 
     // This map is only for backward compatibility with the `sideloadAs` option.


### PR DESCRIPTION
When using polymorphic relationships you are required to define an alias for any model that may belong to a polymorphic relationship:

```
App.Adapter.configure('App.Assignment', {
  alias: 'assignment'
});
```

If this model is also being sideloaded anywhere in the application it can cause the serializer to attempt to pluralize the alias twice.

JSONSerializer.sideload calls JSONSerializer.configureSideloadMappingForType which adds an alias to the serializer. The name of the alias is already in the pluralized form as returned by JSONSerializer.defaultSideloadRootForType.

The net result is that "assignments" would be added to the list of aliases the first time an assignment is sideloaded. If this happens before Serializer._pluralizeAssets is called AND an alias exists for "assignment" (because it was configured to support polymorphic relationships) then _pluralizeAssets will try to add the pluralized version of the alias again and will throw an error.

Since we can not be sure that pluralizing the alias will only occur once, the solution is to check first before adding it to the list of aliases.
