### PR TITLE
Return null from getById if the record isn't found

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -329,7 +329,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
   findById: function(type, id) {
     type = this.modelFor(type);
 
-    var record = this.getById(type, id);
+    var record = this.recordForId(type, id);
 
     var promise = this.fetchRecord(record) || resolve(record);
     return promiseObject(promise);
@@ -389,7 +389,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     Get a record by a given type and ID without triggering a fetch.
 
     This method will synchronously return the record if it's available.
-    Otherwise, it will return undefined.
+    Otherwise, it will return null.
 
     ```js
     var post = store.getById('post', 1);
@@ -405,7 +405,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     if (this.hasRecordForId(type, id)) {
       return this.recordForId(type, id);
     } else {
-      return this.buildRecord(type, id);
+      return null;
     }
   },
 


### PR DESCRIPTION
The `getById` method documentation says that undefined should be returned but that wasn't happening. It now returns null. 

Update `findById` to use `recordForId` so that it had a record to work with in the case that the record wasn't yet in the store.
