### PR TITLE
Correctly define window/global DS namespace in IE7/8.

### DIFF
--- a/packages/ember-data/lib/core.js
+++ b/packages/ember-data/lib/core.js
@@ -8,7 +8,7 @@
   @class DS
   @static
 */
-
+var DS;
 if ('undefined' === typeof DS) {
   DS = Ember.Namespace.create({
     VERSION: '1.0.0-beta.2'

--- a/packages/ember-data/tests/integration/application_test.js
+++ b/packages/ember-data/tests/integration/application_test.js
@@ -64,3 +64,6 @@ test("If a store is instantiated, it should be made available to each controller
   ok(fooController.get('store') instanceof DS.Store, "the store was injected");
 });
 
+test("the DS namespace should be accessible", function() {
+  ok(Ember.Namespace.byName('DS') instanceof Ember.Namespace, "the DS namespace is accessible");
+});


### PR DESCRIPTION
In IE7/8, defining `DS` globally without directly defining it on
`window.DS` causes it to not appear in the for..in loop that
processes namespaces inside of `findNamespaces()` (same issue [here](http://stackoverflow.com/questions/10633187/javascript-global-variable-behaviour-in-ie8)). 

https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/system/namespace.js#L117

This causes `Ember.Namespace.NAMESPACES_BY_ID` to contain an undefined
key instead of `DS`, which leads to issues when resolving across different
namespaces (such as the `DS` namespace when using DjangoRESTAdapter), or
when generating `toString()` outputs of the DS namespace or child objects.

This change allows one existing, failing test to pass in IE8:

https://github.com/emberjs/data/blob/c04b8e47c7de8b158d16bd4850744fec796ca05f/packages/ember-data/tests/unit/model_test.js#L57

which fails because the `DS` part of the expected `toString()` output
is missing.
