### PR TITLE
[doc] hasRecordForId takes a `DS.Model`, not a `String`

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -477,7 +477,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     Returns true if a record for a given type and ID is already loaded.
 
     @method hasRecordForId
-    @param {String} type
+    @param {DS.Model} type
     @param {String|Integer} id
     @returns Boolean
   */


### PR DESCRIPTION
Perhaps the real fix is to use modelFor here, but hasRecordForId is also used in `recordIsLoaded` which require a subclass of DS.Model.
To go further, perhaps all public methods should be consistent, I mean take a string parameters and call modelFor.
