### PR TITLE
Copy metadata when it is assigned to recordArrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Master
 
+* Each RecordArray gets a copy of the models's metada object instead of sharing the same meta object. Enables several paginated arrays to coexist without clobbering each other
 * Drop the `type` argument from `normalizePayload` calls. This argument was not consistently passed. Overridding the `extract` functions on the serializer is a suggested alternative if you require the model type.
 * Introduce `DS._setupContainer()` for use in testing
 * Deprecate the 5 Ember initializers, use just one named "ember-data"

--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -37,7 +37,7 @@ var AdapterPopulatedRecordArray = RecordArray.extend({
     this.setProperties({
       content: Ember.A(records),
       isLoaded: true,
-      meta: meta
+      meta: Ember.copy(meta)
     });
 
     records.forEach(function(record) {

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -600,6 +600,30 @@ test("findQuery - payload 'meta' is accessible on the record array", function() 
   }));
 });
 
+test("findQuery - each record array can have it's own meta object", function() {
+  ajaxResponse({
+    meta: { offset: 5 },
+    posts: [{id: 1, name: "Rails is very expensive sushi"}]
+  });
+
+  store.findQuery('post', { page: 2 }).then(async(function(posts) {
+    equal(
+      posts.get('meta.offset'),
+      5,
+      "Reponse metadata can be accessed with recordArray.meta"
+    );
+    ajaxResponse({
+      meta: { offset: 1 },
+      posts: [{id: 1, name: "Rails is very expensive sushi"}]
+    });
+    store.findQuery('post', { page: 1}).then(async(function(newPosts){
+      equal(newPosts.get('meta.offset'), 1, 'new array has correct metadata');
+      equal(posts.get('meta.offset'), 5, 'metadata on the old array hasnt been clobbered');
+    }));
+  }));
+});
+
+
 test("findQuery - returning an array populates the array", function() {
   ajaxResponse({
     posts: [


### PR DESCRIPTION
Currently metadata is saved on Model classes, such that there is
only ever 1 instance of the meta object in existence. Often however
metadata is a property of a particular array of records and not the
record type. A good example is pagination. It should be possible to
do `store.findQuery()` twice and get two arrays where each has it's
own meta information. However, because metadata is stored on the
Model class, any subsequent request will modify the original
pagination metadata. This commit enables each recordArray to have
it's own unchanging Meta object.
