### PR TITLE
hasMany relationship property are essentially readOnly, lets mark them as such.

### DIFF
--- a/packages/ember-data/lib/system/relationships/has_many.js
+++ b/packages/ember-data/lib/system/relationships/has_many.js
@@ -5,7 +5,7 @@
 var get = Ember.get, set = Ember.set, setProperties = Ember.setProperties;
 
 function asyncHasMany(type, options, meta) {
-  return Ember.computed('data', function(key, value) {
+  return Ember.computed('data', function(key) {
     var relationship = this._relationships[key],
         promiseLabel = "DS: Async hasMany " + this + " : " + key;
 
@@ -34,7 +34,7 @@ function asyncHasMany(type, options, meta) {
     return DS.PromiseArray.create({
       promise: promise
     });
-  }).meta(meta);
+  }).meta(meta).readOnly();
 }
 
 function buildRelationship(record, key, options, callback) {
@@ -68,13 +68,13 @@ function hasRelationship(type, options) {
     return asyncHasMany(type, options, meta);
   }
 
-  return Ember.computed('data', function(key, value) {
+  return Ember.computed('data', function(key) {
     return buildRelationship(this, key, options, function(store, data) {
       var records = data[key];
       Ember.assert("You looked up the '" + key + "' relationship on '" + this + "' but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", Ember.A(records).everyProperty('isEmpty', false));
       return store.findMany(this, data[key], meta.type);
     });
-  }).meta(meta);
+  }).meta(meta).readOnly();
 }
 
 /**

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -330,10 +330,8 @@ test("When a record is created on the client, its async hasMany arrays should be
     comments: DS.hasMany('comment', { async: true })
   });
 
-  var post;
-
-  Ember.run(function() {
-    post = env.store.createRecord('post');
+  var post = Ember.run(function() {
+    return env.store.createRecord('post');
   });
 
   ok(get(post, 'isLoaded'), "The post should have isLoaded flag");
@@ -344,4 +342,31 @@ test("When a record is created on the client, its async hasMany arrays should be
     ok(get(comments, 'isLoaded'), "The comments should have isLoaded flag");
   });
 
+});
+
+test("a records SYNC HM relationship property is readOnly", function(){
+  expect(1);
+  var post = Ember.run(function() {
+    return env.store.createRecord('post');
+  });
+
+  raises(function(){
+    post.set('comments');
+  }, 'Cannot Set: comments on: ' + Ember.inspect(post));
+});
+
+
+test("a records ASYNC HM relationship property is readOnly", function(){
+  expect(1);
+  Post.reopen({
+    comments: DS.hasMany('comment', { async: true })
+  });
+
+  var post = Ember.run(function() {
+    return env.store.createRecord('post');
+  });
+
+  raises(function(){
+    post.set('comments');
+  }, 'Cannot Set: comments on: ' + Ember.inspect(post));
 });


### PR DESCRIPTION
This also fixes a potential issue with minified code changing the arity of these CPs.
This happens because "value"'s only purpose is to increase the arity to 2, such that
setting to this CP has no effect. Unfortunately, when minified it does have an effect.

Also, allowing this property to be set to, even though it has no outcome, is just straight up misleading.
