### PR TITLE
Prepare for publishing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
   "ember-addon": {
     "main": "lib/ember-addon-main.js"
   },
+  "files": [
+    "dist",
+    "lib/ember-addon-main.js"
+  ],
   "scripts": {
-    "postinstall": "bower install",
-    "prepublish": "ember build --output-path=dist/ember-data/ --environment production",
+    "prepublish": "bower install && rm -rf dist/ && ember build --output-path=dist/ember-data/ --environment production && rm -rf dist/ember-data/bower_components dist/ember-data/docs",
     "start": "ember serve",
     "dist": "ember build --environment production",
     "test": "testem -R dot ci",


### PR DESCRIPTION
- Move `bower install` into `prepublish`.  This prevents consumers of the new published `ember-data` package from having `bower` installed globally. Also, nothing changes as far as setup requirements: running `npm install` in the root of the repo runs the `prepublish` script.
- Only publish the specific files that we want (leaves ability in the future to publish other types of things).
