### PR TITLE
Add updatePayload to Store

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -471,7 +471,7 @@ export default JSONSerializer.extend({
     @param {DS.Store} store
     @param {Object} payload
   */
-  pushPayload: function(store, rawPayload) {
+  pushPayload: function(store, rawPayload, _partial) {
     var payload = this.normalizePayload(rawPayload);
 
     for (var prop in payload) {
@@ -484,7 +484,7 @@ export default JSONSerializer.extend({
         return typeSerializer.normalize(type, hash, prop);
       }, this);
 
-      store.pushMany(typeName, normalizedArray);
+      store.pushMany(typeName, normalizedArray, _partial);
     }
   },
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1428,6 +1428,56 @@ Store = Ember.Object.extend({
   },
 
   /**
+    Update existing records in the store from a payload. Unlike
+    [pushPayload](#method_pushPayload), updatePayload will merge the new
+    data properties with the existing properties. This makes it safe
+    to use with a subset of record attributes.
+
+    `updatePayload` is useful if you app broadcasts partial updates to
+    records.
+
+    ```js
+    App.ApplicationSerializer = DS.ActiveModelSerializer;
+
+    store.pushPayload({
+      people: [
+        {id: 1, first_name: "Tom", last_name: "Dale"}
+      ]
+    });
+
+    var tom = store.find('person', 1);
+    tom.get('firstName'); // Tom
+    tom.get('lastName'); // Dale
+
+    store.updatePayload({
+      people: [
+        {id: 1, first_name: "TomHuda"}
+      ]
+    });
+
+    tom.get('firstName'); // TomHuda
+    tom.get('lastName'); // Dale
+    ```
+
+    See [pushPayload](#method_pushPayload) for more details.
+
+    @method updatePayload
+    @param {String} type Optionally, a model used to determine which serializer will be used
+    @param {Object} payload
+  */
+  updatePayload: function (type, payload) {
+    var serializer;
+    if (!payload) {
+      payload = type;
+      serializer = defaultSerializer(this.container);
+      Ember.assert("You cannot use `store#updatePayload` without a type unless your default serializer defines `pushPayload`", serializer.pushPayload);
+    } else {
+      serializer = this.serializerFor(type);
+    }
+    serializer.pushPayload(this, payload, true);
+  },
+
+  /**
     If you have an Array of normalized data to push,
     you can call `pushMany` with the Array, and it will
     call `push` repeatedly for you.
@@ -1437,9 +1487,9 @@ Store = Ember.Object.extend({
     @param {Array} datas
     @return {Array}
   */
-  pushMany: function(type, datas) {
+  pushMany: function(type, datas, _partial) {
     return map(datas, function(data) {
-      return this.push(type, data);
+      return this.push(type, data, _partial);
     }, this);
   },
 

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -316,3 +316,26 @@ test("Calling pushPayload without a type should use a model's serializer when no
 
   equal(person.get('firstName'), "Yehuda", "you can push raw JSON into the store");
 });
+
+test("Calling pushPayload with _partial allows partial updates with raw JSON", function () {
+  env.container.register('serializer:person', DS.ActiveModelSerializer);
+
+  store.pushPayload('person', {people: [{
+    id: '1',
+    first_name: "Robert",
+    last_name: "Jackson"
+  }]});
+
+  var person = store.getById('person', 1);
+
+  equal(person.get('firstName'), "Robert", "you can push raw JSON into the store");
+  equal(person.get('lastName'), "Jackson", "you can push raw JSON into the store");
+
+  store.updatePayload('person', {people: [{
+    id: '1',
+    first_name: "Jacquie"
+  }]});
+
+  equal(person.get('firstName'), "Jacquie", "you can push raw JSON into the store");
+  equal(person.get('lastName'), "Jackson", "existing fields are untouched");
+});


### PR DESCRIPTION
`updatePayload` is like `pushPayload` but allows for partial updates,
similar to `update` and `push`.

I basically cherry picked @rwjblue previous commit in #1791, and removed the useless _partial argument in serializers.

closes #1791
