### PR TITLE
Add option for custom serializer to `Model#serialize`

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -323,11 +323,12 @@ var Model = Ember.Object.extend(Ember.Evented, {
     Create a JSON representation of the record, using the serialization
     strategy of the store's adapter.
 
-   `serialize` takes an optional hash as a parameter, currently
+    `serialize` takes an optional hash as a parameter, currently
     supported options are:
 
-   - `includeId`: `true` if the record's ID should be included in the
+    - `includeId`: `true` if the record's ID should be included in the
       JSON representation.
+    - `serializer`: The serializer name
 
     @method serialize
     @param {Object} options

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -165,6 +165,7 @@ Store = Ember.Object.extend({
 
     * `includeId`: `true` if the record's ID should be included in
       the JSON representation
+    * `serializer`: The serializer name
 
     @method serialize
     @private
@@ -172,7 +173,14 @@ Store = Ember.Object.extend({
     @param {Object} options an options hash
   */
   serialize: function(record, options) {
-    return this.serializerFor(record.constructor.typeKey).serialize(record, options);
+    var serializer;
+    if (options && options.serializer) {
+      serializer = this.container.lookup('serializer:'+options.serializer);
+      Ember.assert('The serializer `' + options.serializer + '` is not registered.', serializer);
+    } else {
+      serializer = this.serializerFor(record.constructor.typeKey);
+    }
+    return serializer.serialize(record, options);
   },
 
   /**

--- a/packages/ember-data/tests/integration/records/serialize_test.js
+++ b/packages/ember-data/tests/integration/records/serialize_test.js
@@ -1,0 +1,57 @@
+var get = Ember.get, set = Ember.set;
+var attr = DS.attr;
+var Person, env;
+
+module("integration/serialize - Serializing Records", {
+  setup: function() {
+    Person = DS.Model.extend({
+      firstName: attr('string'),
+      lastName: attr('string')
+    });
+
+    Person.typeKey = 'person';
+    Person.toString = function() { return "Person"; };
+
+    env = setupStore({ person: Person });
+
+    env.container.register('serializer:personWithName', DS.JSONSerializer.extend({
+      serialize: function(post, options) {
+        var json = this._super(post, options);
+        var firstName = get(post, 'firstName');
+        var lastName  = get(post, 'lastName');
+
+        json.name = firstName + ' ' + lastName;
+
+        return json;
+      }
+    }));
+  },
+
+  teardown: function() {
+    env.container.destroy();
+  }
+});
+
+test('serialize', function() {
+  var person = env.store.createRecord(Person, {
+    firstName: 'Homura',
+    lastName: 'Akemi'
+  });
+  deepEqual(person.serialize(), {
+    firstName: 'Homura',
+    lastName: 'Akemi'
+  });
+});
+
+test('serialize with serializer specification', function() {
+  var person = env.store.createRecord(Person, {
+    firstName: 'Homura',
+    lastName: 'Akemi'
+  });
+
+  deepEqual(person.serialize({serializer: 'personWithName'}), {
+    firstName: 'Homura',
+    lastName: 'Akemi',
+    name: 'Homura Akemi'
+  });
+});


### PR DESCRIPTION
I want to switch serializer on special context.

For example:
* admin can create `Post` with original `Category`.
(This case `Post` will be serialized embedded `Category` **records**.)

* user can only create `Post` with chosen `Category`.
(This case `Post` will be serialized embedded `Category` **ids**.)