### PR TITLE
Ensure that async hasMany is always a promise

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -67,6 +67,15 @@ DS.ManyArray = DS.RecordArray.extend({
 
   isLoaded: false,
 
+  /**
+    Used for async `hasMany` arrays
+    to keep track of when they will resolve.
+
+    @property {Ember.RSVP.Promise}
+    @private
+  */
+  promise: null,
+
   loadingRecordsCount: function(count) {
     this.loadingRecordsCount = count;
   },

--- a/packages/ember-data/tests/integration/adapter/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/store_adapter_test.js
@@ -520,8 +520,30 @@ test("relationships don't get reset if the links is the same", function() {
   })).then(async(function(dogs) {
     equal(dogs.get('length'), 1, "The dogs are loaded");
     store.push('person', { id: 1, name: "Tom Dale", links: { dogs: "/dogs" } });
+    ok(tom.get('dogs') instanceof DS.PromiseArray, 'dogs is a promise');
     return tom.get('dogs');
   })).then(async(function(dogs) {
     equal(dogs.get('length'), 1, "The same dogs are loaded");
+  }));
+});
+
+
+test("async hasMany always returns a promise", function() {
+  Person.reopen({
+    dogs: DS.hasMany({ async: true })
+  });
+
+  adapter.createRecord = function(store, type, record) {
+    var hash = { name: "Tom Dale" };
+    hash.dogs = Ember.A();
+    hash.id = 1;
+    return Ember.RSVP.resolve(hash);
+  };
+
+  var tom = store.createRecord('person', { name: "Tom Dale" });
+  ok(tom.get('dogs') instanceof DS.PromiseArray, "dogs is a promise before save");
+
+  tom.save().then(async(function() {
+    ok(tom.get('dogs') instanceof DS.PromiseArray, "dogs is a promise after save");
   }));
 });


### PR DESCRIPTION
There are cases where an async hasMany would not return a promise (when the CP is not cached but the relationship already exists), and instead returns the `ManyArray` itself. This ensures a promise is always returned even if the relationship exists.

I had to keep track of the relationship's promise so I stored it as a `promise` property on the `ManyArray`.  Another way would be to just nuke and rebuild relationships that aren't loaded (based on the `isLoaded` property of the cached relationship). 

Let me know what you prefer.
