### PR TITLE
Update recordArrays when record has reloaded

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -970,14 +970,15 @@ var Model = Ember.Object.extend(Ember.Evented, {
     var promise = new Promise(function(resolve){
        record.send('reloadRecord', resolve);
     }, promiseLabel).then(function() {
-      record.updateRecordArrays();
       record.set('isReloading', false);
       record.set('isError', false);
       return record;
     }, function(reason) {
       record.set('isError', true);
       throw reason;
-    }, "DS: Model#reload complete, update flags");
+    }, "DS: Model#reload complete, update flags").finally(function () {
+      record.updateRecordArrays();
+    });
 
     return PromiseObject.create({
       promise: promise

--- a/packages/ember-data/tests/integration/filter_test.js
+++ b/packages/ember-data/tests/integration/filter_test.js
@@ -399,7 +399,7 @@ test("it is possible to filter created records by isReloading", function() {
   });
 
   person.reload().then(async(function(person) {
-    equal(filter.get('length'), 1, "isReloading is set to false on the reloaded object");
+    equal(filter.get('length'), 1, "the filter correctly returned a reloaded object");
   }));
 });
 


### PR DESCRIPTION
Previously we weren't correctly refreshing record arrays `isReloading` state, this PR fixes that by calling updateRecordArrays while setting `isReloading` to false.

fixes #2221 
