### PR TITLE
test on latest stable ember version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-data",
   "private": true,
   "dependencies": {
-    "ember": "~1.6.0-beta.5",
+    "ember": "~1.7.0",
     "qunit": "~1.13.0",
     "jquery": "~1.10.x",
     "handlebars": "~1.3.0"


### PR DESCRIPTION
I'm proposing this due to this issue: https://github.com/emberjs/ember.js/issues/5651

With `1.7.0` tests will pass. They will pass with `1.8.0-beta.2` as well, but not with `1.8.0-beta.3`. Maybe we should always have latest beta to find regressions faster.
