### PR TITLE
[Bug] add assertion to prevent from rejecting records without a reason.

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -595,7 +595,7 @@ Store = Ember.Object.extend({
           _findMany(adapter, store, type, ids, requestedRecords).
             then(resolveFoundRecords).
             then(makeMissingRecordsRejector(requestedRecords)).
-            then(null, makeRecordsRejector(requestedRecords));
+            catch(makeRecordsRejector(requestedRecords));
         } else if (ids.length === 1) {
           var pair = Ember.A(recordResolverPairs).findBy('record', groupOfRecords[0]);
           _fetchRecord(pair);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -569,6 +569,8 @@ Store = Ember.Object.extend({
     }
 
     function rejectRecords(records, error) {
+      Ember.assert("cannot reject records without a reason", error instanceof Error);
+
       forEach(records, function(record){
         var pair = Ember.A(recordResolverPairs).findBy('record', record);
         if (pair){

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -553,12 +553,16 @@ Store = Ember.Object.extend({
           resolver.resolve(record);
         }
       });
+
+      return records;
     }
 
     function makeMissingRecordsRejector(requestedRecords) {
       return function rejectMissingRecords(resolvedRecords) {
         var missingRecords = requestedRecords.without(resolvedRecords);
         rejectRecords(missingRecords);
+
+        return resolvedRecords;
       };
     }
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -560,7 +560,7 @@ Store = Ember.Object.extend({
     function makeMissingRecordsRejector(requestedRecords) {
       return function rejectMissingRecords(resolvedRecords) {
         var missingRecords = requestedRecords.without(resolvedRecords);
-        rejectRecords(missingRecords);
+        rejectRecords(missingRecords, new Error('MissingRecords'));
 
         return resolvedRecords;
       };

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -531,8 +531,10 @@ Store = Ember.Object.extend({
       return;
     }
 
-    this._pendingFetch.forEach(this._flushPendingFetchForType, this);
+    var pendingFetch = this._pendingFetch;
     this._pendingFetch = Map.create();
+
+    pendingFetch.forEach(this._flushPendingFetchForType, this);
   },
 
   _flushPendingFetchForType: function (recordResolverPairs, type) {

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -1479,8 +1479,12 @@ test('groupRecordsForFindMany splits up calls for large ids', function() {
 });
 
 test('groupRecordsForFindMany groups calls for small ids', function() {
-  Comment.reopen({ post: DS.belongsTo('post') });
-  Post.reopen({ comments: DS.hasMany('comment', {async: true}) });
+  Comment.reopen({
+    post: DS.belongsTo('post')
+  });
+  Post.reopen({
+    comments: DS.hasMany('comment', { async: true })
+  });
 
   expect(1);
 
@@ -1490,7 +1494,10 @@ test('groupRecordsForFindMany groups calls for small ids', function() {
 
   var a100 = repeatChar('a', 100);
   var b100 = repeatChar('b', 100);
-  var post = store.push('post', { id: 1, comments: [a100, b100] });
+  var post = store.push('post', {
+    id: 1,
+    comments: [a100, b100]
+  });
 
   adapter.coalesceFindRequests = true;
 
@@ -1501,7 +1508,13 @@ test('groupRecordsForFindMany groups calls for small ids', function() {
 
   adapter.findMany = function(store, type, ids, records) {
     deepEqual(ids, [a100, b100]);
-    return Ember.RSVP.resolve({ comments: { id: ids } });
+
+    return {
+      comments: [
+        { id: ids[0] },
+        { id: ids[1] }
+      ]
+    };
   };
 
   post.get('comments');

--- a/packages/ember-data/tests/unit/adapters/rest_adapter/group_records_for_find_many_test.js
+++ b/packages/ember-data/tests/unit/adapters/rest_adapter/group_records_for_find_many_test.js
@@ -1,4 +1,4 @@
-var GroupsAdapter, Store;
+var GroupsAdapter, store;
 var maxLength = -1;
 var lengths = Ember.A([]);
 
@@ -21,29 +21,34 @@ module("unit/adapters/rest_adapter/group_records_for_find_many_test - DS.RESTAda
         maxLength = this.get('maxUrlLength');
         lengths.push(fullUrl.length);
 
-        return Ember.RSVP.Promise.resolve({ 'testRecords' : [] });
+        var response = Ember.EnumerableUtils.map(options.data.ids, function(id) {
+          return {
+            id: id
+          }
+        });
+
+        return Ember.RSVP.Promise.resolve({
+          testRecords: response
+        });
       }
 
     });
 
-    Store = createStore({
+    store = createStore({
       adapter: GroupsAdapter,
       testRecord: DS.Model.extend()
      });
-
   }
 });
 
 test('groupRecordsForFindMany - findMany', function() {
-
   Ember.run(function() {
     for(var i = 1; i <= 1024; i++) {
-      Store.find('testRecord', i);
+      store.find('testRecord', i);
     }
   });
 
   ok(lengths.every(function(len) {
       return len <= maxLength;
     }), "Some URLs are longer than " + maxLength + " chars");
-
 });


### PR DESCRIPTION
When rejecting because records were missing, we currently reject without a reason. This results in non-actionable failures.

I am actually pretty sure the find coalescing doesn't work even with these fixes

I'm going to implement out-side of ember data right now, I'll try to circle back this weekend and figure out whats wrong inside ember-data.

- [ ] the usage of without is still broken
- [ ] switch recordResolverPairs to be a map