### PR TITLE
Reject records that have IDs which are already in store

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -958,6 +958,12 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     Ember.assert("An adapter cannot assign a new id to a record that already has an id. " + record + " had id: " + oldId + " and you tried to update it with " + id + ". This likely happened because your server returned data in response to a find or update that had a different id than the one you sent.", oldId === null || id === oldId);
 
+    existingRecord = this.typeMapFor(record.constructor).idToRecord[id];
+    if (existingRecord) {
+      record.transitionTo('deleted.saved');
+      return;
+    }
+
     this.typeMapFor(record.constructor).idToRecord[id] = record;
 
     set(record, 'id', id);


### PR DESCRIPTION
When app has a push-data (i.e. websocket) connection, this could happen: push update comes before the actual save() call is done, which saves another copy of the record when it finally gets an ID from the backend.
