### PR TITLE
Maintain consistency of internal changed attributes hash.

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -277,6 +277,10 @@ function attr(type, options) {
       var oldValue = getValue(this, key);
 
       if (value !== oldValue) {
+        // Add the new value to the changed attributes hash; it will get deleted by
+        // the 'didSetProperty' handler if it is no different from the original value
+        this._attributes[key] = value;
+
         this.send('didSetProperty', {
           name: key,
           oldValue: oldValue,
@@ -285,7 +289,6 @@ function attr(type, options) {
         });
       }
 
-      this._attributes[key] = value;
       return value;
     } else if (hasValue(this, key)) {
       return getValue(this, key);

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -183,6 +183,22 @@ test("setting a property to undefined on a newly created record should not impac
   equal(get(tag, 'currentState.stateName'), "root.loaded.created.uncommitted");
 });
 
+// NOTE: this is a 'backdoor' test that ensures internal consistency, and should be
+// thrown out if/when the current `_attributes` hash logic is removed.
+test("setting a property back to its original value removes the property from the `_attributes` hash", function() {
+  store.find(Person, 1).then(async(function(person) {
+    equal(person._attributes.name, undefined, "the `_attributes` hash is clean");
+
+    set(person, 'name', "Niceguy Dale");
+
+    equal(person._attributes.name, "Niceguy Dale", "the `_attributes` hash contains the changed value");
+
+    set(person, 'name', "Scumbag Dale");
+
+    equal(person._attributes.name, undefined, "the `_attributes` hash is reset");
+  }));
+});
+
 module("unit/model - with a simple Person model", {
   setup: function() {
     array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];


### PR DESCRIPTION
This change makes sure that a record's `_attributes` hash is always in sync with the `_data` hash's values, namely that there's never a case such that:

``` javascript
// for all valid attributes
record._attributes['attrName'] === record._data['attrName']
```

This can happen due to the order in which values are set in `_attributes` and the `didSetProperty` state machine transition occurs, as shown in [this jsbin](http://emberjs.jsbin.com/eYaMarak/1). Because this is an implementation detail, and unit tests are meant to test public APIs, I didn't think writing a failing test made sense (this change does not make any current tests fail).

Since this doesn't have any impact on the external API, you're probably wondering why it even matters. The answer is being able to extend ED with functionality that use its internals (and is therefore tied to a specific version of ED) without having to modify the source. My attempt at making ['dependent' relationships](https://gist.github.com/slindberg/8660986) is an example of that.
