### PR TITLE
Remove restriction for jQuery version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "private": true,
   "dependencies": {
     "ember": "~1.3.1",
-    "jquery": "~2.0",
     "qunit": "~1.13.0"
   }
 }


### PR DESCRIPTION
This was needed since Ember v1.3.1 only works with jQuery <2.1, but the bower
config for this version didn't specify this restriction. Since this has been
fixed by Señor @rjackson (http://git.io/B2xRbQ) the specific jQuery version is
removed again from `bower.json`.
