### PR TITLE
Fix intermittent errors at completion of unit test cases

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -873,6 +873,10 @@ DS.Store = Ember.Object.extend({
     var pending = this._pendingSave.slice();
     this._pendingSave = [];
 
+    if (this.get('isDestroyed')) {
+      return;
+    }
+
     forEach(pending, function(tuple) {
       var record = tuple[0], resolver = tuple[1],
           adapter = this.adapterFor(record.constructor),


### PR DESCRIPTION
If a test case causes some pending saves to be scheduled just before completing, then App.reset() can be called before those saves are flushed. Then the store will attempt to save the records it has been destroyed and can no longer find the proper adapter, which will result in an exception that looks something like this:

`Uncaught TypeError: Cannot call method 'updateRecord' of undefined ember-data.js:2690
_commit ember-data.js:2690
(anonymous function) ember-data.js:2037
Ember.EnumerableUtils.forEach ember-1.0.0.js:1784
DS.Store.Ember.Object.extend.flushPendingSave ember-data.js:2024
DeferredActionQueues.flush ember-1.0.0.js:5461
Backburner.end ember-1.0.0.js:5545
Backburner.run ember-1.0.0.js:5584
(anonymous function) ember-1.0.0.js:5731`

So, the store just needs to notice if it has been destroyed in this case and return without trying to save any of the pending records.
