### PR TITLE
modelFor is used constantly, the extra normalization and string splittin...

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1211,11 +1211,11 @@ Store = Ember.Object.extend({
     var factory;
 
     if (typeof key === 'string') {
-      var normalizedKey = this.container.normalize('model:' + key);
-
-      factory = this.container.lookupFactory(normalizedKey);
-      if (!factory) { throw new Ember.Error("No model was found for '" + key + "'"); }
-      factory.typeKey = this._normalizeTypeKey(normalizedKey.split(':', 2)[1]);
+      factory = this.container.lookupFactory('model:' + key);
+      if (!factory) {
+        throw new Ember.Error("No model was found for '" + key + "'");
+      }
+      factory.typeKey = factory.typeKey || this._normalizeTypeKey(key);
     } else {
       // A factory already supplied. Ensure it has a normalized key.
       factory = key;


### PR DESCRIPTION
...g was causing measurable slowdown.

before:

![screenshot 2014-08-20 10 34 19](https://cloud.githubusercontent.com/assets/1377/3983530/e3ad5b44-287f-11e4-8edb-31f84e9efaf2.png)

after:

doesn't even show up.
