### PR TITLE
Return factory superclass from Store#modelFor

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1422,6 +1422,12 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     }
 
     var factory = this.container.lookupFactory('model:'+key);
+    // So that App.Person === modelFor('person')
+    // Should likely be removed in the future
+    if (factory._debugContainerKey) {
+      factory = factory.superclass;
+    }
+
     factory.store = this;
 
     return factory;

--- a/packages/ember-data/tests/integration/application_test.js
+++ b/packages/ember-data/tests/integration/application_test.js
@@ -36,6 +36,14 @@ if (Ember.Application.initializer) {
     var fooController = container.lookup('controller:foo');
     ok(fooController.get('store') instanceof DS.Store, "the store was injected");
   });
+
+
+  test("Model accessed directly from the namespace should be the same as modelFor", function() {
+    app.Person = DS.Model.extend();
+    var store = app.__container__.lookup('store:main');
+    store.load(app.Person, { id: 1 });
+    equal(store.find(app.Person, 1), store.modelFor('person').find(1));
+  });
 }
 
 if (Ember.Application.registerInjection) {


### PR DESCRIPTION
See https://github.com/emberjs/ember.js/pull/3233

Makes ED compatible with Ember >= RC8
