### PR TITLE
Makes sure extractArray is normalizing each record in the array instead ...

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -1,5 +1,6 @@
 import {RelationshipChange} from "../system/changes";
-var get = Ember.get, set = Ember.set, isNone = Ember.isNone;
+var get = Ember.get, set = Ember.set, isNone = Ember.isNone,
+    map = Ember.ArrayPolyfills.map;
 
 /**
   In Ember Data a Serializer is used to serialize and deserialize
@@ -649,8 +650,11 @@ var JSONSerializer = Ember.Object.extend({
     @param {Object} payload
     @return {Array} array An array of deserialized objects
   */
-  extractArray: function(store, type, payload) {
-    return this.normalize(type, payload);
+  extractArray: function(store, type, arrayPayload) {
+    var serializer = this;
+    return map.call(arrayPayload, function(singlePayload) {
+      return serializer.normalize(type, singlePayload);
+    });
   },
 
   /**

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -112,3 +112,22 @@ test("serializePolymorphicType", function() {
     postTYPE: "post"
   });
 });
+
+
+test("extractArray normalizes each record in the array", function() {
+  var postNormalizeCount = 0;
+  var posts = [
+    { title: "Rails is omakase"},
+    { title: "Another Post"}
+  ];
+
+  env.container.register('serializer:post', DS.JSONSerializer.extend({
+    normalize: function () {
+      postNormalizeCount++;
+      return this._super.apply(this, arguments);
+    }
+  }));
+
+  env.container.lookup("serializer:post").extractArray(env.store, Post, posts);
+  equal(postNormalizeCount, 2, "two posts are normalized");
+});


### PR DESCRIPTION
...of trying to normalize the whole payload as an object.

This was causing `applyTransforms` to do the transforms in properties of the array instead.

This is an updated version of pr https://github.com/emberjs/data/pull/1479 that is now targeting the master branch.
