### PR TITLE
Add `repository` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-beta.7+canary",
   "namespace": "DS",
   "repository": "git://github.com/emberjs/data.git",
+  "license": "MIT",
   "scripts": {
     "postinstall": "bower install",
     "test": "grunt test:all",


### PR DESCRIPTION
To suppress warning from npm:

```
npm WARN package.json ember-data@1.0.0-beta.7+canary No repository field.
```
