### PR TITLE
[Bugfix] embedded records mixin: key variable needed to be declared

### DIFF
--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -142,6 +142,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     var includeIds = hasSerializeIdsOption(attrs, attr);
     var includeRecords = hasSerializeRecordsOption(attrs, attr);
     var embeddedRecord = record.get(attr);
+    var key;
     if (includeIds) {
       key = this.keyForRelationship(attr, relationship.kind);
       if (!embeddedRecord) {
@@ -150,7 +151,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
         json[key] = get(embeddedRecord, 'id');
       }
     } else if (includeRecords) {
-      var key = this.keyForRelationship(attr);
+      key = getKeyForAttribute.call(this, attr);
       if (!embeddedRecord) {
         json[key] = null;
       } else {


### PR DESCRIPTION
- `key` was not declared prior to assignment in `serializeBelongsTo` method
- when embedded records using `serializeBelongsTo` use `keyForAttribute` not `keyForRelationship` like `serializeHasMany` does
