### PR TITLE
Add support for passing a query of type array to store.find.

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -332,6 +332,14 @@ Store = Ember.Object.extend({
     the query, and return a promise that will be resolved once the server
     responds.
 
+    Alternatively, to find a record by a query call `find` with an array as
+    the second parameter:
+
+    ```javascript
+    var filters = [ { name: 'filter', value: 'age<30' }, { name: 'filter', value: 'age>20'} ];
+    store.find(App.Person, filters });
+    ```
+
     @method find
     @param {String or subclass of DS.Model} type
     @param {Object|String|Integer|null} id
@@ -346,7 +354,7 @@ Store = Ember.Object.extend({
     }
 
     // We are passed a query instead of an id.
-    if (Ember.typeOf(id) === 'object') {
+    if (Ember.typeOf(id) === 'object' || Ember.typeOf(id) === 'array') {
       return this.findQuery(type, id);
     }
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -337,7 +337,7 @@ Store = Ember.Object.extend({
 
     ```javascript
     var filters = [ { name: 'filter', value: 'age<30' }, { name: 'filter', value: 'age>20'} ];
-    store.find(App.Person, filters });
+    store.find('person', filters });
     ```
 
     @method find

--- a/packages/ember-data/tests/integration/adapter/queries_test.js
+++ b/packages/ember-data/tests/integration/adapter/queries_test.js
@@ -35,3 +35,19 @@ test("When a query is made, the adapter should receive a record array it can pop
     equal(queryResults.objectAt(1).get('name'), "Brohuda Katz", "the second record is 'Brohuda Katz'");
   }));
 });
+
+test("When a query is made with an array of objects, the adapter should receive a record array it can populate with the results of the query.", function() {
+  adapter.findQuery = function(store, type, query, recordArray) {
+    equal(type, Person, "the find method is called with the correct type");
+
+    return Ember.RSVP.resolve([{ id: 1, name: "Peter Wagenet" }, { id: 2, name: "Brohuda Katz" }]);
+  };
+
+  store.find('person', [{ filter: 'id<3' }, {filter: 'id>0'}] ).then(async(function(queryResults) {
+    equal(get(queryResults, 'length'), 2, "the record array has a length of 2 after the results are loaded");
+    equal(get(queryResults, 'isLoaded'), true, "the record array's `isLoaded` property should be true");
+
+    equal(queryResults.objectAt(0).get('name'), "Peter Wagenet", "the first record is 'Peter Wagenet'");
+    equal(queryResults.objectAt(1).get('name'), "Brohuda Katz", "the second record is 'Brohuda Katz'");
+  }));
+});


### PR DESCRIPTION
Since the query is passed directly to jQuery, this array follows
the format as specified by jQuery.param.

Use Case:
I need to send multiple filter requests to the server. Since the query is passed to jQuery, jQuery.param() is responsible for serializing the array. http://api.jquery.com/jQuery.param/
The example I added to the documentation follows jQuery's serializeArray() convention.