### PR TITLE
Allow committing a record whilst in invalid state

### DIFF
--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -179,14 +179,18 @@ var Errors = Ember.Object.extend(Ember.Enumerable, Ember.Evented, {
     to the record.
 
     @method clear
+    @param {Boolean} keepState don't automatically transition to valid state after
+    clearing errors
   */
-  clear: function() {
+  clear: function(keepState) {
     if (get(this, 'isEmpty')) { return; }
 
     get(this, 'content').clear();
     this.enumerableContentDidChange();
 
-    this.trigger('becameValid');
+    if(!keepState) {
+      this.trigger('becameValid');
+    }
   },
 
   /**

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -681,6 +681,9 @@ var Model = Ember.Object.extend(Ember.Evented, {
   adapterDidCommit: function(data) {
     set(this, 'isError', false);
 
+    var recordErrors = get(this, 'errors');
+    recordErrors.clear(true);
+
     if (data) {
       this._data = data;
     } else {
@@ -978,6 +981,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
   */
   adapterDidInvalidate: function(errors) {
     var recordErrors = get(this, 'errors');
+    recordErrors.clear(true);
     function addError(name) {
       if (errors[name]) {
         recordErrors.add(name, errors[name]);

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -347,6 +347,10 @@ var DirtyState = {
 
     becomeDirty: Ember.K,
 
+    willCommit: function(record) {
+      record.transitionTo("inFlight");
+    },
+
     rolledBack: function(record) {
       get(record, 'errors').clear();
     },


### PR DESCRIPTION
If the server returns a 422 response with errors, the record enters
the invalid state. This means that it is impossible to save the record
again without setting all of the invalid properties at least once.

Sometimes this makes sense, but if the server is the arbiter of
validity then often it does not, especially if validity of properties
is interdependant or based on external conditions.

Example:

Server validates firstName + lastName must be at least 10 characters
combined.

Server returns {errors: {firstName: "too short", lastName; "too Short"}}

Now set firstName to be 20 characters long. The record is valid according
to the server, but calling record.save() results in an error:

```
Attempted to handle event `willCommit` on <DS.Model> while in state root.loaded.updated.invalid
```

This patch allows save() to be called on an invalid record, meaning
the server can decide if it's valid or not.
