### PR TITLE
Add ajaxSuccess hook to the RESTAdapter

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -2,9 +2,11 @@
   @module ember-data
 */
 
-import {Adapter, InvalidError} from "ember-data/system/adapter";
+import {
+  Adapter,
+  InvalidError
+} from "ember-data/system/adapter";
 var get = Ember.get;
-var set = Ember.set;
 var forEach = Ember.ArrayPolyfills.forEach;
 
 /**
@@ -745,7 +747,7 @@ export default Adapter.extend({
     2. Your API might return errors as successful responses with status code
     200 and an Errors text or object. You can return a DS.InvalidError from
     this hook and it will automatically reject the promise and put your record
-    into  the invald state.
+    into the invald state.
 
     @method ajaxError
     @param  {Object} jqXHR
@@ -788,8 +790,8 @@ export default Adapter.extend({
       var hash = adapter.ajaxOptions(url, type, options);
 
       hash.success = function(json, textStatus, jqXHR) {
-        json = this.ajaxSuccess(jqXHR, json);
-        if (InvalidError.detectInstance(json)){
+        json = adapter.ajaxSuccess(jqXHR, json);
+        if (json instanceof InvalidError) {
           Ember.run(null, reject, json);
         } else {
           Ember.run(null, resolve, json);

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -1461,3 +1461,51 @@ test('groupRecordsForFindMany groups calls for small ids', function() {
 
   post.get('comments');
 });
+
+test("calls adapter.ajaxSuccess with the jqXHR and json", function(){
+  expect(2);
+  var originalAjax = Ember.$.ajax;
+  var jqXHR = {};
+  var data = {
+    post: {
+      id: "1",
+      name: "Docker is amazing"
+    }
+  };
+
+  var receivedData, receivedJqXHR;
+
+  Ember.$.ajax = function(hash){
+    hash.success(data, 'ok', jqXHR);
+  };
+
+  adapter.ajaxSuccess = function(xhr, json) {
+    deepEqual(jqXHR, xhr);
+    deepEqual(json, data);
+    return json;
+  };
+
+  store.find('post', '1');
+  Ember.$.ajax = originalAjax;
+});
+
+test('calls ajaxError with jqXHR, jqXHR.responseText', function(){
+  expect(2);
+  var originalAjax = Ember.$.ajax;
+  var jqXHR = {
+    responseText: 'Nope lol'
+  };
+
+  Ember.$.ajax = function(hash){
+    hash.error(jqXHR, jqXHR.responseText);
+  };
+
+  adapter.ajaxError = function(xhr, responseText) {
+    deepEqual(xhr, jqXHR);
+    deepEqual(responseText, jqXHR.responseText);
+    return {error: {nope: 'lol'}};
+  };
+
+  store.find('post', '1');
+  Ember.$.ajax = originalAjax;
+});


### PR DESCRIPTION
Previously there was no easy way to extract data from response headers
or to reject promises after a 200OK response.
- [ ] add tests
