### PR TITLE
Setting a property to undefined on a new record should not transition th...

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -414,6 +414,8 @@ createdState.uncommitted.rollback = function(record) {
   record.transitionTo('deleted.saved');
 };
 
+createdState.uncommitted.propertyWasReset = Ember.K;
+
 updatedState.uncommitted.deleteRecord = function(record) {
   record.transitionTo('deleted.uncommitted');
   record.clearRelationships();

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -149,6 +149,23 @@ test("a defaultValue for an attribite can be a function", function() {
   equal(get(tag, 'createdAt'), "le default value", "the defaultValue function is evaluated");
 });
 
+test("setting a property to undefined on a newly created record should not impact the current state", function() {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var tag = store.createRecord(Tag);
+
+  set(tag, 'name', 'testing');
+  set(tag, 'name', undefined);
+
+  equal(get(tag, 'currentState.stateName'), "root.loaded.created.uncommitted");
+
+  tag = store.createRecord(Tag, {name: undefined});
+
+  equal(get(tag, 'currentState.stateName'), "root.loaded.created.uncommitted");
+});
+
 module("unit/model - with a simple Person model", {
   setup: function() {
     array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];


### PR DESCRIPTION
...e record to root.deleted.saved

This is a fix for https://github.com/emberjs/data/issues/1648

Setting a property to undefined on a newly created record with no other properties set will run the `propertyWasReset` event which in turn triggers the `rolledBack` event which will transition a record in the `root.loaded.created.uncommitted` state to the `root.deleted.saved` state.

This can happen if a programmer writes an action like the one below where `email` and `password` are bound to `{{input}}`s. If a user causes the `signup` to trigger before focusing the inputs then the `user` record will be transitioned to the `root.deleted.saved` state and will never be able to be persisted to the backend.

``` js
App.SignupController = Ember.ObjectController.extend({
  actions: {
    signup: function() {
        var newUser = this.store.createRecord('user', {
            name: this.get('email'),
            password: this.get('password'),
        });
        newUser.save();
    }
  }
});
```

The fix for this method defines a `propertyWasReset` event on the `root.loaded.created.uncommitted` state which acts as a noop.
