### PR TITLE
check if record exists for asynchronous belongsTo

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -15,7 +15,7 @@ function asyncBelongsTo(type, options, meta) {
       return value === undefined ? null : value;
     }
 
-    return store.fetchRecord(data[key]);
+    return !isNone(data[key]) ? store.fetchRecord(data[key]) : null;
   }).property('data').meta(meta);
 }
 


### PR DESCRIPTION
This fixes a bug when an asynchronous 'belongsTo' relation is defined but does not exist. Before, it would call the `store.fetchRecord` method with an `undefined` 'record' argument, causing an error. 
