### PR TITLE
Merge partial data that comes from the server after a save

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -681,7 +681,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     set(this, 'isError', false);
 
     if (data) {
-      this._data = data;
+      this._data = Ember.mixin(this._data, this._inFlightAttributes, data);
     } else {
       Ember.mixin(this._data, this._inFlightAttributes);
     }

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1550,7 +1550,23 @@ function normalizeRelationships(store, type, data, record) {
     var kind = relationship.kind,
         value = data[key];
 
-    if (value == null) { return; }
+    //If server returned no key we want to keep whatever relationship data we have right now
+    if (value === undefined && record){
+      //This is going to become much cleaner after SSOT
+      //If there is a cached value we want to keep it in case user modified after it came from
+      //the server.
+      if (Ember.meta(record).cache[key]){
+        //However we don't want to trigger a fetch so we check the cache directly
+        data[key] = Ember.meta(record).cache[key];
+      } else if (record._data[key]){
+        //Otherwise we just keep whatever came from the server
+        data[key] = record._data[key];
+      }
+      return;
+    }
+    if (value == null) {
+      return;
+    }
 
     if (kind === 'belongsTo') {
       deserializeRecordId(store, data, key, relationship, value);

--- a/packages/ember-data/tests/integration/records/save_test.js
+++ b/packages/ember-data/tests/integration/records/save_test.js
@@ -2,13 +2,21 @@ var Comment, Post, env;
 
 module("integration/records/save - Save Record", {
   setup: function() {
-    var Post = DS.Model.extend({
+    var Comment = DS.Model.extend({
       title: DS.attr('string')
+    });
+
+    Comment.toString = function() { return "Comment"; };
+
+    var Post = DS.Model.extend({
+      title: DS.attr('string'),
+      otherTitle: DS.attr('string'),
+      comment: DS.belongsTo('comment')
     });
 
     Post.toString = function() { return "Post"; };
 
-    env = setupStore({ post: Post });
+    env = setupStore({ post: Post, comment: Comment });
   },
 
   teardown: function() {
@@ -71,5 +79,50 @@ test("Will reject save on invalid", function() {
 
   post.save().then(function() {}, async(function() {
     ok(true, 'save operation was rejected');
+  }));
+});
+
+test("Will not overwrite current data when createRecord returns partial data", function() {
+  expect(3);
+  var comment = env.store.createRecord('comment', {title: 'my comment'});
+  var post = env.store.createRecord('post', {title: 'toto', otherTitle:'please dont delete me'});
+  post.set('comment', comment);
+
+  env.adapter.createRecord = function(store, type, record) {
+    return Ember.RSVP.resolve({ id: 123, title: 'new title' });
+  };
+
+  //The default serializer creates keys with value set to null if no key was passed by the adapter
+  //That might not always be the desired behavior, so mocking normalize to avoid that
+  env.serializer.normalize = function(type, hash){
+    return hash;
+  };
+
+  post.save().then(async(function(post) {
+    equal(post.get('title'), 'new title', 'title attribute was updated');
+    equal(post.get('otherTitle'), 'please dont delete me', 'the otherTitle attribute was kept');
+    equal(post.get('comment.title'), 'my comment', 'commment relationship was kept');
+  }));
+});
+
+test("Will not overwrite current data when updateRecord returns partial data", function() {
+  expect(3);
+  var comment = env.store.push('comment', {id:5, title: 'my comment'});
+  var post = env.store.push('post', {id:1, comment:5, title: 'toto', otherTitle:'please dont delete me'});
+
+  env.adapter.updateRecord = function(store, type, record) {
+    return Ember.RSVP.resolve({ id: 1, title: 'new title' });
+  };
+
+  //The default serializer creates keys with value set to null if no key was passed by the adapter
+  //That might not always be the desired behavior, so mocking normalize to avoid that
+  env.serializer.normalize = function(type, hash){
+    return hash;
+  };
+
+  post.save().then(async(function(post) {
+    equal(post.get('title'), 'new title', 'title attribute was updated');
+    equal(post.get('otherTitle'), 'please dont delete me', 'the otherTitle attribute was kept');
+    equal(post.get('comment.title'), 'my comment', 'commment relationship was kept');
   }));
 });


### PR DESCRIPTION
Previously if a server returned a partial hash as a response to
a save, the record would lose all the rest of the data it had.
For example if you sent:

``` js
{ id:1, comment_id:10, title:'Awesome PR'}
```

And the server responded with

``` js
{ id: 1}
```

You would have lost the `comment` and `title` data. This PR makes
sure we merge properly when saving similarly like we do for `find`
