### PR TITLE
Extract the filtering of fixtures to easily mimic server retrieval schemes

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -303,13 +303,7 @@ var FixtureAdapter = Adapter.extend({
     @param id
   */
   findFixtureById: function(fixtures, id) {
-    return Ember.A(fixtures).find(function(r) {
-      if(''+get(r, 'id') === ''+id) {
-        return true;
-      } else {
-        return false;
-      }
-    });
+    return this.filterFixturesByIds(fixtures, [''+id])[0];
   },
 
   /*

--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -141,7 +141,7 @@ var FixtureAdapter = Adapter.extend({
     Ember.assert("Unable to find fixtures for model type "+type.toString(), fixtures);
 
     if (fixtures) {
-      fixture = Ember.A(fixtures).findProperty('id', id);
+      fixture = this.findFixtureById(fixtures, id);
     }
 
     if (fixture) {

--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -164,9 +164,7 @@ var FixtureAdapter = Adapter.extend({
     Ember.assert("Unable to find fixtures for model type "+type.toString(), fixtures);
 
     if (fixtures) {
-      fixtures = fixtures.filter(function(item) {
-        return indexOf(ids, item.id) !== -1;
-      });
+      fixtures = this.filterFixturesByIds(fixtures, ids);
     }
 
     if (fixtures) {
@@ -311,6 +309,18 @@ var FixtureAdapter = Adapter.extend({
       } else {
         return false;
       }
+    });
+  },
+
+  /*
+    @method findFixturesByIds
+    @private
+    @param fixtures
+    @param ids
+  */
+  filterFixturesByIds: function(fixtures, ids) {
+    return fixtures.filter(function(item) {
+      return indexOf(ids, item.id) !== -1;
     });
   },
 

--- a/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
@@ -93,6 +93,26 @@ test("should load data asynchronously at the end of the runloop when simulateRem
   equal(get(wycats, 'firstName'), 'Yehuda', 'record properties are defined after runloop finishes');
 });
 
+test("should allow to easily simulate server retrieval schemes", function() {
+  Person.FIXTURES = [{
+    id: 'wycats',
+    firstName: "Yehuda"
+  }];
+
+  PersonAdapter = DS.FixtureAdapter.extend({
+    filterFixturesByIds: function(fixtures, ids) {
+      return fixtures.filter(function(item) {
+        return Ember.EnumerableUtils.indexOf(ids, item.firstName) !== -1;
+      });
+    }
+  });
+  env.store.set('adapter', PersonAdapter);
+
+  env.store.find('person', 'Yehuda').then(async(function(person) {
+    equal(get(person, 'id'), 'wycats', 'record can be found using a custom filter');
+  }));
+});
+
 test("should create record asynchronously when it is committed", function() {
   equal(Person.FIXTURES.length, 0, "Fixtures is empty");
 


### PR DESCRIPTION
Sometimes you want to find a record on the server with keys other than the ids. 

Here is an example:

```js
App.BlogRoute = Ember.Route.extend({
  model: function(params) {
    return this.store.find("blog", params.slug);
  }
});
```

Your API on the server should know to expect a `slug` as the parameter and retrieve the `Blog` object with that slug.

If you want to mimic this in your `FIXTURES`, you have to override the entire `find` function. This PR extracts the filtering for the fixture ids so you can override a simpler, more concise function that the `find` function calls.

This is what you would need for your `FixtureAdapter`.

```js
BlogAdapter = DS.FixtureAdapter.extend({
  filterFixturesByIds: function(fixtures, ids) {
    return fixtures.filter(function(blog) {
      return Ember.EnumerableUtils.indexOf(ids, blog.slug) !== -1;
    });
  }
});
```