### PR TITLE
Do not cache model factories on meta, or on other model CPs

### DIFF
--- a/packages/ember-data/lib/system/relationship-meta.js
+++ b/packages/ember-data/lib/system/relationship-meta.js
@@ -1,0 +1,28 @@
+import {singularize} from "../../../ember-inflector/lib/system";
+
+export function typeForRelationshipMeta(store, meta) {
+  var typeKey, type;
+
+  typeKey = meta.type || meta.key;
+  if (typeof typeKey === 'string') {
+    if (meta.kind === 'hasMany') {
+      typeKey = singularize(typeKey);
+    }
+    type = store.modelFor(typeKey);
+  } else {
+    type = meta.type;
+  }
+
+  return type;
+}
+
+export function relationshipFromMeta(store, meta) {
+  return {
+    key:  meta.key,
+    kind: meta.kind,
+    type: typeForRelationshipMeta(store, meta),
+    options:    meta.options,
+    parentType: meta.parentType,
+    isRelationship: true
+  };
+}

--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -6,6 +6,7 @@ var Promise = Ember.RSVP.Promise;
 import {Model} from "../model";
 import {PromiseObject} from "../store";
 import {RelationshipChange} from "../changes";
+import {relationshipFromMeta, typeForRelationshipMeta} from "../relationship-meta";
 
 /**
   @module ember-data
@@ -18,8 +19,10 @@ function asyncBelongsTo(type, options, meta) {
         promiseLabel = "DS: Async belongsTo " + this + " : " + key,
         promise;
 
+    meta.key = key;
+
     if (arguments.length === 2) {
-      Ember.assert("You can only add a '" + type + "' record to this relationship", !value || value instanceof store.modelFor(type));
+      Ember.assert("You can only add a '" + type + "' record to this relationship", !value || value instanceof typeForRelationshipMeta(store, meta));
       return value === undefined ? null : PromiseObject.create({
         promise: Promise.cast(value, promiseLabel)
       });
@@ -34,7 +37,7 @@ function asyncBelongsTo(type, options, meta) {
         promise: promise
       });
     } else if (link) {
-      promise = store.findBelongsTo(this, link, meta);
+      promise = store.findBelongsTo(this, link, relationshipFromMeta(store, meta));
       return PromiseObject.create({
         promise: promise
       });
@@ -105,7 +108,8 @@ function belongsTo(type, options) {
     type: type,
     isRelationship: true,
     options: options,
-    kind: 'belongsTo'
+    kind: 'belongsTo',
+    key: null
   };
 
   if (options.async) {


### PR DESCRIPTION
**tl;dr: Keep model factory references from leaking between multiple containers (i.e. multiple tests). Without this, the FixtureAdapter is broken in ember-cli, and a lot of other things only really work by coincidence.**

Relationships are hard. Ember-Data has been storing data about a relationship on the meta value for that CP. CPs hang around though, and as a result that data on the meta becomes a cache. For some details about a relationship, this is fine.

If `User` has many `Posts`, and you use `User` via a container, it would cache a reference to the `Post` factory. But if you then destroy that container, the reference to `Post` still exists in the CP meta. Furthermore, if you create a new container and use `User` and `Post` via that new container, the cache factory value for `Post` will be that of the old container and not the new container.

This only is a problem if you expect to have `Post` be a different factory in each container. In ember-cli, `MODEL_FACTORY_INJECTIONS` are enabled. This means _all factories are extended_ before being returned by the container. So every time you have a new container, you have a new factory (though it looks and behaves the same).

This change gets rid of that cache on meta. Instead it creates a function that accepts the store and meta, and returns the relationship object expected throughout Ember-Data. Two alternatives were considered:
1. Always check against `typeKey` instead of `instanceof`, but this felt like a dodge of the real problem and would leave the issue for others to find, or
2. Create a new first-class relationship object, but this would be a far more invasive change, and would impact much of the codebase that the current relationship object has already leaked through.

Additionally, the types were being cached on model class-level CPs. For this patch, those have simply been marked `cacheable(false)`. A later patch should refactor the CPs out of the way, or at least re-write their consumers to expect a relationship object without the factory itself already fetched.
