### PR TITLE
Yield in pushMany: proof of concept

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1440,22 +1440,48 @@ Store = Ember.Object.extend({
   /**
     If you have an Array of normalized data to push,
     you can call `pushMany` with the Array, and it will
-    call `push` repeatedly for you.
+    call `push` repeatedly for you. This operation is
+    asynchronous and returns a promise that resolves with
+    the newly pushed records.
+
+    If `DS.yieldFn` exists, it will be invoked between each
+    push and passed a callback and the index of the record
+    to be pushed next. The function is responsible for
+    calling the callback to continue pushing records.
 
     @method pushMany
     @param {String or subclass of DS.Model} type
     @param {Array} datas
-    @return {Array}
+    @return {Promise} promise
   */
   pushMany: function(type, datas) {
+    var store = this;
+    var yieldFn = DS.yieldFn;
     var length = datas.length;
     var result = new Array(length);
+    var index = 0;
 
-    for (var i = 0; i < length; i++) {
-      result[i] = this.push(type, datas[i]);
+    if (typeof yieldFn === 'function') {
+      return new Ember.RSVP.Promise(function(resolve, reject) {
+        yieldFn(step, index, !length);
+
+        function step() {
+          if (index < length) {
+            result[index] = store.push(type, datas[index]);
+            index++;
+            yieldFn(step, index, index === length);
+          } else {
+            resolve(result);
+          }
+        }
+      });
+    } else {
+      for (var i = 0; i < length; i++) {
+        result[i] = this.push(type, datas[i]);
+      }
+
+      return Ember.RSVP.Promise.cast(result);
     }
-
-    return result;
   },
 
   /**
@@ -1816,9 +1842,10 @@ function _findAll(adapter, store, type, sinceToken) {
 
     Ember.assert("The response from a findAll must be an Array, not " + Ember.inspect(payload), Ember.typeOf(payload) === 'array');
 
-    store.pushMany(type, payload);
-    store.didUpdateAll(type);
-    return store.all(type);
+    return store.pushMany(type, payload).then(function() {
+      store.didUpdateAll(type);
+      return store.all(type);
+    });
   }, null, "DS: Extract payload of findAll " + type);
 }
 

--- a/packages/ember-data/tests/unit/model/relationships_test.js
+++ b/packages/ember-data/tests/unit/model/relationships_test.js
@@ -413,16 +413,22 @@ test("updating the content of a RecordArray updates its content", function() {
   var env = setupStore({ tag: Tag }),
       store = env.store;
 
-  var records = store.pushMany('tag', [{ id: 5, name: "friendly" }, { id: 2, name: "smarmy" }, { id: 12, name: "oohlala" }]);
+  var records = [
+    { id: 5, name: "friendly" },
+    { id: 2, name: "smarmy" },
+    { id: 12, name: "oohlala" }
+  ];
 
-  var tags = DS.RecordArray.create({ content: Ember.A(records.slice(0, 2)), store: store, type: Tag });
+  store.pushMany('tag', records).then(async(function(records) {
+    var tags = DS.RecordArray.create({ content: Ember.A(records.slice(0, 2)), store: store, type: Tag });
 
-  var tag = tags.objectAt(0);
-  equal(get(tag, 'name'), "friendly", "precond - we're working with the right tags");
+    var tag = tags.objectAt(0);
+    equal(get(tag, 'name'), "friendly", "precond - we're working with the right tags");
 
-  set(tags, 'content', Ember.A(records.slice(1, 3)));
-  tag = tags.objectAt(0);
-  equal(get(tag, 'name'), "smarmy", "the lookup was updated");
+    set(tags, 'content', Ember.A(records.slice(1, 3)));
+    tag = tags.objectAt(0);
+    equal(get(tag, 'name'), "smarmy", "the lookup was updated");
+  }));
 });
 
 test("can create child record from a hasMany relationship", function() {

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -1,3 +1,4 @@
+var get = Ember.get;
 var env, store, Person, PhoneNumber, Post;
 var attr = DS.attr, hasMany = DS.hasMany, belongsTo = DS.belongsTo;
 
@@ -335,4 +336,35 @@ test('calling push without data argument as an object raises an error', function
       store.push('person', invalidValue);
     }, /object/);
   });
+});
+
+test('Calling pushMany uses DS.yieldFn if it exists', function() {
+  expect(12);
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var env = setupStore({ person: Person });
+  var store = env.store;
+  var index = 0;
+
+  var records = [
+    { id: 1, name: 'Egon' },
+    { id: 2, name: 'Peter' },
+    { id: 3, name: 'Winston' },
+    { id: 4, name: 'Ray' }
+  ];
+
+  DS.yieldFn = function(next, i, done) {
+    equal(done, index === records.length, 'yieldFn was called with the correct value for done flag');
+    equal(i, index++, 'yieldFn was called with the correct index');
+    next();
+  };
+
+  store.pushMany('person', records).then(async(function(people) {
+    equal(get(people[0], 'name'), 'Egon', 'records were added to the record array');
+    equal(get(people, 'length'), records.length, 'all records were added to the record array');
+    delete DS.yieldFn;
+  }));
 });


### PR DESCRIPTION
Pushing a large number of records into the store can be a very expensive operation. It gets even more expensive the more relations records have to each other. This can then result in the page being unresponsive for an extended period of time, most importantly blocking animations.

This is an experiment to explore solutions to extended blocking. Unfortunately it requires changing the behavior of `store#pushMany` to be asynchronous (something that has surprisingly little impact on ED internals). `pushMany` now looks for `DS.yieldFn` and calls it between each individual call to `store#push`:

```javascript
DS.yieldFn = function(next, index) {
  if (index % 3 === 0) {
    window.requestAnimationFrame(next);
  } else {
    next();
  }
};
```

This allows the browser to breathe every third call to `push`, which is enough for animations to appear smooth. The fixed batch size is a naive solution, but it serves to show what's possible.