### PR TITLE
Ember.Inflector: Ember.String#pluralize Ember.String#singularize

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -1,5 +1,5 @@
 distros = {
-  :full    => %w(ember-data)
+  :full    => %w(ember-data, ember-inflector)
 }
 
 #MEGAHAX

--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -14,3 +14,4 @@ testing_suites:
     - "package=all&dist=build&nojshint=true"
 testing_packages:
   - ember-data
+  - ember-inflector

--- a/packages/ember-data/package.json
+++ b/packages/ember-data/package.json
@@ -12,7 +12,8 @@
 
   "dependencies": {
     "spade": "~> 1.0",
-    "ember-runtime": ">= 0"
+    "ember-runtime": ">= 0",
+    "ember-inflector": "1.0.0-rc.7"
   },
   "dependencies:development": {
     "spade-qunit": "~> 1.0.0"

--- a/packages/ember-inflector/lib/ext/string.js
+++ b/packages/ember-inflector/lib/ext/string.js
@@ -1,0 +1,23 @@
+require('ember-inflector/system/string');
+
+if (Ember.EXTEND_PROTOTYPES) {
+  /**
+    See {{#crossLink "Ember.String/pluralize"}}{{/crossLink}}
+
+    @method pluralize
+    @for String
+  */
+  String.prototype.pluralize = function() {
+    return Ember.String.pluralize(this);
+  };
+
+  /**
+    See {{#crossLink "Ember.String/singularize"}}{{/crossLink}}
+
+    @method singularize
+    @for String
+  */
+  String.prototype.singularize = function() {
+    return Ember.String.singularize(this);
+  };
+}

--- a/packages/ember-inflector/lib/main.js
+++ b/packages/ember-inflector/lib/main.js
@@ -1,0 +1,1 @@
+require('ember-inflector/system');

--- a/packages/ember-inflector/lib/system.js
+++ b/packages/ember-inflector/lib/system.js
@@ -1,0 +1,6 @@
+require('ember-inflector/system/string');
+require('ember-inflector/system/inflector');
+require('ember-inflector/system/inflections');
+require('ember-inflector/ext/string');
+
+Ember.Inflector.inflector = new Ember.Inflector(Ember.Inflector.defaultRules);

--- a/packages/ember-inflector/lib/system/inflections.js
+++ b/packages/ember-inflector/lib/system/inflections.js
@@ -1,0 +1,78 @@
+Ember.Inflector.defaultRules = {
+  plurals: [
+    [/$/, 's'],
+    [/s$/i, 's'],
+    [/^(ax|test)is$/i, '$1es'],
+    [/(octop|vir)us$/i, '$1i'],
+    [/(octop|vir)i$/i, '$1i'],
+    [/(alias|status)$/i, '$1es'],
+    [/(bu)s$/i, '$1ses'],
+    [/(buffal|tomat)o$/i, '$1oes'],
+    [/([ti])um$/i, '$1a'],
+    [/([ti])a$/i, '$1a'],
+    [/sis$/i, 'ses'],
+    [/(?:([^f])fe|([lr])f)$/i, '$1$2ves'],
+    [/(hive)$/i, '$1s'],
+    [/([^aeiouy]|qu)y$/i, '$1ies'],
+    [/(x|ch|ss|sh)$/i, '$1es'],
+    [/(matr|vert|ind)(?:ix|ex)$/i, '$1ices'],
+    [/^(m|l)ouse$/i, '$1ice'],
+    [/^(m|l)ice$/i, '$1ice'],
+    [/^(ox)$/i, '$1en'],
+    [/^(oxen)$/i, '$1'],
+    [/(quiz)$/i, '$1zes']
+  ],
+
+  singular: [
+    [/s$/i, ''],
+    [/(ss)$/i, '$1'],
+    [/(n)ews$/i, '$1ews'],
+    [/([ti])a$/i, '$1um'],
+    [/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i, '$1sis'],
+    [/(^analy)(sis|ses)$/i, '$1sis'],
+    [/([^f])ves$/i, '$1fe'],
+    [/(hive)s$/i, '$1'],
+    [/(tive)s$/i, '$1'],
+    [/([lr])ves$/i, '$1f'],
+    [/([^aeiouy]|qu)ies$/i, '$1y'],
+    [/(s)eries$/i, '$1eries'],
+    [/(m)ovies$/i, '$1ovie'],
+    [/(x|ch|ss|sh)es$/i, '$1'],
+    [/^(m|l)ice$/i, '$1ouse'],
+    [/(bus)(es)?$/i, '$1'],
+    [/(o)es$/i, '$1'],
+    [/(shoe)s$/i, '$1'],
+    [/(cris|test)(is|es)$/i, '$1is'],
+    [/^(a)x[ie]s$/i, '$1xis'],
+    [/(octop|vir)(us|i)$/i, '$1us'],
+    [/(alias|status)(es)?$/i, '$1'],
+    [/^(ox)en/i, '$1'],
+    [/(vert|ind)ices$/i, '$1ex'],
+    [/(matr)ices$/i, '$1ix'],
+    [/(quiz)zes$/i, '$1'],
+    [/(database)s$/i, '$1']
+  ],
+
+  irregularPairs: [
+    ['person', 'people'],
+    ['man', 'men'],
+    ['child', 'children'],
+    ['sex', 'sexes'],
+    ['move', 'moves'],
+    ['cow', 'kine'],
+    ['zombie', 'zombies']
+  ],
+
+  uncountable: [
+    'equipment',
+    'information',
+    'rice',
+    'money',
+    'species',
+    'series',
+    'fish',
+    'sheep',
+    'jeans',
+    'police'
+  ]
+};

--- a/packages/ember-inflector/lib/system/inflector.js
+++ b/packages/ember-inflector/lib/system/inflector.js
@@ -1,0 +1,96 @@
+var BLANK_REGEX = /^\s*$/;
+
+function loadUncountable(rules, uncountable) {
+  for (var i = 0, length = uncountable.length; i < length; i++) {
+    rules.uncountable[uncountable[i]] = true;
+  }
+}
+
+function loadIrregular(rules, irregularPairs) {
+  var pair;
+
+  for (var i = 0, length = irregularPairs.length; i < length; i++) {
+    pair = irregularPairs[i];
+
+    rules.irregular[pair[0]] = pair[1];
+    rules.irregularInverse[pair[1]] = pair[0];
+  }
+}
+
+function Inflector(ruleSet) {
+  ruleSet = ruleSet || {};
+  ruleSet.uncountable = ruleSet.uncountable || {};
+  ruleSet.irregularPairs= ruleSet.irregularPairs|| {};
+
+  var rules = this.rules = {
+    plurals:  ruleSet.plurals || [],
+    singular: ruleSet.singular || [],
+    irregular: {},
+    irregularInverse: {},
+    uncountable: {}
+  };
+
+  loadUncountable(rules, ruleSet.uncountable);
+  loadIrregular(rules, ruleSet.irregularPairs);
+}
+
+Inflector.prototype = {
+  pluralize: function(word) {
+    return this.inflect(word, this.rules.plurals);
+  },
+
+  singularize: function(word) {
+    return this.inflect(word, this.rules.singular);
+  },
+
+  inflect: function(word, typeRules) {
+    var inflection, substitution, result, lowercase, isBlank,
+    isUncountable, isIrregular, isIrregularInverse, rule;
+
+    isBlank = BLANK_REGEX.test(word);
+
+    if (isBlank) {
+      return word;
+    }
+
+    lowercase = word.toLowerCase();
+
+    isUncountable = this.rules.uncountable[lowercase];
+
+    if (isUncountable) {
+      return word;
+    }
+
+    isIrregular = this.rules.irregular[lowercase];
+
+    if (isIrregular) {
+      return isIrregular;
+    }
+
+    isIrregularInverse = this.rules.irregularInverse[lowercase];
+
+    if (isIrregularInverse) {
+      return isIrregularInverse;
+    }
+
+    for (var i = typeRules.length, min = 0; i > min; i--) {
+       inflection = typeRules[i-1];
+       rule = inflection[0];
+
+      if (rule.test(word)) {
+        break;
+      }
+    }
+
+    inflection = inflection || [];
+
+    rule = inflection[0];
+    substitution = inflection[1];
+
+    result = word.replace(rule, substitution);
+
+    return result;
+  }
+};
+
+Ember.Inflector = Inflector;

--- a/packages/ember-inflector/lib/system/string.js
+++ b/packages/ember-inflector/lib/system/string.js
@@ -1,0 +1,7 @@
+Ember.String.pluralize = function(word) {
+  return Ember.Inflector.inflector.pluralize(word);
+};
+
+Ember.String.singularize = function(word) {
+  return Ember.Inflector.inflector.singularize(word);
+};

--- a/packages/ember-inflector/package.json
+++ b/packages/ember-inflector/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ember-inflector",
+  "summary": "Ember Inflections",
+  "descrption": "",
+  "homepage": "http://github.com/emberjs/ember.js",
+  "author": ["Stefan Penner"],
+  "version": "1.0.0-rc.7",
+
+  "directories":{
+    "lib": "lib"
+  },
+
+  "dependencies": {
+    "ember-runtime": ">= 0"
+  },
+
+  "bpm:build": {
+    "bpm_lib.js": {
+      "files": ["lib"],
+      "modes": "*"
+    }
+  }
+}

