### PR TITLE
prefer Ember.create to Object.create

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -142,6 +142,10 @@ globalBuild = wrap(globalBuild, {
 globalBuild = versionStamp(globalBuild, 'ember-data.js');
 namedAMDBuild = versionStamp(namedAMDBuild, 'ember-data.named-amd.js');
 
+if (env === 'production'){
+  testFiles = es3SafeRecast(testFiles);
+}
+
 testFiles = concat(testFiles, {
   inputFiles: ['**/*.js'],
   separator: '\n',

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-data",
   "private": true,
   "dependencies": {
-    "ember": "~1.7.0"
+    "ember": "~1.8.1"
   },
   "devDependencies": {
     "qunit": "~1.13.0",

--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -8,6 +8,7 @@
 // support RSVP 2.x via resolve,  but prefer RSVP 3.x's Promise.cast
 Ember.RSVP.Promise.cast = Ember.RSVP.Promise.cast || Ember.RSVP.resolve;
 
+import "ember-data/system/create";
 import DS from "ember-data/core";
 import "ember-data/ext/date";
 

--- a/packages/ember-data/lib/system/create.js
+++ b/packages/ember-data/lib/system/create.js
@@ -1,0 +1,9 @@
+/*
+  Detect if the user has a correct Object.create shim.
+  Ember has provided this for a long time but has had an incorrect shim before 1.8
+  TODO: Remove for Ember Data 1.0.
+*/
+var object = Ember.create(null);
+if (object.toString !== undefined && Ember.keys(Ember.create({})).length !== 0){
+  throw new Error("Ember Data requires a correct Object.create shim. You should upgrade to Ember >= 1.8 which provides one for you.");
+}

--- a/packages/ember-data/lib/system/map.js
+++ b/packages/ember-data/lib/system/map.js
@@ -25,9 +25,9 @@ testMap.forEach(function(value, key){
   usesOldBehavior = value === 'key' && key === 'value';
 });
 
-Map.prototype            = Object.create(Ember.Map.prototype);
-MapWithDefault.prototype = Object.create(Ember.MapWithDefault.prototype);
-OrderedSet.prototype     = Object.create(Ember.OrderedSet.prototype);
+Map.prototype            = Ember.create(Ember.Map.prototype);
+MapWithDefault.prototype = Ember.create(Ember.MapWithDefault.prototype);
+OrderedSet.prototype     = Ember.create(Ember.OrderedSet.prototype);
 
 OrderedSet.create = function(){
   return new OrderedSet();

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -19,8 +19,8 @@ var retrieveFromCurrentState = Ember.computed('currentState', function(key, valu
   return get(get(this, 'currentState'), key);
 }).readOnly();
 
-var _extractPivotNameCache = Object.create(null);
-var _splitOnDotCache = Object.create(null);
+var _extractPivotNameCache = Ember.create(null);
+var _splitOnDotCache = Ember.create(null);
 
 function splitOnDot(name) {
   return _splitOnDotCache[name] || (
@@ -465,7 +465,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
       would have a implicit post relationship in order to be do things like remove ourselves from the post
       when we are deleted
     */
-    this._implicitRelationships = Object.create(null);
+    this._implicitRelationships = Ember.create(null);
     var model = this;
     //TODO Move into a getter for better perf
     this.constructor.eachRelationship(function(key, descriptor) {

--- a/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/adapter_populated_record_array.js
@@ -6,7 +6,7 @@ import RecordArray from "ember-data/system/record_arrays/record_array";
 var get = Ember.get;
 
 function cloneNull(source) {
-  var clone = Object.create(null);
+  var clone = Ember.create(null);
   for (var key in source) {
     clone[key] = source[key];
   }

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -109,7 +109,7 @@ Model.reopenClass({
   },
 
   inverseMap: Ember.computed(function() {
-    return Object.create(null);
+    return Ember.create(null);
   }),
 
   /**

--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -45,20 +45,24 @@ Relationship.prototype = {
   },
 
   removeRecords: function(records){
-    var that = this;
-    records.forEach(function(record){
-      that.removeRecord(record);
-    });
+    var length = Ember.get(records, 'length');
+    var record;
+    for (var i = 0; i < length; i++){
+      record = records[i];
+      this.removeRecord(record);
+    }
   },
 
   addRecords: function(records, idx){
-    var that = this;
-    records.forEach(function(record){
-      that.addRecord(record, idx);
+    var length = Ember.get(records, 'length');
+    var record;
+    for (var i = 0; i < length; i++){
+      record = records[i];
+      this.addRecord(record, idx);
       if (idx !== undefined) {
         idx++;
       }
-    });
+    }
   },
 
   addRecord: function(record, idx) {
@@ -149,7 +153,7 @@ var ManyRelationship = function(store, record, inverseKey, relationshipMeta) {
   this.manyArray.isPolymorphic = this.isPolymorphic;
 };
 
-ManyRelationship.prototype = Object.create(Relationship.prototype);
+ManyRelationship.prototype = Ember.create(Relationship.prototype);
 ManyRelationship.prototype.constructor = ManyRelationship;
 ManyRelationship.prototype._super$constructor = Relationship;
 
@@ -263,7 +267,7 @@ var BelongsToRelationship = function(store, record, inverseKey, relationshipMeta
   this.inverseRecord = null;
 };
 
-BelongsToRelationship.prototype = Object.create(Relationship.prototype);
+BelongsToRelationship.prototype = Ember.create(Relationship.prototype);
 BelongsToRelationship.prototype.constructor = BelongsToRelationship;
 BelongsToRelationship.prototype._super$constructor = Relationship;
 


### PR DESCRIPTION
also removes methods not on array prototypes
in IE8 such as forEach

refs emberjs/ember.js#9430
fixes emberjs/data#2488
