### PR TITLE
Update to Ember 1.1.0 (and fix tests).

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       timers (~> 1.1.0)
     colored (1.2)
     diff-lcs (1.2.4)
-    ember-source (1.0.0)
+    ember-source (1.1.0)
       handlebars-source (= 1.0.12)
     execjs (2.0.2)
     ffi (1.9.0)

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -18,18 +18,12 @@ module("unit/store/push - DS.Store#push", {
       postTitle: attr('string')
     });
 
-    env = setupStore();
+    env = setupStore({"post": Post,
+                      "person": Person,
+                      "phone-number": PhoneNumber});
 
     store = env.store;
 
-    var DefaultSerializer = DS.JSONSerializer.extend({
-      store: store
-    });
-
-    env.container.register('model:person', Person);
-    env.container.register('model:phone-number', PhoneNumber);
-    env.container.register('model:post', Post);
-    env.container.register('serializer:_default', DefaultSerializer);
     env.container.register('serializer:post', DS.ActiveModelSerializer);
   },
 


### PR DESCRIPTION
Updated Gemfile to use 1.1.0 (latest stable version of Ember).

Ember 1.1.0 does not allow items to be re-registered on a container if they have already been looked up. This change was made in [b8b9878bc](https://github.com/emberjs/ember.js/commit/b8b9878bcf6517ee2b25b0e309f2a5bf5e3ff7d1).

This refactors the tests for `DS.Store#push` so that it does not throw any errors with 1.1.0.
