### PR TITLE
Don't refilter .all() and .find() if only properties changed

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -378,6 +378,15 @@ var Model = Ember.Object.extend(Ember.Evented, {
   },
 
   /**
+    Fired when the record is ready to be interacted with,
+    that is either loaded from the server or created locally.
+
+    @event ready
+  */
+  ready: function() {
+    this.store.recordArrayManager.recordWasLoaded(this);
+  },
+  /**
     Fired when the record is loaded from the server.
 
     @event didLoad

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -275,6 +275,7 @@ var DirtyState = {
 
     rollback: function(record) {
       record.rollback();
+      record.triggerLater('ready');
     }
   },
 
@@ -342,6 +343,7 @@ var DirtyState = {
 
     rolledBack: function(record) {
       get(record, 'errors').clear();
+      record.triggerLater('ready');
     },
 
     becameValid: function(record) {
@@ -473,11 +475,13 @@ var RootState = {
 
     loadedData: function(record) {
       record.transitionTo('loaded.created.uncommitted');
+      record.triggerLater('ready');
     },
 
     pushedData: function(record) {
       record.transitionTo('loaded.saved');
       record.triggerLater('didLoad');
+      record.triggerLater('ready');
     }
   },
 
@@ -499,6 +503,7 @@ var RootState = {
     pushedData: function(record) {
       record.transitionTo('loaded.saved');
       record.triggerLater('didLoad');
+      record.triggerLater('ready');
       set(record, 'isError', false);
     },
 
@@ -618,6 +623,7 @@ var RootState = {
 
       rollback: function(record) {
         record.rollback();
+        record.triggerLater('ready');
       },
 
       becomeDirty: Ember.K,
@@ -625,6 +631,7 @@ var RootState = {
 
       rolledBack: function(record) {
         record.transitionTo('loaded.saved');
+        record.triggerLater('ready');
       }
     },
 

--- a/packages/ember-data/lib/system/record_array_manager.js
+++ b/packages/ember-data/lib/system/record_array_manager.js
@@ -78,7 +78,23 @@ export default Ember.Object.extend({
     record._recordArrays = null;
   },
 
+
+  //Don't need to update non filtered arrays on simple changes
   _recordWasChanged: function (record) {
+    var type = record.constructor;
+    var recordArrays = this.filteredRecordArrays.get(type);
+    var filter;
+
+    forEach(recordArrays, function(array) {
+      filter = get(array, 'filterFunction');
+      if (filter) {
+        this.updateRecordArray(array, filter, type, record);
+      }
+    }, this);
+  },
+
+  //Need to update live arrays on loading
+  recordWasLoaded: function(record) {
     var type = record.constructor;
     var recordArrays = this.filteredRecordArrays.get(type);
     var filter;
@@ -87,9 +103,7 @@ export default Ember.Object.extend({
       filter = get(array, 'filterFunction');
       this.updateRecordArray(array, filter, type, record);
     }, this);
-
   },
-
   /**
     Update an individual filter.
 

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -124,7 +124,7 @@ Relationship.prototype = {
         }
         record._implicitRelationships[this.inverseKeyForImplicit].addRecord(this.record);
       }
-      this.record.updateRecordArrays();
+      this.record.updateRecordArraysLater();
     }
   },
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1102,9 +1102,8 @@ Store = Ember.Object.extend({
   // ............
 
   /**
-    If the adapter updates attributes or acknowledges creation
-    or deletion, the record will notify the store to update its
-    membership in any filters.
+    If the adapter updates attributes the record will notify
+    the store to update its  membership in any filters.
     To avoid thrashing, this method is invoked only once per
 
     run loop per record.
@@ -1612,6 +1611,11 @@ Store = Ember.Object.extend({
     typeMap.records.push(record);
 
     return record;
+  },
+
+  //Called by the state machine to notify the store that the record is ready to be interacted with
+  recordWasLoaded: function(record) {
+    this.recordArrayManager.recordWasLoaded(record);
   },
 
   // ...............

--- a/packages/ember-data/tests/integration/record_array_manager_test.js
+++ b/packages/ember-data/tests/integration/record_array_manager_test.js
@@ -25,9 +25,7 @@ module("integration/record_array_manager- destroy", {
     });
     store = env.store;
 
-    manager = DS.RecordArrayManager.create({
-      store: store
-    });
+    manager = store.recordArrayManager;
 
     env.container.register('model:car', Car);
     env.container.register('model:person', Person);
@@ -102,4 +100,31 @@ test("destroying the store correctly cleans everything up", function() {
 
   equal(filterdSummary.called.length, 1);
   equal(adapterPopulatedSummary.called.length, 1);
+});
+
+
+test("Should not filter a stor.all() array when a record property is changed", function() {
+  var car;
+
+  var filterdSummary = tap(store.recordArrayManager, 'updateRecordArray');
+
+  var allCars = store.all('car');
+
+  run(function(){
+    car = store.push('car', {
+      id: 1,
+      make: 'BMC',
+      model: 'Mini Cooper',
+      person: 1
+    });
+  });
+
+  equal(filterdSummary.called.length, 1);
+
+  run(function(){
+    car.set('model', 'Mini');
+  });
+
+  equal(filterdSummary.called.length, 1);
+
 });

--- a/packages/ember-data/tests/integration/records/delete_record_test.js
+++ b/packages/ember-data/tests/integration/records/delete_record_test.js
@@ -58,6 +58,7 @@ test("when deleted records are rolled back, they are still in their previous rec
 
   equal(all.get('length'), 2, 'precond - we start with two people');
   equal(filtered.get('length'), 2, 'precond - we start with two people');
+
   run(function(){
     jaime.deleteRecord();
     jaime.rollback();


### PR DESCRIPTION
Might need minor cleanup, maybe a unit test. Also would like to rename 'ready' 
@stefanpenner I think this solves sandstorm's problem and overall should lead to major perf
