### PR TITLE
Added documentation for ajaxError with DS.Errors.

### DIFF
--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -11,6 +11,9 @@ var map = Ember.EnumerableUtils.map;
   Every DS.Model has an `errors` property that is an instance of
   `DS.Errors`. This can be used to display validation error
   messages returned from the server when a `record.save()` rejects.
+  This works automatically with `DS.ActiveModelAdapter`, but you
+  can implement [ajaxError](api/data/classes/DS.RESTAdapter.html#method_ajaxError)
+  in other adapters as well.
 
   For Example, if you had an `User` model that looked like this:
 


### PR DESCRIPTION
If my findings are right in #2028, then implementing `ajaxError` is required in order for `DS.Errors` to work.
