### PR TITLE
Do not presume returned data arrays support .pushObjects

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1577,7 +1577,7 @@ function deserializeRecordIds(store, data, key, relationship, ids) {
 // in the payload, so add them back in manually.
 function addUnsavedRecords(record, key, data) {
   if(record) {
-    data.pushObjects(record.get(key).filterBy('isNew'));
+    Ember.A(data).pushObjects(record.get(key).filterBy('isNew'));
   }
 }
 

--- a/packages/ember-data/tests/integration/adapter/store_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/store_adapter_test.js
@@ -624,7 +624,7 @@ test("async hasMany always returns a promise", function() {
 
   adapter.createRecord = function(store, type, record) {
     var hash = { name: "Tom Dale" };
-    hash.dogs = Ember.A();
+    hash.dogs = [];
     hash.id = 1;
     return Ember.RSVP.resolve(hash);
   };


### PR DESCRIPTION
Returned data will cannot be assumed to be an Ember array object. A test should not pass in an Ember array as API response data.
