### PR TITLE
allow attributes to be excluded via the attrs hash (similar to readOnly: true in pre-beta)

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -67,6 +67,30 @@ export default Ember.Object.extend({
     });
     ```
 
+    You can also remove attributes using the `excluded` key in
+    your mapping object.
+
+    Example
+
+    ```javascript
+    App.PersonSerializer = DS.JSONSerializer.extend({
+      attrs: {
+        admin: {excluded: true},
+        occupation: {key: 'career'}
+      }
+    });
+    ```
+
+    When serialized:
+
+    ```javascript
+    {
+      "career": "magician"
+    }
+    ```
+
+    Note that the `admin` is now not included in the payload.
+
     @property attrs
     @type {Object}
   */
@@ -436,6 +460,11 @@ export default Ember.Object.extend({
       value = transform.serialize(value);
     }
 
+    // If attrs.key.excluded, do not include the value in the
+    // response to the server at all.
+    if (attrs && attrs[key] && attrs[key].exclude === true) {
+      return;
+    }
     // if provided, use the mapping provided by `attrs` in
     // the serializer
     if (attrs && attrs[key]) {

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -179,6 +179,22 @@ test('Serializer should respect the attrs hash when serializing records', functi
   equal(payload.title_payload_key, "Rails is omakase");
 });
 
+test('Serializer should respect the attrs hash when serializing records', function(){
+  expect(2);
+  env.container.register("serializer:post", DS.JSONSerializer.extend({
+    attrs: {
+      title: {exclude: true}
+    }
+  }));
+
+  post = env.store.createRecord("post", { title: "Rails is omakase"});
+
+  var payload = env.container.lookup("serializer:post").serialize(post);
+
+  ok(!payload.hasOwnProperty('title'), "Does not add the key to instance");
+  ok(!payload.hasOwnProperty('[object Object]'),"Does not add some random key like [object Object]");
+});
+
 test("Serializer should respect the primaryKey attribute when extracting records", function() {
   env.container.register('serializer:post', DS.JSONSerializer.extend({
     primaryKey: '_ID_'


### PR DESCRIPTION
refs #303

This pull request allows you to declaratively not send attributes to the server when serializing.

As per a discussion I had with @igort and @tomdale yesterday in #emberjs-dev:

adds a shorthnad versus overriding serializeAttribute or
serialize and using this._super

I'm also thinking it would be handy to allow some sort of array syntax for declaring multiple properties if you have a lot:

``` javascript
App.PersonSerializer = DS.JSONSerializer.extend({
  excludedAttributes: [ 'admin' ]
});
```

Thoughts?
