### PR TITLE
Fix the ActiveModelAdapter @extends docstring

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_adapter.js
+++ b/packages/activemodel-adapter/lib/system/active_model_adapter.js
@@ -58,7 +58,7 @@ var decamelize = Ember.String.decamelize,
   @class ActiveModelAdapter
   @constructor
   @namespace DS
-  @extends DS.Adapter
+  @extends DS.RESTAdapter
 **/
 
 var ActiveModelAdapter = RESTAdapter.extend({


### PR DESCRIPTION
The RESTAdapter properties should show up on the ActiveModelAdapter
api docs page.
