### PR TITLE
Reimplemented `rootForType`

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -324,11 +324,8 @@ DS.RESTAdapter = DS.Adapter.extend({
   /**
     Builds a URL for a given type and optional ID.
 
-    By default, it pluralizes the type's name (for example,
-    'post' becomes 'posts' and 'person' becomes 'people').
-
-    If an ID is specified, it adds the ID to the plural form
-    of the type, separated by a `/`.
+    If an ID is specified, it adds the ID to the root generated
+    for the type, separated by a `/`.
 
     @method buildURL
     @param {String} type
@@ -343,13 +340,41 @@ DS.RESTAdapter = DS.Adapter.extend({
     if (host) { url.push(host); }
     if (namespace) { url.push(namespace); }
 
-    url.push(Ember.String.pluralize(type));
+    url.push(this.rootForType(type));
     if (id) { url.push(id); }
 
     url = url.join('/');
     if (!host) { url = '/' + url; }
 
     return url;
+  },
+
+  /**
+    Determines the pathname root for a given type.
+
+    By default, it pluralizes the type's name (for example,
+    'post' becomes 'posts' and 'person' becomes 'people').
+
+    ### Pathname root customization
+
+    For example if you have an object LineItem with an
+    endpoint of "/line_items/".
+
+    ```js
+    DS.RESTAdapter.reopen({
+      rootForType: function(type) {
+        var decamelized = Ember.String.decamelize(type);
+        return Ember.String.pluralize(decamelized);
+      };
+    });
+    ```
+
+    @method rootForType
+    @param {String} type
+    @returns String
+  **/
+  rootForType: function(type) {
+    return Ember.String.pluralize(type);
   },
 
   /**

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -1,4 +1,4 @@
-var env, store, adapter, Post, Person, Comment;
+var env, store, adapter, Post, Person, Comment, SuperUser;
 var originalAjax, passedUrl, passedVerb, passedHash;
 
 module("integration/adapter/rest_adapter - REST Adapter", {
@@ -15,9 +15,12 @@ module("integration/adapter/rest_adapter - REST Adapter", {
       name: DS.attr("string")
     });
 
+    SuperUser = DS.Model.extend();
+
     env = setupStore({
       post: Post,
       comment: Comment,
+      superUser: SuperUser,
       adapter: DS.RESTAdapter
     });
 
@@ -644,6 +647,21 @@ test('buildURL - with host and namespace', function() {
 
   store.find('post', 1).then(async(function(post) {
     equal(passedUrl, "http://example.com/api/v1/posts/1");
+  }));
+});
+
+test('buildURL - with camelized names', function() {
+  adapter.setProperties({
+    rootForType: function(type) {
+      var decamelized = Ember.String.decamelize(type);
+      return Ember.String.pluralize(decamelized);
+    }
+  });
+
+  ajaxResponse({ superUsers: [{ id: 1 }] });
+
+  store.find('superUser', 1).then(async(function(post) {
+    equal(passedUrl, "/super_users/1");
   }));
 });
 


### PR DESCRIPTION
Currently if you have a double-barreled model name the AJAX request is to the camelized version of the URL.

``` js
adapter.buildURL("lineItem") => "/lineItems"
```

This PR doesn't change the default but adds back the `rootForType` method for customizing the default.

An example is given for hooking it up with AMS.

I personally think the default implementation should probably be changed as well, although that isn't included in this PR
