### PR TITLE
Add queryOne method

### DIFF
--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -1254,6 +1254,24 @@ export default Serializer.extend({
     return this.extractArray(store, typeClass, payload, id, requestType);
   },
   /**
+    TODO: remove this in a couple of days
+
+    `extractQueryRecord` is a hook into the extract method used when a
+    call is made to `DS.Store#queryRecord`. By default this method is an
+    alias for [extractSingle](#method_extractSingle).
+
+    @method extractQueryRecord
+    @param {DS.Store} store
+    @param {DS.Model} typeClass
+    @param {Object} payload
+    @param {(String|Number)} id
+    @param {String} requestType
+    @return {Object} object A hash of deserialized object
+  */
+  extractQueryRecord: function(store, typeClass, payload, id, requestType) {
+    return this.extractSingle(store, typeClass, payload, id, requestType);
+  },
+  /**
     `extractFindMany` is a hook into the extract method used when a
     call is made to `DS.Store#findMany`. By default this method is
     alias for [extractArray](#method_extractArray).

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -190,6 +190,44 @@ var Adapter = Ember.Object.extend({
   findQuery: null,
 
   /**
+    The `queryRecord()` method is invoked when the store is asked for a single
+    record through a query object.
+
+    In response to `queryRecord()` being called, you should always fetch fresh
+    data. Once found, you can asynchronously call the store's `push()` method
+    to push the record into the store.
+
+    Here is an example `queryRecord` implementation:
+
+    Example
+
+    ```javascript
+    App.ApplicationAdapter = DS.Adapter.extend({
+      queryRecord: function(store, typeClass, query) {
+        var url = [type.typeKey, id].join('/');
+
+        return new Ember.RSVP.Promise(function(resolve, reject) {
+          jQuery.getJSON(url, query).then(function(data) {
+            Ember.run(null, resolve, data);
+          }, function(jqXHR) {
+            jqXHR.then = null; // tame jQuery's ill mannered promises
+            Ember.run(null, reject, jqXHR);
+          });
+        });
+      }
+    });
+    ```
+
+    @method queryRecord
+    @param {DS.Store} store
+    @param {subclass of DS.Model} type
+    @param {Object} query
+    @param {String} id
+    @return {Promise} promise
+  */
+  queryRecord: null,
+
+  /**
     If the globally unique IDs for your records should be generated on the client,
     implement the `generateIdForRecord()` method. This method will be invoked
     each time you create a new record, and the value returned from it will be

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -165,3 +165,25 @@ export function _query(adapter, store, typeClass, query, recordArray) {
 
   }, null, "DS: Extract payload of findQuery " + typeClass);
 }
+
+export function _queryRecord(adapter, store, typeClass, query) {
+  var modelName = typeClass.modelName;
+  var promise = adapter.queryRecord(store, typeClass, query);
+  var serializer = serializerForAdapter(store, adapter, modelName);
+  var label = "DS: Handle Adapter#queryRecord of " + typeClass;
+
+  promise = Promise.cast(promise, label);
+  promise = _guard(promise, _bind(_objectIsAlive, store));
+
+  return promise.then(function(adapterPayload) {
+    var record;
+    store._adapterRun(function() {
+      var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'queryRecord');
+      //TODO Optimize
+      record = pushPayload(store, payload);
+    });
+
+    return record;
+
+  }, null, "DS: Extract payload of queryRecord " + typeClass);
+}

--- a/packages/ember-data/tests/integration/store/query-record-test.js
+++ b/packages/ember-data/tests/integration/store/query-record-test.js
@@ -1,0 +1,63 @@
+var Person, store, env;
+var run = Ember.run;
+
+module("integration/store/query-record - Query one record with a query hash", {
+  setup: function() {
+    Person = DS.Model.extend({
+      updatedAt: DS.attr('string'),
+      name: DS.attr('string'),
+      firstName: DS.attr('string'),
+      lastName: DS.attr('string')
+    });
+
+    env = setupStore({
+      person: Person
+    });
+    store = env.store;
+  },
+
+  teardown: function() {
+    run(store, 'destroy');
+  }
+});
+
+test("It raises an assertion when no type is passed", function() {
+  expectAssertion(function() {
+    store.queryRecord();
+  }, "You need to pass a type to the store's queryRecord method");
+});
+
+test("It raises an assertion when no query hash is passed", function() {
+  expectAssertion(function() {
+    store.queryRecord('person');
+  }, "You need to pass a query hash to the store's queryRecord method");
+});
+
+test("When a record is requested, the adapter's queryRecord method should be called.", function() {
+  expect(1);
+
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    queryRecord: function(store, type, query) {
+      equal(type, Person, "the query method is called with the correct type");
+      return Ember.RSVP.resolve({ id: 1, name: "Peter Wagenet" });
+    }
+  }));
+
+  run(function() {
+    store.queryRecord('person', { related: 'posts' });
+  });
+});
+
+test("When a record is requested, and the promise is rejected, .queryRecord() is rejected.", function() {
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    queryRecord: function(store, type, query) {
+      return Ember.RSVP.reject();
+    }
+  }));
+
+  run(function() {
+    store.queryRecord('person', {}).then(null, async(function(reason) {
+      ok(true, "The rejection handler was called");
+    }));
+  });
+});


### PR DESCRIPTION
The findQueryOne method let developers query their server-side API for a single record and also pass a query parameter to this call.

For instance, you could do the following:

```javascript
this.store.findQueryOne('post', 1, { include: 'comments' });
```