### PR TITLE
[DOC] Add note about expected JSON for ActiveModelAdapter relationships

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_adapter.js
+++ b/packages/activemodel-adapter/lib/system/active_model_adapter.js
@@ -28,6 +28,10 @@ var decamelize = Ember.String.decamelize,
 
   The ActiveModelAdapter expects the JSON returned from your server to follow
   the REST adapter conventions substituting underscored keys for camelcased ones.
+  
+  Unlike the DS.RESTAdapter, async relationship keys must be the singular form
+  of the relationship name, followed by "_id" for DS.belongsTo relationships,
+  or "_ids" for DS.hasMany relationships.
 
   ### Conventional Names
 


### PR DESCRIPTION
This is covered in the recently added [example](https://github.com/emberjs/data/commit/70a1f842c47cd6827f6131c270e8bd68f74c65f0), but not explicit.
