### PR TITLE
fix incorrect iteration issues in Relationship#clear

### DIFF
--- a/packages/ember-data/lib/system/relationships/relationship.js
+++ b/packages/ember-data/lib/system/relationships/relationship.js
@@ -29,9 +29,13 @@ Relationship.prototype = {
   destroy: Ember.K,
 
   clear: function() {
-    this.members.forEach(function(member) {
+    var members = this.members.list;
+    var member;
+
+    while (members.length > 0){
+      member = members[0];
       this.removeRecord(member);
-    }, this);
+    }
   },
 
   disconnect: function(){

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -1020,6 +1020,36 @@ test("Passing a model as type to hasMany should not work", function () {
   }, /The first argument to DS.hasMany must be a string/);
 });
 
+test("Relationship.clear removes all records correctly", function(){
+  var post;
+
+  run(function(){
+    post = env.store.push('post', { id: 2, title: 'Sailing the Seven Seas', comments: [1,2] });
+    env.store.pushMany('comment', [
+      {
+        id: 1,
+        post: 2
+      },
+      {
+        id: 2,
+        post: 2
+      },
+      {
+        id: 3,
+        post: 2
+      }
+    ]);
+  });
+
+  run(function(){
+    post._relationships['comments'].clear();
+    var comments = Em.A(env.store.all('comment'));
+    deepEqual(comments.mapBy('post'), [undefined, undefined, undefined]);
+  });
+
+});
+
+
 test('unloading a record with associated records does not prevent the store from tearing down', function(){
   var post;
 


### PR DESCRIPTION
currently, Relationship.prototype.clear uses the `forEach` from Ember.Set/OrderedSet. The implementation of forEach looks like:

``` javascript
forEach = function(callback) {
  for(var i =0; i < this.members.length; i++){
    callback(this.members[i]);
  }
}
```

If you are _mutating_ the set (adding or removing) in the callback passed to forEach, you will run into subtle bugs. For instance, the forEach callback may not be called with records in the set, which is what happened to trigger the bug demonstrated by the failing test case commit.
