### PR TITLE
Allow errors to be added to arbitrary fields, not just attributes and associations

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -977,15 +977,9 @@ var Model = Ember.Object.extend(Ember.Evented, {
   */
   adapterDidInvalidate: function(errors) {
     var recordErrors = get(this, 'errors');
-    function addError(name) {
-      if (errors[name]) {
-        recordErrors.add(name, errors[name]);
-      }
-    }
-
-    this.eachAttribute(addError);
-    this.eachRelationship(addError);
-  },
+    Object.keys(errors).forEach(function(errorName) {
+      recordErrors.add(errorName, errors[errorName]);
+    });
 
   /**
     @method adapterDidError


### PR DESCRIPTION
Currently, errors that do not belong to named field/association are silently ignored. For example, if you're using Rails, it's not uncommon to add an error to "base" to describe an error that doesn't fit in any particular attribute.

This small patch makes all errors available. More discussion here https://github.com/emberjs/data/issues/1877
