### PR TITLE
Deprecate store.update()

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -791,8 +791,8 @@ export default Ember.Object.extend({
 
   /**
     `extractCreateRecord` is a hook into the extract method used when a
-    call is made to `DS.Store#createRecord`. By default this method is
-    alias for [extractSave](#method_extractSave).
+    call is made to `DS.Model#save` and the record is new. By default
+    this method is alias for [extractSave](#method_extractSave).
 
     @method extractCreateRecord
     @param {DS.Store} store
@@ -807,8 +807,8 @@ export default Ember.Object.extend({
   },
   /**
     `extractUpdateRecord` is a hook into the extract method used when
-    a call is made to `DS.Store#update`. By default this method is alias
-    for [extractSave](#method_extractSave).
+    a call is made to `DS.Model#save` and the record has been updated.
+    By default this method is alias for [extractSave](#method_extractSave).
 
     @method extractUpdateRecord
     @param {DS.Store} store
@@ -823,8 +823,8 @@ export default Ember.Object.extend({
   },
   /**
     `extractDeleteRecord` is a hook into the extract method used when
-    a call is made to `DS.Store#deleteRecord`. By default this method is
-    alias for [extractSave](#method_extractSave).
+    a call is made to `DS.Model#save` and the record has been deleted.
+    By default this method is alias for [extractSave](#method_extractSave).
 
     @method extractDeleteRecord
     @param {DS.Store} store

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -866,17 +866,11 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @method setupData
     @private
     @param {Object} data
-    @param {Boolean} partial the data should be merged into
-      the existing data, not replace it.
   */
-  setupData: function(data, partial) {
+  setupData: function(data) {
     Ember.assert("Expected an object as `data` in `setupData`", Ember.typeOf(data) === 'object');
 
-    if (partial) {
-      merge(this._data, data);
-    } else {
-      this._data = data;
-    }
+    Ember.merge(this._data, data);
 
     this.pushedData();
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -95,7 +95,7 @@ function coerceId(id) {
   You can learn more about writing a custom adapter by reading the `DS.Adapter`
   documentation.
 
-  ### Store createRecord() vs. push() vs. pushPayload() vs. update()
+  ### Store createRecord() vs. push() vs. pushPayload()
 
   The store provides multiple ways to create new record objects. They have
   some subtle differences in their use which are detailed below:
@@ -108,7 +108,7 @@ function coerceId(id) {
   [push](#method_push) is used to notify Ember Data's store of new or
   updated records that exist in the backend. This will return a record
   in the `loaded.saved` state. The primary use-case for `store#push` is
-  to notify Ember Data about record updates that happen
+  to notify Ember Data about record updates (full or partial) that happen
   outside of the normal adapter methods (for example
   [SSE](http://dev.w3.org/html5/eventsource/) or [Web
   Sockets](http://www.w3.org/TR/2009/WD-websockets-20091222/)).
@@ -116,10 +116,6 @@ function coerceId(id) {
   [pushPayload](#method_pushPayload) is a convenience wrapper for
   `store#push` that will deserialize payloads if the
   Serializer implements a `pushPayload` method.
-
-  [update](#method_update) works like `push`, except it can handle
-  partial attributes without overwriting the existing record
-  properties.
 
   Note: When creating a new record using any of the above methods
   Ember Data will update `DS.RecordArray`s such as those returned by
@@ -1227,14 +1223,12 @@ Store = Ember.Object.extend({
     @private
     @param {String or subclass of DS.Model} type
     @param {Object} data
-    @param {Boolean} partial the data should be merged into
-      the existing data, not replace it.
   */
-  _load: function(type, data, partial) {
+  _load: function(type, data) {
     var id = coerceId(data.id);
     var record = this.recordForId(type, id);
 
-    record.setupData(data, partial);
+    record.setupData(data);
     this.recordArrayManager.recordDidChange(record);
 
     return record;
@@ -1341,12 +1335,9 @@ Store = Ember.Object.extend({
     @return {DS.Model} the record that was created or
       updated.
   */
-  push: function(typeName, data, _partial) {
-    // _partial is an internal param used by `update`.
-    // If passed, it means that the data should be
-    // merged into the existing data, not replace it.
-    Ember.assert("Expected an object as `data` in a call to `push`/`update` for " + typeName + " , but was " + data, Ember.typeOf(data) === 'object');
-    Ember.assert("You must include an `id` for " + typeName + " in an object passed to `push`/`update`", data.id != null && data.id !== '');
+  push: function(typeName, data) {
+    Ember.assert("Expected an object as `data` in a call to `push` for " + typeName + " , but was " + data, Ember.typeOf(data) === 'object');
+    Ember.assert("You must include an `id` for " + typeName + " in an object passed to `push`", data.id != null && data.id !== '');
 
     var type = this.modelFor(typeName);
     var filter = Ember.EnumerableUtils.filter;
@@ -1369,7 +1360,7 @@ Store = Ember.Object.extend({
 
     // Actually load the record into the store.
 
-    this._load(type, data, _partial);
+    this._load(type, data);
 
     var record = this.recordForId(type, data.id);
 
@@ -1465,39 +1456,15 @@ Store = Ember.Object.extend({
   },
 
   /**
-    Update existing records in the store. Unlike [push](#method_push),
-    update will merge the new data properties with the existing
-    properties. This makes it safe to use with a subset of record
-    attributes. This method expects normalized data.
-
-    `update` is useful if your app broadcasts partial updates to
-    records.
-
-    ```js
-    App.Person = DS.Model.extend({
-      firstName: DS.attr('string'),
-      lastName: DS.attr('string')
-    });
-
-    store.get('person', 1).then(function(tom) {
-      tom.get('firstName'); // Tom
-      tom.get('lastName'); // Dale
-
-      var updateEvent = {id: 1, firstName: "TomHuda"};
-      store.update('person', updateEvent);
-
-      tom.get('firstName'); // TomHuda
-      tom.get('lastName'); // Dale
-    });
-    ```
-
     @method update
     @param {String} type
     @param {Object} data
     @return {DS.Model} the record that was updated.
+    @deprecated Use [push](#method_push) instead
   */
   update: function(type, data) {
-    return this.push(type, data, true);
+    Ember.deprecate('Using store.update() has been deprecated since store.push() now handles partial updates. You should use store.push() instead.');
+    return this.push(type, data);
   },
 
   /**

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -99,7 +99,15 @@ test("Calling push triggers `didLoad` even if the record hasn't been requested f
   });
 });
 
-test("Calling update with partial records updates just those attributes", function() {
+test("Calling update should be deprecated", function() {
+  expectDeprecation(function() {
+    run(function() {
+      store.update('person', { id: '1', name: 'Tomster' });
+    });
+  });
+});
+
+test("Calling push with partial records updates just those attributes", function() {
   var person;
   run(function(){
     person = store.push('person', {
@@ -124,7 +132,7 @@ test("Calling update with partial records updates just those attributes", functi
   });
 });
 
-test("Calling update on normalize allows partial updates with raw JSON", function () {
+test("Calling push on normalize allows partial updates with raw JSON", function () {
   env.container.register('serializer:person', DS.RESTSerializer);
   var person;
 
@@ -135,7 +143,7 @@ test("Calling update on normalize allows partial updates with raw JSON", functio
       lastName: "Jackson"
     });
 
-    store.update('person', store.normalize('person', {
+    store.push('person', store.normalize('person', {
       id: '1',
       firstName: "Jacquie"
     }));
@@ -145,7 +153,7 @@ test("Calling update on normalize allows partial updates with raw JSON", functio
   equal(person.get('lastName'), "Jackson", "existing fields are untouched");
 });
 
-test("Calling update with partial records triggers observers for just those attributes", function() {
+test("Calling push with partial records triggers observers for just those attributes", function() {
   expect(1);
   var person;
 
@@ -166,7 +174,7 @@ test("Calling update with partial records triggers observers for just those attr
   });
 
   run(function(){
-    store.update('person', {
+    store.push('person', {
       id: 'wat',
       lastName: "Katz!"
     });
@@ -383,6 +391,39 @@ test("Calling pushPayload without a type should use a model's serializer when no
   var person = store.getById('person', 2);
 
   equal(person.get('firstName'), "Yehuda", "you can push raw JSON into the store");
+});
+
+test("Calling pushPayload allows partial updates with raw JSON", function () {
+  env.container.register('serializer:person', DS.RESTSerializer);
+
+  var person;
+
+  run(function() {
+    store.pushPayload('person', {
+      people: [{
+        id: '1',
+        firstName: "Robert",
+        lastName: "Jackson"
+      }]
+    });
+  });
+
+  var person = store.getById('person', 1);
+
+  equal(person.get('firstName'), "Robert", "you can push raw JSON into the store");
+  equal(person.get('lastName'), "Jackson", "you can push raw JSON into the store");
+
+  run(function() {
+    store.pushPayload('person', {
+      people: [{
+        id: '1',
+        firstName: "Jacquie"
+      }]
+    });
+  });
+
+  equal(person.get('firstName'), "Jacquie", "you can push raw JSON into the store");
+  equal(person.get('lastName'), "Jackson", "existing fields are untouched");
 });
 
 test('calling push without data argument as an object raises an error', function(){


### PR DESCRIPTION
- store.push() now handles partial updates
- store.update() has been deprecated

Todo:
- [x] Improve docs as per https://github.com/emberjs/data/pull/2460#issuecomment-62781099 (original PR, splitted into two)
- [X] Document breaking change in CHANGELOG (#2546)
