### PR TITLE
Document required structure for DS.InvalidError

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -32,6 +32,17 @@ var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'n
     }
   });
   ```
+  
+  The `DS.InvalidError` must be constructed with a single object whose
+  keys are the invalid model properties, and whose values are the
+  corresponding error messages. For example:
+  
+  ```javascript
+  return new DS.InvalidError({
+    length: 'Must be less than 15',
+    name: 'Must not be blank
+  });
+  ```
 
   @class InvalidError
   @namespace DS


### PR DESCRIPTION
I found it hard to figure out what was necessary for `DS.InvalidError` to be constructed with, so I've added some documentation.
