### PR TITLE
Fix incorrect documentation for model.isError

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -216,15 +216,14 @@ var Model = Ember.Object.extend(Ember.Evented, {
 
   /**
     If `true` the adapter reported that it was unable to save local
-    changes to the backend. This may also result in the record having
-    its `isValid` property become false if the adapter reported that
-    server-side validations failed.
+    changes to the backend for any reason other than a server-side
+    validation error.
 
     Example
 
     ```javascript
     record.get('isError'); // false
-    record.set('foo', 'invalid value');
+    record.set('foo', 'valid value');
     record.save().then(null, function() {
       record.get('isError'); // true
     });


### PR DESCRIPTION
If the server returns a validation error, then isError is not set to true.

You can see the implementation below (which only calls recordWasError if there is no validation errors):
https://github.com/emberjs/data/blob/20adb1d5b0db0058b9fda35265c9916f2fe7c964/packages/ember-data/lib/system/store.js#L1781

This is further documented in the comment for recordWasError:
https://github.com/emberjs/data/blob/20adb1d5b0db0058b9fda35265c9916f2fe7c964/packages/ember-data/lib/system/store.js#L1011

Note: I linked the currently most recent commit in case the line numbers end up changing.
