### PR TITLE
use defaultValue without supplying type

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -268,7 +268,12 @@ function getValue(record, key) {
 */
 
 export default function attr(type, options) {
-  options = options || {};
+  if (typeof type === 'object') {
+    options = type;
+    type = undefined;
+  } else {
+    options = options || {};
+  }
 
   var meta = {
     type: type,

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -148,6 +148,16 @@ test("a DS.Model does not require an attribute type", function() {
   equal(get(tag, 'name'), "test", "the value is persisted");
 });
 
+test("a DS.Model can have a defaultValue without an attribute type", function() {
+  var Tag = DS.Model.extend({
+    name: DS.attr({ defaultValue: "unknown" })
+  });
+
+  var tag = store.createRecord(Tag);
+
+  equal(get(tag, 'name'), "unknown", "the default value is found");
+});
+
 module("unit/model - DS.Model updating", {
   setup: function() {
     array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];


### PR DESCRIPTION
I prefer to use `DS.attr()` without a type when possible, but when I
want to use a defaultValue, I must supply a type. This would make it so
that you can supply a defaultValue, but still have an attribute without
a transform.
