### PR TITLE
Issue #1487: JSONSerializer does not serialize manyToOne relationship in...

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -94,9 +94,9 @@ DS.JSONSerializer = Ember.Object.extend({
 
     var relationshipType = DS.RelationshipChange.determineRelationshipType(record.constructor, relationship);
 
-    if (relationshipType === 'manyToNone' || relationshipType === 'manyToMany') {
+    if (relationshipType === 'manyToOne' || relationshipType === 'manyToMany') {
       json[key] = get(record, key).mapBy('id');
-      // TODO support for polymorphic manyToNone and manyToMany relationships
+      // TODO support for polymorphic manyToOne and manyToMany relationships
     }
   },
 

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -4,7 +4,8 @@ var Post, post, Comment, comment, env;
 module("integration/serializer/json - JSONSerializer", {
   setup: function() {
     Post = DS.Model.extend({
-      title: DS.attr('string')
+      title: DS.attr('string'),
+      comments: DS.hasMany('comment')
     });
     Comment = DS.Model.extend({
       body: DS.attr('string'),
@@ -110,5 +111,23 @@ test("serializePolymorphicType", function() {
   deepEqual(json, {
     post: "1",
     postTYPE: "post"
+  });
+});
+
+test("serializeHasMany", function() {
+  env.container.register('serializer:post', DS.JSONSerializer.extend({
+    keyForRelationship: function(key, type) {
+      return key.toUpperCase();
+    }
+  }));
+  post = env.store.createRecord(Post, { title: "Rails is omakase", comments: [ "2", "3" ], id: "1"});
+  comment = env.store.createRecord(Comment, { body: "Omakase is delicious", post: post, id : "2" });
+  comment = env.store.createRecord(Comment, { body: "Agreed", post: post, id : "3" });
+  var json = {};
+
+  env.container.lookup("serializer:post").serializeHasMany(post, json, {key: "comments", options: {}});
+
+  deepEqual(json, {
+    comments: [ "2", "3" ]
   });
 });


### PR DESCRIPTION
... function serializeHasMany

The serializer did serialize manyToNone and manyToMany relationships.
There is nothing to do in a manyToNone relationship.
ManyToOne relationships weren't handled so I changed manyToNone into manyToOne
