### PR TITLE
Created a default queryFixtures

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -78,7 +78,8 @@ DS.FixtureAdapter = DS.Adapter.extend({
   },
 
   /**
-    Implement this method in order to query fixtures data
+    Return all fixtures that match the query.
+    When the query is empty, all fixtures are returned.
 
     @method queryFixtures
     @param {Array} fixture
@@ -87,7 +88,14 @@ DS.FixtureAdapter = DS.Adapter.extend({
     @return {Promise|Array}
   */
   queryFixtures: function(fixtures, query, type) {
-    Ember.assert('Not implemented: You must override the DS.FixtureAdapter::queryFixtures method to support querying the fixture store.');
+    return fixtures.filter(function(record) {
+      for(var key in query) {
+        if (!query.hasOwnProperty(key)) { continue; }
+        var value = query[key];
+        if (record[key] !== value) { return false; }
+      }
+      return true;
+    });
   },
 
   /**

--- a/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
@@ -259,3 +259,36 @@ test("should throw if ids are not defined in the FIXTURES", function() {
     ok(false, "should not get here");
   });
 });
+
+test("should filter the fixtures", function() {
+  Person.FIXTURES = [{
+    id: 1,
+    firstName: "Adam",
+    lastName: "Hawkins",
+    height: 65
+  },{
+    id: 2,
+    firstName: 'Yehuda',
+    lastName: 'Katz',
+    height: 50
+  }];
+
+  env.store.find('person', { firstName: 'Adam', lastName: 'Hawkins' }).then(async(function(found) {
+    equal(get(found, 'length'), 1);
+    equal(get(found, 'firstObject.firstName'), 'Adam');
+  }), function() {
+    ok(false, "should not get here");
+  });
+
+  env.store.find('person', { firstName: 'Yehuda', lastName: 'KATZ' }).then(async(function(found) {
+    equal(get(found, 'length'), 0);
+  }), function() {
+    ok(false, "should not get here");
+  });
+
+  env.store.find('person', {}).then(async(function(found) {
+    equal(get(found, 'length'), 2);
+  }), function() {
+    ok(false, "should not get here");
+  });
+});


### PR DESCRIPTION
I think there isn't problem in give a default implementation for queryFixutres.
This is also requested [here](https://github.com/emberjs/data/pull/706#issuecomment-25315628)
