### PR TITLE
fixed behaviour of store.unloadAll() in combination with store.all()

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -729,7 +729,7 @@ DS.Store = Ember.Object.extend({
     type = this.modelFor(type);
 
     var typeMap = this.typeMapFor(type),
-        records = typeMap.records, record;
+        records = typeMap.records.splice(0), record;
 
     while(record = records.pop()) {
       record.unloadRecord();

--- a/packages/ember-data/tests/integration/records/unload_test.js
+++ b/packages/ember-data/tests/integration/records/unload_test.js
@@ -52,3 +52,17 @@ test("removes findAllCache after unloading all records", function () {
 
   equal(env.store.all('person').get('length'), 0);
 });
+
+test("unloading all records also updates record array from all()", function() {
+  var adam = env.store.push('person', {id: 1, name: "Adam Sunderland"});
+  var bob = env.store.push('person', {id: 2, name: "Bob Bobson"});
+  var all = env.store.all('person');
+
+  equal(all.get('length'), 2);
+
+  Ember.run(function(){
+    env.store.unloadAll('person');
+  });
+
+  equal(all.get('length'), 0);
+});


### PR DESCRIPTION
There was a bug in store.unloadAll() which caused elements fetched previously via store.all() to stay in the RecordArray, even if they should have been removed. see #1611

Here is a jsfiddle which demonstrates the problem in combination with emberjs:
http://jsfiddle.net/6XmLn/12/
