### PR TITLE
allow polymorphic relationship types to not exist

### DIFF
--- a/packages/ember-data/lib/system/relationship-meta.js
+++ b/packages/ember-data/lib/system/relationship-meta.js
@@ -8,7 +8,7 @@ export function typeForRelationshipMeta(store, meta) {
     if (meta.kind === 'hasMany') {
       typeKey = singularize(typeKey);
     }
-    type = store.modelFor(typeKey);
+    type = meta.options.polymorphic ? (store.modelFactoryFor(typeKey) && store.modelFor(typeKey)|| null ) : store.modelFor(typeKey);
   } else {
     type = meta.type;
   }

--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -6,7 +6,7 @@ import {
   OrderedSet
 } from "ember-data/system/map";
 
-var Relationship = function(store, record, inverseKey, relationshipMeta) {
+function Relationship(store, record, inverseKey, relationshipMeta) {
   this.members = new OrderedSet();
   this.store = store;
   this.key = relationshipMeta.key;
@@ -16,13 +16,18 @@ var Relationship = function(store, record, inverseKey, relationshipMeta) {
   this.relationshipMeta = relationshipMeta;
   //This probably breaks for polymorphic relationship in complex scenarios, due to
   //multiple possible typeKeys
-  this.inverseKeyForImplicit = this.store.modelFor(this.record.constructor).typeKey + this.key;
+  this.isPolymorphic = relationshipMeta.options.polymorphic;
+  this.inverseKeyForImplicit = this._inverseKeyForImplicit();
   //Cached promise when fetching the relationship from a link
   this.linkPromise = null;
-};
+}
 
 Relationship.prototype = {
   constructor: Relationship,
+
+  _inverseKeyForImplicit: function Relationship_inverseKeyForImplicit(){
+    return this.store.modelFor(this.record.constructor).typeKey + this.key;
+  },
 
   destroy: Ember.K,
 
@@ -62,6 +67,11 @@ Relationship.prototype = {
   },
 
   addRecord: function(record, idx) {
+    if (!this.isPolymorphic) {
+      var type = this.relationshipMeta.type;
+      debugger
+      Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", record instanceof type);
+    }
     if (!this.members.has(record)) {
       this.members.add(record);
       this.notifyRecordRelationshipAdded(record, idx);
@@ -145,7 +155,6 @@ var ManyRelationship = function(store, record, inverseKey, relationshipMeta) {
   this.belongsToType = relationshipMeta.type;
   this.manyArray = store.recordArrayManager.createManyArray(this.belongsToType, Ember.A());
   this.manyArray.relationship = this;
-  this.isPolymorphic = relationshipMeta.options.polymorphic;
   this.manyArray.isPolymorphic = this.isPolymorphic;
 };
 
@@ -279,7 +288,7 @@ BelongsToRelationship.prototype._super$addRecord = Relationship.prototype.addRec
 BelongsToRelationship.prototype.addRecord = function(newRecord) {
   if (this.members.has(newRecord)){ return;}
   var type = this.relationshipMeta.type;
-  Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", newRecord instanceof type);
+  Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", !this.isPolymorphic || newRecord instanceof type);
 
   if (this.inverseRecord) {
     this.removeRecord(this.inverseRecord);

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -99,6 +99,9 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
 
 test("Only a record of the same type can be used with a monomorphic belongsTo relationship", function() {
   expect(1);
+  env.store.modelFor('post').reopen({
+    user: DS.belongsTo('user', {inverse: null})
+  });
 
   store.push('post', { id: 1 });
   store.push('comment', { id: 2 });


### PR DESCRIPTION
Previously, you had to have a model defined
for polymorphic relationships. However, the
polymorphic relationship belongsTo/hasMany
did not actually have to be an instanceof the
base type declared in DS.belongsTo(‘modelType’).

This commit removes that check for polymorphic
types only.

fixes GH-2212
