### PR TITLE
Allow `recordIsLoaded` to be called with a string for the type.

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -399,8 +399,6 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     @param id
   */
   getById: function(type, id) {
-    type = this.modelFor(type);
-
     if (this.hasRecordForId(type, id)) {
       return this.recordForId(type, id);
     } else {
@@ -483,7 +481,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
   */
   hasRecordForId: function(type, id) {
     id = coerceId(id);
-
+    type = this.modelFor(type);
     return !!this.typeMapFor(type).idToRecord[id];
   },
 
@@ -786,7 +784,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     will result in a request or that it will be a cache hit.
 
     @method recordIsLoaded
-    @param {Class} type
+    @param type
     @param {string} id
     @return {boolean}
   */

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -176,7 +176,9 @@ module("unit/model - with a simple Person model", {
     Person = DS.Model.extend({
       name: DS.attr('string')
     });
-    store = createStore();
+    store = createStore({
+      person: Person
+    });
     store.pushMany(Person, array);
   },
   teardown: function() {
@@ -209,7 +211,9 @@ test("when a DS.Model updates its attributes, its changes affect its filtered Ar
 
 test("can ask if record with a given id is loaded", function() {
   equal(store.recordIsLoaded(Person, 1), true, 'should have person with id 1');
-  equal(store.recordIsLoaded(Person, 4), false, 'should not have person with id 2');
+  equal(store.recordIsLoaded('person', 1), true, 'should have person with id 1');
+  equal(store.recordIsLoaded(Person, 4), false, 'should not have person with id 4');
+  equal(store.recordIsLoaded('person', 4), false, 'should not have person with id 4');
 });
 
 test("a listener can be added to a record", function() {


### PR DESCRIPTION
`recordIsLoaded` did not support execution with a string as the `type`
argument, only a DS.Model class reference. This commit makes either
form possible. Consistent with `find`, the `type` argument is
passed through `modelFor` to resolve a class reference.
