### PR TITLE
fix unloadAll not actually unloading all

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -718,7 +718,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     type = this.modelFor(type);
 
     var typeMap = this.typeMapFor(type),
-        records = typeMap.records, record;
+        records = typeMap.records.slice(0), record;
 
     while(record = records.pop()) {
       record.unloadRecord();
@@ -740,7 +740,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     If any of a record's properties change, or if it changes state, the
     filter function will be invoked again to determine whether it should
     still be in the array.
-    
+
     Optionally you can pass a query which will be triggered at first. The
     results returned by the server could then appear in the filter if they
     match the filter function.

--- a/packages/ember-data/tests/integration/records/unload_test.js
+++ b/packages/ember-data/tests/integration/records/unload_test.js
@@ -30,6 +30,7 @@ test("can unload all records for a given type", function () {
   var adam = env.store.push('person', {id: 1, name: "Adam Sunderland"});
   var bob = env.store.push('person', {id: 2, name: "Bob Bobson"});
 
+  equal(env.store.all('person').get('length'), 2);
   env.store.unloadAll('person');
 
   equal(env.store.all('person').get('length'), 0);


### PR DESCRIPTION
`unloadAll` was, until now, unloading every other record in the records array.

`dematerializeRecord` calls slice which would effectively pop another record without actually properly unloading it.  When the `findAllCache` was present calls to all would return the records that had not been unloaded correctly.

The test for this has been updated to correctly cache the results prior to unloading.