--- a/packages/ember-inflector/tests/system/inflector_test.js
+++ b/packages/ember-inflector/tests/system/inflector_test.js
@@ -1,0 +1,158 @@
+module('ember-inflector.unit');
+
+test('plurals', function() {
+  expect(1);
+
+  var inflector = new Ember.Inflector({
+    plurals: [
+      [/$/, 's'],
+      [/s$/i, 's']
+    ]
+  });
+
+  equal(inflector.pluralize('apple'), 'apples');
+});
+
+test('singularization',function(){
+  expect(1);
+
+  var inflector = new Ember.Inflector({
+    singular: [
+      [/s$/i, ''],
+      [/(ss)$/i, '$1']
+    ]
+  });
+
+  equal(inflector.singularize('apple'), 'apple');
+});
+
+test('plural',function(){
+  expect(1);
+
+  var inflector = new Ember.Inflector({
+    plurals: [
+      ['1', '1'],
+      ['2', '2'],
+      ['3', '3']
+    ]
+  });
+
+  equal(inflector.rules.plurals.length, 3);
+});
+
+test('singular',function(){
+  expect(1);
+
+  var inflector = new Ember.Inflector({
+    singular: [
+      ['1', '1'],
+      ['2', '2'],
+      ['3', '3']
+    ]
+  });
+
+  equal(inflector.rules.singular.length, 3);
+});
+
+test('irregular',function(){
+  expect(6);
+
+  var inflector = new Ember.Inflector({
+    irregularPairs: [
+      ['1', '12'],
+      ['2', '22'],
+      ['3', '32']
+    ]
+  });
+
+  equal(inflector.rules.irregular['1'], '12');
+  equal(inflector.rules.irregular['2'], '22');
+  equal(inflector.rules.irregular['3'], '32');
+
+  equal(inflector.rules.irregularInverse['12'], '1');
+  equal(inflector.rules.irregularInverse['22'], '2');
+  equal(inflector.rules.irregularInverse['32'], '3');
+});
+
+test('uncountable',function(){
+  expect(3);
+
+  var inflector = new Ember.Inflector({
+    uncountable: [
+      '1',
+      '2',
+      '3'
+    ]
+  });
+
+  equal(inflector.rules.uncountable['1'], true);
+  equal(inflector.rules.uncountable['2'], true);
+  equal(inflector.rules.uncountable['3'], true);
+});
+
+test('inflect.nothing', function(){
+  expect(2);
+
+  var inflector = new Ember.Inflector();
+
+  equal(inflector.inflect('',  []), '');
+  equal(inflector.inflect(' ', []), ' ');
+});
+
+test('inflect.noRules',function(){
+  expect(1);
+
+  var inflector = new Ember.Inflector();
+
+  equal(inflector.inflect('word', []),'word');
+});
+
+test('inflect.uncountable', function(){
+  expect(1);
+
+  var inflector = new Ember.Inflector({
+    plural: [
+      [/$/,'s']
+    ],
+    uncountable: [
+      'word'
+    ]
+  });
+
+  var rules = [];
+
+  equal(inflector.inflect('word', rules), 'word');
+});
+
+test('inflect.irregular', function(){
+  expect(2);
+
+  var inflector = new Ember.Inflector({
+    irregularPairs: [
+      ['word', 'wordy']
+    ]
+  });
+
+  var rules = [];
+
+  equal(inflector.inflect('word', rules), 'wordy');
+  equal(inflector.inflect('wordy', rules), 'word');
+});
+
+test('inflect.basicRules', function(){
+  expect(1);
+
+  var inflector = new Ember.Inflector();
+  var rules = [[/$/, 's']];
+
+  equal(inflector.inflect('word', rules ), 'words');
+});
+
+test('inflect.advancedRules', function(){
+  expect(1);
+
+  var inflector = new Ember.Inflector();
+  var rules = [[/^(ox)$/i, '$1en']];
+
+  equal(inflector.inflect('ox', rules), 'oxen');
+});

--- a/packages/ember-inflector/tests/system/integration_test.js
+++ b/packages/ember-inflector/tests/system/integration_test.js
@@ -1,0 +1,17 @@
+module("ember-inflector.integration");
+
+test("pluralize", function(){
+  expect(3);
+
+  equal(Ember.String.pluralize('word'),     'words');
+  equal(Ember.String.pluralize('ox'),       'oxen');
+  equal(Ember.String.pluralize('octopus'),  'octopi');
+});
+
+test("singularize", function(){
+  expect(3);
+
+  equal(Ember.String.singularize('words'),  'word');
+  equal(Ember.String.singularize('oxen'),   'ox');
+  equal(Ember.String.singularize('octopi'), 'octopus');
+});


### PR DESCRIPTION
(cc @wycats)

Should have rails inflector parity, as to work out-of-the-box with AMS.
This does mean it brings along some railsisms such as the crazy `cow` -> `kine` pluralization.

With rules:

```
Original: 1.35KB gzipped (4.01KB uncompressed)
compiled: 945 bytes gzipped (2.16KB uncompressed)
```

Without rules:

```
810 bytes gzipped (2.44KB uncompressed)
401 bytes gzipped (795 bytes uncompressed)
```
