### PR TITLE
Fix failing test on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ node_js:
 install:
 - "bin/cached-npm install"
 - "bower install"
-script: grunt test:all
-after_success: grunt dist publish
+after_success: npm publish
 env:
   global:
   - S3_BUILD_CACHE_BUCKET=emberjs-build-cache

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "namespace": "DS",
   "scripts": {
     "postinstall": "bower install",
-    "test": "grunt test"
+    "test": "grunt test:all",
+    "publish": "grunt dist publish"
   },
   "devDependencies": {
     "defeatureify": "~0.1.4",
@@ -25,9 +26,7 @@
     "grunt-ember-defeatureify": "~0.1.0",
     "aws-sdk": "~2.0.0-rc8",
     "grunt-contrib-yuidoc": "~0.5.0",
-    "lockfile": "~0.4.2"
-  },
-  "peerDependencies": {
+    "lockfile": "~0.4.2",
     "grunt-cli": "~0.1.13"
   }
 }


### PR DESCRIPTION
On Travis CI, tests couldn't be run for `/home/travis/build.sh: line 251: grunt: command not found`.
