### PR TITLE
Nicer errors when pushing belongsTo/hasMany with invalid values

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1644,6 +1644,7 @@ function deserializeRecordId(store, data, key, relationship, id) {
   if (isNone(id) || id instanceof Model) {
     return;
   }
+  Ember.assert("A " + relationship.parentType + " record was pushed into the store with the value of " + key + " being " + Ember.inspect(id) + ", but " + key + " is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.", !Ember.isArray(id));
 
   var type;
 
@@ -1665,9 +1666,11 @@ function typeFor(relationship, key, data) {
 }
 
 function deserializeRecordIds(store, data, key, relationship, ids) {
-  if (!Ember.isArray(ids)) {
+  if (isNone(ids)) {
     return;
   }
+
+  Ember.assert("A " + relationship.parentType + " record was pushed into the store with the value of " + key + " being '" + Ember.inspect(ids) + "', but " + key + " is a hasMany relationship so the value must be an array. You should probably check your data payload or serializer.", Ember.isArray(ids));
   for (var i=0, l=ids.length; i<l; i++) {
     deserializeRecordId(store, ids, i, relationship, ids[i]);
   }

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -8,15 +8,24 @@ module("unit/store/push - DS.Store#push", {
       lastName: attr('string'),
       phoneNumbers: hasMany('phone-number')
     });
+    Person.toString = function() {
+      return 'Person';
+    };
 
     PhoneNumber = DS.Model.extend({
       number: attr('string'),
       person: belongsTo('person')
     });
+    PhoneNumber.toString = function() {
+      return 'PhoneNumber';
+    };
 
     Post = DS.Model.extend({
       postTitle: attr('string')
     });
+    Post.toString = function() {
+      return 'Post';
+    };
 
     env = setupStore({"post": Post,
                       "person": Person,
@@ -350,7 +359,7 @@ test('Calling push with a link containing an object throws an assertion error', 
   },  "You have pushed a record of type 'person' with 'phoneNumbers' as a link, but the value of that link is not a string.");
 });
 
-test('Calling push with a link containing the value null', function() {  
+test('Calling push with a link containing the value null', function() {
   store.push('person', {
     id: '1',
     firstName: 'Tan',
@@ -362,4 +371,28 @@ test('Calling push with a link containing the value null', function() {
   var person = store.getById('person', 1);
 
   equal(person.get('firstName'), "Tan", "you can use links that contain null as a value");
+});
+
+test('calling push with hasMany relationship the value must be an array', function(){
+  var invalidValues = [
+    1,
+    'string',
+    Ember.Object.create(),
+    Ember.Object.extend(),
+    true
+  ];
+
+  expect(invalidValues.length);
+
+  Ember.EnumerableUtils.forEach(invalidValues, function(invalidValue){
+    throws(function() {
+      store.push('person', { id: 1, phoneNumbers: invalidValue });
+    }, /must be an array/);
+  });
+});
+
+test('calling push with belongsTo relationship the value must not be an array', function(){
+  throws(function() {
+    store.push('phone-number', { id: 1, person: [1] });
+  }, /must not be an array/);
 });


### PR DESCRIPTION
Me and @sly7-7 have been working on the same issue (#2367) and after discussing on IRC I'm creating a PR too. The major difference is asserts instead of throwing errors and takes care of both belongsTo and hasMany.

May the best PR win :)
