### PR TITLE
a bit verbose, but lets ensure we don’t deoptimize these functions in so...

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -1054,13 +1054,30 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @private
     @param name
   */
-  trigger: function(name) {
-    Ember.tryInvoke(this, name, [].slice.call(arguments, 1));
+  trigger: function() {
+    var length = arguments.length;
+    var args = new Array(length - 1);
+    var name = arguments[0];
+
+    for (var i = 1; i < length; i++ ){
+      args[i - 1] = arguments[i];
+    }
+
+    Ember.tryInvoke(this, name, args);
     this._super.apply(this, arguments);
   },
 
   triggerLater: function() {
-    if (this._deferredTriggers.push(arguments) !== 1) { return; }
+    var length = arguments.length;
+    var args = new Array(length);
+
+    for (var i = 0; i < length; i++ ){
+      args[i] = arguments[i];
+    }
+
+    if (this._deferredTriggers.push(args) !== 1) {
+      return;
+    }
     Ember.run.schedule('actions', this, '_triggerDeferredTriggers');
   },
 

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -270,7 +270,9 @@ test("when an event is triggered on a record the method with the same name is in
 
 test("when a method is invoked from an event with the same name the arguments are passed through", function(){
   var eventMethodArgs = null;
-  var F = function() { eventMethodArgs = arguments; };
+  var F = function() {
+    eventMethodArgs = arguments;
+  };
   var record = store.createRecord(Person);
 
   record.eventThatTriggersMethod = F;


### PR DESCRIPTION
...me runtimes.
- passing arguments object to another function (other then via apply) deoptimizes function body
- materializing the arguments object via splice deoptimizes the function body
