### PR TITLE
Removing deleted records from RecordArrays is now async.

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -267,10 +267,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   updateRecordArrays: function() {
-    var store = get(this, 'store');
-    if (store) {
-      store.dataWasUpdated(this.constructor, this);
-    }
+    get(this, 'store').dataWasUpdated(this.constructor, this);
   },
 
   /**

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -587,9 +587,7 @@ var RootState = {
 
     // TRANSITIONS
     setup: function(record) {
-      var store = get(record, 'store');
-
-      store.recordArrayManager.remove(record);
+      record.updateRecordArrays();
     },
 
     // SUBSTATES

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -811,8 +811,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     If the adapter updates attributes or acknowledges creation
     or deletion, the record will notify the store to update its
     membership in any filters.
-
     To avoid thrashing, this method is invoked only once per
+
     run loop per record.
 
     @method dataWasUpdated
@@ -822,20 +822,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     @param {DS.Model} record
   */
   dataWasUpdated: function(type, record) {
-    // Because data updates are invoked at the end of the run loop,
-    // it is possible that a record might be deleted after its data
-    // has been modified and this method was scheduled to be called.
-    //
-    // If that's the case, the record would have already been removed
-    // from all record arrays; calling updateRecordArrays would just
-    // add it back. If the record is deleted, just bail. It shouldn't
-    // give us any more trouble after this.
-
-    if (get(record, 'isDeleted')) { return; }
-
-    if (get(record, 'isLoaded')) {
-      this.recordArrayManager.recordDidChange(record);
-    }
+    this.recordArrayManager.recordDidChange(record);
   },
 
   // ..............

--- a/packages/ember-data/tests/integration/records/delete_record_test.js
+++ b/packages/ember-data/tests/integration/records/delete_record_test.js
@@ -1,0 +1,60 @@
+var get = Ember.get, set = Ember.set;
+var attr = DS.attr;
+var Person, env;
+
+module("integration/deletedRecord - Deleting Records", {
+  setup: function() {
+    Person = DS.Model.extend({
+      name: attr('string')
+    });
+
+    Person.toString = function() { return "Person"; };
+
+    env = setupStore({
+      person: Person
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function(){
+      env.container.destroy();
+    });
+  }
+});
+
+test("records can be deleted during record array enumeration", function () {
+  var adam = env.store.push('person', {id: 1, name: "Adam Sunderland"});
+  var dave = env.store.push('person', {id: 2, name: "Dave Sunderland"});
+  var all  = env.store.all('person');
+
+  // pre-condition
+  equal(all.get('length'), 2, 'expected 2 records');
+
+  Ember.run(function(){
+    all.forEach(function(record) {
+      record.deleteRecord();
+    });
+  });
+
+  equal(all.get('length'), 0, 'expected 0 records');
+});
+
+test("when deleted records are rolled back, they are still in their previous record arrays", function () {
+  var jaime = env.store.push('person', {id: 1, name: "Jaime Lannister"});
+  var cersei = env.store.push('person', {id: 2, name: "Cersei Lannister"});
+  var all = env.store.all('person');
+  var filtered = env.store.filter('person', function () {
+    return true;
+  });
+
+  equal(all.get('length'), 2, 'precond - we start with two people');
+  equal(filtered.get('length'), 2, 'precond - we start with two people');
+
+  Ember.run(function () {
+    jaime.deleteRecord();
+    jaime.rollback();
+  });
+
+  equal(all.get('length'), 2, 'record was not removed');
+  equal(filtered.get('length'), 2, 'record was not removed');
+});

--- a/packages/ember-data/tests/integration/records/unload_test.js
+++ b/packages/ember-data/tests/integration/records/unload_test.js
@@ -14,14 +14,18 @@ module("integration/unload - Unloading Records", {
   },
 
   teardown: function() {
-    env.container.destroy();
+    Ember.run(function(){
+      env.container.destroy();
+    });
   }
 });
 
 test("can unload a single record", function () {
   var adam = env.store.push('person', {id: 1, name: "Adam Sunderland"});
 
-  adam.unloadRecord();
+  Ember.run(function(){
+    adam.unloadRecord();
+  });
 
   equal(env.store.all('person').get('length'), 0);
 });
@@ -30,7 +34,9 @@ test("can unload all records for a given type", function () {
   var adam = env.store.push('person', {id: 1, name: "Adam Sunderland"});
   var bob = env.store.push('person', {id: 2, name: "Bob Bobson"});
 
-  env.store.unloadAll('person');
+  Ember.run(function(){
+    env.store.unloadAll('person');
+  });
 
   equal(env.store.all('person').get('length'), 0);
 });

--- a/packages/ember-data/tests/unit/model/rollback_test.js
+++ b/packages/ember-data/tests/unit/model/rollback_test.js
@@ -81,7 +81,7 @@ test("new record can be rollbacked", function() {
   equal(person.get('isNew'), true, "must be new");
   equal(person.get('isDirty'), true, "must be dirty");
 
-  person.rollback();
+  Ember.run(person, 'rollback');
 
   equal(person.get('isNew'), false, "must not be new");
   equal(person.get('isDirty'), false, "must not be dirty");

--- a/packages/ember-data/tests/unit/store/unload_test.js
+++ b/packages/ember-data/tests/unit/store/unload_test.js
@@ -17,7 +17,7 @@ module("unit/store/unload - Store unloading records", {
   },
 
   teardown: function() {
-    store.destroy();
+    Ember.run(store, 'destroy');
   }
 });
 


### PR DESCRIPTION
Previously filtered record arrays were updated asynchronously when records were added, but record arrays were updated synchronously when records were deleted.  This led to surprising behavior such as:

``` js

myRecordArray.get('length') // => 2
myRecordArray.invoke('deleteRecord');

// we didn't delete everything, because we mutated the record array during iteration
myRecordArray.get('length') // => 1
```

Now all record array updating goes through the same code path.

-- David J. Hamilton & Stefan Penner
