### PR TITLE
Use plain ASCII for License.

### DIFF
--- a/generators/license.js
+++ b/generators/license.js
@@ -1,7 +1,7 @@
 // ==========================================================================
 // Project:   Ember Data
-// Copyright: ©2011-2013 Tilde Inc. and contributors.
-//            Portions ©2011 LivingSocial Inc.
+// Copyright: Copyright 2011-2013 Tilde Inc. and contributors.
+//            Portions Copyright 2011 LivingSocial Inc.
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 


### PR DESCRIPTION
The current file uses © (correct UTF copyright symbol), but when
generated into the build artifacts (as ASCII text) it looks garbled (`//
Copyright: Â©2011-2013`).

Resolves #1419.

References: 
- http://www.copyright.gov/circs/circ01.pdf
- http://stackoverflow.com/questions/221376/putting-copyright-symbol-into-a-python-file#221380
