### PR TITLE
Include ember-data.js.map in S3 upload

### DIFF
--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -1,30 +1,30 @@
 module.exports = function(revision, tag, date){
   return {
-    'ember-data.js': fileObject('ember-data', '.js', 'text/javascript', revision, tag, date),
-    'ember-data.min.js': fileObject('ember-data.min', '.js', 'text/javascript', revision, tag, date),
-    'ember-data.prod.js': fileObject('ember-data.prod', '.js', 'text/javascript', revision, tag, date)
+    'ember-data.js': fileObject('ember-data.js', 'text/javascript', revision, tag, date),
+    'ember-data.js.map': fileObject('ember-data.js.map', 'application/json', revision, tag, date),
+    'ember-data.min.js': fileObject('ember-data.min.js', 'text/javascript', revision, tag, date),
+    'ember-data.prod.js': fileObject('ember-data.prod.js', 'text/javascript', revision, tag, date)
   }
 }
 
-function fileObject(baseName, extension, contentType, currentRevision, tag, date) {
-  var fullName = "/" + baseName + extension;
+function fileObject(fileName, contentType, currentRevision, tag, date) {
   return {
     contentType: contentType,
     destinations: {
       canary: [
-        'canary' + fullName,
-        'canary/daily/' + date + fullName,
-        'canary/shas/' + currentRevision + fullName
+        'canary' + fileName,
+        'canary/daily/' + date + fileName,
+        'canary/shas/' + currentRevision + fileName
       ],
       stable: [
-        'stable' + fullName,
-        'stable/daily/' + date + fullName,
-        'stable/shas/' + currentRevision + fullName
+        'stable' + fileName,
+        'stable/daily/' + date + fileName,
+        'stable/shas/' + currentRevision + fileName
       ],
       beta: [
-        'beta' + fullName,
-        'beta/daily/' + date + fullName,
-        'beta/shas/' + currentRevision + fullName
+        'beta' + fileName,
+        'beta/daily/' + date + fileName,
+        'beta/shas/' + currentRevision + fileName
       ]
     }
   }


### PR DESCRIPTION
Added `ember.data.js.map` to be uploaded with `application/json` as content type, I figured it's JSON in the file and should probably be treated as such.

I also modified `fileObject()` to accept a `fileName` instead of `baseName` and `extension` since they weren't used by themselves anyways.

Somewhat related #2557
