### PR TITLE
Support embedded objects extraction

### DIFF
--- a/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
@@ -111,6 +111,38 @@ test("extractSingle", function() {
   }));
 });
 
+test("extractSingle with embedded objects", function() {
+  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend({
+    attrs: {
+      superVillains: {embedded: 'always'}
+    }
+  }));
+
+  var serializer = env.container.lookup("serializer:homePlanet");
+  var json_hash = {
+    home_planet: {
+      id: "1",
+      name: "Umber",
+      super_villains: [{
+        id: "1",
+        first_name: "Tom",
+        last_name: "Dale"
+      }]
+    }
+  };
+  var json = serializer.extractSingle(env.store, HomePlanet, json_hash);
+
+  deepEqual(json, {
+    id: "1",
+    name: "Umber",
+    superVillains: ["1"]
+  });
+  env.store.find("superVillain", 1).then(async(function(minion) {
+    equal(minion.get('firstName'), "Tom");
+  }));
+});
+
 test("extractArray", function() {
   env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
 
@@ -125,6 +157,42 @@ test("extractArray", function() {
     "id": "1",
     "name": "Umber",
     "superVillains": [1]
+  }]);
+
+  env.store.find("superVillain", 1).then(async(function(minion){
+    equal(minion.get('firstName'), "Tom");
+  }));
+});
+
+// TODO
+test("extractArray with embedded objects", function() {
+  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend({
+    attrs: {
+      superVillains: {embedded: 'always'}
+    }
+  }));
+
+  var serializer = env.container.lookup("serializer:homePlanet");
+
+  var json_hash = {
+    home_planets: [{
+      id: "1",
+      name: "Umber",
+      super_villains: [{
+        id: "1",
+        first_name: "Tom",
+        last_name: "Dale"
+      }]
+    }]
+  };
+
+  var array = serializer.extractArray(env.store, HomePlanet, json_hash);
+
+  deepEqual(array, [{
+    id: "1",
+    name: "Umber",
+    superVillains: ["1"]
   }]);
 
   env.store.find("superVillain", 1).then(async(function(minion){


### PR DESCRIPTION
I supported embedded objects extraction via `DS.ActiveModelSerializer`.

When the related objects are embedded in parent object such as the following json:

``` json
{
  "post": {
    "id": 1,
    "comments": [
      {"id": 1, "title": "hi", "body": "Foo"}
    ]
  }
}
```

We can extract it via its serializer:

``` javascript
App.PostSerializer = DS.ActiveModelSerializer.extend({
  attrs: {
    comments: { embedded: 'always' } // or 'load'
  }
});
```
