### PR TITLE
Add a `diff` implementation for models

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -255,12 +255,12 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   /**
     Gets the diff for the current model.
 
-    @method diff
+    @method changedAttributes
 
     @returns {Object} an object, whose keys are changed properties,
       and value is an [oldProp, newProp] array.
   */
-  diff: Ember.computed(function() {
+  changedAttributes: function() {
     var oldData = get(this, '_data'),
         newData = get(this, '_attributes'),
         diffData = {},
@@ -271,7 +271,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
     }
 
     return diffData;
-  }).property().volatile(),
+  },
 
   adapterWillCommit: function() {
     this.send('willCommit');


### PR DESCRIPTION
For #1355

``` coffeescript
# foo is a record instance of App.Foo
# let's say foo started with property "value" as "a"
foo.get('value') # 'a'
foo.get('diff') # {}
foo.set('value', 'b')
foo.get('value') # 'b'
foo.get('diff') # { value: ['a', 'b'] }
```
