### PR TITLE
async belongsTo returns the `inverseRecord` when is neither `isLoading` nor `isEmpty`

### DIFF
--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -229,7 +229,12 @@ BelongsToRelationship.prototype.getRecord = function() {
         return record;
       });
     } else if (this.inverseRecord) {
-      promise = this.store._findByRecord(this.inverseRecord);
+      var record = this.inverseRecord;
+      if (record.get('isEmpty') || record.get('isLoading')) {
+        promise = this.store._findByRecord(record);
+      } else {
+        promise = Ember.RSVP.resolve(record);
+      }
     } else {
       promise = Ember.RSVP.Promise.resolve(null);
     }

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -1245,6 +1245,30 @@ test('buildURL - buildURL takes a record from create', function() {
   }));
 });
 
+test('buildURL - buildURL takes a record from create to query a resolved async belongsTo relationship', function() {
+  Comment.reopen({ post: DS.belongsTo('post', {async: true}) });
+
+  ajaxResponse({ posts: [{ id: 2 }] });
+
+  store.find('post', 2).then(async(function(post) {
+    equal(post.get('id'), 2);
+
+    adapter.buildURL = function(type, id, record) {
+      return "/posts/" + record.get('post.id') + '/comments/';
+    };
+
+    ajaxResponse({ comments: [{ id: 1 }] });
+
+    var comment = store.createRecord('comment');
+    comment.set('post', post);
+    comment.save().then(async(function(post) {
+      equal(passedUrl, "/posts/2/comments/");
+    }));
+
+  }));
+
+});
+
 test('buildURL - buildURL takes a record from update', function() {
   Comment.reopen({ post: DS.belongsTo('post') });
   adapter.buildURL = function(type, id, record) {


### PR DESCRIPTION
This is a #2223 duplicated pull request for the master branch instead of the sync_ssot old branch.
