### PR TITLE
Update the TRANSITION document with data about new reqs for setting up relationships.

### DIFF
--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -616,3 +616,44 @@ App.PostSerializer = DS.Serializer.extend({
   }
 });
 ```
+
+
+# Relationships
+
+## Defining relationships in models
+
+Defining relationships now uses the 'shorthand' name of your mode, not
+the fully qualified path to the class.
+
+Instead of "App.Comment", use "comment".
+
+Instead of "App.BlogPost", use "blog-post".
+
+Ember Data 0.13:
+
+```js
+App.BlogPost = DS.Model.extend({
+  comments : DS.hasMany("App.Comment")
+});
+
+App.Comment = DS.Model.extend({
+  post : DS.belongsTo("App.BlogPost")
+});
+```
+
+Ember Data 1.0.beta.1:
+
+```js
+App.BlogPost = DS.Model.extend({
+  comments : DS.hasMany("comment")
+});
+
+App.Comment = DS.Model.extend({
+  post : DS.belongsTo("blog_post")
+});
+```
+
+Note : Instead of "blog_post" above you could potentially
+use "blog-post" or "blogPost", however this would cause EmberData
+to look for your endpoint at "/blog-posts" or "/blogPosts".
+


### PR DESCRIPTION
This info is still missing from the Transition document, and isn't called out specifically anywhere that I can find.  The last PR that I put in for this also included info about the differences in the JSON format ("comments" vs "comment_ids").  I've removed the JSON info and am trying again to get the relationship info included.  Maybe it'll work this time...
