### PR TITLE
Call extract for findQuery. (closes #1521)

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1552,7 +1552,7 @@ function _findQuery(adapter, store, type, query, recordArray) {
       serializer = serializerForAdapter(adapter, type);
 
   return resolve(promise, "DS: Handle Adapter#findQuery of " + type).then(function(payload) {
-    payload = serializer.extract(store, type, payload, null, 'findAll');
+    payload = serializer.extract(store, type, payload, null, 'findQuery');
 
     Ember.assert("The response from a findQuery must be an Array, not " + Ember.inspect(payload), Ember.typeOf(payload) === 'array');
 

--- a/packages/ember-data/tests/unit/store/adapter_interop_test.js
+++ b/packages/ember-data/tests/unit/store/adapter_interop_test.js
@@ -159,6 +159,38 @@ test("loadMany takes an optional Object and passes it on to the Adapter", functi
   store.find(Person, passedQuery);
 });
 
+test("Find with query calls the correct extract", function() {
+  var passedQuery = { page: 1 };
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var adapter = TestAdapter.extend({
+    findQuery: function(store, type, query) {
+      return Ember.RSVP.resolve([]);
+    }
+  });
+
+  var callCount = 0;
+
+  var ApplicationSerializer = DS.JSONSerializer.extend({
+    extractFindQuery: function(store, type, payload) {
+      callCount++;
+      return [];
+    }
+  });
+
+  var store = createStore({
+    adapter: adapter
+  });
+
+  store.container.register('serializer:application', ApplicationSerializer);
+
+  store.find(Person, passedQuery);
+  equal(callCount, 1, 'extractFindQuery was called');
+});
+
 test("all(type) returns a record array of all records of a specific type", function() {
   var store = createStore();
   var Person = DS.Model.extend({


### PR DESCRIPTION
Initial bug was found by @ssured (#1521), this just adds a simple test and a better commit message.

Passing `findAll` or `findQuery` is used by `extract` to determinate the `specificExtract`  for the `requestType`. 

Currently returns the same result since  `extractFindAll` and `extractFindQuery` are both aliased to `extractArray`. 

To keep consistency we should pass `findQuery` so  `extractFindQuery` is called.
