### PR TITLE
[BUGFIX] Possible undefined errors in response via ActiveModelAdapter

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_adapter.js
+++ b/packages/activemodel-adapter/lib/system/active_model_adapter.js
@@ -97,12 +97,16 @@ DS.ActiveModelAdapter = DS.RESTAdapter.extend({
     var error = this._super(jqXHR);
 
     if (jqXHR && jqXHR.status === 422) {
-      var jsonErrors = Ember.$.parseJSON(jqXHR.responseText)["errors"],
+      var response = Ember.$.parseJSON(jqXHR.responseText),
           errors = {};
 
-      forEach(Ember.keys(jsonErrors), function(key) {
-        errors[Ember.String.camelize(key)] = jsonErrors[key];
-      });
+      if (response.errors !== undefined) {
+        var jsonErrors = response.errors;
+
+        forEach(Ember.keys(jsonErrors), function(key) {
+          errors[Ember.String.camelize(key)] = jsonErrors[key];
+        });
+      }
 
       return new DS.InvalidError(errors);
     } else {


### PR DESCRIPTION
When `errors` in response are `undefined`, because there were no text errors, so the interpreter will display error:

```
TypeError: jsonErrors is not an object
```

It happens on the line [103](https://github.com/emberjs/data/blob/373f1698cca56019f41a95ba434f1743db30fd69/packages/activemodel-adapter/lib/system/active_model_adapter.js#L103) of `active_model_adapter.js`:

``` javascript
forEach(Ember.keys(jsonErrors), function(key) {
```

Error should be displayed by **Ember.js** rather than by interpreter.
