### PR TITLE
Create record response with new associations fix

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -708,11 +708,11 @@ export default Ember.Object.extend({
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extract: function(store, type, payload, id, requestType) {
+  extract: function(store, type, payload, id, requestType, record) {
     this.extractMeta(store, type, payload);
 
     var specificExtract = "extract" + requestType.charAt(0).toUpperCase() + requestType.substr(1);
-    return this[specificExtract](store, type, payload, id, requestType);
+    return this[specificExtract](store, type, payload, id, requestType, record);
   },
 
   /**
@@ -793,8 +793,8 @@ export default Ember.Object.extend({
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractCreateRecord: function(store, type, payload, id, requestType) {
-    return this.extractSave(store, type, payload, id, requestType);
+  extractCreateRecord: function(store, type, payload, id, requestType, record) {
+    return this.extractSave(store, type, payload, id, requestType, record);
   },
   /**
     `extractUpdateRecord` is a hook into the extract method used when
@@ -874,8 +874,8 @@ export default Ember.Object.extend({
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractSave: function(store, type, payload, id, requestType) {
-    return this.extractSingle(store, type, payload, id, requestType);
+  extractSave: function(store, type, payload, id, requestType, record) {
+    return this.extractSingle(store, type, payload, id, requestType, record);
   },
 
   /**

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -706,6 +706,7 @@ export default Ember.Object.extend({
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
+    @param record
     @return {Object} json The deserialized payload
   */
   extract: function(store, type, payload, id, requestType, record) {
@@ -791,6 +792,7 @@ export default Ember.Object.extend({
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
+    @param record
     @return {Object} json The deserialized payload
   */
   extractCreateRecord: function(store, type, payload, id, requestType, record) {
@@ -872,6 +874,7 @@ export default Ember.Object.extend({
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
+    @param record
     @return {Object} json The deserialized payload
   */
   extractSave: function(store, type, payload, id, requestType, record) {

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -322,24 +322,15 @@ export default JSONSerializer.extend({
       var isPrimary = type.typeKey === primaryTypeName;
       var value = payload[prop];
 
-      // legacy support for singular resources
-      if (isPrimary && Ember.typeOf(value) !== "array" ) {
-        primaryRecord = this.normalize(primaryType, value, prop);
-        return primaryRecord;
-      }
-      // end legacy support for singular resources
+      if (!isPrimary) { continue; }
 
-      /*jshint loopfunc:true*/
-      forEach.call(value, function(hash) {
-        var isFirstCreatedRecord = isPrimary && !primaryRecord;
-        if (isFirstCreatedRecord) {
-          var typeName = this.typeForRoot(prop);
-          var type = store.modelFor(typeName);
-          var typeSerializer = store.serializerFor(type);
-          hash = typeSerializer.normalize(type, hash, prop);
-          primaryRecord = hash;
-        }
-      }, this);
+      // legacy support for singular resources
+      if (Ember.typeOf(value) !== "array" ) {
+        primaryRecord = this.normalize(primaryType, value, prop);
+      } else if (value && value[0]) {
+        var typeSerializer = store.serializerFor(type);
+        primaryRecord = typeSerializer.normalize(type, value[0], prop);
+      }
     }
 
     return primaryRecord;

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -259,6 +259,8 @@ export default JSONSerializer.extend({
     @param {subclass of DS.Model} primaryType
     @param {Object} payload
     @param {String} recordId
+    @param {String} requestType
+    @param record
     @return {Object} the primary response to the original request
   */
   extractSingle: function(store, primaryType, rawPayload, recordId, requestType, record) {
@@ -267,7 +269,7 @@ export default JSONSerializer.extend({
     var primaryRecord;
 
     if (record && !recordId) {
-      primaryRecord = this.extractPrimaryRecord(store, primaryType, payload, record);
+      primaryRecord = this.extractPrimaryRecord(store, primaryType, payload);
       if (primaryRecord) {
         store.updateId(record, primaryRecord);
       }

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -2007,7 +2007,7 @@ function _commit(adapter, store, operation, record) {
     var payload;
 
     if (adapterPayload) {
-      payload = serializer.extract(store, type, adapterPayload, get(record, 'id'), operation);
+      payload = serializer.extract(store, type, adapterPayload, get(record, 'id'), operation, record);
     } else {
       payload = adapterPayload;
     }

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -368,6 +368,33 @@ test("create - a record on the many side of a hasMany relationship should update
   }));
 });
 
+test("create - response can contain relationships the client doesn't yet know about", function() {
+  expect(2);
+
+  ajaxResponse({
+    posts: [{
+      id: "1",
+      name: "Rails is omakase",
+      comments: [2]
+    }],
+    comments: [{
+      id: "2",
+      name: "Another Comment",
+      post: 1
+    }]
+  });
+
+  Post.reopen({ comments: DS.hasMany('comment') });
+  Comment.reopen({ post: DS.belongsTo('post') });
+
+  var post = store.createRecord('post', { name: "Rails is omakase" });
+
+  post.save().then(async(function(comment) {
+    equal(post.get('comments.firstObject.post'), post, "the comments are related to the correct post model");
+    equal(store.typeMapFor(Post).records.length, 1, "There should only be one post record");
+  }));
+});
+
 test("create - relationships are not duplicated", function() {
   var post, comment;
 

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -389,7 +389,7 @@ test("create - response can contain relationships the client doesn't yet know ab
 
   var post = store.createRecord('post', { name: "Rails is omakase" });
 
-  post.save().then(async(function(comment) {
+  post.save().then(async(function(post) {
     equal(post.get('comments.firstObject.post'), post, "the comments are related to the correct post model");
     equal(store.typeMapFor(Post).records.length, 1, "There should only be one post record");
   }));


### PR DESCRIPTION
Associations aren't hooked up correctly when the json returned from a create sideloads records that the client doesn't know about yet.  Their `belongsTo` will point at a duplicate of the original object returned from the `createRecord` call.  The original record did not get its `id` set in time for the child records to find it during normalization.

see the test in 6395fe046f15501cc27c5913165871cb87950b78

paired with @denisnazarov 

If this approach is acceptable I can clean up things like updating comments on methods whose signatures changed.