### PR TITLE
Fix ember-data version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.7+canary",
   "namespace": "DS",
   "devDependencies": {
     "defeatureify": "~0.1.4",

--- a/packages/ember-data/lib/core.js
+++ b/packages/ember-data/lib/core.js
@@ -13,11 +13,11 @@ if ('undefined' === typeof DS) {
   /**
     @property VERSION
     @type String
-    @default 'VERSION_STRING_PLACEHOLDER'
+    @default '<%= pkg.version %>'
     @static
   */
   DS = Ember.Namespace.create({
-    VERSION: 'VERSION_STRING_PLACEHOLDER'
+    VERSION: '<%= pkg.version %>'
   });
 
   if ('undefined' !== typeof window) {


### PR DESCRIPTION
Currently, `package.json` is used for built ember-data version instead of `VERSION` file or `VERSION_STRING_PLACEHOLDER` string.
