### PR TITLE
Fix documentation for DS.Model.isNew

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -149,7 +149,7 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
     var record = store.createRecord(App.Model);
     record.get('isNew'); // true
 
-    store.find('model', 1).then(function(model) {
+    record.save().then(function(model) {
       model.get('isNew'); // false
     });
     ```


### PR DESCRIPTION
The act of finding a model in the store doest not implicitly save the record, thus the record.isNew property would still be true.  The record must be saved/committed to the server and if this promise is fulfilled, then it is no longer considered new.

If my assumption is incorrect, and store.find(...) is correct I would still prefer for a something else in code example since there is no clear indication of why finding a model with an id of 1 would imply to find the previously created record.
