### PR TITLE
Type parameter of registerAdapter method can be now a string or an array of string

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1749,8 +1749,11 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 });
 
 DS.Store.reopenClass({
-  registerAdapter: DS._Mappable.generateMapFunctionFor('adapters', function(type, adapter, map) {
-    map.set(type, adapter);
+  registerAdapter: DS._Mappable.generateMapFunctionFor('adapters', function(types, adapter, map) {
+    if (!Ember.isArray(types)) types = [types];
+    types.forEach(function(type) {
+      map.set(type, adapter);
+    });
   }),
 
   transformMapKey: function(key) {


### PR DESCRIPTION
Instead of

``` javascript
App.Store.registerAdapter('App.User', App.myRESTAdapter);
App.Store.registerAdapter('App.Post', App.myRESTAdapter);
App.Store.registerAdapter('App.Comment', App.myRESTAdapter);
```

now you can do

``` javascript
App.Store.registerAdapter(['App.User', 'App.Post', 'App.Comment'], App.myRESTAdapter);
```
