### PR TITLE
fix emberjs/data/issues/2032 - add modelFor to adapterFor

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1477,6 +1477,7 @@ Store = Ember.Object.extend({
     @return DS.Adapter
   */
   adapterFor: function(type) {
+    type = this.modelFor(type);
     var container = this.container, adapter;
 
     if (container) {


### PR DESCRIPTION
I think the correct syntax for calling `adapterFor` in @jrhe examples from https://github.com/emberjs/data/issues/2032 should be `this.store.adapterFor('cat').toString();` instead of `this.store.adapterFor(App.Cat).toString();` and `this.store.adapterFor('dog').toString();` instead of `this.store.adapterFor(App.Dog).toString();`

Updating the syntax will not work without my change to add modelFor to adapterFor, which I believe is needed and should be used.

@igorT, do you agree with that assessment, should modelFor be getting called within adapterFor? 

If that is true and the syntax used by @jrhe was incorrect as I suspect, what should the failure mode be for users that do not pass in a string value to adapterFor?
