### PR TITLE
[BUGFIX] Fix for ManyArray.arrangedContentDidChange calling fetch()

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -137,7 +137,11 @@ export default RecordArray.extend({
   },
 
   arrangedContentDidChange: function() {
-    Ember.run.once(this, 'fetch');
+    var owner = get(this, 'owner');
+
+    if (!owner._suspendedRelationships) {
+      Ember.run.once(this, 'fetch');
+    }
   },
 
   arrayContentWillChange: function(index, removed, added) {

--- a/packages/ember-data/tests/unit/record_arrays/many_array_test.js
+++ b/packages/ember-data/tests/unit/record_arrays/many_array_test.js
@@ -1,0 +1,29 @@
+var container, store, manyArray;
+var ManyArray = DS.ManyArray;
+
+module("unit/record_arrays/many_array - DS.ManyArray", {
+  setup: function() {
+    store = createStore({});
+    container = store.container;
+
+    manyArray = ManyArray.create({
+      store: store
+    });
+  },
+
+  teardown: function() {
+    container.destroy();
+    store.destroy();
+  }
+});
+
+test("when calling arrangedContentDidChange on a manyArray where owner._suspendedRelationships is true, fetch is not called ", function() {
+  expect(0)
+
+  Ember.run(function(){
+    manyArray.set('owner', { _suspendedRelationships: true });
+    manyArray.fetch = function() { throw new Error("fetch should not be called"); }
+    manyArray.arrangedContentDidChange();
+  });
+});
+


### PR DESCRIPTION
[BUGFIX] Fix for ManyArray.arrangedContentDidChange calling fetch() when _suspendedRelationships is true.

This can happen if:
 1) you have a ArrayController that relies on arrangedContent
 2) The arrangedContent points at a hasMany relationship (the ManyArray)
 3) You call model.rollback()

Currently, arrangedContentDidChange on ManyArray does not check if the model is currently rolling back before firing fetch. 

This commit resolves this issue. 
