### PR TITLE
Throw a useful error when deserializing an embedded relationship

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1669,6 +1669,7 @@ function deserializeRecordId(store, data, key, relationship, id) {
     data[key] = store.recordForId(type, id);
   } else if (typeof id === 'object') {
     // polymorphic
+    Ember.assert('Ember Data expected a number or string to represent the record(s) in the `' + relationship.key + '` relationship instead it found an object. If this is a polymorphic relationship please specify a `type` key. If this is an embedded relationship please include the `DS.EmbeddedRecordsMixin` and specify the `' + relationship.key +'` property in your serializer\'s attrs hash.', id.type);
     data[key] = store.recordForId(id.type, id.id);
   }
 }

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -436,6 +436,18 @@ test('calling push with belongsTo relationship the value must not be an array', 
   }, /must not be an array/);
 });
 
+test('calling push with an embedded relationship throws a useful error', function(){
+  throws(function() {
+    store.push('person', {
+      id: 1,
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      phoneNumbers: [
+        {number: '5551212', person: 1}
+      ] });
+  }, /If this is an embedded relationship/);
+});
+
 test("Calling push with unknown keys in the provided payload should warn", function() {
   warns(function() {
     store.push('person', {


### PR DESCRIPTION
I had my Serializer misconfigured for an embedded relationship (typo in the relationship name in the attrs hash) and I was greeted with this error.

![screen shot 2014-11-23 at 6 55 15 pm](https://cloud.githubusercontent.com/assets/54056/5159816/769a1764-7342-11e4-8250-47ce9e69d4e7.png)

This pr improves the error message to make the reason for failing more apparent. 

I'm open to any feedback or improvements on the message content.
#### After

![screen shot 2014-11-23 at 6 55 34 pm](https://cloud.githubusercontent.com/assets/54056/5159834/1a85cf76-7343-11e4-9e57-728a7cfa551e.png)
