### PR TITLE
Document and explicitely test specifying relationships type is optional

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -41,11 +41,22 @@ import { Model } from 'ember-data/system/model';
   });
   ```
 
+  You can avoid passing a string as the first parameter. In that case Ember Data
+  will infer the type from the key name.
+
+  ```javascript
+  App.Comment = DS.Model.extend({
+    post: DS.belongsTo()
+  });
+  ```
+
+  will lookup for a Post type.
+
   @namespace
   @method belongsTo
   @for DS
-  @param {String} type the model type of the relationship
-  @param {Object} options a hash of options
+  @param {String} type (optional) type of the relationship
+  @param {Object} options (optional) a hash of options
   @return {Ember.computed} relationship
 */
 function belongsTo(type, options) {

--- a/packages/ember-data/lib/system/relationships/has_many.js
+++ b/packages/ember-data/lib/system/relationships/has_many.js
@@ -42,6 +42,17 @@ import { Model } from "ember-data/system/model";
   });
   ```
 
+  You can avoid passing a string as the first parameter. In that case Ember Data
+  will infer the type from the singularized key name.
+
+  ```javascript
+  App.Post = DS.Model.extend({
+    tags: DS.hasMany()
+  });
+  ```
+
+  will lookup for a Tag type.
+
   #### Explicit Inverses
 
   Ember Data will do its best to discover which relationships map to
@@ -78,8 +89,8 @@ import { Model } from "ember-data/system/model";
   @namespace
   @method hasMany
   @for DS
-  @param {String} type the model type of the relationship
-  @param {Object} options a hash of options
+  @param {String} type (optional) type of the relationship
+  @param {Object} options (optional) a hash of options
   @return {Ember.computed} relationship
 */
 function hasMany(type, options) {

--- a/packages/ember-data/tests/unit/model/relationships_test.js
+++ b/packages/ember-data/tests/unit/model/relationships_test.js
@@ -194,37 +194,25 @@ test("hasMany lazily loads async relationships", function() {
   });
 });
 
-test("should be able to retrieve the type for a hasMany relationship from its metadata", function() {
-  var Tag = DS.Model.extend({
-    name: DS.attr('string')
-  });
+test("should be able to retrieve the type for a hasMany relationship without specifying a type from its metadata", function() {
+  var Tag = DS.Model.extend({});
 
   var Person = DS.Model.extend({
-    name: DS.attr('string'),
-    tags: DS.hasMany('tag')
+    tags: DS.hasMany()
   });
 
-  var store = createStore({
+  var env = setupStore({
     tag: Tag,
     person: Person
   });
-  var tag, person;
 
-  run(function() {
-    tag = store.createRecord('tag');
-    person = store.createRecord('person');
-  });
-
-  equal(Person.typeForRelationship('tags'), Tag, "returns the relationship type");
+  equal(env.store.modelFor('person').typeForRelationship('tags'), Tag, "returns the relationship type");
 });
 
 test("should be able to retrieve the type for a hasMany relationship specified using a string from its metadata", function() {
-  var Tag = DS.Model.extend({
-    name: DS.attr('string')
-  });
+  var Tag = DS.Model.extend({});
 
   var Person = DS.Model.extend({
-    name: DS.attr('string'),
     tags: DS.hasMany('tag')
   });
 
@@ -236,14 +224,11 @@ test("should be able to retrieve the type for a hasMany relationship specified u
   equal(env.store.modelFor('person').typeForRelationship('tags'), Tag, "returns the relationship type");
 });
 
-test("should be able to retrieve the type for a belongsTo relationship from its metadata", function() {
-  var Tag = DS.Model.extend({
-    name: DS.attr('string')
-  });
+test("should be able to retrieve the type for a belongsTo relationship without specifying a type from its metadata", function() {
+  var Tag = DS.Model.extend({});
 
   var Person = DS.Model.extend({
-    name: DS.attr('string'),
-    tags: DS.belongsTo('tag')
+    tag: DS.belongsTo()
   });
 
   var env = setupStore({
@@ -251,7 +236,7 @@ test("should be able to retrieve the type for a belongsTo relationship from its 
     person: Person
   });
 
-  equal(env.store.modelFor('person').typeForRelationship('tags'), Tag, "returns the relationship type");
+  equal(env.store.modelFor('person').typeForRelationship('tag'), Tag, "returns the relationship type");
 });
 
 test("should be able to retrieve the type for a belongsTo relationship specified using a string from its metadata", function() {
@@ -260,7 +245,6 @@ test("should be able to retrieve the type for a belongsTo relationship specified
   });
 
   var Person = DS.Model.extend({
-    name: DS.attr('string'),
     tags: DS.belongsTo('tag')
   });
 


### PR DESCRIPTION
First shot to fix #2531. Probably needs doc rewrite :)

cc @igorT 

As a side note, #2529 made effectively that work for belongsTo, thanks @wecc
