### PR TITLE
Changed example code for  underscored roots

### DIFF
--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -717,8 +717,7 @@ If your server uses underscored root objects you can define the
 ```js
 App.ApplicationSerializer = DS.RESTSerializer.extend({
   typeForRoot: function(root) {
-    var camelized = Ember.String.camelize(root);
-    return Ember.String.singularize(camelized);
+    return Ember.String.singularize(root);
   }
 });
 ```


### PR DESCRIPTION
Examples code for underscored root contained regular AMS code. Changed it to the code needed to get underscored root objects working.
