### PR TITLE
Remove misplaced comma that breaks IE8

### DIFF
--- a/packages/ember-data/lib/system/debug/debug_info.js
+++ b/packages/ember-data/lib/system/debug/debug_info.js
@@ -36,7 +36,7 @@ DS.Model.reopen({
       {
         name: 'Attributes',
         properties: attributes,
-        expand: true,
+        expand: true
       },
       {
         name: 'Belongs To',


### PR DESCRIPTION
This pull request fixes a bug that was crashing my application in IE8 (when using IE 9 in IE8 mode via developer tools)
Just removes a misplaced comma from an hash.

![screen shot 2013-09-23 at 16 12 22](https://f.cloud.github.com/assets/10764/1192436/98e59bca-2462-11e3-88a5-bb2b8fc8d053.png)
