### PR TITLE
[BUGFIX] Clean up findAllCache after unloading all records.

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -719,6 +719,8 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
     while(record = records.pop()) {
       record.unloadRecord();
     }
+
+    typeMap.findAllCache = null;
   },
 
   /**

--- a/packages/ember-data/tests/integration/records/unload_test.js
+++ b/packages/ember-data/tests/integration/records/unload_test.js
@@ -40,3 +40,15 @@ test("can unload all records for a given type", function () {
 
   equal(env.store.all('person').get('length'), 0);
 });
+
+test("removes findAllCache after unloading all records", function () {
+  var adam = env.store.push('person', {id: 1, name: "Adam Sunderland"});
+  var bob = env.store.push('person', {id: 2, name: "Bob Bobson"});
+
+  Ember.run(function(){
+    env.store.all('person');
+    env.store.unloadAll('person');
+  });
+
+  equal(env.store.all('person').get('length'), 0);
+});


### PR DESCRIPTION
When calling `store.all('type)` it creates a cache which is not cleaned after unloading all records, it causes `store.all('type')` to keep returning records even after they have been unloaded.
