### PR TITLE
Removed unused notify on 'data' property

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -473,7 +473,6 @@ var RootState = {
 
     loadedData: function(record) {
       record.transitionTo('loaded.created.uncommitted');
-      record.notifyPropertyChange('data');
     },
 
     pushedData: function(record) {


### PR DESCRIPTION
Since #2460 removed all properties with `data` as a dependent key, this `notifyPropertyChange` call has no function.
