### PR TITLE
Implement JSONSerializer#serializeIntoHash to make it easier to use with...

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -1,5 +1,6 @@
 import {RelationshipChange} from "../system/changes";
-var get = Ember.get, set = Ember.set, isNone = Ember.isNone;
+var get = Ember.get, set = Ember.set, isNone = Ember.isNone,
+    merge = Ember.merge;
 
 /**
   In Ember Data a Serializer is used to serialize and deserialize
@@ -271,6 +272,30 @@ var JSONSerializer = Ember.Object.extend({
     }, this);
 
     return json;
+  },
+
+  /**
+    You can use this method to customize the root keys serialized into the JSON.
+    By default the REST Serializer sends camelized root keys.
+    For example, your server may expect underscored root objects.
+
+    ```js
+    App.ApplicationSerializer = DS.RESTSerializer.extend({
+      serializeIntoHash: function(data, type, record, options) {
+        var root = Ember.String.decamelize(type.typeKey);
+        data[root] = this.serialize(record, options);
+      }
+    });
+    ```
+
+    @method serializeIntoHash
+    @param {Object} hash
+    @param {subclass of DS.Model} type
+    @param {DS.Model} record
+    @param {Object} options
+  */
+  serializeIntoHash: function(hash, type, record, options) {
+    merge(hash, this.serialize(record, options));
   },
 
   /**

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -750,26 +750,6 @@ var RESTSerializer = JSONSerializer.extend({
     return this._super.apply(this, arguments);
   },
 
-  /**
-    You can use this method to customize the root keys serialized into the JSON.
-    By default the REST Serializer sends camelized root keys.
-    For example, your server may expect underscored root objects.
-
-    ```js
-    App.ApplicationSerializer = DS.RESTSerializer.extend({
-      serializeIntoHash: function(data, type, record, options) {
-        var root = Ember.String.decamelize(type.typeKey);
-        data[root] = this.serialize(record, options);
-      }
-    });
-    ```
-
-    @method serializeIntoHash
-    @param {Object} hash
-    @param {subclass of DS.Model} type
-    @param {DS.Model} record
-    @param {Object} options
-  */
   serializeIntoHash: function(hash, type, record, options) {
     var root = Ember.String.camelize(type.typeKey);
     hash[root] = this.serialize(record, options);

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -92,6 +92,17 @@ test("serializeBelongsTo respects keyForRelationship", function() {
   });
 });
 
+test("serializeIntoHash", function() {
+  post = env.store.createRecord("post", { title: "Rails is omakase"});
+  var json = {};
+
+  env.serializer.serializeIntoHash(json, Post, post);
+
+  deepEqual(json, {
+    title: "Rails is omakase"
+  });
+});
+
 test("serializePolymorphicType", function() {
   env.container.register('serializer:comment', DS.JSONSerializer.extend({
     serializePolymorphicType: function(record, json, relationship) {


### PR DESCRIPTION
... the RESTAdapter

Lately I've been using Ember Data with some legacy backends who's payload does not follow http://jsonapi.org/ conventions. This usually involves using the `JSONSerializer` to extract ember models from the response payload and the `RESTAdapter` to manage making requests to the backed. In order to get these 2 pieces working together I often extend or reopen `JSONSerialize` to implement a `serializeIntoHash` function and an `extractArray` function to work around issue #1479.

The combination of this pr and issue #1479, will allow developers to use the `JSONSerializer` with the `RESTAdapter` out of the box by simply making their `JSONSerializer` be the `ApplicationSerializer`.

``` js
App.ApplicationSerializer = JSONSerializer;
```

Some examples of `serializeIntoHash` being implemented on the `JSONSerializer` used in the wild.
[ember-data-tastypie-adapter](https://github.com/escalant3/ember-data-tastypie-adapter/blob/1334bd4b2f2c020891df69ad768c70eb95fab9ee/packages/ember-data-tastypie-adapter/lib/tastypie_serializer.js#L180-L182)
[ember-data-django-tastypie](https://github.com/ddemid/ember-data-django-tastypie/blob/284399422350cbbd0ec15e6fc65f5a11fa96fe86/adapter.js)
[ember-data-sails-adapter](https://github.com/bmac/ember-data-sails-adapter#applicationserializer-1)
