### PR TITLE
Fix Travis failures and publishing of builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
 install:
 - "npm install"
 - "bundle install --deployment"
+- sudo apt-get update && sudo apt-get install git
 script: rake test[all]
 after_success: bundle exec rake publish_build
 notifications:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 56b02fa1e623c6a22c793bd9d24b5be0bcd98f4b
+  revision: 75023dad4926fa9aacc0a53fa42dadcde3d30c4e
   branch: master
   specs:
     ember-dev (0.1)
@@ -33,12 +33,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.25.0)
+    aws-sdk (1.29.1)
       json (~> 1.4)
-      nokogiri (>= 1.4.4, < 1.6.0)
+      nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
     colored (1.2)
     diff-lcs (1.2.5)
     ember-source (1.1.0)
@@ -51,16 +49,20 @@ GEM
       posix-spawn (~> 0.3.6)
     handlebars-source (1.0.12)
     json (1.8.1)
-    kicker (2.6.1)
-      listen
-    listen (2.2.0)
-      celluloid (>= 0.15.2)
+    kicker (3.0.0)
+      listen (~> 1.3.0)
+      notify (~> 0.5.2)
+    listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    mime-types (1.25)
-    nokogiri (1.5.10)
-    posix-spawn (0.3.6)
-    puma (2.6.0)
+      rb-kqueue (>= 0.2)
+    mime-types (1.25.1)
+    mini_portile (0.5.2)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
+    notify (0.5.2)
+    posix-spawn (0.3.8)
+    puma (2.7.1)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
     rake (10.1.0)
@@ -70,9 +72,10 @@ GEM
     rb-fsevent (0.9.3)
     rb-inotify (0.9.2)
       ffi (>= 0.5.0)
+    rb-kqueue (0.2.0)
+      ffi (>= 0.5.0)
     thor (0.18.1)
-    timers (1.1.0)
-    uglifier (2.3.1)
+    uglifier (2.3.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     uuidtools (2.1.4)


### PR DESCRIPTION
Updates to the latest ember-dev which ensures that the git config
user.name and git config user.email values are present before calling
git cherry-pick. This is due to a recent change in git 1.8.5 which
requires the user information be present prior to a cherry-pick.

Travis accidentally reverted to using an older git version that does not 
support the `--points-at` flag that we are using in `ember-dev`.

This forces the system to upgrade to the latest version.

Travis ticket for reference: 
https://github.com/travis-ci/travis-ci/issues/1710.
