### PR TITLE
Fix async belongsTo to return the record when data it's already loaded

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -19,7 +19,8 @@ function asyncBelongsTo(type, options, meta) {
     belongsTo = data[key];
 
     if(!isNone(belongsTo)) {
-      return store.fetchRecord(belongsTo);
+      var promise = store.fetchRecord(belongsTo) || Ember.RSVP.resolve(belongsTo);
+      return DS.PromiseObject.create({promise: promise});
     } else {
       return null;
     }

--- a/packages/ember-data/tests/unit/model/relationships_test.js
+++ b/packages/ember-data/tests/unit/model/relationships_test.js
@@ -516,6 +516,31 @@ test("async belongsTo relationships work when the data hash has not been loaded"
   }));
 });
 
+test("async belongsTo relationships work when the data hash has already been loaded", function() {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tag: DS.belongsTo('tag', { async: true })
+  });
+
+  var env = setupStore({ tag: Tag, person: Person }),
+      store = env.store;
+
+    store.push('tag', { id: 2, name: "friendly"});
+    store.push('person', { id: 1, name: "Tom Dale", tag: 2});
+
+    store.find('person', 1).then(async(function(person) {
+        equal(get(person, 'name'), "Tom Dale", "The person is now populated");
+        return get(person, 'tag');
+    })).then(async(function(tag) {
+        equal(get(tag, 'name'), "friendly", "Tom Dale is now friendly");
+        equal(get(tag, 'isLoaded'), true, "Tom Dale is now loaded");
+  }));
+});
+
 test("calling createRecord and passing in an undefined value for a relationship should be treated as if null", function () {
   var Tag = DS.Model.extend({
     name: DS.attr('string'),


### PR DESCRIPTION
If the record referenced by a belongsTo async relationship is already loaded in the store, record.get('...') currently returns null.
