### PR TITLE
ActiveModelAdapter: interpret 422 responses as invalid.

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_adapter.js
+++ b/packages/activemodel-adapter/lib/system/active_model_adapter.js
@@ -69,5 +69,25 @@ DS.ActiveModelAdapter = DS.RESTAdapter.extend({
   pathForType: function(type) {
     var decamelized = Ember.String.decamelize(type);
     return Ember.String.pluralize(decamelized);
+  },
+
+  /**
+    The ActiveModelAdapter overrides the `ajaxError` method
+    to return a DS.InvalidError for all 422 Unprocessable Entity
+    responses.
+
+    @method ajaxError
+    @param jqXHR
+    @returns error
+  */
+  ajaxError: function(jqXHR) {
+    var error = this._super(jqXHR);
+
+    if (jqXHR && jqXHR.status === 422) {
+      var json = JSON.parse(jqXHR.responseText);
+      return new DS.InvalidError(json["errors"]);
+    } else {
+      return error;
+    }
   }
 });

--- a/packages/activemodel-adapter/tests/integration/active_model_adapter_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_adapter_test.js
@@ -29,3 +29,23 @@ function ajaxResponse(value) {
 test('buildURL - decamelizes names', function() {
   equal(adapter.buildURL('superUser', 1), "/super_users/1");
 });
+
+test('ajaxError - returns invalid error if 422 response', function() {
+  var error = new DS.InvalidError({ name: "can't be blank" });
+
+  var jqXHR = {
+    status: 422,
+    responseText: JSON.stringify({ errors: { name: "can't be blank" } })
+  };
+
+  equal(adapter.ajaxError(jqXHR), "Error: The backend rejected the commit because it was invalid: {name: can't be blank}");
+});
+
+test('ajaxError - returns ajax response if not 422 response', function() {
+  var jqXHR = {
+    status: 500,
+    responseText: "Something went wrong"
+  };
+
+  equal(adapter.ajaxError(jqXHR), jqXHR);
+});

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -418,6 +418,24 @@ DS.RESTAdapter = DS.Adapter.extend({
   },
 
   /**
+    Takes an ajax response, and returns a relavant error.
+
+    By default, it has the following behavior:
+
+    * It simply returns the ajax response.
+
+    @method ajaxError
+    @param  jqXHR
+  */
+  ajaxError: function(jqXHR) {
+    if (jqXHR) {
+      jqXHR.then = null;
+    }
+
+    return jqXHR;
+  },
+
+  /**
     Takes a URL, an HTTP method and a hash of data, and makes an
     HTTP request.
 
@@ -469,11 +487,7 @@ DS.RESTAdapter = DS.Adapter.extend({
       };
 
       hash.error = function(jqXHR, textStatus, errorThrown) {
-        if (jqXHR) {
-          jqXHR.then = null;
-        }
-
-        Ember.run(null, reject, jqXHR);
+        Ember.run(null, reject, adapter.ajaxError(jqXHR));
       };
 
       Ember.$.ajax(hash);


### PR DESCRIPTION
A follow up to #1278: this adds support for returning a `DS.InvalidError` for all `422` responses when using `DS.ActiveModelAdapter`.

I had to modify `DS.RestAdapter` to expose an overridable method.  If there's a better way to achieve the same thing, I'm happy to rework the solution.

Thanks!
