### PR TITLE
Fix async polymorphic belongsTo serialization

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -4,8 +4,7 @@ import RESTSerializer from "ember-data/serializers/rest_serializer";
   @module ember-data
 */
 
-var get = Ember.get,
-    forEach = Ember.EnumerableUtils.forEach,
+var forEach = Ember.EnumerableUtils.forEach,
     camelize =   Ember.String.camelize,
     capitalize = Ember.String.capitalize,
     decamelize = Ember.String.decamelize,
@@ -154,19 +153,18 @@ var ActiveModelSerializer = RESTSerializer.extend({
     Serializes a polymorphic type as a fully capitalized model name.
 
     @method serializePolymorphicType
-    @param {DS.Model} record
+    @param {DS.Model} record the relationship's inverse record
     @param {Object} json
-    @param {Object} relationship
+    @param {Object} relationship the relationship's descriptor
   */
   serializePolymorphicType: function(record, json, relationship) {
     var key = relationship.key;
-    var belongsTo = get(record, key);
     var jsonKey = underscore(key + "_type");
 
-    if (Ember.isNone(belongsTo)) {
+    if (Ember.isNone(record)) {
       json[jsonKey] = null;
     } else {
-      json[jsonKey] = capitalize(camelize(belongsTo.constructor.typeKey));
+      json[jsonKey] = capitalize(camelize(record.constructor.typeKey));
     }
   },
 

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -601,7 +601,13 @@ export default Ember.Object.extend({
       }
 
       if (relationship.options.polymorphic) {
-        this.serializePolymorphicType(record, json, relationship);
+        var inverseRecord;
+        if (relationship.options.async) {
+          inverseRecord = get(belongsTo, 'content');
+        } else {
+          inverseRecord = belongsTo;
+        }
+        this.serializePolymorphicType(inverseRecord, json, relationship);
       }
     }
   },
@@ -677,9 +683,9 @@ export default Ember.Object.extend({
    ```
 
     @method serializePolymorphicType
-    @param {DS.Model} record
+    @param {DS.Model} record relationship's inverse record
     @param {Object} json
-    @param {Object} relationship
+    @param {Object} relationship the relationship's descriptor
   */
   serializePolymorphicType: Ember.K,
 

--- a/packages/ember-data/lib/serializers/rest_serializer.js
+++ b/packages/ember-data/lib/serializers/rest_serializer.js
@@ -3,7 +3,6 @@
 */
 
 import JSONSerializer from "ember-data/serializers/json_serializer";
-var get = Ember.get;
 var forEach = Ember.ArrayPolyfills.forEach;
 var map = Ember.ArrayPolyfills.map;
 var camelize = Ember.String.camelize;
@@ -732,18 +731,17 @@ var RESTSerializer = JSONSerializer.extend({
     the attribute and value from the model's camelcased model name.
 
     @method serializePolymorphicType
-    @param {DS.Model} record
+    @param {DS.Model} record the relationship's inverse record
     @param {Object} json
-    @param {Object} relationship
+    @param {Object} relationship the relationship's descriptor
   */
   serializePolymorphicType: function(record, json, relationship) {
     var key = relationship.key;
-    var belongsTo = get(record, key);
     key = this.keyForAttribute ? this.keyForAttribute(key) : key;
-    if (Ember.isNone(belongsTo)) {
+    if (Ember.isNone(record)) {
       json[key + "Type"] = null;
     } else {
-      json[key + "Type"] = Ember.String.camelize(belongsTo.constructor.typeKey);
+      json[key + "Type"] = Ember.String.camelize(record.constructor.typeKey);
     }
   }
 });


### PR DESCRIPTION
Closes #2551, Fixes #2385, Fixes #2508, Closes #1491

Very naive implementation, also I didn't change anything in the embedded mixin because I don't know how/if it's supposed to be handled.

When reading #1535, I'm assuming the serialization process stays synchronous.

I think this should be considered as a breaking change because even if the signature does not change, the passed record to `serializePolymorphicType` is the inverse record instead of the record itself.

cc/ @jherdman @igorT 