### PR TITLE
Fix hasMany not being serialized

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -94,7 +94,7 @@ DS.JSONSerializer = Ember.Object.extend({
 
     var relationshipType = DS.RelationshipChange.determineRelationshipType(record.constructor, relationship);
 
-    if (relationshipType === 'manyToNone' || relationshipType === 'manyToMany') {
+    if (relationshipType === 'manyToOne' || relationshipType === 'manyToMany') {
       json[key] = get(record, key).mapBy('id');
       // TODO support for polymorphic manyToNone and manyToMany relationships
     }


### PR DESCRIPTION
Possible fix for the trouble experienced in issues below.

https://github.com/emberjs/data/issues/1276
https://github.com/emberjs/data/issues/1177
https://github.com/emberjs/data/issues/1269

Fixed the similar trouble I had while using DS.FixtureAdapter and loading a lot of data in ApplicationRoute's 'model' then going to a route which used that data. The parent no longer had the children when loaded since it did not save a set of child ids to the fixtures.

Ran tests (rake test) and ran 1048 tests with no failures.
