### PR TITLE
Fixed a loose semicolon

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -130,7 +130,7 @@ var forEach = Ember.ArrayPolyfills.forEach;
         "API_KEY": Ember.get(document.cookie.match(/apiKey\=([^;]*)/), "1"),
         "ANOTHER_HEADER": "Some header value"
       };
-    }.property().volatile();
+    }.property().volatile()
   });
   ```
 


### PR DESCRIPTION
Semicolon was unnecessary and causing a javascript error.
