### PR TITLE
Fixed model rollback in the case where an attribute is not assigned so t...

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -907,6 +907,8 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @method rollback
   */
   rollback: function() {
+    var dirtyKeys = this.dirtyKeys();
+
     this._attributes = Ember.create(null);
 
     if (get(this, 'isError')) {
@@ -931,8 +933,17 @@ var Model = Ember.Object.extend(Ember.Evented, {
 
     this.send('rolledBack');
 
-    this._notifyProperties(Ember.keys(this._data));
+    this._notifyProperties(dirtyKeys);
+  },
 
+  dirtyKeys: function() {
+    var keys = Ember.keys(this._attributes);
+
+    if (get(this, 'isNew')) {
+      keys.concat(Ember.keys(this._data));
+    }
+
+    return keys;
   },
 
   toStringExtension: function() {

--- a/packages/ember-data/tests/unit/model/rollback_test.js
+++ b/packages/ember-data/tests/unit/model/rollback_test.js
@@ -30,6 +30,23 @@ test("changes to attributes can be rolled back", function() {
   equal(person.get('isDirty'), false);
 });
 
+test("changes to unassigned attributes can be rolled back", function() {
+  var person;
+  run(function(){
+    person = store.push('person', { id: 1, lastName: "Dale" });
+    person.set('firstName', "Thomas");
+  });
+
+  equal(person.get('firstName'), "Thomas");
+
+  run(function(){
+    person.rollback();
+  });
+
+  equal(person.get('firstName'), undefined);
+  equal(person.get('isDirty'), false);
+});
+
 test("changes to attributes made after a record is in-flight only rolls back the local changes", function() {
   env.adapter.updateRecord = function(store, type, record) {
     // Make sure the save is async


### PR DESCRIPTION
Came across this issue when the server does not populate all attributes on a model on load and then the unassigned attribute gets assigned a value and rollback is attempted but the attribute's cached value remains.
