### PR TITLE
update buildURLForHasMany hook

### DIFF
--- a/packages/ember-data/lib/adapters/build-url-mixin.js
+++ b/packages/ember-data/lib/adapters/build-url-mixin.js
@@ -238,6 +238,18 @@ export default Ember.Mixin.create({
     return url.join('/');
   },
 
+  /**
+    Builds a URL for hasMany associations given relationshipName, recordName and record.
+
+    Optionally used to generate a URL if payload does not include links or ids.
+
+    @method buildURLForHasMany
+    @param {String} relationshipName
+    @param {String} recordName
+    @param {DS.Model} record
+    @return {String} url
+  */
+  buildURLForHasMany: null,
 
   /**
     Determines the pathname for a given type.

--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -603,7 +603,6 @@ var RestAdapter = Adapter.extend(BuildURLMixin, {
 
   _stripIDFromURL: function(store, snapshot) {
     var url = this.buildURL(snapshot.modelName, snapshot.id, snapshot);
-
     var expandedURL = url.split('/');
     //Case when the url is of the format ...something/:id
     var lastSegment = expandedURL[expandedURL.length - 1];

--- a/packages/ember-data/lib/system/relationships/state/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs-to.js
@@ -16,6 +16,22 @@ BelongsToRelationship.prototype = Ember.create(Relationship.prototype);
 BelongsToRelationship.prototype.constructor = BelongsToRelationship;
 BelongsToRelationship.prototype._super$constructor = Relationship;
 
+BelongsToRelationship.prototype.updateFromAdapter = function(data) {
+  var key   = this.key;
+  var value = data[key];
+
+  if (data.links && data.links[key]) {
+    this.updateLink(data.links[key]);
+  }
+
+  if (value === undefined) {
+    return;
+  }
+
+  this.setCanonicalRecord(value);
+  this.setHasData(true);
+};
+
 BelongsToRelationship.prototype.setRecord = function(newRecord) {
   if (newRecord) {
     this.addRecord(newRecord);

--- a/packages/ember-data/lib/system/relationships/state/has-many.js
+++ b/packages/ember-data/lib/system/relationships/state/has-many.js
@@ -24,6 +24,21 @@ ManyRelationship.prototype = Ember.create(Relationship.prototype);
 ManyRelationship.prototype.constructor = ManyRelationship;
 ManyRelationship.prototype._super$constructor = Relationship;
 
+ManyRelationship.prototype.updateFromAdapter = function(data) {
+  var key   = this.key;
+  var value = data[key];
+  var link  = data.links && data.links[key] || this.generateLink();
+
+  if (link) {
+    this.updateLink(link);
+  }
+
+  if (value !== undefined) {
+    this.updateRecordsFromAdapter(value);
+    this.setHasData(true);
+  }
+};
+
 ManyRelationship.prototype.destroy = function() {
   this.manyArray.destroy();
 };
@@ -190,6 +205,20 @@ ManyRelationship.prototype.getRecords = function() {
       this.manyArray.set('isLoaded', true);
     }
     return this.manyArray;
+  }
+};
+
+ManyRelationship.prototype.generateLink = function() {
+
+  if (!this.isAsync) {
+    return;
+  }
+
+  var adapter = this.store.adapterFor(this.type);
+  var buildUrl = adapter.buildURLForHasMany;
+
+  if (typeof buildUrl === "function") {
+    return buildUrl.call(adapter, this.key, this.inverseKey, this.record);
   }
 };
 

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -7,6 +7,7 @@ function Relationship(store, record, inverseKey, relationshipMeta) {
   this.canonicalMembers = new OrderedSet();
   this.store = store;
   this.key = relationshipMeta.key;
+  this.type = relationshipMeta.type;
   this.inverseKey = inverseKey;
   this.record = record;
   this.isAsync = relationshipMeta.options.async;
@@ -20,7 +21,7 @@ function Relationship(store, record, inverseKey, relationshipMeta) {
 
 Relationship.prototype = {
   constructor: Relationship,
-
+  updateFromAdapter: Ember.K,
   destroy: Ember.K,
 
   clear: function() {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -2130,24 +2130,9 @@ function setupRelationships(store, record, data) {
   var typeClass = record.type;
 
   typeClass.eachRelationship(function(key, descriptor) {
-    var kind = descriptor.kind;
-    var value = data[key];
-    var relationship;
+    var relationship = record._relationships.get(key);
 
-    if (data.links && data.links[key]) {
-      relationship = record._relationships.get(key);
-      relationship.updateLink(data.links[key]);
-    }
-
-    if (value !== undefined) {
-      if (kind === 'belongsTo') {
-        relationship = record._relationships.get(key);
-        relationship.setCanonicalRecord(value);
-      } else if (kind === 'hasMany') {
-        relationship = record._relationships.get(key);
-        relationship.updateRecordsFromAdapter(value);
-      }
-    }
+    relationship.updateFromAdapter(data);
   });
 }
 


### PR DESCRIPTION
Implement #2168 buildURLForHasMany hook on current build. It uses an explicit buildURL option rather than depending on links and ids being nil.  I'm with @tomdale that a dsl is needed but I have needed/wanted this feature from day one. 

@igorT  let me know what you think #2162.
