### PR TITLE
Add _debugInfo to DS.Model

### DIFF
--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -37,3 +37,4 @@ require("ember-data/system/record_array_manager");
 require("ember-data/system/adapter");
 require("ember-data/system/serializer");
 require("ember-data/adapters");
+require("ember-data/system/debug");

--- a/packages/ember-data/lib/system/debug.js
+++ b/packages/ember-data/lib/system/debug.js
@@ -1,0 +1,4 @@
+/**
+  @module ember-data
+*/
+require("ember-data/system/debug/debug_info");

--- a/packages/ember-data/lib/system/debug/debug_info.js
+++ b/packages/ember-data/lib/system/debug/debug_info.js
@@ -1,0 +1,64 @@
+require("ember-data/system/model/model");
+
+DS.Model.reopen({
+
+  /**
+   Provides info about the model for debugging purposes
+   by grouping the properties into more semantic groups.
+
+   Meant to be used by debugging tools such as the Chrome Ember Extension.
+
+   - Groups all attributes in "Attributes" group.
+   - Groups all belongsTo relationships in "Belongs To" group.
+   - Groups all hasMany relationships in "Has Many" group.
+   - Groups all flags in "Flags" group.
+   - Flags relationship CPs as expensive properties.
+  */
+  _debugInfo: function() {
+    var attributes = ['id'],
+        relationships = { belongsTo: [], hasMany: [] },
+        expensiveProperties = [];
+
+    this.eachAttribute(function(name, meta) {
+      attributes.push(name);
+    }, this);
+
+    this.eachRelationship(function(name, relationship) {
+      relationships[relationship.kind].push(name);
+      expensiveProperties.push(name);
+    });
+
+    var groups = [
+      {
+        name: 'Attributes',
+        properties: attributes,
+        expand: true,
+      },
+      {
+        name: 'Belongs To',
+        properties: relationships.belongsTo,
+        expand: true
+      },
+      {
+        name: 'Has Many',
+        properties: relationships.hasMany,
+        expand: true
+      },
+      {
+        name: 'Flags',
+        properties: ['isLoaded', 'isDirty', 'isSaving', 'isDeleted', 'isError', 'isNew', 'isValid']
+      }
+    ];
+
+    return {
+      propertyInfo: {
+        // include all other mixins / properties (not just the grouped ones)
+        includeOtherProperties: true,
+        groups: groups,
+        // don't pre-calculate unless cached
+        expensiveProperties: expensiveProperties
+      }
+    };
+  }
+
+});

--- a/packages/ember-data/tests/unit/debug_test.js
+++ b/packages/ember-data/tests/unit/debug_test.js
@@ -1,0 +1,44 @@
+var get = Ember.get, set = Ember.set;
+
+var store;
+
+var TestAdapter = DS.Adapter.extend();
+
+module("Debug", {
+  setup: function() {
+    store = DS.Store.create({
+      adapter: TestAdapter.create(),
+    });
+  },
+
+  teardown: function() {
+    store.destroy();
+    store = null;
+  }
+});
+
+test("_debugInfo groups the attributes and relationships correctly", function() {
+  var MaritalStatus = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var Post = DS.Model.extend({
+    title: DS.attr('string')
+  });
+
+  var User = DS.Model.extend({
+    name: DS.attr('string'),
+    isDrugAddict: DS.attr('boolean'),
+    maritalStatus: DS.belongsTo(MaritalStatus),
+    posts: DS.hasMany(Post)
+  });
+
+  var record = store.createRecord(User);
+
+  var propertyInfo = record._debugInfo().propertyInfo;
+
+  equal(propertyInfo.groups.length, 4);
+  deepEqual(propertyInfo.groups[0].properties, ['id', 'name', 'isDrugAddict']);
+  deepEqual(propertyInfo.groups[1].properties, ['maritalStatus']);
+  deepEqual(propertyInfo.groups[2].properties, ['posts']);
+});


### PR DESCRIPTION
Provides a `_debugInfo` method to group `DS.Model` attributes in a meaningful way.

Will be used by the Chrome extension.

Developed in parallel with https://github.com/tildeio/ember-extension/pull/36
