### PR TITLE
Handle case of single object pushPayload

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -519,7 +519,7 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
           type = store.modelFor(typeName);
 
       /*jshint loopfunc:true*/
-      var normalizedArray = map.call(payload[prop], function(hash) {
+      var normalizedArray = map.call(Ember.makeArray(payload[prop]), function(hash) {
         return this.normalize(type, hash, prop);
       }, this);
 

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -197,3 +197,21 @@ test("Calling pushPayload allows pushing raw JSON", function () {
 
   equal(post.get('postTitle'), "Ember rocks (updated)", "You can update data in the store");
 });
+
+test("Calling pushPayload allows pushing singular payload properties", function () {
+  store.pushPayload('post', {post: {
+    id: '1',
+    post_title: "Ember rocks"
+  }});
+
+  var post = store.getById('post', 1);
+
+  equal(post.get('postTitle'), "Ember rocks", "you can push raw JSON into the store");
+
+  store.pushPayload('post', {post: {
+    id: '1',
+    post_title: "Ember rocks (updated)"
+  }});
+
+  equal(post.get('postTitle'), "Ember rocks (updated)", "You can update data in the store");
+});


### PR DESCRIPTION
The standard response from ActiveModel::Serializers is acceptable for ember-data when responding to something like `GET /posts/1` from `store.find('post', 1)`. This will include a singular Post, and any associations, such as a set of comments.

If however, I wanted to use this same serializer to push a Post over Server-Sent Events or WebSockets, I would not currently be able to use `store.pushPayload`. While it would load the array of associated comments just fine, the actual object I care about, the single post, would be ignored.

This simple (if inelegant) change wraps the `payload[prop]` in a call to `Ember.makeArray`, so that even single objects will work inside the `map.call` when attempting to "normalize" the array.

Thank you for your time.
