### PR TITLE
Temporary fix for #2344 rollback after delete for recordArrays

### DIFF
--- a/packages/ember-data/lib/system/record_array_manager.js
+++ b/packages/ember-data/lib/system/record_array_manager.js
@@ -74,6 +74,8 @@ export default Ember.Object.extend({
     recordArrays.forEach(function(array){
       array.removeRecord(record);
     });
+
+    record._recordArrays = null;
   },
 
   _recordWasChanged: function (record) {

--- a/packages/ember-data/tests/integration/records/delete_record_test.js
+++ b/packages/ember-data/tests/integration/records/delete_record_test.js
@@ -49,12 +49,9 @@ test("when deleted records are rolled back, they are still in their previous rec
 
   equal(all.get('length'), 2, 'precond - we start with two people');
   equal(filtered.get('length'), 2, 'precond - we start with two people');
-
-  Ember.run(function () {
-    jaime.deleteRecord();
-    jaime.rollback();
-  });
-
+  jaime.deleteRecord();
+  jaime.rollback();
   equal(all.get('length'), 2, 'record was not removed');
   equal(filtered.get('length'), 2, 'record was not removed');
+
 });


### PR DESCRIPTION
This is a temporary fix, it's clear this code needs to be refactored.
Moreover I am not sure that removing deleted records from recordArrays
before they are deleted is a correct design decision.
