### PR TITLE
Fix computed property check

### DIFF
--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -51,7 +51,7 @@ Model.reopen({
   */
   didDefineProperty: function(proto, key, value) {
     // Check if the value being set is a computed property.
-    if (value instanceof Ember.Descriptor) {
+    if (value instanceof Ember.ComputedProperty) {
 
       // If it is, get the metadata for the relationship. This is
       // populated by the `DS.belongsTo` helper when it is creating


### PR DESCRIPTION
The new alias descriptor doesn't have a meta and shouldn't be included in the computed property check anyways.

This is required for any Model that contains an alias/oneWay/readOnly/etc...

``` javascript
export default DS.Model.extend({
  foo: Ember.computed.alias('bar')
})
```
