### PR TITLE
Remove unused `didReload` hook.

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -83,13 +83,6 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   didLoad: Ember.K,
 
   /**
-    Fired when the record is reloaded from the server.
-
-    @event didReload
-  */
-  didReload: Ember.K,
-
-  /**
     Fired when the record is updated.
 
     @event didUpdate


### PR DESCRIPTION
As mentioned [here](https://github.com/emberjs/data/issues/1128#issuecomment-23630395) in #1128 `didReload` shouldn't exist anymore.

This really just brings the docs back inline...
