### PR TITLE
Removes `hasOwnProperty` checks to improve overall performance.

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -202,7 +202,6 @@ export default Ember.Object.extend({
       type.eachAttribute(function(key) {
         payloadKey = this.keyForAttribute(key);
         if (key === payloadKey) { return; }
-        if (!hash.hasOwnProperty(payloadKey)) { return; }
 
         hash[key] = hash[payloadKey];
         delete hash[payloadKey];
@@ -221,7 +220,6 @@ export default Ember.Object.extend({
       type.eachRelationship(function(key, relationship) {
         payloadKey = this.keyForRelationship(key, relationship.kind);
         if (key === payloadKey) { return; }
-        if (!hash.hasOwnProperty(payloadKey)) { return; }
 
         hash[key] = hash[payloadKey];
         delete hash[payloadKey];


### PR DESCRIPTION
Tested using a real application, it can be found [here](https://github.com/stefanpenner/perf-stress).

Fixes #2206.

`normalizeAttributes`

before:
![normalize-attributes-before](https://cloud.githubusercontent.com/assets/1131196/3999543/37a1ce48-2951-11e4-8490-4f696a430637.png)

after:
![normalize-attributes-after](https://cloud.githubusercontent.com/assets/1131196/3999558/5dcdb9a6-2951-11e4-9304-bd4920bf8969.png)

`normalizeRelationships`

before:
![normalize-relationships-before](https://cloud.githubusercontent.com/assets/1131196/3999695/a111ce86-2952-11e4-81da-268aaecc7fb7.png)

after the change, it doesn't get registered.

thanks to @stefanpenner for pointing it out.
