### PR TITLE
Work around type check issues with MODEL_FACTORY_INJECTIONS.

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs_to.js
@@ -62,7 +62,15 @@ BelongsToRelationship.prototype._super$addRecord = Relationship.prototype.addRec
 BelongsToRelationship.prototype.addRecord = function(newRecord) {
   if (this.members.has(newRecord)){ return;}
   var type = this.relationshipMeta.type;
-  Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", newRecord instanceof type);
+  Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", (function () {
+    if (newRecord instanceof type) {
+      return true;
+    } else if (Ember.MODEL_FACTORY_INJECTIONS) {
+      return newRecord instanceof type.superclass;
+    }
+
+    return false;
+  })());
 
   if (this.inverseRecord) {
     this.removeRecord(this.inverseRecord);

--- a/packages/ember-data/lib/system/relationships/state/has_many.js
+++ b/packages/ember-data/lib/system/relationships/state/has_many.js
@@ -78,7 +78,17 @@ ManyRelationship.prototype.removeRecordFromOwn = function(record, idx) {
 };
 
 ManyRelationship.prototype.notifyRecordRelationshipAdded = function(record, idx) {
-  Ember.assert("You cannot add '" + record.constructor.typeKey + "' records to this relationship (only '" + this.belongsToType.typeKey + "' allowed)", !this.belongsToType || record instanceof this.belongsToType);
+  var type = this.relationshipMeta.type;
+  Ember.assert("You cannot add '" + record.constructor.typeKey + "' records to the " + this.record.constructor.typeKey + "." + this.key + " relationship (only '" + this.belongsToType.typeKey + "' allowed)", (function () {
+    if (record instanceof type) {
+      return true;
+    } else if (Ember.MODEL_FACTORY_INJECTIONS) {
+      return record instanceof type.superclass;
+    }
+
+    return false;
+  })());
+
   this.record.notifyHasManyAdded(this.key, record, idx);
 };
 

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -13,13 +13,13 @@ module("integration/relationship/belongs_to Belongs-To Relationships", {
   setup: function() {
     User = DS.Model.extend({
       name: attr('string'),
-      messages: hasMany('message', {polymorphic: true})
-      //favouriteMessage: belongsTo('message', {polymorphic: true})
+      messages: hasMany('message', {polymorphic: true}),
+      favouriteMessage: belongsTo('message', {polymorphic: true, inverse: null}),
     });
     User.toString = stringify('User');
 
     Message = DS.Model.extend({
-      user: belongsTo('user'),
+      user: belongsTo('user', { inverse: 'messages' }),
       created_at: attr('date')
     });
     Message.toString = stringify('Message');
@@ -290,6 +290,26 @@ test("A record with an async belongsTo relationship returning null should resolv
   })).then(async(function(group) {
     ok(group === null, "group should be null");
   }));
+});
+
+test("polymorphic belongsTo type-checks check the superclass when MODEL_FACTORY_INJECTIONS is enabled", function() {
+  expect(1);
+
+  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
+  Ember.MODEL_FACTORY_INJECTIONS = true;
+
+  try {
+    run(function () {
+      var igor = env.store.createRecord('user', { name: 'Igor' });
+      var post = env.store.createRecord('post', { title: "Igor's unimaginative blog post" });
+
+      igor.set('favouriteMessage', post);
+
+      equal(igor.get('favouriteMessage.title'), "Igor's unimaginative blog post");
+    });
+  } finally {
+    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+  }
 });
 
 test("relationshipsByName does not cache a factory", function() {

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -628,6 +628,28 @@ test("When a polymorphic hasMany relationship is accessed, the store can call mu
   });
 });
 
+test("polymorphic hasMany type-checks check the superclass when MODEL_FACTORY_INJECTIONS is enabled", function() {
+  expect(1);
+
+  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
+  Ember.MODEL_FACTORY_INJECTIONS = true;
+
+  try {
+    run(function () {
+      var igor = env.store.createRecord('user', { name: 'Igor' });
+      var comment = env.store.createRecord('comment', { body: "Well I thought the title was fine" });
+
+      igor.get('messages').addObject(comment);
+
+      equal(igor.get('messages.firstObject.body'), "Well I thought the title was fine");
+    });
+  } finally {
+    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+  }
+});
+
+
+
 test("Type can be inferred from the key of a hasMany relationship", function() {
   expect(1);
   run(function(){
@@ -731,7 +753,7 @@ test("Only records of the same type can be added to a monomorphic hasMany relati
     Ember.RSVP.all([ env.store.find('post', 1), env.store.find('post', 2) ]).then(function(records) {
       expectAssertion(function() {
         records[0].get('comments').pushObject(records[1]);
-      }, /You cannot add 'post' records to this relationship/);
+      }, /You cannot add 'post' records to the post.comments relationship \(only 'comment' allowed\)/);
     });
   });
 });
@@ -764,7 +786,7 @@ test("Only records of the same base type can be added to a polymorphic hasMany r
 
       expectAssertion(function() {
         records.messages.pushObject(records.anotherUser);
-      }, /You cannot add 'user' records to this relationship/);
+      }, /You cannot add 'user' records to the user.messages relationship \(only 'message' allowed\)/);
     });
   });
 });


### PR DESCRIPTION
The container subclasses types retrieved via `modelFor`, so that if A is a
subtype of B, modelFor('model:A') will not be a subtype of
modelFor('model:B'). This breaks the type check for polymorphic
associations.

This commit works around this issue by checking the superclass when doing
its type checks, if MODEL_FACTORY_INJECTIONS is enabled.

Paired with @igort
