### PR TITLE
[DOC] Fix extractArray example

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -636,7 +636,7 @@ var JSONSerializer = Ember.Object.extend({
     App.PostSerializer = DS.JSONSerializer.extend({
       extractArray: function(store, type, payload) {
         return payload.map(function(json) {
-          return this.extractSingle(json);
+          return this.extractSingle(store, type, json);
         }, this);
       }
     });


### PR DESCRIPTION
It makes the use of extractSingle consistent with the signature see #1743

As a side note I realize the store is not used in the extractSingle function, but I guess it could be usefull for people overriding it ?
