### PR TITLE
Explicitly define a bower install directory

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
`bower install` will put its files into a folder specified by the first .bowerrc file it finds in or above the project root. It's possible for bower to install its files in a place we do not expect without this explicit declaration.
