### PR TITLE
Use string model lookup instead of class lookup in docs

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -59,7 +59,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     Example
 
     ```javascript
-    var record = store.createRecord(App.Model);
+    var record = store.createRecord('model');
     record.get('isLoaded'); // true
 
     store.find('model', 1).then(function(model) {
@@ -81,7 +81,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     Example
 
     ```javascript
-    var record = store.createRecord(App.Model);
+    var record = store.createRecord('model');
     record.get('isDirty'); // true
 
     store.find('model', 1).then(function(model) {
@@ -105,7 +105,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     Example
 
     ```javascript
-    var record = store.createRecord(App.Model);
+    var record = store.createRecord('model');
     record.get('isSaving'); // false
     var promise = record.save();
     record.get('isSaving'); // true
@@ -130,7 +130,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     Example
 
     ```javascript
-    var record = store.createRecord(App.Model);
+    var record = store.createRecord('model');
     record.get('isDeleted'); // false
     record.deleteRecord();
     record.get('isDeleted'); // true
@@ -150,7 +150,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     Example
 
     ```javascript
-    var record = store.createRecord(App.Model);
+    var record = store.createRecord('model');
     record.get('isNew'); // true
 
     record.save().then(function(model) {
@@ -186,7 +186,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     Example
 
     ```javascript
-    var record = store.createRecord(App.Model);
+    var record = store.createRecord('model');
     record.get('dirtyType'); // 'created'
     ```
 
@@ -253,7 +253,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     attribute.
 
     ```javascript
-    var record = store.createRecord(App.Model);
+    var record = store.createRecord('model');
     record.get('id'); // null
 
     store.find('model', 1).then(function(model) {

--- a/packages/ember-data/lib/system/record_arrays/record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/record_array.js
@@ -45,7 +45,7 @@ var RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
     Example
 
     ```javascript
-    var people = store.all(App.Person);
+    var people = store.all('person');
     people.get('isLoaded'); // true
     ```
 
@@ -59,7 +59,7 @@ var RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
     Example
 
     ```javascript
-    var people = store.all(App.Person);
+    var people = store.all('person');
     people.get('isUpdating'); // false
     people.update();
     people.get('isUpdating'); // true
@@ -100,7 +100,7 @@ var RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
     Example
 
     ```javascript
-    var people = store.all(App.Person);
+    var people = store.all('person');
     people.get('isUpdating'); // false
     people.update();
     people.get('isUpdating'); // true
@@ -145,7 +145,7 @@ var RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
     Example
 
     ```javascript
-    var messages = store.all(App.Message);
+    var messages = store.all('message');
     messages.forEach(function(message) {
       message.set('hasBeenSeen', true);
     });


### PR DESCRIPTION
I grepped through the codebase for "App." and so there should be no more places where this problem occurs, unless they are happening with an example not based of an application called "App" (or "MyApp" or whatever) 
