### PR TITLE
Test for singularization of irregulars

### DIFF
--- a/packages/ember-inflector/tests/system/inflector_test.js
+++ b/packages/ember-inflector/tests/system/inflector_test.js
@@ -73,6 +73,18 @@ test('singularization',function(){
   equal(inflector.singularize('apple'), 'apple');
 });
 
+test('singularization of irregulars', function(){
+  expect(1);
+  
+  var inflector = new Ember.Inflector({
+    irregularPairs: [
+      ['person', 'people']
+    ]
+  });
+  
+  equal(inflector.singularize('person'), 'person');
+});
+
 test('plural',function(){
   expect(1);
 


### PR DESCRIPTION
_The new singularization library is great, however I think there may be a slight glitch when singularizing irregulars._

It's expected that `singularize('person'); //=> 'person'` but instead `'people'` is returned.

This causes problems with `modelTypeFromRoot` (which I think is renamed on master), when extracting a single payload looking like this:

```
{
  person: { "foo" : "..." }
}
```

because it will attempt to find a model by the name 'people' (return value of singularize).
