### PR TITLE
Do not serialize fixtures when deleting

### DIFF
--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -260,9 +260,7 @@ export default Adapter.extend({
     @return {Promise} promise
   */
   deleteRecord: function(store, type, record) {
-    var fixture = this.mockJSON(store, type, record);
-
-    this.deleteLoadedFixture(type, fixture);
+    this.deleteLoadedFixture(type, record);
 
     return this.simulateRemoteCall(function() {
       // no payload in a deletion

--- a/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
@@ -151,7 +151,10 @@ test("should delete record asynchronously when it is committed", function() {
 
   var paul = env.store.push('person', { id: 'paul', firstName: 'Paul', lastName: 'Chavard', height: 70 });
 
-  paul.deleteRecord();
+  paul.save().then(function(){
+    paul.deleteRecord();
+    paul.save();
+  });
 
   paul.on('didDelete', function() {
     clearTimeout(timer);
@@ -163,7 +166,6 @@ test("should delete record asynchronously when it is committed", function() {
     equal(Person.FIXTURES.length, 0, "Record removed from FIXTURES");
   });
 
-  paul.save();
 });
 
 test("should follow isUpdating semantics", function() {


### PR DESCRIPTION
There was no point in doing this and it only increased complexity.
Couldn't figure out a nice way to test it, but no new behaviour is
added so seems ok.

The delete fixture test was broken, so fixed the test as well.
