### PR TITLE
Remove unnessary loop in extracting single using DS.EmbeddedRecordsMixin

### DIFF
--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -472,11 +472,8 @@ function updatePayloadWithEmbeddedBelongsTo(serializer, store, primaryType, rela
   }
   payload[embeddedTypeKey] = payload[embeddedTypeKey] || [];
   var embeddedType = store.modelFor(relationship.type.typeKey);
-  for (var key in partial) {
-    if (partial.hasOwnProperty(key) && camelize(key) === attr) {
-      updatePayloadWithEmbedded(_serializer, store, embeddedType, payload, partial[key]);
-    }
-  }
+  // Recursive call for nested record
+  updatePayloadWithEmbedded(_serializer, store, embeddedType, payload, partial[attribute]);
   partial[expandedKey] = partial[attribute].id;
   // Need to move an embedded `belongsTo` object into a pluralized collection
   payload[embeddedTypeKey].push(partial[attribute]);


### PR DESCRIPTION
- updatePayloadWithEmbeddedBelongsTo: removed unnessary loop

Per chat w/ Igor `partial[attribute]` is all that is needed, not looping necessary to find the same thing.
