### PR TITLE
[DOC] Fix validation comments for DS.Model#isValid

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -182,9 +182,9 @@ var Model = Ember.Object.extend(Ember.Evented, {
   */
   isNew: retrieveFromCurrentState,
   /**
-    If this property is `true` the record is in the `valid` state. A
-    record will be in the `valid` state when no client-side
-    validations have failed and the adapter did not report any
+    If this property is `true` the record is in the `valid` state.
+
+    A record will be in the `valid` state when the adapter did not report any
     server-side validation failures.
 
     @property isValid

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -220,8 +220,8 @@ function didSetProperty(record, context) {
 //   adapter reported that server-side validations failed.
 // * isNew: The record was created on the client and the adapter
 //   did not yet report that it was successfully saved.
-// * isValid: No client-side validations have failed and the
-//   adapter did not report any server-side validation failures.
+// * isValid: The adapter did not report any server-side validation
+//   failures.
 
 // The dirty state is a abstract state whose functionality is
 // shared between the `created` and `updated` states.
@@ -326,8 +326,7 @@ var DirtyState = {
     }
   },
 
-  // A record is in the `invalid` state when its client-side
-  // invalidations have failed, or if the adapter has indicated
+  // A record is in the `invalid` if the adapter has indicated
   // the the record failed server-side invalidations.
   invalid: {
     // FLAGS


### PR DESCRIPTION
- Api docs included comments on failing client-side validation
- DS.model doesn't have client side validation
- Only code that sets errors and changes  is a result of an invalid response from server

Perhaps I just couldn't find it but I don't see any support for client-side validations in Ember Data but the documentation stated that a model can become invalid when client-side validations fail. It seemed confusing as I can't find any documentation or code on how ember data supports client side validations. See : http://emberjs.com/api/data/classes/DS.Model.html#property_isValid
