### PR TITLE
Extract embedded belongsTo relationships in DS.EmbeddedRecordsMixin

### DIFF
--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -90,7 +90,7 @@ function updatePayloadWithEmbedded(store, serializer, type, partial, payload) {
         serializer = store.serializerFor(relationship.type.typeKey),
         primaryKey = get(serializer, "primaryKey");
 
-    if (relationship.kind !== "hasMany") {
+    if (relationship.kind !== "hasMany" && relationship.kind !== "belongsTo") {
       return;
     }
 
@@ -107,15 +107,24 @@ function updatePayloadWithEmbedded(store, serializer, type, partial, payload) {
       }
 
       payload[embeddedTypeKey] = payload[embeddedTypeKey] || [];
+      var embeddedType = store.modelFor(relationship.type.typeKey);
 
-      forEach(partial[attribute], function(data) {
-        var embeddedType = store.modelFor(relationship.type.typeKey);
+      if (relationship.kind === "hasMany") {
+        forEach(partial[attribute], function(data) {
+          updatePayloadWithEmbedded(store, serializer, embeddedType, data, payload);
+          ids.push(data[primaryKey]);
+          payload[embeddedTypeKey].push(data);
+        });
+
+        partial[expandedKey] = ids;
+      } else {
+        var data = partial[attribute];
         updatePayloadWithEmbedded(store, serializer, embeddedType, data, payload);
-        ids.push(data[primaryKey]);
+        var id = data[primaryKey];
         payload[embeddedTypeKey].push(data);
-      });
+        partial[expandedKey] = id;
+      }
 
-      partial[expandedKey] = ids;
       delete partial[attribute];
     }
   }, serializer);


### PR DESCRIPTION
DS.EmbeddedRecordsMixin handles embedded hasMany relationships, but not embedded belongsTo relationships. This patch attempts implements nested belongsTo extraction, with full unit tests, but not the corresponding serialization primitives.

Use case: I'm dealing with a project that has an array of values, each of which contains an embedded array, each value in which contains another embedded belongsTo value, which in turns contains another embedded array. DS.EmbeddedRecordsMixin _almost_ handles this, but it breaks on the embedded belongsTo value.

It would be nice to implement the corresponding serialization support, for the sake of completeness, but I don't know whether anybody would use it.

Please let me know if I can improve this patch in any way. Thank you for all your work on Ember Data!
