### PR TITLE
Added one failing spec (and one that passes for clarification purposes)

### DIFF
--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -41,6 +41,26 @@ function ajaxResponse(value) {
   };
 }
 
+test("Can set custom headers dynamically by reopening adapter", function() {
+  DS.RESTAdapter.reopen({
+    headers: {token: 'new_token' }
+  });
+  ok(DS.RESTAdapter.prototype.ajaxOptions().context.headers, "header set reopen");
+
+  DS.RESTAdapter.reopenClass({
+    headers: {token: 'new_token_2' }
+  });
+  ok(DS.RESTAdapter.prototype.ajaxOptions().context.headers, "header set reopenClass");
+});
+
+test("Can set custom headers dynamically by setting property on adapter's prototype", function() {
+  DS.RESTAdapter.prototype.setProperties({
+    headers: {token: 'new_token_3' }
+  });
+  ok(DS.RESTAdapter.prototype.ajaxOptions().context.headers, "header set prototype.setProperties");
+  equal('new_token_3', DS.RESTAdapter.prototype.ajaxOptions().context.headers.token);
+});
+
 test("find - basic payload", function() {
   ajaxResponse({ posts: [{ id: 1, name: "Rails is omakase" }] });
 


### PR DESCRIPTION
In https://github.com/emberjs/data/blob/master/packages/ember-data/lib/adapters/rest_adapter.js#L88 (and elsewhere in that same file), achieving Headers Customization is advised to be done by reopening the adapter class. However, this does not seem to work.

This PR is just one failing test, and one passing (an example of how you can achieve this with ugly reach on to `prototype.setProperties` of said adapter [not ideal of course]). You could of course just hijack `ajax` and `hash.beforeSend` and call `_super` but this seems neither idiomatic or ideal.

I'm happy to work more on this and provide a solution, but as a newcomer want to first have bug acknowledged and also be advised any preferred approaches before starting on implementing. Thanks.
