### PR TITLE
Add support for polymorphic hasMany associations.

### DIFF
--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -926,15 +926,16 @@ Ember Data 1.0.beta.3:
 }
 ```
 
-You can override this behaviour by defining the `serializePolymorphicType` method
+You can override this behaviour by defining the `serializePolymorphicBelongsTo` method
 on your serializer.
 
 ```
 App.CommentSerializer = DS.RESTSerializer.extend({
-  serializePolymorphicType: function(record, json, relationship) {
+  serializePolymorphicBelongsTo: function(record, json, relationship) {
     var key = relationship.key,
         belongsTo = get(record, key);
     key = this.keyForAttribute ? this.keyForAttribute(key) : key;
+    json[key] = get(belongsTo, "id");
     json[key + "_type"] = belongsTo.constructor.typeKey;
   }
 });

--- a/packages/activemodel-adapter/tests/integration/active_model_adapter_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_adapter_test.js
@@ -1,30 +1,79 @@
-var env, store, adapter, SuperUser;
-var originalAjax, passedUrl, passedVerb, passedHash;
-module("integration/active_model_adapter - AMS Adapter", {
-  setup: function() {
-    SuperUser = DS.Model.extend();
+var env, store, adapter, SuperUser, MyMessage, MyPost, MyComment, MyUser;
+var ajaxCalls, ajaxReturnedValue, ajaxParams;
 
-    env = setupStore({
-      superUser: SuperUser,
-      adapter: DS.ActiveModelAdapter
+function setupTest( async ) {
+  MyUser = DS.Model.extend({
+    name: DS.attr('string'),
+    messages: DS.hasMany('myMessage', {
+      polymorphic: true,
+      inverse: 'user',
+      async: async
+    })
+  });
+
+  MyMessage = DS.Model.extend({
+    comments: DS.hasMany('myComment', {
+      inverse: 'message'
+    }),
+    user: DS.belongsTo('myUser')
+  });
+
+  MyPost = MyMessage.extend({
+    name: DS.attr('string')
+  });
+
+  MyComment = MyMessage.extend({
+    name: DS.attr('string'),
+    message: DS.belongsTo('myMessage', {
+      polymorphic: true,
+      inverse: 'comments',
+      async: async
+    })
+  });
+
+  SuperUser = DS.Model.extend();
+
+  env = setupStore({
+    myUser: MyUser,
+    myPost: MyPost,
+    myMessage: MyMessage,
+    myComment: MyComment,
+    superUser: SuperUser,
+    adapter: DS.ActiveModelAdapter
+  });
+
+  env.container.register('serializer:_ams', DS.ActiveModelSerializer);
+
+  store = env.store;
+  adapter = env.adapter;
+
+  ajaxCalls = [];
+  ajaxReturnedValue = [];
+
+  adapter.ajax = function(url, verb, value) {
+    ajaxCalls.push( {
+      passedUrl: url,
+      passedVerb: verb,
+      passedHash: value
     });
 
-    store = env.store;
-    adapter = env.adapter;
-
-    passedUrl = passedVerb = passedHash = null;
-  }
-});
-
-function ajaxResponse(value) {
-  adapter.ajax = function(url, verb, hash) {
-    passedUrl = url;
-    passedVerb = verb;
-    passedHash = hash;
-
-    return Ember.RSVP.resolve(value);
+    return Ember.RSVP.resolve( ajaxReturnedValue.shift() );
   };
 }
+
+function ajaxResponse(value) {
+  ajaxReturnedValue.push(value);
+}
+
+function lastAjaxCall() {
+  return ajaxCalls.shift();
+}
+
+module("integration/active_model_adapter - AMS Adapter", {
+  setup: function() {
+    setupTest(false);
+  }
+});
 
 test('buildURL - decamelizes names', function() {
   equal(adapter.buildURL('superUser', 1), "/super_users/1");
@@ -59,4 +108,208 @@ test('ajaxError - returns ajax response if not 422 response', function() {
   };
 
   equal(adapter.ajaxError(jqXHR), jqXHR);
+});
+
+test("The store can load a polymorphic belongsTo association", function() {
+  ajaxResponse({
+    my_comment: [{
+      id: 2,
+      name: "Rails is omakase",
+      message: {
+        type: 'my_post',
+        id: 1
+      }}],
+    my_posts: [{
+      id:1,
+      name: "OMG"
+    }]
+  });
+
+  store.find('myComment', 2).then(async(function(comment) {
+    ajaxParams = lastAjaxCall();
+
+    equal(ajaxParams.passedUrl, "/my_comments/2");
+    equal(ajaxParams.passedVerb, "GET");
+    equal(ajaxParams.passedHash, undefined);
+
+    equal(comment.get('id'), "2");
+    equal(comment.get('name'), "Rails is omakase");
+
+    equal(comment.get('message.id'), "1");
+    equal(comment.get('message.name'), "OMG");
+  }));
+});
+
+test("The store can load a polymorphic hasMany association", function() {
+  var messages;
+
+  ajaxResponse({
+    my_user: [{
+      id: 1,
+      name: "Cyril Fluck",
+      messages: [{
+        type: 'my_post',
+        id: 1
+      }, {
+        type: 'my_comment',
+        id: 2
+      }]
+    }],
+    my_posts: [{
+      id:1,
+      name: "OMG"
+    }],
+    my_comments: [{
+      id: 2,
+      name: "Rails is omakase"
+    }]
+  });
+
+  store.find('myUser', 1).then(async(function(user) {
+    ajaxParams = lastAjaxCall();
+
+    equal(ajaxParams.passedUrl, "/my_users/1");
+    equal(ajaxParams.passedVerb, "GET");
+    equal(ajaxParams.passedHash, undefined);
+
+    equal(user.get('id'), "1");
+    equal(user.get('name'), "Cyril Fluck");
+
+    equal(user.get('messages.length'), 2);
+    messages = user.get('messages');
+    equal(messages.objectAt(0).get('id'), "1");
+  }));
+});
+
+test("The store can save a polymorphic belongsTo association", function() {
+  ajaxResponse({ my_post: { id: "1", name: "Awesome" } });
+  var post = store.push('myPost', { id: "1", name: "OMG" });
+  var comment = store.createRecord('myComment', { id: "2", name: "Awesome"});
+  comment.set('message', post);
+
+  comment.save().then(async(function(comment) {
+    ajaxParams = lastAjaxCall();
+
+    equal(ajaxParams.passedUrl, "/my_comments");
+    equal(ajaxParams.passedVerb, "POST");
+    deepEqual(ajaxParams.passedHash.data, { my_comment: { id: "2", name: "Awesome", message: {id: "1", type: "my_post"}, user_id: null } });
+
+    equal(comment.get('isDirty'), false, "the post isn't dirty anymore");
+    equal(comment.get('name'), "Awesome", "the post was updated");
+  }));
+});
+
+test("The store can save a polymorphic hasMany association", function() {
+  ajaxResponse({
+    my_user: {
+      id: "1",
+      name: "Cedric Fluck",
+      messages: [{
+        type: "my_comment",
+        id: 2
+      }]
+    }
+  });
+  var comment = store.push('myComment', {id: 2, name: "OMG!!"});
+  var user = store.createRecord('myUser', {name: "Cyril Fluck"});
+  user.get('messages').pushObject( comment );
+
+  user.save().then(async(function(user) {
+    ajaxParams = lastAjaxCall();
+
+    equal(ajaxParams.passedUrl, "/my_users");
+    equal(ajaxParams.passedVerb, "POST");
+    deepEqual(ajaxParams.passedHash.data, { my_user: { name: "Cyril Fluck" }});
+
+    equal(user.get('isDirty'), false, "the user isn't dirty anymore");
+    equal(user.get('id'), "1", "the user was updated");
+  }));
+});
+
+module("integration/active_model_adapter - AMS Adapter - async", {
+  setup: function() {
+    setupTest(true);
+  }
+});
+
+test("The store can load an async polymorphic belongsTo association", function() {
+  ajaxResponse({
+    my_comment: [{
+      id: 2,
+      name: "Rails is omakase",
+      message: {
+        type: 'my_post',
+        id: 1
+      }
+    }]
+  });
+
+  store.find('myComment', 2).then(async(function(comment) {
+    ajaxParams = lastAjaxCall();
+
+    equal(ajaxParams.passedUrl, "/my_comments/2");
+    equal(ajaxParams.passedVerb, "GET");
+    equal(ajaxParams.passedHash, undefined);
+
+    equal(comment.get('id'), "2");
+    equal(comment.get('name'), "Rails is omakase");
+
+    ajaxResponse({
+      my_post: {
+        id: 1,
+        name: 'OMG'
+      }
+    });
+    comment.get('message').then(async(function(message) {
+      equal(message.get('id'), "1");
+      equal(message.get('name'), "OMG");
+    }));
+  }));
+});
+
+test("The store can load an async polymorphic hasMany association", function() {
+  var messages;
+
+  ajaxResponse({
+    my_user: [{
+      id: 1,
+      name: "Cyril Fluck",
+      messages: [{
+        type: 'my_post',
+        id: 1
+      }, {
+        type: 'my_comment',
+        id: 2
+      }]
+    }]
+  });
+
+  store.find('myUser', 1).then(async(function(user) {
+    ajaxParams = lastAjaxCall();
+
+    equal(ajaxParams.passedUrl, "/my_users/1");
+    equal(ajaxParams.passedVerb, "GET");
+    equal(ajaxParams.passedHash, undefined);
+
+    equal(user.get('id'), "1");
+    equal(user.get('name'), "Cyril Fluck");
+
+    ajaxResponse({
+      my_posts: [{
+        id: 1,
+        name: "OMG"
+      }]
+    });
+    ajaxResponse({
+      my_comments: [{
+        id: 2,
+        name: "Rails is omakase"
+      }]
+    });
+    user.get('messages').then(function(messages) {
+      equal(messages.get('length'), 2);
+      equal(messages.objectAt(0).get('id'), "1");
+      equal(messages.objectAt(1).get('id'), "2");
+    });
+  }));
 });

--- a/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
@@ -515,8 +515,10 @@ test("serialize polymorphic", function() {
 
   deepEqual(json, {
     name:  "DeathRay",
-    evil_minion_type: "YellowMinion",
-    evil_minion_id: "124"
+    evil_minion: {
+      id: "124",
+      type: "yellow_minion"
+    }
   });
 });
 
@@ -619,14 +621,14 @@ test("extractPolymorphic hasMany when the related data is not specified", functi
 
 test("extractPolymorphic does not break hasMany relationships", function() {
   var json = {
-    popular_villain: {id: 1, name: "Dr. Evil", evil_minions: []}
+    home_planet: {id: 1, name: "Krypton", villain_ids: []}
   };
 
-  json = env.amsSerializer.extractSingle(env.store, PopularVillain, json);
+  json = env.amsSerializer.extractSingle(env.store, HomePlanet, json);
 
   deepEqual(json, {
     "id": 1,
-    "name": "Dr. Evil",
-    "evilMinions": []
+    "name": "Krypton",
+    "villains": []
   });
 });

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -76,17 +76,25 @@ DS.JSONSerializer = Ember.Object.extend({
 
     var belongsTo = get(record, key);
 
-    key = this.keyForRelationship ? this.keyForRelationship(key, "belongsTo") : key;
+    key = this.keyForRelationship ? this.keyForRelationship(key, relationship) : key;
 
     if (isNone(belongsTo)) {
       json[key] = belongsTo;
     } else {
-      json[key] = get(belongsTo, 'id');
+      if( relationship.options.polymorphic ) {
+        this.serializePolymorphicBelongsTo(record, json, relationship);
+      } else {
+        json[key] = get(belongsTo, 'id');
+      }
     }
+  },
 
-    if (relationship.options.polymorphic) {
-      this.serializePolymorphicType(record, json, relationship);
-    }
+  serializePolymorphicBelongsTo: function(record, json, relationship) {
+    var key = relationship.key,
+        belongsTo = get(record, key);
+    key = this.keyForRelationship ? this.keyForRelationship(key, relationship) : key;
+    json[key] = get(belongsTo, 'id');
+    json[key + "Type"] = belongsTo.constructor.typeKey;
   },
 
   serializeHasMany: function(record, json, relationship) {
@@ -99,11 +107,6 @@ DS.JSONSerializer = Ember.Object.extend({
       // TODO support for polymorphic manyToNone and manyToMany relationships
     }
   },
-
-  /**
-    You can use this method to customize how polymorphic objects are serialized.
-  */
-  serializePolymorphicType: Ember.K,
 
   // EXTRACT
 

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -45,8 +45,8 @@ function coerceId(id) {
   ```
 
   You can also implement `keyForRelationship`, which takes the name
-  of the relationship as the first parameter, and the kind of
-  relationship (`hasMany` or `belongsTo`) as the second parameter.
+  of the relationship as the first parameter, and the relationship
+  as the second parameter.
 
   @class RESTSerializer
   @namespace DS
@@ -721,22 +721,5 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
   */
   serializeIntoHash: function(hash, type, record, options) {
     hash[type.typeKey] = this.serialize(record, options);
-  },
-
-  /**
-    You can use this method to customize how polymorphic objects are serialized.
-    By default the JSON Serializer creates the key by appending `Type` to
-    the attribute and value from the model's camelcased model name.
-
-    @method serializePolymorphicType
-    @param {DS.Model} record
-    @param {Object} json
-    @param relationship
-  */
-  serializePolymorphicType: function(record, json, relationship) {
-    var key = relationship.key,
-        belongsTo = get(record, key);
-    key = this.keyForAttribute ? this.keyForAttribute(key) : key;
-    json[key + "Type"] = belongsTo.constructor.typeKey;
   }
 });

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -125,9 +125,10 @@ test("The store can load a polymorphic belongsTo association", function() {
 });
 
 test("The store can serialize a polymorphic belongsTo association", function() {
-  env.serializer.serializePolymorphicType = function(record, json, relationship) {
-    ok(true, "The serializer's serializePolymorphicType method should be called");
+  env.serializer.serializePolymorphicBelongsTo = function(record, json, relationship) {
+    ok(true, "The serializer's serializePolymorphicBelongsTo method should be called");
     json["message_type"] = "post";
+    json["message"] = "1";
   };
   env.store.push('post', { id: 1 });
   env.store.push('comment', { id: 2, message: 1, messageType: 'post' });

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -92,11 +92,12 @@ test("serializeBelongsTo respects keyForRelationship", function() {
   });
 });
 
-test("serializePolymorphicType", function() {
+test("serializePolymorphicBelongsTo", function() {
   env.container.register('serializer:comment', DS.JSONSerializer.extend({
-    serializePolymorphicType: function(record, json, relationship) {
+    serializePolymorphicBelongsTo: function(record, json, relationship) {
       var key = relationship.key,
           belongsTo = get(record, key);
+      json[relationship.key] = get(belongsTo, "id");
       json[relationship.key + "TYPE"] = belongsTo.constructor.typeKey;
     }
   }));


### PR DESCRIPTION
Saving async polymorphic associations is not currently supported.

Fixes the payload required by the ActiveModelAdapter to match the
Rails ActiveModel Serializers.

```js
  MyUser = DS.Model.extend({
    name: DS.attr('string'),
    messages: DS.hasMany('myMessage', {
      polymorphic: true,
      inverse: 'user'
    })
  });

  MyMessage = DS.Model.extend({
    name: DS.attr('string')
    comments: DS.hasMany('myComment', {
      inverse: 'message'
    }),
    user: DS.belongsTo('myUser')
  });

  MyPost = MyMessage.extend({
  });

  MyComment = MyMessage.extend({
    message: DS.belongsTo('myMessage', {
      polymorphic: true,
      inverse: 'comments'
    })
  });
```

The expected payload for a polymorphic `belongsTo` association is then:

```js
  my_comment: [{
    id: 2,
    name: "Rails is omakase",
    message: {
      type: 'my_post',
      id: 1
    }
  }],

  my_posts: [{
    id:1,
    name: "OMG"
  }]
```

The expected payload for a polymorphic `hasMany` association is then:

```js
  my_user: [{
    id: 1,
    name: "Cyril Fluck",
    messages: [{
        type: 'my_post',
        id: 1
      }, {
        type: 'my_comment',
        id: 2
    }]
  }],

  my_posts: [{
    id:1,
    name: "OMG"
  }],

  my_comments: [{
    id: 2,
    name: "Rails is omakase"
  }]
```