### PR TITLE
Ability to serialize null belongsTo

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -76,10 +76,13 @@ DS.JSONSerializer = Ember.Object.extend({
 
     var belongsTo = get(record, key);
 
-    if (isNone(belongsTo)) { return; }
-
     key = this.keyForRelationship ? this.keyForRelationship(key, "belongsTo") : key;
-    json[key] = get(belongsTo, 'id');
+
+    if (isNone(belongsTo)) {
+      json[key] = belongsTo;
+    } else {
+      json[key] = get(belongsTo, 'id');
+    }
 
     if (relationship.options.polymorphic) {
       json[key + "_type"] = belongsTo.constructor.typeKey;

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -62,6 +62,17 @@ test("serializeBelongsTo", function() {
   deepEqual(json, {
     post: "1"
   });
+
+  json = {};
+
+  set(comment, 'post', null);
+
+  env.serializer.serializeBelongsTo(comment, json, {key: "post", options: {}});
+
+  deepEqual(json, {
+    post: null
+  }, "Can set a belongsTo to a null value");
+
 });
 
 test("serializeBelongsTo respects keyForRelationship", function() {


### PR DESCRIPTION
`belongsTo` is sometimes optional and a null value should be included in the serialized hash.
