### PR TITLE
Use the new naming for active_model_adapter integration tests.

### DIFF
--- a/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
@@ -41,10 +41,10 @@ module("integration/active_model - ActiveModelSerializer", {
     env.store.modelFor('doomsdayDevice');
     env.store.modelFor('mediocreVillain');
     env.container.register('serializer:application', DS.ActiveModelSerializer);
-    env.container.register('serializer:ams', DS.ActiveModelSerializer);
-    env.container.register('adapter:ams', DS.ActiveModelAdapter);
-    env.amsSerializer = env.container.lookup("serializer:ams");
-    env.amsAdapter    = env.container.lookup("adapter:ams");
+    env.container.register('serializer:-active-model', DS.ActiveModelSerializer);
+    env.container.register('adapter:-active-model', DS.ActiveModelAdapter);
+    env.amsSerializer = env.container.lookup("serializer:-active-model");
+    env.amsAdapter    = env.container.lookup("adapter:-active-model");
   },
 
   teardown: function() {

--- a/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
+++ b/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
@@ -33,10 +33,10 @@ module("integration/embedded_records_mixin - EmbeddedRecordsMixin", {
     env.store.modelFor('evilMinion');
     env.store.modelFor('comment');
     env.container.register('serializer:application', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
-    env.container.register('serializer:ams',         DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
-    env.container.register('adapter:ams',    DS.ActiveModelAdapter);
-    env.amsSerializer = env.container.lookup("serializer:ams");
-    env.amsAdapter    = env.container.lookup("adapter:ams");
+    env.container.register('serializer:-active-model',         DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
+    env.container.register('adapter:-active-model',    DS.ActiveModelAdapter);
+    env.amsSerializer = env.container.lookup("serializer:-active-model");
+    env.amsAdapter    = env.container.lookup("adapter:-active-model");
   },
 
   teardown: function() {


### PR DESCRIPTION
As the tests were written they worked just fine, but this may help anyone that
comes along and looks to the tests for inspiration.
