### PR TITLE
Improve Error detection heuristics

### DIFF
--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -131,11 +131,31 @@
   };
 
   minispade.register('ember-data/~test-setup', function() {
+    var ERRORS = [
+      Error,
+      EvalError,
+      RangeError,
+      ReferenceError,
+      SyntaxError,
+      TypeError,
+      URIError
+    ]
+
+    function isError(error) {
+      for(var i=0, l = ERRORS.length; i < l; i++) {
+        if (error instanceof ERRORS[i]) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
     Ember.RSVP.configure('onerror', function(reason) {
       // only print error messages if they're exceptions;
       // otherwise, let a future turn of the event loop
       // handle the error.
-      if (reason && reason.stack) {
+      if (reason && isError(reason)) {
         console.log(reason.stack);
         throw reason;
       }


### PR DESCRIPTION
Apparently safari injects a stack property onto anything thrown.

seems to fix crazy safari test failure of #1270
