### PR TITLE
Remove es3 rule in .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -38,7 +38,6 @@
 
     "node" : false,
     "browser" : true,
-    "es3": true,
     "boss" : true,
     "curly": false,
     "debug": false,


### PR DESCRIPTION
I would remove this to make ember-data .jshintrc have the same config than ember does.
