### PR TITLE
[DOC] Fix jsdoc for `Serializer#extractSingle`

### DIFF
--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -517,7 +517,7 @@ totally work.
 
 ```js
 App.PostSerializer = DS.RESTSerializer.extend({
-  extractSingle: function(store, type, payload, id, requestType) {
+  extractSingle: function(store, type, payload, id) {
     var post = {}, commentIds = [];
 
     post.id = payload.id;
@@ -536,7 +536,7 @@ App.PostSerializer = DS.RESTSerializer.extend({
     
     var post_payload = { post: post, comments: comments };
 
-    return this._super(store, type, post_payload, id, requestType);
+    return this._super(store, type, post_payload, id);
   }
 });
 ```
@@ -547,7 +547,7 @@ normalization to do on different pieces of the JSON.
 
 ```js
 App.PostSerializer = DS.RESTSerializer.extend({
-  extractSingle: function(store, type, payload, id, requestType) {
+  extractSingle: function(store, type, payload, id) {
     var post = {}, commentIds = [];
 
     post.id = payload.id;
@@ -562,7 +562,7 @@ App.PostSerializer = DS.RESTSerializer.extend({
     
     var post_payload = { post: post, comments: comments };
 
-    return this._super(store, type, post_payload, id, requestType);
+    return this._super(store, type, post_payload, id);
   },
 
   normalizeHash: {
@@ -800,7 +800,7 @@ You could handle embedded records like this:
 
 ```js
 App.PostSerializer = DS.RESTSerializer.extend({
-  extractSingle: function(store, type, payload, id, requestType) {
+  extractSingle: function(store, type, payload, id) {
     var comments = payload.post.comments,
         commentIds = comments.mapProperty('id');
 

--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -140,7 +140,7 @@ var ActiveModelSerializer = RESTSerializer.extend({
     Convert `snake_cased` links  to `camelCase`
 
     @method normalizeLinks
-    @param {Object} hash
+    @param {Object} data
   */
 
   normalizeLinks: function(data){

--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -209,7 +209,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     }
   },
 
-  /*
+  /**
     When serializing an embedded record, modify the property (in the json payload)
     that refers to the parent record (foreign key for relationship).
 
@@ -288,7 +288,6 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     @param {subclass of DS.Model} primaryType
     @param {Object} payload
     @param {String} recordId
-    @param {'find'|'createRecord'|'updateRecord'|'deleteRecord'} requestType
     @return Object the primary response to the original request
   */
   extractSingle: function(store, primaryType, payload, recordId) {


### PR DESCRIPTION
Now the argument `requestType` is unused.
This commit is a part of be797b992 .
