### PR TITLE
Added id and requestType back to extract* hooks

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -619,10 +619,12 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Array} array An array of deserialized objects
   */
-  extractFindAll: function(store, type, payload){
-    return this.extractArray(store, type, payload);
+  extractFindAll: function(store, type, payload, id, requestType){
+    return this.extractArray(store, type, payload, id, requestType);
   },
   /**
     `extractFindQuery` is a hook into the extract method used when a
@@ -633,10 +635,12 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Array} array An array of deserialized objects
   */
-  extractFindQuery: function(store, type, payload){
-    return this.extractArray(store, type, payload);
+  extractFindQuery: function(store, type, payload, id, requestType){
+    return this.extractArray(store, type, payload, id, requestType);
   },
   /**
     `extractFindMany` is a hook into the extract method used when a
@@ -647,10 +651,12 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Array} array An array of deserialized objects
   */
-  extractFindMany: function(store, type, payload){
-    return this.extractArray(store, type, payload);
+  extractFindMany: function(store, type, payload, id, requestType){
+    return this.extractArray(store, type, payload, id, requestType);
   },
   /**
     `extractFindHasMany` is a hook into the extract method used when a
@@ -661,10 +667,12 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Array} array An array of deserialized objects
   */
-  extractFindHasMany: function(store, type, payload){
-    return this.extractArray(store, type, payload);
+  extractFindHasMany: function(store, type, payload, id, requestType){
+    return this.extractArray(store, type, payload, id, requestType);
   },
 
   /**
@@ -676,10 +684,12 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractCreateRecord: function(store, type, payload) {
-    return this.extractSave(store, type, payload);
+  extractCreateRecord: function(store, type, payload, id, requestType) {
+    return this.extractSave(store, type, payload, id, requestType);
   },
   /**
     `extractUpdateRecord` is a hook into the extract method used when
@@ -690,10 +700,12 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractUpdateRecord: function(store, type, payload) {
-    return this.extractSave(store, type, payload);
+  extractUpdateRecord: function(store, type, payload, id, requestType) {
+    return this.extractSave(store, type, payload, id, requestType);
   },
   /**
     `extractDeleteRecord` is a hook into the extract method used when
@@ -704,10 +716,12 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractDeleteRecord: function(store, type, payload) {
-    return this.extractSave(store, type, payload);
+  extractDeleteRecord: function(store, type, payload, id, requestType) {
+    return this.extractSave(store, type, payload, id, requestType);
   },
 
   /**
@@ -719,10 +733,12 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractFind: function(store, type, payload) {
-    return this.extractSingle(store, type, payload);
+  extractFind: function(store, type, payload, id, requestType) {
+    return this.extractSingle(store, type, payload, id, requestType);
   },
   /**
     `extractFindBelongsTo` is a hook into the extract method used when
@@ -733,10 +749,12 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractFindBelongsTo: function(store, type, payload) {
-    return this.extractSingle(store, type, payload);
+  extractFindBelongsTo: function(store, type, payload, id, requestType) {
+    return this.extractSingle(store, type, payload, id, requestType);
   },
   /**
     `extractSave` is a hook into the extract method used when a call
@@ -747,10 +765,12 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractSave: function(store, type, payload) {
-    return this.extractSingle(store, type, payload);
+  extractSave: function(store, type, payload, id, requestType) {
+    return this.extractSingle(store, type, payload, id, requestType);
   },
 
   /**
@@ -774,9 +794,11 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractSingle: function(store, type, payload) {
+  extractSingle: function(store, type, payload, id, requestType) {
     payload = this.normalizePayload(payload);
     return this.normalize(type, payload);
   },
@@ -801,9 +823,11 @@ export default Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} payload
+    @param {String or Number} id
+    @param {String} requestType
     @return {Array} array An array of deserialized objects
   */
-  extractArray: function(store, type, arrayPayload) {
+  extractArray: function(store, type, arrayPayload, id, requestType) {
     arrayPayload = this.normalizePayload(arrayPayload);
     var serializer = this;
     return map.call(arrayPayload, function(singlePayload) {


### PR DESCRIPTION
id and requestType parameters went missing in when removing aliasMethod. See commit dd964d2b7fe87ef7368336bd401c40834950f736 :
https://github.com/emberjs/data/commit/dd964d2b7fe87ef7368336bd401c40834950f736

This pr is a rebased version of #1779. The changes to `normalize` introduced in that commit have also been removed. 
