### PR TITLE
Add example for expected JSON relationship keys.

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_adapter.js
+++ b/packages/activemodel-adapter/lib/system/active_model_adapter.js
@@ -49,10 +49,47 @@ var decamelize = Ember.String.decamelize,
   ```js
   {
     "famous_person": {
+      "id": 1,
       "first_name": "Barack",
       "last_name": "Obama",
       "occupation": "President"
     }
+  }
+  ```
+
+  Let's imagine that `Occupation` is just another model:
+
+  ```js
+  App.Person = DS.Model.extend({
+    firstName: DS.attr('string'),
+    lastName: DS.attr('string'),
+    occupation: DS.belongsTo('occupation')
+  });
+
+  App.Occupation = DS.Model.extend({
+    name: DS.attr('string'),
+    salary: DS.attr('number'),
+    people: DS.hasMany('person')
+  });
+  ```
+
+  The JSON needed to avoid extra server calls, should look like this:
+
+  ```js
+  {
+    "people": [{
+      "id": 1,
+      "first_name": "Barack",
+      "last_name": "Obama",
+      "occupation_id": 1
+    }],
+
+    "occupations": [{
+      "id": 1,
+      "name": "President",
+      "salary": 100000,
+      "person_ids": [1]
+    }]
   }
   ```
 

--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -49,10 +49,47 @@ var get = Ember.get,
   ```js
   {
     "famous_person": {
+      "id": 1,
       "first_name": "Barack",
       "last_name": "Obama",
       "occupation": "President"
     }
+  }
+  ```
+
+  Let's imagine that `Occupation` is just another model:
+
+  ```js
+  App.Person = DS.Model.extend({
+    firstName: DS.attr('string'),
+    lastName: DS.attr('string'),
+    occupation: DS.belongsTo('occupation')
+  });
+
+  App.Occupation = DS.Model.extend({
+    name: DS.attr('string'),
+    salary: DS.attr('number'),
+    people: DS.hasMany('person')
+  });
+  ```
+
+  The JSON needed to avoid extra server calls, should look like this:
+
+  ```js
+  {
+    "people": [{
+      "id": 1,
+      "first_name": "Barack",
+      "last_name": "Obama",
+      "occupation_id": 1
+    }],
+
+    "occupations": [{
+      "id": 1,
+      "name": "President",
+      "salary": 100000,
+      "person_ids": [1]
+    }]
   }
   ```
 


### PR DESCRIPTION
- Add 'id' key to the first example of expected JSON. Ember Data always requires the presence of the 'id' key.
- Add example for model associations and expected JSON relationship keys, the DS.ActiveModelAdapter needs the relationship keys to be named in a different way than DS.RESTAdapter.
