### PR TITLE
Support trailing slashes on urls for coalesceFindMany.

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -589,6 +589,10 @@ export default Adapter.extend({
     var url = this.buildURL(type.typeKey, record.get('id'), record);
 
     var expandedURL = url.split('/');
+    // Handle urls with trailing slash
+    if (expandedURL[expandedURL.length - 1] === '') {
+      delete expandedURL[expandedURL.length - 1];
+    }
     //Case when the url is of the format ...something/:id
     var lastSegment = expandedURL[ expandedURL.length - 1 ];
     var id = record.get('id');


### PR DESCRIPTION
Currently if you override your adapter as follows, coalesceFindRequests will break (silently).  
```javascript
export default DS.ActiveModelAdapter.extend({
    buildURL: function(type, id, record){
      return this._super(type, id, record) + '/';
    },
});
```
As _stripIDFromURL is marked as a private method I do not think it should be expected that users override it.  This provides a simple fix.  Happy to add a test if someone can suggest a simple approach for testing this.

I've noticed the build is failing. I'll wait to hear whether this would be a merge candidate before fixing. I will also need to make some adjustments to make sure that coalesce uses a trailing slash in the url if a trailing slash url is already being used.
