### PR TITLE
Make dependencies clearer.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,12 +2,12 @@
   "name": "ember-data",
   "private": true,
   "dependencies": {
-    "ember": "~1.7.0",
-    "qunit": "~1.13.0",
-    "jquery": "~1.10.x",
-    "handlebars": "~1.3.0"
+    "ember": "~1.7.0"
   },
   "devDependencies": {
+    "qunit": "~1.13.0",
+    "jquery": "~1.10.x",
+    "handlebars": "~1.3.0",
     "loader.js": "~1.0.0",
     "ember-inflector": "https://github.com/stefanpenner/ember-inflector.git#v1.1.0",
     "es5-shim": "~4.0.3"


### PR DESCRIPTION
This is mostly just for easier discovery/understanding for passers by looking at the `bower.json` in the root of the repo. The actual `bower.json` that we put in components/ember-data is correct already.
