### PR TITLE
Add package.json to built gem

### DIFF
--- a/ember-data-source.gemspec
+++ b/ember-data-source.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "ember-source"
 
-  gem.files = Dir['dist/ember-data*.js', 'lib/ember/data/*.rb']
+  gem.files = %w(package.json) + Dir['dist/ember-data*.js', 'lib/ember/data/*.rb']
 end


### PR DESCRIPTION
`Ember::Data::VERSION` is defined by `package.json` since 7d7ccfa44.
Without thi file, ember-data-source couldn't resolve own version.
#1905 breaks ember-data-source.gem.

I'm sorry to my halfway work... :disappointed: 
