### PR TITLE
Use defeatureify to strip debug statements from output.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,7 @@ module.exports = function(grunt){
   grunt.registerTask('buildTests', ['concat:tests']);
   grunt.registerTask('dev', [ 'buildPackages', 'buildTests', 'connect', 'watch' ]);
   grunt.registerTask('server', 'dev');
-  grunt.registerTask('test', ['buildPackages', 'buildTests', 'connect', 'qunit', 'uglify']);
+  grunt.registerTask('test', ['buildPackages', 'buildTests', 'connect', 'qunit']);
+  grunt.registerTask('dist', ['buildPackages', 'emberDefeatureify:stripDebug', 'uglify']);
   grunt.registerTask('default', ['test']);
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt-contrib-connect": "~0.6.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-uglify": "~0.3.0",
-    "bower": "~1.2"
+    "bower": "~1.2",
+    "grunt-ember-defeatureify": "~0.1.0"
   }
 }

--- a/tasks/options/emberDefeatureify.js
+++ b/tasks/options/emberDefeatureify.js
@@ -1,0 +1,18 @@
+module.exports = {
+  options: {
+    debugStatements: [
+      "Ember.warn",
+      "Ember.assert",
+      "Ember.deprecate",
+      "Ember.debug",
+      "Ember.Logger.info"
+    ]
+  },
+  stripDebug: {
+    options: {
+      enableStripDebug: true
+    },
+    src: 'dist/ember-data.js',
+    dest: 'dist/ember-data.prod.js'
+  }
+};

--- a/tasks/options/uglify.js
+++ b/tasks/options/uglify.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   dist: {
     files: [{
-     src: 'dist/ember-data.js',
+     src: 'dist/ember-data.prod.js',
      dest: 'dist/ember-data.min.js',
     }]
   }


### PR DESCRIPTION
- Adds `grunt-ember-defeatureify`
- Adds `dist` task, which now is roughly equivalent to previous `rake dist`.
- Removes `uglify` from `test` task (moved to `dist`).
