### PR TITLE
Async BelongsTo should return a DS.PromiseObject

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -18,11 +18,10 @@ function asyncBelongsTo(type, options, meta) {
 
     belongsTo = data[key];
 
-    if(!isNone(belongsTo)) {
-      return store.fetchRecord(belongsTo);
-    } else {
+    if(isNone(belongsTo)) {
       return null;
     }
+    return DS.PromiseObject.create({ promise: store.fetchRecord(belongsTo) });
   }).property('data').meta(meta);
 }
 


### PR DESCRIPTION
1) While traversing aync relationships:

``` js
post.get('author') // this belongsTo returns an Ember.RSVP.Promise
post.get('comments') // this hasMany returns a DS.PromiseArray
```

Currently, an `asyncBelongsTo` relationship returns a regular `Promise`. I believe that it should be return a `DS.PromiseObject` instead so that the value returned may also serve as a proxy for the related object. This pull request changes the behavoir of asyncBelongsTo so that it returns a `DS.PromiseObject` instead of a `Promise`. 

2) For various find requests:

``` js
store.find('post', 1) // returns a DS.PromiseObject
store.findAll('post') // returns a DS.PromiseArray
store.findMany('post', [1,2,3]) // returns a DS.ManyArray
store.findQuery('post', { ... }) // returns a DS.PromiseArray
```

All find requests, except `findMany`, currently return a thenable proxy. Is there any reason `findMany` can't also return a `DS.PromiseArray`? This pull request does not address this but I thought it related to my first comment above, so I wanted some feedback... I think it could be easily incorporated into this pull request.
