### PR TITLE
[DOC] Fix markup for AcriveModelAdapter

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_adapter.js
+++ b/packages/activemodel-adapter/lib/system/active_model_adapter.js
@@ -13,7 +13,7 @@ var decamelize = Ember.String.decamelize,
   The ActiveModelAdapter is a subclass of the RESTAdapter designed to integrate
   with a JSON API that uses an underscored naming convention instead of camelCasing.
   It has been designed to work out of the box with the
-  [active_model_serializers](http://github.com/rails-api/active_model_serializers)
+  [active\_model\_serializers](http://github.com/rails-api/active_model_serializers)
   Ruby gem. This Adapter expects specific settings using ActiveModel::Serializers,
   `embed :ids, embed_in_root: true` which sideloads the records.
 

--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -14,7 +14,7 @@ var get = Ember.get,
   The ActiveModelSerializer is a subclass of the RESTSerializer designed to integrate
   with a JSON API that uses an underscored naming convention instead of camelCasing.
   It has been designed to work out of the box with the
-  [active_model_serializers](http://github.com/rails-api/active_model_serializers)
+  [active\_model\_serializers](http://github.com/rails-api/active_model_serializers)
   Ruby gem. This Serializer expects specific settings using ActiveModel::Serializers,
   `embed :ids, embed_in_root: true` which sideloads the records.
 


### PR DESCRIPTION
`active_model_serializer` will be rendered to `active<em>model</em>serializer` against our expectation.
`_` should be escaped.

Before:
![2014-12-21 3 38 42](https://cloud.githubusercontent.com/assets/290782/5515876/36d15250-88c3-11e4-8b35-fce543be512f.png)

After:
![2014-12-21 3 41 26](https://cloud.githubusercontent.com/assets/290782/5515878/45ce3426-88c3-11e4-9a61-ced9da25c95a.png)
