### PR TITLE
MODEL_FACTORY_INJECTIONS needs to be consulted for polymorphic type assertions

### DIFF
--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -130,7 +130,14 @@ ManyRelationship.prototype.destroy = function() {
 };
 
 ManyRelationship.prototype.notifyRecordRelationshipAdded = function(record, idx) {
-  Ember.assert("You cannot add '" + record.constructor.typeKey + "' records to this relationship (only '" + this.belongsToType.typeKey + "' allowed)", !this.belongsToType || record instanceof this.belongsToType);
+  Ember.assert(
+    "You cannot add '" + record.constructor.typeKey +
+    "' records to this relationship (only '" + this.belongsToType.typeKey + "' allowed)",
+    !this.belongsToType || record instanceof this.belongsToType || (
+      Ember.MODEL_FACTORY_INJECTIONS &&
+      record instanceof this.store.container.resolve('model:' + this.belongsToType.typeKey)
+    )
+  );
   this.record.notifyHasManyAdded(this.key, record, idx);
 };
 
@@ -233,7 +240,12 @@ BelongsToRelationship.prototype._super$addRecord = Relationship.prototype.addRec
 BelongsToRelationship.prototype.addRecord = function(newRecord) {
   if (this.members.has(newRecord)){ return;}
   var type = this.relationshipMeta.type;
-  Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", newRecord instanceof type);
+  Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship",
+    newRecord instanceof type || (
+      Ember.MODEL_FACTORY_INJECTIONS &&
+      newRecord instanceof this.store.container.resolve('model:' + type.typeKey)
+    )
+  );
 
   if (this.inverseRecord && this.inverseKey) {
     this.removeRecord(this.inverseRecord);


### PR DESCRIPTION
when building via _ember-cli_, the factory that is checked in these spots is different because of how the resolver works.

Original work by @krisselden and I updated it to post SSOT merge.  cc: @lukemelia 
