### PR TITLE
[BUGFIX] Use keyForRelationship in DS.JSONSerializer#serializeHasMany

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -381,11 +381,12 @@ var JSONSerializer = Ember.Object.extend({
   */
   serializeHasMany: function(record, json, relationship) {
     var key = relationship.key;
-
+    var payloadKey = this.keyForRelationship ? this.keyForRelationship(key, "hasMany") : key;
     var relationshipType = RelationshipChange.determineRelationshipType(record.constructor, relationship);
+    var relationshipTypes = ['manyToNone', 'manyToMany', 'manyToOne'];
 
-    if (relationshipType === 'manyToNone' || relationshipType === 'manyToMany') {
-      json[key] = get(record, key).mapBy('id');
+    if (relationshipTypes.indexOf(relationshipType) > -1) {
+      json[payloadKey] = get(record, key).mapBy('id');
       // TODO support for polymorphic manyToNone and manyToMany relationships
     }
   },

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -4,7 +4,8 @@ var Post, post, Comment, comment, env;
 module("integration/serializer/json - JSONSerializer", {
   setup: function() {
     Post = DS.Model.extend({
-      title: DS.attr('string')
+      title: DS.attr('string'),
+      comments: DS.hasMany('comment')
     });
     Comment = DS.Model.extend({
       body: DS.attr('string'),
@@ -89,6 +90,23 @@ test("serializeBelongsTo respects keyForRelationship", function() {
 
   deepEqual(json, {
     POST: "1"
+  });
+});
+
+test("serializeHasMany respects keyForRelationship", function() {
+  env.container.register('serializer:post', DS.JSONSerializer.extend({
+    keyForRelationship: function(key, type) {
+      return key.toUpperCase();
+    }
+  }));
+  post = env.store.createRecord(Post, { title: "Rails is omakase", id: "1"});
+  comment = env.store.createRecord(Comment, { body: "Omakase is delicious", post: post, id: "1"});
+  var json = {};
+
+  env.container.lookup("serializer:post").serializeHasMany(post, json, {key: "comments", options: {}});
+
+  deepEqual(json, {
+    COMMENTS: ["1"]
   });
 });
 

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -264,7 +264,8 @@ test("serializeIntoHash", function() {
 
   deepEqual(json, {
     homePlanet: {
-      name: "Umber"
+      name: "Umber",
+      superVillains: []
     }
   });
 });
@@ -278,7 +279,8 @@ test("serializeIntoHash with decamelized typeKey", function() {
 
   deepEqual(json, {
     homePlanet: {
-      name: "Umber"
+      name: "Umber",
+      superVillains: []
     }
   });
 });


### PR DESCRIPTION
- serializeBelongsTo uses the same already

Currently the serializeHasMany method uses only relationship.key; however the serializeBelongsTo correctly looks up the key with optionally calling keyForRelationship if the serializer defines it.
