### PR TITLE
Added a failing test for #2088.

### DIFF
--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -554,6 +554,27 @@ test("delete - a payload with sideloaded updates pushes the updates", function()
   }));
 });
 
+test("delete - a payload with sidloaded updates pushes the updates when the original record is omitted", function() {
+  store.push('post', { id: 1, name: "Rails is omakase" });
+
+  store.find('post', 1).then(async(function(post) {
+   ajaxResponse({ posts: [{ id: 2, name: "The Parley Letter" }] });
+
+    post.deleteRecord();
+    return post.save();
+  })).then(async(function(post) {
+    equal(passedUrl, "/posts/1");
+    equal(passedVerb, "DELETE");
+    equal(passedHash, undefined);
+
+    equal(post.get('isDirty'), false, "the original post isn't dirty anymore");
+    equal(post.get('isDeleted'), true, "the original post is now deleted");
+
+    var newPost = store.getById('post', 2);
+    equal(newPost.get('name'), "The Parley Letter", "The new post was added to the store");
+  }));
+});
+
 test("delete - deleting a newly created record should not throw an error", function() {
   var post = store.createRecord('post');
 


### PR DESCRIPTION
This test ensures the serializer does not confuse a new record
returned in response to a delete with the original record when both
records are of the same type.

I have confirmed that if we pass the `recordId` to `extractDeleteRecord` (similar to what pr https://github.com/emberjs/data/pull/1779 is proposing) this test will pass. That parameter was previously being passed to all the `extact*` functions but it appears to have been accidentally dropped when `aliasMethod` was removed to improve debugging in https://github.com/emberjs/data/commit/dd964d2b7fe87ef7368336bd401c40834950f736. 
