### PR TITLE
allow attributes to be excluded via the attrs hash

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -67,6 +67,30 @@ export default Ember.Object.extend({
     });
     ```
 
+    You can also remove attributes by setting the `serialize` key to
+    false in your mapping object.
+
+    Example
+
+    ```javascript
+    App.PersonSerializer = DS.JSONSerializer.extend({
+      attrs: {
+        admin: {serialize: false},
+        occupation: {key: 'career'}
+      }
+    });
+    ```
+
+    When serialized:
+
+    ```javascript
+    {
+      "career": "magician"
+    }
+    ```
+
+    Note that the `admin` is now not included in the payload.
+
     @property attrs
     @type {Object}
   */
@@ -436,6 +460,11 @@ export default Ember.Object.extend({
       value = transform.serialize(value);
     }
 
+    // If attrs.key.serialize is false, do not include the value in the
+    // response to the server at all.
+    if (attrs && attrs[key] && attrs[key].serialize === false) {
+      return;
+    }
     // if provided, use the mapping provided by `attrs` in
     // the serializer
     if (attrs && attrs[key]) {

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -179,6 +179,22 @@ test('Serializer should respect the attrs hash when serializing records', functi
   equal(payload.title_payload_key, "Rails is omakase");
 });
 
+test('Serializer respects `serialize: false` on the attrs hash', function(){
+  expect(2);
+  env.container.register("serializer:post", DS.JSONSerializer.extend({
+    attrs: {
+      title: {serialize: false}
+    }
+  }));
+
+  post = env.store.createRecord("post", { title: "Rails is omakase"});
+
+  var payload = env.container.lookup("serializer:post").serialize(post);
+
+  ok(!payload.hasOwnProperty('title'), "Does not add the key to instance");
+  ok(!payload.hasOwnProperty('[object Object]'),"Does not add some random key like [object Object]");
+});
+
 test("Serializer should respect the primaryKey attribute when extracting records", function() {
   env.container.register('serializer:post', DS.JSONSerializer.extend({
     primaryKey: '_ID_'


### PR DESCRIPTION
(Reopening in hopes that travis will run it correctly this time).

refs #303

As per a discussion I had with @igort and @tomdale yesterday in #emberjs-dev:

This pull request allows you to declaratively (instead of overriding serializeAttribute and using `this._super`) not send attributes to the server when serializing.

So you can now say:

``` javascript
App.PersonSerializer = DS.JSONSerializer.extend({
  attrs: {
    admin: { exclude: true }
  }
});
```

and `admin` will be removed from the payload when serialized to the server.

I'm also thinking it would be handy to allow some sort of array syntax for declaring multiple properties if you have a lot:

``` javascript
App.PersonSerializer = DS.JSONSerializer.extend({
  excludedAttributes: [ 'admin' ]
});
```

Thoughts?
