### PR TITLE
Export `Store` as default from ./system/store

### DIFF
--- a/packages/ember-data/lib/initializers.js
+++ b/packages/ember-data/lib/initializers.js
@@ -1,4 +1,4 @@
-import {Store} from "./system/store";
+import Store from "./system/store";
 import {JSONSerializer, RESTSerializer} from "./serializers";
 import {RESTAdapter} from "./adapters";
 import DebugAdapter from "./system/debug/debug_adapter";

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1681,3 +1681,4 @@ function _commit(adapter, store, operation, record) {
 }
 
 export {Store, PromiseArray, PromiseObject};
+export default Store;


### PR DESCRIPTION
This allows it to import it simply via `import Store from "./system/store"` instead of `import {Store} from "./system/store"`.

Another option could be to move the `PromiseArray` and `PromiseObject` definitions in `system/store.js` to `system/promise.js` and import them accordingly.
