### PR TITLE
Update the TRANSITION document with data about new reqs for setting up relationships.

### DIFF
--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -616,3 +616,74 @@ App.PostSerializer = DS.Serializer.extend({
   }
 });
 ```
+
+
+# Relationships
+
+## Defining relationships in models
+
+Defining relationships now uses the 'shorthand' name of your mode, not
+the fully qualified path to the class.
+
+Instead of "App.Comment", use "comment".
+
+Instead of "App.BlogPost", use "blog-post".
+
+Ember Data 0.13:
+
+```js
+App.BlogPost = DS.Model.extend({
+  comments : DS.hasMany("App.Comment")
+});
+
+App.Comment = DS.Model.extend({
+  post : DS.belongsTo("App.BlogPost")
+});
+```
+
+Ember Data 1.0.beta.1:
+
+```js
+App.BlogPost = DS.Model.extend({
+  comments : DS.hasMany("comment")
+});
+
+App.Comment = DS.Model.extend({
+  post : DS.belongsTo("blog-post")
+});
+```
+
+## Default JSON format for relationships
+
+The default JSON format now expects the ids of related objects to be
+included in the model data without '_ids' appended to the name of the
+attribute.  
+
+Ember Data 0.13:
+
+```js
+  {
+    post : {
+      comment_ids :  [1,2]
+    },
+    comments : [
+      {id : 1, text : "comment 1"},
+      {id : 2, text : "comment 2"},
+    ]
+  }
+```
+
+Ember Data 1.0.beta.1:
+
+```js
+  {
+    post : {
+      comments :  [1,2]
+    },
+    comments : [
+      {id : 1, text : "comment 1"},
+      {id : 2, text : "comment 2"},
+    ]
+  }
+```
+


### PR DESCRIPTION
Relationships are another breaking change since 0.13 and should be included in the TRANSITION doc to ease the pain of Ember devs everywhere.
