### PR TITLE
add failing test for DS.Model#toJSON()

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -72,8 +72,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
     @returns {Object} A JSON representation of the object.
   */
   toJSON: function(options) {
-    var serializer = DS.JSONSerializer.create();
-    return serializer.serialize(this, options);
+    return this.get('jsonSerializer').serialize(this, options);
   },
 
   /**

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1116,6 +1116,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     var record = type._create({
       id: id,
       store: this,
+      jsonSerializer: this.container.lookup('serializer:_default')
     });
 
     if (data) {

--- a/packages/ember-data/tests/unit/debug_test.js
+++ b/packages/ember-data/tests/unit/debug_test.js
@@ -6,8 +6,8 @@ var TestAdapter = DS.Adapter.extend();
 
 module("Debug", {
   setup: function() {
-    store = DS.Store.create({
-      adapter: TestAdapter.extend(),
+    store = createStore({
+      adapter: TestAdapter.extend()
     });
   },
 

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -342,6 +342,15 @@ test("a DS.Model can describe Date attributes", function() {
   convertsWhenSet('date', date, dateString);
 });
 
+test("a DS.Model can be jsonified", function() {
+  var Person = DS.Model.extend({
+    name: DS.attr('string')
+  });
+  var store = createStore({person: Person});
+  var record = store.createRecord('person', {name: "TomHuda"});
+  deepEqual(record.toJSON(), {name: "TomHuda"});
+});
+
 test("don't allow setting", function(){
   var store = createStore();
 


### PR DESCRIPTION
Since the containerization of the transform, calling `toJSON` on a model will throw 

```
TypeError: Cannot call method 'lookup' of undefined
```

I don't know if this method is intented to be kept or removed. If it should be kept, I imagine that the JSON serializer should be looked up from the container, or injected into each DS.Model
