### PR TITLE
Zombie record when id query mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
 * move some requires around
 * move grunt tasks into folders
 * ES6!
+* Ensure place-holder records do are removed after querying and an id
+  mismatch
 
 ### Ember Data 1.0.0-beta.6 _(January 25, 2014)_
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -448,6 +448,13 @@ Store = Ember.Object.extend({
     Ember.assert("You tried to find a record but your adapter (for " + type + ") does not implement 'find'", adapter.find);
 
     var promise = _find(adapter, this, type, id);
+
+    promise.then(function(newRecord) {
+      if (!record.get('isNew') && newRecord.get('id') !== record.get('id')) {
+        record.transitionTo('deleted.uncommitted');
+      }
+    });
+
     record.loadingData(promise);
     return promise;
   },

--- a/packages/ember-data/tests/integration/adapter/find_test.js
+++ b/packages/ember-data/tests/integration/adapter/find_test.js
@@ -56,6 +56,45 @@ test("When a single record is requested, the adapter's find method should be cal
   store.find(Person, 1);
 });
 
+test("When a single record is requested and the resulting record's id differs from the requested record's id, the requested record should be deleted.", function() {
+  expect(1);
+
+  var count = 0;
+
+  store = createStore({ adapter: DS.Adapter.extend({
+      find: function(store, type, id) {
+        return { id: 2 };
+      }
+    })
+  });
+
+  store.find(Person, 1).then(function() {
+    var ids = store.all(Person).map(function(p) { return p.get('id') });
+    ok(!ids.contains('1'), "Person record of id '1' should not exist");
+  });;
+});
+
+test("When a single record is requested and the resulting record's id differs from the requested record's id, the requested record should not be deleted if it previously existed.", function() {
+  expect(1);
+
+  var count = 0;
+
+  store = createStore({ adapter: DS.Adapter.extend({
+      find: function(store, type, id) {
+        return { id: 2 };
+      }
+    })
+  });
+
+  var existingRecord = store.createRecord(Person, {id: 1});
+  existingRecord.transitionTo('loaded.saved');
+
+  store.find(Person, 1).then(function() {
+    var ids = store.all(Person).map(function(p) { return p.get('id') });
+    ok(ids.contains('1'), "Person record of id '1' should still exist");
+  });;
+});
+
 test("When a single record is requested multiple times, all .find() calls are resolved after the promise is resolved", function() {
   var deferred = Ember.RSVP.defer();
 


### PR DESCRIPTION
If I query for a record of id `1` and the server returns a record of id
`2` the store will have records of id `1` and id `2` as Ember Data
pre-emptively instantiates the record you are querying for.

A common use-case where this occurs is when querying for records with
a slug for an id. If I have a slug library server side for a Rails
application I do not want to just map my id column for the slug because
all of the relationships and foreign keys in my database are using the
auto-incrementing id column, not the slugs. The slugs are there for
presentation purposes only. However, on the client I will sometimes only
have a slug as the unique identifier to search for a given record on the
server.

This PR will do the following:

If you query the server for id `1` and it returns a record of id `2` it
will delete the previously instantiated record of id `1`.

If you already have a pre-existing record of id `1` that is committed
and query the server for id `1` and the server returns a record of id
`2` it will **not** delete the record of id `1`.