### PR TITLE
Ensure production builds do not use require internally.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -15,6 +15,7 @@ var version       = require('git-repo-version')(10);
 var renderTemplate = require('broccoli-render-template');
 var yuidoc = require('broccoli-yuidoc');
 var replace = require('broccoli-string-replace');
+var derequire = require('broccoli-derequire');
 
 function moveFromLibAndMainJS(packageName, vendored){
   var root = vendored ? 'bower_components/' + packageName + "/packages/" + packageName + '/lib':
@@ -175,24 +176,25 @@ configurationFiles = replace(configurationFiles, {
   }
 });
 
-var trees = merge([
+var trees = [
   testFiles,
-  globalBuild,
   namedAMDBuild,
   testRunner,
   bower,
   configurationFiles
-]);
+];
 
 if (env === 'production') {
+  globalBuild = derequire(globalBuild);
+
   var minifiedAMD = minify(namedAMDBuild, 'ember-data.named-amd');
   var minifiedGlobals = minify(globalBuild, 'ember-data');
-  trees = merge([
-    yuidocTree,
-    trees,
-    minifiedAMD,
-    minifiedGlobals
-  ]);
+
+  trees.push(yuidocTree);
+  trees.push(minifiedAMD);
+  trees.push(minifiedGlobals);
 }
 
-module.exports = trees;
+trees.push(globalBuild);
+
+module.exports = merge(trees);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "broccoli-cli": "0.0.1",
     "broccoli-concat": "0.0.7",
     "broccoli-defeatureify": "^0.3.0",
+    "broccoli-derequire": "0.0.1",
     "broccoli-env": "0.0.1",
     "broccoli-es3-safe-recast": "0.0.8",
     "broccoli-es6-module-transpiler": "^0.1.1",
@@ -48,8 +49,8 @@
     "ejs": "^1.0.0",
     "ember-cli": "0.0.43",
     "ember-publisher": "0.0.6",
+    "git-repo-version": "0.0.2",
     "testem": "^0.6.19",
-    "yuidocjs": "~0.3.46",
-    "git-repo-version": "0.0.2"
+    "yuidocjs": "~0.3.46"
   }
 }


### PR DESCRIPTION
Follows suit with https://github.com/emberjs/ember.js/pull/9415.
