### PR TITLE
Docs use model on controller instead of route

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -547,13 +547,13 @@ var Model = Ember.Object.extend(Ember.Evented, {
     App.ModelDeleteRoute = Ember.Route.extend({
       actions: {
         softDelete: function() {
-          this.get('model').deleteRecord();
+          this.controller.get('model').deleteRecord();
         },
         confirm: function() {
-          this.get('model').save();
+          this.controller.get('model').save();
         },
         undo: function() {
-          this.get('model').rollback();
+          this.controller.get('model').rollback();
         }
       }
     });
@@ -575,7 +575,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
       actions: {
         delete: function() {
           var controller = this.controller;
-          this.get('model').destroyRecord().then(function() {
+          controller.get('model').destroyRecord().then(function() {
             controller.transitionToRoute('model.index');
           });
         }
@@ -922,7 +922,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     App.ModelViewRoute = Ember.Route.extend({
       actions: {
         reload: function() {
-          this.get('model').reload();
+          this.controller.get('model').reload();
         }
       }
     });


### PR DESCRIPTION
Changed the documentation so that the model property referenced is on
the controller of the route rather than the route itself. Since the
route already has a method called model, referencing the model property
as an Ember-Data model can be confusing.  Could also change the example to use a controller class instead of a route class, but kept it as it was.
