### PR TITLE
Remove incorrect semicolon from pathForType example.

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -495,11 +495,11 @@ var RESTAdapter = Adapter.extend({
     endpoint of "/line_items/".
 
     ```js
-    DS.RESTAdapter.reopen({
+    App.ApplicationAdapter = DS.RESTAdapter.extend({
       pathForType: function(type) {
         var decamelized = Ember.String.decamelize(type);
         return Ember.String.pluralize(decamelized);
-      };
+      }
     });
     ```
 


### PR DESCRIPTION
Also changed the example to use .extend instead of reopen
