### PR TITLE
Update `ember-dev` to (b0b12c4).

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 0c0743979a05a81cecf82d90bfed660c5645f25d
+  revision: b0b12c4758e264db45ef1e9d804105e6b3daeca1
   branch: master
   specs:
     ember-dev (0.1)
@@ -33,10 +33,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.19.0)
+    aws-sdk (1.21.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4, < 1.6.0)
       uuidtools (~> 2.1)
+    celluloid (0.15.2)
+      timers (~> 1.1.0)
     colored (1.2)
     diff-lcs (1.2.4)
     ember-source (1.0.0)
@@ -51,12 +53,12 @@ GEM
     json (1.8.0)
     kicker (2.6.1)
       listen
-    listen (1.3.1)
+    listen (2.1.0)
+      celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-      rb-kqueue (>= 0.2)
     mime-types (1.25)
-    multi_json (1.8.0)
+    multi_json (1.8.2)
     nokogiri (1.5.10)
     posix-spawn (0.3.6)
     puma (2.6.0)
@@ -69,9 +71,8 @@ GEM
     rb-fsevent (0.9.3)
     rb-inotify (0.9.2)
       ffi (>= 0.5.0)
-    rb-kqueue (0.2.0)
-      ffi (>= 0.5.0)
     thor (0.18.1)
+    timers (1.1.0)
     uglifier (2.2.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)


### PR DESCRIPTION
Updates `ember-dev` to (b0b12c4) which includes the following changes:
- Will not attempt to `unshallow` a full git repo
- Makes default test suite (packages only) run with features enabled and
  disabled.
- Fixes bug where the wrong Project name is used in the auto-generated
  CHANGELOG.
- Allows overriding the build type. (Simply set `ENV['BUILD_TYPE']='canary'`)
- Add `ember:generate_static_test_site` task to create a static HTML
  file for running the test suite.
- Add custom test results gathering for use in cross-browser testing.
- Make sure that the test file being used in the `Assetfile` is prefixed
  with the proper dasherized project name (prior to this Ember Data
  tests were still named `ember-tests.js` and now they will be
  `ember-data-tests.js`).
- Fixes issue where local `rake test` runs would attempt to perform git
  operations (`checkout` and `cherry-pick`). Now git operations will
  only be attempted if `ENV['CI']=true`.

For further reference:

https://github.com/emberjs/ember-dev/compare/0c0743979a...b0b12c4758e26
