### PR TITLE
Generate static site tests.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: b0b12c4758e264db45ef1e9d804105e6b3daeca1
+  revision: debb6c233ea0f0c9b02d542be5250ecab4ebd1ca
   branch: master
   specs:
     ember-dev (0.1)

--- a/Rakefile
+++ b/Rakefile
@@ -12,14 +12,16 @@ task :dist => "ember:dist"
 task :test, [:suite] => "ember:test"
 task :default => :dist
 
-task :publish_build => [:dist, :docs] do
+task :publish_build => [:dist, :docs, 'ember:generate_static_test_site'] do
   root_dir = Pathname.new(__FILE__).dirname
   dist_dir = root_dir.join('dist')
 
   FileUtils.cp root_dir.join('docs', 'build', 'data.json'),
                dist_dir.join('ember-data-docs.json')
 
-  files = %w{ember-data.js ember-data-docs.json}
+  files = %w{ember-data.js ember-data-docs.json
+             ember-data-spade.js ember-data-tests.js
+             ember-data-tests.html}
 
   EmberDev::Publish.to_s3({
     :access_key_id => ENV['S3_ACCESS_KEY_ID'],

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -191,8 +191,7 @@
   });
 
   EmberDev.distros = {
-    //spade:   'ember-data-spade.js',
-    spade:   'ember-spade.js',
+    spade:   'ember-data-spade.js',
     build:   'ember-data.js'
   };
 


### PR DESCRIPTION
This will publish a ember-tests.html static test site along with the builds. This makes it extremely simple to test the latest canary/beta/release builds on various devices. It is also critical to the cross-browser testing that we have been working on.
