### PR TITLE
Stop using deprecated methods

### DIFF
--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -522,7 +522,7 @@ App.PostSerializer = DS.RESTSerializer.extend({
 
     post.id = payload.id;
     post.title = payload.title;
-    post.links = { user: payload._links.mapProperty('user').findProperty('href').href };
+    post.links = { user: payload._links.mapBy('user').findBy('href').href };
 
     // Leave the original un-normalized comments alone, but put them
     // in the right place in the payload. We'll normalize the comments
@@ -552,13 +552,13 @@ App.PostSerializer = DS.RESTSerializer.extend({
 
     post.id = payload.id;
     post.title = payload.title;
-    post.links = { user: payload._links.mapProperty('user').findProperty('href').href };
+    post.links = { user: payload._links.mapBy('user').findBy('href').href };
 
     // Leave the original un-normalized comments alone, but put them
     // in the right place in the payload. We'll normalize the comments
     // below in `normalizeHash`
     var comments = payload._embedded.comments;
-    post.comments = comments.mapProperty('ID_');
+    post.comments = comments.mapBy('ID_');
     
     var post_payload = { post: post, comments: comments };
 
@@ -802,7 +802,7 @@ You could handle embedded records like this:
 App.PostSerializer = DS.RESTSerializer.extend({
   extractSingle: function(store, type, payload, id) {
     var comments = payload.post.comments,
-        commentIds = comments.mapProperty('id');
+        commentIds = comments.mapBy('id');
 
     payload.comments = comments;
     payload.post.comments = commentIds;

--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -141,7 +141,7 @@ var FixtureAdapter = Adapter.extend({
     Ember.assert("Unable to find fixtures for model type "+type.toString() +". If you're defining your fixtures using `Model.FIXTURES = ...`, please change it to `Model.reopenClass({ FIXTURES: ... })`.", fixtures);
 
     if (fixtures) {
-      fixture = Ember.A(fixtures).findProperty('id', id);
+      fixture = Ember.A(fixtures).findBy('id', id);
     }
 
     if (fixture) {

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -228,7 +228,7 @@ var JSONSerializer = Ember.Object.extend({
         var json = {
           POST_TTL: post.get('title'),
           POST_BDY: post.get('body'),
-          POST_CMS: post.get('comments').mapProperty('id')
+          POST_CMS: post.get('comments').mapBy('id')
         }
 
         if (options.includeId) {

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -654,7 +654,7 @@ var RESTSerializer = JSONSerializer.extend({
         var json = {
           POST_TTL: post.get('title'),
           POST_BDY: post.get('body'),
-          POST_CMS: post.get('comments').mapProperty('id')
+          POST_CMS: post.get('comments').mapBy('id')
         }
 
         if (options.includeId) {

--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -121,7 +121,7 @@ var ManyArray = RecordArray.extend({
         store = get(this, 'store'),
         owner = get(this, 'owner');
 
-    var unloadedRecords = records.filterProperty('isEmpty', true);
+    var unloadedRecords = records.filterBy('isEmpty', true);
     store.fetchMany(unloadedRecords, owner);
   },
 

--- a/packages/ember-data/lib/system/relationships/has_many.js
+++ b/packages/ember-data/lib/system/relationships/has_many.js
@@ -76,7 +76,7 @@ function hasRelationship(type, options) {
   return Ember.computed('data', function(key) {
     return buildRelationship(this, key, options, function(store, data) {
       var records = data[key];
-      Ember.assert("You looked up the '" + key + "' relationship on '" + this + "' but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", Ember.A(records).everyProperty('isEmpty', false));
+      Ember.assert("You looked up the '" + key + "' relationship on '" + this + "' but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", Ember.A(records).isEvery('isEmpty', false));
       return store.findMany(this, data[key], typeForRelationshipMeta(store, meta));
     });
   }).meta(meta).readOnly();

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -537,7 +537,7 @@ Store = Ember.Object.extend({
     var promises = [];
 
     forEach(recordsByTypeMap, function(type, records) {
-      var ids = records.mapProperty('id'),
+      var ids = records.mapBy('id'),
           adapter = this.adapterFor(type);
 
       Ember.assert("You tried to load many records but you have no adapter (for " + type + ")", adapter);
@@ -601,7 +601,7 @@ Store = Ember.Object.extend({
 
     records = Ember.A(records);
 
-    var unloadedRecords = records.filterProperty('isEmpty', true),
+    var unloadedRecords = records.filterBy('isEmpty', true),
         manyArray = this.recordArrayManager.createManyArray(type, records);
 
     forEach(unloadedRecords, function(record) {


### PR DESCRIPTION
Replace to use some methods that Ember.js recommends.
- `findProperty` -> `findBy`
- `mapProperty` -> `mapBy`
- `filterProperty` -> `filterBy`
- `everyProperty` -> `isEvery`
