### PR TITLE
allow store to deserialize polymorphic relationships

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -568,7 +568,7 @@ Store = Ember.Object.extend({
     @param {String|Integer} id
     @returns {DS.Model} record
   */
-  recordForId: function(type, id) {
+  recordForId: function(type, id, data) {
     type = this.modelFor(type);
 
     id = coerceId(id);
@@ -576,7 +576,7 @@ Store = Ember.Object.extend({
     var record = this.typeMapFor(type).idToRecord[id];
 
     if (!record) {
-      record = this.buildRecord(type, id);
+      record = this.buildRecord(type, id, data);
     }
 
     return record;
@@ -1533,7 +1533,7 @@ function deserializeRecordId(store, data, key, relationship, id) {
     data[key] = store.recordForId(type, id);
   } else if (typeof id === 'object') {
     // polymorphic
-    data[key] = store.recordForId(id.type, id.id);
+    data[key] = store.recordForId(id.type || typeFor(relationship, key, data), id.id, data[key]);
   }
 }
 


### PR DESCRIPTION
With this change, no need to change the JSON structure to have all objects at the root, with referential ids in the value of the parent attributes.

I feel this is helpful in the fact that you don't need to create extra serializers to overwrite the extractSingle function in order to change traditional JSON to what Ember-data expects.  However, if you prefer to create specific serializers that will tranform your payload, this is a non-breaking change.