### PR TITLE
Fix the links to DS.Model and DS.Transform in the DS Namespace method docs

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -229,12 +229,12 @@ function getValue(record, key) {
 }
 
 /**
-  `DS.attr` defines an attribute on a [DS.Model](DS.Model.html).
+  `DS.attr` defines an attribute on a [DS.Model](/api/data/classes/DS.Model.html).
   By default, attributes are passed through as-is, however you can specify an
   optional type to have the value automatically transformed.
   Ember Data ships with four basic transform types: `string`, `number`,
   `boolean` and `date`. You can define your own transforms by subclassing
-  [DS.Transform](DS.Transform.html).
+  [DS.Transform](/api/data/classes/DS.Transform.html).
 
   `DS.attr` takes an optional hash as a second parameter, currently
   supported options are:

--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -44,7 +44,7 @@ function asyncBelongsTo(type, options, meta) {
 
 /**
   `DS.belongsTo` is used to define One-To-One and One-To-Many
-  relationships on a [DS.Model](DS.Model.html).
+  relationships on a [DS.Model](/api/data/classes/DS.Model.html).
 
 
   `DS.belongsTo` takes an optional hash as a second parameter, currently

--- a/packages/ember-data/lib/system/relationships/has_many.js
+++ b/packages/ember-data/lib/system/relationships/has_many.js
@@ -79,7 +79,7 @@ function hasRelationship(type, options) {
 
 /**
   `DS.hasMany` is used to define One-To-Many and Many-To-Many
-  relationships on a [DS.Model](DS.Model.html).
+  relationships on a [DS.Model](/api/data/classes/DS.Model.html).
 
   `DS.hasMany` takes an optional hash as a second parameter, currently
   supported options are:


### PR DESCRIPTION
This is a fix for https://github.com/emberjs/website/issues/1262
