### PR TITLE
lazy create errors object on models

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -285,7 +285,17 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @property errors
     @type {Object}
   */
-  errors: null,
+  errors: Ember.computed(function() {
+    var errors = Errors.create();
+
+    errors.registerHandlers(this, function() {
+      this.send('becameInvalid');
+    }, function() {
+      this.send('becameValid');
+    });
+
+    return errors;
+  }),
 
   /**
     Create a JSON representation of the record, using the serialization
@@ -382,13 +392,6 @@ var Model = Ember.Object.extend(Ember.Evented, {
 
   init: function() {
     set(this, 'currentState', DS.RootState.empty);
-    var errors = Errors.create();
-    errors.registerHandlers(this, function() {
-      this.send('becameInvalid');
-    }, function() {
-      this.send('becameValid');
-    });
-    set(this, 'errors', errors);
     this._super();
     this._setup();
   },


### PR DESCRIPTION
@wycats we talked about it. I don't see any draw back on creating `errors` in a lazy way and should help with perfs.
