### PR TITLE
Move key lookup for ajaxError into model and serializer

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -131,6 +131,29 @@ var ActiveModelSerializer = RESTSerializer.extend({
     }
   },
 
+  /**
+    Converts camelCased attributes to underscored when looking up error keys.
+
+    @method errorKeyForAttribute
+    @param {String} attribute or relationship name
+    @return String
+  */
+  errorKeyForAttribute: function(name) {
+    return this.keyForAttribute(name);
+  },
+
+  /**
+    Converts camelCased relationships to underscored when looking up error keys.
+
+    @method errorKeyForRelationship
+    @param {String} attribute or relationship name
+    @param {String} kind The kind of relationship, e.g., belongsTo/hasMany
+    @return String
+  */
+  errorKeyForRelationship: function(name, kind) {
+    return this.keyForRelationship(name, kind);
+  },
+
   /*
     Does not serialize hasMany relationships by default.
   */

--- a/packages/activemodel-adapter/tests/integration/active_model_adapter_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_adapter_test.js
@@ -31,17 +31,6 @@ test('ajaxError - returns invalid error if 422 response', function() {
   equal(adapter.ajaxError(jqXHR), error.toString());
 });
 
-test('ajaxError - invalid error has camelized keys', function() {
-  var error = new DS.InvalidError({ firstName: "can't be blank" });
-
-  var jqXHR = {
-    status: 422,
-    responseText: JSON.stringify({ errors: { first_name: "can't be blank" } })
-  };
-
-  equal(adapter.ajaxError(jqXHR), error.toString());
-});
-
 test('ajaxError - returns ajax response if not 422 response', function() {
   var jqXHR = {
     status: 500,

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -197,16 +197,14 @@ export default Ember.Object.extend({
   normalizeAttributes: function(type, hash) {
     var payloadKey;
 
-    if (this.keyForAttribute) {
-      type.eachAttribute(function(key) {
-        payloadKey = this.keyForAttribute(key);
-        if (key === payloadKey) { return; }
-        if (!hash.hasOwnProperty(payloadKey)) { return; }
+    type.eachAttribute(function(key) {
+      payloadKey = this.keyForAttribute(key);
+      if (key === payloadKey) { return; }
+      if (!hash.hasOwnProperty(payloadKey)) { return; }
 
-        hash[key] = hash[payloadKey];
-        delete hash[payloadKey];
-      }, this);
-    }
+      hash[key] = hash[payloadKey];
+      delete hash[payloadKey];
+    }, this);
   },
 
   /**
@@ -1015,6 +1013,29 @@ export default Ember.Object.extend({
 
   keyForRelationship: function(key, type){
     return key;
+  },
+
+  /**
+    Converts camelCased attributes to underscored when looking up error keys.
+
+    @method errorKeyForAttribute
+    @param {String} attribute or relationship name
+    @return String
+  */
+  errorKeyForAttribute: function(name) {
+    return name;
+  },
+
+  /**
+    Converts camelCased relationships to underscored when looking up error keys.
+
+    @method errorKeyForRelationship
+    @param {String} attribute or relationship name
+    @param {String} kind The kind of relationship, e.g., belongsTo/hasMany
+    @return String
+  */
+  errorKeyForRelationship: function(name, kind) {
+    return name;
   },
 
   // HELPERS

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -721,7 +721,7 @@ export default JSONSerializer.extend({
   serializePolymorphicType: function(record, json, relationship) {
     var key = relationship.key;
     var belongsTo = get(record, key);
-    key = this.keyForAttribute ? this.keyForAttribute(key) : key;
+    key = this.keyForAttribute(key);
     if (Ember.isNone(belongsTo)) {
       json[key + "Type"] = null;
     } else {

--- a/packages/ember-data/tests/unit/model/lifecycle_callbacks_test.js
+++ b/packages/ember-data/tests/unit/model/lifecycle_callbacks_test.js
@@ -152,6 +152,7 @@ test("a record receives a becameInvalid callback when it became invalid", functi
       equal(get(this, 'isDirty'), true, "record should be dirty");
     }
   });
+  Person.typeKey = "person";
 
   var adapter = DS.Adapter.extend({
     find: function(store, type, id) {
@@ -165,9 +166,11 @@ test("a record receives a becameInvalid callback when it became invalid", functi
     }
   });
 
-  var store = createStore({
-    adapter: adapter
+  var env = setupStore({
+    adapter: adapter,
+    "person": Person
   });
+  var store = env.store;
 
   var asyncPerson = store.find(Person, 1);
   equal(callCount, 0, "precond - becameInvalid callback was not called yet");


### PR DESCRIPTION
Moves the responsibility of looking up the key to
be used for error <=> attribute mapping into the
model's adapterDidInvalidate addError behavior and
uses the serializer to find errorKeyForAttribute/
Relationship to do the key conversion using similar
logic to serialization since the errors returned
from the active model adapter ajax call will have
keys that match the serialized form.

This has the added benefit of allowing a serializer
to override this behavior to perform key name
mapping much the way normalizeHash does inside
the serializer.