### PR TITLE
Fixes hasMany records being duplicated after payload returns from server

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1596,8 +1596,16 @@ function deserializeRecordIds(store, data, key, relationship, ids) {
 // in the payload, so add them back in manually.
 function addUnsavedRecords(record, key, data) {
   if(record) {
-    Ember.A(data).pushObjects(record.get(key).filterBy('isNew'));
+    var unsavedRecords = uniqById(Ember.A(data), record.get(key).filterBy('isNew'));
+    Ember.A(data).pushObjects(unsavedRecords);
   }
+}
+
+function uniqById(data, records) {
+  var currentIds = data.mapBy("id");
+  return records.reject(function(record) {
+    return Ember.A(currentIds).contains(record.id);
+  });
 }
 
 // Delegation to the adapter and promise management


### PR DESCRIPTION
There is an edge case where a hasMany record gets duplicated (same ID).
Basically, if we generate a record locally using UUID or any custom ID
format, then push it to production which will return the same ID
previously defined, the store's array that holds records to be resolved
is going to duplicate both items, even if they have the same ID.

This commit fixes that by not allowing duplicated IDs in that array.
