### PR TITLE
warn instead of throw when resolving keys to model

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -32,8 +32,9 @@
         "invokeAsync",
         "jQuery",
         "expectAssertion",
-        "expectDeprecation"
-
+        "expectDeprecation",
+        "warns",
+        "noWarns"
     ],
 
     "node" : false,

--- a/config/ember-defeatureify.js
+++ b/config/ember-defeatureify.js
@@ -2,10 +2,16 @@ module.exports = {
   options: {
     debugStatements: [
       "Ember.warn",
+      "emberWarn",
       "Ember.assert",
+      "emberAssert",
       "Ember.deprecate",
+      "emberDeprecate",
       "Ember.debug",
-      "Ember.Logger.info"
+      "emberDebug",
+      "Ember.Logger.info",
+      "Ember.runInDebug",
+      "runInDebug"
     ]
   },
   stripDebug: {

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -54,7 +54,7 @@ function coerceId(id) {
   @namespace DS
   @extends DS.JSONSerializer
 */
-export default JSONSerializer.extend({
+var RESTSerializer = JSONSerializer.extend({
   /**
     If you want to do normalizations specific to some part of the payload, you
     can specify those under `normalizeHash`.
@@ -267,6 +267,10 @@ export default JSONSerializer.extend({
 
     for (var prop in payload) {
       var typeName  = this.typeForRoot(prop);
+      if (!store.modelFactoryFor(typeName)){
+        Ember.warn(this.warnMessageNoModelForKey(prop, typeName), false);
+        continue;
+      }
       var type = store.modelFor(typeName);
       var isPrimary = type.typeKey === primaryTypeName;
       var value = payload[prop];
@@ -420,6 +424,10 @@ export default JSONSerializer.extend({
       }
 
       var typeName = this.typeForRoot(typeKey);
+      if (!store.modelFactoryFor(typeName)) {
+        Ember.warn(this.warnMessageNoModelForKey(prop, typeName), false);
+        continue;
+      }
       var type = store.modelFor(typeName);
       var typeSerializer = store.serializerFor(type);
       var isPrimary = (!forcedSecondary && (type.typeKey === primaryTypeName));
@@ -475,6 +483,10 @@ export default JSONSerializer.extend({
 
     for (var prop in payload) {
       var typeName = this.typeForRoot(prop);
+      if (!store.modelFactoryFor(typeName, prop)){
+        Ember.warn(this.warnMessageNoModelForKey(prop, typeName), false);
+        continue;
+      }
       var type = store.modelFor(typeName);
       var typeSerializer = store.serializerFor(type);
 
@@ -729,3 +741,13 @@ export default JSONSerializer.extend({
     }
   }
 });
+
+Ember.runInDebug(function(){
+  RESTSerializer.reopen({
+    warnMessageNoModelForKey: function(prop, typeKey){
+      return 'Encountered "' + prop + '" in payload, but no model was found for model name "' + typeKey + '" (resolved model name using ' + this.constructor.toString() + '.typeForRoot("' + prop + '"))';
+    }
+  });
+});
+
+export default RESTSerializer;

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1208,7 +1208,7 @@ Store = Ember.Object.extend({
     var factory;
 
     if (typeof key === 'string') {
-      factory = this.container.lookupFactory('model:' + key);
+      factory = this.modelFactoryFor(key);
       if (!factory) {
         throw new Ember.Error("No model was found for '" + key + "'");
       }
@@ -1223,6 +1223,10 @@ Store = Ember.Object.extend({
 
     factory.store = this;
     return factory;
+  },
+
+  modelFactoryFor: function(key){
+    return this.container.lookupFactory('model:' + key);
   },
 
   /**

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -212,4 +212,37 @@
   // to make the QUnit global check run clean
   jQuery(window).data('testing', true);
 
+  window.warns = function(callback, regex){
+    var warnWasCalled = false;
+    var oldWarn = Ember.warn;
+    Ember.warn = function Ember_assertWarning(message, test){
+      warnWasCalled = true;
+      if (regex && !test) {
+        ok(regex.test(message), 'Ember.warn called with expected message, but was called with ' + message);
+      } else if (test) {
+        ok(false, "Expected warn to receive a falsy test, but got a truthy test");
+      }
+    };
+    try {
+      callback();
+      ok(warnWasCalled, 'expected Ember.warn to warn, but was not called');
+    } finally {
+      Ember.warn = oldWarn;
+    }
+  };
+
+  window.noWarns = function(callback){
+    var oldWarn = Ember.warn;
+    var warnWasCalled = false;
+    Ember.warn = function Ember_noWarn(message, test){
+      warnWasCalled = !test;
+    };
+    try {
+      callback();
+    } finally {
+      ok(!warnWasCalled, 'Ember.warn warned when it should not have warned');
+      Ember.warn = oldWarn;
+    }
+  };
+
 })();


### PR DESCRIPTION
Before this commit, if you had a payload like:

``` json
{
  "posts": []
}
```

But didn’t have a “Post” model defined, Ember
Data would blow up. As discussed in the data
team meeting, we decided to warn if the model
could not be resolved. In this spirit,
Ember Data just doesn’t process what it doesn’t
understand, but can still provide you with a
better debugging message to give you hints on
what your payload should look like.

fixes GH-2337
