### PR TITLE
[DOCS] Fix ajaxSuccess docblock return value

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -770,7 +770,7 @@ export default Adapter.extend({
     @method ajaxSuccess
     @param  {Object} jqXHR
     @param  {Object} jsonPayload
-    @return {Object} jqXHR
+    @return {Object} jsonPayload
   */
 
   ajaxSuccess: function(jqXHR, jsonPayload) {


### PR DESCRIPTION
Also, I noticed the `ajaxSuccess` hook [is absent from the docs](http://emberjs.com/api/data/classes/DS.RESTAdapter.html#method_ajaxSuccess). Why is that? `ajaxError` is there.
