### PR TITLE
Typo

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -195,7 +195,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     It makes an Ajax request to a URL computed by `buildURL`, and returns a
     promise for the resulting payload.
 
-    @method findQuery
+    @method findMany
     @see RESTAdapter/buildURL
     @see RESTAdapter/ajax
     @param {DS.Store} store


### PR DESCRIPTION
`@method` tag in the findMany docs was findQuery instead
