### PR TITLE
ActiveModelAdapter doesn't camelize errors

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_adapter.js
+++ b/packages/activemodel-adapter/lib/system/active_model_adapter.js
@@ -7,7 +7,8 @@ import {pluralize} from "ember-inflector";
 */
 
 var decamelize = Ember.String.decamelize,
-    underscore = Ember.String.underscore;
+    underscore = Ember.String.underscore,
+    camelize   = Ember.String.camelize;
 
 /**
   The ActiveModelAdapter is a subclass of the RESTAdapter designed to integrate
@@ -141,7 +142,16 @@ var ActiveModelAdapter = RESTAdapter.extend({
     var error = this._super(jqXHR);
 
     if (jqXHR && jqXHR.status === 422) {
-      return new InvalidError(Ember.$.parseJSON(jqXHR.responseText));
+      var parsedError = Ember.$.parseJSON(jqXHR.responseText);
+      var camelizedErrors = {};
+
+      for(var key in parsedError.errors) {
+        camelizedErrors[camelize(key)] = parsedError.errors[key];
+      }
+
+      parsedError.errors = camelizedErrors;
+
+      return new InvalidError(parsedError);
     } else {
       return error;
     }

--- a/packages/activemodel-adapter/tests/integration/active_model_adapter_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_adapter_test.js
@@ -41,7 +41,7 @@ test('ajaxError - invalid error has camelized keys', function() {
 
   var ajaxResponse = adapter.ajaxError(jqXHR);
 
-  equal(Ember.keys(ajaxResponse.errors.errors), Ember.keys(error.errors.errors));
+  deepEqual(Ember.keys(ajaxResponse.errors.errors), Ember.keys(error.errors.errors));
 });
 
 test('ajaxError - returns ajax response if not 422 response', function() {


### PR DESCRIPTION
As explained in #2600, the ActiveModelAdapter doesn't camelize the errors in `ajaxResponse` which causes them to not be included in the models errors hash.
This is a first attempt at fixing the issue, as far as I've tested "it works for me" (tm)
