### PR TITLE
Implements FixtureAdapter's `queryFixture`

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -53,7 +53,11 @@ DS.FixtureAdapter = DS.Adapter.extend({
   },
 
   /**
-    Implement this method in order to query fixtures data
+    This method is responsible for filtering the array of fixtures and
+    returning only what's relevant given the query parameter.
+
+    If you have any specific behavior in your server, you can extend this method
+    to replicate it in the fixtures.
 
     @method queryFixtures
     @param  fixture
@@ -61,7 +65,20 @@ DS.FixtureAdapter = DS.Adapter.extend({
     @param  type
   */
   queryFixtures: function(fixtures, query, type) {
-    Ember.assert('Not implemented: You must override the DS.FixtureAdapter::queryFixtures method to support querying the fixture store.');
+    return fixtures.filter(function(fixture) {
+      for(var queryKey in query) {
+        var value = query[queryKey];
+
+        if (!query.hasOwnProperty(queryKey)) {
+          continue;
+        }
+
+        if (fixture[queryKey] !== value) {
+          return false;
+        }
+      }
+      return true;
+    });
   },
 
   /**

--- a/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
@@ -73,6 +73,28 @@ test("should load data for a type asynchronously when it is requested", function
   }, 1000));
 });
 
+test("should query a fixture by field", function() {
+  expect(4);
+
+  stop();
+  Person.FIXTURES = [{
+    id: 'tony', firstName: "Tony", lastName: "Montana"
+  }, {
+    id: 'rambo', firstName: "John", lastName: "Rambo"
+  }];
+
+  env.store.find('person', {firstName: 'John'}).then(function(found) {
+    equal(found.get('length'), 1, "only one record is returned");
+
+    var firstObject = found.get('firstObject');
+
+    equal(get(firstObject, 'id'),        'rambo', "id is loaded correctly");
+    equal(get(firstObject, 'firstName'), 'John',  "lastName is loaded correctly");
+    equal(get(firstObject, 'lastName'),  'Rambo', "lastName is loaded correctly");
+    start();
+  });
+});
+
 test("should load data asynchronously at the end of the runloop when simulateRemoteResponse is false", function() {
   Person.FIXTURES = [{
     id: 'wycats',


### PR DESCRIPTION
This commit allows developers to query for specific fields in fixtures, such as

```
store.find('person', {firstName: "John"})
```

Up to this point, most people just copy and paste this implementation in
their own apps.
