### PR TITLE
RESTAdapter suppress DELETE request when deleted record has already been saved

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -661,7 +661,11 @@ var RootState = {
       invokeLifecycleCallbacks: function(record) {
         record.triggerLater('didDelete', record);
         record.triggerLater('didCommit', record);
-      }
+      },
+
+      willCommit: Ember.K,
+
+      didCommit: Ember.K
     }
   },
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -915,7 +915,9 @@ DS.Store = Ember.Object.extend({
           adapter = this.adapterFor(record.constructor),
           operation;
 
-      if (get(record, 'isNew')) {
+      if (get(record, 'currentState.stateName') === 'root.deleted.saved') {
+        return resolver.resolve(record);
+      } else if (get(record, 'isNew')) {
         operation = 'createRecord';
       } else if (get(record, 'isDeleted')) {
         operation = 'deleteRecord';

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -460,6 +460,20 @@ test("delete - a payload with sideloaded updates pushes the updates", function()
   }));
 });
 
+test("delete - deleting a newly created record should not throw an error", function() {
+  var post = store.createRecord('post');
+
+  post.deleteRecord();
+  post.save().then(async(function(post) {
+    equal(passedUrl, null, "There is no ajax call to delete a record that has never been saved.");
+    equal(passedVerb, null, "There is no ajax call to delete a record that has never been saved.");
+    equal(passedHash, null, "There is no ajax call to delete a record that has never been saved.");
+
+    equal(post.get('isDeleted'), true, "the post is now deleted");
+    equal(post.get('isError'), false, "the post is not an error");
+  }));
+});
+
 test("findAll - returning an array populates the array", function() {
   ajaxResponse({
     posts: [


### PR DESCRIPTION
This is a fix for https://github.com/emberjs/data/issues/1669 and https://github.com/emberjs/data/issues/1593
