### PR TITLE
Add Test Coverage for `DS.NumberTransform`

### DIFF
--- a/packages/ember-data/lib/transforms/date.js
+++ b/packages/ember-data/lib/transforms/date.js
@@ -46,7 +46,6 @@ if (Ember.SHIM_ES5) {
 }
 
 export default Transform.extend({
-
   deserialize: function(serialized) {
     var type = typeof serialized;
 

--- a/packages/ember-data/tests/unit/transform/boolean_test.js
+++ b/packages/ember-data/tests/unit/transform/boolean_test.js
@@ -1,0 +1,38 @@
+module("unit/transform - DS.BooleanTransform");
+
+test("#serialize", function() {
+  var transform = new DS.BooleanTransform();
+
+  equal(transform.serialize(null),      false);
+  equal(transform.serialize(undefined), false);
+
+  equal(transform.serialize(true),      true);
+  equal(transform.serialize(false),     false);
+});
+
+test("#deserialize", function() {
+  var transform = new DS.BooleanTransform();
+
+  equal(transform.deserialize(null),      false);
+  equal(transform.deserialize(undefined), false);
+
+  equal(transform.deserialize(true),      true);
+  equal(transform.deserialize(false),     false);
+
+  equal(transform.deserialize("true"),    true);
+  equal(transform.deserialize("TRUE"),    true);
+  equal(transform.deserialize("false"),   false);
+  equal(transform.deserialize("FALSE"),   false);
+
+  equal(transform.deserialize("t"),       true);
+  equal(transform.deserialize("T"),       true);
+  equal(transform.deserialize("f"),       false);
+  equal(transform.deserialize("F"),       false);
+
+  equal(transform.deserialize("1"),       true);
+  equal(transform.deserialize("0"),       false);
+
+  equal(transform.deserialize(1),         true);
+  equal(transform.deserialize(2),         false);
+  equal(transform.deserialize(0),         false);
+});

--- a/packages/ember-data/tests/unit/transform/date_test.js
+++ b/packages/ember-data/tests/unit/transform/date_test.js
@@ -1,0 +1,31 @@
+module("unit/transform - DS.DateTransform");
+
+var dateString = "2015-01-01T00:00:00.000Z";
+var dateInMillis = Ember.Date.parse(dateString);
+var date = new Date(dateInMillis);
+
+test("#serialize", function() {
+  var transform = new DS.DateTransform();
+
+  equal(transform.serialize(null),      null);
+  equal(transform.serialize(undefined), null);
+
+  equal(transform.serialize(date), dateString);
+});
+
+test("#deserialize", function() {
+  var transform = new DS.DateTransform();
+
+  // from String
+  equal(transform.deserialize(dateString).toISOString(),        dateString);
+
+  // from Number
+  equal(transform.deserialize(dateInMillis).valueOf(),          dateInMillis);
+
+  // from other
+  equal(transform.deserialize({}),                              null);
+
+  // from none
+  equal(transform.deserialize(null),                            null);
+  equal(transform.deserialize(undefined),                       null);
+});

--- a/packages/ember-data/tests/unit/transform/number_test.js
+++ b/packages/ember-data/tests/unit/transform/number_test.js
@@ -1,0 +1,25 @@
+module("unit/transform - DS.NumberTransform");
+
+test("#serialize", function() {
+  var transform = new DS.NumberTransform();
+
+  equal(transform.serialize(null),            null);
+  equal(transform.serialize(undefined),       null);
+  equal(transform.serialize("1.1"),           1.1);
+  equal(transform.serialize(1.1),             1.1);
+  equal(transform.serialize(new Number(1.1)), 1.1);
+
+  ok(isNaN(transform.serialize(NaN)));
+});
+
+test("#deserialize", function() {
+  var transform = new DS.NumberTransform();
+
+  equal(transform.deserialize(null),            null);
+  equal(transform.deserialize(undefined),       null);
+  equal(transform.deserialize("1.1"),           1.1);
+  equal(transform.deserialize(1.1),             1.1);
+  equal(transform.deserialize(new Number(1.1)), 1.1);
+
+  ok(isNaN(transform.deserialize(NaN)));
+});

--- a/packages/ember-data/tests/unit/transform/string_test.js
+++ b/packages/ember-data/tests/unit/transform/string_test.js
@@ -1,0 +1,21 @@
+module("unit/transform - DS.StringTransform");
+
+test("#serialize", function() {
+  var transform = new DS.StringTransform();
+
+  equal(transform.serialize(null),      null);
+  equal(transform.serialize(undefined), null);
+
+  equal(transform.serialize("foo"),     "foo");
+  equal(transform.serialize(1),         "1");
+});
+
+test("#deserialize", function() {
+  var transform = new DS.StringTransform();
+
+  equal(transform.deserialize(null),      null);
+  equal(transform.deserialize(undefined), null);
+
+  equal(transform.deserialize("foo"),     "foo");
+  equal(transform.deserialize(1),         "1");
+});


### PR DESCRIPTION
Transforms are not tested at the `unit` level. Adding tests at the
`unit` granularity allows for regression testing if the implementation covered
by the `acceptance` level tests should change.
