### PR TITLE
Alias "int" for NumberTransform

### DIFF
--- a/packages/ember-data/lib/initializers.js
+++ b/packages/ember-data/lib/initializers.js
@@ -61,6 +61,7 @@ Ember.onLoad('Ember.Application', function(Application) {
       application.register('transform:boolean', DS.BooleanTransform);
       application.register('transform:date', DS.DateTransform);
       application.register('transform:number', DS.NumberTransform);
+      application.register('transform:int', DS.NumberTransform);
       application.register('transform:string', DS.StringTransform);
     }
   });

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -326,6 +326,12 @@ test("a DS.Model can describe Number attributes", function() {
   converts('number', false, 0);
 });
 
+test("a DS.Model can describe Number attributes via 'int' alias", function() {
+  converts('int', "1", 1);
+  converts('int', "0", 0);
+  converts('int', 1, 1);
+});
+
 test("a DS.Model can describe Boolean attributes", function() {
   converts('boolean', "1", true);
   converts('boolean', "", false);

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -177,6 +177,7 @@
       'boolean': DS.BooleanTransform.create(),
       'date': DS.DateTransform.create(),
       'number': DS.NumberTransform.create(),
+      'int': DS.NumberTransform.create(),
       'string': DS.StringTransform.create()
     };
 


### PR DESCRIPTION
Myself and a few others starting with Ember run into confusion when trying to use `DS.attr('int')` or `DS.attr('integer')`. While it's stated in the documentation that there's a `number` attribute, it may be helpful to have something like this for such a common error.

If not an alias, then perhaps a warning/error for undefined `DS.attr()` in debug mode? 

I'm not very familiar with the codebase, and I can see this getting rejected for many reasons =) 

Related: https://github.com/emberjs/data/issues/23
