### PR TITLE
Refactor serializeAttribute out of serialize

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -78,21 +78,8 @@ DS.JSONSerializer = Ember.Object.extend({
       }
     }
 
-    var attrs = get(this, 'attrs');
-
     record.eachAttribute(function(key, attribute) {
-      var value = get(record, key), type = attribute.type;
-
-      if (type) {
-        var transform = this.transformFor(type);
-        value = transform.serialize(value);
-      }
-
-      // if provided, use the mapping provided by `attrs` in
-      // the serializer
-      key = attrs && attrs[key] || key;
-
-      json[key] = value;
+      this.serializeAttribute(record, json, key, attribute);
     }, this);
 
     record.eachRelationship(function(key, relationship) {
@@ -104,6 +91,22 @@ DS.JSONSerializer = Ember.Object.extend({
     }, this);
 
     return json;
+  },
+
+  serializeAttribute: function(record, json, key, attribute) {
+    var attrs = get(this, 'attrs');
+    var value = get(record, key), type = attribute.type;
+
+    if (type) {
+      var transform = this.transformFor(type);
+      value = transform.serialize(value);
+    }
+
+    // if provided, use the mapping provided by `attrs` in
+    // the serializer
+    key = attrs && attrs[key] || key;
+
+    json[key] = value;
   },
 
   serializeBelongsTo: function(record, json, relationship) {
@@ -124,7 +127,7 @@ DS.JSONSerializer = Ember.Object.extend({
     var key = relationship.key;
 
     var relationshipType = DS.RelationshipChange.determineRelationshipType(record.constructor, relationship);
-    
+
     if (relationshipType === 'manyToNone' || relationshipType === 'manyToMany') {
       json[key] = get(record, key).mapBy('id');
       // TODO support for polymorphic manyToNone and manyToMany relationships


### PR DESCRIPTION
Add a parallel `serializeAttribute` to match `serializeBelongsTo` and `serializeHasMany`.

Am working on a `DS.ActiveModelSerializer` and if this function existed I wouldn't have to override the whole `serialize` method.

Another option would be to reuse the `keyForAttribute`.

Thoughts?
