### PR TITLE
Added DS.DebugAdapter which extends Ember.DataAdapter

### DIFF
--- a/packages/ember-data/lib/initializers.js
+++ b/packages/ember-data/lib/initializers.js
@@ -1,5 +1,5 @@
 require("ember-data/serializers/new_json_serializer");
-
+require("ember-data/system/debug/debug_adapter");
 /**
   @module ember-data
 */
@@ -50,12 +50,26 @@ Ember.onLoad('Ember.Application', function(Application) {
     }
   });
 
+  // Keep ED compatible with previous versions of ember
+  // TODO: Remove the if statement for Ember 1.0
+  if (DS.DebugAdapter) {
+    Application.initializer({
+      name: "dataAdapter",
+
+      initialize: function(container, application) {
+        application.register('dataAdapter:main', DS.DebugAdapter);
+      }
+    });
+  }
+
   Application.initializer({
     name: "injectStore",
 
     initialize: function(container, application) {
       application.inject('controller', 'store', 'store:main');
       application.inject('route', 'store', 'store:main');
+      application.inject('dataAdapter', 'store', 'store:main');
     }
   });
+
 });

--- a/packages/ember-data/lib/system/debug.js
+++ b/packages/ember-data/lib/system/debug.js
@@ -2,3 +2,4 @@
   @module ember-data
 */
 require("ember-data/system/debug/debug_info");
+require("ember-data/system/debug/debug_adapter");

--- a/packages/ember-data/lib/system/debug/debug_adapter.js
+++ b/packages/ember-data/lib/system/debug/debug_adapter.js
@@ -1,0 +1,109 @@
+/**
+  @module ember-data
+*/
+// Keep ED compatible with previous versions of ember
+// TODO: Remove this check for Ember 1.0
+if (!Ember.DataAdapter) { return; }
+
+var get = Ember.get, capitalize = Ember.String.capitalize, underscore = Ember.String.underscore, DS = window.DS ;
+
+/**
+  Extend `Ember.DataAdapter` with ED specific code.
+*/
+DS.DebugAdapter = Ember.DataAdapter.extend({
+  getFilters: function() {
+    return [
+      { name: 'isNew', desc: 'New' },
+      { name: 'isModified', desc: 'Modified' },
+      { name: 'isClean', desc: 'Clean' }
+    ];
+  },
+
+  detect: function(klass) {
+    return klass !== DS.Model && DS.Model.detect(klass);
+  },
+
+  columnsForType: function(type) {
+    var columns = [{ name: 'id', desc: 'Id' }], count = 0, self = this;
+    Ember.A(get(type, 'attributes')).forEach(function(name, meta) {
+        if (count++ > self.attributeLimit) { return false; }
+        var desc = capitalize(underscore(name).replace('_', ' '));
+        columns.push({ name: name, desc: desc });
+    });
+    return columns;
+  },
+
+  getRecords: function(type) {
+    return this.get('store').all(type);
+  },
+
+  getRecordColumnValues: function(record) {
+    var self = this, count = 0,
+        columnValues = { id: get(record, 'id') };
+
+    record.eachAttribute(function(key) {
+      if (count++ > self.attributeLimit) {
+        return false;
+      }
+      var value = get(record, key);
+      columnValues[key] = value;
+    });
+    return columnValues;
+  },
+
+  getRecordKeywords: function(record) {
+    var keywords = [], keys = Ember.A(['id']);
+    record.eachAttribute(function(key) {
+      keys.push(key);
+    });
+    keys.forEach(function(key) {
+      keywords.push(get(record, key));
+    });
+    return keywords;
+  },
+
+  getRecordFilterValues: function(record) {
+    return {
+      isNew: record.get('isNew'),
+      isModified: record.get('isDirty') && !record.get('isNew'),
+      isClean: !record.get('isDirty')
+    };
+  },
+
+  getRecordColor: function(record) {
+    var color = 'black';
+    if (record.get('isNew')) {
+      color = 'green';
+    } else if (record.get('isDirty')) {
+      color = 'blue';
+    }
+    return color;
+  },
+
+  observeRecord: function(record, recordUpdated) {
+    var releaseMethods = Ember.A(), self = this,
+        keysToObserve = Ember.A(['id', 'isNew', 'isDirty']);
+
+    record.eachAttribute(function(key) {
+      keysToObserve.push(key);
+    });
+
+    keysToObserve.forEach(function(key) {
+      var handler = function() {
+        recordUpdated(self.wrapRecord(record));
+      };
+      Ember.addObserver(record, key, handler);
+      releaseMethods.push(function() {
+        Ember.removeObserver(record, key, handler);
+      });
+    });
+
+    var release = function() {
+      releaseMethods.forEach(function(fn) { fn(); } );
+    };
+
+    return release;
+  }
+
+});
+

--- a/packages/ember-data/tests/integration/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/belongs_to_test.js
@@ -63,6 +63,7 @@ module("Belongs-To Relationships", {
     serializer.destroy();
     adapter.destroy();
     store.destroy();
+    App.destroy();
     Ember.lookup = originalLookup;
   }
 });

