### PR TITLE
Refactored InvalidError handling into a serializer concern.

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_adapter.js
+++ b/packages/activemodel-adapter/lib/system/active_model_adapter.js
@@ -6,7 +6,6 @@ import {pluralize} from "ember-inflector";
   @module ember-data
 */
 
-var forEach = Ember.EnumerableUtils.forEach;
 var decamelize = Ember.String.decamelize,
     underscore = Ember.String.underscore;
 
@@ -142,18 +141,7 @@ var ActiveModelAdapter = RESTAdapter.extend({
     var error = this._super(jqXHR);
 
     if (jqXHR && jqXHR.status === 422) {
-      var response = Ember.$.parseJSON(jqXHR.responseText),
-          errors = {};
-
-      if (response.errors !== undefined) {
-        var jsonErrors = response.errors;
-
-        forEach(Ember.keys(jsonErrors), function(key) {
-          errors[Ember.String.camelize(key)] = jsonErrors[key];
-        });
-      }
-
-      return new InvalidError(errors);
+      return new InvalidError(Ember.$.parseJSON(jqXHR.responseText));
     } else {
       return error;
     }

--- a/packages/activemodel-adapter/tests/integration/active_model_adapter_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_adapter_test.js
@@ -21,7 +21,7 @@ test('buildURL - decamelizes names', function() {
 });
 
 test('ajaxError - returns invalid error if 422 response', function() {
-  var error = new DS.InvalidError({ name: "can't be blank" });
+  var error = new DS.InvalidError({ errors: { name: "can't be blank" } });
 
   var jqXHR = {
     status: 422,
@@ -32,7 +32,7 @@ test('ajaxError - returns invalid error if 422 response', function() {
 });
 
 test('ajaxError - invalid error has camelized keys', function() {
-  var error = new DS.InvalidError({ firstName: "can't be blank" });
+  var error = new DS.InvalidError({ errors: { firstName: "can't be blank" } });
 
   var jqXHR = {
     status: 422,

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -697,11 +697,17 @@ export default Adapter.extend({
   },
 
   /**
-    Takes an ajax response, and returns a relevant error.
+    Takes an ajax response, and returns an error payload.
 
     Returning a `DS.InvalidError` from this method will cause the
     record to transition into the `invalid` state and make the
     `errors` object available on the record.
+
+    This function should return the entire payload as received from the
+    server.  Error object extraction and normalization of model errors
+    should be performed by `extractErrors` on the serializer.
+
+    Example
 
     ```javascript
     App.ApplicationAdapter = DS.RESTAdapter.extend({
@@ -709,7 +715,7 @@ export default Adapter.extend({
         var error = this._super(jqXHR);
 
         if (jqXHR && jqXHR.status === 422) {
-          var jsonErrors = Ember.$.parseJSON(jqXHR.responseText)["errors"];
+          var jsonErrors = Ember.$.parseJSON(jqXHR.responseText);
 
           return new DS.InvalidError(jsonErrors);
         } else {

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -23,6 +23,10 @@ var errorProps = [
   transition to the `invalid` state and the errors will be set to the
   `errors` property on the record.
 
+  This function should return the entire payload as received from the
+  server.  Error object extraction and normalization of model errors
+  should be performed by `extractErrors` on the serializer.
+
   Example
 
   ```javascript
@@ -31,7 +35,7 @@ var errorProps = [
       var error = this._super(jqXHR);
 
       if (jqXHR && jqXHR.status === 422) {
-        var jsonErrors = Ember.$.parseJSON(jqXHR.responseText)["errors"];
+        var jsonErrors = Ember.$.parseJSON(jqXHR.responseText);
         return new DS.InvalidError(jsonErrors);
       } else {
         return error;

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1869,7 +1869,9 @@ function _commit(adapter, store, operation, record) {
     return record;
   }, function(reason) {
     if (reason instanceof InvalidError) {
-      store.recordWasInvalid(record, reason.errors);
+      var errors = serializer.extractErrors(store, type, reason.errors, get(record, 'id'));
+      store.recordWasInvalid(record, errors);
+      reason = new InvalidError(errors);
     } else {
       store.recordWasError(record, reason);
     }


### PR DESCRIPTION
Refactored `InvalidError` handling into a serializer concern.

Addresses #1977 by ensuring error keys undergo the same mapping treatment that model attribute and relationship keys do.

Supports #1984 and #1877 by moving the model error serialization concern into the serializer. This PR should remove any objections for not applying all errors which have been sanctioned by the serializer to the record/model errors.

Paves the way for embedded record error handling, with the intent that errors can be mapped/normalized for the specific embedded records to which they apply.
