### PR TITLE
Properly clean up destroyed record arrays

### DIFF
--- a/packages/ember-data/lib/system/record_array_manager.js
+++ b/packages/ember-data/lib/system/record_array_manager.js
@@ -195,7 +195,8 @@ export default Ember.Object.extend({
       type: type,
       content: Ember.A(),
       store: this.store,
-      isLoaded: true
+      isLoaded: true,
+      manager: this
     });
 
     this.registerFilteredRecordArray(array, type);

--- a/packages/ember-data/lib/system/record_arrays/filtered_record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/filtered_record_array.js
@@ -64,16 +64,4 @@ export default RecordArray.extend({
     Ember.run.once(this, this._updateFilter);
   }, 'filterFunction'),
 
-  /**
-    @method _unregisterFromManager
-    @private
-  */
-  _unregisterFromManager: function(){
-    this.manager.unregisterFilteredRecordArray(this);
-  },
-
-  willDestroy: function(){
-    this._unregisterFromManager();
-    this._super();
-  }
 });

--- a/packages/ember-data/lib/system/record_arrays/record_array.js
+++ b/packages/ember-data/lib/system/record_arrays/record_array.js
@@ -196,7 +196,20 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     });
   },
 
+  /**
+    @method _unregisterFromManager
+    @private
+  */
+  _unregisterFromManager: function(){
+    var manager = get(this, 'manager');
+    //We will stop needing this stupid if statement soon, once manyArray are refactored to not be RecordArrays
+    if (manager) {
+      manager.unregisterFilteredRecordArray(this);
+    }
+  },
+
   willDestroy: function(){
+    this._unregisterFromManager();
     this._dissociateFromOwnRecords();
     this._super();
   }

--- a/packages/ember-data/tests/unit/record_array_test.js
+++ b/packages/ember-data/tests/unit/record_array_test.js
@@ -43,6 +43,29 @@ test("acts as a live query", function() {
   equal(get(recordArray, 'lastObject.name'), 'brohuda');
 });
 
+test("stops updating when destroyed", function() {
+  expect(3);
+  var store = createStore();
+
+  var recordArray = store.all(Person);
+  run(function(){
+    store.push(Person, { id: 1, name: 'wycats' });
+  });
+
+  run(function() {
+    recordArray.destroy();
+  });
+
+  run(function() {
+    equal(recordArray.get('length'), undefined, "Has no more records");
+    store.push(Person, { id: 2, name: 'brohuda' });
+  });
+
+  equal(recordArray.get('length'), undefined, "Has not been updated");
+  equal(recordArray.get('content'), undefined, "Has not been updated");
+});
+
+
 test("a loaded record is removed from a record array when it is deleted", function() {
   var Tag = DS.Model.extend({
     people: DS.hasMany('person')


### PR DESCRIPTION
This build upon #2361 which cleaned up filtered record arrays, but did not clean up
record arrays coming from .all and .find
