### PR TITLE
Failing test: DS.Model.save() causes an inconsistent attribute changes

### DIFF
--- a/packages/ember-data/tests/unit/model/rollback_test.js
+++ b/packages/ember-data/tests/unit/model/rollback_test.js
@@ -64,14 +64,17 @@ test("a record's changes can be made if it fails to save", function() {
   var person = store.push('person', { id: 1, firstName: "Tom", lastName: "Dale" });
 
   person.set('firstName', "Thomas");
+  deepEqual(person.changedAttributes(), {firstName: ["Tom", "Thomas"]});
 
   person.save().then(null, async(function() {
     equal(person.get('isError'), true);
+    deepEqual(person.changedAttributes(), {firstName: ["Tom", "Thomas"]});
 
     person.rollback();
 
     equal(person.get('firstName'), "Tom");
     equal(person.get('isError'), false);
+    deepEqual(person.changedAttributes(), {});
   }));
 });
 


### PR DESCRIPTION
Even if `DS.Model.save()` is rejected, it will empty `changeAttributes()`.
