### PR TITLE
Fixes a method documentation typo.

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -277,7 +277,7 @@ var JSONSerializer = Ember.Object.extend({
    `serializeAttribute` can be used to customize how `DS.attr`
    properties are serialized
 
-   For example if you wanted to ensure all you attributes were always
+   For example if you wanted to ensure all your attributes were always
    serialized as properties on an `attributes` object you could
    write:
 


### PR DESCRIPTION
Fixes a typo in the documentation of the serializeAttribute method of json_serializer.js
