### PR TITLE
Add integration test for normalizeHash - fix  bug when calling normalizeHash (Closes #1411).

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -124,7 +124,7 @@ DS.RESTSerializer = DS.JSONSerializer.extend({
     this.normalizeRelationships(type, hash);
 
     if (this.normalizeHash && this.normalizeHash[prop]) {
-      return this.normalizeHash[prop](hash);
+      this.normalizeHash[prop](hash);
     }
 
     return this._super(type, hash, prop);

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -187,3 +187,42 @@ test('normalizeHash normalizes specific parts of the payload', function(){
     "superVillains": [1]
   }]);
 });
+
+test('normalizeHash works with transforms', function(){
+  env.container.register('serializer:application', DS.RESTSerializer.extend({
+    normalizeHash: {
+      evilMinions: function(hash) {
+        hash.condition = hash._condition;
+        delete hash._condition;
+        return hash;
+      }
+    }
+  }));
+
+  env.container.register('transform:condition', DS.Transform.extend({
+    deserialize: function(serialized) {
+      if (serialized === 1) {
+        return "healing";
+      } else {
+        return "unknown";
+      }
+    },
+    serialize: function(deserialized) {
+      if (deserialized === "healing") {
+        return 1;
+      } else {
+        return 2;
+      }
+    }
+  }));
+
+  EvilMinion.reopen({ condition: DS.attr('condition') });
+
+  var jsonHash = {
+    evilMinions: [{id: "1", name: "Tom Dale", superVillain: 1, _condition: 1}]
+  };
+
+  var array = env.restSerializer.extractArray(env.store, EvilMinion, jsonHash);
+
+  equal(array[0].condition, "healing");
+});


### PR DESCRIPTION
normalizedHash has been reported to not be tested (#1411) and when called it wasn't allowing transforms to be applied.

This adds a test for normalizeHash and fixes the mentioned issue.
