### PR TITLE
Normalize key in modelFor when a factory is not given.

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1026,10 +1026,13 @@ DS.Store = Ember.Object.extend({
   modelFor: function(key) {
     var factory;
 
+
     if (typeof key === 'string') {
-      factory = this.container.lookupFactory('model:' + key);
+      var normalizedKey = this.container.normalize('model:' + key);
+
+      factory = this.container.lookupFactory(normalizedKey);
       if (!factory) { throw new Ember.Error("No model was found for '" + key + "'"); }
-      factory.typeKey = key;
+      factory.typeKey = normalizedKey.split(':', 2)[1];
     } else {
       // A factory already supplied.
       factory = key;

--- a/packages/ember-data/tests/unit/store/model_for_test.js
+++ b/packages/ember-data/tests/unit/store/model_for_test.js
@@ -1,0 +1,21 @@
+var container, store;
+
+module("unit/store/model_for - DS.Store#modelFor", {
+  setup: function() {
+    store = createStore({blogPost: DS.Model.extend()});
+    container = store.container;
+  },
+
+  teardown: function() {
+    container.destroy();
+    store.destroy();
+  }
+});
+
+test("sets a normalized key as typeKey", function() {
+  container.normalize = function(fullName){
+    return Ember.String.camelize(fullName);
+  };
+
+  ok(store.modelFor("blog.post").typeKey, "blogPost", "typeKey is normalized");
+});


### PR DESCRIPTION
@stefanpenner this is basically what we discuss on Saturday, with this we no longer need #1571 as the model name would be correctly normalized with the resolver.

About this line https://github.com/emberjs/data/blob/master/packages/ember-data/lib/system/store.js#L1038, seems like @wycats  has started some refactoring in https://github.com/emberjs/data/tree/single-source-of-truth and that touches the code which is using it.
