### PR TITLE
[DOC] Update usage of AMS

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_adapter.js
+++ b/packages/activemodel-adapter/lib/system/active_model_adapter.js
@@ -16,7 +16,7 @@ var decamelize = Ember.String.decamelize,
   It has been designed to work out of the box with the
   [active_model_serializers](http://github.com/rails-api/active_model_serializers)
   Ruby gem. This Adapter expects specific settings using ActiveModel::Serializers,
-  `embed :ids, include: true` which sideloads the records.
+  `embed :ids, embed_in_root: true` which sideloads the records.
 
   This adapter extends the DS.RESTAdapter by making consistent use of the camelization,
   decamelization and pluralization methods to normalize the serialized JSON into a

--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -16,7 +16,7 @@ var get = Ember.get,
   It has been designed to work out of the box with the
   [active_model_serializers](http://github.com/rails-api/active_model_serializers)
   Ruby gem. This Serializer expects specific settings using ActiveModel::Serializers,
-  `embed :ids, include: true` which sideloads the records.
+  `embed :ids, embed_in_root: true` which sideloads the records.
 
   This serializer extends the DS.RESTSerializer by making consistent
   use of the camelization, decamelization and pluralization methods to


### PR DESCRIPTION
`include` option is renamed as `embed_in_root` in current stable version 0.9.
- https://github.com/rails-api/active_model_serializers/blob/0-9-stable/lib/active_model/serializer/association.rb#L11
