### PR TITLE
make asyncBelongsTo computed property return a promise when setting

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -12,7 +12,7 @@ function asyncBelongsTo(type, options, meta) {
 
     if (arguments.length === 2) {
       Ember.assert("You can only add a '" + type + "' record to this relationship", !value || value instanceof store.modelFor(type));
-      return value === undefined ? null : value;
+      return value === undefined ? null : DS.PromiseObject.create({ promise: Ember.RSVP.resolve(value) });
     }
 
     var link = data.links && data.links[key],

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -202,8 +202,8 @@ test('A record with an async belongsTo relationship always returns a promise for
         seat.set('person', person);
         ok(person.get('seat').then, 'seat should be a PromiseObject');
     }));
-  }))
-})
+  }));
+});
 
 test("TODO (embedded): The store can load an embedded polymorphic belongsTo association", function() {
   expect(0);


### PR DESCRIPTION
This is again linked to my issue opened at #1409

These changes make setting a record as value to an async belongsTo property still put a promise in the property cache instead of a record.
