### PR TITLE
[BUG?] embedded records mixin does not use the customized `keyForAttribute`

### DIFF
--- a/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
@@ -701,6 +701,45 @@ test("serialize with embedded object (belongsTo relationship)", function() {
   });
 });
 
+test("serialize with embedded object (belongsTo relationship) with custom keyForAttribute", function() {
+  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: {embedded: 'always'}
+    },
+    keyForAttribute: function (attr) {
+      if (attr === 'minionCapacity') {
+        return 'capacity';
+      } else {
+        return this._super(attr);
+      }
+    }
+  }));
+  var serializer = env.container.lookup("serializer:superVillain");
+
+  // records with an id, persisted
+
+  var tom = env.store.createRecord(
+    SuperVillain,
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord(SecretLab, { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" })
+    }
+  );
+
+  var json = serializer.serialize(tom);
+  deepEqual(json, {
+    first_name: get(tom, "firstName"),
+    last_name: get(tom, "lastName"),
+    home_planet_id: get(tom, "homePlanet").get("id"),
+    secret_lab: {
+      id: get(tom, "secretLab").get("id"),
+      capacity: get(tom, "secretLab").get("minionCapacity"),
+      vicinity: get(tom, "secretLab").get("vicinity")
+    }
+  });
+});
+
 test("serialize with embedded object (belongsTo relationship) works with different primaryKeys", function() {
   env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
   env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {


### PR DESCRIPTION
I would like to customize the `keyForAttribute` function in such a way that some keys are serialized with a different key(name). Defining this as an extension on the serializer works fine. However when this key is in a nested object it doesn't.

I wrote an integration spec reproducing the bug. Should I try to solve it, or is this expected behaviour?