### PR TITLE
Adds support for pushing promise objects to hasMany relationships

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -108,7 +108,17 @@ export default RecordArray.extend({
       this.get('relationship').removeRecords(records);
     }
     if (objects){
-      this.get('relationship').addRecords(objects, idx);
+      var underlyingRecords = objects.map(function(record) {
+        if (record && record.then) {
+          var underlyingRecord = record.get('content');
+          Ember.assert("You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo or hasMany relationship to the get call.`)", underlyingRecord !== undefined);
+          return underlyingRecord;
+        } else {
+          return record;
+        }
+      });
+
+      this.get('relationship').addRecords(underlyingRecords, idx);
     }
   },
   /**


### PR DESCRIPTION
 Added the hasMany support further out as you suggested. Has a few tests for the various code-paths, not sure of the best way to test that all of them work as expected... Hard when theres like 10 ways to add a record to a `ManyArray` :(

@igorT 