### PR TITLE
Support for manyToNone and manyToMany relationships

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -120,7 +120,16 @@ DS.JSONSerializer = Ember.Object.extend({
     }
   },
 
-  serializeHasMany: Ember.K,
+  serializeHasMany: function(record, json, relationship) {
+    var key = relationship.key;
+
+    var relationshipType = DS.RelationshipChange.determineRelationshipType(record.constructor, relationship);
+    
+    if (relationshipType === 'manyToNone' || relationshipType === 'manyToMany') {
+      json[key] = get(record, key).mapProperty('id');
+      // TODO support for polymorphic manyToNone and manyToMany relationships
+    }
+  },
 
   // EXTRACT
 


### PR DESCRIPTION
Current implementation discards manyToNone and manyToMany relationships as it does not serialize any hasMany relations.
