### PR TITLE
findQuery populates meta hash in AdapterPopulatedRecordArrays

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -22,11 +22,13 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
   load: function(data) {
     var store = get(this, 'store'),
         type = get(this, 'type'),
-        records = store.pushMany(type, data);
+        records = store.pushMany(type, data),
+        meta = store.metadataFor(type);
 
     this.setProperties({
       content: Ember.A(records),
-      isLoaded: true
+      isLoaded: true,
+      meta: meta
     });
 
     // TODO: does triggering didLoad event should be the last action of the runLoop?

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -512,6 +512,14 @@ test("metadata is accessible", function() {
   }));
 });
 
+test("findQuery - payload 'meta' is accessible on the record array", function() {
+  ajaxResponse({ meta: { offset: 5 }, posts: [{id: 1, name: "Rails is very expensive sushi"}] });
+
+  store.findQuery('post', { page: 2 }).then(async(function(posts) {
+    equal(posts.get('meta.offset'), 5, "Reponse metadata can be accessed with recordArray.meta");
+  }));
+});
+
 test("findQuery - returning an array populates the array", function() {
   ajaxResponse({ posts: [{ id: 1, name: "Rails is omakase" }, { id: 2, name: "The Parley Letter" }] });
 


### PR DESCRIPTION
Passes through the `meta` hash returned in a **store.findQuery** onto the resulting **RecordArray**. Allows a controller to bind easily to meta information.
