### PR TITLE
Changing an async belongsTo association does not load unfetched record.

### DIFF
--- a/packages/ember-data/lib/system/changes/relationship_change.js
+++ b/packages/ember-data/lib/system/changes/relationship_change.js
@@ -3,6 +3,7 @@
 */
 
 import Model from "ember-data/system/model/model";
+import { isSyncRelationship } from 'ember-data/system/relationship-meta';
 
 var get = Ember.get;
 var set = Ember.set;
@@ -342,13 +343,6 @@ RelationshipChange.prototype = {
 
 RelationshipChangeAdd.prototype = Ember.create(RelationshipChange.create({}));
 RelationshipChangeRemove.prototype = Ember.create(RelationshipChange.create({}));
-
-function isSyncRelationship(record, relationshipName) {
-  var meta = Ember.meta(record);
-  var desc = meta.descs[relationshipName];
-
-  return desc && !desc._meta.options.async;
-}
 
 RelationshipChangeAdd.prototype.changeType = 'add';
 RelationshipChangeAdd.prototype.sync = function() {

--- a/packages/ember-data/lib/system/relationship-meta.js
+++ b/packages/ember-data/lib/system/relationship-meta.js
@@ -26,3 +26,10 @@ export function relationshipFromMeta(store, meta) {
     isRelationship: true
   };
 }
+
+export function isSyncRelationship(record, relationshipName) {
+  var meta = Ember.meta(record);
+  var desc = meta.descs[relationshipName];
+
+  return desc && !desc._meta.options.async;
+}

--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -8,7 +8,8 @@ import { PromiseObject } from 'ember-data/system/store';
 import { RelationshipChange } from 'ember-data/system/changes';
 import {
   relationshipFromMeta,
-  typeForRelationshipMeta
+  typeForRelationshipMeta,
+  isSyncRelationship
 } from 'ember-data/system/relationship-meta';
 
 /**
@@ -168,7 +169,7 @@ Model.reopen({
     @param key
   */
   belongsToWillChange: Ember.beforeObserver(function(record, key) {
-    if (get(record, 'isLoaded')) {
+    if (get(record, 'isLoaded') && isSyncRelationship(record, key)) {
       var oldParent = get(record, key);
 
       if (oldParent) {

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -328,7 +328,7 @@ test("asdf", function() {
 
   env.adapter.deleteRecord = function(store, type, record) {
     ok(record instanceof type);
-    equal(record.id, 1, 'should first comment')
+    equal(record.id, 1, 'should first comment');
     return record;
   };
 
@@ -337,4 +337,39 @@ test("asdf", function() {
   };
 
   comment.destroyRecord();
+});
+
+test("Destroying a record with an unloaded aync belongsTo association does not fetch the record", function() {
+  expect(2);
+  var post;
+
+  env.store.modelFor('message').reopen({
+    user: DS.hasMany('user', {
+      async: true
+    })
+  });
+
+  env.store.modelFor('post').reopen({
+    user: DS.belongsTo('user', {
+      async: true,
+      inverse: 'messages'
+    })
+  });
+
+  post = env.store.push('post', {
+    id: 1,
+    user: 2
+  });
+
+  env.adapter.find = function() {
+    throw new Error("Adapter's find method should not be called");
+  };
+
+  env.adapter.deleteRecord = function(store, type, record) {
+    ok(record instanceof type);
+    equal(record.id, 1, 'should first post');
+    return record;
+  };
+
+  post.destroyRecord();
 });


### PR DESCRIPTION
[Fixes #1567]
