### PR TITLE
[BUGFIX beta] Prevent error in failed reload().

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -556,7 +556,11 @@ var RootState = {
 
       didCommit: function(record) {
         record.send('invokeLifecycleCallbacks', get(record, 'lastDirtyType'));
-      }
+      },
+
+      // loaded.saved.notFound would be triggered by a failed
+      // `reload()` on an unchanged record
+      notFound: Ember.K
 
     },
 


### PR DESCRIPTION
This seems like the logical solution to #1511 since a `notFound` event on an otherwise already looked up record doesn't really make any sense.

If another route is preferred to fix this issue, please let me know and I'd be happy to update this PR.

Resolves #1511.
