### PR TITLE
Support embedded ids

### DIFF
--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -12,10 +12,20 @@ var forEach = Ember.EnumerableUtils.forEach;
     attrs: {
       comments: {embedded: 'always'}
     }
-  })
+  });
   ```
 
-  Currently only `{embedded: 'always'}` records are supported.
+  Also you can embed only ids.
+
+  ```js
+  App.PostSerializer = DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      categories: {embedded: 'ids'}
+    }
+  });
+  ```
+
+  Currently only `{embedded: 'always'}` records and `{embedded: 'ids'}` are supported.
 
   @class EmbeddedRecordsMixin
   @namespace DS
@@ -30,17 +40,21 @@ DS.EmbeddedRecordsMixin = Ember.Mixin.create({
   serializeHasMany: function(record, json, relationship) {
     var key   = relationship.key,
         attrs = get(this, 'attrs'),
-        embed = attrs && attrs[key] && attrs[key].embedded === 'always';
+        embed = attrs && attrs[key] && attrs[key].embedded,
+        primaryKey = get(this, 'primaryKey');
 
-    if (embed) {
+    if (embed === 'always') {
       json[this.keyForAttribute(key)] = get(record, key).map(function(relation) {
-        var data = relation.serialize(),
-            primaryKey = get(this, 'primaryKey');
+        var data = relation.serialize();
 
         data[primaryKey] = get(relation, primaryKey);
 
         return data;
       }, this);
+    } else if (embed === 'ids') {
+      json[this.keyForRelationship(key, relationship.kind)] = get(record, key).map(function(relation) {
+        return get(relation, primaryKey);
+      });
     }
   },
 

--- a/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
+++ b/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
@@ -429,3 +429,24 @@ test("serialize with embedded objects", function() {
     }]
   });
 });
+
+test("serialize with embedded ids", function() {
+  league = env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" });
+  var tom = env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league });
+
+  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      villains: {embedded: 'ids'}
+    }
+  }));
+  var serializer = env.container.lookup("serializer:homePlanet");
+
+  var json = serializer.serialize(league);
+
+  deepEqual(json, {
+    name: "Villain League",
+    villain_ids: [
+      get(tom, "id")
+    ]
+  });
+});


### PR DESCRIPTION
I supported embedded object serialization not only objects but also _ids_.

Usage:

When there are model definitions:

``` js
App.Post = DS.Model.extend({
  title: DS.attr(),
  categories: DS.hasMany('category')
});

App.Category = DS.Model.extend({
});
```

`{embedded: 'ids'}` behave like the followings:

``` js
App.PostSerializer = DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
  attrs: {
    categories: {embedded: 'ids'}
  }
});

post.serialize();
//=> {title: "My blog", category_ids: [1, 2]}
```

Some case, embedded objects may be enough only ids.
