### PR TITLE
The store's adapter property requires a string or factory

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -68,7 +68,7 @@ DS.InvalidError.prototype = Ember.create(Error.prototype);
 
   ```javascript
   App.store = DS.Store.create({
-    adapter: App.MyAdapter.create()
+    adapter: 'MyAdapter'
   });
   ```
 


### PR DESCRIPTION
The current example code will trigger an assert error: https://github.com/emberjs/data/blob/master/packages/ember-data/lib/system/store.js#L159

As a related question is setting the `adapter` property on the store still the blessed way to register an adapter? Or should the docs be encouraging users to register an `application` adapter on the container or App object instead? 
