### PR TITLE
Added assertion for updateLink

### DIFF
--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -12,7 +12,6 @@ var Relationship = function(store, record, inverseKey, relationshipMeta) {
   this.key = relationshipMeta.key;
   this.inverseKey = inverseKey;
   this.record = record;
-  this.key = relationshipMeta.key;
   this.isAsync = relationshipMeta.options.async;
   this.relationshipMeta = relationshipMeta;
   //This probably breaks for polymorphic relationship in complex scenarios, due to
@@ -112,6 +111,7 @@ Relationship.prototype = {
   },
 
   updateLink: function(link) {
+    Ember.assert("You have pushed a record of type '" + this.record.constructor.typeKey + "' with '" + this.key + "' as a link, but the value of that link is not a string.", typeof link === 'string' || link === null);
     if (link !== this.link) {
       this.link = link;
       this.linkPromise = null;

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -336,3 +336,30 @@ test('calling push without data argument as an object raises an error', function
     }, /object/);
   });
 });
+
+test('Calling push with a link containing an object throws an assertion error', function() {
+  expectAssertion(function() {
+    store.push('person', {
+      id: '1',
+      links: {
+        phoneNumbers: {
+          href: '/api/people/1/phone-numbers'
+        }
+      }
+    });
+  },  "You have pushed a record of type 'person' with 'phoneNumbers' as a link, but the value of that link is not a string.");
+});
+
+test('Calling push with a link containing the value null', function() {  
+  store.push('person', {
+    id: '1',
+    firstName: 'Tan',
+    links: {
+      phoneNumbers: null
+    }
+  });
+
+  var person = store.getById('person', 1);
+
+  equal(person.get('firstName'), "Tan", "you can use links that contain null as a value");
+});


### PR DESCRIPTION
Added an assertion for string type. Since you could also pass objects
to `updateLink` (which would always result in false in the next if
statement) containing a link. This PR notifies creators of serializers
so they always use a string when handling links.
