### PR TITLE
[BUGFIX] missing return statement in RecordArray#update

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/record_array.js
@@ -113,7 +113,7 @@ DS.RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
     var store = get(this, 'store'),
         type = get(this, 'type');
 
-    store.fetchAll(type, this);
+    return store.fetchAll(type, this);
   },
 
   /**

--- a/packages/ember-data/tests/unit/record_array_test.js
+++ b/packages/ember-data/tests/unit/record_array_test.js
@@ -146,3 +146,16 @@ test("an AdapterPopulatedRecordArray knows if it's loaded or not", function() {
     equal(get(people, 'isLoaded'), true, "The array is now loaded");
   }));
 });
+
+test("a record array should return a promise when updating", function() {
+  var env = setupStore({ person: Person }),
+      store = env.store, recordArray, promise;
+  
+  env.adapter.findAll = function(store, type, query, recordArray) {
+    return Ember.RSVP.resolve(array);
+  };
+  
+  recordArray = store.all(Person);
+  promise = recordArray.update();
+  ok((promise.then && typeof promise.then === "function"), "#update returns a promise");
+});


### PR DESCRIPTION
Is there a reason why DS.RecordArray#update() can't return the promise received from the call to store#fetchAll?

https://github.com/emberjs/data/blob/master/packages/ember-data/lib/system/record_arrays/record_array.js#L110-117

I'm trying to refresh the data without changing route and this would help a lot, e.g.:

```
recordArray.update().then(function() {
    // finalize live update process here
});
```
