### PR TITLE
Fix ember inflector default rules

### DIFF
--- a/packages/ember-inflector/lib/main.js
+++ b/packages/ember-inflector/lib/main.js
@@ -1,6 +1,6 @@
-import {Inflector, inflections, pluralize, singularize} from "./system";
+import {Inflector, defaultRules, pluralize, singularize} from "./system";
 
-Inflector.defaultRules = inflections;
+Inflector.defaultRules = defaultRules;
 Ember.Inflector        = Inflector;
 
 Ember.String.pluralize   = pluralize;

--- a/packages/ember-inflector/tests/system/inflector_test.js
+++ b/packages/ember-inflector/tests/system/inflector_test.js
@@ -233,3 +233,32 @@ test('inflect.advancedRules', function(){
 
   equal(inflector.inflect('ox', rules), 'oxen');
 });
+
+test('Inflector.defaultRules', function(){
+  expect(1);
+
+  var rules = Ember.Inflector.defaultRules;
+  ok(rules, 'has defaultRules');
+});
+
+test('Ember.Inflector.inflector exists', function(){
+  expect(1);
+
+  ok(Ember.Inflector.inflector, 'Ember.Inflector.inflector exists');
+});
+
+test('new Ember.Inflector with defaultRules matches docs', function(){
+  expect(4);
+
+  var inflector = new Ember.Inflector(Ember.Inflector.defaultRules);
+
+  // defaultRules includes these special rules
+  equal(inflector.pluralize('cow'), 'kine');
+  equal(inflector.singularize('kine'), 'cow');
+
+  // defaultRules adds 's' to singular
+  equal(inflector.pluralize('item'), 'items');
+
+  // defaultRules removes 's' from plural
+  equal(inflector.singularize('items'), 'item');
+});


### PR DESCRIPTION
In this large-ish commit (https://github.com/emberjs/data/commit/b1d7448be0c2aff866de6449749441fb7e1d4f98), we lost Ember.Inflector.defaultRules. They were set to `undefined` because the wrong name was imported.

Two jsbins showing it working (1.0.0-beta.6) and `undefined` in (1.0.0-beta.7):
- 1.0.0-beta.6: http://emberjs.jsbin.com/pezix/1/edit?html,js,output
- 1.0.0-beta.7: http://emberjs.jsbin.com/pezix/3/edit?html,js,output

I added a few tests that ensure the functionality fairly closely matches that described in the docs here:
https://github.com/emberjs/data/blob/v1.0.0-beta.7/packages/ember-inflector/lib/system/inflector.js#L20

Also a small typo fix in the tests.
