### PR TITLE
Do not trigger didSetProperty if value is unchanged.

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -274,14 +274,16 @@ DS.attr = function(type, options) {
   return Ember.computed(function(key, value) {
     if (arguments.length > 1) {
       Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.constructor.toString(), key !== 'id');
-      var oldValue = this._attributes[key] || this._inFlightAttributes[key] || this._data[key];
+      var oldValue = getValue(this, key);
 
-      this.send('didSetProperty', {
-        name: key,
-        oldValue: oldValue,
-        originalValue: this._data[key],
-        value: value
-      });
+      if (value !== oldValue) {
+        this.send('didSetProperty', {
+          name: key,
+          oldValue: oldValue,
+          originalValue: this._data[key],
+          value: value
+        });
+      }
 
       this._attributes[key] = value;
       return value;


### PR DESCRIPTION
Also, fix determination of oldValue (previous a falsy value would not be found
in `this._attributes`).
