### PR TITLE
Removed unused resolver from ManyArray.fetch

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -119,11 +119,10 @@ var ManyArray = RecordArray.extend({
   fetch: function() {
     var records = get(this, 'content'),
         store = get(this, 'store'),
-        owner = get(this, 'owner'),
-        resolver = Ember.RSVP.defer("DS: ManyArray#fetch " + get(this, 'type'));
+        owner = get(this, 'owner');
 
     var unloadedRecords = records.filterProperty('isEmpty', true);
-    store.fetchMany(unloadedRecords, owner, resolver);
+    store.fetchMany(unloadedRecords, owner);
   },
 
   // Overrides Ember.Array's replace method to implement


### PR DESCRIPTION
This is a small refactor. I noticed in investigating another bug that the resolver in ManyArray.fetch is no longer used. It shows up in the Ember Inspector as a pending promise. 
