### PR TITLE
Test against all Ember channels.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: a71fb819341c94df0bde8bedda7ccae5e089c913
+  revision: 56b02fa1e623c6a22c793bd9d24b5be0bcd98f4b
   branch: master
   specs:
     ember-dev (0.1)
@@ -33,18 +33,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.21.0)
+    aws-sdk (1.25.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4, < 1.6.0)
       uuidtools (~> 2.1)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     colored (1.2)
-    diff-lcs (1.2.4)
+    diff-lcs (1.2.5)
     ember-source (1.1.0)
       handlebars-source (= 1.0.12)
     execjs (2.0.2)
-    ffi (1.9.0)
+    ffi (1.9.3)
     grit (2.5.0)
       diff-lcs (~> 1.1)
       mime-types (~> 1.15)
@@ -53,12 +53,11 @@ GEM
     json (1.8.1)
     kicker (2.6.1)
       listen
-    listen (2.1.1)
+    listen (2.2.0)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mime-types (1.25)
-    multi_json (1.8.2)
     nokogiri (1.5.10)
     posix-spawn (0.3.6)
     puma (2.6.0)
@@ -73,9 +72,9 @@ GEM
       ffi (>= 0.5.0)
     thor (0.18.1)
     timers (1.1.0)
-    uglifier (2.2.1)
+    uglifier (2.3.1)
       execjs (>= 0.3.0)
-      multi_json (~> 1.0, >= 1.0.2)
+      json (>= 1.8.0)
     uuidtools (2.1.4)
 
 PLATFORMS

--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -5,13 +5,17 @@ testing_suites:
   default:
     - "package=all"
   all:
-    - "package=all"
+    - "package=all&emberchannel=release"
+    - "package=all&emberchannel=beta"
+    - "package=all&emberchannel=canary"
     - "package=all&jquery=1.7.2&nojshint=true"
     - "package=all&jquery=1.8.3&nojshint=true"
     - "package=all&jquery=1.9.1&nojshint=true"
     - "package=all&extendprototypes=true&nojshint=true"
     - "package=all&extendprototypes=true&jquery=1.9.1&nojshint=true"
-    - "package=all&dist=build&nojshint=true"
+    - "package=all&dist=build&nojshint=true&emberchannel=release"
+    - "package=all&dist=build&nojshint=true&emberchannel=beta"
+    - "package=all&dist=build&nojshint=true&emberchannel=canary"
 testing_packages:
   - ember-data
   - ember-inflector


### PR DESCRIPTION
This updates to the latest `ember-dev` (56b02fa) which allows testing against
each Ember channel using the `emberchannel` URL param, and updates the tests
run by CI to run against all three channels.
