### PR TITLE
fix addRecords error iterating over records

### DIFF
--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -6,6 +6,8 @@ import {
   OrderedSet
 } from "ember-data/system/map";
 
+var forEach = Ember.EnumerableUtils.forEach;
+
 var Relationship = function(store, record, inverseKey, relationshipMeta) {
   this.members = new OrderedSet();
   this.store = store;
@@ -45,24 +47,20 @@ Relationship.prototype = {
   },
 
   removeRecords: function(records){
-    var length = Ember.get(records, 'length');
-    var record;
-    for (var i = 0; i < length; i++){
-      record = records[i];
-      this.removeRecord(record);
-    }
+    var self = this;
+    forEach(records, function(record){
+      self.removeRecord(record);
+    });
   },
 
   addRecords: function(records, idx){
-    var length = Ember.get(records, 'length');
-    var record;
-    for (var i = 0; i < length; i++){
-      record = records[i];
-      this.addRecord(record, idx);
+    var self = this;
+    forEach(records, function(record){
+      self.addRecord(record, idx);
       if (idx !== undefined) {
         idx++;
       }
-    }
+    });
   },
 
   addRecord: function(record, idx) {

--- a/packages/ember-data/tests/unit/model/relationships_test.js
+++ b/packages/ember-data/tests/unit/model/relationships_test.js
@@ -334,6 +334,42 @@ test("it is possible to add a new item to a relationship", function() {
   }));
 });
 
+test("possible to replace items in a relationship using setObjects w/ Ember Enumerable Array/Object as the argument (GH-2533)", function(){
+  var Tag = DS.Model.extend({
+    name: DS.attr('string'),
+    person: DS.belongsTo('person')
+  });
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tags: DS.hasMany('tag')
+  });
+
+  var env   = setupStore({ tag: Tag, person: Person });
+  var store = env.store;
+  var run   = Ember.run;
+
+  Ember.run(function(){
+    store.push('person', { id: 1, name: "Tom Dale", tags: [ 1 ] });
+    store.push('person', { id: 2, name: "Sylvain Mina", tags: [ 2 ] });
+    store.push('tag', { id: 1, name: "ember" });
+    store.push('tag', { id: 2, name: "ember-data" });
+  });
+
+  var tom, sylvain;
+
+  run(function(){
+    tom = store.getById('person', '1');
+    sylvain = store.getById('person', '2');
+    // Test that since sylvain.get('tags') instanceof DS.ManyArray,
+    // addRecords on Relationship iterates correctly.
+    tom.get('tags').setObjects(sylvain.get('tags'));
+  });
+
+  equal(tom.get('tags.length'), 1);
+  equal(tom.get('tags.firstObject'), store.getById('tag', 2));
+});
+
 test("it is possible to remove an item from a relationship", function() {
   var Tag = DS.Model.extend({
     name: DS.attr('string'),


### PR DESCRIPTION
Reverts a change in commit c6b451c that used a
traditional for loop, assuming that “records” in
addRecords/removeRecords would always be a plain
JavaScript array. This assumption was inaccurate.

We use the Ember.EnumerableUtils to safely
iterate over the objects when forEach/etc aren’t
present. For example, IE8 with
Ember.EXTEND_PROTOTYPES = false;

fixes Github Issue #2533
