### PR TITLE
Do not clear own relationships when deleting records

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -642,6 +642,12 @@ var Model = Ember.Object.extend(Ember.Evented, {
     }, this);
   },
 
+  disconnectRelationships: function() {
+    this.eachRelationship(function(name, relationship) {
+      this._relationships[name].disconnect();
+    }, this);
+  },
+
   /**
     @method updateRecordArrays
     @private

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -324,7 +324,7 @@ var DirtyState = {
     // EVENTS
     deleteRecord: function(record) {
       record.transitionTo('deleted.uncommitted');
-      record.clearRelationships();
+      record.disconnectRelationships();
     },
 
     didSetProperty: function(record, context) {
@@ -405,7 +405,7 @@ var updatedState = dirtyState({
 });
 
 createdState.uncommitted.deleteRecord = function(record) {
-  record.clearRelationships();
+  record.disconnectRelationships();
   record.transitionTo('deleted.saved');
 };
 
@@ -424,7 +424,7 @@ updatedState.inFlight.unloadRecord = assertAgainstUnloadRecord;
 
 updatedState.uncommitted.deleteRecord = function(record) {
   record.transitionTo('deleted.uncommitted');
-  record.clearRelationships();
+  record.disconnectRelationships();
 };
 
 var RootState = {
@@ -565,7 +565,7 @@ var RootState = {
 
       deleteRecord: function(record) {
         record.transitionTo('deleted.uncommitted');
-        record.clearRelationships();
+        record.disconnectRelationships();
       },
 
       unloadRecord: function(record) {

--- a/packages/ember-data/tests/integration/relationships/many_to_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/many_to_many_test.js
@@ -127,4 +127,26 @@ test("Removing a record from a hasMany reflects on the other hasMany side - sync
 });
 
 
+/*
+Deleting tests
+*/
 
+test("Deleting a record that has a hasMany relationship removes it from the otherMany array but does not remove the other record from itself - async", function () {
+  var user = store.push('user', {id:1, name: 'Stanley', topics: [2]});
+  var topic = store.push('topic', {id: 2, title: 'EmberFest was great'});
+  topic.deleteRecord();
+  topic.get('users').then(async(function(fetchedUsers) {
+    equal(fetchedUsers.get('length'), 1, 'Users are still there');
+  }));
+  user.get('topics').then(async(function(fetchedTopics) {
+    equal(fetchedTopics.get('length'), 0, 'Topic got removed from the user');
+  }));
+});
+
+test("Deleting a record that has a hasMany relationship removes it from the otherMany array but does not remove the other record from itself - sync", function () {
+  var account = store.push('account', {id:2 , state: 'lonely'});
+  var user = store.push('user', {id:1, name: 'Stanley', accounts: [2]});
+  account.deleteRecord();
+  equal(account.get('users.length'), 1, 'Users are still there');
+  equal(user.get('accounts.length'), 0, 'Acocount got removed from the user');
+});

--- a/packages/ember-data/tests/integration/relationships/one_to_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/one_to_many_test.js
@@ -295,3 +295,48 @@ test("Setting the belongsTo side to null removes the record from the hasMany sid
 
   equal(user.get('accounts.length'), 0, 'the account got removed correctly');
 });
+
+/*
+Deleting
+*/
+
+test("When deleting a record that has a belongsTo it is removed from the hasMany side but not the belongsTo side- async", function () {
+  var user = store.push('user', {id:1, name: 'Stanley', messages: [2]});
+  var message = store.push('message', {id: 2, title: 'EmberFest was great'});
+  message.deleteRecord();
+  message.get('user').then(async(function(fetchedUser) {
+    equal(fetchedUser, user, 'Message still has the user');
+  }));
+  user.get('messages').then(async(function(fetchedMessages) {
+    equal(fetchedMessages.get('length'), 0, 'User was removed from the messages');
+  }));
+});
+
+test("When deleting a record that has a belongsTo it is removed from the hasMany side but not the belongsTo side- sync", function () {
+  var account = store.push('account', {id:2 , state: 'lonely'});
+  var user = store.push('user', {id:1, name: 'Stanley', accounts: [2]});
+  account.deleteRecord();
+  equal(user.get('accounts.length'), 0, "User was removed from the accounts");
+  equal(account.get('user'), user, 'Account still has the user');
+});
+
+test("When deleting a record that has a hasMany it is removed from the belongsTo side but not the hasMany side- async", function () {
+  var user = store.push('user', {id:1, name: 'Stanley', messages: [2]});
+  var message = store.push('message', {id: 2, title: 'EmberFest was great'});
+  user.deleteRecord();
+  message.get('user').then(async(function(fetchedUser) {
+    equal(fetchedUser, null, 'Message does not have the user anymore');
+  }));
+  user.get('messages').then(async(function(fetchedMessages) {
+    equal(fetchedMessages.get('length'), 1, 'User still has the messages');
+  }));
+});
+
+test("When deleting a record that has a hasMany it is removed from the belongsTo side but not the hasMany side - sync", function () {
+  var account = store.push('account', {id:2 , state: 'lonely'});
+  var user = store.push('user', {id:1, name: 'Stanley', accounts: [2]});
+  user.deleteRecord();
+  equal(user.get('accounts.length'), 1, "User still has the accounts");
+  equal(account.get('user'), null, 'Account no longer has the user');
+});
+

--- a/packages/ember-data/tests/integration/relationships/one_to_one_test.js
+++ b/packages/ember-data/tests/integration/relationships/one_to_one_test.js
@@ -167,3 +167,27 @@ test("Setting a belongsTo to a different record, sets the old relationship to nu
   equal(newBetterJob.get('user'), user, 'New job setup correctly');
 });
 
+/*
+Deleting tests
+*/
+
+test("When deleting a record that has a belongsTo relationship, the record is removed from the inverse but still has access to its own relationship - async", function () {
+  var stanley = store.push('user', {id:1, name: 'Stanley', bestFriend:2});
+  var stanleysFriend = store.push('user', {id:2, name: "Stanley's friend"});
+  stanley.deleteRecord();
+  stanleysFriend.get('bestFriend').then(async(function(fetchedUser) {
+    equal(fetchedUser, null, 'Stanley got removed');
+  }));
+  stanley.get('bestFriend').then(async(function(fetchedUser) {
+    equal(fetchedUser, stanleysFriend, 'Stanleys friend did not get removed');
+  }));
+});
+
+test("When deleting a record that has a belongsTo relationship, the record is removed from the inverse but still has access to its own relationship - sync", function () {
+  var job = store.push('job', {id:2 , isGood: true});
+  var user = store.push('user', {id:1, name: 'Stanley', job:2 });
+  job.deleteRecord();
+  equal(user.get('job'), null, 'Job got removed from the user');
+  equal(job.get('user'), user, 'Job still has the user');
+});
+


### PR DESCRIPTION
If a record had a relationship, such as a `comment` having a `post`, previously
if you did `comment.deleteRecord()`, `comment.get('post')` would immediately be set
to `null`.

This behavior was wrong for several reasons:
  1.It prevented future rollback support for relationships
  2.If you had nested URLs, you would not be able to send a DELETE request to /post/1/comments/1
    because comment.get('post') would already have been deleted

We now only clear the inverse side of the relationships when the record is deleted.
The resulting refactor also enables us to add support for a record in a `404` state to be removed
from relationships and for removing records from manyArrays that do not have inverses.

Paired with @jcollins1991
