### PR TITLE
Destroying the store cleanups up after itself:

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -206,7 +206,7 @@ var FixtureAdapter = Adapter.extend({
   findQuery: function(store, type, query, array) {
     var fixtures = this.fixturesForType(type);
 
-    Ember.assert("Unable to find fixtures for model type "+type.toString(), fixtures);
+    Ember.assert("Unable to find fixtures for model type " + type.toString(), fixtures);
 
     fixtures = this.queryFixtures(fixtures, query, type);
 

--- a/packages/ember-data/lib/system/record_array_manager.js
+++ b/packages/ember-data/lib/system/record_array_manager.js
@@ -19,6 +19,7 @@ var RecordArrayManager = Ember.Object.extend({
     });
 
     this.changedRecords = [];
+    this._adapterPopulatedRecordArrays = [];
   },
 
   recordDidChange: function(record) {
@@ -219,12 +220,16 @@ var RecordArrayManager = Ember.Object.extend({
     @return {DS.AdapterPopulatedRecordArray}
   */
   createAdapterPopulatedRecordArray: function(type, query) {
-    return DS.AdapterPopulatedRecordArray.create({
+    var array = DS.AdapterPopulatedRecordArray.create({
       type: type,
       query: query,
       content: Ember.A(),
       store: this.store
     });
+
+    this._adapterPopulatedRecordArrays.push(array);
+
+    return array;
   },
 
   /**
@@ -254,7 +259,40 @@ var RecordArrayManager = Ember.Object.extend({
     var loadingRecordArrays = record._loadingRecordArrays || [];
     loadingRecordArrays.push(array);
     record._loadingRecordArrays = loadingRecordArrays;
+  },
+
+  willDestroy: function(){
+    this._super();
+
+    flatten(values(this.filteredRecordArrays.values)).forEach(destroy);
+    this._adapterPopulatedRecordArrays.forEach(destroy);
   }
 });
+
+function values(obj) {
+  var result = [];
+  var keys = Ember.keys(obj);
+
+  for (var i = 0; i < keys.length; i++) {
+    result.push(obj[keys[i]]);
+  }
+
+  return result;
+}
+
+function destroy(entry) {
+  entry.destroy();
+}
+
+function flatten(list) {
+  var length = list.length;
+  var result = Ember.A();
+
+  for (var i = 0; i < length; i++) {
+    result = result.concat(list[i]);
+  }
+
+  return result;
+}
 
 export default RecordArrayManager;

--- a/packages/ember-data/lib/system/record_arrays/record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/record_array.js
@@ -162,6 +162,23 @@ var RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
     }, null, "DS: RecordArray#save apply Ember.NativeArray");
 
     return PromiseArray.create({ promise: promise });
+  },
+
+  _dissociateFromOwnRecords: function() {
+    var array = this;
+
+    this.forEach(function(record){
+      var recordArrays = record._recordArrays;
+
+      if (recordArrays) {
+        recordArrays.remove(array);
+      }
+    });
+  },
+
+  willDestroy: function(){
+    this._dissociateFromOwnRecords();
+    this._super();
   }
 });
 

--- a/packages/ember-data/tests/integration/record_array_manager_test.js
+++ b/packages/ember-data/tests/integration/record_array_manager_test.js
@@ -1,0 +1,99 @@
+var store, env;
+
+var Person = DS.Model.extend({
+  name: DS.attr('string'),
+  cars: DS.hasMany('car')
+});
+
+Person.toString = function() { return "Person"; };
+
+var Car = DS.Model.extend({
+  make: DS.attr('string'),
+  model: DS.attr('string'),
+  person: DS.belongsTo('person')
+});
+
+Car.toString = function() { return "Car"; };
+
+var manager;
+
+module("integration/record_array_manager- destroy", {
+  setup: function(){
+    env = setupStore({
+      adapter: DS.FixtureAdapter.extend()
+    });
+    store = env.store;
+
+    manager = DS.RecordArrayManager.create({
+      store: store
+    });
+
+    env.container.register('model:car', Car);
+    env.container.register('model:person', Person);
+  }
+});
+
+function tap(obj, methodName, callback) {
+  var old = obj[methodName];
+
+  var summary = { called: [] };
+
+  obj[methodName] = function() {
+    var result = old.apply(obj, arguments);
+    if (callback) {
+      callback.apply(obj, arguments);
+    }
+    summary.called.push(arguments);
+    return result;
+  };
+
+  return summary;
+}
+
+test("destroying the store correctly cleans everything up", function() {
+  var query = { };
+
+  store.push('car', {
+    id: 1,
+    make: 'BMC',
+    model: 'Mini Cooper',
+    person: 1
+  });
+
+  var person = store.push('person', {
+    id: 1,
+    name: 'Tom Dale',
+    cars: [1]
+  });
+
+  var filterd = manager.createFilteredRecordArray(Person, function(){ return true; });
+  var filterd2 = manager.createFilteredRecordArray(Person, function(){ return true; });
+  var adapterPopulated = manager.createAdapterPopulatedRecordArray(Person, query);
+
+  var filterdSummary = tap(filterd, 'willDestroy');
+  var filterd2Summary = tap(filterd2, 'willDestroy');
+
+  var adapterPopulatedSummary = tap(adapterPopulated, 'willDestroy');
+
+  equal(filterdSummary.called.length, 0);
+  equal(adapterPopulatedSummary.called.length, 0);
+
+  equal(filterd2Summary.called.length, 0);
+
+  equal(person._recordArrays.list.length, 2, 'expected the person to be a member of 2 recordArrays');
+
+  Ember.run(filterd2, filterd2.destroy);
+
+  equal(person._recordArrays.list.length, 1, 'expected the person to be a member of 1 recordArrays');
+
+  equal(filterd2Summary.called.length, 1);
+
+  Ember.run(manager, manager.destroy);
+
+  equal(person._recordArrays.list.length, 0, 'expected the person to be a member of no recordArrays');
+
+  equal(filterd2Summary.called.length, 1);
+
+  equal(filterdSummary.called.length, 1);
+  equal(adapterPopulatedSummary.called.length, 1);
+});

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -15,24 +15,28 @@ module("integration/relationship/belongs_to Belongs-To Relationships", {
       messages: hasMany('message', {polymorphic: true}),
       favouriteMessage: belongsTo('message', {polymorphic: true})
     });
+
     User.toString = stringify('User');
 
     Message = DS.Model.extend({
       user: belongsTo('user'),
       created_at: attr('date')
     });
+
     Message.toString = stringify('Message');
 
     Post = Message.extend({
       title: attr('string'),
       comments: hasMany('comment')
     });
+
     Post.toString = stringify('Post');
 
     Comment = Message.extend({
       body: DS.attr('string'),
       message: DS.belongsTo('message', { polymorphic: true })
     });
+
     Comment.toString = stringify('Comment');
 
     env = setupStore({
@@ -60,15 +64,23 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
   expect(1);
 
   env.store.modelFor('post').reopen({
-    user: DS.belongsTo('user', { async: true })
+    user: DS.belongsTo('user', {
+      async: true,
+      inverse: 'messages'
+    })
   });
 
   env.adapter.find = function(store, type, id) {
     ok(true, "The adapter's find method should be called");
-    return Ember.RSVP.resolve({ id: 1 });
+    return Ember.RSVP.resolve({
+      id: 1
+    });
   };
 
-  env.store.push('post', { id: 1, user: 2});
+  env.store.push('post', {
+    id: 1,
+    user: 2
+  });
 
   env.store.find('post', 1).then(async(function(post) {
     post.get('user');
@@ -81,7 +93,10 @@ test("Only a record of the same type can be used with a monomorphic belongsTo re
   store.push('post', { id: 1 });
   store.push('comment', { id: 2 });
 
-  hash({ post: store.find('post', 1), comment: store.find('comment', 2) }).then(async(function(records) {
+  hash({
+    post: store.find('post', 1),
+    comment: store.find('comment', 2)
+  }).then(async(function(records) {
     expectAssertion(function() {
       records.post.set('user', records.comment);
     }, /You can only add a 'user' record to this relationship/);
@@ -119,7 +134,10 @@ test("The store can load a polymorphic belongsTo association", function() {
   env.store.push('post', { id: 1 });
   env.store.push('comment', { id: 2, message: 1, messageType: 'post' });
 
-  hash({ message: store.find('post', 1), comment: store.find('comment', 2) }).then(async(function(records) {
+  hash({
+    message: store.find('post', 1),
+    comment: store.find('comment', 2)
+  }).then(async(function(records) {
     equal(records.comment.get('message'), records.message);
   }));
 });

--- a/packages/ember-data/tests/integration/store_test.js
+++ b/packages/ember-data/tests/integration/store_test.js
@@ -1,0 +1,106 @@
+var store, env;
+
+var Person = DS.Model.extend({
+  name: DS.attr('string'),
+  cars: DS.hasMany('car')
+});
+
+Person.toString = function() { return "Person"; };
+
+var Car = DS.Model.extend({
+  make: DS.attr('string'),
+  model: DS.attr('string'),
+  person: DS.belongsTo('person')
+});
+
+Car.toString = function() { return "Car"; };
+
+module("integration/store - destroy", {
+  setup: function(){
+    env = setupStore({
+      adapter: DS.FixtureAdapter.extend()
+    });
+    store = env.store;
+
+    env.container.register('model:car', Car);
+    env.container.register('model:person', Person);
+  }
+});
+
+function tap(obj, methodName, callback) {
+  var old = obj[methodName];
+
+  var summary = { called: [] };
+
+  obj[methodName] = function() {
+    var result = old.apply(obj, arguments);
+    if (callback) {
+      callback.apply(obj, arguments);
+    }
+    summary.called.push(arguments);
+    return result;
+  };
+
+  return summary;
+}
+
+
+test("destroying the store correctly cleans everything up", function() {
+  var car = store.push('car', {
+    id: 1,
+    make: 'BMC',
+    model: 'Mini',
+    person: 1
+  });
+
+  var person = store.push('person', {
+    id: 1,
+    name: 'Tom Dale',
+    cars: [1]
+  });
+
+  var personWillDestroy = tap(person, 'willDestroy');
+  var carWillDestroy = tap(car, 'willDestroy');
+  var carsWillDestroy = tap(car.get('person.cars'), 'willDestroy');
+
+  env.adapter.findQuery = function() {
+    return [{
+      id: 2,
+      name: 'Yehuda'
+    }];
+  };
+
+  var adapterPopulatedPeople = store.find('person', {
+    someCrazy: 'query'
+  });
+
+  var filterdPeople = store.filter('person', function(){ return true; });
+
+  var filterdPeopleWillDestroy =  tap(filterdPeople.content, 'willDestroy');
+  var adapterPopulatedPeopleWillDestroy = tap(adapterPopulatedPeople.content, 'willDestroy');
+
+  var adapterPopulatedPerson = store.find('person', 2);
+
+  equal(personWillDestroy.called.length, 0, 'expected person.willDestroy to not have been called');
+  equal(carWillDestroy.called.length, 0, 'expected car.willDestroy to not have been called');
+  equal(carsWillDestroy.called.length, 0, 'expected cars.willDestroy to not have been called');
+  equal(adapterPopulatedPeopleWillDestroy.called.length, 0, 'expected adapterPopulatedPeople.willDestroy to not have been called');
+  equal(filterdPeopleWillDestroy.called.length, 0, 'expected filterdPeople.willDestroy to not have been called');
+
+  equal(filterdPeople.get('length'), 2, 'expected filterdPeople to have 2 entries');
+
+  equal(car.get('person'), person, "expected car's person to be the correct person");
+  equal(person.get('cars.firstObject'), car, " expected persons cars's firstRecord to be the correct car");
+
+  Ember.run(person, person.destroy);
+  Ember.run(store, 'destroy');
+
+  equal(car.get('person'), null, "expected car.person to no longer be present");
+  equal(person.get('cars'), undefined, "expected person.cars to be empty");
+
+  equal(personWillDestroy.called.length, 1, 'expected person to have recieved willDestroy once');
+  equal(carWillDestroy.called.length, 1, 'expected car to recieve willDestroy once');
+  equal(carsWillDestroy.called.length, 1, 'expected cars to recieve willDestroy once');
+  equal(adapterPopulatedPeopleWillDestroy.called.length, 1, 'expected adapterPopulatedPeople to recieve willDestroy once');
+  equal(filterdPeopleWillDestroy.called.length, 1, 'expected filterdPeople.willDestroy to have been called once');
+});

--- a/packages/ember-data/tests/unit/store/unload_test.js
+++ b/packages/ember-data/tests/unit/store/unload_test.js
@@ -22,15 +22,23 @@ module("unit/store/unload - Store unloading records", {
 });
 
 test("unload a dirty record", function() {
-  store.push(Record, {id: 1, title: 'toto'});
+  store.push(Record, {
+    id: 1,
+    title: 'toto'
+  });
 
   store.find(Record, 1).then(async(function(record) {
     record.set('title', 'toto2');
 
+    record.send('willCommit');
     equal(get(record, 'isDirty'), true, "record is dirty");
+
     expectAssertion(function() {
       record.unloadRecord();
-    }, "You can only unload a loaded, non-dirty record.", "can not unload dirty record");
+    }, "You can only unload a record which is not inFlight. `" + Ember.inspect(record) + "`", "can not unload dirty record");
+
+    // force back into safe to unload mode.
+    record.transitionTo('deleted.saved');
   }));
 });
 


### PR DESCRIPTION
- unload's all Records
- unload's all RecordArrays
- destroy's all records (so life cycle hooks get called for cleanup)
- destroy's all RecordArrays

please _note_ unloading a record is now allowed, unless the record is inflight. (previously it was disallowed for all dirty states)
- [x] much peer review
- [x] fix the bugs
- [x] fix the next set of bugs
- [x] consider performance implication (destroying a store, now actually does stuff)
