### PR TITLE
Fix bug where an undefined id would trigger a `findAll`

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -338,7 +338,10 @@ Store = Ember.Object.extend({
     @return {Promise} promise
   */
   find: function(type, id) {
-    if (id === undefined) {
+    Ember.assert("You need to pass a type to the store's find method", arguments.length >= 1);
+    Ember.assert("You may not pass `" + id + "` as id to the store's find method", arguments.length === 1 || !Ember.isNone(id));
+
+    if (arguments.length === 1) {
       return this.findAll(type);
     }
 

--- a/packages/ember-data/tests/integration/adapter/find_test.js
+++ b/packages/ember-data/tests/integration/adapter/find_test.js
@@ -16,6 +16,26 @@ module("integration/adapter/find - Finding Records", {
   }
 });
 
+test("It raises an assertion when no type is passed", function() {
+  store = createStore();
+
+  expectAssertion(function() {
+    store.find();
+  }, "You need to pass a type to the store's find method");
+});
+
+test("It raises an assertion when `undefined` is passed as id (#1705)", function() {
+  store = createStore();
+
+  expectAssertion(function() {
+    store.find(Person, undefined);
+  }, "You may not pass `undefined` as id to the store's find method");
+
+  expectAssertion(function() {
+    store.find(Person, null);
+  }, "You may not pass `null` as id to the store's find method");
+});
+
 test("When a single record is requested, the adapter's find method should be called unless it's loaded.", function() {
   expect(2);
 


### PR DESCRIPTION
This has been observed by the eagle eyes of @stefanpenner, reported in issue #1705.
