### PR TITLE
Add force option to store find method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@
 * move some requires around
 * move grunt tasks into folders
 * ES6!
+* Add `force` option to the store's `find` method which will bypass a
+  record lookup in the local store and always delegate to the adapter's
+  `find` method
 
 ### Ember Data 1.0.0-beta.6 _(January 25, 2014)_
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -342,6 +342,13 @@ Store = Ember.Object.extend({
     The `find` method will always resolve its promise with the same object for
     a given type and `id`.
 
+    If you pass `true` as the last argument the local store will be bypassed and
+    the adapter's `find` method will always be used to find the necessary data.
+
+    ```javascript
+    store.find('person', 1, true);
+    ```
+
     ---
 
     To find all records for a type, call `find` with no additional parameters:
@@ -370,9 +377,10 @@ Store = Ember.Object.extend({
     @method find
     @param {String or subclass of DS.Model} type
     @param {Object|String|Integer|null} id
+    @param {Boolean} force
     @return {Promise} promise
   */
-  find: function(type, id) {
+  find: function(type, id, force) {
     Ember.assert("You need to pass a type to the store's find method", arguments.length >= 1);
     Ember.assert("You may not pass `" + id + "` as id to the store's find method", arguments.length === 1 || !Ember.isNone(id));
 
@@ -385,7 +393,7 @@ Store = Ember.Object.extend({
       return this.findQuery(type, id);
     }
 
-    return this.findById(type, coerceId(id));
+    return this.findById(type, coerceId(id), force);
   },
 
   /**
@@ -397,11 +405,11 @@ Store = Ember.Object.extend({
     @param {String|Integer} id
     @return {Promise} promise
   */
-  findById: function(type, id) {
+  findById: function(type, id, force) {
     type = this.modelFor(type);
 
     var record = this.recordForId(type, id);
-    var fetchedRecord = this.fetchRecord(record);
+    var fetchedRecord = this.fetchRecord(record, force);
 
     return promiseObject(fetchedRecord || record, "DS: Store#findById " + type + " with id: " + id);
   },
@@ -434,10 +442,10 @@ Store = Ember.Object.extend({
     @param {DS.Model} record
     @returns {Promise} promise
   */
-  fetchRecord: function(record) {
+  fetchRecord: function(record, force) {
     if (isNone(record)) { return null; }
     if (record._loadingPromise) { return record._loadingPromise; }
-    if (!get(record, 'isEmpty')) { return null; }
+    if (!force && !get(record, 'isEmpty')) { return null; }
 
     var type = record.constructor,
         id = get(record, 'id');

--- a/packages/ember-data/tests/integration/adapter/find_test.js
+++ b/packages/ember-data/tests/integration/adapter/find_test.js
@@ -56,6 +56,28 @@ test("When a single record is requested, the adapter's find method should be cal
   store.find(Person, 1);
 });
 
+test("When a single record is requested, the adapter's find method should be called when forced even if it's loaded.", function() {
+  expect(2);
+
+  var count = 0, expectedCount = 0;
+
+  store = createStore({ adapter: DS.Adapter.extend({
+      find: function(store, type, id) {
+        equal(count, expectedCount, "the find method is only called once");
+
+        count++;
+        return { id: 1, name: "Braaaahm Dale" };
+      }
+    })
+  });
+
+  var record = store.find(Person, 1).then(async(function(person) {
+    expectedCount = 1;
+    person.transitionTo('empty');
+    store.find(Person, 1, true);
+  }));
+});
+
 test("When a single record is requested multiple times, all .find() calls are resolved after the promise is resolved", function() {
   var deferred = Ember.RSVP.defer();
 


### PR DESCRIPTION
Passing `true` as the last argument on find will always delegate the
record lookup to the adapter's find method rather than relying on the
local store's copy.