### PR TITLE
Embedded Records assert payload includes root element before extracting

### DIFF
--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -350,6 +350,8 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     var root = getKeyForAttribute.call(this, key);
     var partial = payload[root];
 
+    Ember.assert('EmbeddedRecordsMixin expected your payload to include a root element for your primary record named "' + root + '"', !!partial);
+
     updatePayloadWithEmbedded(this, store, primaryType, payload, partial);
 
     return this._super(store, primaryType, payload, recordId);
@@ -409,6 +411,8 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     var key = primaryType.typeKey;
     var root = getKeyForAttribute.call(this, key);
     var partials = payload[pluralize(root)];
+
+    Ember.assert('EmbeddedRecordsMixin expected your payload to include a root element for your primary records named "' + pluralize(root) + '"', partials && partials.length);
 
     forEach(partials, function(partial) {
       updatePayloadWithEmbedded(this, store, primaryType, payload, partial);
@@ -536,7 +540,7 @@ function updatePayloadWithEmbeddedBelongsTo(serializer, store, primaryType, rela
   var embeddedType = store.modelFor(relationship.type.typeKey);
   // Recursive call for nested record
   updatePayloadWithEmbedded(_serializer, store, embeddedType, payload, partial[attribute]);
-  partial[expandedKey] = partial[attribute].id;
+  partial[expandedKey] = partial[attribute][primaryKey];
   // Need to move an embedded `belongsTo` object into a pluralized collection
   payload[embeddedTypeKey].push(partial[attribute]);
   // Need a reference to the parent so relationship works between both `belongsTo` records

--- a/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
+++ b/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
@@ -181,6 +181,18 @@ test("extractSingle with embedded objects of same type", function() {
   equal(env.store.recordForId("comment", "3").get("body"), "Foo", "Secondary records found in the store");
 });
 
+test( 'extractSingle throws an error if payload does not include root key', function() {
+  env.container.register('adapter:comment', DS.ActiveModelAdapter);
+  env.container.register('serializer:comment', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {}));
+  var serializer = env.container.lookup("serializer:comment");
+
+  var json_hash = {};
+
+  throws(function() {
+    serializer.extractSingle(env.store, Comment, json_hash);
+  }, /EmbeddedRecordsMixin expected your payload to include a root element for your primary record named/);
+});
+
 test("extractSingle with embedded objects inside embedded objects of same type", function() {
   env.container.register('adapter:comment', DS.ActiveModelAdapter);
   env.container.register('serializer:comment', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
@@ -309,6 +321,23 @@ test("extractArray with embedded objects", function() {
   env.store.find("superVillain", 1).then(async(function(minion){
     equal(minion.get('firstName'), "Tom");
   }));
+});
+
+test( 'extractArray throws an error if payload does not include root key', function() {
+  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      villains: {embedded: 'always'}
+    }
+  }));
+
+  var serializer = env.container.lookup("serializer:homePlanet");
+
+  var json_hash = {};
+
+  throws(function() {
+    env.amsSerializer.extractArray(env.store, HomePlanet, json_hash);
+  }, /EmbeddedRecordsMixin expected your payload/, 'expected error to be thrown for missing root key');
 });
 
 test("extractArray with embedded objects of same type as primary type", function() {


### PR DESCRIPTION
This PR adds an assertion to `extractSingle` and `extractArray` within the `EmbeddedRecordsMixin` to help with debugging, especially when working with non-standard data which would first need to be normalized.

It also fixes a bug when extracting embedded belongsTo associations which use non-standard IDs.
