### PR TITLE
PERF: O(n) -> O(1) record within recordArray check

### DIFF
--- a/packages/ember-data/lib/system/record_array_manager.js
+++ b/packages/ember-data/lib/system/record_array_manager.js
@@ -117,8 +117,10 @@ export default Ember.Object.extend({
     var recordArrays = this.recordArraysForRecord(record);
 
     if (shouldBeInArray) {
-      recordArrays.add(array);
-      array.addRecord(record);
+      if (!recordArrays.has(array)) {
+        array.addRecord(record);
+        recordArrays.add(array);
+      }
     } else if (!shouldBeInArray) {
       recordArrays.remove(array);
       array.removeRecord(record);


### PR DESCRIPTION
If a record changes, we attempt to re-add it to the array, addRecord only adds unique records to the array but does so with an O(n) indexOf. A proper solution would be for addRecord to utilize an index, unfortunately it does not (yet). Luckily we already have just such an index, that records recordArrays map.

We should strongly consider our recordArrays using these indexes instead of addObjects indexOf, to accomplish this we must ensure that these indexes are maintained. I suspect this is dramatically help costs associated with large amounts of records.

cc @lukemelia @igorT 
