### PR TITLE
Add `createRecord` to PromiseArray so it proxies to ManyArray

### DIFF
--- a/packages/ember-data/lib/system/promise_proxies.js
+++ b/packages/ember-data/lib/system/promise_proxies.js
@@ -80,6 +80,7 @@ var promiseArray = function(promise, label) {
   to the underlying manyArray.
   Right now we proxy:
     `reload()`
+    `createRecord()`
 */
 
 var PromiseManyArray = PromiseArray.extend({
@@ -87,6 +88,12 @@ var PromiseManyArray = PromiseArray.extend({
     //I don't think this should ever happen right now, but worth guarding if we refactor the async relationships
     Ember.assert('You are trying to reload an async manyArray before it has been created', get(this, 'content'));
     return get(this, 'content').reload();
+  },
+
+  createRecord: function() {
+    var content = get(this, 'content');
+    content.createRecord.apply(content, arguments);
+    return this;
   }
 });
 

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -349,6 +349,32 @@ test("A hasMany relationship can be directly reloaded if it was fetched via ids"
   }));
 });
 
+test("PromiseArray proxies createRecord to its ManyArray once hasMany is loaded", function() {
+  expect(3);
+
+  Post.reopen({
+    comments: DS.hasMany('comment', { async: true })
+  });
+
+  env.adapter.findHasMany = function(store, record, link, relationship) {
+    return Ember.RSVP.resolve([
+      { id: 1, body: "First" },
+      { id: 2, body: "Second" }
+    ]);
+  };
+
+  var post = env.store.push('post', {id:1, links: {comments: 'someLink'}});
+
+  post.get('comments').then(async(function(comments) {
+    equal(comments.get('isLoaded'), true, "comments are loaded");
+    equal(comments.get('length'), 2, "comments have 2 length");
+
+    post.get('comments').createRecord().then(async(function() {
+      equal(comments.get('length'), 3, "comments have 3 length, including new record");
+    }));
+  }));
+});
+
 test("An updated `links` value should invalidate a relationship cache", function() {
   expect(8);
   Post.reopen({


### PR DESCRIPTION
`createRecord` function is currently not proxied to the hasMany relationships.
