### PR TITLE
Latest ember-dev uses local packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ tests/ember-data-tests.js
 
 docs/build/
 docs/node_modules/
+
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@
 rvm:
 - 1.9.3
 install:
-- "npm install -g defeatureify"
-- "npm install -g yuidocjs"
+- "npm install"
 - "bundle install --deployment"
 script: rake test[all]
 after_success: bundle exec rake publish_build

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "defeatureify": "~0.1.4",
+    "yuidocjs": "~0.3.46"
+  }
+}


### PR DESCRIPTION
Builds are only published if all files are found, but the latest `ember-dev` requires that `yuidocjs` be installed locally (in `node_modules/`). Since `/docs/build/data.json` (the `yuidoc` output file) was not found, the builds were not being published.
