### PR TITLE
README formatting fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ A [guide is provided on the Ember.js site](http://emberjs.com/guides/models/) th
 
 The latest passing build from the "master" branch is available on [builds.emberjs.com](http://builds.emberjs.com):
 
-[Development](http://builds.emberjs.com.s3.amazonaws.com/ember-data-latest.js)
-[Minified](http://builds.emberjs.com.s3.amazonaws.com/ember-data-latest.min.js)
+* [Development](http://builds.emberjs.com.s3.amazonaws.com/ember-data-latest.js)
+* [Minified](http://builds.emberjs.com.s3.amazonaws.com/ember-data-latest.min.js)
 
 
 You also have the option to build ember-data.js yourself.  Clone the repository, run `bundle` then `rake dist`. You'll find ember-data.js in the `dist` directory.


### PR DESCRIPTION
Newlines in Markdown don't actually insert new lines in the output (well, not without explicitly forcing them with two spaces at the end of the line).  But this is probably intended to be an unordered list anyway, so that's what was done.
