### PR TITLE
Stop extending if `String` flag is `false`

### DIFF
--- a/packages/ember-inflector/lib/ext/string.js
+++ b/packages/ember-inflector/lib/ext/string.js
@@ -1,6 +1,6 @@
 require('ember-inflector/system/string');
 
-if (Ember.EXTEND_PROTOTYPES) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
   /**
     See {{#crossLink "Ember.String/pluralize"}}{{/crossLink}}
 


### PR DESCRIPTION
Allow `Ember.EXTEND_PROTOTYPES.String` is `false`.
