### PR TITLE
Easy access to Model corresponding adapter.

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1492,6 +1492,7 @@ Store = Ember.Object.extend({
     var record = type._create({
       id: id,
       store: this,
+      adapter: this.adapterFor(type),
       container: this.container
     });
 

--- a/packages/ember-data/tests/unit/store/create_record_test.js
+++ b/packages/ember-data/tests/unit/store/create_record_test.js
@@ -19,6 +19,13 @@ test("doesn't modify passed in properties hash", function(){
   deepEqual(attributes, { foo: 'bar' }, "The properties hash is not modified");
 });
 
+test("model has access to store and adapter", function() {
+  var attrs = { foo: 'bar'}
+  record1 = store.createRecord(Record, attrs);
+  equal(record1.get('store'), store);
+  equal(record1.get('adapter'), store.adapterFor(Record));
+});
+
 module("unit/store/createRecord - Store with models by dash", {
   setup: function() {
     var env = setupStore({


### PR DESCRIPTION
Just like save & delete, enhancing model with extra actions make sense
and action implementation should go into the adapter.

This commit adds easy access to the corresponding model's adapter
by @get('adapter').
