### PR TITLE
Polymorphic belongsTo attributes are camelized by the REST adapter.

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -717,6 +717,6 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
     var key = relationship.key,
         belongsTo = get(record, key);
     key = this.keyForAttribute ? this.keyForAttribute(key) : key;
-    json[key + "_type"] = belongsTo.constructor.typeKey;
+    json[key + "Type"] = belongsTo.constructor.typeKey;
   }
 });

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -73,7 +73,7 @@ test("serialize polymorphicType", function() {
 
   deepEqual(json, {
     name:  "DeathRay",
-    evilMinion_type: "yellowMinion",
+    evilMinionType: "yellowMinion",
     evilMinion: "124"
   });
 });


### PR DESCRIPTION
This model:

``` js
App.Comment = DS.Model.extend({
  blogMessage: DS.belongsTo('message' {
    polymorphic: true
  })
});
```

generates a JSON object like:

``` js
{
  "blogMessage": 12,
  "blogMessageType": "post"
}
```
