### PR TITLE
add test: FixtureAdapter doesn't save hasMany records

### DIFF
--- a/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
@@ -263,7 +263,7 @@ test("should throw if ids are not defined in the FIXTURES", function() {
   });
 });
 
-asyncTest("copies fixtures instead of passing the direct reference", function(){
+asyncTest("copies fixtures instead of passing the direct reference", function() {
   var returnedFixture;
 
   expect(2);
@@ -293,4 +293,46 @@ asyncTest("copies fixtures instead of passing the direct reference", function(){
   }, function(err){
     ok(false, 'got error' + err);
   });
+});
+
+test("should save hasMany records", function() {
+  var tom, phone, createPhone, savePerson, assertPersonPhones;
+
+  expect(3);
+
+  Person.FIXTURES = [{ id: 'tomjerry', firstName: "Tom", lastName: "Jerry", height: 3 }];
+
+  createPhone = async(function(tom) {
+    env.store.createRecord('phone', {person: tom});
+
+    return tom.get('phones').then(async(function(p) {
+      equal(p.get('length'), 1, "hasMany relationships are created in the store");
+      return tom;
+    }));
+  });
+
+  savePerson = async(function(tom) {
+    return tom.save();
+  });
+
+  assertPersonPhones = async(function(record) {
+    var phonesPromise = record.get('phones');
+
+    return phonesPromise.then(async(function(phones) {
+      equal(phones.get('length'), 1, "hasMany relationship saved correctly");
+    }));
+  });
+
+  ensureFixtureAdapterDoesNotLeak = async(function(){
+    env.store.destroy();
+    env = setupStore({ person: Person, phone: Phone, adapter: DS.FixtureAdapter });
+    return env.store.find('phone').then(async(function(phones) {
+      equal(phones.get('length'), 0, "the fixture adapter should not leak after destroying the store");
+    }));
+  });
+  env.store.find('person', 'tomjerry').then(createPhone)
+                                      .then(savePerson)
+                                      .then(assertPersonPhones)
+                                      .then(ensureFixtureAdapterDoesNotLeak);
+
 });


### PR DESCRIPTION
This test proves a bug exists when a record is created in the
store with a hasMany relationships. The relationships are simply lost upon
`phones.createRecord('name', {person: tom})`, where `tom` is the record
that has `phones`.

closes #1606, closes #1750