--- a/packages/ember-data/tests/integration/debug_adapter_test.js
+++ b/packages/ember-data/tests/integration/debug_adapter_test.js
@@ -1,0 +1,98 @@
+var App, store, debugAdapter, get = Ember.get;
+
+module("DS.DebugAdapter", {
+  setup: function() {
+    Ember.run(function() {
+      App = Ember.Application.create({
+        toString: function() { return 'App'; }
+      });
+      App.Store = DS.Store.extend({
+        adapter: DS.Adapter.create()
+      });
+      App.Post = DS.Model.extend({
+        title: DS.attr('string')
+      });
+      App.advanceReadiness();
+    });
+
+    store = App.__container__.lookup('store:main');
+    debugAdapter = App.__container__.lookup('dataAdapter:main');
+
+    debugAdapter.reopen({
+      getModelTypes: function() {
+        return [App.Post];
+      }
+    });
+  },
+  teardown: function() {
+    App.destroy();
+  }
+});
+
+test("Watching Model Types", function() {
+  expect(5);
+
+  var added = function(types) {
+    equal(types.length, 1);
+    equal(types[0].name, 'App.Post');
+    equal(types[0].count, 0);
+    strictEqual(types[0].object, App.Post);
+  };
+
+  var updated = function(types) {
+    equal(types[0].count, 1);
+  };
+
+  debugAdapter.watchModelTypes(added, updated);
+
+  store.load(App.Post, [{id: 1, title: 'Post Title'}]);
+});
+
+test("Watching Records", function() {
+  var post, args, record;
+
+  Ember.run(function() {
+    store.load(App.Post, { id: '1', title: 'Clean Post'});
+  });
+
+  var callback = function() {
+    args = arguments;
+  };
+
+  debugAdapter.watchRecords(App.Post, callback, callback, callback);
+
+  equal(get(args[0], 'length'), 1);
+  record = args[0][0];
+  deepEqual(record.columnValues, { id: '1', title: 'Clean Post'} );
+  deepEqual(record.filterValues, { isNew: false, isModified: false, isClean: true } );
+  deepEqual(record.searchKeywords, ['1', 'Clean Post'] );
+  deepEqual(record.color, 'black' );
+
+  Ember.run(function() {
+    post = App.Post.find(1);
+  });
+
+  Ember.run(function() {
+    post.set('title', 'Modified Post');
+  });
+
+  record = args[0][0];
+  deepEqual(record.columnValues, { id: '1', title: 'Modified Post'});
+  deepEqual(record.filterValues, { isNew: false, isModified: true, isClean: false });
+  deepEqual(record.searchKeywords, ['1', 'Modified Post'] );
+  deepEqual(record.color, 'blue' );
+
+  post = App.Post.createRecord({ id: '2', title: 'New Post' });
+  record = args[0][0];
+  deepEqual(record.columnValues, { id: '2', title: 'New Post'});
+  deepEqual(record.filterValues, { isNew: true, isModified: false, isClean: false });
+  deepEqual(record.searchKeywords, ['2', 'New Post'] );
+  deepEqual(record.color, 'green' );
+
+  Ember.run(post, 'deleteRecord');
+
+  var index = args[0];
+  var count = args[1];
+  equal(index, 1);
+  equal(count, 1);
+});

--- a/packages/ember-data/tests/integration/dirtiness_test.js
+++ b/packages/ember-data/tests/integration/dirtiness_test.js
@@ -168,4 +168,6 @@ test("When adding a newly created record to a hasMany relationship, the parent s
 
   equal(post.get('isDirty'), false, "The record should no longer be dirty");
   equal(post.get('isSaving'), false, "The record should no longer be saving");
+
+  App.destroy();
 });

--- a/packages/ember-data/tests/integration/embedded/embedded_loading_test.js
+++ b/packages/ember-data/tests/integration/embedded/embedded_loading_test.js
@@ -140,7 +140,7 @@ Ember.ArrayPolyfills.forEach.call([Person, "Person"], function(mapping) {
 
       setTimeout(function() {
         Ember.run(function() {
-          self.didFindRecord(store, type, { 
+          self.didFindRecord(store, type, {
             comments: [
               {
                 id: 3,
@@ -154,7 +154,7 @@ Ember.ArrayPolyfills.forEach.call([Person, "Person"], function(mapping) {
               id: 3,
               title: "Embedded via sideload",
               comment_ids: [3]
-            } 
+            }
           }, id);
         });
 


### PR DESCRIPTION
This adds `DS.DebugAdapter` which extends `Ember.DataAdapter` (see https://github.com/emberjs/ember.js/pull/3129).

This will allow inspection of models in the Chrome Ember extension (see https://github.com/tildeio/ember-extension/pull/38).

I kept ED backwards compatible with previous versions of Ember (at least until Ember 1.0).

The build will currently fail until the Ember PR is merged, and the gem version is bumped.
