### PR TITLE
[BUGFIX beta] camelize before singularize to apply uncountability properly

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -590,7 +590,7 @@ var RESTSerializer = JSONSerializer.extend({
     @return {String} the model's typeKey
   */
   typeForRoot: function(key) {
-    return camelize(singularize(key));
+    return singularize(camelize(key));
   },
 
   // SERIALIZE

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -48,6 +48,29 @@ module("integration/serializer/rest - RESTSerializer", {
   }
 });
 
+test("typeForRoot basic behaviour", function() {
+  typeKey = env.restSerializer.typeForRoot("random_key_i_dont_know");
+  equal(typeKey, "randomKeyIDontKnow");
+});
+
+test("typeForRoot should work for normal uncountable keys", function() {
+  Ember.Inflector.inflector.uncountable("cars");
+  typeKey = env.restSerializer.typeForRoot("cars");
+  equal(typeKey, "cars");
+});
+
+test("typeForRoot should play nice with underscore prefixed uncountable keys", function() {
+  Ember.Inflector.inflector.uncountable("cars");
+  typeKey = env.restSerializer.typeForRoot("_cars");
+  equal(typeKey, "cars");
+})
+
+test("typeForRoot should work for underscored uncountable keys", function() {
+  Ember.Inflector.inflector.uncountable("toycars");
+  typeKey = env.restSerializer.typeForRoot("toy_cars");
+  equal(typeKey, "toyCars");
+});
+
 test("extractArray with custom typeForRoot", function() {
   env.restSerializer.typeForRoot = function(root) {
     var camelized = Ember.String.camelize(root);


### PR DESCRIPTION
This is an issue with the typeForRoot function of the RestSerializer not properly accounting for uncountable keys (snake cased keys as expected by the serializer, or underscore prefixed as used by the embedded records mixin). By normalizing the key first using camelize, we can then properly transform it using singularize which can then recognize any values that have been marked as "uncountable".

@igorT
