### PR TITLE
Pagination

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -166,8 +166,9 @@ DS.FixtureAdapter = DS.Adapter.extend({
   },
 
   handlePagination: function(array, request) {
-    if( request.page && request.pageSize ) {
-      var start = (request.page - 1) * request.pageSize;
+    if( request.pageSize ) {
+      var page = request.page || 1,
+          start = (page - 1) * request.pageSize;
       return array.slice(start, start + request.pageSize);
     }
     else {

--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -150,14 +150,16 @@ DS.FixtureAdapter = DS.Adapter.extend({
 
   /**
     @method findAll
-    @param  store
-    @param  type
+    @param {DS.Store} store
+    @param {subclass of DS.Model} type
+    @param {DS.Request} request
   */
-  findAll: function(store, type) {
+  findAll: function(store, type, request) {
     var fixtures = this.fixturesForType(type);
 
     Ember.assert("Unable to find fixtures for model type "+type.toString(), fixtures);
 
+    fixtures = store.handlePagination(fixtures, request);
     return this.simulateRemoteCall(function() {
       return fixtures;
     }, this);
@@ -165,17 +167,19 @@ DS.FixtureAdapter = DS.Adapter.extend({
 
   /**
     @method findQuery
-    @param  store
-    @param  type
-    @param  query
-    @param  array
+    @param {DS.Store} store
+    @param {subclass of DS.Model} type
+    @param {Object} query
+    @param {DS.RecordArray} array
+    @param {DS.Request} request
   */
-  findQuery: function(store, type, query, array) {
+  findQuery: function(store, type, query, array, request) {
     var fixtures = this.fixturesForType(type);
 
     Ember.assert("Unable to find fixtures for model type "+type.toString(), fixtures);
 
     fixtures = this.queryFixtures(fixtures, query, type);
+    fixtures = store.handlePagination(fixtures, request);
 
     if (fixtures) {
       return this.simulateRemoteCall(function() {

--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -159,10 +159,20 @@ DS.FixtureAdapter = DS.Adapter.extend({
 
     Ember.assert("Unable to find fixtures for model type "+type.toString(), fixtures);
 
-    fixtures = store.handlePagination(fixtures, request);
+    fixtures = this.handlePagination(fixtures, request);
     return this.simulateRemoteCall(function() {
       return fixtures;
     }, this);
+  },
+
+  handlePagination: function(array, request) {
+    if( request.page && request.pageSize ) {
+      var start = (request.page - 1) * request.pageSize;
+      return array.slice(start, start + request.pageSize);
+    }
+    else {
+      return array;
+    }
   },
 
   /**
@@ -179,7 +189,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
     Ember.assert("Unable to find fixtures for model type "+type.toString(), fixtures);
 
     fixtures = this.queryFixtures(fixtures, query, type);
-    fixtures = store.handlePagination(fixtures, request);
+    fixtures = this.handlePagination(fixtures, request);
 
     if (fixtures) {
       return this.simulateRemoteCall(function() {

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -183,10 +183,10 @@ DS.RESTAdapter = DS.Adapter.extend({
       query.since = request.sinceToken;
     }
     if (request.page) {
-      query.page = request.page;
+      query[this.pageParameter || 'page'] = request.page;
     }
     if (request.pageSize) {
-      query.pageSize = request.pageSize;
+      query[this.pageSizeParameter || 'pageSize'] = request.pageSize;
     }
     return query;
   },

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -183,10 +183,10 @@ DS.RESTAdapter = DS.Adapter.extend({
       query.since = request.sinceToken;
     }
     if (request.page) {
-      query[this.pageParameter || 'page'] = request.page;
+      query[this.pageParameter] = request.page;
     }
     if (request.pageSize) {
-      query[this.pageSizeParameter || 'pageSize'] = request.pageSize;
+      query[this.pageSizeParameter] = request.pageSize;
     }
     return query;
   },

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -148,8 +148,11 @@ DS.RESTAdapter = DS.Adapter.extend({
     @returns Promise
   */
   findAll: function(store, type, request) {
-    var query = this.paginateRequest(null, request);
-    return this.ajax(this.buildURL(type.typeKey), 'GET', { data: query });
+    var query = this.paginateRequest(null, request), hash = {};
+    if (query) {
+      hash.data = query;
+    }
+    return this.ajax(this.buildURL(type.typeKey), 'GET', hash);
   },
 
   /**
@@ -173,12 +176,14 @@ DS.RESTAdapter = DS.Adapter.extend({
     @returns Promise
   */
   findQuery: function(store, type, query, recordArray, request) {
-    query = this.paginateRequest(query || {}, request);
+    query = this.paginateRequest(query, request);
     return this.ajax(this.buildURL(type.typeKey), 'GET', { data: query });
   },
 
   paginateRequest: function(query, request) {
-    query = query ? Ember.$.extend({}, query) : {};
+    if (request.sinceToken || request.page || request.pageSize) {
+      query = query || {};
+    }
     if (request.sinceToken) {
       query.since = request.sinceToken;
     }

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -144,16 +144,11 @@ DS.RESTAdapter = DS.Adapter.extend({
     @see RESTAdapter/ajax
     @param {DS.Store} store
     @param {subclass of DS.Model} type
-    @param {String} sinceToken
+    @param {DS.Request} request
     @returns Promise
   */
-  findAll: function(store, type, sinceToken) {
-    var query;
-
-    if (sinceToken) {
-      query = { since: sinceToken };
-    }
-
+  findAll: function(store, type, request) {
+    var query = this.paginateRequest(null, request);
     return this.ajax(this.buildURL(type.typeKey), 'GET', { data: query });
   },
 
@@ -173,10 +168,27 @@ DS.RESTAdapter = DS.Adapter.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} query
+    @param {DS.RecordArray} recordArray
+    @param {DS.Request} request
     @returns Promise
   */
-  findQuery: function(store, type, query) {
+  findQuery: function(store, type, query, recordArray, request) {
+    query = this.paginateRequest(query || {}, request);
     return this.ajax(this.buildURL(type.typeKey), 'GET', { data: query });
+  },
+
+  paginateRequest: function(query, request) {
+    query = query ? Ember.$.extend({}, query) : {};
+    if (request.sinceToken) {
+      query.since = request.sinceToken;
+    }
+    if (request.page) {
+      query.page = request.page;
+    }
+    if (request.pageSize) {
+      query.pageSize = request.pageSize;
+    }
+    return query;
   },
 
   /**

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -27,6 +27,18 @@ DS.JSONSerializer = Ember.Object.extend({
     return hash;
   },
 
+  /**
+    You can use this method to apply any necessary transformations
+    so that any metadata provided in a response is mapped to the standard 
+    properties: `page`, `pageSize`, `total`, `isFinished`
+    @method normalizeMetadata
+    @param {DS.Model} type
+    @param {Object} hash
+   */
+  normalizeMetadata: function(type, hash) {
+    return hash;
+  },
+
   // SERIALIZE
 
   serialize: function(record, options) {
@@ -144,7 +156,7 @@ DS.JSONSerializer = Ember.Object.extend({
 
   extractMeta: function(store, type, payload) {
     if (payload && payload.meta) {
-      store.metaForType(type, payload.meta);
+      store.metaForType(type, this.normalizeMetadata(type, payload.meta));
       delete payload.meta;
     }
   },

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -137,7 +137,10 @@ DS.JSONSerializer = Ember.Object.extend({
   },
 
   extractArray: function(store, type, payload) {
-    return this.normalize(type, payload);
+    var normalized = Ember.EnumerableUtils.map(payload, function (hash) {
+      return this.normalize(type, hash);
+    }, this);
+    return Ember.A(normalized);
   },
 
   extractMeta: function(store, type, payload) {

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -224,7 +224,7 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     @param {DS.Store} store
     @param {subclass of DS.Model} type the DS.Model class of the records
     @param {} query option query params
-    @param {integer} page optional page number for pagination (0-indexed)
+    @param {integer} page optional page number for pagination (1 is the first page)
    */
   requestFor: function(store, type, query, page) {
     return DS.Request.create({

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -223,14 +223,16 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     @method requestFor
     @param {DS.Store} store
     @param {subclass of DS.Model} type the DS.Model class of the records
+    @param {} query option query params
     @param {integer} page optional page number for pagination (0-indexed)
    */
-  requestFor: function(store, type, page) {
+  requestFor: function(store, type, query, page) {
     return DS.Request.create({
       store: store,
       type: type,
-      pageSize: this.pageSize,
-      page: page
+      query: query,
+      page: page,
+      pageSize: this.pageSize
     });
   }
 

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -243,7 +243,7 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
       type: type,
       query: query,
       page: page,
-      pageSize: this.pageSize
+      pageSize: get(this, 'pageSize')
     });
   }
 

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -2,7 +2,7 @@
   @module ember-data
 */
 
-var get = Ember.get, set = Ember.set;
+var get = Ember.get;
 var map = Ember.ArrayPolyfills.map;
 
 var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'number', 'stack'];
@@ -231,19 +231,28 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
   /**
     Create a Request that may specify a page number and size for pagination.
 
+        var fetchPage = function(store, type, query, page) {
+          return store.findAll(type, page);
+        };
+        var request = adapter.requestFor(store, type, null, 0, fetchPage);
+
     @method requestFor
     @param {DS.Store} store
     @param {subclass of DS.Model} type the DS.Model class of the records
-    @param {} query option query params
+    @param {hash} query option query params
     @param {integer} page optional page number for pagination (1 is the first page)
+    @param {Function} a callback function that can be used to fetch another page.
+      This function is called with arguments: `store`, `type`, `query` and the `page`
+      number to be fetched.
    */
-  requestFor: function(store, type, query, page) {
+  requestFor: function(store, type, query, page, fetchPage) {
     return DS.Request.create({
       store: store,
       type: type,
       query: query,
       page: page,
-      pageSize: get(this, 'pageSize')
+      pageSize: get(this, 'pageSize'),
+      fetchPage: fetchPage
     });
   }
 

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -139,6 +139,23 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
   generateIdForRecord: null,
 
   /**
+   Request parameter to use for the page number.
+   */
+  pageParameter: 'page',
+
+  /**
+   The maximum number of results to be fetched by `findAll` or `findQuery`, optional.
+   @property 
+   */
+  pageSize: null,
+
+  /**
+   Request parameter to use for specifying the page size.
+   @property 
+   */
+  pageSizeParameter: 'pageSize',
+
+  /**
     Proxies to the serializer's `serialize` method.
 
     @method serialize
@@ -210,12 +227,6 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
 
     return Ember.RSVP.all(promises);
   },
-
-  /**
-   The maximum number of results to be fetched by `findAll` or `findQuery`, optional.
-   @property 
-   */
-  pageSize: null,
 
   /**
     Create a Request that may specify a page number and size for pagination.

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -95,9 +95,9 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     Optional
 
     @method findAll
-    @param  store
-    @param  type
-    @param  since
+    @param {DS.Store} store
+    @param {subclass of DS.Model} type
+    @param {DS.Request} request
   */
   findAll: null,
 
@@ -105,10 +105,11 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     Optional
 
     @method findQuery
-    @param  store
-    @param  type
-    @param  query
-    @param  recordArray
+    @param {DS.Store} store
+    @param {subclass of DS.Model} type
+    @param {Object} query
+    @param {DS.RecordArray} recordArray
+    @param {DS.Request} request
   */
   findQuery: null,
 
@@ -208,5 +209,29 @@ DS.Adapter = Ember.Object.extend(DS._Mappable, {
     }, this);
 
     return Ember.RSVP.all(promises);
+  },
+
+  /**
+   The maximum number of results to be fetched by `findAll` or `findQuery`, optional.
+   @property 
+   */
+  pageSize: null,
+
+  /**
+    Create a Request that may specify a page number and size for pagination.
+
+    @method requestFor
+    @param {DS.Store} store
+    @param {subclass of DS.Model} type the DS.Model class of the records
+    @param {integer} page optional page number for pagination (0-indexed)
+   */
+  requestFor: function(store, type, page) {
+    return DS.Request.create({
+      store: store,
+      type: type,
+      pageSize: this.pageSize,
+      page: page
+    });
   }
+
 });

--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -1,4 +1,5 @@
 require("ember-data/system/record_arrays/record_array");
+require("ember-data/system/record_arrays/paginated_array_mixin");
 
 /**
   @module ember-data
@@ -11,50 +12,8 @@ var get = Ember.get, set = Ember.set, computed = Ember.computed;
   @namespace DS
   @extends DS.RecordArray
 */
-DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
+DS.AdapterPopulatedRecordArray = DS.RecordArray.extend(DS.PaginatedArrayMixin, {
   query: null,
-
-  /**
-    The Request that was used to create this record array.
-    @property request
-    @type DS.Request
-  */
-  request: null,
-
-  endPage: null,
-  promiseHead: null,
-
-  init: function() {
-    this._super();
-    var page = this.request.page || 1;
-    set(this, 'startPage', page);
-    set(this, 'endPage', page);
-    this.promiseHead = this.request.deferred.promise;
-  },
-
-  pageBinding: 'request.page',
-
-  pageSize: Ember.computed(function() {
-    var pageSize = get(this, 'meta.pageSize');
-    if (!pageSize) {
-      pageSize = this.request.pageSize;
-    }
-    return pageSize;
-  }).property('meta.pageSize'),
-
-  totalBinding: 'meta.total',
-
-  totalPages: Ember.computed(function() {
-    var pageSize = get(this, 'pageSize'),
-        total = get(this, 'total');
-    if (pageSize > 0 && total !== undefined) {
-      return Math.ceil(total / pageSize);
-    }
-  }).property('pageSize', 'total'),
-
-  isFinished: Ember.computed(function() {
-    return get(this, 'meta.isFinished') || (get(this, 'endPage') >= get(this, 'totalPages'));
-  }).property('meta.isFinished', 'endPage', 'totalPages'),
 
   replace: function() {
     var type = get(this, 'type').toString();
@@ -75,33 +34,6 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
 
     // TODO: does triggering didLoad event should be the last action of the runLoop?
     Ember.run.once(this, 'trigger', 'didLoad');
-  },
-
-  loadMore: function() {
-    var nextPage = +this.endPage + 1,
-        request = this.request,
-        resolver = Ember.RSVP.defer(),
-        reject = resolver.reject,
-        array = this;
-    // ensure that pages are loaded in order
-    this.promiseHead.then(function() {
-      request.promiseHead = request.loadPage(nextPage, array).then(function(more) {
-        set(array, 'endPage', nextPage);
-        array.pushObjects(get(more, 'content'));
-        resolver.resolve(array);
-      }, reject);
-    }, reject);
-    return resolver.promise;
-  },
-
-  loadPage: function( page ) {
-    var request = get(this, 'request'),
-        array = this;
-    return request.loadPage(page).then(function (more) {
-      set(array, 'startPage', page);
-      set(array, 'endPage', page);
-      array.setObjects(get(more, 'content'));
-    });
   }
 
 });

--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -21,6 +21,9 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
   */
   request: null,
 
+  pageBinding: 'request.page',
+  pageSizeBinding: 'request.pageSize',
+
   replace: function() {
     var type = get(this, 'type').toString();
     throw new Error("The result of a server query (on " + type + ") is immutable.");

--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -38,6 +38,14 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
   loadMore: function() {
     var request = get(this, 'request');
     request.loadMore(this);
+  },
+
+  loadPage: function( page ) {
+    var request = get(this, 'request'),
+        that = this;
+    request.loadPage(page).then(function (array) {
+      that.setObjects(get(array, 'content'));
+    });
   }
 
 });

--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -34,27 +34,27 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
 
   pageBinding: 'request.page',
 
-  pageSize: function() {
+  pageSize: Ember.computed(function() {
     var pageSize = get(this, 'meta.pageSize');
-    if( !pageSize ) {
+    if (!pageSize) {
       pageSize = this.request.pageSize;
     }
     return pageSize;
-  }.property('meta.pageSize'),
+  }).property('meta.pageSize'),
 
   totalBinding: 'meta.total',
 
-  totalPages: function() {
+  totalPages: Ember.computed(function() {
     var pageSize = get(this, 'pageSize'),
         total = get(this, 'total');
-    if( pageSize > 0 && total !== undefined ) {
+    if (pageSize > 0 && total !== undefined) {
       return Math.ceil(total / pageSize);
     }
-  }.property('pageSize', 'total'),
+  }).property('pageSize', 'total'),
 
-  isFinished: function() {
+  isFinished: Ember.computed(function() {
     return get(this, 'meta.isFinished') || (get(this, 'endPage') >= get(this, 'totalPages'));
-  }.property('meta.isFinished', 'endPage', 'totalPages'),
+  }).property('meta.isFinished', 'endPage', 'totalPages'),
 
   replace: function() {
     var type = get(this, 'type').toString();

--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -14,6 +14,13 @@ var get = Ember.get, set = Ember.set;
 DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
   query: null,
 
+  /**
+    The Request that was used to create this record array.
+    @property request
+    @type DS.Request
+  */
+  request: null,
+
   replace: function() {
     var type = get(this, 'type').toString();
     throw new Error("The result of a server query (on " + type + ") is immutable.");
@@ -37,14 +44,14 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
 
   loadMore: function() {
     var request = get(this, 'request');
-    request.loadMore(this);
+    return request.loadMore(this);
   },
 
   loadPage: function( page ) {
     var request = get(this, 'request'),
-        that = this;
-    request.loadPage(page).then(function (array) {
-      that.setObjects(get(array, 'content'));
+        array = this;
+    return request.loadPage(page).then(function (more) {
+      array.setObjects(get(more, 'content'));
     });
   }
 

--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -33,5 +33,11 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
 
     // TODO: does triggering didLoad event should be the last action of the runLoop?
     Ember.run.once(this, 'trigger', 'didLoad');
+  },
+
+  loadMore: function() {
+    var request = get(this, 'request');
+    request.loadMore(this);
   }
+
 });

--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -4,7 +4,7 @@ require("ember-data/system/record_arrays/record_array");
   @module ember-data
 */
 
-var get = Ember.get, set = Ember.set;
+var get = Ember.get, set = Ember.set, computed = Ember.computed;
 
 /**
   @class AdapterPopulatedRecordArray
@@ -21,8 +21,40 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
   */
   request: null,
 
+  endPage: null,
+  promiseHead: null,
+
+  init: function() {
+    this._super();
+    var page = this.request.page || 1;
+    set(this, 'startPage', page);
+    set(this, 'endPage', page);
+    this.promiseHead = this.request.deferred.promise;
+  },
+
   pageBinding: 'request.page',
-  pageSizeBinding: 'request.pageSize',
+
+  pageSize: function() {
+    var pageSize = get(this, 'meta.pageSize');
+    if( !pageSize ) {
+      pageSize = this.request.pageSize;
+    }
+    return pageSize;
+  }.property('meta.pageSize'),
+
+  totalBinding: 'meta.total',
+
+  totalPages: function() {
+    var pageSize = get(this, 'pageSize'),
+        total = get(this, 'total');
+    if( pageSize > 0 && total !== undefined ) {
+      return Math.ceil(total / pageSize);
+    }
+  }.property('pageSize', 'total'),
+
+  isFinished: function() {
+    return get(this, 'meta.isFinished') || (get(this, 'endPage') >= get(this, 'totalPages'));
+  }.property('meta.isFinished', 'endPage', 'totalPages'),
 
   replace: function() {
     var type = get(this, 'type').toString();
@@ -46,14 +78,28 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
   },
 
   loadMore: function() {
-    var request = get(this, 'request');
-    return request.loadMore(this);
+    var nextPage = +this.endPage + 1,
+        request = this.request,
+        resolver = Ember.RSVP.defer(),
+        reject = resolver.reject,
+        array = this;
+    // ensure that pages are loaded in order
+    this.promiseHead.then(function() {
+      request.promiseHead = request.loadPage(nextPage, array).then(function(more) {
+        set(array, 'endPage', nextPage);
+        array.pushObjects(get(more, 'content'));
+        resolver.resolve(array);
+      }, reject);
+    }, reject);
+    return resolver.promise;
   },
 
   loadPage: function( page ) {
     var request = get(this, 'request'),
         array = this;
     return request.loadPage(page).then(function (more) {
+      set(array, 'startPage', page);
+      set(array, 'endPage', page);
       array.setObjects(get(more, 'content'));
     });
   }

--- a/packages/ember-data/lib/system/record_arrays/paginated_array_mixin.js
+++ b/packages/ember-data/lib/system/record_arrays/paginated_array_mixin.js
@@ -1,0 +1,85 @@
+/**
+  @module ember-data
+*/
+
+var get = Ember.get, set = Ember.set, computed = Ember.computed;
+
+/**
+  Provides pagination support for `RecordArray`s
+  @class PaginatedArrayMixin
+  @namespace DS
+*/
+
+DS.PaginatedArrayMixin = Ember.Mixin.create({
+
+  /**
+    The Request that was used to create this record array.
+    @property request
+    @type DS.Request
+  */
+  request: null,
+  endPage: null,
+  promiseHead: null,
+
+  init: function() {
+    this._super();
+    var page = this.request.page || 1;
+    set(this, 'startPage', page);
+    set(this, 'endPage', page);
+    this.promiseHead = this.request.deferred.promise;
+  },
+
+  pageBinding: 'request.page',
+
+  pageSize: Ember.computed('meta.pageSize', function() {
+    var pageSize = get(this, 'meta.pageSize');
+    if (!pageSize) {
+      pageSize = this.request.pageSize;
+    }
+    return pageSize;
+  }),
+
+  totalBinding: 'meta.total',
+
+  totalPages: Ember.computed('pageSize', 'total', function() {
+    var pageSize = get(this, 'pageSize'),
+        total = get(this, 'total');
+    if (pageSize > 0 && total !== undefined) {
+      return Math.ceil(total / pageSize);
+    }
+  }),
+
+  isFinished: Ember.computed('meta.isFinished', 'endPage', 'totalPages', function() {
+    return get(this, 'meta.isFinished') || (get(this, 'endPage') >= get(this, 'totalPages'));
+  }),
+
+  loadMore: function() {
+    var nextPage = +this.endPage + 1,
+        request = this.request,
+        array = this;
+    return new Ember.RSVP.Promise(function(resolve, reject) {
+      // ensure that pages are loaded in order
+      return array.promiseHead.then(function() {
+        var nextPromise = request.loadPage(nextPage, array);
+        nextPromise.then(function(more) {
+          set(array, 'endPage', nextPage);
+          array.pushObjects(get(more, 'content'));
+          resolve(array);
+        });
+        request.promiseHead = nextPromise;
+        return nextPromise;
+      });
+    });
+  },
+
+  loadPage: function( page ) {
+    var request = get(this, 'request'),
+        array = this;
+    return request.loadPage(page).then(function (more) {
+      set(array, 'startPage', page);
+      set(array, 'endPage', page);
+      array.setObjects(get(more, 'content'));
+    });
+  }
+
+});

--- a/packages/ember-data/lib/system/request.js
+++ b/packages/ember-data/lib/system/request.js
@@ -1,0 +1,20 @@
+DS.Request = Ember.Object.extend({
+
+  store: null,
+  type: null,
+  promise: null,
+  resolve: null,
+  reject: null,
+  sinceToken: null,
+  page: null,
+  pageSize: null,
+
+  init: function() {
+    this.deferred = Ember.RSVP.defer();
+    this.promise = this.deferred.promise;
+    this.resolve = this.deferred.resolve;
+    this.reject = this.deferred.reject;
+    this.sinceToken = this.store.typeMapFor(this.type).metadata.since;
+  }
+
+});

--- a/packages/ember-data/lib/system/request.js
+++ b/packages/ember-data/lib/system/request.js
@@ -25,9 +25,7 @@ DS.Request = Ember.Object.extend({
   init: function() {
     this.endPage = this.page || 0;
     this.deferred = Ember.RSVP.defer();
-    this.promise = this.promiseHead = this.deferred.promise;
-    this.resolve = this.deferred.resolve;
-    this.reject = this.deferred.reject;
+    this.promiseHead = this.deferred.promise;
     this.sinceToken = this.store.typeMapFor(this.type).metadata.since;
   },
 

--- a/packages/ember-data/lib/system/request.js
+++ b/packages/ember-data/lib/system/request.js
@@ -30,17 +30,23 @@ DS.Request = Ember.Object.extend({
   },
 
   loadMore: function( array ) {
-    var store = get(this, 'store'),
-        type = get(this, 'type'),
-        query = get(this, 'query'),
+    var nextPage = +this.endPage + 1,
         that = this;
-
-    Ember.assert('You tried to call loadMore but no fetchPage method has been provided', this.fetchPage);
+    // ensure that pages are loaded in order
     this.promiseHead.then(function() {
-      that.promiseHead = that.fetchPage(store, type, query, ++that.endPage).then(function(more) {
+      that.promiseHead = that.loadPage(nextPage, array).then(function(more) {
         array.pushObjects(get(more, 'content'));
       });
     });
+  },
+
+  loadPage: function( page ) {
+    var store = get(this, 'store'),
+        type = get(this, 'type'),
+        query = get(this, 'query');
+    Ember.assert('You tried to call loadMore but no fetchPage method has been provided', this.fetchPage);
+    this.endPage = page;
+    return this.fetchPage(store, type, query, page);
   }
 
 });

--- a/packages/ember-data/lib/system/request.js
+++ b/packages/ember-data/lib/system/request.js
@@ -31,20 +31,24 @@ DS.Request = Ember.Object.extend({
 
   loadMore: function( array ) {
     var nextPage = +this.endPage + 1,
-        that = this;
+        request = this,
+        resolver = Ember.RSVP.defer(),
+        reject = resolver.reject;
     // ensure that pages are loaded in order
     this.promiseHead.then(function() {
-      that.promiseHead = that.loadPage(nextPage, array).then(function(more) {
+      request.promiseHead = request.loadPage(nextPage, array).then(function(more) {
         array.pushObjects(get(more, 'content'));
-      });
-    });
+        resolver.resolve(array);
+      }, reject);
+    }, reject);
+    return resolver.promise;
   },
 
   loadPage: function( page ) {
     var store = get(this, 'store'),
         type = get(this, 'type'),
         query = get(this, 'query');
-    Ember.assert('You tried to call loadMore but no fetchPage method has been provided', this.fetchPage);
+    Ember.assert('You tried to call Request.loadPage but no fetchPage method has been provided', this.fetchPage);
     this.endPage = page;
     return this.fetchPage(store, type, query, page);
   }

--- a/packages/ember-data/lib/system/request.js
+++ b/packages/ember-data/lib/system/request.js
@@ -2,7 +2,7 @@
   @module ember-data
 */
 
-var get = Ember.get, set = Ember.set;
+var get = Ember.get;
 
 /**
   @class Request
@@ -13,12 +13,13 @@ DS.Request = Ember.Object.extend({
 
   store: null,
   type: null,
-  promise: null,
-  resolve: null,
-  reject: null,
-  sinceToken: null,
+  query: null,
+  fetchPage: null,
   page: null,
   pageSize: null,
+  sinceToken: null,
+
+  deferred: null,
 
   init: function() {
     this.deferred = Ember.RSVP.defer();
@@ -29,7 +30,7 @@ DS.Request = Ember.Object.extend({
     var store = get(this, 'store'),
         type = get(this, 'type'),
         query = get(this, 'query');
-    Ember.assert('You tried to call Request.loadPage but no fetchPage method has been provided', this.fetchPage);
+    Ember.assert('You tried to call Request.loadPage but no fetchPage function has been provided', this.fetchPage);
     return this.fetchPage(store, type, query, page);
   }
 

--- a/packages/ember-data/lib/system/request.js
+++ b/packages/ember-data/lib/system/request.js
@@ -23,7 +23,7 @@ DS.Request = Ember.Object.extend({
   promiseHead: null,
 
   init: function() {
-    this.endPage = this.page || 0;
+    this.endPage = this.page || 1;
     this.deferred = Ember.RSVP.defer();
     this.promiseHead = this.deferred.promise;
     this.sinceToken = this.store.typeMapFor(this.type).metadata.since;

--- a/packages/ember-data/lib/system/request.js
+++ b/packages/ember-data/lib/system/request.js
@@ -19,29 +19,10 @@ DS.Request = Ember.Object.extend({
   sinceToken: null,
   page: null,
   pageSize: null,
-  endPage: null,
-  promiseHead: null,
 
   init: function() {
-    this.endPage = this.page || 1;
     this.deferred = Ember.RSVP.defer();
-    this.promiseHead = this.deferred.promise;
-    this.sinceToken = this.store.typeMapFor(this.type).metadata.since;
-  },
-
-  loadMore: function( array ) {
-    var nextPage = +this.endPage + 1,
-        request = this,
-        resolver = Ember.RSVP.defer(),
-        reject = resolver.reject;
-    // ensure that pages are loaded in order
-    this.promiseHead.then(function() {
-      request.promiseHead = request.loadPage(nextPage, array).then(function(more) {
-        array.pushObjects(get(more, 'content'));
-        resolver.resolve(array);
-      }, reject);
-    }, reject);
-    return resolver.promise;
+    this.sinceToken = this.store.metadataFor(this.type).since;
   },
 
   loadPage: function( page ) {
@@ -49,7 +30,6 @@ DS.Request = Ember.Object.extend({
         type = get(this, 'type'),
         query = get(this, 'query');
     Ember.assert('You tried to call Request.loadPage but no fetchPage method has been provided', this.fetchPage);
-    this.endPage = page;
     return this.fetchPage(store, type, query, page);
   }
 

--- a/packages/ember-data/lib/system/request.js
+++ b/packages/ember-data/lib/system/request.js
@@ -1,3 +1,14 @@
+/**
+  @module ember-data
+*/
+
+var get = Ember.get, set = Ember.set;
+
+/**
+  @class Request
+  @namespace DS
+*/
+
 DS.Request = Ember.Object.extend({
 
   store: null,
@@ -8,13 +19,30 @@ DS.Request = Ember.Object.extend({
   sinceToken: null,
   page: null,
   pageSize: null,
+  endPage: null,
+  promiseHead: null,
 
   init: function() {
+    this.endPage = this.page || 0;
     this.deferred = Ember.RSVP.defer();
-    this.promise = this.deferred.promise;
+    this.promise = this.promiseHead = this.deferred.promise;
     this.resolve = this.deferred.resolve;
     this.reject = this.deferred.reject;
     this.sinceToken = this.store.typeMapFor(this.type).metadata.since;
+  },
+
+  loadMore: function( array ) {
+    var store = get(this, 'store'),
+        type = get(this, 'type'),
+        query = get(this, 'query'),
+        that = this;
+
+    Ember.assert('You tried to call loadMore but no fetchPage method has been provided', this.fetchPage);
+    this.promiseHead.then(function() {
+      that.promiseHead = that.fetchPage(store, type, query, ++that.endPage).then(function(more) {
+        array.pushObjects(get(more, 'content'));
+      });
+    });
   }
 
 });

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -371,18 +371,18 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     var type = record.constructor,
         id = get(record, 'id'),
-        request = DS.Request.create();
+        resolver = Ember.RSVP.defer();
 
-    record.loadingData(request.deferred.promise);
+    record.loadingData(resolver.promise);
 
     var adapter = this.adapterFor(type);
 
     Ember.assert("You tried to find a record but you have no adapter (for " + type + ")", adapter);
     Ember.assert("You tried to find a record but your adapter (for " + type + ") does not implement 'find'", adapter.find);
 
-    _find(adapter, this, type, id, request);
+    _find(adapter, this, type, id, resolver);
 
-    return request.deferred.promise;
+    return resolver.promise;
   },
 
   /**

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -609,12 +609,11 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
   findQuery: function(type, query, page) {
     type = this.modelFor(type);
 
-    var adapter = this.adapterFor(type),
-        request = adapter.requestFor(this, type, query, page);
-
-    request.fetchPage = function(store, type, query, page) {
+    var adapter = this.adapterFor(type);
+    var fetchPage = function(store, type, query, page) {
       return store.findQuery(type, query, page);
     };
+    var request = adapter.requestFor(this, type, query, page, fetchPage);
 
     var array = DS.AdapterPopulatedRecordArray.create({
       type: type,
@@ -657,12 +656,11 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     @returns Promise
   */
   fetchAll: function(type, array, page) {
-    var adapter = this.adapterFor(type),
-        request = adapter.requestFor(this, type, null, page);
-
-    request.fetchPage = function(store, type, query, page) {
+    var adapter = this.adapterFor(type);
+    var fetchPage = function(store, type, query, page) {
       return store.findAll(type, page);
     };
+    var request = adapter.requestFor(this, type, null, page, fetchPage);
 
     set(array, 'isUpdating', true);
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1320,16 +1320,6 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     return toReturn;
   },
 
-  handlePagination: function(array, request) {
-    if( request.page && request.pageSize ) {
-      var start = request.page * request.pageSize;
-      return array.slice(start, start + request.pageSize);
-    }
-    else {
-      return array;
-    }
-  },
-
   // ......................
   // . PER-TYPE ADAPTERS
   // ......................
@@ -1555,7 +1545,7 @@ function _findAll(adapter, store, type, request) {
 
     var recordArray = DS.AdapterPopulatedRecordArray.create({
       type: type,
-      content: store.handlePagination(store.all(type), request),
+      content: payload,
       meta: store.metadataFor(type),
       store: this,
       request: request

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1543,15 +1543,19 @@ function _findAll(adapter, store, type, request) {
     store.pushMany(type, payload);
     store.didUpdateAll(type);
 
-    var recordArray = DS.AdapterPopulatedRecordArray.create({
-      type: type,
-      content: payload,
-      meta: store.metadataFor(type),
-      store: this,
-      request: request
-    });
-
-    return recordArray;
+    if( request.page ) {
+      var recordArray = DS.AdapterPopulatedRecordArray.create({
+        type: type,
+        meta: store.metadataFor(type),
+        store: store,
+        request: request
+      });
+      recordArray.load(payload);
+      return recordArray;
+    }
+    else {
+      return store.all(type);
+    }
   }).then(request.deferred.resolve, request.deferred.reject);
 }
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -373,7 +373,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
         id = get(record, 'id'),
         request = DS.Request.create();
 
-    record.loadingData(request.promise);
+    record.loadingData(request.deferred.promise);
 
     var adapter = this.adapterFor(type);
 
@@ -382,7 +382,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     _find(adapter, this, type, id, request);
 
-    return request.promise;
+    return request.deferred.promise;
   },
 
   /**
@@ -629,7 +629,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     _findQuery(adapter, this, type, query, array, request);
 
-    return promiseArray(request.promise);
+    return promiseArray(request.deferred.promise);
   },
 
   /**
@@ -667,7 +667,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     _findAll(adapter, this, type, request);
 
-    return promiseArray(request.promise);
+    return promiseArray(request.deferred.promise);
   },
 
   /**
@@ -1558,7 +1558,7 @@ function _findAll(adapter, store, type, request) {
     });
 
     return recordArray;
-  }).then(request.resolve, request.reject);
+  }).then(request.deferred.resolve, request.deferred.reject);
 }
 
 function _findQuery(adapter, store, type, query, recordArray, request) {
@@ -1572,7 +1572,7 @@ function _findQuery(adapter, store, type, query, recordArray, request) {
 
     recordArray.load(payload);
     return recordArray;
-  }).then(request.resolve, request.reject);
+  }).then(request.deferred.resolve, request.deferred.reject);
 }
 
 function _commit(adapter, store, operation, record, resolver) {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1304,7 +1304,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
   relationshipChangePairsFor: function(record){
     var toReturn = [];
 
-    if( !record ) { return toReturn; }
+    if (!record) { return toReturn; }
 
     //TODO(Igor) What about the other side
     var changesObject = this._relationshipChanges[record.clientId];
@@ -1543,7 +1543,7 @@ function _findAll(adapter, store, type, request) {
     store.pushMany(type, payload);
     store.didUpdateAll(type);
 
-    if( request.pageSize ) {
+    if (request.pageSize || store.metadataFor(type).pageSize) {
       var recordArray = DS.AdapterPopulatedRecordArray.create({
         type: type,
         meta: store.metadataFor(type),

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -993,7 +993,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     typeMap = {
       idToRecord: {},
       records: [],
-      metadata: {}
+      metadata: Ember.Object.create()
     };
 
     typeMaps[guid] = typeMap;
@@ -1199,7 +1199,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
   metaForType: function(type, metadata) {
     type = this.modelFor(type);
 
-    Ember.merge(this.typeMapFor(type).metadata, metadata);
+    this.typeMapFor(type).metadata.setProperties(metadata);
   },
 
   /**

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1543,7 +1543,7 @@ function _findAll(adapter, store, type, request) {
     store.pushMany(type, payload);
     store.didUpdateAll(type);
 
-    if( request.page ) {
+    if( request.pageSize ) {
       var recordArray = DS.AdapterPopulatedRecordArray.create({
         type: type,
         meta: store.metadataFor(type),

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -603,7 +603,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     @private
     @param {String} type
     @param {any} query an opaque query to be used by the adapter
-    @param {integer} page optional page number for pagination (0-indexed)
+    @param {integer} page optional page number for pagination (1 is the first page)
     @return Promise
   */
   findQuery: function(type, query, page) {
@@ -639,7 +639,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     @method findAll
     @param {Class} type
-    @param {integer} page optional page number for pagination (0-indexed)
+    @param {integer} page optional page number for pagination (1 is the first page)
     @return {DS.AdapterPopulatedRecordArray}
   */
   findAll: function(type, page) {
@@ -653,12 +653,16 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     @private
     @param {Class} type
     @param array
-    @param {integer} page optional page number for pagination (0-indexed)
+    @param {integer} page optional page number for pagination (1 is the first page)
     @returns Promise
   */
   fetchAll: function(type, array, page) {
     var adapter = this.adapterFor(type),
         request = adapter.requestFor(this, type, null, page);
+
+    request.fetchPage = function(store, type, query, page) {
+      return store.findAll(type, page);
+    };
 
     set(array, 'isUpdating', true);
 

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -876,6 +876,18 @@ test('normalizeKey - to set up _ids and _id', function() {
   }));
 });
 
+test("findAll - page and page size are included in the request", function() {
+  ajaxResponse({ posts: [{ id: 1, name: "Rails is omakase" }, { id: 2, name: "The Parley Letter" }] });
+  var page = 1, pageSize = 10;
+  adapter.set('pageSize', pageSize);
+  store.findAll('post', page).then(async(function(posts) {
+    var test = {};
+    test[adapter.pageParameter] = page;
+    test[adapter.pageSizeParameter] = pageSize;
+    deepEqual(passedHash.data, test);
+  }));
+});
+
 //test("creating a record with a 422 error marks the records as invalid", function(){
   //expect(1);
 

--- a/packages/ember-data/tests/unit/pagination_test.js
+++ b/packages/ember-data/tests/unit/pagination_test.js
@@ -1,0 +1,54 @@
+var get = Ember.get, set = Ember.set;
+var resolve = Ember.RSVP.resolve;
+var env, Person, Phone, Adapter, pageSize = 1;
+
+module("unit/pagination - Pagination", {
+  setup: function() {
+    // TestAdapter = DS.Adapter.extend();
+    Person = DS.Model.extend({
+      name: DS.attr('string'),
+      phones: DS.hasMany('phone', { async: true })
+    });
+
+    Phone = DS.Model.extend({
+      person: DS.belongsTo('person')
+    });
+
+    Adapter = DS.FixtureAdapter.extend({
+      queryFixtures: function(fixtures, query, type) {
+        return fixtures;
+      }
+    });
+
+    env = setupStore({ person: Person, phone: Phone, adapter: Adapter });
+    // env.adapter.simulateRemoteResponse = true;
+    set(env.adapter, 'pageSize', pageSize);
+  },
+  teardown: function() {
+    if (env.store) { env.store.destroy(); }
+  }
+});
+
+test("findAll takes an optional page number and paginates the results", function() {
+  var page = 1;
+  Person.FIXTURES = [
+    {id: 1, name: 'Dimebag Dale'},
+    {id: 2, name: 'Yehuda Brynjolffsosysdfon'}
+  ];
+  env.store.findAll(Person, 1).then(async(function(results) {
+    equal(get(results, 'length'), pageSize);
+    equal(get(results.objectAt(0), 'id'), 1);
+  }));
+});
+
+test("findQuery takes an optional page number and paginates the results", function() {
+  var page = 1;
+  Person.FIXTURES = [
+    {id: 1, name: 'Dimebag Dale'},
+    {id: 2, name: 'Yehuda Brynjolffsosysdfon'}
+  ];
+  env.store.findQuery(Person, {}, 2).then(async(function(results) {
+    equal(get(results, 'length'), pageSize);
+    equal(get(results.objectAt(0), 'id'), 2);
+  }));
+});

--- a/packages/ember-data/tests/unit/record_array_test.js
+++ b/packages/ember-data/tests/unit/record_array_test.js
@@ -1,7 +1,7 @@
 var get = Ember.get, set = Ember.set;
 var indexOf = Ember.EnumerableUtils.indexOf;
 
-var Person, array, adapter;
+var Person, array, adapter, passedUrl, passedVerb, passedHash;
 
 function ajaxResponse(adapter, value) {
   adapter.ajax = function(url, verb, hash) {

--- a/packages/ember-data/tests/unit/record_array_test.js
+++ b/packages/ember-data/tests/unit/record_array_test.js
@@ -146,3 +146,41 @@ test("an AdapterPopulatedRecordArray knows if it's loaded or not", function() {
     equal(get(people, 'isLoaded'), true, "The array is now loaded");
   }));
 });
+
+test("an AdapterPopulatedRecordArray can load more records", function() {
+  var env = setupStore({ person: Person, adapter: DS.FixtureAdapter }),
+      store = env.store;
+
+  Person.FIXTURES = [
+    {id: 1, name: 'Dimebag Dale'},
+    {id: 2, name: 'Yehuda Brynjolffsosysdfon'}
+  ];
+
+  store.adapterFor(Person).set('pageSize', 1);
+  store.findAll('person').then(async(function(people) {
+    equal(get(people, 'length'), 1, "First page of results loaded");
+    people.loadMore().then(async(function() {
+      equal(get(people, 'length'), 2, "Second page of results loaded");
+    }));
+  }));
+});
+
+test("an AdapterPopulatedRecordArray can load a specific page", function() {
+  var env = setupStore({ person: Person, adapter: DS.FixtureAdapter }),
+      store = env.store;
+
+  Person.FIXTURES = [
+    {id: 1, name: 'Dimebag Dale'},
+    {id: 2, name: 'Yehuda Brynjolffsosysdfon'},
+    {id: 3, name: 'Brynjolffsosysdfon Katz'}
+  ];
+
+  store.adapterFor(Person).set('pageSize', 1);
+  store.findAll('person').then(async(function(people) {
+    equal(get(people, 'length'), 1, "First page of results loaded");
+    people.loadPage(3).then(async(function() {
+      equal(get(people, 'length'), 1, "Only one page is loaded at a time");
+      equal(people.objectAt(0).get('id'), 3, "Third page of results loaded");
+    }));
+  }));
+});

--- a/packages/ember-data/tests/unit/record_array_test.js
+++ b/packages/ember-data/tests/unit/record_array_test.js
@@ -184,3 +184,20 @@ test("an AdapterPopulatedRecordArray can load a specific page", function() {
     }));
   }));
 });
+
+test("an AdapterPopulatedRecordArray contains the requested page and pageSize", function() {
+  var env = setupStore({ person: Person, adapter: DS.FixtureAdapter }),
+      store = env.store, pageSize = 1, page = 2;
+
+  Person.FIXTURES = [
+    {id: 1, name: 'Dimebag Dale'},
+    {id: 2, name: 'Yehuda Brynjolffsosysdfon'},
+    {id: 3, name: 'Brynjolffsosysdfon Katz'}
+  ];
+
+  store.adapterFor(Person).set('pageSize', pageSize);
+  store.findAll('person', page).then(async(function(people) {
+    equal(get(people, 'page'), page);
+    equal(get(people, 'pageSize'), pageSize);
+  }));
+});


### PR DESCRIPTION
This PR adds the foundation for pagination support in Ember Data. Example usage using an 'infinite-scroll' `loadMore` approach can be [seen here](http://emberjs.jsbin.com/cofi/latest/edit). The goal of this PR is to provide the underlying requirements to support pagination, so that the community can iterate on rest of the implementation in userland until we've got something we're happy with.

The solution adds a `DS.Request` class to contain information about the parameters that were used to create a given `AdapterPopulatedArray`, thereby allowing for more pages of results to be fetched from the server.

I've folded the `sinceToken` into the `Request` class, but this is the only 'breaking' change. So `Adapter.findAll: function(store, type, sinceToken)` is now `Adapter.findAll: function(store, type, request)`.

Please feel free to offer any feedback - I've tried to stay close to the style of the rest of the project, but happy to take on board any feedback.

One possible concern is that I'm using `page` and `pageSize` parameters which is nice and simple but there's an edge case where the `pageSize` changes and leads to duplicate/missing records in the series of pages. I'd prefer to use `offset` and `limit`, but the common practice seems to be `page` and `pageSize` so I've used this approach instead.

# Todo

- Currently only `findQuery()` and `findAll()` support pagination, I'll add support for the other `find...()` methods now