### PR TITLE
Break Down JSONSerializer#serializeBelongsTo Test

### DIFF
--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -62,17 +62,17 @@ test("serializeBelongsTo", function() {
   deepEqual(json, {
     post: "1"
   });
+});
 
-  json = {};
-
-  set(comment, 'post', null);
+test("serializeBelongsTo with null", function() {
+  comment = env.store.createRecord(Comment, { body: "Omakase is delicious", post: null});
+  var json = {};
 
   env.serializer.serializeBelongsTo(comment, json, {key: "post", options: {}});
 
   deepEqual(json, {
     post: null
   }, "Can set a belongsTo to a null value");
-
 });
 
 test("serializeBelongsTo respects keyForRelationship", function() {


### PR DESCRIPTION
There were multiple assertions in "serializeBelongsTo" test. Break it into two to make things easier to understand.
