### PR TITLE
Inverse async relationships are not updated

### DIFF
--- a/packages/ember-data/tests/integration/relationships/inverse_relationships_test.js
+++ b/packages/ember-data/tests/integration/relationships/inverse_relationships_test.js
@@ -99,6 +99,28 @@ test("When a record's belongsTo relationship is set, it can specify the inverse 
   equal(post.get('everyoneWeKnowComments.length'), 0, "everyoneWeKnowComments has no posts");
 });
 
+test("When a record's async belongsTo relationship is set, it can update the inverse relationship", function() {
+  Post = DS.Model.extend({
+    comments: DS.hasMany('comment', { async: true}),
+  });
+
+  Comment = DS.Model.extend({
+    post: DS.belongsTo('post', { async: true })
+  });
+
+  var env = setupStore({ post: Post, comment: Comment }),
+      store = env.store;
+
+  var comment = store.push('comment', {id: 2});
+  var post = store.push('post', {id: 1});
+
+  equal(post.get('comments.length'), 0, "comments has no posts");
+
+  comment.set('post', post);
+
+  equal(post.get('comments.length'), 1, "comments had the post added");
+});
+
 test("When a record is added to or removed from a polymorphic has-many relationship, the inverse belongsTo can be set explicitly", function() {
   User = DS.Model.extend({
     messages: DS.hasMany('message', {


### PR DESCRIPTION
This is a failing test to describe the problem that can be seen in this jsbin http://emberjs.jsbin.com/sulup/3 (add a fixture and then remove the newly created: the room's fixtures don't get updated)

It fails because `RelationshipChangeAdd` and `RelationshipChangeRemove` expect to receive `DS.Model`s but instead get sometimes `DS.PromiseObject`s (See https://github.com/emberjs/data/blob/ff371b5d60904cff92ee4e01c1d9890ffb51d310/packages/ember-data/lib/system/changes/relationship_change.js#L364 ).
