### PR TITLE
Fixes a small typo in DS.Store deleteRecord docs

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -253,7 +253,7 @@ DS.Store = Ember.Object.extend({
       title: "Rails is omakase"
     });
 
-    store.deletedRecord(post);
+    store.deleteRecord(post);
     ```
 
     @method deleteRecord


### PR DESCRIPTION
There was a small typo in the docs for DS.Store#deleteRecord, where it said `store.deletedRecord(post)` instead of `store.deleteRecord(post)`. Not a crucial fix, but it's nice to have docs that have the correct method names in the examples ;)
