### PR TITLE
Remove attr() data dependency

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -276,7 +276,7 @@ export default function attr(type, options) {
     options: options
   };
 
-  return Ember.computed('data', function(key, value) {
+  return Ember.computed(function(key, value) {
     if (arguments.length > 1) {
       Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.constructor.toString(), key !== 'id');
       var oldValue = getValue(this, key);

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -760,6 +760,16 @@ var Model = Ember.Object.extend(Ember.Evented, {
   },
 
   /**
+    @method _notifyProperties
+    @private
+  */
+  _notifyProperties: function(keys) {
+    Ember.beginPropertyChanges();
+    map.call(keys, this.notifyPropertyChange, this);
+    Ember.endPropertyChanges();
+  },
+
+  /**
     Returns an object, whose keys are changed properties, and value is
     an [oldProp, newProp] array.
 
@@ -824,7 +834,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
 
     if (!data) { return; }
 
-    this.notifyPropertyChange('data');
+    this._notifyProperties(Ember.keys(data));
   },
 
   /**
@@ -857,15 +867,17 @@ var Model = Ember.Object.extend(Ember.Evented, {
       the existing data, not replace it.
   */
   setupData: function(data, partial) {
+    Ember.assert("Expected an object as `data` in `setupData`", Ember.typeOf(data) === 'object');
+
     if (partial) {
       Ember.merge(this._data, data);
     } else {
       this._data = data;
     }
 
-    if (data) { this.pushedData(); }
+    this.pushedData();
 
-    this.notifyPropertyChange('data');
+    this._notifyProperties(Ember.keys(data));
   },
 
   materializeId: function(id) {
@@ -922,7 +934,8 @@ var Model = Ember.Object.extend(Ember.Evented, {
 
     this.send('rolledBack');
 
-    this.notifyPropertyChange('data');
+    this._notifyProperties(Ember.keys(this._data));
+
   },
 
   toStringExtension: function() {

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -133,6 +133,29 @@ test("Calling update on normalize allows partial updates with raw JSON", functio
   equal(person.get('lastName'), "Jackson", "existing fields are untouched");
 });
 
+test("Calling update with partial records triggers observers for just those attributes", function() {
+  expect(1);
+
+  var person = store.push('person', {
+    id: 'wat',
+    firstName: "Yehuda",
+    lastName: "Katz"
+  });
+
+  person.addObserver('firstName', function() {
+    ok(false, 'firstName observer should not be triggered');
+  });
+
+  person.addObserver('lastName', function() {
+    ok(true, 'lastName observer should be triggered');
+  });
+
+  store.update('person', {
+    id: 'wat',
+    lastName: "Katz!"
+  });
+});
+
 test("Calling push with a normalized hash containing related records returns a record", function() {
   var number1 = store.push('phone-number', {
     id: 1,


### PR DESCRIPTION
- attr() no longer depends on data
- model.setupData() calls notifyPropertyChange() for provided properties only

Fixes #2450, #2461.

Todo:
- [x] Wrap calls to notifyPropertyChange in beginPropertyChanges/endPropertyChanges
