### PR TITLE
add test for multiwords typeKey

### DIFF
--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -48,6 +48,14 @@ module("integration/serializer/rest - RESTSerializer", {
   }
 });
 
+test("typeForRoot returns always same typeKey even for uncountable multi words keys", function() {
+  expect(2);
+  Ember.Inflector.inflector.uncountable('words');
+  expectedTypeKey = 'multiWords';
+  equal(env.restSerializer.typeForRoot('multi_words'), expectedTypeKey);
+  equal(env.restSerializer.typeForRoot('multiWords'), expectedTypeKey);
+});
+
 test("extractArray with custom typeForRoot", function() {
   env.restSerializer.typeForRoot = function(root) {
     var camelized = Ember.String.camelize(root);


### PR DESCRIPTION
In https://github.com/emberjs/data/commit/766f0c9a8cdc8d21b99d80378c01678f8c404aa3 the typeKey normalization changed from `singularize(camelize)` to `camelize(singularize)`.
This breaks an edge case when I am defining a 'multiword uncountable' rule in the inflector.

cc/ @mixonic, @stefanpenner

Ultimately, @stefanpenner suggested to improve the inflector to take in account such a case.
