### PR TITLE
Update ember-dev.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 ---
 rvm:
 - 1.9.3
+install:
+- "npm install -g defeatureify"
+- "npm install -g yuidocjs"
+- "bundle install --deployment"
 script: rake test[all]
 after_success: bundle exec rake publish_build
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,5 @@ gem 'ember-dev', :git => 'https://github.com/emberjs/ember-dev.git', :branch => 
 
 gem 'ember-source', '~> 1.0'
 gem 'puma'
-gem 'thin'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 534ffdfc4b3468edb3951e9e2012cead25b36997
+  revision: 0c0743979a05a81cecf82d90bfed660c5645f25d
   branch: master
   specs:
     ember-dev (0.1)
@@ -9,6 +9,7 @@ GIT
       execjs
       grit
       kicker
+      puma
       rack
       rake-pipeline (~> 0.8.0)
       rake-pipeline-web-filters (~> 0.7.0)
@@ -16,11 +17,11 @@ GIT
 
 GIT
   remote: https://github.com/livingsocial/rake-pipeline.git
-  revision: 65b1e744defa208e313703d89f3453447cc103b2
+  revision: a75d96fbadcc659a35a0ae59212e0bc60b58cc54
   specs:
     rake-pipeline (0.8.0)
       json
-      rake (~> 10.0.0)
+      rake (~> 10.1.0)
       thor
 
 PATH
@@ -32,17 +33,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.16.1)
+    aws-sdk (1.19.0)
       json (~> 1.4)
-      nokogiri (< 1.6.0)
+      nokogiri (>= 1.4.4, < 1.6.0)
       uuidtools (~> 2.1)
     colored (1.2)
-    daemons (1.1.9)
     diff-lcs (1.2.4)
     ember-source (1.0.0)
       handlebars-source (= 1.0.12)
-    eventmachine (1.0.3)
-    execjs (2.0.1)
+    execjs (2.0.2)
     ffi (1.9.0)
     grit (2.5.0)
       diff-lcs (~> 1.1)
@@ -52,30 +51,26 @@ GEM
     json (1.8.0)
     kicker (2.6.1)
       listen
-    listen (1.3.0)
+    listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
     mime-types (1.25)
-    multi_json (1.7.9)
+    multi_json (1.8.0)
     nokogiri (1.5.10)
     posix-spawn (0.3.6)
-    puma (2.4.1)
+    puma (2.6.0)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
-    rake (10.0.4)
+    rake (10.1.0)
     rake-pipeline-web-filters (0.7.0)
       rack
       rake-pipeline (~> 0.6)
     rb-fsevent (0.9.3)
-    rb-inotify (0.9.1)
+    rb-inotify (0.9.2)
       ffi (>= 0.5.0)
     rb-kqueue (0.2.0)
       ffi (>= 0.5.0)
-    thin (1.5.1)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
     thor (0.18.1)
     uglifier (2.2.1)
       execjs (>= 0.3.0)
@@ -91,4 +86,3 @@ DEPENDENCIES
   ember-source (~> 1.0)
   puma
   rake-pipeline!
-  thin

--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,30 @@
 require "bundler/setup"
 require "ember-dev/tasks"
 
+require 'pathname'
+require 'fileutils'
+
 directory "tmp"
 
+task :docs => "ember:docs"
 task :clean => "ember:clean"
 task :dist => "ember:dist"
 task :test, [:suite] => "ember:test"
 task :default => :dist
 
-task :publish_build do
-  root = File.expand_path(File.dirname(__FILE__)) + '/dist/'
+task :publish_build => [:dist, :docs] do
+  root_dir = Pathname.new(__FILE__).dirname
+  dist_dir = root_dir.join('dist')
+
+  FileUtils.cp root_dir.join('docs', 'build', 'data.json'),
+               dist_dir.join('ember-data-docs.json')
+
+  files = %w{ember-data.js ember-data-docs.json}
+
   EmberDev::Publish.to_s3({
     :access_key_id => ENV['S3_ACCESS_KEY_ID'],
     :secret_access_key => ENV['S3_SECRET_ACCESS_KEY'],
     :bucket_name => ENV['S3_BUCKET_NAME'],
-    :files => [ root + 'ember-data.js' ]
+    :files => files.map { |f| dist_dir.join(f) }
   })
 end


### PR DESCRIPTION
Major new features:
- Automated multi-branch testing for commits with specially formatted
  commit messages (BUGFIX, SECURITY, etc).
- Documentation generator via `rake docs` task.
- Automatic publishing of generated docs for each build.
- Will wait for the Rack server to be ready for connections before
  initiating tests (hopefully mitigates the phantomjs timeout issue)
- Will test each package both with and without feature flags.
- Will abort tests if `defeatureify` is not present and a
  `features.json` file exists.
- Updates to QUnit 1.12.0.
- Updates to use Puma for automated tests.
- Many test improvements.

The updated QUnit runner fixes the issue with ember-data causing the 
moduleDone output (totals for test count, time, errors, failures) to be 
printed once for each test (instead of only once per module).
