### PR TITLE
Do not generate a gzip report from uglify:dist.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,6 @@ module.exports = function(grunt){
   grunt.registerTask('dev', [ 'test:server', 'watch' ]);
   grunt.registerTask('server', 'dev');
 
-  grunt.registerTask('dist', ['buildPackages', 'emberDefeatureify:stripDebug', 'uglify']);
+  grunt.registerTask('dist', ['buildPackages', 'emberDefeatureify:stripDebug', 'uglify:dist']);
   grunt.registerTask('default', ['test']);
 };

--- a/tasks/options/uglify.js
+++ b/tasks/options/uglify.js
@@ -1,7 +1,7 @@
 var grunt = require('grunt');
 module.exports = {
   options: {
-    report: 'gzip',
+    report: 'min',
     banner: grunt.file.read('generators/license.js'),
   },
   dist: {
@@ -9,5 +9,14 @@ module.exports = {
      src: 'dist/ember-data.prod.js',
      dest: 'dist/ember-data.min.js',
     }]
-  }
+  },
+  report: {
+    options:{
+      report: 'gzip'
+    },
+    files: [{
+     src: 'dist/ember-data.prod.js',
+     dest: 'dist/ember-data.min.js',
+    }]
+  },
 };


### PR DESCRIPTION
We currently discard the gzipped output, and this is solely used to display
the results to the screen.  This adds between 5x and 10x to the total time
required for the `uglify` task.

To see the full `gzip` report, run `grunt uglify:report`.
