### PR TITLE
amend asynchronous belongsTo fix

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -8,14 +8,21 @@ var get = Ember.get, set = Ember.set,
 function asyncBelongsTo(type, options, meta) {
   return Ember.computed(function(key, value) {
     var data = get(this, 'data'),
-        store = get(this, 'store');
+        store = get(this, 'store'),
+        belongsTo;
 
     if (arguments.length === 2) {
       Ember.assert("You can only add a '" + type + "' record to this relationship", !value || value instanceof store.modelFor(type));
       return value === undefined ? null : value;
     }
 
-    return !isNone(data[key]) ? store.fetchRecord(data[key]) : null;
+    belongsTo = data[key];
+
+    if(!isNone(belongsTo) && get(belongsTo, 'isEmpty')) {
+      return store.fetchRecord(belongsTo);
+    } else {
+      return null;
+    }
   }).property('data').meta(meta);
 }
 


### PR DESCRIPTION
This is an addition to issue #1208, which addresses a problem caused by my previous PR. The fetchRecord method would be called for a record that was already loaded, causing an error. 
