### PR TITLE
Make sure store sets container on serializer (thanks @twokul)

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1363,6 +1363,10 @@ function serializerForAdapter(adapter, type) {
     serializer = serializerFor(container, type.typeKey, defaultSerializer);
   }
 
+  if (serializer.container === undefined) {
+    serialize.container = container;
+  }
+
   if (serializer === null || serializer === undefined) {
     serializer = {
       extract: function(store, type, payload) { return payload; }


### PR DESCRIPTION
I had an issue where JSONSerializer#tranformerFor was getting called without a container on the serializer. I paired on this with @twokul, we could not find where the container was supposed to get set, but this seemed a logical place to make sure it's there.
