### PR TITLE
get primaryKey from mappings

### DIFF
--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -870,7 +870,7 @@ DS.Serializer = Ember.Object.extend({
     @returns {String} the primary key for the type
   */
   _primaryKey: function(type) {
-    var config = this.configurationForType(type),
+    var config = this.mappingForType(type),
         primaryKey = config && config.primaryKey;
 
     if (primaryKey) {


### PR DESCRIPTION
In DS.Serializer @desc

``` javascript
  App.Adapter.map('App.Person', {
    primaryKey: '_id'
  });
```

but in DS.Serializer#_primaryKey, use DS.Serializer#configurationForType to get primaryKey mapping
