### PR TITLE
Use the ApplicationAdapter property instead of creating a custom Store

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -67,8 +67,8 @@ InvalidError.prototype = Ember.create(Error.prototype);
 
   ### Creating an Adapter
 
-  Create a new subclass of `DS.Adapter` then assign
-  it to the `ApplicationAdapter` property.
+  Create a new subclass of `DS.Adapter`, then assign
+  it to the `ApplicationAdapter` property of the application.
 
   ```javascript
   var MyAdapter = DS.Adapter.extend({
@@ -78,12 +78,12 @@ InvalidError.prototype = Ember.create(Error.prototype);
   App.ApplicationAdapter = MyAdapter;
   ```
 
-  Model specific adapters can be created by assigning the adapter
-  class to the `ModelName` + `Adapter` property.
+  Model-specific adapters can be created by assigning your adapter
+  class to the `ModelName` + `Adapter` property of the application.
 
   ```javascript
   var MyPostAdapter = DS.Adapter.extend({
-    // ...post specific adapter code goes here
+    // ...Post-specific adapter code goes here
   });
 
   App.PostAdapter = MyPostAdapter;


### PR DESCRIPTION
just to create a custom adapter.

The Transition guide for ember data make it seem like extending `DS.Store` to create a custom adapter is the old ember data .13 way of doing things. 
https://github.com/emberjs/data/blob/master/TRANSITION.md#adapters
