### PR TITLE
Correctly rollback attributes only set on the client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ docs/node_modules/
 node_modules/
 bower_components/
 .metadata_never_index
+*.swp

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -907,9 +907,11 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @method rollback
   */
   rollback: function() {
+    var toNotify = this._attributes;
     this._attributes = Ember.create(null);
 
     if (get(this, 'isError')) {
+      Ember.merge(toNotify, this._inFlightAttributes);
       this._inFlightAttributes = Ember.create(null);
       set(this, 'isError', false);
     }
@@ -926,12 +928,13 @@ var Model = Ember.Object.extend(Ember.Evented, {
     }
 
     if (!get(this, 'isValid')) {
+      Ember.merge(toNotify, this._inFlightAttributes);
       this._inFlightAttributes = Ember.create(null);
     }
 
     this.send('rolledBack');
 
-    this._notifyProperties(Ember.keys(this._data));
+    this._notifyProperties(Ember.keys(toNotify));
 
   },
 

--- a/packages/ember-data/tests/unit/model/rollback_test.js
+++ b/packages/ember-data/tests/unit/model/rollback_test.js
@@ -141,6 +141,21 @@ test("new record can be rollbacked", function() {
   equal(person.get('isDeleted'), true, "must be deleted");
 });
 
+test("locally set attributes can be rolled back", function() {
+  var person;
+
+  run(function(){
+    person = store.push('person', { id: 1 });
+    person.set('firstName', 'wecc');
+  });
+
+
+  equal(person.get('firstName'), 'wecc', "firstName is set originally");
+  Ember.run(person, 'rollback');
+
+  equal(person.get('firstName'), undefined, "must be deleted");
+});
+
 test("deleted record can be rollbacked", function() {
   var person, people;
 


### PR DESCRIPTION
Previous if the server did not provide any value for an attribute,
and the value was set only locally we would fail to roll it back properly.
We now correctly(I hope) deduce which attributes need to be reset.

This change has a side effect of only resetting/notifying the changes of attributes
that were modified from their server state.

cc @wecc 
