### PR TITLE
Use the adapter host for host-relative URLs in findHasMany.

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -237,6 +237,8 @@ DS.RESTAdapter = DS.Adapter.extend({
     This method will be called with the parent record and `/posts/1/comments`.
 
     It will make an Ajax request to the originally specified URL.
+    If the URL is host-relative (starting with a single slash), the
+    request will use the host specified on the adapter (if any).
 
     @method findHasMany
     @see RESTAdapter/buildURL
@@ -247,8 +249,13 @@ DS.RESTAdapter = DS.Adapter.extend({
     @returns Promise
   */
   findHasMany: function(store, record, url) {
-    var id   = get(record, 'id'),
+    var host = get(this, 'host'),
+        id   = get(record, 'id'),
         type = record.constructor.typeKey;
+
+    if (host && url.charAt(0) === '/' && url.charAt(1) !== '/') {
+      url = host + url;
+    }
 
     return this.ajax(this.urlPrefix(url, this.buildURL(type, id)), 'GET');
   },


### PR DESCRIPTION
TL;DR: findHasMany should use the host setting on the adapter when a canonical URL is not given. This PR implements that.

As specified in the [documentation of findHasMany](http://emberjs.com/api/data/classes/DS.RESTAdapter.html#method_findHasMany), you can send a link to where a relation can be lazy-loaded, instead of providing the data up front.

This currently works great if the Ember app and the REST server runs from the same domain name, but in this example, the Ember app runs at `https://www.example.org`, and the REST server is available at `https://api.example.net`:
1. When responding with the initial object, the REST server provides a (host-relative) URL for comments to be fetched on demand, `/posts/42/comments`.
2. Ember Data processes this, and decides to attempt loading the comments, and makes the getJSON call to `/posts/42/comments`.
3. The browser looks at the calling JavaScript, and sees the host-relative URL, and since the JavaScript triggering the XHR originates from `https://www.example.org`, it proceeds to request `https://www.example.org/posts/42/comments`
4. The server at `https://www.example.org/` responds with a 404, since it's just a poor static file server, knowing nothing of what goes on at the REST server.

I think that it's a reasonable assumption that, when the REST server replies with a host-relative URL, it's referring to an URL on its own host.

Since the REST server might behind a proxy, it does not necessarily know what it's full URL is (it might also have several), it's rather impractical host-relative URLs don't work.

Thus, this little fix.
