### PR TITLE
Update recordArrays whenever there are changes to relationships

### DIFF
--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -62,6 +62,7 @@ import "ember-data/ember-initializer";
 import setupContainer from "ember-data/setup-container";
 
 import ContainerProxy from "ember-data/system/container_proxy";
+import {Relationship} from "ember-data/system/relationships/relationship";
 
 DS.Store         = Store;
 DS.PromiseArray  = PromiseArray;
@@ -102,6 +103,8 @@ DS.EmbeddedRecordsMixin  = EmbeddedRecordsMixin;
 
 DS.belongsTo = belongsTo;
 DS.hasMany   = hasMany;
+
+DS.Relationship  = Relationship;
 
 DS.ContainerProxy = ContainerProxy;
 

--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -51,6 +51,7 @@ Relationship.prototype = {
       if (this.inverseKey) {
         record._relationships[this.inverseKey].addRecord(this.record);
       }
+      this.record.updateRecordArrays();
     }
   },
 
@@ -65,6 +66,7 @@ Relationship.prototype = {
           inverseRelationship.removeRecord(this.record);
         }
       }
+      this.record.updateRecordArrays();
     }
   },
 

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -177,6 +177,9 @@
       clear: syncForTest()
     });
 
+    DS.Relationship.prototype.addRecord = syncForTest(DS.Relationship.prototype.addRecord);
+    DS.Relationship.prototype.removeRecord = syncForTest(DS.Relationship.prototype.removeRecord);
+
     var transforms = {
       'boolean': DS.BooleanTransform.create(),
       'date': DS.DateTransform.create(),


### PR DESCRIPTION
Previously we weren't correctly refreshing record arrays when there
were relationship changes. This was causing `store.filter` not to
update correctly whenever there were relationship changes

fixes #2222
