### PR TITLE
Coalesce find requests, add support for preloading data

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -254,6 +254,10 @@ var DirtyState = {
     // EVENTS
     didSetProperty: didSetProperty,
 
+    //TODO(Igor) reloading now triggers a
+    //loadingData event, though it seems fine?
+    loadingData: Ember.K,
+
     propertyWasReset: function(record, name) {
       var stillDirty = false;
 
@@ -535,6 +539,10 @@ var RootState = {
 
     // FLAGS
     isLoaded: true,
+
+    //TODO(Igor) Reloading now triggers a loadingData event,
+    //but it should be ok?
+    loadingData: Ember.K,
 
     // SUBSTATES
 

--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -122,7 +122,7 @@ export default RecordArray.extend({
     var owner = get(this, 'owner');
 
     var unloadedRecords = records.filterBy('isEmpty', true);
-    store.fetchMany(unloadedRecords, owner);
+    store.scheduleFetchMany(unloadedRecords, owner);
   },
 
   // Overrides Ember.Array's replace method to implement

--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -35,7 +35,13 @@ function asyncBelongsTo(type, options, meta) {
     var belongsTo = data[key];
 
     if (!isNone(belongsTo)) {
-      promise = store.fetchRecord(belongsTo) || Promise.cast(belongsTo, promiseLabel);
+      var inverse = this.constructor.inverseFor(key);
+      //but for now only in the oneToOne case
+      if (inverse && inverse.kind === 'belongsTo'){
+        set(belongsTo, inverse.name, this);
+      }
+      //TODO(Igor) after OR doesn't seem that will be called
+      promise = store.findById(belongsTo.constructor, belongsTo.get('id')) || Promise.cast(belongsTo, promiseLabel);
       return PromiseObject.create({
         promise: promise
       });
@@ -139,7 +145,7 @@ function belongsTo(type, options) {
 
     if (isNone(belongsTo)) { return null; }
 
-    store.fetchRecord(belongsTo);
+    store.findById(belongsTo.constructor, belongsTo.get('id'));
 
     return belongsTo;
   }).meta(meta);

--- a/packages/ember-data/lib/system/relationships/has_many.js
+++ b/packages/ember-data/lib/system/relationships/has_many.js
@@ -12,6 +12,7 @@ import {
 var get = Ember.get;
 var set = Ember.set;
 var setProperties = Ember.setProperties;
+var map = Ember.EnumerableUtils.map;
 
 function asyncHasMany(type, options, meta) {
   return Ember.computed('data', function(key) {
@@ -28,7 +29,19 @@ function asyncHasMany(type, options, meta) {
         if (link) {
           rel = store.findHasMany(this, link, relationshipFromMeta(store, meta), resolver);
         } else {
-          rel = store.findMany(this, data[key], typeForRelationshipMeta(store, meta), resolver);
+          //This is a temporary workaround for setting owner on the relationship
+          //until single source of truth lands. It only works for OneToMany atm
+          var records = data[key];
+          var inverse = this.constructor.inverseFor(key);
+          var owner = this;
+          if (inverse && records) {
+            if (inverse.kind === 'belongsTo'){
+              map(records, function(record){
+                set(record, inverse.name, owner);
+              });
+            }
+          }
+          rel = store.findMany(owner, data[key], typeForRelationshipMeta(store, meta), resolver);
         }
         // cache the promise so we can use it
         // when we come back and don't need to rebuild

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -141,6 +141,8 @@ Store = Ember.Object.extend({
     });
     this._relationshipChanges = {};
     this._pendingSave = [];
+    //Used to keep track of all the find requests that need to be coalesced
+    this._pendingFetch = Ember.Map.create();
   },
 
   /**
@@ -349,6 +351,30 @@ Store = Ember.Object.extend({
 
     ---
 
+    You can optionally preload specific attributes and relationships that you know of
+    by passing them as the third argument to find.
+
+    For example, if your Ember route looks like `/posts/1/comments/2` and you API route
+    for the comment also looks like `/posts/1/comments/2` if you want to fetch the comment
+    without fetching the post you can pass in the post to the `find` call:
+
+    ```javascript
+    store.find('comment', 2, {post: 1});
+    ```
+
+    If you have access to the post model you can also pass the model itself:
+
+    ```javascript
+    var myPostModel = store.find('post', 1);
+    store.find('comment', 2, {post: myPostModel});
+    ```
+
+    This way, your adapter's `find` or `buildURL` method will be able to look up the
+    relationship on the record and construct the nested URL without having to first
+    fetch the post.
+
+    ---
+
     To find all records for a type, call `find` with no additional parameters:
 
     ```javascript
@@ -377,7 +403,7 @@ Store = Ember.Object.extend({
     @param {Object|String|Integer|null} id
     @return {Promise} promise
   */
-  find: function(type, id) {
+  find: function(type, id, preload) {
     Ember.assert("You need to pass a type to the store's find method", arguments.length >= 1);
     Ember.assert("You may not pass `" + id + "` as id to the store's find method", arguments.length === 1 || !Ember.isNone(id));
 
@@ -390,7 +416,7 @@ Store = Ember.Object.extend({
       return this.findQuery(type, id);
     }
 
-    return this.findById(type, coerceId(id));
+    return this.findById(type, coerceId(id), preload);
   },
 
   /**
@@ -402,10 +428,22 @@ Store = Ember.Object.extend({
     @param {String|Integer} id
     @return {Promise} promise
   */
-  findById: function(typeName, id) {
+  findById: function(typeName, id, preload) {
+    var fetchedRecord;
+
     var type = this.modelFor(typeName);
     var record = this.recordForId(type, id);
-    var fetchedRecord = this.fetchRecord(record);
+
+    if (preload) {
+      record._preloadData(preload);
+    }
+
+    if (get(record, 'isEmpty')) {
+      fetchedRecord = this.scheduleFetch(record);
+      //TODO double check about reloading
+    } else if (get(record, 'isLoading')){
+      fetchedRecord = record._loadingPromise;
+    }
 
     return promiseObject(fetchedRecord || record, "DS: Store#findById " + type + " with id: " + id);
   },
@@ -440,20 +478,123 @@ Store = Ember.Object.extend({
     @return {Promise} promise
   */
   fetchRecord: function(record) {
-    if (isNone(record)) { return null; }
-    if (record._loadingPromise) { return record._loadingPromise; }
-    if (!get(record, 'isEmpty')) { return null; }
+    var type = record.constructor,
+        id = get(record, 'id');
 
-    var type = record.constructor;
-    var id = get(record, 'id');
     var adapter = this.adapterFor(type);
 
     Ember.assert("You tried to find a record but you have no adapter (for " + type + ")", adapter);
     Ember.assert("You tried to find a record but your adapter (for " + type + ") does not implement 'find'", adapter.find);
 
-    var promise = _find(adapter, this, type, id);
-    record.loadingData(promise);
+    var promise = _find(adapter, this, type, id, record);
     return promise;
+  },
+
+  scheduleFetchMany: function(records) {
+    return Ember.RSVP.all(map(records, this.scheduleFetch, this));
+  },
+
+  scheduleFetch: function(record) {
+    var type = record.constructor;
+    if (isNone(record)) { return null; }
+    if (record._loadingPromise) { return record._loadingPromise; }
+
+    var resolver = Ember.RSVP.defer("Fetching " + type + "with id: " + record.get('id'));
+    var recordResolverPair = {record: record, resolver: resolver};
+    var promise = resolver.promise;
+
+    record.loadingData(promise);
+
+    if (!this._pendingFetch.get(type)){
+      this._pendingFetch.set(type, [recordResolverPair]);
+    } else {
+      this._pendingFetch.get(type).push(recordResolverPair);
+    }
+    Ember.run.scheduleOnce('afterRender', this, this.flushAllPendingFetches);
+
+    return promise;
+  },
+
+  flushAllPendingFetches: function(){
+    if (this.isDestroyed || this.isDestroying) {
+      return;
+    }
+
+    this._pendingFetch.forEach(this._flushPendingFetchForType, this);
+    this._pendingFetch = Ember.Map.create();
+  },
+
+  _flushPendingFetchForType: function (type, recordResolverPairs) {
+    var store = this;
+    var adapter = store.adapterFor(type);
+    var shouldCoalesce = !!adapter.findMany && adapter.coalesceFindRequests;
+    var records = Ember.A(recordResolverPairs).mapBy('record');
+    var resolvers = Ember.A(recordResolverPairs).mapBy('resolver');
+
+    function _fetchRecord(recordResolverPair) {
+      var resolver = recordResolverPair.resolver;
+      store.fetchRecord(recordResolverPair.record).then(function(record){
+        resolver.resolve(record);
+      }, function(error){
+        resolver.reject(error);
+      });
+    }
+
+    function resolveFoundRecords(records) {
+      forEach(records, function(record){
+        var pair = Ember.A(recordResolverPairs).findBy('record', record);
+        if (pair){
+          var resolver = pair.resolver;
+          resolver.resolve(record);
+        }
+      });
+    }
+
+    function makeMissingRecordsRejector(requestedRecords) {
+      return function rejectMissingRecords(resolvedRecords) {
+        var missingRecords = requestedRecords.without(resolvedRecords);
+        rejectRecords(missingRecords);
+      };
+    }
+
+    function makeRecordsRejector(records) {
+      return function (error) {
+        rejectRecords(records, error);
+      };
+    }
+
+    function rejectRecords(records, error) {
+      forEach(records, function(record){
+        var pair = Ember.A(recordResolverPairs).findBy('record', record);
+        if (pair){
+          var resolver = pair.resolver;
+          resolver.reject(error);
+        }
+      });
+    }
+
+    if (recordResolverPairs.length === 1) {
+      _fetchRecord(recordResolverPairs[0]);
+    } else if (shouldCoalesce) {
+      var groups = adapter.groupRecordsForFindMany(this, records);
+      forEach(groups, function (groupOfRecords) {
+        var requestedRecords = Ember.A(groupOfRecords);
+        var ids = requestedRecords.mapBy('id');
+        if (ids.length > 1) {
+          _findMany(adapter, store, type, ids, requestedRecords).
+            then(resolveFoundRecords).
+            then(makeMissingRecordsRejector(requestedRecords)).
+            then(null, makeRecordsRejector(requestedRecords));
+        } else if (ids.length === 1) {
+          var pair = Ember.A(recordResolverPairs).findBy('record', groupOfRecords[0]);
+          _fetchRecord(pair);
+        } else {
+          Ember.assert("You cannot return an empty array from adapter's method groupRecordsForFindMany", false);
+        }
+      });
+    } else {
+      forEach(recordResolverPairs, _fetchRecord);
+    }
   },
 
   /**
@@ -505,54 +646,7 @@ Store = Ember.Object.extend({
     Ember.assert("You tried to reload a record but you have no adapter (for " + type + ")", adapter);
     Ember.assert("You tried to reload a record but your adapter does not implement `find`", adapter.find);
 
-    return _find(adapter, this, type, id);
-  },
-
-  /**
-    This method takes a list of records, groups the records by type,
-    converts the records into IDs, and then invokes the adapter's `findMany`
-    method.
-
-    The records are grouped by type to invoke `findMany` on adapters
-    for each unique type in records.
-
-    It is used both by a brand new relationship (via the `findMany`
-    method) or when the data underlying an existing relationship
-    changes.
-
-    @method fetchMany
-    @private
-    @param {Array} records
-    @param {DS.Model} owner
-    @return {Promise} promise
-  */
-  fetchMany: function(records, owner) {
-    if (!records.length) {
-      return Ember.RSVP.resolve(records);
-    }
-
-    // Group By Type
-    var recordsByTypeMap = Ember.MapWithDefault.create({
-      defaultValue: function() { return Ember.A(); }
-    });
-
-    forEach(records, function(record) {
-      recordsByTypeMap.get(record.constructor).push(record);
-    });
-
-    var promises = [];
-
-    forEach(recordsByTypeMap, function(type, records) {
-      var ids = records.mapBy('id'),
-          adapter = this.adapterFor(type);
-
-      Ember.assert("You tried to load many records but you have no adapter (for " + type + ")", adapter);
-      Ember.assert("You tried to load many records but your adapter does not implement `findMany`", adapter.findMany);
-
-      promises.push(_findMany(adapter, this, type, ids, owner));
-    }, this);
-
-    return Ember.RSVP.all(promises);
+    return this.scheduleFetch(record);
   },
 
   /**
@@ -604,13 +698,9 @@ Store = Ember.Object.extend({
   findMany: function(owner, inputRecords, typeName, resolver) {
     var type = this.modelFor(typeName);
     var records = Ember.A(inputRecords);
-    var unloadedRecords = records.filterBy('isEmpty', true);
+    var unloadedRecords = records.filterProperty('isEmpty', true);
+
     var manyArray = this.recordArrayManager.createManyArray(type, records);
-
-    forEach(unloadedRecords, function(record) {
-      record.loadingData();
-    });
-
     manyArray.loadingRecordsCount = unloadedRecords.length;
 
     if (unloadedRecords.length) {
@@ -618,7 +708,7 @@ Store = Ember.Object.extend({
         this.recordArrayManager.registerWaitingRecordArray(record, manyArray);
       }, this);
 
-      resolver.resolve(this.fetchMany(unloadedRecords, owner));
+      resolver.resolve(this.scheduleFetchMany(unloadedRecords, owner));
     } else {
       if (resolver) { resolver.resolve(); }
       manyArray.set('isLoaded', true);
@@ -1776,10 +1866,10 @@ function _bind(fn) {
   };
 }
 
-function _find(adapter, store, type, id) {
-  var promise = adapter.find(store, type, id);
-  var serializer = serializerForAdapter(adapter, type);
-  var label = "DS: Handle Adapter#find of " + type + " with id: " + id;
+function _find(adapter, store, type, id, record) {
+  var promise = adapter.find(store, type, id, record),
+      serializer = serializerForAdapter(adapter, type),
+      label = "DS: Handle Adapter#find of " + type + " with id: " + id;
 
   promise = Promise.cast(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));
@@ -1798,12 +1888,12 @@ function _find(adapter, store, type, id) {
   }, "DS: Extract payload of '" + type + "'");
 }
 
-function _findMany(adapter, store, type, ids, owner) {
-  var promise = adapter.findMany(store, type, ids, owner);
-  var serializer = serializerForAdapter(adapter, type);
-  var label = "DS: Handle Adapter#findMany of " + type;
-  var guardedPromise;
 
+function _findMany(adapter, store, type, ids, records) {
+  var promise = adapter.findMany(store, type, ids, records),
+      serializer = serializerForAdapter(adapter, type),
+      label = "DS: Handle Adapter#findMany of " + type;
+  var guardedPromise;
   promise = Promise.cast(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
@@ -1812,7 +1902,7 @@ function _findMany(adapter, store, type, ids, owner) {
 
     Ember.assert("The response from a findMany must be an Array, not " + Ember.inspect(payload), Ember.typeOf(payload) === 'array');
 
-    store.pushMany(type, payload);
+    return store.pushMany(type, payload);
   }, null, "DS: Extract payload of " + type);
 }
 
@@ -1929,4 +2019,5 @@ export {
   PromiseArray,
   PromiseObject
 };
+
 export default Store;

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -844,6 +844,7 @@ test("findQuery - data is normalized through custom serializers", function() {
 
 test("findMany - findMany uses a correct URL to access the records", function() {
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
+  adapter.coalesceFindRequests = true;
 
   store.push('post', { id: 1, name: "Rails is omakase", comments: [ 1, 2, 3 ] });
 
@@ -861,9 +862,29 @@ test("findMany - findMany uses a correct URL to access the records", function() 
   }));
 });
 
+test("findMany - findMany does not coalesce by default", function() {
+  Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
+
+  store.push('post', { id: 1, name: "Rails is omakase", comments: [ 1, 2, 3 ] });
+
+  var post = store.getById('post', 1);
+  //It's still ok to return this even without coalescing  because RESTSerializer supports sideloading
+  ajaxResponse({
+    comments: [
+      { id: 1, name: "FIRST" },
+      { id: 2, name: "Rails is unagi" },
+      { id: 3, name: "What is omakase?" }
+    ]
+  });
+  post.get('comments').then(async(function(comments) {
+    equal(passedUrl, "/comments/3");
+    equal(passedHash, null);
+  }));
+});
 
 test("findMany - returning an array populates the array", function() {
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
+  adapter.coalesceFindRequests = true;
 
   store.push('post', { id: 1, name: "Rails is omakase", comments: [ 1, 2, 3 ] });
 
@@ -896,6 +917,7 @@ return post.get('comments');
 
 test("findMany - returning sideloaded data loads the data", function() {
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
+  adapter.coalesceFindRequests = true;
 
   store.push('post', { id: 1, name: "Rails is omakase", comments: [ 1, 2, 3 ] });
 
@@ -940,6 +962,7 @@ test("findMany - a custom serializer is used if present", function() {
     attrs: { name: '_NAME_' }
   }));
 
+  adapter.coalesceFindRequests = true;
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
 
   store.push('post', { id: 1, name: "Rails is omakase", comments: [ 1, 2, 3 ] });
@@ -1007,6 +1030,7 @@ test("findHasMany - returning an array populates the array", function() {
 
 test("findMany - returning sideloaded data loads the data", function() {
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
+  adapter.coalesceFindRequests = true;
 
   store.push(
     'post',
@@ -1170,6 +1194,144 @@ test('buildURL - with camelized names', function() {
   store.find('superUser', 1).then(async(function(post) {
     equal(passedUrl, "/super_users/1");
   }));
+});
+
+test('buildURL - buildURL takes a record from find', function() {
+  Comment.reopen({ post: DS.belongsTo('post') });
+  adapter.buildURL = function(type, id, record) {
+    return "/posts/" + record.get('post.id') + '/comments/' + record.get('id');
+  };
+
+  ajaxResponse({ comments: [{ id: 1 }] });
+
+  var post = store.push('post', { id: 2 });
+  store.find('comment', 1, {post: post}).then(async(function(post) {
+    equal(passedUrl, "/posts/2/comments/1");
+  }));
+});
+
+test('buildURL - buildURL takes the records from findMany', function() {
+  Comment.reopen({ post: DS.belongsTo('post') });
+  Post.reopen({ comments: DS.hasMany('comment', {async: true}) });
+
+  adapter.buildURL = function(type, ids, records) {
+    return "/posts/" + records.get('firstObject.post.id') + '/comments/';
+  };
+  adapter.coalesceFindRequests = true;
+
+  ajaxResponse({ comments: [{ id: 1 }, {id:2}, {id:3}] });
+
+  var post = store.push('post', { id: 2, comments: [1,2,3] });
+
+  post.get('comments').then(async(function(post) {
+    equal(passedUrl, "/posts/2/comments/");
+  }));
+});
+
+test('buildURL - buildURL takes a record from create', function() {
+  Comment.reopen({ post: DS.belongsTo('post') });
+  adapter.buildURL = function(type, id, record) {
+    return "/posts/" + record.get('post.id') + '/comments/';
+  };
+
+  ajaxResponse({ comments: [{ id: 1 }] });
+
+  var post = store.push('post', { id: 2 });
+  var comment = store.createRecord('comment');
+  comment.set('post', post);
+  comment.save().then(async(function(post) {
+    equal(passedUrl, "/posts/2/comments/");
+  }));
+});
+
+test('buildURL - buildURL takes a record from update', function() {
+  Comment.reopen({ post: DS.belongsTo('post') });
+  adapter.buildURL = function(type, id, record) {
+    return "/posts/" + record.get('post.id') + '/comments/' + record.get('id');
+  };
+
+  ajaxResponse({ comments: [{ id: 1 }] });
+
+  var post = store.push('post', { id: 2 });
+  var comment = store.push('comment', { id: 1 });
+  comment.set('post', post);
+  comment.save().then(async(function(post) {
+    equal(passedUrl, "/posts/2/comments/1");
+  }));
+});
+
+test('buildURL - buildURL takes a record from delete', function() {
+  Comment.reopen({ post: DS.belongsTo('post') });
+  adapter.buildURL = function(type, id, record) {
+    return '/comments/' + record.get('id');
+  };
+
+  ajaxResponse({ comments: [{ id: 1 }] });
+
+  var post = store.push('post', { id: 2 });
+  var comment = store.push('comment', { id: 1 });
+
+  comment.set('post', post);
+  comment.deleteRecord();
+  comment.save().then(async(function(post) {
+    equal(passedUrl, "/comments/1");
+  }));
+});
+
+test('groupRecordsForFindMany groups records based on their url', function() {
+  Comment.reopen({ post: DS.belongsTo('post') });
+  Post.reopen({ comments: DS.hasMany('comment', {async: true}) });
+  adapter.coalesceFindRequests = true;
+
+  adapter.buildURL = function(type, id, record) {
+    if (id === '1'){
+      return '/comments/1';
+    } else {
+      return '/other_comments/' + id;
+    }
+  };
+
+  adapter.find = function(store, type, id, record ) {
+    equal(id, '1');
+    return Ember.RSVP.resolve({comments: {id:1}});
+  };
+
+  adapter.findMany = function(store, type, ids, records ) {
+    deepEqual(ids, ['2', '3']);
+    return Ember.RSVP.resolve({comments: [{id:2}, {id:3}]});
+  };
+
+  var post = store.push('post', { id: 2, comments: [1,2,3] });
+
+  post.get('comments');
+});
+
+test('groupRecordsForFindMany groups records correctly when singular URLs are encoded as query params', function() {
+  Comment.reopen({ post: DS.belongsTo('post') });
+  Post.reopen({ comments: DS.hasMany('comment', {async: true}) });
+  adapter.coalesceFindRequests = true;
+
+  adapter.buildURL = function(type, id, record) {
+    if (id === '1'){
+      return '/comments?id=1';
+    } else {
+      return '/other_comments?id=' + id;
+    }
+  };
+
+  adapter.find = function(store, type, id, record ) {
+    equal(id, '1');
+    return Ember.RSVP.resolve({comments: {id:1}});
+  };
+
+  adapter.findMany = function(store, type, ids, records ) {
+    deepEqual(ids, ['2', '3']);
+    return Ember.RSVP.resolve({comments: [{id:2}, {id:3}]});
+  };
+
+  var post = store.push('post', { id: 2, comments: [1,2,3] });
+
+  post.get('comments');
 });
 
 test('normalizeKey - to set up _ids and _id', function() {

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -163,16 +163,16 @@ test("When a polymorphic hasMany relationship is accessed, the adapter's findMan
   }));
 });
 
-test("When a polymorphic hasMany relationship is accessed, the store can call multiple adapters' findMany method if the records are not loaded", function() {
+test("When a polymorphic hasMany relationship is accessed, the store can call multiple adapters' findMany or find methods if the records are not loaded", function() {
   User.reopen({
     messages: hasMany('message', { polymorphic: true, async: true })
   });
 
-  env.adapter.findMany = function(store, type) {
+  env.adapter.find = function(store, type) {
     if (type === Post) {
-      return Ember.RSVP.resolve([{ id: 1 }]);
+      return Ember.RSVP.resolve({ id: 1 });
     } else if (type === Comment) {
-      return Ember.RSVP.resolve([{ id: 3 }]);
+      return Ember.RSVP.resolve({ id: 3 });
     }
   };
 

--- a/packages/ember-data/tests/unit/store/unload_test.js
+++ b/packages/ember-data/tests/unit/store/unload_test.js
@@ -55,8 +55,9 @@ test("unload a record", function() {
     equal(get(record, 'isDeleted'), true, "record is deleted");
 
     tryToFind = false;
-    store.find(Record, 1);
-    equal(tryToFind, true, "not found record with id 1");
+    store.find(Record, 1).then(async(function(){
+      equal(tryToFind, true, "not found record with id 1");
+    }));
   }));
 });
 

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -158,7 +158,9 @@
       didUpdateAttribute: syncForTest(),
       didUpdateAttributes: syncForTest(),
       didUpdateRelationship: syncForTest(),
-      didUpdateRelationships: syncForTest()
+      didUpdateRelationships: syncForTest(),
+      scheduleFetch: syncForTest(),
+      scheduleFetchMany: syncForTest()
     });
 
     DS.Model.reopen({


### PR DESCRIPTION
I am still adding comments, cleaning up a bit, but feel like the branch is ready to be reviewed. 

This PR brings following improvements/changes:
1. Find calls from the same runloop will be coalesced into findMany
   requests if the adapter has a findMany method
2. Adds a groupRecordsForFindMany hook on the adapter that allows you
   to decide how to coalesce the record requests. This will enable fixing
   of bugs such as #651, by segmenting on the number of records
3. Allows users to preset attributes and relationships on a model when
   doing a find call. For relationships you can either pass in a record or
   an id
4. Gives rudimentary support for nested urls, by passing in the record
   object to the buildUrl method
5. Removes the owner being passed to findMany becuase it can be looked
   up on the original record
6. Adds couple special cased SSOT features that were needed for
   buildUrl/removal of owner property to be viable

This PR lays the groundwork for:
1. Adding support for reloading hasManys
2. Making nice sugar for nestedUrls in the RestAdater
