### PR TITLE
[DOC] Clarify adapter settings with ActiveModel::Serializers

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_adapter.js
+++ b/packages/activemodel-adapter/lib/system/active_model_adapter.js
@@ -14,10 +14,11 @@ var decamelize = Ember.String.decamelize,
 
 /**
   The ActiveModelAdapter is a subclass of the RESTAdapter designed to integrate
-  with a JSON API that uses an underscored naming convention instead of camelcasing.
+  with a JSON API that uses an underscored naming convention instead of camelCasing.
   It has been designed to work out of the box with the
   [active_model_serializers](http://github.com/rails-api/active_model_serializers)
-  Ruby gem.
+  Ruby gem. This Adapter expects specific settings using ActiveModel::Serializers,
+  `embed :ids, include: true` which sideloads the records.
 
   This adapter extends the DS.RESTAdapter by making consistent use of the camelization,
   decamelization and pluralization methods to normalize the serialized JSON into a


### PR DESCRIPTION
Clarify settings for using the DS.ActiveModelAdapter.

"You are intended to create an ApplicationSerializer and include `embed :ids, include: true` for Ember apps, which will make all your Rails serializers use sideloading."
- See https://github.com/emberjs/data/pull/1615#issuecomment-37785301
