### PR TITLE
Use transform to store attribute values in deserialized format.

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -278,6 +278,11 @@ function attr(type, options) {
       Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.constructor.toString(), key !== 'id');
       var oldValue = getValue(this, key);
 
+      var transform = this.container.lookup('transform:' + type);
+      if (transform) {
+        value = transform.deserialize(value);
+      }
+
       if (value !== oldValue) {
         // Add the new value to the changed attributes hash; it will get deleted by
         // the 'didSetProperty' handler if it is no different from the original value

--- a/packages/ember-data/lib/transforms/date.js
+++ b/packages/ember-data/lib/transforms/date.js
@@ -23,7 +23,9 @@ var DateTransform = Transform.extend({
   deserialize: function(serialized) {
     var type = typeof serialized;
 
-    if (type === "string") {
+    if (serialized instanceof Date) {
+      return serialized;
+    } else if (type === "string") {
       return new Date(Ember.Date.parse(serialized));
     } else if (type === "number") {
       return new Date(serialized);

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -86,7 +86,7 @@ test("it should cache attributes", function() {
   var store = createStore();
 
   var Post = DS.Model.extend({
-    updatedAt: DS.attr('string')
+    updatedAt: DS.attr('date')
   });
 
   var dateString = "Sat, 31 Dec 2011 00:08:16 GMT";
@@ -203,7 +203,8 @@ module("unit/model - with a simple Person model", {
   setup: function() {
     array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];
     Person = DS.Model.extend({
-      name: DS.attr('string')
+      name: DS.attr('string'),
+      age: DS.attr('number')
     });
     store = createStore({
       person: Person
@@ -405,4 +406,11 @@ test("A DS.Model can be JSONified", function() {
   var store = createStore({ person: Person });
   var record = store.createRecord('person', { name: "TomHuda" });
   deepEqual(record.toJSON(), { name: "TomHuda" });
+});
+
+test("setting a property causes the attributes transform to be applied", function() {
+  var record = store.createRecord(Person);
+  set(record, 'age', '1');
+
+  strictEqual(get(record, 'age'), 1, "property was set on the record");
 });

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -62,6 +62,11 @@
       adapter: adapter
     }));
 
+    container.register('transform:boolean', DS.BooleanTransform);
+    container.register('transform:date', DS.DateTransform);
+    container.register('transform:number', DS.NumberTransform);
+    container.register('transform:string', DS.StringTransform);
+
     container.register('serializer:-default', DS.JSONSerializer);
     container.register('serializer:-rest', DS.RESTSerializer);
     container.register('adapter:-rest', DS.RESTAdapter);


### PR DESCRIPTION
This forces the attribute values in `_attributes` to be stored in the deserialized format.

This essentially makes the internal values much more consistent. Currently if you bind a non-string value in a template (`boolean`, `date`, or `number`) the internal attribute is represented in string form (since `{{input}}` will always be a string). This is an issue if you use `Em.computed`'s on the attribute that expect a given attribute format.

For instance:

Storing a `count` field (`DS.attr('number')`), and using an `Em.computed.sum` accros multiple records starts simply appending strings after one is set with an `{{input}}`.

----

There may be a wonderful reason that this is not done at the moment, but it wasn't obvious to me.