### PR TITLE
store.filter should always return a FilteredRecordArray

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -762,7 +762,7 @@ DS.Store = Ember.Object.extend({
     @param {Class} type
     @param {Object} query optional query
     @param {Function} filter
-    @return {DS.FilteredRecordArray}
+    @return {DS.PromiseArray}
   */
   filter: function(type, query, filter) {
     var promise;
@@ -785,12 +785,11 @@ DS.Store = Ember.Object.extend({
     });
 
     this.recordArrayManager.registerFilteredRecordArray(array, type, filter);
+    promise = promise || resolve(array);
 
-    if (promise) {
-      return promise.then(function() { return array; }, null, "DS: Store#filter of " + type);
-    } else {
+    return promiseArray(promise.then(function() {
       return array;
-    }
+    }, null, "DS: Store#filter of " + type));
   },
 
   /**


### PR DESCRIPTION
This pull request makes the `store.filter` method return a `promiseArray` when a 3rd `query` argument is provided. 

Currently `store.filter` returns a promise when the `query` argument is provided and a `DS.FilteredRecordArray` when the `query` argument is not present. Returning a `promiseArray` will allow users to treat the output from `store.filter` as an array in all cases while still supporting users that expect promises.

Returning a promiseArray is also consistent with other store methods such as `findAll` and `findQuery`.
