### PR TITLE
Support embedded objects for DS.ActiveModelSerializer.serialize

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -41,9 +41,26 @@ DS.ActiveModelSerializer = DS.RESTSerializer.extend({
   },
 
   /**
-    Does not serialize hasMany relationships
+    Serialize has-may relationship when it is configured as embedded objects.
+
+    @method serializeHasMany
   */
-  serializeHasMany: Ember.K,
+  serializeHasMany: function(record, json, relationship) {
+    var key   = relationship.key,
+        attrs = get(this, 'attrs'),
+        embed = attrs && attrs[key] && attrs[key].embedded === 'always';
+
+    if (embed) {
+      json[this.keyForAttribute(key)] = get(record, key).map(function(relation) {
+        var data = relation.serialize(),
+            primaryKey = get(this, 'primaryKey');
+
+        data[primaryKey] = get(relation, primaryKey);
+
+        return data;
+      }, this);
+    }
+  },
 
   /**
     Underscores the JSON root keys when serializing.

--- a/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
@@ -41,6 +41,11 @@ module("integration/active_model - ActiveModelSerializer", {
     env.store.modelFor('doomsdayDevice');
     env.store.modelFor('popularVillain');
     env.container.register('serializer:ams', DS.ActiveModelSerializer);
+    env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend({
+      attrs: {
+        superVillains: {embedded: 'always'}
+      }
+    }));
     env.container.register('adapter:ams', DS.ActiveModelAdapter);
     env.amsSerializer = env.container.lookup("serializer:ams");
     env.amsAdapter    = env.container.lookup("adapter:ams");
@@ -142,6 +147,26 @@ test("serialize polymorphic", function() {
     name:  "DeathRay",
     evil_minion_type: "YellowMinion",
     evil_minion_id: "124"
+  });
+});
+
+test("serialize with embedded", function() {
+  league = env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" });
+  var tom = env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league });
+
+  var serializer = env.container.lookup("serializer:homePlanet");
+
+  var json = serializer.serialize(league);
+
+  deepEqual(json, {
+    name: "Villain League",
+    super_villains: [{
+      id: get(tom, "id"),
+      firstName: "Tom",
+      lastName: "Dale",
+      homePlanet: get(league, "id"),
+      evilMinions: []
+    }]
   });
 });
 


### PR DESCRIPTION
This is a compatible way for [embedded objects](http://emberjs.com/guides/models/defining-models/#toc_embedded-objects) using `DS.ActiveModelSerializer`.

In 0.13:

``` javascript
DS.RESTAdapter.map('App.Post', {
  comments: { embedded: 'always' }
});
```

Using this patch:

``` javascript
App.PostSerializer = DS.ActiveModelSerializer.extend({
  attrs: {
    comments: { embedded: 'always' }
  }
});
```
