### PR TITLE
Mention store.normalize in the store.push docs.

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1304,9 +1304,15 @@ Store = Ember.Object.extend({
     }
     ```
 
-    If you're streaming data or implementing an adapter,
-    make sure that you have converted the incoming data
-    into this form.
+    If you're streaming data or implementing an adapter, make sure
+    that you have converted the incoming data into this form. The
+    store's [normalize](#method_normalize) method is a convenience
+    helper for converting a json payload into the form Ember Data
+    expects.
+
+    ```js
+    store.push('person', store.normalize('person', data));
+    ```
 
     This method can be used both to push in brand new
     records, as well as to update existing records.


### PR DESCRIPTION
The `store.push` docs were written before `store.normalize` was added but they spend most of their lines explaining the concept of "normalized data" in Ember Data. This pr adds a simple example of using `store.push` with `store.normalize` to the end of the doc block.

![screen shot 2014-11-29 at 10 22 51 pm](https://cloud.githubusercontent.com/assets/54056/5236677/6304bb0e-7816-11e4-99a7-b65e5a9ebed4.png)
