### PR TITLE
Require the initializer in the ActiveModel package

### DIFF
--- a/packages/activemodel-adapter/lib/main.js
+++ b/packages/activemodel-adapter/lib/main.js
@@ -1,1 +1,2 @@
 require('activemodel-adapter/system');
+require('activemodel-adapter/initializers');


### PR DESCRIPTION
Without this require, the adapter is available and can be used.
But since the serializer hasn't been registered, it will fallback on `JSONSerializer` by default.
