### PR TITLE
Store#findHasMany return value and documentation fix

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1768,6 +1768,7 @@ function _findHasMany(adapter, store, record, link, relationship) {
 
     var records = store.pushMany(relationship.type, payload);
     record.updateHasMany(relationship.key, records);
+    return records;
   }, null, "DS: Extract payload of " + record + " : hasMany " + relationship.type);
 }
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -646,7 +646,8 @@ Store = Ember.Object.extend({
     @param {DS.Model} owner
     @param {any} link
     @param {String or subclass of DS.Model} type
-    @return {Promise} promise
+    @param {Resolver} resolver
+    @return {DS.ManyArray}
   */
   findHasMany: function(owner, link, relationship, resolver) {
     var adapter = this.adapterFor(owner.constructor);


### PR DESCRIPTION
The documentation for `Store#findHasMany` was incorrectly changed in https://github.com/emberjs/data/commit/7ab338bea001437002b05a1965367e3e94c404c8.

I then realized that the intended behavior didn't work anyway so fixed that by returning the retrieved records from `_findHasMany`.