### PR TITLE
Switch .jshintrc to use es3 mode insteaad of es5 mode. 

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -34,7 +34,7 @@
     ],
 
     "node" : false,
-    "es5" : true,
+    "es3" : true,
     "browser" : true,
 
     "boss" : true,

--- a/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
@@ -605,7 +605,7 @@ test("extractPolymorphic when the related data is not specified", function() {
 
 test("extractPolymorphic hasMany when the related data is not specified", function() {
   var json = {
-    popular_villain: {id: 1, name: "Dr Horrible"},
+    popular_villain: {id: 1, name: "Dr Horrible"}
   };
 
   json = env.amsSerializer.extractSingle(env.store, PopularVillain, json);

--- a/packages/ember-data/tests/integration/adapter/find_test.js
+++ b/packages/ember-data/tests/integration/adapter/find_test.js
@@ -42,7 +42,7 @@ test("When a single record is requested multiple times, all .find() calls are re
   store = createStore({ adapter: DS.Adapter.extend({
       find:  function(store, type, id) {
         return deferred.promise;
-      },
+      }
     })
   });
 

--- a/packages/ember-data/tests/integration/records/unload_test.js
+++ b/packages/ember-data/tests/integration/records/unload_test.js
@@ -5,7 +5,7 @@ var Person, env;
 module("integration/unload - Unloading Records", {
   setup: function() {
     Person = DS.Model.extend({
-      name: attr('string'),
+      name: attr('string')
     });
 
     Person.toString = function() { return "Person"; };

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -12,7 +12,7 @@ module("integration/relationships/has_many - Has-Many Relationships", {
     User = DS.Model.extend({
       name: attr('string'),
       messages: hasMany('message', { polymorphic: true }),
-      contacts: hasMany(),
+      contacts: hasMany()
     });
 
     Contact = DS.Model.extend({
@@ -288,7 +288,7 @@ test("A record can be removed from a polymorphic association", function() {
 
   var asyncRecords = Ember.RSVP.hash({
     user: env.store.find('user', 1),
-    comment: env.store.find('comment', 3),
+    comment: env.store.find('comment', 3)
   });
 
   asyncRecords.then(async(function(records) {

--- a/packages/ember-data/tests/integration/relationships/inverse_relationships_test.js
+++ b/packages/ember-data/tests/integration/relationships/inverse_relationships_test.js
@@ -146,7 +146,7 @@ test("When a record's belongsTo relationship is set, it can specify the inverse 
   User = DS.Model.extend({
     meMessages: DS.hasMany('message', { polymorphic: true }),
     youMessages: DS.hasMany('message', { polymorphic: true }),
-    everyoneWeKnowMessages: DS.hasMany('message', { polymorphic: true }),
+    everyoneWeKnowMessages: DS.hasMany('message', { polymorphic: true })
   });
 
   Message = DS.Model.extend({
@@ -191,7 +191,7 @@ test("When a record's polymorphic belongsTo relationship is set, it can specify 
     message: DS.belongsTo('message', {
       polymorphic: true,
       inverse: 'youMessages'
-    }),
+    })
   });
 
   var env = setupStore({ comment: Comment, message: Message, post: Post }),

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -98,7 +98,7 @@ test("serializePolymorphicType", function() {
       var key = relationship.key,
           belongsTo = get(record, key);
       json[relationship.key + "TYPE"] = belongsTo.constructor.typeKey;
-    },
+    }
   }));
 
   post = env.store.createRecord(Post, { title: "Rails is omakase", id: "1"});

--- a/packages/ember-data/tests/unit/debug_test.js
+++ b/packages/ember-data/tests/unit/debug_test.js
@@ -7,7 +7,7 @@ var TestAdapter = DS.Adapter.extend();
 module("Debug", {
   setup: function() {
     store = DS.Store.create({
-      adapter: TestAdapter.extend(),
+      adapter: TestAdapter.extend()
     });
   },
 

--- a/packages/ember-data/tests/unit/model/relationships_test.js
+++ b/packages/ember-data/tests/unit/model/relationships_test.js
@@ -549,7 +549,7 @@ test("calling createRecord and passing in an undefined value for a relationship 
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
-    tag: DS.belongsTo('tag'),
+    tag: DS.belongsTo('tag')
   });
 
   var env = setupStore({ tag: Tag, person: Person }),

--- a/packages/ember-data/tests/unit/store/adapter_interop_test.js
+++ b/packages/ember-data/tests/unit/store/adapter_interop_test.js
@@ -198,7 +198,7 @@ test("a new record of a particular type is created via store.createRecord(type)"
 test("a new record with a specific id can't be created if this id is already used in the store", function() {
   var store = createStore();
   var Person = DS.Model.extend({
-    name: DS.attr('string'),
+    name: DS.attr('string')
   });
 
   Person.reopenClass({


### PR DESCRIPTION
This now catches trailing commas, es5 mode does not: http://jslinterrors.com/extra-comma/

jshint will now catch issues like this: https://github.com/emberjs/data/pull/1432
