### PR TITLE
Fixing an issue when grouping requests could result in long URL

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -450,6 +450,7 @@ var Adapter = Ember.Object.extend({
     The default implementation returns the records as a single group.
 
     @method groupRecordsForFindMany
+    @param {DS.Store} store
     @param {Array} records
     @return {Array}  an array of arrays of records, each of which is to be
                       loaded separately by `findMany`.

--- a/packages/ember-data/tests/unit/adapters/rest_adapter/group_records_for_find_many_test.js
+++ b/packages/ember-data/tests/unit/adapters/rest_adapter/group_records_for_find_many_test.js
@@ -1,0 +1,49 @@
+var GroupsAdapter, Store;
+var maxLength = -1;
+var lengths = [];
+
+module("unit/adapters/rest_adapter/group_records_for_find_many_test - DS.RESTAdapter#groupRecordsForFindMany", { 
+  setup: function() {
+    GroupsAdapter = DS.RESTAdapter.extend({
+
+      coalesceFindRequests: true,
+
+      find: function(store, type, id) {
+        return Ember.RSVP.Promise.resolve({ id: id });
+      },
+
+      ajax: function(url, type, options) {
+        var queryString = options.data.ids.map(function(i) {
+          return encodeURIComponent('ids[]') + '=' + encodeURIComponent(i);
+        }).join('&');
+        var fullUrl = url + '?' + queryString;
+
+        maxLength = this.get('maxUrlLength');
+        lengths.push(fullUrl.length);
+
+        return Ember.RSVP.Promise.resolve({ 'testRecords' : [] });
+      }
+
+    });
+
+    Store = createStore({ 
+      adapter: GroupsAdapter,
+      testRecord: DS.Model.extend()
+     });
+
+  }
+});
+
+test('groupRecordsForFindMany - findMany', function() {
+
+  Ember.run(function() {
+    for(var i = 1; i <= 1024; i++) {
+      Store.find('testRecord', i);
+    }
+  });
+
+  ok(lengths.every(function(len) {
+      return len <= maxLength;
+    }), "Some URLs are longer than " + maxLength + " chars");
+
+});


### PR DESCRIPTION
I've got some requests from the Ember app failing with 404.14 and 404.15 errors when app model requested a lot of records. So I found that  RESTAdapter#groupRecordsForFindMany doesn't uri-encode [ ] when groups ids and result of RESTAdapter#pathForType and therefore produce URLs much longer than expected.

So I'm fixing this issue and exposing maxUrlLength as the adapter property so it could be adjusted when needed.
