### PR TITLE
Bring back relationship parameter for findHasMany & findBelongsTo

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -392,7 +392,7 @@ export default Adapter.extend({
     @param {String} url
     @return {Promise} promise
   */
-  findHasMany: function(store, record, url) {
+  findHasMany: function(store, record, url, relationship) {
     var host = get(this, 'host');
     var id   = get(record, 'id');
     var type = record.constructor.typeKey;
@@ -431,7 +431,7 @@ export default Adapter.extend({
     @param {String} url
     @return {Promise} promise
   */
-  findBelongsTo: function(store, record, url) {
+  findBelongsTo: function(store, record, url, relationship) {
     var id   = get(record, 'id');
     var type = record.constructor.typeKey;
 

--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -138,7 +138,7 @@ ManyRelationship.prototype.getRecords = function() {
     var self = this;
     var promise;
     if (this.link && !this.hasFetchedLink) {
-      promise = this.store.findHasMany(this.record, this.link, this.belongsToType).then(function(records){
+      promise = this.store.findHasMany(this.record, this.link, this.relationshipMeta).then(function(records){
         self.updateRecordsFromAdapter(records);
         self.hasFetchedLink = true;
         //TODO(Igor) try to abstract the isLoaded part

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1765,23 +1765,23 @@ function _findMany(adapter, store, type, ids, records) {
   }, null, "DS: Extract payload of " + type);
 }
 
-function _findHasMany(adapter, store, record, link, type) {
-  var promise = adapter.findHasMany(store, record, link);
-  var serializer = serializerForAdapter(adapter, type);
-  var label = "DS: Handle Adapter#findHasMany of " + record + " : " + type;
+function _findHasMany(adapter, store, record, link, relationship) {
+  var promise = adapter.findHasMany(store, record, link, relationship);
+  var serializer = serializerForAdapter(adapter, relationship.type);
+  var label = "DS: Handle Adapter#findHasMany of " + record + " : " + relationship.type;
 
   promise = Promise.cast(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));
   promise = _guard(promise, _bind(_objectIsAlive, record));
 
   return promise.then(function(adapterPayload) {
-    var payload = serializer.extract(store, type, adapterPayload, null, 'findHasMany');
+    var payload = serializer.extract(store, relationship.type, adapterPayload, null, 'findHasMany');
 
     Ember.assert("The response from a findHasMany must be an Array, not " + Ember.inspect(payload), Ember.typeOf(payload) === 'array');
 
-    var records = store.pushMany(type, payload);
+    var records = store.pushMany(relationship.type, payload);
     return records;
-  }, null, "DS: Extract payload of " + record + " : hasMany " + type);
+  }, null, "DS: Extract payload of " + record + " : hasMany " + relationship.type);
 }
 
 function _findBelongsTo(adapter, store, record, link, relationship) {

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -99,8 +99,9 @@ test("A serializer can materialize a hasMany as an opaque token that can be lazi
     throw new Error("Adapter's findMany should not be called");
   };
 
-  env.adapter.findHasMany = function(store, record, link) {
+  env.adapter.findHasMany = function(store, record, link, relationship) {
     equal(link, "/posts/1/comments", "findHasMany link was /posts/1/comments");
+    equal(relationship.type.typeKey, "comment", "relationship was passed correctly");
 
     return Ember.RSVP.resolve([
       { id: 1, body: "First" },
@@ -118,12 +119,14 @@ test("A serializer can materialize a hasMany as an opaque token that can be lazi
 });
 
 test("An updated `links` value should invalidate a relationship cache", function() {
-  expect(6);
+  expect(8);
   Post.reopen({
     comments: DS.hasMany('comment', { async: true })
   });
 
-  env.adapter.findHasMany = function(store, record, link) {
+  env.adapter.findHasMany = function(store, record, link, relationship) {
+    equal(relationship.type.typeKey, "comment", "relationship was passed correctly");
+
     if (link === '/first') {
       return Ember.RSVP.resolve([
         { id: 1, body: "First" },


### PR DESCRIPTION
This PR brings back the `relationship` parameter for `findHasMany` & `findBelongsTo`.

Signed-off-by: Alessandro D'Aquino (elara) alex@midokura.com
