### PR TITLE
adapt usage example for TemperatureTransform

### DIFF
--- a/packages/ember-data/lib/transforms/base.js
+++ b/packages/ember-data/lib/transforms/base.js
@@ -25,7 +25,7 @@
   var attr = DS.attr;
   App.Requirement = DS.Model.extend({
     name: attr('string'),
-    optionsArray: attr('raw')
+    temperature: attr('temperature')
   });
   ```
 


### PR DESCRIPTION
Adapt usage example to reflect the TemperatureTransform. 'raw' doesn't make sense here as it is not registered as such.
