### PR TITLE
Error when payload without id is pushed to the store

### DIFF
--- a/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
@@ -98,11 +98,12 @@ test("normalize", function() {
     yellowMinion: DS.belongsTo('yellowMinion')
   })
 
-  var superVillain_hash = {first_name: "Tom", last_name: "Dale", home_planet_id: "123", evil_minion_ids: [1,2]};
+  var superVillain_hash = {id: "1", first_name: "Tom", last_name: "Dale", home_planet_id: "123", evil_minion_ids: [1,2]};
 
   var json = env.amsSerializer.normalize(SuperVillain, superVillain_hash, "superVillain");
 
   deepEqual(json, {
+    id: "1",
     firstName: "Tom",
     lastName: "Dale",
     homePlanet: "123",

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -254,10 +254,12 @@ export default Ember.Object.extend({
   normalizeId: function(hash) {
     var primaryKey = get(this, 'primaryKey');
 
-    if (primaryKey === 'id') { return; }
+    if (primaryKey !== 'id') {
+      hash.id = hash[primaryKey];
+      delete hash[primaryKey];
+    }
 
-    hash.id = hash[primaryKey];
-    delete hash[primaryKey];
+    Ember.assert("Ember Data requires every record to have an ID but no '" + primaryKey + "' property was found in your payload.", !isNone(hash.id));
   },
 
   /**

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -160,8 +160,8 @@ test("serializePolymorphicType", function() {
 test("extractArray normalizes each record in the array", function() {
   var postNormalizeCount = 0;
   var posts = [
-    { title: "Rails is omakase"},
-    { title: "Another Post"}
+    { id: "1", title: "Rails is omakase"},
+    { id: "2", title: "Another Post"}
   ];
 
   env.container.register('serializer:post', DS.JSONSerializer.extend({
@@ -184,6 +184,7 @@ test('Serializer should respect the attrs hash when extracting records', functio
   }));
 
   var jsonHash = {
+    id: "1",
     title_payload_key: "Rails is omakase",
     my_comments: [1, 2]
   };


### PR DESCRIPTION
This is an attempt to fix #2401.

However, there's still one test failing test, see https://github.com/emberjs/data/blob/master/packages/ember-data/tests/integration/serializers/rest_serializer_test.js#L389-L409

The reason is that it uses `normalizeHash` to handle a custom named ID property name (wouldn't http://emberjs.com/api/data/classes/DS.JSONSerializer.html#property_primaryKey be the preferred way to do this?) and the code handling this (https://github.com/emberjs/data/blob/master/packages/ember-data/lib/serializers/rest_serializer.js#L178-L180) is run after `normalizeId`, where I've put the assert to check for the presence of an ID field.

Would like some input on what method would be recommended to proceed here:
1. Change the test to test something else than `_id` => `id`? Perhaps `_title` => `title`?
2. Move the code handling `normalizeHash` above the call to `normalizeId` (doesn't _feel_ right)
3. Not having the assert in `normalizeId` but instead put it in `normalize` in both JSONSerializer and RESTSerializer? (less DRY?)
