### PR TITLE
Add dataType override in ajaxOptions()

### DIFF
--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -277,6 +277,24 @@ export default Adapter.extend(BuildURLMixin, {
   coalesceFindRequests: false,
 
   /**
+    By default the RESTAdapter will expect response data to be in json format. Override `responseDataType`
+    to specify a different type.
+
+    ```javascript
+    App.ApplicationAdapter = DS.RESTAdapter.extend({
+      responseDataType: 'jsonp'
+    });
+    ```
+
+    Response data types are limited to types accepted by the [jQuery library](http://api.jquery.com/jQuery.ajax/).
+
+    @property responseDataType
+    @type {String}
+    @default 'json'
+  */
+  responseDataType: 'json',
+
+  /**
     Endpoint paths can be prefixed with a `namespace` by setting the namespace
     property on the adapter:
 
@@ -805,7 +823,7 @@ export default Adapter.extend(BuildURLMixin, {
     var hash = options || {};
     hash.url = url;
     hash.type = type;
-    hash.dataType = 'json';
+    hash.dataType = get(this, 'responseDataType');
     hash.context = this;
 
     if (hash.data && type !== 'GET') {

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -1955,3 +1955,13 @@ test('ajaxError wraps the error string in an Error object', function() {
     Ember.$.ajax = originalAjax;
   }
 });
+
+test('uses responseDataType when overriden', function(){
+  adapter.setProperties({
+    responseDataType: 'jsonp'
+  });
+
+  var hash = adapter.ajaxOptions("posts/1",'GET');
+
+  equal(hash.dataType, 'jsonp');
+});

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -1956,12 +1956,12 @@ test('ajaxError wraps the error string in an Error object', function() {
   }
 });
 
-test('uses responseDataType when overriden', function(){
+test('uses responseDataType when overridden', function() {
   adapter.setProperties({
     responseDataType: 'jsonp'
   });
 
-  var hash = adapter.ajaxOptions("posts/1",'GET');
+  var hash = adapter.ajaxOptions("posts/1", 'GET');
 
   equal(hash.dataType, 'jsonp');
 });


### PR DESCRIPTION
This change allows ajaxOptions to set jQuery dataType based on a value set on the adapter, defaulting to 'json' if not present. This allows rest_adapter to be extended and specify an alternate, like 'jsonp', for a third party API, without needing to override the entire ajaxOptions function.

I'd be happy to write a test for this, but I'm a little lost as to where to test for this type of change. The current Test Suite continues to pass.