### PR TITLE
Add failing test on PromiseArray.createRecord when called before the hasMany is loaded

### DIFF
--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -375,6 +375,27 @@ test("PromiseArray proxies createRecord to its ManyArray once hasMany is loaded"
   }));
 });
 
+test("PromiseArray proxies createRecord to its ManyArray before the hasMany is loaded", function() {
+  expect(1);
+
+  Post.reopen({
+    comments: DS.hasMany('comment', { async: true })
+  });
+
+  env.adapter.findHasMany = function(store, record, link, relationship) {
+    return Ember.RSVP.resolve([
+      { id: 1, body: "First" },
+      { id: 2, body: "Second" }
+    ]);
+  };
+
+  var post = env.store.push('post', {id:1, links: {comments: 'someLink'}});
+
+  post.get('comments').createRecord().then(async(function(comments) {
+    equal(comments.get('length'), 3, "comments have 3 length, including new record");
+  }));
+});
+
 test("An updated `links` value should invalidate a relationship cache", function() {
   expect(8);
   Post.reopen({


### PR DESCRIPTION
2 bugs present in this PR:

1) Calling createRecord on a PromiseManyArray before the hasMany is loaded remove the newly created record once the promises resolves.
2) The test itself is not suppose to load comments before `post.get('comments')` gets called, but it appears to behave differently. Any idea?

/cc @igorT 