### PR TITLE
Documentation detailfix on pushPayload

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1212,7 +1212,6 @@ DS.Store = Ember.Object.extend({
 
     @method pushPayload
     @param {String} type
-    @param {String or subclass of DS.Model} type
     @param {Object} payload
     @return {DS.Model} the record that was created or updated.
   */


### PR DESCRIPTION
pushPayload had documentation describing 3 parameters, but defined with only two.

This is my first attempted contribution ever to an open-source project, a small step heh ;>
