### PR TITLE
Resolve issue with pushPayload and createRecord duplicate records

### DIFF
--- a/packages/ember-data/tests/integration/push_payload_and_create_record_test.js
+++ b/packages/ember-data/tests/integration/push_payload_and_create_record_test.js
@@ -1,0 +1,44 @@
+var get = Ember.get, set = Ember.set;
+
+var Person, store, payload;
+
+module("integration/push_payload_and_create_record - pushing a payload and ", {
+  setup: function() {
+    Person = DS.Model.extend({ name: DS.attr('string') });
+    payload = {people: [{name: "Alex", id: 1}]};
+
+    store = createStore({ person: Person,
+      adapter: DS.RESTAdapter.extend({
+        createRecord: function(store, type, record) {
+          var promise = new Em.RSVP.Promise(function(resolve, reject){
+            Em.run.later(function() {
+              start();
+              resolve(payload);
+            }, 100);
+          });
+          return promise;
+        }
+      })
+    });
+  },
+  teardown: function() {
+    store.destroy();
+    Person = null;
+    paylod = null;
+  }
+});
+
+
+test("pushPayload and createRecord should live together in harmony", function () {
+
+  var person = store.createRecord(Person, {name: "Alex"});
+
+  person.save().then(function(person) {
+    equal(get(person, 'id'), '1');
+    equal(get(person, 'name'), 'Alex');
+    equal(get(store.all('person'), 'length'), 1);
+  });
+
+  store.pushPayload(Person, payload);
+  stop();
+});


### PR DESCRIPTION
When designing a realtime system with websockets, a common pattern is
to push all changes out to clients using websockets after create, update or delete.
Because store operations are idempotent this works great most of the time.

However, there is an issue when using createRecord. A common pattern
in a backend is to receive the payload, create a new database record,
push the details of the created records to listening clients via
websockets, then return the response to the POST request (including
the new record id) to the HTTP client.

Unfortunately, this can easily lead to a race condition for the client
creating the record, as if they receive a websocket push before
the ajax response they end up with two records with the same id in the
store.

This pull request resolves this issue by checking in the didSaveRecord
callback whether a record with the same id has been already pushed to
the store before the callback was called. It also ensures the promise
returned from record.save() resolves with the already existing record.
