### PR TITLE
Update header comment format to keep it on minify

### DIFF
--- a/generators/license.js
+++ b/generators/license.js
@@ -1,7 +1,6 @@
-// ==========================================================================
-// Project:   Ember Data
-// Copyright: Copyright 2011-2013 Tilde Inc. and contributors.
-//            Portions Copyright 2011 LivingSocial Inc.
-// License:   Licensed under MIT license (see license.js)
-// ==========================================================================
-
+/*!
+ * @overview  Ember Data
+ * @copyright Copyright 2011-2013 Tilde Inc. and contributors.
+ *            Portions Copyright 2011 LivingSocial Inc.
+ * @license   Licensed under MIT license (see license.js)
+ */


### PR DESCRIPTION
Some minifier keep header comment over its format.
1. YUI Compressor
   It keeps the header comments beggining with `/*!`
   - http://yui.github.io/yuicompressor/css.html#special-comments
2. Closure compiler
   It keeps the header comments containing `@license` or `@preserve`
   - https://developers.google.com/closure/compiler/docs/js-for-compiler#tag-license

I think header comment is very important because it includes its own license.

This PR is the same change as emberjs/ember.js#3865.
