### PR TITLE
EmbeddedRecordsMixin with Multiple Stores

### DIFF
--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -1014,7 +1014,67 @@ export default Ember.Object.extend({
     }
     return payload;
   },
+  
+  // LOAD
+  
+  /**
+    
+    
+    TBC
+    
+    @method pushIntoStore
+    @param {DS.Store} store
+    @param {String or subclass of DS.Model} type
+    @param {Object} data
+    
+    @return {DS.Model} the record that was created or updated 
+      from the store.
+  */
+  
+  // TODO: remove this? should it only be used/defined in EmbeddedRecordsMixin
+  
+  //pushIntoStore: function(store, type, data) {
+  //  return store.push(type, data);
+  //},
+  
+  /**
+    
+    TBC
+    
+    @method pushManyIntoStore
+    @param {DS.Store} store
+    @param {String or subclass of DS.Model} type
+    @param {Array} datas
+    @return {Array}
 
+  */
+  
+  // TODO: remove this? should it only be used/defined in EmbeddedRecordsMixin
+  
+  //pushManyIntoStore: function(store, type, datas) {
+  //  return store.pushMany(type, datas);
+  //},
+  
+  /**
+    
+    TBC
+    
+    @method loadRecordArray
+    @param {DS.RecordArray} recordArray
+    @param {DS.Store} store
+    @param {subclass of DS.Model} type
+    @param {Array} datas
+    
+    @return {DS.RecordArray}
+  */
+  
+  // TODO: remove this? should it only be used/defined in EmbeddedRecordsMixin
+  
+  //loadRecordArray: function(recordArray, store, type, datas) {
+  //  recordArray.load(datas);
+  //  return recordArray;
+  //},
+  
   /**
    `keyForAttribute` can be used to define rules for how to convert an
    attribute name in your model to a key in your JSON.


### PR DESCRIPTION
This pull request is related to issue #2588.

When using more then one store the EmbeddedRecordsMixin fails.

These changes remove the EmbeddedRecordsMixin#normalise function (breaking change?) and define 3 new methods used on serialisers:
- pushIntoStore
- pushManyIntoStore
- loadRecordArray (not yet tested)

This is a first attempt at this and I'm not 100% that these methods are in the right place but the rationale behind it was I didn't think it made sense that the normalize function shouldn't be pushing data to the store.

If implemented in this way it may make sense that extractSingle/extractArray also use these functions rather than push to the store themselves. Also thinking now that if implemented in this way the normalize function should be returned but deprecated if possible?

As a consequence of doing these changes another issue was discovered (see [comments](https://github.com/jmurphyau/data/commit/3b86a4afeea78e2107778fc0e4e436bf7e2fd1cb#diff-f33931d6152ee09540f3827cd4d64417R226)) and some tests have been changed to explicitly work around this. I'll investigate this a bit more and log it as a separate issue.

This is my first pull request on GitHub and I'm not sure on how they work (can it be updated later with new commits?) - but I don't expect this to be implemented as is. If it's decided to be implemented like this I would expect some more changes are required (e.g. documentation, issue above resolved, deprecated warnings (?), etc). I wanted to log this to get thoughts on the implementation before doing those things.
