### PR TITLE
[FIX] typeof null actually returns 'object'

### DIFF
--- a/packages/ember-data/lib/system/changes/relationship_change.js
+++ b/packages/ember-data/lib/system/changes/relationship_change.js
@@ -359,7 +359,7 @@ RelationshipChangeRemove.prototype = Ember.create(RelationshipChange.create({}))
 
 // the object is a value, and not a promise
 function isValue(object) {
-  return typeof object === 'object' && (!object.then || typeof object.then !== 'function');
+  return object && typeof object === 'object' && (!object.then || typeof object.then !== 'function');
 }
 
 RelationshipChangeAdd.prototype.changeType = "add";


### PR DESCRIPTION
Fixed an issue where calling `isValue` with null would throw a `TypeError` (Cannot read property then of null)

I know it is missing an integration test but that's like hours I'm trying to reproduce this with some tests and cannot spend more time on it now. Tho I didn't want it to be forgotten so here it is.
It is pretty obvious tho, so in case you merge I'll do another PR to add tests.
