### PR TITLE
Expose ManyArray name property

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -48,6 +48,14 @@ DS.ManyArray = DS.RecordArray.extend({
   },
 
   /**
+    The property name of the relationship
+
+    @property {String}
+    @private
+  */
+  name: null,
+
+  /**
     The record to which this relationship belongs.
 
     @property {DS.Model}


### PR DESCRIPTION
This property is setup [here](https://github.com/emberjs/data/blob/6a2c661e66acc175370507b9ac5bdc1c782b2c59/packages/ember-data/lib/system/relationships/has_many.js#L43) but is not documented.
