### PR TITLE
ActiveModelSerializer: support embedded objects with belongsTo relationship

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -43,6 +43,8 @@ DS.ActiveModelSerializer = DS.RESTSerializer.extend({
 
   /**
     Does not serialize hasMany relationships by default.
+
+    @see EmbeddedRecordsMixin for supporting embedded records
   */
   serializeHasMany: Ember.K,
 

--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -10,6 +10,7 @@ var forEach = Ember.EnumerableUtils.forEach;
   ```js
   App.PostSerializer = DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
+      author: {embedded: 'always},
       comments: {embedded: 'always'}
     }
   })
@@ -23,9 +24,131 @@ var forEach = Ember.EnumerableUtils.forEach;
 DS.EmbeddedRecordsMixin = Ember.Mixin.create({
 
   /**
-    Serialize has-may relationship when it is configured as embedded objects.
+    Serialize `belongsTo` relationship when it is configured as an embedded object.
+
+    This example of an author model belongs to a post model:
+
+    ```js
+    Post = DS.Model.extend({
+      title:    DS.attr('string'),
+      body:     DS.attr('string'),
+      author:   DS.belongsTo('author')
+    });
+
+    Author = DS.Model.extend({
+      name:     DS.attr('string'),
+      post:     DS.belongsTo('post')
+    });
+    ```
+
+    Use a custom (type) serializer for the post model to configure embedded author
+
+    ```js
+    App.PostSerializer = DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+      attrs: {
+        author: {embedded: 'always'}
+      }
+    })
+    ```
+
+    A payload with an attribute configured for embedded records can serialize
+    the records together under the root attribute's payload:
+
+    ```js
+    {
+      "post": {
+        "id": "1"
+        "title": "Rails is omakase",
+        "author": {
+          "id": "2"
+          "name": "dhh"
+        }
+      }
+    }
+    ```
+
+    @method serializeBelongsTo
+    @param {DS.Model} record
+    @param {Object} json
+    @param relationship
+  */
+  serializeBelongsTo: function(record, json, relationship) {
+    var attr = relationship.key, config = this.get('attrs');
+
+    if (!config || !isEmbedded(config[attr])) {
+      this._super(record, json, relationship);
+      return;
+    }
+    var key = this.keyForAttribute(attr);
+    var embeddedRecord = record.get(attr);
+    if (!embeddedRecord) {
+      json[key] = null;
+    } else {
+      json[key] = embeddedRecord.serialize();
+      var id = embeddedRecord.get('id');
+      if (id) {
+        json[key].id = id;
+      }
+      var parentKey = this.keyForAttribute(relationship.parentType.typeKey);
+      if (parentKey) {
+        removeId(parentKey, json[key]);
+      }
+      delete json[key][parentKey];
+    }
+  },
+
+  /**
+    Serialize `hasMany` relationship when it is configured as embedded objects.
+
+    This example of a post model has many comments:
+
+    ```js
+    Post = DS.Model.extend({
+      title:    DS.attr('string'),
+      body:     DS.attr('string'),
+      comments: DS.hasMany('comment')
+    });
+
+    Comment = DS.Model.extend({
+      body:     DS.attr('string'),
+      post:     DS.belongsTo('post')
+    });
+    ```
+
+    Use a custom (type) serializer for the post model to configure embedded comments
+
+    ```js
+    App.PostSerializer = DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+      attrs: {
+        comments: {embedded: 'always'}
+      }
+    })
+    ```
+
+    A payload with an attribute configured for embedded records can serialize
+    the records together under the root attribute's payload:
+
+    ```js
+    {
+      "post": {
+        "id": "1"
+        "title": "Rails is omakase",
+        "body": "I want this for my ORM, I want that for my template language..."
+        "comments": [{
+          "id": "1",
+          "body": "Rails is unagi"
+        }, {
+          "id": "2",
+          "body": "Omakase O_o"
+        }]
+      }
+    }
+    ```
 
     @method serializeHasMany
+    @param {DS.Model} record
+    @param {Object} json
+    @param relationship
   */
   serializeHasMany: function(record, json, relationship) {
     var key   = relationship.key,
@@ -45,78 +168,213 @@ DS.EmbeddedRecordsMixin = Ember.Mixin.create({
   },
 
   /**
-    Extract embedded objects out of the payload for a single object
-    and add them as sideloaded objects instead.
+    Extract an embedded object from the payload for a single object
+    and add the object in the compound document (side-loaded) format instead.
+
+    A payload with an attribute configured for embedded records needs to be extracted:
+
+    ```js
+    {
+      "post": {
+        "id": 1
+        "title": "Rails is omakase",
+        "author": {
+          "id": 2
+          "name": "dhh"
+        }
+        "comments": []
+      }
+    }
+    ```
+
+    Ember Data is expecting a payload with a compound document (side-loaded) like:
+
+    ```js
+    {
+      "post": {
+        "id": "1"
+        "title": "Rails is omakase",
+        "author": "2"
+        "comments": []
+      },
+      "authors": [{
+        "id": "2"
+        "post": "1"
+        "name": "dhh"
+      }]
+      "comments": []
+    }
+    ```
+
+    The payload's `author` attribute represents an object with a `belongsTo` relationship.
+    The `post` attribute under `author` is the foreign key with the id for the post
 
     @method extractSingle
+    @param {DS.Store} store
+    @param {subclass of DS.Model} primaryType
+    @param {Object} payload
+    @param {String} recordId
+    @param {'find'|'createRecord'|'updateRecord'|'deleteRecord'} requestType
+    @returns Object the primary response to the original request
   */
   extractSingle: function(store, primaryType, payload, recordId, requestType) {
     var root = this.keyForAttribute(primaryType.typeKey),
         partial = payload[root];
 
-    updatePayloadWithEmbedded(store, this, primaryType, partial, payload);
+    updatePayloadWithEmbedded.call(this, store, primaryType, payload, partial);
 
     return this._super(store, primaryType, payload, recordId, requestType);
   },
 
   /**
-    Extract embedded objects out of a standard payload
-    and add them as sideloaded objects instead.
+    Extract embedded objects in an array when an attr is configured for embedded,
+    and add them as side-loaded objects instead.
+
+    A payload with an attr configured for embedded records needs to be extracted:
+
+    ```js
+    {
+      "post": {
+        "id": "1"
+        "title": "Rails is omakase",
+        "comments": [{
+          "id": "1",
+          "body": "Rails is unagi"
+        }, {
+          "id": "2",
+          "body": "Omakase O_o"
+        }]
+      }
+    }
+    ```
+
+    Ember Data is expecting a payload with compound document (side-loaded) like:
+
+    ```js
+    {
+      "post": {
+        "id": "1"
+        "title": "Rails is omakase",
+        "comments": ["1", "2"]
+      },
+      "comments": [{
+        "id": "1",
+        "body": "Rails is unagi"
+      }, {
+        "id": "2",
+        "body": "Omakase O_o"
+      }]
+    }
+    ```
+
+    The payload's `comments` attribute represents records in a `hasMany` relationship
 
     @method extractArray
+    @param {DS.Store} store
+    @param {subclass of DS.Model} primaryType
+    @param {Object} payload
+    @returns {Array<Object>} The primary array that was returned in response
+      to the original query.
   */
-  extractArray: function(store, type, payload) {
-    var root = this.keyForAttribute(type.typeKey),
+  extractArray: function(store, primaryType, payload) {
+    var root = this.keyForAttribute(primaryType.typeKey),
         partials = payload[Ember.String.pluralize(root)];
 
     forEach(partials, function(partial) {
-      updatePayloadWithEmbedded(store, this, type, partial, payload);
+      updatePayloadWithEmbedded.call(this, store, primaryType, payload, partial);
     }, this);
 
-    return this._super(store, type, payload);
+    return this._super(store, primaryType, payload);
   }
 });
 
-function updatePayloadWithEmbedded(store, serializer, type, partial, payload) {
-  var attrs = get(serializer, 'attrs');
+// checks config for embedded flag
+function isEmbedded(config) {
+  return config && (config.embedded === 'always' || config.embedded === 'load');
+}
+
+// used to remove id (foreign key) when embedding
+function removeId(key, json) {
+  var idKey = key + '_id';
+  if (json.hasOwnProperty(idKey)) {
+    delete json[idKey];
+  }
+}
+
+// chooses a relationship kind to branch which function is used to update payload
+// does not change payload if attr is not embedded
+function updatePayloadWithEmbedded(store, type, payload, partial) {
+  var attrs = get(this, 'attrs');
 
   if (!attrs) {
     return;
   }
-
   type.eachRelationship(function(key, relationship) {
-    var expandedKey, embeddedTypeKey, attribute, ids,
-        config = attrs[key],
-        serializer = store.serializerFor(relationship.type.typeKey),
-        primaryKey = get(serializer, "primaryKey");
+    var config = attrs[key];
 
-    if (relationship.kind !== "hasMany") {
-      return;
-    }
-
-    if (config && (config.embedded === 'always' || config.embedded === 'load')) {
-      // underscore forces the embedded records to be side loaded.
-      // it is needed when main type === relationship.type
-      embeddedTypeKey = '_' + Ember.String.pluralize(relationship.type.typeKey);
-      expandedKey = this.keyForRelationship(key, relationship.kind);
-      attribute  = this.keyForAttribute(key);
-      ids = [];
-
-      if (!partial[attribute]) {
-        return;
+    if (isEmbedded(config)) {
+      if (relationship.kind === "hasMany") {
+        updatePayloadWithEmbeddedHasMany.call(this, store, key, relationship, payload, partial);
       }
-
-      payload[embeddedTypeKey] = payload[embeddedTypeKey] || [];
-
-      forEach(partial[attribute], function(data) {
-        var embeddedType = store.modelFor(relationship.type.typeKey);
-        updatePayloadWithEmbedded(store, serializer, embeddedType, data, payload);
-        ids.push(data[primaryKey]);
-        payload[embeddedTypeKey].push(data);
-      });
-
-      partial[expandedKey] = ids;
-      delete partial[attribute];
+      if (relationship.kind === "belongsTo") {
+        updatePayloadWithEmbeddedBelongsTo.call(this, store, key, relationship, payload, partial);
+      }
     }
-  }, serializer);
+  }, this);
+}
+
+// handles embedding for `hasMany` relationship
+function updatePayloadWithEmbeddedHasMany(store, primaryType, relationship, payload, partial) {
+  var serializer = store.serializerFor(relationship.type.typeKey),
+      primaryKey = get(this, 'primaryKey');
+
+  // underscore forces the embedded records to be side loaded.
+  // it is needed when main type === relationship.type
+  var embeddedTypeKey = '_' + Ember.String.pluralize(relationship.type.typeKey);
+  var expandedKey = this.keyForRelationship(primaryType, relationship.kind);
+  var attribute  = this.keyForAttribute(primaryType);
+  var ids = [];
+
+  if (!partial[attribute]) {
+    return;
+  }
+
+  payload[embeddedTypeKey] = payload[embeddedTypeKey] || [];
+
+  forEach(partial[attribute], function(data) {
+    var embeddedType = store.modelFor(relationship.type.typeKey);
+    updatePayloadWithEmbedded.call(serializer, store, embeddedType, payload, data);
+    ids.push(data[primaryKey]);
+    payload[embeddedTypeKey].push(data);
+  });
+
+  partial[expandedKey] = ids;
+  delete partial[attribute];
+}
+
+// handles embedding for `belongsTo` relationship
+function updatePayloadWithEmbeddedBelongsTo(store, primaryType, relationship, payload, partial) {
+  var attrs = this.get('attrs');
+
+  if (!attrs ||
+    !(isEmbedded(attrs[Ember.String.camelize(primaryType)]) || isEmbedded(attrs[primaryType]))) {
+    return;
+  }
+  var serializer = store.serializerFor(relationship.type.typeKey),
+      primaryKey = get(serializer, 'primaryKey'),
+      embeddedTypeKey = Ember.String.pluralize(relationship.type.typeKey),
+      expandedKey = serializer.keyForRelationship(primaryType, relationship.kind),
+      attribute = serializer.keyForAttribute(primaryType);
+
+  if (!partial[attribute]) {
+    return;
+  }
+  payload[embeddedTypeKey] = payload[embeddedTypeKey] || [];
+  var embeddedType = store.modelFor(relationship.type.typeKey);
+  partial[expandedKey] = partial[attribute].id;
+  // Need to move an embedded `belongsTo` object into a pluralized collection
+  payload[embeddedTypeKey].push(partial[attribute]);
+  // Need a reference to the parent so relationship works between both `belongsTo` records
+  partial[attribute][relationship.parentType.typeKey + '_id'] = partial.id;
+  delete partial[attribute];
 }

--- a/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
+++ b/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
@@ -1,5 +1,5 @@
 var get = Ember.get, set = Ember.set;
-var HomePlanet, league, SuperVillain, superVillain, EvilMinion, Comment, env;
+var HomePlanet, league, SuperVillain, superVillain, SecretLab, EvilMinion, Comment, env;
 
 module("integration/embedded_records_mixin - EmbeddedRecordsMixin", {
   setup: function() {
@@ -7,11 +7,17 @@ module("integration/embedded_records_mixin - EmbeddedRecordsMixin", {
       firstName:     DS.attr('string'),
       lastName:      DS.attr('string'),
       homePlanet:    DS.belongsTo("homePlanet"),
+      secretLab:     DS.belongsTo("secretLab"),
       evilMinions:   DS.hasMany("evilMinion")
     });
     HomePlanet = DS.Model.extend({
       name:          DS.attr('string'),
       villains:      DS.hasMany('superVillain')
+    });
+    SecretLab = DS.Model.extend({
+      minionCapacity: DS.attr('number'),
+      vicinity:       DS.attr('string'),
+      superVillain:   DS.belongsTo('superVillain')
     });
     EvilMinion = DS.Model.extend({
       superVillain: DS.belongsTo('superVillain'),
@@ -25,11 +31,13 @@ module("integration/embedded_records_mixin - EmbeddedRecordsMixin", {
     env = setupStore({
       superVillain:   SuperVillain,
       homePlanet:     HomePlanet,
+      secretLab:      SecretLab,
       evilMinion:     EvilMinion,
       comment:        Comment
     });
     env.store.modelFor('superVillain');
     env.store.modelFor('homePlanet');
+    env.store.modelFor('secretLab');
     env.store.modelFor('evilMinion');
     env.store.modelFor('comment');
     env.container.register('serializer:application', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
@@ -44,7 +52,50 @@ module("integration/embedded_records_mixin - EmbeddedRecordsMixin", {
   }
 });
 
-test("extractSingle with embedded objects", function() {
+test("extractSingle with embedded object (belongsTo relationship)", function() {
+  expect(4);
+  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: {embedded: 'always'}
+    }
+  }));
+  var serializer = env.container.lookup("serializer:superVillain");
+
+  var json_hash = {
+    super_villain: {
+      id: "1",
+      first_name: "Tom",
+      last_name: "Dale",
+      home_planet_id: "123",
+      evil_minion_ids: ["1", "2", "3"],
+      secret_lab: {
+        minion_capacity: 5000,
+        vicinity: "California, USA",
+        id: "101"
+      }
+    }
+  };
+
+  var json = serializer.extractSingle(env.store, SuperVillain, json_hash);
+
+  deepEqual(json, {
+    "id": "1",
+    "firstName": "Tom",
+    "lastName": "Dale",
+    "homePlanet": "123",
+    "evilMinions": ["1", "2", "3"],
+    "secretLab": "101"
+  });
+
+  env.store.find("secretLab", 101).then(async(function(secretLab) {
+    equal(secretLab.get('id'), '101');
+    equal(secretLab.get('minionCapacity'), 5000);
+    equal(secretLab.get('vicinity'), 'California, USA');
+  }));
+});
+
+test("extractSingle with embedded objects (hasMany relationship)", function() {
   env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
   env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -406,7 +457,7 @@ test("extractArray with embedded objects of same type, but from separate attribu
   equal(env.store.recordForId("superVillain", "6").get("firstName"), "Trek", "Secondary records found in the store");
 });
 
-test("serialize with embedded objects", function() {
+test("serialize with embedded objects (hasMany relationship)", function() {
   league = env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" });
   var tom = env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league });
 
@@ -425,7 +476,97 @@ test("serialize with embedded objects", function() {
       id: get(tom, "id"),
       first_name: "Tom",
       last_name: "Dale",
-      home_planet_id: get(league, "id")
+      home_planet_id: get(league, "id"),
+      secret_lab_id: null
     }]
+  });
+});
+
+test("seriailize with embedded object (belongsTo relationship)", function() {
+  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: {embedded: 'always'}
+    }
+  }));
+  var serializer = env.container.lookup("serializer:superVillain");
+
+  // records with an id, persisted
+
+  var tom = env.store.createRecord(
+    SuperVillain,
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord(SecretLab, { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" })
+    }
+  );
+
+  var json = serializer.serialize(tom);
+  deepEqual(json, {
+    first_name: get(tom, "firstName"),
+    last_name: get(tom, "lastName"),
+    home_planet_id: get(tom, "homePlanet").get("id"),
+    secret_lab: {
+      id: get(tom, "secretLab").get("id"),
+      minion_capacity: get(tom, "secretLab").get("minionCapacity"),
+      vicinity: get(tom, "secretLab").get("vicinity")
+    }
+  });
+});
+
+test("seriailize with embedded object (belongsTo relationship, new no id)", function() {
+  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: {embedded: 'always'}
+    }
+  }));
+
+  var serializer = env.container.lookup("serializer:superVillain");
+
+  // records without ids, new
+
+  var tom = env.store.createRecord(
+    SuperVillain,
+    { firstName: "Tom", lastName: "Dale",
+      secretLab: env.store.createRecord(SecretLab, { minionCapacity: 5000, vicinity: "California, USA" }),
+      homePlanet: env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" })
+    }
+  );
+
+  var json = serializer.serialize(tom);
+  deepEqual(json, {
+    first_name: get(tom, "firstName"),
+    last_name: get(tom, "lastName"),
+    home_planet_id: get(tom, "homePlanet").get("id"),
+    secret_lab: {
+      minion_capacity: get(tom, "secretLab").get("minionCapacity"),
+      vicinity: get(tom, "secretLab").get("vicinity")
+    }
+  });
+});
+
+test("when related record is not present, serialize embedded record (with a belongsTo relationship) as null", function() {
+  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: {embedded: 'always'}
+    }
+  }));
+  var serializer = env.container.lookup("serializer:superVillain");
+
+  var tom = env.store.createRecord(
+    SuperVillain,
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      homePlanet: env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" })
+    }
+  );
+
+  var json = serializer.serialize(tom);
+  deepEqual(json, {
+    first_name: get(tom, "firstName"),
+    last_name: get(tom, "lastName"),
+    home_planet_id: get(tom, "homePlanet").get("id"),
+    secret_lab: null
   });
 });


### PR DESCRIPTION
See [proposal on discuss.emberjs.com][0]
- DS.ActiveModelSerializer to support embedded hasMany and belongsTo payloads.

[0]:
http://discuss.emberjs.com/t/extend-ds-activemodelserializer-support-for-embedded-objects-belongsto-relationship-using-has-one
