### PR TITLE
Dematerialize rejected _find() if record isEmpty

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1911,6 +1911,9 @@ function _find(adapter, store, type, id, record) {
     var record = store.getById(type, id);
     if (record) {
       record.notFound();
+      if (get(record, 'isEmpty')) {
+        store.dematerializeRecord(record);
+      }
     }
     throw error;
   }, "DS: Extract payload of '" + type + "'");

--- a/packages/ember-data/tests/integration/adapter/find_test.js
+++ b/packages/ember-data/tests/integration/adapter/find_test.js
@@ -120,3 +120,22 @@ test("When a single record is requested, and the promise is rejected, .find() is
     }));
   });
 });
+
+test("When a single record is requested, and the promise is rejected, the record should be dematerialized.", function() {
+  expect(2);
+
+  store = createStore({ adapter: DS.Adapter.extend({
+      find: function(store, type, id) {
+        return Ember.RSVP.reject();
+      }
+    })
+  });
+
+  run(function() {
+    store.find(Person, 1).then(null, async(function(reason) {
+      ok(true, "The rejection handler was called");
+    }));
+  });
+
+  ok(!store.hasRecordForId(Person, 1), "The record has been dematerialized");
+});


### PR DESCRIPTION
This dematerializes records that has been created when doing a `store.find('thing', 1)` and it fails/gets rejected. Not 100% sure if `isEmpty` is the correct condition here though.

Also, is this the behaviour we want?

Fixes #1747, fixes #1767, fixes #1931, fixes #2150