### PR TITLE
Make many arrays update correctly

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -123,7 +123,24 @@ var ManyArray = RecordArray.extend({
         resolver = Ember.RSVP.defer("DS: ManyArray#fetch " + get(this, 'type'));
 
     var unloadedRecords = records.filterProperty('isEmpty', true);
-    store.fetchMany(unloadedRecords, owner, resolver);
+    store.fetchMany(this, unloadedRecords, owner, resolver);
+  },
+
+  update: function() {
+    var records = get(this, 'content'),
+        store = get(this, 'store'),
+        owner = get(this, 'owner'),
+        type = get(this, 'type'),
+        name = get(this, 'name'),
+        resolver = Ember.RSVP.defer();
+
+      var meta = owner.constructor.metaForProperty(name);
+      var link = owner._data.links && owner._data.links[meta.key];
+      if (link) {
+        store.fetchHasMany(this, owner, link, meta, resolver);
+      } else {
+        store.fetchMany(this, records, owner, resolver);
+      }
   },
 
   // Overrides Ember.Array's replace method to implement

--- a/packages/ember-data/tests/unit/store/adapter_interop_test.js
+++ b/packages/ember-data/tests/unit/store/adapter_interop_test.js
@@ -331,7 +331,8 @@ test("store.fetchMany should not resolve until all the records are resolve", fun
     adapter: adapter
   });
 
-  var owner = store.createRecord(Person);
+  var owner = store.createRecord(Person),
+    manyArray = DS.ManyArray.create();
 
   var records = Ember.A([
     store.recordForId(Person, 10),
@@ -339,7 +340,7 @@ test("store.fetchMany should not resolve until all the records are resolve", fun
     store.recordForId(Phone, 21)
   ]);
 
-  store.fetchMany(records, owner).then(async(function() {
+  store.fetchMany(manyArray, records, owner).then(async(function() {
     var unloadedRecords = records.filterBy('isEmpty');
     equal(get(unloadedRecords, 'length'), 0, 'All unloaded records should be loaded');
   }));


### PR DESCRIPTION
At the moment, when `update` method is called in a many array, the record array implementation is taken, and this make the `adapter.findAll` be called. For example: `post.get('comments').update()` will send a request to `/comments`.

With this PR when a many array call update, is used `adapter.findMany` so a request is sent to `/comments?ids[]=1&ds[]=2&ds[]=3...`

In the case of a payload with links the `adapter.findHasMany` is used and a resquest is sent to `/post/1/comments`.

//cc @bradleypriest @sly7-7
