### PR TITLE
[DOC] `bower install` is part of `npm install`, removing it from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ You also have the option to build ember-data.js yourself.  Clone the repository,
 
 2. Install grunt and bower. `npm install -g grunt-cli bower`
 
-3. Run `npm install && bower install` inside the project root to install the JS dependencies.
+3. Run `npm install` inside the project root to install the JS dependencies.
 
 ### In Your Browser
 
 1. To start the development server, run `grunt dev`.
+
+2. Visit http://localhost:9997/tests
 
 ### From the CLI
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "bower": "~1.2",
     "grunt-ember-defeatureify": "~0.1.0",
     "aws-sdk": "~2.0.0-rc8",
-    "grunt-cli": "~0.1.13",
     "grunt-contrib-yuidoc": "~0.5.0",
     "lockfile": "~0.4.2"
+  },
+  "peerDependencies": {
+    "grunt-cli": "~0.1.13"
   }
 }


### PR DESCRIPTION
Updates the readme to only say `npm install`, since `bower install` is part of npm install.

Adds the URL to visit to view tests in the browser.

Changes `grunt-cli` to an npm peerDependency (this removes the warning ">> Local Npm module "grunt-cli" not found. Is it installed?" that one sees when running `grunt dev`)
