### PR TITLE
Added owner parameter to the findMany function

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -206,7 +206,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     @param {Array<String>} ids
     @returns Promise
   */
-  findMany: function(store, type, ids) {
+  findMany: function(store, type, ids, owner) {
     return this.ajax(this.buildURL(type), 'GET', { data: { ids: ids } });
   },
 


### PR DESCRIPTION
I found that the code is still pushing the "owner" into this method (for other adapters -like the django cllient I maintain). I wanted to see this included to others reading the source would notice it as available
