### PR TITLE
Use Ember getter to retrieve the RESTAdapter headers.

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -599,8 +599,8 @@ var RESTAdapter = Adapter.extend({
       hash.data = JSON.stringify(hash.data);
     }
 
-    if (this.headers !== undefined) {
-      var headers = this.headers;
+    var headers = get(this, 'headers');
+    if (headers !== undefined) {
       hash.beforeSend = function (xhr) {
         forEach.call(Ember.keys(headers), function(key) {
           xhr.setRequestHeader(key, headers[key]);


### PR DESCRIPTION
The `host` and `namespace` properties on `DS.RESTAdapter` can be computed properties. However, `headers` somehow cannot. This change adds computed property support for `headers`.

In my case, my use case is setting the _Authorization_ header, which is dynamic since a user can login / logout at any point in time. With this change, I can now simply do:

```
Ember.RESTAdapter.extend({
  ...
  headers: function() {
    return {
      Authorization    : myUserToken,
      X-Another-Header : 'Foo'
    };
  }.property('myUserToken'),
  ...
});
```
