### PR TITLE
JSONSerializer should use the attrs hash when extracting records

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -179,7 +179,8 @@ var RESTSerializer = JSONSerializer.extend({
       this.normalizeHash[prop](hash);
     }
 
-    return this._super(type, hash, prop);
+    this.applyTransforms(type, hash);
+    return hash;
   },
 
   /**
@@ -217,27 +218,6 @@ var RESTSerializer = JSONSerializer.extend({
 
     hash.id = hash[primaryKey];
     delete hash[primaryKey];
-  },
-
-  /**
-    @method normalizeUsingDeclaredMapping
-    @private
-  */
-  normalizeUsingDeclaredMapping: function(type, hash) {
-    var attrs = get(this, 'attrs'), payloadKey, key;
-
-    if (attrs) {
-      for (key in attrs) {
-        payloadKey = attrs[key];
-        if (payloadKey && payloadKey.key) {
-          payloadKey = payloadKey.key;
-        }
-        if (typeof payloadKey === 'string') {
-          hash[key] = hash[payloadKey];
-          delete hash[payloadKey];
-        }
-      }
-    }
   },
 
   /**

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -131,7 +131,6 @@ test("serializePolymorphicType", function() {
   });
 });
 
-
 test("extractArray normalizes each record in the array", function() {
   var postNormalizeCount = 0;
   var posts = [
@@ -148,4 +147,34 @@ test("extractArray normalizes each record in the array", function() {
 
   env.container.lookup("serializer:post").extractArray(env.store, Post, posts);
   equal(postNormalizeCount, 2, "two posts are normalized");
+});
+
+test('Serializer should respect the attrs hash when extracting records', function(){
+  env.container.register("serializer:post", DS.JSONSerializer.extend({
+    attrs: {
+      title: "title_payload_key"
+    }
+  }));
+
+  var jsonHash = {
+    title_payload_key: "Rails is omakase"
+  };
+
+  var post = env.container.lookup("serializer:post").extractSingle(env.store, Post, jsonHash);
+
+  equal(post.title, "Rails is omakase");
+});
+
+test('Serializer should respect the attrs hash when serializing records', function(){
+  env.container.register("serializer:post", DS.JSONSerializer.extend({
+    attrs: {
+      title: "title_payload_key"
+    }
+  }));
+
+  post = env.store.createRecord("post", { title: "Rails is omakase"});
+
+  var payload = env.container.lookup("serializer:post").serialize(post);
+
+  equal(payload.title_payload_key, "Rails is omakase");
 });


### PR DESCRIPTION
Currently the `attrs` hash which is used to declare a mapping between property names on `DS.Model` records and payload keys only works correctly in the `RESTSerializer`.

The `JSONSerializer` will use the `attrs` mappings when serializing records but it does **NOT** used the `attrs` hash when extracting records. This pr ensures the transformations declared in the `attrs` mapping are run in the `JSONSerializer`'s normalize function.
