### PR TITLE
Remove metaForType()/metadataFor() ambiguousness

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -961,7 +961,7 @@ export default Ember.Object.extend({
     App.PostSerializer = DS.JSONSerializer.extend({
       extractMeta: function(store, type, payload) {
         if (payload && payload._pagination) {
-          store.metaForType(type, payload._pagination);
+          store.setMetadataFor(type, payload._pagination);
           delete payload._pagination;
         }
       }
@@ -975,7 +975,7 @@ export default Ember.Object.extend({
   */
   extractMeta: function(store, type, payload) {
     if (payload && payload.meta) {
-      store.metaForType(type, payload.meta);
+      store.setMetadataFor(type, payload.meta);
       delete payload.meta;
     }
   },

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1033,12 +1033,25 @@ Store = Ember.Object.extend({
     This method returns the metadata for a specific type.
 
     @method metadataFor
-    @param {String or subclass of DS.Model} type
+    @param {String or subclass of DS.Model} typeName
     @return {object}
   */
-  metadataFor: function(type) {
-    type = this.modelFor(type);
+  metadataFor: function(typeName) {
+    var type = this.modelFor(typeName);
     return this.typeMapFor(type).metadata;
+  },
+
+  /**
+    This method sets the metadata for a specific type.
+
+    @method setMetadataFor
+    @param {String or subclass of DS.Model} typeName
+    @param {Object} metadata metadata to set
+    @return {object}
+  */
+  setMetadataFor: function(typeName, metadata) {
+    var type = this.modelFor(typeName);
+    Ember.merge(this.typeMapFor(type).metadata, metadata);
   },
 
   // ............
@@ -1521,17 +1534,14 @@ Store = Ember.Object.extend({
   },
 
   /**
-    If you have some metadata to set for a type
-    you can call `metaForType`.
-
     @method metaForType
-    @param {String or subclass of DS.Model} type
+    @param {String or subclass of DS.Model} typeName
     @param {Object} metadata
+    @deprecated Use [setMetadataFor](#method_setMetadataFor) instead
   */
   metaForType: function(typeName, metadata) {
-    var type = this.modelFor(typeName);
-
-    Ember.merge(this.typeMapFor(type).metadata, metadata);
+    Ember.deprecate('Using store.metaForType() has been deprecated. Use store.setMetadataFor() to set metadata for a specific type.');
+    this.setMetadataFor(typeName, metadata);
   },
 
   /**

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -769,7 +769,7 @@ test("findAll - since token is passed to the adapter", function() {
     ]
   });
 
-  store.metaForType('post', { since: 'now' });
+  store.setMetadataFor('post', { since: 'now' });
 
   store.findAll('post').then(async(function(posts) {
     equal(passedUrl, '/posts');

--- a/packages/ember-data/tests/unit/store/metadata_for_test.js
+++ b/packages/ember-data/tests/unit/store/metadata_for_test.js
@@ -1,0 +1,41 @@
+var store;
+
+var run = Ember.run;
+
+module("unit/store/metadata_for - DS.Store#metadataFor", {
+  setup: function() {
+    store = createStore({
+      post: DS.Model.extend(),
+      comment: DS.Model.extend()
+    });
+  },
+
+  teardown: function() {
+    run(function(){
+      store.destroy();
+    });
+  }
+});
+
+test("metaForType should be deprecated", function() {
+  expect(1);
+
+  expectDeprecation(function() {
+    store.metaForType('post', { foo: 'bar' });
+  });
+});
+
+test("metadataFor and setMetadataFor should return and set correct metadata", function() {
+  expect(4);
+
+  deepEqual(store.metadataFor('post'), {}, 'metadata for post is initially empty');
+
+  store.setMetadataFor('post', { foo: 'bar' });
+
+  deepEqual(store.metadataFor('post'), { foo: 'bar' }, 'metadata for post contains foo:bar');
+
+  store.setMetadataFor('post', { hello: 'world' });
+
+  deepEqual(store.metadataFor('post'), { foo: 'bar', hello: 'world' }, 'metadata for post contains both foo:bar and hello:world');
+  deepEqual(store.metadataFor('comment'), {}, 'metadata for comment is empty');
+});


### PR DESCRIPTION
- Deprecated store.metaForType()
- Added store.setMetadataFor() to set metadata for a specific type
- Added tests

In response to https://github.com/emberjs/data/issues/1916#issuecomment-64937289
