### PR TITLE
Allow for polymorphic async relations

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -737,6 +737,9 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
     var key = relationship.key,
         belongsTo = get(record, key);
     key = this.keyForAttribute ? this.keyForAttribute(key) : key;
+    if (relationship.options.async && DS.PromiseObject.detectInstance(belongsTo)) {
+      belongsTo = belongsTo.get('content');
+    }
     json[key + "Type"] = belongsTo.constructor.typeKey;
   }
 });


### PR DESCRIPTION
Async relations are wrapped in a DS.PromiseObject, if so, unwrap before querying the typeKey