### PR TITLE
Failing test to demonstrate that changing a belongsTo relationship on a record doesn't dirty the record

### DIFF
--- a/packages/ember-data/tests/unit/model/relationships_test.js
+++ b/packages/ember-data/tests/unit/model/relationships_test.js
@@ -659,7 +659,7 @@ test("changing a belongsTo relationship marks the record as dirty", function() {
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
-    tags: DS.belongsTo('tag')
+    tag: DS.belongsTo('tag')
   });
 
   var env = setupStore({


### PR DESCRIPTION
It also doesn't update the underlying `data` hash. It does superficially update the relationship in so much as asking for the value of the property after setting the belongsTo relationship will return the record you set it to.

It appears that the belongsToWillChange and belongsToDidChange observers are not being fired correctly.

I noticed this in the pre-beta build as well and it appears to have been around for a while although I only noticed it recently so it's possible it's got something to do with a recent change to ember core around observers?  
