### PR TITLE
Clear inverseRecord for deleted belongsTo properly

### DIFF
--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -305,9 +305,9 @@ BelongsToRelationship.prototype.notifyRecordRelationshipRemoved = function(recor
 
 BelongsToRelationship.prototype._super$removeRecordFromOwn = Relationship.prototype.removeRecordFromOwn;
 BelongsToRelationship.prototype.removeRecordFromOwn = function(record) {
-  if (!this.members.has(record)){ return;}
-  this._super$removeRecordFromOwn(record);
+  if (!this.members.has(record)) { return; }
   this.inverseRecord = null;
+  this._super$removeRecordFromOwn(record);
 };
 
 BelongsToRelationship.prototype.findRecord = function() {


### PR DESCRIPTION
After a deep dive of the relationship internals together with @sly7-7 we've managed to find that if something observes a belongsTo relationship directly, a delete causes `notifyRecordRelationshipRemoved()` and in turn `notifyPropertyChange()` to get called before `inverseRecord` has been set to `null`, which results in observers getting the old value of the relationship from `getRecord()`.

Fixes #2447 
