### PR TITLE
Deprecate App.Store in favor of App.ApplicationStore.

### DIFF
--- a/packages/ember-data/lib/initializers.js
+++ b/packages/ember-data/lib/initializers.js
@@ -20,6 +20,7 @@ var set = Ember.set;
   This code registers an injection for Ember.Application.
 
   If an Ember.js developer defines a subclass of DS.Store on their application,
+  as `App.ApplicationStore` (or via a module system that resolves to `store:application`)
   this code will automatically instantiate it and make it available on the
   router.
 
@@ -28,7 +29,7 @@ var set = Ember.set;
 
   For example, imagine an Ember.js application with the following classes:
 
-  App.Store = DS.Store.extend({
+  App.ApplicationStore = DS.Store.extend({
     adapter: 'custom'
   });
 
@@ -36,7 +37,7 @@ var set = Ember.set;
     // ...
   });
 
-  When the application is initialized, `App.Store` will automatically be
+  When the application is initialized, `App.ApplicationStore` will automatically be
   instantiated, and the instance of `App.PostsController` will have its `store`
   property set to that instance.
 
@@ -51,7 +52,10 @@ Ember.onLoad('Ember.Application', function(Application) {
     name: "store",
 
     initialize: function(container, application) {
-      application.register('store:main', application.Store || Store);
+      Ember.deprecate('Specifying a custom Store for Ember Data on your global namespace as `App.Store` ' +
+                      'has been deprecated. Please use `App.ApplicationStore` instead.', !application.Store);
+
+      application.register('store:main', container.lookupFactory('store:application') || application.Store || Store);
 
       // allow older names to be looked up
 

--- a/packages/ember-data/tests/integration/application_test.js
+++ b/packages/ember-data/tests/integration/application_test.js
@@ -9,7 +9,7 @@ module("integration/application - Injecting a Custom Store", {
   setup: function() {
     Ember.run(function() {
       app = Ember.Application.create({
-        Store: DS.Store.extend({ isCustom: true }),
+        ApplicationStore: DS.Store.extend({ isCustom: true }),
         FooController: Ember.Controller.extend(),
         ApplicationView: Ember.View.extend(),
         BazController: {},
@@ -33,6 +33,26 @@ test("If a Store property exists on an Ember.Application, it should be instantia
 test("If a store is instantiated, it should be made available to each controller.", function() {
   var fooController = container.lookup('controller:foo');
   ok(fooController.get('store.isCustom'), "the custom store was injected");
+});
+
+test("registering App.Store is deprecated but functional", function(){
+  Ember.run(app, 'destroy');
+
+  expectDeprecation(function(){
+    Ember.run(function() {
+        app = Ember.Application.create({
+          Store: DS.Store.extend({ isCustomButDeprecated: true }),
+          FooController: Ember.Controller.extend(),
+        });
+    });
+  }, 'Specifying a custom Store for Ember Data on your global namespace as `App.Store` ' +
+     'has been deprecated. Please use `App.ApplicationStore` instead.');
+
+  container = app.__container__;
+  ok(container.lookup('store:main').get('isCustomButDeprecated'), "the custom store was instantiated");
+
+  var fooController = container.lookup('controller:foo');
+  ok(fooController.get('store.isCustomButDeprecated'), "the custom store was injected");
 });
 
 module("integration/application - Injecting the Default Store", {

--- a/packages/ember-data/tests/integration/debug_adapter_test.js
+++ b/packages/ember-data/tests/integration/debug_adapter_test.js
@@ -7,7 +7,7 @@ module("DS.DebugAdapter", {
         toString: function() { return 'App'; }
       });
 
-      App.Store = DS.Store.extend({
+      App.ApplicationStore = DS.Store.extend({
         adapter: DS.Adapter.extend()
       });
 


### PR DESCRIPTION
This makes the application level store lookup much closer to the reset of our conventions (ala `App.ApplicationAdapter` and `App.ApplicationSerializer`).

This change also allows specifying a custom store when using non-global resolver (i.e. EAK/ember-cli). Previously, we were only looking for a property `Store` hung off of the application instance. Now you can have a module named (in the case of stock EAK setup): `app/stores/application` or `app/application/store.js` (pods structure).

A deprecation warning was added, and the prior technique still works so this is not a breaking change (although I believe that we should remove before the prior lookup prior to 1.0).
