### PR TITLE
Push payload support for sided-loaded embedded records

### DIFF
--- a/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
+++ b/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
@@ -425,6 +425,52 @@ test("extractArray with embedded objects of same type, but from separate attribu
   equal(env.store.recordForId("superVillain", "6").get("firstName"), "Trek", "Secondary records found in the store");
 });
 
+test("extract payload with embedded objects in side-loaded data", function() {
+  expect(4);
+  env.container.register('serializer:secretLab', DS.ActiveModelSerializer);
+  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretWeapons: {embedded: 'always'},
+      homePlanet: {embedded: 'always'}
+    }
+  }));
+
+  env.store.pushPayload({
+    secret_lab: [{
+      id: '1',
+      minion_capacity: 0,
+      vicinity: 'New York',
+      super_villain: ['2']
+    }],
+    super_villains: [{
+      id: '2',
+      first_name: 'Lex',
+      last_name: 'Luthor',
+      secret_lab: '1',
+      secret_weapons: [{
+        id: '3',
+        name: 'superior intellect and utter ruthlessness'
+      }],
+      home_planet: {
+        id: '4',
+        name: 'Earth',
+        villain_ids: ['2']
+      },
+      evil_minions: []
+    }]
+  });
+
+  secretLab = env.store.getById('secretLab', '1');
+  superVillain = env.store.getById('superVillain', '2');
+  secretWeapon = env.store.getById('secretWeapon', '3');
+  homePlanet = env.store.getById('homePlanet', '4');
+
+  ok(secretLab && secretLab.get('vicinity'));
+  ok(superVillain && superVillain.get('firstName'));
+  ok(secretWeapon && secretWeapon.get('name'));
+  ok(homePlanet && homePlanet.get('name'));
+});
+
 test("serialize with embedded objects (hasMany relationship)", function() {
   league = env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" });
   var tom = env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });


### PR DESCRIPTION
Currently the DS.EmbeddedRecordsMixin doesn't support embedding records in the JSON payload for side-loading. The root part of the payload for a given resource does have embedded records extracted. With the addition of `pushPayload` to the DS.EmbeddedRecordsMixin the side-loaded portion of the payload may also have embedded records. Only embedded records that are configured in a serializer, (e.g. with `embedded: 'always'`) will be extracted in the side-loaded or root portions of the JSON payload.
- Store calls serializer's pushPayload when side-loading
- Adds pushPayload method to DS.EmbeddedRecordsMixin
- When pushing payloads with embedded records they are also pushed into the store

Related to issue: #1638 but does not fix that, only allows `pushPayload` to extract embedded records.
