### PR TITLE
Update contributing links. Closes #2440

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,8 @@ demo should be fully operational with the exception of the bug you want to
 demonstrate. The more pared down, the better. A preconfigured [JSBin][1] |
 [JSFiddle][2] with mocked requests is available.
 
-[1]: http://emberjs.jsbin.com/butef/1/edit
-[2]: http://jsfiddle.net/ty6xgfqc/
+[1]: http://emberjs.jsbin.com/qovara/1/edit?html,js,output
+[2]: http://jsfiddle.net/842xesgc/
 
 4. If possible, submit a Pull Request with a failing test. Better yet, take
 a stab at fixing the bug yourself if you can!


### PR DESCRIPTION
- Handlebars 2.0 with canary builds
- Use the correct canary build URL

closes #2440 
