### PR TITLE
Don't modify passed in properties hash (Fixes #420).

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -15,6 +15,7 @@ var forEach = Ember.EnumerableUtils.forEach;
 var indexOf = Ember.EnumerableUtils.indexOf;
 var map = Ember.EnumerableUtils.map;
 var resolve = Ember.RSVP.resolve;
+var copy = Ember.copy;
 
 // Implementors Note:
 //
@@ -189,7 +190,7 @@ DS.Store = Ember.Object.extend(DS._Mappable, {
   createRecord: function(type, properties) {
     type = this.modelFor(type);
 
-    properties = properties || {};
+    properties = copy(properties) || {};
 
     // If the passed properties do not include a primary key,
     // give the adapter an opportunity to generate one. Typically,

--- a/packages/ember-data/tests/unit/store/create_record_test.js
+++ b/packages/ember-data/tests/unit/store/create_record_test.js
@@ -1,0 +1,20 @@
+var get = Ember.get, set = Ember.set;
+var store, Record;
+
+module("unit/store/createRecord - Store creating records", {
+  setup: function() {
+    store = createStore({ adapter: DS.Adapter.extend()});
+
+    Record = DS.Model.extend({
+      title: DS.attr('string')
+    });
+  }
+});
+
+test("doesn't modify passed in properties hash", function(){
+  var attributes = { foo: 'bar' },
+      record1 = store.createRecord(Record, attributes),
+      record2 = store.createRecord(Record, attributes);
+
+  deepEqual(attributes, { foo: 'bar' }, "The properties hash is not modified");
+});


### PR DESCRIPTION
The properties hash is being modified when calling `createRecord`, reported in #420, this fixes the issue.
