### PR TITLE
Allow async belongsTo to return null

### DIFF
--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -267,6 +267,7 @@ var RESTSerializer = JSONSerializer.extend({
 
     for (var prop in payload) {
       var typeName  = this.typeForRoot(prop);
+
       if (!store.modelFactoryFor(typeName)){
         Ember.warn(this.warnMessageNoModelForKey(prop, typeName), false);
         continue;
@@ -274,6 +275,10 @@ var RESTSerializer = JSONSerializer.extend({
       var type = store.modelFor(typeName);
       var isPrimary = type.typeKey === primaryTypeName;
       var value = payload[prop];
+
+      if (value === null) {
+        continue;
+      }
 
       // legacy support for singular resources
       if (isPrimary && Ember.typeOf(value) !== "array" ) {

--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -321,7 +321,9 @@ BelongsToRelationship.prototype.findRecord = function() {
 BelongsToRelationship.prototype.fetchLink = function() {
   var self = this;
   return this.store.findBelongsTo(this.record, this.link, this.relationshipMeta).then(function(record){
-    self.addRecord(record);
+    if (record) {
+      self.addRecord(record);
+    }
     return record;
   });
 };

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1804,6 +1804,11 @@ function _findBelongsTo(adapter, store, record, link, relationship) {
 
   return promise.then(function(adapterPayload) {
     var payload = serializer.extract(store, relationship.type, adapterPayload, null, 'findBelongsTo');
+
+    if (!payload) {
+      return null;
+    }
+
     var record = store.push(relationship.type, payload);
     return record;
   }, null, "DS: Extract payload of " + record + " : " + relationship.type);

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -232,6 +232,37 @@ test('A record with an async belongsTo relationship always returns a promise for
   }));
 });
 
+test("A record with an async belongsTo relationship returning null should resolve null", function() {
+  expect(1);
+
+  var Group = DS.Model.extend({
+    people: DS.hasMany()
+  });
+
+  var Person = DS.Model.extend({
+    group: DS.belongsTo({ async: true })
+  });
+
+  env.container.register('model:group', Group);
+  env.container.register('model:person', Person);
+
+  store.push('person', { id: 1, links: { group: '/people/1/group' } });
+
+  env.adapter.find = function() {
+    throw new Error("Adapter's find method should not be called");
+  };
+
+  env.adapter.findBelongsTo = async(function(store, record, link, relationship) {
+    return Ember.RSVP.resolve(null);
+  });
+
+  env.store.find('person', 1).then(async(function(person) {
+    return person.get('group');
+  })).then(async(function(group) {
+    ok(group === null, "group should be null");
+  }));
+});
+
 test("TODO (embedded): The store can load an embedded polymorphic belongsTo association", function() {
   expect(0);
   //serializer.keyForEmbeddedType = function() {

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -366,6 +366,18 @@ test("extractSingle loads secondary records with correct serializer", function()
   equal(superVillainNormalizeCount, 1, "superVillain is normalized once");
 });
 
+test("extractSingle returns null if payload contains null", function() {
+  expect(1);
+
+  var jsonHash = {
+    evilMinion: null
+  };
+
+  var value = env.restSerializer.extractSingle(env.store, EvilMinion, jsonHash);
+
+  equal(value, null, "returned value is null");
+});
+
 test("extractArray loads secondary records with correct serializer", function() {
   var superVillainNormalizeCount = 0;
 


### PR DESCRIPTION
This makes sure that the store handles empty (null) async belongsTo relationships.

Fixes #2452.
