### PR TITLE
Fix performance issue with DS.Model.relationshipsByName

### DIFF
--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -429,7 +429,7 @@ Model.reopenClass({
     });
 
     return map;
-  }).cacheable(false).readOnly(),
+  }).readOnly(),
 
   /**
     A map whose keys are the fields of the model and whose values are strings


### PR DESCRIPTION
This PR addresses a performance issue with `DS.Model.relationshipsByName`.

I noticed after profiling my application that on large results that a lot of time is spent in the `relationshipsByName` computed property which is called by `typeForRelationship`.

Despite what the comments say about those properties becoming 'frozen', when `typeForRelationship` calls `get(this, 'relationshipsByName')`  the name/relationship-descriptor map is rebuilt every time, adding considerable overhead to response processing.

By removing `.cacheable(false)` from the computed property, the map is now only every built once per model class **and halves the load time for ~300 models** (from ~2000ms down to ~1000ms) on a high end laptop, so the benefit on mobile devices or larger result sets would probably be greater.

I have read that the `.caheable()` property modifier has been removed in recent Ember commits, and probably `volatile()` should be used where required instead.  There may be other places in Ember Data that use deprecated CP modifiers, but I haven't had time to do an audit.

All tests pass, and given the contract in the documentation that such properties are supposed to be frozen, it seems like a valid change and a dramatic performance improvement.
