### PR TITLE
JSONSerializer normalize each record passed to extractArray

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -649,7 +649,9 @@ var JSONSerializer = Ember.Object.extend({
     @return {Array} array An array of deserialized objects
   */
   extractArray: function(store, type, payload) {
-    return this.normalize(type, payload);
+    return payload.map(function(json) {
+      return this.extractSingle(store, type, json);
+    }, this);
   },
 
   /**

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -23,6 +23,18 @@ module("integration/serializer/json - JSONSerializer", {
   }
 });
 
+test('extractArray - normalize main type records', function() {
+  Post.reopen({
+    count: DS.attr('number')
+  });
+
+  var posts = [{id: "1", count: "3"}];
+
+  var array = env.serializer.extractArray(env.store, Post, posts);
+
+  strictEqual(array[0].count, 3);
+});
+
 test("serializeAttribute", function() {
   post = env.store.createRecord("post", { title: "Rails is omakase"});
   var json = {};


### PR DESCRIPTION
`extractArray` was expecting a hash but arrays are passed to its payload argument. 
Implementation was documented, so this is just a copy/paste PR.

This fix issues with [ember-localstorage-adapter](https://github.com/rpflorence/ember-localstorage-adapter) that was not able to deserialize numbers / dates properly.
