### PR TITLE
Returning existing records in the store immediately when calling store.find()

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -660,7 +660,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     _findAll(adapter, this, type, sinceToken, resolver);
 
-    return promiseArray(resolver.promise);
+    return promiseArrayWithContent(resolver.promise, array);
   },
 
   /**
@@ -1428,6 +1428,10 @@ function promiseObject(promise) {
 
 function promiseArray(promise) {
   return DS.PromiseArray.create({ promise: promise });
+}
+
+function promiseArrayWithContent(promise, content) {
+  return DS.PromiseArray.create({ promise: promise, content: content });
 }
 
 function isThenable(object) {


### PR DESCRIPTION
The method `find()` in ember-data 0.13 returns the existing data in the store and updates them when the request is completed. With ember-data 1.0 the `find` method is returning an empty array.

It's very useful to return the cached data because the app can display the existing records and update them in the background.