### PR TITLE
Use consistent versioning.

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -21,12 +21,14 @@ distros.each do |name, modules|
     match "#{name}.js" do
       filter VersionInfo
       filter EmberLicenseFilter
+      filter AddProjectVersionNumber
     end
 
     # Strip dev code
     match "#{name}.prod.js" do
       filter VersionInfo
       filter EmberLicenseFilter
+      filter AddProjectVersionNumber
       filter(EmberStripDebugMessagesFilter) { ["#{name}.prod.js", "min/#{name}.js"] }
     end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: debb6c233ea0f0c9b02d542be5250ecab4ebd1ca
+  revision: a71fb819341c94df0bde8bedda7ccae5e089c913
   branch: master
   specs:
     ember-dev (0.1)
@@ -27,7 +27,7 @@ GIT
 PATH
   remote: .
   specs:
-    ember-data-source (1.0.0.beta.3)
+    ember-data-source (1.0.0.beta.4.canary)
       ember-source
 
 GEM
@@ -50,10 +50,10 @@ GEM
       mime-types (~> 1.15)
       posix-spawn (~> 0.3.6)
     handlebars-source (1.0.12)
-    json (1.8.0)
+    json (1.8.1)
     kicker (2.6.1)
       listen
-    listen (2.1.0)
+    listen (2.1.1)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.0.0-beta.3
+1.0.0-beta.4+canary

--- a/ember-data-source.gemspec
+++ b/ember-data-source.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{ember-data source code wrapper.}
   gem.description   = %q{ember-data source code wrapper for use with Ruby libs.}
   gem.homepage      = "https://github.com/emberjs/data"
-  gem.version       = Ember::Data::VERSION.sub('-', '.')
+  gem.version       = Ember::Data::VERSION.gsub(/[-\+]/, '.')
 
   gem.add_dependency "ember-source"
 

--- a/packages/ember-data/lib/core.js
+++ b/packages/ember-data/lib/core.js
@@ -11,7 +11,7 @@
 var DS;
 if ('undefined' === typeof DS) {
   DS = Ember.Namespace.create({
-    VERSION: '1.0.0-beta.2'
+    VERSION: 'VERSION_STRING_PLACEHOLDER'
   });
 
   if ('undefined' !== typeof window) {


### PR DESCRIPTION
Update to latest `ember-dev` and utilize a consistent version number for all builds. This means that the version comment and the `Ember.VERSION` constant will be the same.

The `/VERSION` file in each branches directory will indicate the next tagged release version along with custom metadata (`+pre` for release/beta and `+canary` for master) indicating it is a prerelease version.

See https://github.com/emberjs/ember-dev/commit/4018355f5ee9c2dd0533e78c9cfa15dd72497096 for a more complete explanation.
