### PR TITLE
Honour the processData flag in RESTAdapter#ajaxOptions.

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -632,14 +632,9 @@ var RESTAdapter = Adapter.extend({
     hash.dataType = 'json';
     hash.context = this;
 
-    if (type !== 'GET') {
-      if (FormData && hash.data instanceof FormData) {
-        hash.contentType = false;
-        hash.processData = false;
-      } else if (hash.data) {
-        hash.contentType = 'application/json; charset=utf-8';
-        hash.data = JSON.stringify(hash.data);
-      }
+    if (hash.data && hash.processData !== false && type !== 'GET') {
+      hash.contentType = 'application/json; charset=utf-8';
+      hash.data = JSON.stringify(hash.data);
     }
 
     var headers = get(this, 'headers');

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -632,9 +632,14 @@ var RESTAdapter = Adapter.extend({
     hash.dataType = 'json';
     hash.context = this;
 
-    if (hash.data && type !== 'GET') {
-      hash.contentType = 'application/json; charset=utf-8';
-      hash.data = JSON.stringify(hash.data);
+    if (type !== 'GET') {
+      if (hash.data instanceof FormData) {
+        hash.contentType = false;
+        hash.processData = false;
+      } else if (hash.data) {
+        hash.contentType = 'application/json; charset=utf-8';
+        hash.data = JSON.stringify(hash.data);
+      }
     }
 
     var headers = get(this, 'headers');
@@ -646,10 +651,8 @@ var RESTAdapter = Adapter.extend({
       };
     }
 
-
     return hash;
   }
-
 });
 
 export default RESTAdapter;

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -633,7 +633,7 @@ var RESTAdapter = Adapter.extend({
     hash.context = this;
 
     if (type !== 'GET') {
-      if (hash.data instanceof FormData) {
+      if (FormData && hash.data instanceof FormData) {
         hash.contentType = false;
         hash.processData = false;
       } else if (hash.data) {

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -618,6 +618,28 @@ var RESTAdapter = Adapter.extend({
   },
 
   /**
+   * This is a hook called before making an AJAX request that affords
+   * extending and modifying the options that are ultimately passed
+   * to Ember.$.ajax.
+   *
+   * In general, the options here behave exactly the same as the
+   * options that you can pass to `jQuery.ajax`. There are, however,
+   * a few notable changes:
+   *
+   *  - `dataType` is always set to `json`.
+   *
+   *  - `processData`, if true or undefined, will JSON stringify the
+   *     data passed and set the `contentType` to `application/json`.
+   *     If `false`, the adapter will not touch the data passed in the
+   *     AJAX request.
+   *
+   *  - `context` is always set to `this`, which is the adapter used
+   *     to make the ajax request. This ultimately ends up as the value
+   *     of `this` in the AJAX request callbacks.
+   *
+   * Finally, this will add any headers defined in a `headers` property
+   * to the AJAX request.
+   *
     @method ajaxOptions
     @private
     @param {String} url
@@ -631,6 +653,10 @@ var RESTAdapter = Adapter.extend({
     hash.type = type;
     hash.dataType = 'json';
     hash.context = this;
+
+    if (typeof hash.processData === 'undefined') {
+      hash.processData = true;
+    }
 
     if (hash.data && hash.processData !== false && type !== 'GET') {
       hash.contentType = 'application/json; charset=utf-8';

--- a/packages/ember-data/tests/unit/adapters/rest_adapter/ajax_options_test.js
+++ b/packages/ember-data/tests/unit/adapters/rest_adapter/ajax_options_test.js
@@ -17,6 +17,18 @@ test('ajaxOptions - allows JSON', function() {
   equal(hash.contentType, 'application/json; charset=utf-8');
 });
 
+test('ajaxOptions - sets default for processData', function() {
+  var hash = adapter.ajaxOptions(null, null, { data: null });
+
+  equal(hash.processData, true);
+});
+
+test('ajaxOptions - respects false for processData', function() {
+  var hash = adapter.ajaxOptions(null, null, { data: null, processData: false });
+
+  equal(hash.processData, false);
+});
+
 test('ajaxOptions - honours processData', function() {
   var data = 'foo=bar',
       hash = adapter.ajaxOptions(null, null, { data: data, processData: false });

--- a/packages/ember-data/tests/unit/adapters/rest_adapter/ajax_options_test.js
+++ b/packages/ember-data/tests/unit/adapters/rest_adapter/ajax_options_test.js
@@ -23,16 +23,11 @@ test('ajaxOptions - sets default for processData', function() {
   equal(hash.processData, true);
 });
 
-test('ajaxOptions - respects false for processData', function() {
-  var hash = adapter.ajaxOptions(null, null, { data: null, processData: false });
-
-  equal(hash.processData, false);
-});
-
 test('ajaxOptions - honours processData', function() {
   var data = 'foo=bar',
       hash = adapter.ajaxOptions(null, null, { data: data, processData: false });
 
   equal(hash.data, data);
+  equal(hash.processData, false);
   equal(hash.contentType, undefined);
 });

--- a/packages/ember-data/tests/unit/adapters/rest_adapter/ajax_options_test.js
+++ b/packages/ember-data/tests/unit/adapters/rest_adapter/ajax_options_test.js
@@ -17,11 +17,10 @@ test('ajaxOptions - allows JSON', function() {
   equal(hash.contentType, 'application/json; charset=utf-8');
 });
 
-test('ajaxOptions - allows FormData', function() {
-  var data = new FormData(),
-      hash = adapter.ajaxOptions(null, null, { data: data });
+test('ajaxOptions - honours processData', function() {
+  var data = 'foo=bar',
+      hash = adapter.ajaxOptions(null, null, { data: data, processData: false });
 
-  strictEqual(hash.data, data);
-  equal(hash.contentType, false);
-  equal(hash.processData, false);
+  equal(hash.data, data);
+  equal(hash.contentType, undefined);
 });

--- a/packages/ember-data/tests/unit/adapters/rest_adapter/ajax_options_test.js
+++ b/packages/ember-data/tests/unit/adapters/rest_adapter/ajax_options_test.js
@@ -1,0 +1,27 @@
+var env, store, adapter;
+module("unit/adapters/rest_adapter/ajax_options - DS.RESTAdapter#ajaxOptions", {
+  setup: function() {
+    env = setupStore({
+      adapter: DS.RESTAdapter
+    });
+
+    adapter = env.adapter;
+  }
+});
+
+test('ajaxOptions - allows JSON', function() {
+  var data = { foo: 'bar', bar: 'baz' },
+      hash = adapter.ajaxOptions(null, null, { data: data });
+
+  equal(hash.data, JSON.stringify(data));
+  equal(hash.contentType, 'application/json; charset=utf-8');
+});
+
+test('ajaxOptions - allows FormData', function() {
+  var data = new FormData(),
+      hash = adapter.ajaxOptions(null, null, { data: data });
+
+  strictEqual(hash.data, data);
+  equal(hash.contentType, false);
+  equal(hash.processData, false);
+});


### PR DESCRIPTION
This change allows users to pass the `processData` flag to the `RESTAdapter#ajaxOptions`. This flag ultimately tells jQuery that it shouldn't perform any transformations to the data passed to the ajax request.

Previously, ember-data didn't honour this flag and would blindly `JSON.stringify` any data passed along for the request. This is normally the exact behaviour you want, but it prevents passing strings or instances of `FormData`, which is useful for file uploads and custom data you want to pass to the server.

Now, if `processData: false` is passed, then ember-data will not perform any transformations to the data object passed. It will also not assume that the content-type is `application/json`.
