### PR TITLE
normalizePayload only gets the payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Master
 
+* Drop the `type` argument from `normalizePayload` calls. This argument was not consistently passed. Overridding the `extract` functions on the serializer is a suggested alternative if you require the model type.
 * Introduce `DS._setupContainer()` for use in testing
 * Deprecate the 5 Ember initializers, use just one named "ember-data"
 

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -187,7 +187,7 @@ var RESTSerializer = JSONSerializer.extend({
 
     ```js
     App.ApplicationSerializer = DS.RESTSerializer.extend({
-      normalizePayload: function(type, payload) {
+      normalizePayload: function(payload) {
         delete payload.version;
         delete payload.status;
         return payload;
@@ -196,11 +196,10 @@ var RESTSerializer = JSONSerializer.extend({
     ```
 
     @method normalizePayload
-    @param {subclass of DS.Model} type
     @param {Object} payload
     @return {Object} the normalized payload
   */
-  normalizePayload: function(type, payload) {
+  normalizePayload: function(payload) {
     return payload;
   },
 
@@ -351,8 +350,7 @@ var RESTSerializer = JSONSerializer.extend({
     @return {Object} the primary response to the original request
   */
   extractSingle: function(store, primaryType, payload, recordId) {
-    payload = this.normalizePayload(primaryType, payload);
-
+    payload = this.normalizePayload(payload);
     var primaryTypeName = primaryType.typeKey,
         primaryRecord;
 
@@ -496,7 +494,7 @@ var RESTSerializer = JSONSerializer.extend({
       to the original query.
   */
   extractArray: function(store, primaryType, payload) {
-    payload = this.normalizePayload(primaryType, payload);
+    payload = this.normalizePayload(payload);
 
     var primaryTypeName = primaryType.typeKey,
         primaryArray;
@@ -562,7 +560,7 @@ var RESTSerializer = JSONSerializer.extend({
     @param {Object} payload
   */
   pushPayload: function(store, payload) {
-    payload = this.normalizePayload(null, payload);
+    payload = this.normalizePayload(payload);
 
     for (var prop in payload) {
       var typeName = this.typeForRoot(prop),

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -54,12 +54,12 @@ test("extractArray with custom typeForRoot", function() {
     return Ember.String.singularize(camelized);
   };
 
-  var json_hash = {
+  var jsonHash = {
     home_planets: [{id: "1", name: "Umber", superVillains: [1]}],
     super_villains: [{id: "1", firstName: "Tom", lastName: "Dale", homePlanet: "1"}]
   };
 
-  var array = env.restSerializer.extractArray(env.store, HomePlanet, json_hash);
+  var array = env.restSerializer.extractArray(env.store, HomePlanet, jsonHash);
 
   deepEqual(array, [{
     "id": "1",
@@ -78,13 +78,13 @@ test("extractArray failure with custom typeForRoot", function() {
     return Ember.String.singularize(root);
   };
 
-  var json_hash = {
+  var jsonHash = {
     home_planets: [{id: "1", name: "Umber", superVillains: [1]}],
     super_villains: [{id: "1", firstName: "Tom", lastName: "Dale", homePlanet: "1"}]
   };
 
   raises(function(){
-    env.restSerializer.extractArray(env.store, HomePlanet, json_hash);
+    env.restSerializer.extractArray(env.store, HomePlanet, jsonHash);
   }, "No model was found for 'home_planets'",
   "raised error message expected to contain \"No model was found for 'home_planets'\"");
 });
@@ -112,8 +112,26 @@ test("serialize polymorphicType with decamelized typeKey", function() {
   deepEqual(json["evilMinionType"], "yellowMinion");
 });
 
+test("normalizePayload is called during extractSingle", function() {
+  env.container.register('serializer:application', DS.RESTSerializer.extend({
+    normalizePayload: function(payload) {
+      return payload.response;
+    }
+  }));
+
+  var jsonHash = { response: {
+    evilMinion: {id: "1", name: "Tom Dale", superVillain: 1},
+    superVillains: [{id: "1", firstName: "Yehuda", lastName: "Katz", homePlanet: "1"}]
+  } };
+
+  var applicationSerializer = env.container.lookup('serializer:application');
+  var data = applicationSerializer.extractSingle(env.store, EvilMinion, jsonHash);
+
+  equal(data.name, jsonHash.response.evilMinion.name, "normalize reads off the response");
+});
+
 test("extractArray can load secondary records of the same type without affecting the query count", function() {
-  var json_hash = {
+  var jsonHash = {
     comments: [{id: "1", body: "Parent Comment", root: true, children: [2, 3]}],
     _comments: [
       { id: "2", body: "Child Comment 1", root: false },
@@ -121,7 +139,7 @@ test("extractArray can load secondary records of the same type without affecting
     ]
   };
 
-  var array = env.restSerializer.extractArray(env.store, Comment, json_hash);
+  var array = env.restSerializer.extractArray(env.store, Comment, jsonHash);
 
   deepEqual(array, [{
     "id": "1",
@@ -146,12 +164,12 @@ test("extractSingle loads secondary records with correct serializer", function()
     }
   }));
 
-  var json_hash = {
+  var jsonHash = {
     evilMinion: {id: "1", name: "Tom Dale", superVillain: 1},
     superVillains: [{id: "1", firstName: "Yehuda", lastName: "Katz", homePlanet: "1"}]
   };
 
-  var array = env.restSerializer.extractSingle(env.store, EvilMinion, json_hash);
+  var array = env.restSerializer.extractSingle(env.store, EvilMinion, jsonHash);
 
   equal(superVillainNormalizeCount, 1, "superVillain is normalized once");
 });
@@ -166,12 +184,12 @@ test("extractArray loads secondary records with correct serializer", function() 
     }
   }));
 
-  var json_hash = {
+  var jsonHash = {
     evilMinions: [{id: "1", name: "Tom Dale", superVillain: 1}],
     superVillains: [{id: "1", firstName: "Yehuda", lastName: "Katz", homePlanet: "1"}]
   };
 
-  var array = env.restSerializer.extractArray(env.store, EvilMinion, json_hash);
+  var array = env.restSerializer.extractArray(env.store, EvilMinion, jsonHash);
 
   equal(superVillainNormalizeCount, 1, "superVillain is normalized once");
 });


### PR DESCRIPTION
`normalizePayload` has been living a lie. It claims to be passed the model type when called, but in often does not receive this argument (null is passed instead). This only serves to confuse the use-case for `normalizePayload`, and encourage its use when overriding an extraction helper is actually the right choice.

This tradeoff, dropping the argument of type in all cases, means `normalizePayload` can still be run over data added with `pushPayload`. `pushPayload` knows nothing of which model is being pushed, and thus cannot provide the type reliably.

Also adds a test for `normalizePayload`. There were none 0_o
