### PR TITLE
Throw instead of assert in `modelFor` when type can't be resolved.

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1011,7 +1011,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
 
     if (typeof key === 'string') {
       factory = this.container.lookupFactory('model:' + key);
-      Ember.assert("No model was found for '" + key + "'", factory);
+      if (!factory) { throw new Ember.Error("No model was found for '" + key + "'"); }
       factory.typeKey = key;
     } else {
       // A factory already supplied.

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -72,6 +72,23 @@ test("extractArray with custom typeForRoot", function() {
   }));
 });
 
+test("extractArray failure with custom typeForRoot", function() {
+  env.restSerializer.typeForRoot = function(root) {
+    //should be camelized too, but, whoops, the developer forgot!
+    return Ember.String.singularize(root);
+  };
+
+  var json_hash = {
+    home_planets: [{id: "1", name: "Umber", superVillains: [1]}],
+    super_villains: [{id: "1", firstName: "Tom", lastName: "Dale", homePlanet: "1"}]
+  };
+
+  raises(function(){
+    env.restSerializer.extractArray(env.store, HomePlanet, json_hash);
+  }, "No model was found for 'home_planets'",
+  "raised error message expected to contain \"No model was found for 'home_planets'\"");
+});
+
 test("serialize polymorphicType", function() {
   var tom = env.store.createRecord(YellowMinion,   {name: "Alex", id: "124"});
   var ray = env.store.createRecord(DoomsdayDevice, {evilMinion: tom, name: "DeathRay"});


### PR DESCRIPTION
Background: Asserts are stripped out of production builds. In production,
it is possible that a root key in an API response changes in a way that
your serializer's `typeForRoot` implementation does not convert properly.
Since the assert in `modelFor` is stripped in production builds, the
javascript error raised in a production environment would be:

  "Cannot set property 'typeKey' on undefined"

This commit changes the assert to a check and throw so the error
raised would be something like:

  "No model was found for 'home_planet'"

The provides a much more helpful error for real-world production
errors at a relatively small price (one extra line of code and
a simple value check).
