### PR TITLE
Include the type when calling the serializer's pushPayload from the stor...

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -563,9 +563,10 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
 
     @method pushPayload
     @param {DS.Store} store
+    @param {subclass of DS.Model} primaryType
     @param {Object} payload
   */
-  pushPayload: function(store, payload) {
+  pushPayload: function(store, primaryType, payload) {
     payload = this.normalizePayload(null, payload);
 
     for (var prop in payload) {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1224,7 +1224,7 @@ DS.Store = Ember.Object.extend({
     } else {
       serializer = this.serializerFor(type);
     }
-    serializer.pushPayload(this, payload);
+    serializer.pushPayload(this, type, payload);
   },
 
   update: function(type, data) {

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -214,9 +214,9 @@ test("Calling pushPayload without a type uses application serializer", function 
   expect(2);
 
   env.container.register('serializer:application', DS.RESTSerializer.extend({
-    pushPayload: function(store, payload) {
+    pushPayload: function(store, primaryType, payload) {
       ok(true, "pushPayload is called on Application serializer");
-      return this._super(store, payload);
+      return this._super(store, primaryType, payload);
     }
   }));
 


### PR DESCRIPTION
...e's pushPayload.

The [store's `pushPayload` method](https://github.com/emberjs/data/blob/master/packages/ember-data/lib/system/store.js#L1153-L1156) is currently called with a model type so that the correct serializer is used.

``` javascript
store.pushPayload('post', pushData);
```

This change just passes the type along to the serializer's `pushPayload` as well.

[ember-data-django-rest-adapter's](https://github.com/toranb/ember-data-django-rest-adapter) JSON format doesn't include the model names as keys in the JSON payload, meaning that if the serializer doesn't get passed the `type` then it will have no way to know which model to use when extracting the data (https://github.com/toranb/ember-data-django-rest-adapter/issues/51). This change allows the django-rest-adapter's serializer implementation to determine the correct model type to use.
