### PR TITLE
DS.EmbeddedRecordsMixin methods for serializing relationships call super

### DIFF
--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -85,10 +85,12 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
   serializeBelongsTo: function(record, json, relationship) {
     var attr = relationship.key;
     var attrs = this.get('attrs');
-
-    var includeIds = hasSerializeIdsOption(attrs, attr) || noSerializeOptionSpecified(attrs, attr);
+    if (noSerializeOptionSpecified(attrs, attr)) {
+      this._super(record, json, relationship);
+      return;
+    }
+    var includeIds = hasSerializeIdsOption(attrs, attr);
     var includeRecords = hasSerializeRecordsOption(attrs, attr);
-
     var embeddedRecord = record.get(attr);
     if (includeIds) {
       key = this.keyForRelationship(attr, relationship.kind);
@@ -107,7 +109,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
       }
     }
   },
-  
+
   /**
     Serialize `hasMany` relationship when it is configured as embedded objects.
 
@@ -192,10 +194,13 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
   serializeHasMany: function(record, json, relationship) {
     var attr = relationship.key;
     var attrs = this.get('attrs');
+    if (noSerializeOptionSpecified(attrs, attr)) {
+      this._super(record, json, relationship);
+      return;
+    }
     var includeIds = hasSerializeIdsOption(attrs, attr);
     var includeRecords = hasSerializeRecordsOption(attrs, attr);
     var key;
-
     if (includeIds) {
       key = this.keyForRelationship(attr, relationship.kind);
       json[key] = get(record, attr).mapBy('id');


### PR DESCRIPTION
[Fixes #1971]

The `serializeBelongsTo` and `serializeHasMany` may need to call super. 

In the case of using the mixin with `DS.ActiveModelSerializer` the `serializeHasMany` method is a no-op `Em.K` but if the mixin is used with another serializer (e.g. extending `DS.RESTSerializer`) that does use `serializeBelongsTo` and `serializeHasMany` hooks, then the DS.EmbeddedRecordsMixin should call super when the `attrs` setting is not set for a relationship (the default behavior would be used for not embedding). 

*Use case:( A serializer is setup with multiple hasMany/belongsTo relationships where some are embedded and some are not. Those methods for `serializeBelongsTo` and `serializeHasMany` call `_super` if the `attrs` property (config) doesn't have the relationship being serialized as setup for embedding.
