### PR TITLE
[DOC] Add page for `DS.PromiseManyArray`

### DIFF
--- a/packages/ember-data/lib/system/promise_proxies.js
+++ b/packages/ember-data/lib/system/promise_proxies.js
@@ -79,13 +79,18 @@ var promiseArray = function(promise, label) {
   A PromiseManyArray is a PromiseArray that also proxies certain method calls
   to the underlying manyArray.
   Right now we proxy:
-    `reload()`
-    `createRecord()`
-    `on()`
-    `one()`
-    `trigger()`
-    `off()`
-    `has()`
+
+    * `reload()`
+    * `createRecord()`
+    * `on()`
+    * `one()`
+    * `trigger()`
+    * `off()`
+    * `has()`
+
+  @class PromiseManyArray
+  @namespace DS
+  @extends Ember.ArrayProxy
 */
 
 function proxyToContent(method) {


### PR DESCRIPTION
The following page will be rendered by `@class PromiseManyArray`(current master branch has no this page).
![2014-12-21 3 50 30](https://cloud.githubusercontent.com/assets/290782/5515902/bd232300-88c4-11e4-9049-6e0bd39bced3.png)
