### PR TITLE
Fixes hasMany records being duplicated after payload returns from server

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1553,6 +1553,7 @@ function normalizeRelationships(store, type, data, record) {
     if (kind === 'belongsTo') {
       deserializeRecordId(store, data, key, relationship, value);
     } else if (kind === 'hasMany') {
+      if (typeof value.pushObjects !== 'function') { value = Ember.A(value); }
       deserializeRecordIds(store, data, key, relationship, value);
       addUnsavedRecords(record, key, value);
     }
@@ -1595,9 +1596,17 @@ function deserializeRecordIds(store, data, key, relationship, ids) {
 // If there are any unsaved records that are in a hasMany they won't be
 // in the payload, so add them back in manually.
 function addUnsavedRecords(record, key, data) {
-  if(record) {
-    Ember.A(data).pushObjects(record.get(key).filterBy('isNew'));
+  if(record && data.length) {
+    var unsavedRecords = uniqById(data, record.get(key).filterBy('isNew'));
+    data.pushObjects(unsavedRecords);
   }
+}
+
+function uniqById(data, records) {
+  var currentIds = data.mapBy("id");
+  return records.reject(function(record) {
+    return Ember.A(currentIds).contains(record.id);
+  });
 }
 
 // Delegation to the adapter and promise management


### PR DESCRIPTION
There is an edge case where a hasMany record gets duplicated (same ID).
Basically, if we generate a record locally using UUID or any custom ID
format, then push it to production which will return the same ID
previously defined, the store's array that holds records to be resolved
is going to duplicate both items, even if they have the same ID.

This commit fixes that by not allowing duplicated IDs in that array.

I need this badly for my app.
