### PR TITLE
Converted Changelog to Markdown, with small fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-*Ember Data 1.0.0-beta.3 (September 28, 2013)*
+# Ember Data Changelog
+
+### Ember Data 1.0.0-beta.3 _(September 28, 2013)_
 
 * Add `normalizePayload` to `RESTAdapter` for payload normalization that is the same
   across all requests.
@@ -32,7 +34,7 @@
 * Properly handle absolute and relative links in the `RESTAdapter`
 * Records become clean again if their properties are set back to the original values
 
-*Ember Data 1.0.0-beta.2 (September 04, 2013)*
+### Ember Data 1.0.0-beta.2 _(September 04, 2013)_
 
 * Add support for `host` and `namespace` in the RESTAdapter
 * Always use shorthand (`post`, not `App.Post`) in models
@@ -52,25 +54,25 @@
   Floren Jaby, Gordon Hempton, Ivan Vanderbyl, Johannes Würbach, Márcio Júnior,
   Nick Ragaz, Ricardo Mendes, Ryunosuke SATO, Sylvain Mina, and ssured
 
-*Ember Data 1.0.0-beta.1 (September 01, 2013)*
+### Ember Data 1.0.0-beta.1 _(September 01, 2013)_
 
-* Added DS.DebugAdapter which extends Ember.DataAdapter
+* Added `DS.DebugAdapter` which extends `Ember.DataAdapter`
 * Explain how to deal with embedded records
 * Start on a transition guide
 * Make willCommit while in flight a noop
 * Update examples
 * Move normalization and extraction to serializer
-* deleteRecord when already deleted is a noop
+* `deleteRecord` when already deleted is a noop
 * Explain "originally passed as an Array of IDs"
 * Shortens unnecessary verbiage
 * Add Promise Proxies
 * Add back serializers
 * More consistency for serializerFor
-* Rename NewJSONSerializer to JSONSerializer
+* Rename `NewJSONSerializer` to `JSONSerializer`
 * Don't invalidate `data` if there's no new data
 * Use the inflector instead of dumb pluralization
-* store.create({adapter:'name'}) uses the container
-* Remove resolveOn
+* `store.create({adapter:'name'})` uses the container
+* Remove `resolveOn`
 * Thread more promises through the adapter
 * Fix invokeLifecycleCallbacks on still dirty record
 * Initialize adapter in the store
@@ -83,37 +85,36 @@
 * Move extraction layers to adapter
 * Added support for URL lookups
 * Inject the default DS.Store if none is provided
-* Add findAll, findMany and findQuery to RESTAdapter
-* Add findAll plus request-type-specific extracts
+* Add `findAll`, `findMany` and `findQuery` to RESTAdapter
+* Add `findAll` plus request-type-specific extracts
 * Make serializer respect primaryKey/attrs
 * REST Adapter payload stuff
-* Ember.Inflector: Ember.String#pluralize Ember.String#singularize
-* remove handlePromise indirection.
+* Ember.Inflector: `Ember.String#pluralize` and `Ember.String#singularize`
+* Remove `handlePromise` indirection.
 * Queries are now using promises properly
-* Share code between sync and async hasMany
+* Share code between sync and async `hasMany`
 * Unload test passing
 * Adapter Interop test passing (plus findByIds)
 * Get reloading passing
 * Got record persistence test passing
 * Records are no longer thenables
 * Require application.Store to be defined - Fixes #1084
-* Added DS.DebugAdapter which extends Ember.DataAdapter
 * Relationship changes operate on records
 * Don't assign DS to window unless window exists - Fixes #681
 * Client ID generation passing
 * Eagerly generate the jQuery expando on window
 * Allowing inverse relationships to be nullable.
-* fetchRecord replaced findById here
-* Eliminate lazy materialization from belongsTo
+* `fetchRecord` replaced `findById` here
+* Eliminate lazy materialization from `belongsTo`
 * Start consolidating API around records
 * Make the data materialized again
-* Add debugInfo to DS.Model
-* Add store.push and store.recordFor
-* remove redundant `[]` from `Ember.A()` calls
-* bump ember-source
+* Add `debugInfo` to `DS.Model`
+* Add `store.push` and `store.recordFor`
+* Remove redundant `[]` from `Ember.A()` calls
+* Bump ember-source
 * Flatten model's `data` structure into single hash
 * Fix deprecation warning
-* Add serializerFor API to DS.Store
+* Add serializerFor API to `DS.Store`
 * Removed duplicate method declaration
 * `save` method is not private
 * Prevent resolution of jQuery's self fulfilling jqXHR thenable Since it resolves on another turn, it will cause needless and unwrappable auto-runs
@@ -122,24 +123,24 @@
 * Update jQuery version for `rake test[all]`
 * Remove unnecessary inspector for `object`
 * Remove option to specify router
-* Declared ajaxHeaders.
+* Declared `ajaxHeaders`.
 * Specify additional headers for RESTAdapter.
 * Update supported ruby version
 * Use `Ember.EnumerableUtils.map`
 * Use `Ember.EnumerableUtils.indexOf`
 * Use `Ember.EnumerableUtils.forEach`
 * Modify code indent
-* bump ember-source to 1.0.0-rc.6
+* Bump ember-source to 1.0.0-rc.6
 * Include the version number in the javascript.
-* this expression makes my brain hurt, lets atleast expand this to two lines. (We need some sort of macro system to improve these assertions.
-* improve variable naming consistency
-* remove nested run loop.
+* This expression makes my brain hurt, lets atleast expand this to two lines. (We need some sort of macro system to improve these assertions.
+* Improve variable naming consistency
+* Remove nested run loop.
 * Allow metadata value to be zero
 * Remove redundant serialized variable. :/
-* Better serializeId implementation that takes empty strings into consideration and fixed a logic error in isNaN(id) check
-* id serialization correctly returns null for null or undefined id values rather than 0
+* Better serializeId implementation that takes empty strings into consideration and fixed a logic error in `isNaN(id)` check
+* Id serialization correctly returns null for null or undefined id values rather than 0
 * Remove bundled jQuery
-* first pass at uncatchable assertions
+* First pass at uncatchable assertions
 * English, do you speak it?
 * Remove unused variables
 * Remove unused helper
@@ -151,10 +152,10 @@
 * RESTAdapter: reject with xhr only
 * Fix: record must be invalid on 422
 * Add failing integration test to expose bug #1005
-* remove revision reference.
+* Remove revision reference.
 * Check against `null` and `undefined`
 
 
-*Ember Data 0.13 (May 28, 2013)
+### Ember Data 0.13 _(May 28, 2013)_
 
 * Initial Release


### PR DESCRIPTION
Converted CHANGELOG to CHANGELOG.md, with additional fixes. Fixes include:
- Capitalization
- Code Highlight 
- Removal of duplicate item
