### PR TITLE
Refactored EmbeddedRecordsMixin to push records instead of sideload

### DIFF
--- a/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
+++ b/packages/activemodel-adapter/tests/integration/embedded_records_mixin_test.js
@@ -975,7 +975,7 @@ test("serializing relationships with an embedded and without calls super when no
   var Serializer = DS.RESTSerializer.extend({
     serializeBelongsTo: function(record, json, relationship) {
       calledSerializeBelongsTo = true;
-      return DS.RESTSerializer.prototype.serializeBelongsTo.call(this, record, json, relationship);
+      return this._super(record, json, relationship);
     },
     serializeHasMany: function(record, json, relationship) {
       calledSerializeHasMany = true;

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -794,7 +794,9 @@ export default Ember.Object.extend({
    @param {String} key
    @return {String} normalized key
   */
-
+  keyForAttribute: function(key){
+    return key;
+  },
 
   /**
    `keyForRelationship` can be used to define a custom key when
@@ -816,6 +818,10 @@ export default Ember.Object.extend({
    @param {String} relationship type
    @return {String} normalized key
   */
+
+  keyForRelationship: function(key, type){
+    return key;
+  },
 
   // HELPERS
 


### PR DESCRIPTION
Previously EmbeddedRecordsMixin just moved records around and relied on sideloading for their extraction. Now they are pushed to the store as they are parsed.

Benefits include:
1. Less confusing code
2. Out of the box sideloading support
3. Support for using EmbeddedRecordsMixin with JSONSerializer
