### PR TITLE
WIP: Add options hash to model.save

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -334,6 +334,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type   the DS.Model class of the record
     @param {DS.Model} record
+    @param {Object} options
     @return {Promise} promise
   */
   createRecord: Ember.required(Function),
@@ -374,6 +375,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type   the DS.Model class of the record
     @param {DS.Model} record
+    @param {Object} options
     @return {Promise} promise
   */
   updateRecord: Ember.required(Function),
@@ -414,6 +416,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type   the DS.Model class of the record
     @param {DS.Model} record
+    @param {Object} options
     @return {Promise} promise
   */
   deleteRecord: Ember.required(Function),

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -958,11 +958,11 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @return {Promise} a promise that will be resolved when the adapter returns
     successfully or rejected if the adapter returns with an error.
   */
-  save: function() {
-    var promiseLabel = "DS: Model#save " + this;
+  save: function(options) {
+    var promiseLabel = 'DS: Model#save ' + this;
     var resolver = Ember.RSVP.defer(promiseLabel);
 
-    this.get('store').scheduleSave(this, resolver);
+    this.get('store').scheduleSave(this, resolver, options);
     this._inFlightAttributes = this._attributes;
     this._attributes = Ember.create(null);
 

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -955,6 +955,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     });
     ```
     @method save
+    @param {Object} options a hash specifying save options sent to the server.
     @return {Promise} a promise that will be resolved when the adapter returns
     successfully or rejected if the adapter returns with an error.
   */

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1131,10 +1131,15 @@ Store = Ember.Object.extend({
     @private
     @param {DS.Model} record
     @param {Resolver} resolver
+    @param {Object} options
   */
-  scheduleSave: function(record, resolver) {
+  scheduleSave: function(record, resolver, options) {
     record.adapterWillCommit();
-    this._pendingSave.push([record, resolver]);
+    this._pendingSave.push({
+      record: record,
+      resolver: resolver,
+      options: options
+    });
     once(this, 'flushPendingSave');
   },
 
@@ -1149,8 +1154,10 @@ Store = Ember.Object.extend({
     var pending = this._pendingSave.slice();
     this._pendingSave = [];
 
-    forEach(pending, function(tuple) {
-      var record = tuple[0], resolver = tuple[1];
+    forEach(pending, function(pendingItem) {
+      var record = pendingItem.record;
+      var resolver = pendingItem.resolver;
+      var options = pendingItem.options;
       var adapter = this.adapterFor(record.constructor);
       var operation;
 
@@ -1164,7 +1171,7 @@ Store = Ember.Object.extend({
         operation = 'updateRecord';
       }
 
-      resolver.resolve(_commit(adapter, this, operation, record));
+      resolver.resolve(_commit(adapter, this, operation, record, options));
     }, this);
   },
 
@@ -1967,9 +1974,9 @@ function _findQuery(adapter, store, type, query, recordArray) {
   }, null, "DS: Extract payload of findQuery " + type);
 }
 
-function _commit(adapter, store, operation, record) {
+function _commit(adapter, store, operation, record, options) {
   var type = record.constructor;
-  var promise = adapter[operation](store, type, record);
+  var promise = adapter[operation](store, type, record, options);
   var serializer = serializerForAdapter(adapter, type);
   var label = "DS: Extract and notify about " + operation + " completion of " + record;
 


### PR DESCRIPTION
**WIP - Don't merge or close please**

## Use Case

Creating more specific methods apart from the basic CRUD methods.

For example:

```js
user.revoke();
// DELETE api/users/123/revoke
```
Where the endpoint checks if the user has accepted the invitation, if not it's revoked. 

Passing options to `Model#save` allows for creating methods like this, instead of writing
ajax calls and executing `model.unloadRecord()`.

## Usage

The hash is passed to `model.save({ /* .. */ });` and passed to the adapter method that is
responsible for the save, where the adapter will do what's needed, usually passing the data to the server, or to the serializer.

## Questions to Address
- [x] Should the adapter accept another argument, or pass via model as `model._options` or something.
  * pass another argument to adapter/serializer
- [ ] Should options be passed via QPs or the body, e.g. `{ meta: { /* here */ } }` or directly for delete

cc @igorT @grapho 