### PR TITLE
EmbeddedRecordsMixin looses associated records when payload key is same as normalized hash key

### DIFF
--- a/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
+++ b/packages/activemodel-adapter/lib/system/embedded_records_mixin.js
@@ -510,7 +510,9 @@ function updatePayloadWithEmbeddedHasMany(serializer, store, primaryType, relati
   });
 
   partial[expandedKey] = ids;
-  delete partial[attribute];
+  if (expandedKey !== attribute) {
+    delete partial[attribute];
+  }
 }
 
 // handles embedding for `belongsTo` relationship


### PR DESCRIPTION
**EmbeddedRecordsMixin#updatePayloadWithEmbeddedBelongsTo** extracts embedded records and replaces the attribute key with ids of the embedded records. It assumes that the payload property that had the embedded records is different than the property that will have the record ids.

This assumption causes it to loose associations to embedded records when the target property name is same as the original property name.
