### PR TITLE
value of primaryKey in JSONSerializer not referenced

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -100,7 +100,21 @@ var JSONSerializer = Ember.Object.extend({
     if (!hash) { return hash; }
 
     this.applyTransforms(type, hash);
+    this.normalizeId(hash);
     return hash;
+  },
+
+  /**
+    @method normalizeId
+    @private
+  */
+  normalizeId: function(hash) {
+    var primaryKey = get(this, 'primaryKey');
+
+    if (primaryKey === 'id') { return; }
+
+    hash.id = hash[primaryKey];
+    delete hash[primaryKey];
   },
 
   // SERIALIZE

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -166,7 +166,6 @@ var RESTSerializer = JSONSerializer.extend({
     @return {Object}
   */
   normalize: function(type, hash, prop) {
-    this.normalizeId(hash);
     this.normalizeAttributes(type, hash);
     this.normalizeRelationships(type, hash);
 
@@ -202,19 +201,6 @@ var RESTSerializer = JSONSerializer.extend({
   */
   normalizePayload: function(type, payload) {
     return payload;
-  },
-
-  /**
-    @method normalizeId
-    @private
-  */
-  normalizeId: function(hash) {
-    var primaryKey = get(this, 'primaryKey');
-
-    if (primaryKey === 'id') { return; }
-
-    hash.id = hash[primaryKey];
-    delete hash[primaryKey];
   },
 
   /**

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1186,8 +1186,7 @@ Store = Ember.Object.extend({
     // If passed, it means that the data should be
     // merged into the existing data, not replace it.
 
-    var primaryKey = get(this.serializerFor(type), "primaryKey");
-    Ember.assert("You must include an `id` in a hash passed to `push`", data[primaryKey] != null);
+    Ember.assert("You must include an `id` in a hash passed to `push`", data.id != null);
 
     type = this.modelFor(type);
 

--- a/packages/ember-data/tests/integration/adapter/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/store_adapter_test.js
@@ -543,3 +543,19 @@ test("async hasMany always returns a promise", function() {
     ok(tom.get('dogs') instanceof DS.PromiseArray, "dogs is a promise after save");
   }));
 });
+
+test("find - payload with an serializer-specified primary key", function() {
+  env.container.register('serializer:person', DS.JSONSerializer.extend({
+    primaryKey: '_ID_'
+  }));
+
+  adapter.find = function(store, type) {
+    equal(type, Person, "the type is correct");
+    return Ember.RSVP.resolve({ "_ID_": 1, name: "Tom Dale" });
+  };
+
+  store.find('person', 1).then(async(function(person) {
+    equal(person.get('id'), "1");
+    equal(person.get('name'), "Tom Dale");
+  }));
+});


### PR DESCRIPTION
An error is incorrectly thrown when reading an array of data with a custom id defined by the primaryKey attribute of the JSONSerializer.
