### PR TITLE
[BUGFIX] Use declared mapping during serialization, even if keyForAttribute or keyForRelationship are defined

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -410,10 +410,17 @@ export default Ember.Object.extend({
    @param {Object} relationship
   */
   serializeBelongsTo: function(record, json, relationship) {
+    var attrs = get(this, 'attrs');
     var key = relationship.key;
     var belongsTo = get(record, key);
 
-    key = this.keyForRelationship ? this.keyForRelationship(key, "belongsTo") : key;
+    // if provided, use the mapping provided by `attrs` in
+    // the serializer
+    if (attrs && attrs[key]) {
+      key = attrs[key];
+    } else if (this.keyForRelationship) {
+      key = this.keyForRelationship(key, "belongsTo");
+    }
 
     if (isNone(belongsTo)) {
       json[key] = belongsTo;
@@ -451,8 +458,20 @@ export default Ember.Object.extend({
    @param {Object} relationship
   */
   serializeHasMany: function(record, json, relationship) {
+    var attrs = get(this, 'attrs');
     var key = relationship.key;
-    var payloadKey = this.keyForRelationship ? this.keyForRelationship(key, "hasMany") : key;
+    var payloadKey;
+
+    // if provided, use the mapping provided by `attrs` in
+    // the serializer
+    if (attrs && attrs[key]) {
+      payloadKey = attrs[key];
+    } else if (this.keyForRelationship) {
+      payloadKey = this.keyForRelationship(key, "hasMany");
+    } else {
+      payloadKey = key;
+    }
+
     var relationshipType = RelationshipChange.determineRelationshipType(record.constructor, relationship);
 
     if (relationshipType === 'manyToNone' || relationshipType === 'manyToMany') {

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -274,6 +274,53 @@ test("create - a serializer's attribute mapping takes precdence over keyForAttri
   }));
 });
 
+test("create - a serializer's attribute mapping takes precedence over keyForRelationship (belongsTo) when building the payload", function() {
+  env.container.register('serializer:comment', DS.RESTSerializer.extend({
+    attrs: {
+      post: 'article'
+    },
+
+    keyForRelationship: function(attr, kind) {
+      return attr.toUpperCase();
+    }
+  }));
+
+  ajaxResponse();
+
+  Comment.reopen({ post: DS.belongsTo('post') });
+
+  var post = store.createRecord('post', { id: "a-post-id", name: "The Parley Letter" });
+  var comment = store.createRecord('comment', { id: "some-uuid", name: "Letters are fun", post: post });
+
+  comment.save().then(async(function(post) {
+    deepEqual(passedHash.data, { comment: { article: "a-post-id", id: "some-uuid", name: "Letters are fun" } });
+  }));
+});
+
+test("create - a serializer's attribute mapping takes precedence over keyForRelationship (hasMany) when building the payload", function() {
+  env.container.register('serializer:post', DS.RESTSerializer.extend({
+    attrs: {
+      comments: 'opinions'
+    },
+
+    keyForRelationship: function(attr, kind) {
+      return attr.toUpperCase();
+    }
+  }));
+
+  ajaxResponse();
+
+  Post.reopen({ comments: DS.hasMany('comment') });
+
+  var comment = store.createRecord('comment', { id: "a-comment-id", name: "First!" });
+  var post = store.createRecord('post', { id: "some-uuid", name: "The Parley Letter" });
+  post.get('comments').pushObject(comment);
+
+  post.save().then(async(function(post) {
+    deepEqual(passedHash.data, { post: { opinions: [ "a-comment-id" ], id: "some-uuid", name: "The Parley Letter" } });
+  }));
+});
+
 test("create - a record on the many side of a hasMany relationship should update relationships when data is sideloaded", function() {
   expect(3);
 


### PR DESCRIPTION
**TL;DR:** The `attrs` mapping feature now works for serializing data.

---

As you know, we're able to "map" an Ember Data attribute key to a completely different one that a backend expects by doing the following:

``` js
var PostSerializer = DS.RESTSerializer.extend({
   attrs: {
    name: 'title'
  }
});
```

The method responsible for this mapping during normalization is `JSONSerializer#normalizeUsingDeclaredMapping()`, which performs this mapping on both regular attributes & related attributes (`belongsTo`, `hasMany`).
#### There are a few problems on the serializing side:
1. If `keyForAttribute` is defined, it will clobber the mapping during serialization for regular attributes. (41c4a0bfd773c51080cd5e1d017f339d4ece6b68)
2. _There is no mapping for `belongsTo` or `hasMany` attributes!_ (a979c52acfeaba076453194403f8f645de4d0c4f)

This Pull Request fixes those two issues, allowing for true bi-directional mapping (serialization and deserialization/normalization) as one would assume. If `keyForAttribute` or `keyForRelationship` is defined, they're ignored for the explicitly mapped attribute. Consider this example:

``` js
var ApplicationSerializer = DS.RESTSerializer.extend({
  // backend needs all keys to be snake_case
  keyForAttribute: function(attr) {
    return Ember.String.decamelize(attr);
  },
  keyForRelationship: function(attr, kind) {
    return Ember.String.decamelize(attr);
  },
});

var PostSerializer = ApplicationSerializer.extend({
  attrs: {
    // the backend requires the Post.name attribute to have a special serialized key,
    // different from the backend's own convention of snake_casing serialized keys.
    name: 'posttitle'
  }
});
```

Integration tests have been added for regular, `belongsTo`, and `hasMany` attributes favouring the mapping over `keyFor*` hooks.
