### PR TITLE
RESTAdapter should ignore properties with no model.

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -267,8 +267,15 @@ export default JSONSerializer.extend({
     var primaryRecord;
 
     for (var prop in payload) {
-      var typeName  = this.typeForRoot(prop);
-      var type = store.modelFor(typeName);
+      var typeName = this.typeForRoot(prop);
+      var type;
+
+      try {
+        type = store.modelFor(typeName);
+      } catch (e) {
+        continue;
+      }
+
       var isPrimary = type.typeKey === primaryTypeName;
       var value = payload[prop];
 

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -174,6 +174,16 @@ test("extractSingle loads secondary records with correct serializer", function()
   equal(superVillainNormalizeCount, 1, "superVillain is normalized once");
 });
 
+test("extractSingle ignores payload properties without models", function() {
+  var jsonHash = {
+    evilMinion: {id: "1", name: "Tom Dale", superVillain: 1},
+    unknownModel: [{id: "1"}]
+  };
+
+  var array = env.restSerializer.extractSingle(env.store, EvilMinion, jsonHash);
+  ok(true);
+});
+
 test("extractArray loads secondary records with correct serializer", function() {
   var superVillainNormalizeCount = 0;
 


### PR DESCRIPTION
Right now [this line](https://github.com/emberjs/data/blob/75d89a6781b0d7712c80e78a0a61086a5b04d9ef/packages/ember-data/lib/serializers/rest_serializer.js#L271) in `extractSingle` with throw if the payload contains a key with no associated model. I think it would be better for the serializer to ignore data that it doesn't understand.

I'm working on a mobile app so I have to handle outdated clients using my API. I want to send data for a new model down, but old clients will break if I do this. My only option is to increment the API version for this addition, but it's not technically a breaking change — I'm not changing any existing API behavior.
