### PR TITLE
Follow rails conventions for serializing embedded objects

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -111,6 +111,10 @@ var ActiveModelSerializer = RESTSerializer.extend({
     return decamelize(attr);
   },
 
+  formatEmbeddedKey: function(key){
+    return key + "_attributes";
+  },
+
   /**
     Underscores relationship names and appends "_id" or "_ids" when serializing
     relationship keys.

--- a/packages/ember-data/lib/serializers/embedded_records_mixin.js
+++ b/packages/ember-data/lib/serializers/embedded_records_mixin.js
@@ -121,6 +121,11 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     }
   },
 
+  keyForEmbeddedAttribute: function(attr){
+    var key = this.keyForAttribute(attr);
+    return this.formatEmbeddedKey ? this.formatEmbeddedKey(key) : key;
+  },
+
   /**
     Serialize `belongsTo` relationship when it is configured as an embedded object.
 
@@ -189,7 +194,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
         json[key] = get(embeddedRecord, 'id');
       }
     } else if (includeRecords) {
-      key = this.keyForAttribute(attr);
+      key = this.keyForEmbeddedAttribute(attr);
       if (!embeddedRecord) {
         json[key] = null;
       } else {
@@ -294,7 +299,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
       key = this.keyForRelationship(attr, relationship.kind);
       json[key] = get(record, attr).mapBy('id');
     } else if (includeRecords) {
-      key = this.keyForAttribute(attr);
+      key = this.keyForEmbeddedAttribute(attr);
       json[key] = get(record, attr).map(function(embeddedRecord) {
         var serializedEmbeddedRecord = embeddedRecord.serialize({includeId: true});
         this.removeEmbeddedForeignKey(record, embeddedRecord, relationship, serializedEmbeddedRecord);

--- a/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
@@ -537,7 +537,7 @@ test("serialize with embedded objects (hasMany relationship)", function() {
 
   deepEqual(json, {
     name: "Villain League",
-    villains: [{
+    villains_attributes: [{
       id: get(tom, "id"),
       first_name: "Tom",
       last_name: "Dale",
@@ -579,7 +579,7 @@ test("serialize with (new) embedded objects (hasMany relationship)", function() 
   var json = serializer.serialize(league);
   deepEqual(json, {
     name: "Villain League",
-    villains: [{
+    villains_attributes: [{
       first_name: "Tom",
       last_name: "Dale",
       home_planet_id: get(league, "id"),
@@ -608,7 +608,7 @@ test("serialize with embedded objects (hasMany relationships, including related 
     first_name: get(superVillain, "firstName"),
     last_name: get(superVillain, "lastName"),
     home_planet_id: null,
-    evil_minions: [{
+    evil_minions_attributes: [{
       id: get(evilMinion, "id"),
       name: get(evilMinion, "name"),
       super_villain_id: "1"
@@ -688,7 +688,7 @@ test("serialize with embedded object (belongsTo relationship)", function() {
     first_name: get(tom, "firstName"),
     last_name: get(tom, "lastName"),
     home_planet_id: get(tom, "homePlanet").get("id"),
-    secret_lab: {
+    secret_lab_attributes: {
       id: get(tom, "secretLab").get("id"),
       minion_capacity: get(tom, "secretLab").get("minionCapacity"),
       vicinity: get(tom, "secretLab").get("vicinity")
@@ -725,7 +725,7 @@ test("serialize with embedded object (belongsTo relationship) works with differe
     first_name: get(tom, "firstName"),
     last_name: get(tom, "lastName"),
     home_planet_id: get(tom, "homePlanet").get("id"),
-    secret_lab: {
+    secret_lab_attributes: {
       crazy_id: get(tom, "secretLab").get("id"),
       minion_capacity: get(tom, "secretLab").get("minionCapacity"),
       vicinity: get(tom, "secretLab").get("vicinity")
@@ -758,7 +758,7 @@ test("serialize with embedded object (belongsTo relationship, new no id)", funct
     first_name: get(tom, "firstName"),
     last_name: get(tom, "lastName"),
     home_planet_id: get(tom, "homePlanet").get("id"),
-    secret_lab: {
+    secret_lab_attributes: {
       minion_capacity: get(tom, "secretLab").get("minionCapacity"),
       vicinity: get(tom, "secretLab").get("vicinity")
     }
@@ -894,7 +894,7 @@ test("when related record is not present, serialize embedded record (with a belo
     first_name: get(tom, "firstName"),
     last_name: get(tom, "lastName"),
     home_planet_id: get(tom, "homePlanet").get("id"),
-    secret_lab: null
+    secret_lab_attributes: null
   });
 });
 


### PR DESCRIPTION
In https://github.com/emberjs/data/issues/1950 there was a lot of talk about how people expected the embedded objects to be serialized with _attributes when they're embedded (as per the rails convention). This PR will add _attributes to any embedded objects when the EmbeddedRecordsMixin is used.

It does break the existing behaviour but I think it's fair to say the existing behaviour is broken for rails. If someone does need the existing behaviour they can revert to it by overriding the formatEmbeddedKey method e.g.

    App.ApplicationSerializer = DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
      formatEmbeddedKey: function(key){
        return key;
      },

      attrs: {
        video: { embedded: 'always' }
      }
    });
