### PR TITLE
Allow async relationship changes and rollbacks.

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -273,18 +273,19 @@ DS.attr = function(type, options) {
 
   return Ember.computed(function(key, value) {
     if (arguments.length > 1) {
-      Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.constructor.toString(), key !== 'id');
-      var oldValue = this._attributes[key] || this._inFlightAttributes[key] || this._data[key];
+      value = (value === undefined ? null : value);
 
+      Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.constructor.toString(), key !== 'id');
+
+      var oldValue = this._attributes[key] || this._inFlightAttributes[key] || this._data[key];
       this.send('didSetProperty', {
+        meta: meta,
         name: key,
         oldValue: oldValue,
         originalValue: this._data[key],
         value: value
       });
-
-      this._attributes[key] = value;
-      return value;
+      return this._attributes[key] = value;
     } else if (hasValue(this, key)) {
       return getValue(this, key);
     } else {

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -699,7 +699,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
     var hasMany = this._relationships[key];
 
     if (hasMany) {
-      var records = this._data[key] || [];
+      var records = this._data[key] ? this._data[key].slice() : [];
 
       set(hasMany, 'content', Ember.A(records));
       set(hasMany, 'isLoaded', true);
@@ -733,7 +733,6 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
 
     this.eachRelationship(function(name, rel) {
       if (data.links && data.links[name]) { return; }
-      if (rel.options.async) { relationships[name] = null; }
     });
 
     if (data) { this.pushedData(); }
@@ -805,11 +804,11 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
       this._inFlightAttributes = {};
     }
 
-    this.send('rolledBack');
+    this._relationships = {};
 
-    this.suspendRelationshipObservers(function() {
-      this.notifyPropertyChange('data');
-    });
+    this.notifyPropertyChange('data');
+
+    this.send('rolledBack');
   },
 
   toStringExtension: function() {

--- a/packages/ember-data/tests/unit/model/attributes_test.js
+++ b/packages/ember-data/tests/unit/model/attributes_test.js
@@ -1,0 +1,22 @@
+module("unit/model/attributes - DS.attr");
+
+test("calling createRecord and passing in an undefined value for an attribute should be treated as if null", function () {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string'),
+    person: DS.belongsTo('person')
+  });
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tag: DS.belongsTo('tag')
+  });
+
+  var env = setupStore({ tag: Tag, person: Person }),
+      store = env.store;
+
+  store.createRecord('person', {id: 1, name: undefined});
+
+  store.find(Person, 1).then(async(function(person) {
+    strictEqual(person.get('name'), null, "undefined values should return null attributes");
+  }));
+});

--- a/packages/ember-data/tests/unit/model/relationships_test.js
+++ b/packages/ember-data/tests/unit/model/relationships_test.js
@@ -541,7 +541,7 @@ test("async belongsTo relationships work when the data hash has already been loa
   }));
 });
 
-test("calling createRecord and passing in an undefined value for a relationship should be treated as if null", function () {
+test("calling createRecord and passing in an undefined value for a belongsTo should be treated as if null", function () {
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     person: DS.belongsTo('person')

--- a/packages/ember-data/tests/unit/store/unload_test.js
+++ b/packages/ember-data/tests/unit/store/unload_test.js
@@ -65,8 +65,6 @@ test("can commit store after unload record with relationships", function() {
     })
   });
 
-  var like, product, brand;
-
   var Brand = DS.Model.extend({
     name: DS.attr('string')
   });
@@ -89,7 +87,7 @@ test("can commit store after unload record with relationships", function() {
   });
 
   asyncRecords.then(async(function(records) {
-    like = store.createRecord(Like, { id: 1, product: product });
+    var like = store.createRecord(Like, { id: 1, product: records.product });
     records.like = like.save();
     return Ember.RSVP.hash(records);
   })).then(async(function(records) {


### PR DESCRIPTION
Most of my applications resolve relationships asynchronously. Before ember-data recently underwent a somewhat large refactor, resolving async relationships wasn't perfect but I was able to accomplish what I needed to using the various hooks available to me (such as materialize_, dirtyRecordFor_, etc...). However, with the recent refactor, most of those hooks are now gone, async relationship changes were effectively disabled and rolling back anything is basically broken. I had put off upgrading from pre-1.0 ember-data for as long as I could, but am at the point were I really need bring some of our applications current (which stand to gain a lot from recent releases of ember.js).

Anyway, here's my attempt at putting some of these things back into working condition. I believe that it conceptually falls in line with recent changes. At the very least this might help someone that needs to get by for the time being.

This commit provides for the following:
- Proper relationship changes for async relationships.
  - Don't maintainInvariant on manyToOne change if parent === child.parent
  - Don't unnecessarily fetch an unloaded async hasMany during change operations
  - Don't unnecessarily fetch an unloaded async belongsTo during change operations
  - Allow relationship changes on newly created records when it makes sense
  - Handles promises from async relationships properly
- Proper rollback of relationships.
- Refactored DS.hasMany and DS.belongsTo.
- Added _relationship to DS.belongsTo (similar to _attributes in DS.attr).
- Allow didSetProperty to work with belongsTo relationships in model states.
  - belongsTos are basically no different than attributes so this handles them similarly
- Fixed a test that was passing with old code but was not actually right
  - It was doing so only because async relationships weren't triggering any relationship changes
- Added a test to ensure undefined is always handled as null when setting an attribute value

Relationship changes now propagate correctly and model.rollback() works on both belongsTo and hasMany relationships. New tests, specific to async relationship changes and relationship rollbacks, still need to be written to verify that all this is working as intended. However, in my test application everything is working as I intended it too. In addition, nothing here breaks any existing behavior as this commit passes all current tests. 
