### PR TITLE
[BUGFIX] Normalize typeKeys to always be camelCase

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -78,23 +78,11 @@ var ActiveModelSerializer = RESTSerializer.extend({
 
     if (belongsTo) {
       key = this.keyForAttribute(key);
-      json[key + "_type"] = capitalize(camelize(belongsTo.constructor.typeKey));
+      json[key + "_type"] = capitalize(belongsTo.constructor.typeKey);
     }
   },
 
   // EXTRACT
-
-  /**
-    Extracts the model typeKey from underscored root objects.
-
-    @method typeForRoot
-    @param {String} root
-    @return String the model's typeKey
-  */
-  typeForRoot: function(root) {
-    var camelized = camelize(root);
-    return singularize(camelized);
-  },
 
   /**
     Add extra step to `DS.RESTSerializer.normalize` so links are normalized.

--- a/packages/ember-data/tests/unit/store/create_record_test.js
+++ b/packages/ember-data/tests/unit/store/create_record_test.js
@@ -1,5 +1,5 @@
 var get = Ember.get, set = Ember.set;
-var store, Record;
+var store, container, Record;
 
 module("unit/store/createRecord - Store creating records", {
   setup: function() {
@@ -17,4 +17,62 @@ test("doesn't modify passed in properties hash", function(){
       record2 = store.createRecord(Record, attributes);
 
   deepEqual(attributes, { foo: 'bar' }, "The properties hash is not modified");
+});
+
+module("unit/store/createRecord - Store with models by dash", {
+  setup: function() {
+    var env = setupStore({
+      'some-thing': DS.Model.extend({ foo: DS.attr('string') })
+    });
+    store = env.store;
+    container = env.container;
+    container.normalize = function(key){
+      return Ember.String.dasherize(key);
+    };
+  }
+});
+
+test("creating a record by camel-case string finds the model", function(){
+  var attributes = { foo: 'bar' },
+      record = store.createRecord('someThing', attributes);
+
+  equal(record.get('foo'), attributes.foo, "The record is created");
+  equal(store.modelFor('someThing').typeKey, 'someThing');
+});
+
+test("creating a record by dasherize string finds the model", function(){
+  var attributes = { foo: 'bar' },
+      record = store.createRecord('some-thing', attributes);
+
+  equal(record.get('foo'), attributes.foo, "The record is created");
+  equal(store.modelFor('some-thing').typeKey, 'someThing');
+});
+
+module("unit/store/createRecord - Store with models by camelCase", {
+  setup: function() {
+    var env = setupStore({
+      'someThing': DS.Model.extend({ foo: DS.attr('string') })
+    });
+    store = env.store;
+    container = env.container;
+    container.normalize = function(key){
+      return Ember.String.camelize(key);
+    };
+  }
+});
+
+test("creating a record by camel-case string finds the model", function(){
+  var attributes = { foo: 'bar' },
+      record = store.createRecord('someThing', attributes);
+
+  equal(record.get('foo'), attributes.foo, "The record is created");
+  equal(store.modelFor('someThing').typeKey, 'someThing');
+});
+
+test("creating a record by dasherize string finds the model", function(){
+  var attributes = { foo: 'bar' },
+      record = store.createRecord('some-thing', attributes);
+
+  equal(record.get('foo'), attributes.foo, "The record is created");
+  equal(store.modelFor('some-thing').typeKey, 'someThing');
 });

--- a/packages/ember-data/tests/unit/store/model_for_test.js
+++ b/packages/ember-data/tests/unit/store/model_for_test.js
@@ -1,8 +1,14 @@
 var container, store;
 
+var camelize  = Ember.String.camelize,
+    dasherize = Ember.String.dasherize;
+
 module("unit/store/model_for - DS.Store#modelFor", {
   setup: function() {
-    store = createStore({blogPost: DS.Model.extend()});
+    store = createStore({
+      blogPost: DS.Model.extend(),
+      "blog-post": DS.Model.extend()
+    });
     container = store.container;
   },
 
@@ -12,10 +18,30 @@ module("unit/store/model_for - DS.Store#modelFor", {
   }
 });
 
-test("sets a normalized key as typeKey", function() {
+test("when fetching factory from string, sets a normalized key as typeKey", function() {
   container.normalize = function(fullName){
-    return Ember.String.camelize(fullName);
+    return camelize(fullName);
   };
 
-  ok(store.modelFor("blog.post").typeKey, "blogPost", "typeKey is normalized");
+  equal(container.normalize('some.post'), 'somePost', 'precond - container camelizes');
+  equal(store.modelFor("blog.post").typeKey, "blogPost", "typeKey is normalized to camelCase");
+});
+
+test("when fetching factory from string and dashing normalizer, sets a normalized key as typeKey", function() {
+  container.normalize = function(fullName){
+    return dasherize(camelize(fullName));
+  };
+
+  equal(container.normalize('some.post'), 'some-post', 'precond - container dasherizes');
+  equal(store.modelFor("blog.post").typeKey, "blogPost", "typeKey is normalized to camelCase");
+});
+
+test("when returning passed factory, sets a normalized key as typeKey", function() {
+  var factory = {typeKey: 'some-thing'};
+  equal(store.modelFor(factory).typeKey, "someThing", "typeKey is normalized to camelCase");
+});
+
+test("when returning passed factory without typeKey, allows it", function() {
+  var factory = {typeKey: undefined};
+  equal(store.modelFor(factory).typeKey, undefined, "typeKey is undefined");
 });


### PR DESCRIPTION
typeKeys must have a strong formatting convention, since they are used for comparison in several spots of the code. Prior to this commit:
- The container's normalized version of the factory name was set to the model's `typeKey`. This leaked the container concerns about name formatting up to Ember-Data, and to the user's interaction with API calls like `find('some-module')`
- The `typeKey` property of a model class was allowed to pass into the code without normalization.

In general, for a developer to know which to pick of `find('some-car')`, `find('someCar')` or `find('some_car')` they had to understand which resolver their container was using. This demonstrates a bad coupling, and makes documenting Ember-Data exceedingly hard (we should not need to mention a caveat about picking a resolver).

This commit normalizes typeKeys to always be camelCase, both those returned by `typeForRoot` (for which the documentation has been improved) and for those set on factories by `modelFor`.

From here on, `find('someCar')` should be considered the standard format for multi-word model names.

Please, feedback. **tl;dr, I should not need to think about resolvers to use multiple word class names**.
