### PR TITLE
Fix lost reference to hash (data) passed into RESTAdapter#ajax

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -499,10 +499,10 @@ DS.RESTAdapter = DS.Adapter.extend({
     @param  hash
   */
   ajax: function(url, type, hash) {
-    var adapter = this;
+    var adapter = this, _hash = hash;
 
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      hash = adapter.ajaxOptions(url, type, hash);
+      hash = adapter.ajaxOptions(url, type, _hash);
 
       hash.success = function(json) {
         Ember.run(null, resolve, json);


### PR DESCRIPTION
- function passed into new RSVP expects hash reference for ajax data
- reference to hash arg is lost after promise constructor call
- added a local reference in the closure scope to prevent lossing scope
- unit tests mock response with resolved promise so doesn't catch this case

See:
https://github.com/emberjs/data/blob/master/packages/ember-data/lib/adapters/rest_adapter.js#L501-L517
https://github.com/emberjs/data/blob/master/packages/ember-data/tests/integration/adapter/rest_adapter_test.js#L156-L169
https://github.com/emberjs/data/blob/master/packages/ember-data/tests/integration/adapter/rest_adapter_test.js#L34-L42

I noticed the issue using Ember.data canary on 10/8 both the RESTAdapter methods `createRecord` and `updateRecord`did pass my model's data for sending to the server however in the RESTAdapter#ajax the `hash` reference was lost as the promise was created the `hash` was undefined when passed into `adapter.ajaxOptions`. My server responded with `{"meta":{"error":"No Attributes"}}` I looked into the test "integration/adapter/rest_adapter - REST Adapter: create - a payload with a new ID and data applies the updates" and noticed that the `ajaxResponse` function mocks the RESTAdapter#ajax by returning a resolved promise and assigned the ajax options to a variable to compare. Those options are not passed into a RSVP#Promise constructor so the test is not failing. However in an application with a live server the POST and PUT requests are not sending any data.
