### PR TITLE
Allowing inverse relationships to be nullable.

### DIFF
--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -108,6 +108,9 @@ DS.Model.reopenClass({
     if (!inverseType) { return null; }
 
     var options = this.metaForProperty(name).options;
+
+    if (options.inverse === null) { return null; }
+    
     var inverseName, inverseKind;
 
     if (options.inverse) {

--- a/packages/ember-data/tests/integration/inverse_relationships_test.js
+++ b/packages/ember-data/tests/integration/inverse_relationships_test.js
@@ -30,6 +30,23 @@ test("When a record is added to a has-many relationship, the inverse belongsTo i
   equal(comment.get('post'), post, "post was set on the comment");
 });
 
+test("Inverse relationships can be explicitly nullable", function () {
+  User = DS.Model.extend();
+
+  Post = DS.Model.extend({
+    lastParticipant: DS.belongsTo(User, { inverse: null }),
+    participants: DS.hasMany(User, { inverse: 'posts' })
+  });
+
+  User.reopen({
+    posts: DS.hasMany(Post, { inverse: 'participants' })
+  });
+
+  equal(User.inverseFor('posts').name, 'participants', 'User.posts inverse is Post.participants');
+  equal(Post.inverseFor('lastParticipant'), null, 'Post.lastParticipant has no inverse');
+  equal(Post.inverseFor('participants').name, 'posts', 'Post.participants inverse is User.posts');
+});
+
 test("When a record is added to a has-many relationship, the inverse belongsTo can be set explicitly", function() {
   Post = DS.Model.extend();
 


### PR DESCRIPTION
Greetings,

I ran into a case where Model A has two relationships defined on it - a belongsTo and a hasMany - each of which lead to a type of Model B. Model B has a single hasMany relationship defined on it whose inverse is the hasMany property of Model A, thus:

Model A is in a many-to-many relationship with Model B _and_ Model A is in a one-to-none relationship with Model B that is unrelated to the former many-to-many relationship.

The problem happens when you change the value of the one-to-none property: The current logic checks for a truthy `inverse` property defined on the belongsTo relationship. When it doesn't find one, it simply tries to find one for me, so it looks at Model B, sees the hasMany relationship back to Model A, and incorrectly decides that this must be the relationship I'm talking about (interesting that it doesn't seem to check the found inverse property's `inverse` to see if it isn't already explicitly defined to be the inverse of a relationship that is not the current one in question).

Included is a one-line fix inside the `inverseFor` function that looks for explicit nulls on the inverse. Also included is a test case that will fail on emberjs/data:master because it will incorrectly identify an inverse relationship to the `lastParticipant` belongsTo property.

Hopefully this is helpful to some folks.
