### PR TITLE
fixed extractArray after findQuery

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -500,8 +500,7 @@ var RESTSerializer = JSONSerializer.extend({
   extractArray: function(store, primaryType, payload) {
     payload = this.normalizePayload(primaryType, payload);
 
-    var primaryTypeName = primaryType.typeKey,
-        primaryArray;
+    var primaryArray;
 
     for (var prop in payload) {
       var typeKey = prop,
@@ -515,7 +514,7 @@ var RESTSerializer = JSONSerializer.extend({
       var typeName = this.typeForRoot(typeKey),
           type = store.modelFor(typeName),
           typeSerializer = store.serializerFor(type),
-          isPrimary = (!forcedSecondary && (type.typeKey === primaryTypeName));
+          isPrimary = (!forcedSecondary && (type.typeKey === primaryType.typeKey));
 
       /*jshint loopfunc:true*/
       var normalizedArray = map.call(payload[prop], function(hash) {


### PR DESCRIPTION
Storing the primaryType.typeKey (primaryTypeName) early stores the key uncapitalised. Ie in my app stores 'node' - when it should be 'Node'. This changes after the calls after line 514 (scary), so storing the reference updates the string to 'Node' as expected and evaluates correctly.

Keeping a consistent type/naming system across the whole app ie node is class,type, etc. would be my 2c. Otherwise removing sometimes camel cased sometimes capitalised references altogether and replacing all references tolower might stop these errors from occurring. 
