### PR TITLE
Refactor hasMany code for comments and clarity

### DIFF
--- a/packages/ember-data/lib/system/relationships/has_many.js
+++ b/packages/ember-data/lib/system/relationships/has_many.js
@@ -14,42 +14,71 @@ var set = Ember.set;
 var setProperties = Ember.setProperties;
 var map = Ember.EnumerableUtils.map;
 
+/**
+  Returns a computed property that synchronously returns a ManyArray for
+  this relationship. If not all of the records in this relationship are
+  loaded, it will raise an exception.
+*/
+
+function syncHasMany(type, options, meta) {
+  return Ember.computed('data', function(key) {
+    return buildRelationship(this, key, options, function(store, data) {
+      // Configure the metadata for the computed property to contain
+      // the key.
+      meta.key = key;
+
+      var records = data[key];
+
+      Ember.assert("You looked up the '" + key + "' relationship on '" + this + "' but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", Ember.A(records).isEvery('isEmpty', false));
+
+      return store.findMany(this, data[key], typeForRelationshipMeta(store, meta));
+    });
+  }).meta(meta).readOnly();
+}
+
+/**
+  Returns a computed property that itself returns a promise that resolves to a
+  ManyArray.
+ */
+
 function asyncHasMany(type, options, meta) {
   return Ember.computed('data', function(key) {
-    var relationship = this._relationships[key];
-    var promiseLabel = "DS: Async hasMany " + this + " : " + key;
-
+    // Configure the metadata for the computed property to contain
+    // the key.
     meta.key = key;
 
-    if (!relationship) {
+    var relationship = buildRelationship(this, key, options, function(store, data) {
+      var link = data.links && data.links[key];
+      var rel;
+      var promiseLabel = "DS: Async hasMany " + this + " : " + key;
       var resolver = Ember.RSVP.defer(promiseLabel);
-      relationship = buildRelationship(this, key, options, function(store, data) {
-        var link = data.links && data.links[key];
-        var rel;
-        if (link) {
-          rel = store.findHasMany(this, link, relationshipFromMeta(store, meta), resolver);
-        } else {
-          //This is a temporary workaround for setting owner on the relationship
-          //until single source of truth lands. It only works for OneToMany atm
-          var records = data[key];
-          var inverse = this.constructor.inverseFor(key);
-          var owner = this;
-          if (inverse && records) {
-            if (inverse.kind === 'belongsTo'){
-              map(records, function(record){
-                set(record, inverse.name, owner);
-              });
-            }
+
+      if (link) {
+        rel = store.findHasMany(this, link, relationshipFromMeta(store, meta), resolver);
+      } else {
+
+        //This is a temporary workaround for setting owner on the relationship
+        //until single source of truth lands. It only works for OneToMany atm
+        var records = data[key];
+        var inverse = this.constructor.inverseFor(key);
+        var owner = this;
+        if (inverse && records) {
+          if (inverse.kind === 'belongsTo'){
+            map(records, function(record){
+              set(record, inverse.name, owner);
+            });
           }
-          rel = store.findMany(owner, data[key], typeForRelationshipMeta(store, meta), resolver);
         }
-        // cache the promise so we can use it
-        // when we come back and don't need to rebuild
-        // the relationship.
-        set(rel, 'promise', resolver.promise);
-        return rel;
-      });
-    }
+
+        rel = store.findMany(owner, data[key], typeForRelationshipMeta(store, meta), resolver);
+      }
+
+      // Cache the promise so we can use it when we come back and don't
+      // need to rebuild the relationship.
+      set(rel, 'promise', resolver.promise);
+
+      return rel;
+    });
 
     var promise = relationship.get('promise').then(function() {
       return relationship;
@@ -61,6 +90,12 @@ function asyncHasMany(type, options, meta) {
   }).meta(meta).readOnly();
 }
 
+/*
+  Builds the ManyArray for a relationship using the provided callback,
+  but only if it had not been created previously. After building, it
+  sets some metadata on the created ManyArray, such as the record which
+  owns it and the name of the relationship.
+*/
 function buildRelationship(record, key, options, callback) {
   var rels = record._relationships;
 
@@ -76,30 +111,6 @@ function buildRelationship(record, key, options, callback) {
     name: key,
     isPolymorphic: options.polymorphic
   });
-}
-
-function hasRelationship(type, options) {
-  options = options || {};
-
-  var meta = {
-    type: type,
-    isRelationship: true,
-    options: options,
-    kind: 'hasMany',
-    key: null
-  };
-
-  if (options.async) {
-    return asyncHasMany(type, options, meta);
-  }
-
-  return Ember.computed('data', function(key) {
-    return buildRelationship(this, key, options, function(store, data) {
-      var records = data[key];
-      Ember.assert("You looked up the '" + key + "' relationship on '" + this + "' but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", Ember.A(records).isEvery('isEmpty', false));
-      return store.findMany(this, data[key], typeForRelationshipMeta(store, meta));
-    });
-  }).meta(meta).readOnly();
 }
 
 /**
@@ -185,7 +196,26 @@ function hasMany(type, options) {
     options = type;
     type = undefined;
   }
-  return hasRelationship(type, options);
+
+  options = options || {};
+
+  // Metadata about relationships is stored on the meta of
+  // the relationship. This is used for introspection and
+  // serialization. Note that `key` is populated lazily
+  // the first time the CP is called.
+  var meta = {
+    type: type,
+    isRelationship: true,
+    options: options,
+    kind: 'hasMany',
+    key: null
+  };
+
+  if (options.async) {
+    return asyncHasMany(type, options, meta);
+  } else {
+    return syncHasMany(type, options, meta);
+  }
 }
 
 export default hasMany;


### PR DESCRIPTION
This is a clean-up of the `DS.hasMany` code, which has gotten quite messy. To the best of my knowledge, this does not change any behavior (tests continue to pass) but I believe it improves the clarity of the code.
