### PR TITLE
Fix rollback on invalid record after set

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -357,6 +357,10 @@ var DirtyState = {
 
     invokeLifecycleCallbacks: function(record) {
       record.triggerLater('becameInvalid', record);
+    },
+
+    exit: function(record) {
+      record._inFlightAttributes = {};
     }
   }
 };


### PR DESCRIPTION
Rolling back an invalid record fails after a `set` is performed. This is resolved by clearing `_inFlightAttributes` when exiting the invalid state.

[JSFiddle illustrating this issue](http://jsfiddle.net/mandrakus/ABULY/4/)
