### PR TITLE
Move s3 publishing config from ember-publisher to ember data

### DIFF
--- a/bin/publish_to_s3.js
+++ b/bin/publish_to_s3.js
@@ -15,5 +15,6 @@
 // ./bin/publish_to_s3.js
 // ```
 var S3Publisher = require('ember-publisher');
-publisher = new S3Publisher({project: 'ember-data'});
+var configPath = require('path').join(__dirname, '../config/s3ProjectConfig.js')
+publisher = new S3Publisher({projectConfigPath: configPath});
 publisher.publish();

--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -1,0 +1,31 @@
+module.exports = function(revision, tag, date){
+  return {
+    'ember-data.js': fileObject('ember-data', '.js', 'text/javascript', revision, tag, date),
+    'ember-data.min.js': fileObject('ember-data.min', '.js', 'text/javascript', revision, tag, date),
+    'ember-data.prod.js': fileObject('ember-data.prod', '.js', 'text/javascript', revision, tag, date)
+  }
+}
+
+function fileObject(baseName, extension, contentType, currentRevision, tag, date) {
+  var fullName = "/" + baseName + extension;
+  return {
+    contentType: contentType,
+    destinations: {
+      canary: [
+        'canary' + fullName,
+        'canary/daily/' + date + fullName,
+        'canary/shas/' + currentRevision + fullName
+      ],
+      stable: [
+        'stable' + fullName,
+        'stable/daily/' + date + fullName,
+        'stable/shas/' + currentRevision + fullName
+      ],
+      beta: [
+        'beta' + fullName,
+        'beta/daily/' + date + fullName,
+        'beta/shas/' + currentRevision + fullName
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "aws-sdk": "~2.0.0-rc8",
     "bower": "~1.3",
     "defeatureify": "~0.1.4",
-    "ember-publisher": "0.0.3",
+    "ember-publisher": "0.0.6",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
Several of us working on ember-publisher have decided that it would be better to keep the configuration within the including app. This allows us to update the publishing for the including app without having to push a change to ember-publisher itself. [reference]

This PR should not change the functionality of bin/publish_to_s3.js at all.

See equivalent change in ember.js at https://github.com/emberjs/ember.js/pull/5257
