### PR TITLE
Initial implementation of the Snapshot API

### DIFF
--- a/packages/activemodel-adapter/lib/system/active_model_serializer.js
+++ b/packages/activemodel-adapter/lib/system/active_model_serializer.js
@@ -4,12 +4,12 @@ import RESTSerializer from "ember-data/serializers/rest_serializer";
   @module ember-data
 */
 
-var get = Ember.get;
 var forEach = Ember.EnumerableUtils.forEach;
 var camelize =   Ember.String.camelize;
 var capitalize = Ember.String.capitalize;
 var decamelize = Ember.String.decamelize;
 var underscore = Ember.String.underscore;
+
 /**
   The ActiveModelSerializer is a subclass of the RESTSerializer designed to integrate
   with a JSON API that uses an underscored naming convention instead of camelCasing.
@@ -142,31 +142,31 @@ var ActiveModelSerializer = RESTSerializer.extend({
     @method serializeIntoHash
     @param {Object} hash
     @param {subclass of DS.Model} type
-    @param {DS.Model} record
+    @param {DS.Snapshot} snapshot
     @param {Object} options
   */
-  serializeIntoHash: function(data, type, record, options) {
+  serializeIntoHash: function(data, type, snapshot, options) {
     var root = underscore(decamelize(type.typeKey));
-    data[root] = this.serialize(record, options);
+    data[root] = this.serialize(snapshot, options);
   },
 
   /**
     Serializes a polymorphic type as a fully capitalized model name.
 
     @method serializePolymorphicType
-    @param {DS.Model} record
+    @param {DS.Snapshot} snapshot
     @param {Object} json
     @param {Object} relationship
   */
-  serializePolymorphicType: function(record, json, relationship) {
+  serializePolymorphicType: function(snapshot, json, relationship) {
     var key = relationship.key;
-    var belongsTo = get(record, key);
+    var belongsTo = snapshot.belongsTo(key);
     var jsonKey = underscore(key + "_type");
 
     if (Ember.isNone(belongsTo)) {
       json[jsonKey] = null;
     } else {
-      json[jsonKey] = capitalize(camelize(belongsTo.constructor.typeKey));
+      json[jsonKey] = capitalize(camelize(belongsTo.typeKey));
     }
   },
 

--- a/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
@@ -60,7 +60,7 @@ test("serialize", function() {
     tom           = env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league });
   });
 
-  var json = env.amsSerializer.serialize(tom);
+  var json = env.amsSerializer.serialize(tom._createSnapshot());
 
   deepEqual(json, {
     first_name: "Tom",
@@ -75,7 +75,7 @@ test("serializeIntoHash", function() {
   });
   var json = {};
 
-  env.amsSerializer.serializeIntoHash(json, HomePlanet, league);
+  env.amsSerializer.serializeIntoHash(json, HomePlanet, league._createSnapshot());
 
   deepEqual(json, {
     home_planet: {
@@ -91,7 +91,7 @@ test("serializeIntoHash with decamelized types", function() {
   });
   var json = {};
 
-  env.amsSerializer.serializeIntoHash(json, HomePlanet, league);
+  env.amsSerializer.serializeIntoHash(json, HomePlanet, league._createSnapshot());
 
   deepEqual(json, {
     home_planet: {
@@ -195,7 +195,7 @@ test("serialize polymorphic", function() {
     ray = env.store.createRecord(DoomsdayDevice, { evilMinion: tom, name: "DeathRay" });
   });
 
-  var json = env.amsSerializer.serialize(ray);
+  var json = env.amsSerializer.serialize(ray._createSnapshot());
 
   deepEqual(json, {
     name: "DeathRay",
@@ -212,7 +212,7 @@ test("serialize polymorphic when type key is not camelized", function() {
     ray = env.store.createRecord(DoomsdayDevice, { evilMinion: tom, name: "DeathRay" });
   });
 
-  var json = env.amsSerializer.serialize(ray);
+  var json = env.amsSerializer.serialize(ray._createSnapshot());
 
   deepEqual(json["evil_minion_type"], "YellowMinion");
 });
@@ -221,7 +221,7 @@ test("serialize polymorphic when associated object is null", function() {
   var ray, json;
   run(function() {
     ray = env.store.createRecord(DoomsdayDevice, { name: "DeathRay" });
-    json = env.amsSerializer.serialize(ray);
+    json = env.amsSerializer.serialize(ray._createSnapshot());
   });
 
   deepEqual(json["evil_minion_type"], null);

--- a/packages/ember-data/lib/adapters/fixture_adapter.js
+++ b/packages/ember-data/lib/adapters/fixture_adapter.js
@@ -110,11 +110,13 @@ export default Adapter.extend({
     Implement this method in order to provide json for CRUD methods
 
     @method mockJSON
+    @param {DS.Store} store
     @param {Subclass of DS.Model} type
     @param {DS.Model} record
   */
   mockJSON: function(store, type, record) {
-    return store.serializerFor(type).serialize(record, { includeId: true });
+    var snapshot = record._createSnapshot();
+    return store.serializerFor(snapshot.typeKey).serialize(snapshot, { includeId: true });
   },
 
   /**

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -524,7 +524,8 @@ export default Adapter.extend({
     var data = {};
     var serializer = store.serializerFor(type.typeKey);
 
-    serializer.serializeIntoHash(data, type, record, { includeId: true });
+    var snapshot = record._createSnapshot();
+    serializer.serializeIntoHash(data, type, snapshot, { includeId: true });
 
     return this.ajax(this.buildURL(type.typeKey, null, record), "POST", { data: data });
   },
@@ -549,7 +550,8 @@ export default Adapter.extend({
     var data = {};
     var serializer = store.serializerFor(type.typeKey);
 
-    serializer.serializeIntoHash(data, type, record);
+    var snapshot = record._createSnapshot();
+    serializer.serializeIntoHash(data, type, snapshot);
 
     var id = get(record, 'id');
 

--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -32,6 +32,7 @@ import {
   RootState,
   attr
 } from "ember-data/system/model";
+import Snapshot from "ember-data/system/snapshot";
 import {
   InvalidError,
   Adapter
@@ -82,6 +83,8 @@ DS.Model     = Model;
 DS.RootState = RootState;
 DS.attr      = attr;
 DS.Errors    = Errors;
+
+DS.Snapshot = Snapshot;
 
 DS.Adapter      = Adapter;
 DS.InvalidError = InvalidError;

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -297,7 +297,8 @@ var Adapter = Ember.Object.extend({
     @return {Object} serialized record
   */
   serialize: function(record, options) {
-    return get(record, 'store').serializerFor(record.constructor.typeKey).serialize(record, options);
+    var snapshot = record._createSnapshot();
+    return get(record, 'store').serializerFor(snapshot.typeKey).serialize(snapshot, options);
   },
 
   /**

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -4,6 +4,7 @@ import { PromiseObject } from "ember-data/system/promise_proxies";
 import merge from "ember-data/system/merge";
 import JSONSerializer from "ember-data/serializers/json_serializer";
 import createRelationshipFor from "ember-data/system/relationships/state/create";
+import Snapshot from "ember-data/system/snapshot";
 
 /**
   @module ember-data
@@ -401,7 +402,9 @@ var Model = Ember.Object.extend(Ember.Evented, {
   toJSON: function(options) {
     // container is for lazy transform lookups
     var serializer = JSONSerializer.create({ container: this.container });
-    return serializer.serialize(this, options);
+    var snapshot = this._createSnapshot();
+
+    return serializer.serialize(snapshot, options);
   },
 
   /**
@@ -972,6 +975,14 @@ var Model = Ember.Object.extend(Ember.Evented, {
     this.send('rolledBack');
 
     this._notifyProperties(dirtyKeys);
+  },
+
+  /**
+    @method _createSnapshot
+    @private
+  */
+  _createSnapshot: function() {
+    return new Snapshot(this);
   },
 
   toStringExtension: function() {

--- a/packages/ember-data/lib/system/snapshot.js
+++ b/packages/ember-data/lib/system/snapshot.js
@@ -1,0 +1,361 @@
+/**
+  @module ember-data
+*/
+
+var get = Ember.get;
+
+/**
+  @class Snapshot
+  @namespace DS
+  @private
+  @constructor
+  @param {DS.Model} record The record to create a snapshot from
+*/
+function Snapshot(record) {
+  this._attributes = Ember.create(null);
+  this._belongsToRelationships = Ember.create(null);
+  this._belongsToIds = Ember.create(null);
+  this._hasManyRelationships = Ember.create(null);
+  this._hasManyIds = Ember.create(null);
+
+  record.eachAttribute(function(keyName) {
+    this._attributes[keyName] = get(record, keyName);
+  }, this);
+
+  this.id = get(record, 'id');
+  this.record = record;
+  this.type = record.constructor;
+  this.typeKey = record.constructor.typeKey;
+
+  // The following code is here to keep backwards compatibility when accessing
+  // `constructor` directly.
+  //
+  // With snapshots you should use `type` instead of `constructor`.
+  //
+  // Remove for Ember Data 1.0.
+  if (Ember.platform.hasPropertyAccessors) {
+    var callDeprecate = true;
+
+    Ember.defineProperty(this, 'constructor', {
+      get: function() {
+        // Ugly hack since accessing error.stack (done in `Ember.deprecate()`)
+        // causes the internals of Chrome to access the constructor, which then
+        // causes an infinite loop if accessed and calls `Ember.deprecate()`
+        // again.
+        if (callDeprecate) {
+          callDeprecate = false;
+          Ember.deprecate('Usage of `snapshot.constructor` is deprecated, use `snapshot.type` instead.');
+          callDeprecate = true;
+        }
+
+        return this.type;
+      }
+    });
+  } else {
+    this.constructor = this.type;
+  }
+}
+
+Snapshot.prototype = {
+  constructor: Snapshot,
+
+  /**
+    The id of the snapshot's underlying record
+
+    Example
+
+    ```javascript
+    var post = store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
+    var snapshot = post._createSnapshot();
+
+    snapshot.id; // => '1'
+    ```
+
+    @property id
+    @type {String}
+  */
+  id: null,
+
+  /**
+    The underlying record for this snapshot. Can be used to access methods and
+    properties defined on the record.
+
+    Example
+
+    ```javascript
+    var json = snapshot.record.toJSON();
+    ```
+
+    @property record
+    @type {DS.Model}
+  */
+  record: null,
+
+  /**
+    The type of the underlying record for this snapshot, as a subclass of DS.Model.
+
+    @property type
+    @type {subclass of DS.Model}
+  */
+  type: null,
+
+  /**
+    The name of the type of the underlying record for this snapshot, as a string.
+
+    @property typeKey
+    @type {String}
+  */
+  typeKey: null,
+
+  /**
+    Returns the value of an attribute.
+
+    Example
+
+    ```javascript
+    var post = store.createRecord('post', { author: 'Tomster', title: 'Ember.js rocks' });
+    var snapshot = post._createSnapshot();
+
+    snapshot.attr('author'); // => 'Tomster'
+    snapshot.attr('title'); // => 'Ember.js rocks'
+    ```
+
+    Note: Values are loaded eagerly and cached when the snapshot is created.
+
+    @method attr
+    @param {String} keyName
+    @return {Object} The attribute value or undefined
+  */
+  attr: function(keyName) {
+    if (keyName in this._attributes) {
+      return this._attributes[keyName];
+    }
+    throw new Ember.Error("Model '" + Ember.inspect(this.record) + "' has no attribute named '" + keyName + "' defined.");
+  },
+
+  /**
+    Returns all attributes and their corresponding values.
+
+    Example
+
+    ```javascript
+    var post = store.createRecord('post', { author: 'Tomster', title: 'Ember.js rocks' });
+    var snapshot = post._createSnapshot();
+
+    snapshot.attributes(); // => { author: 'Tomster', title: 'Ember.js rocks' }
+    ```
+
+    @method attributes
+    @return {Array} All attributes for the current snapshot
+  */
+  attributes: function() {
+    return Ember.copy(this._attributes);
+  },
+
+  /**
+    Returns the current value of a belongsTo relationship.
+
+    `belongsTo` takes an optional hash of options as a second parameter,
+    currently supported options are:
+
+   - `id`: set to `true` if you only want the ID of the related record to be
+      returned.
+
+    Example
+
+    ```javascript
+    var post = store.push('post', { id: 1, title: 'Hello World' });
+    var comment = store.createRecord('comment', { body: 'Lorem ipsum', post: post });
+    var snapshot = comment._createSnapshot();
+
+    snapshot.belongsTo('post'); // => DS.Snapshot of post
+    snapshot.belongsTo('post', { id: true }); // => '1'
+    ```
+
+    Calling `belongsTo` will return a new Snapshot as long as there's any
+    data available, such as an ID. If there's no data available `belongsTo` will
+    return undefined.
+
+    Note: Relationships are loaded lazily and cached upon first access.
+
+    @method belongsTo
+    @param {String} keyName
+    @param {Object} [options]
+    @return {DS.Snapshot|String|undefined} A snapshot or ID of a belongsTo relationship, or undefined
+  */
+  belongsTo: function(keyName, options) {
+    var id = options && options.id;
+    var result;
+    var relationship, inverseRecord;
+
+    if (id && keyName in this._belongsToIds) {
+      return this._belongsToIds[keyName];
+    }
+
+    if (!id && keyName in this._belongsToRelationships) {
+      return this._belongsToRelationships[keyName];
+    }
+
+    relationship = this.record._relationships[keyName];
+    if (!(relationship && relationship.relationshipMeta.kind === 'belongsTo')) {
+      throw new Ember.Error("Model '" + Ember.inspect(this.record) + "' has no belongsTo relationship named '" + keyName + "' defined.");
+    }
+
+    inverseRecord = get(relationship, 'inverseRecord');
+    if (id) {
+      if (inverseRecord) {
+        result = get(inverseRecord, 'id');
+      }
+      this._belongsToIds[keyName] = result;
+    } else {
+      if (inverseRecord) {
+        result = inverseRecord._createSnapshot();
+      }
+      this._belongsToRelationships[keyName] = result;
+    }
+
+    return result;
+  },
+
+  /**
+    Returns the current value of a hasMany relationship.
+
+    `hasMany` takes an optional hash of options as a second parameter,
+    currently supported options are:
+
+   - `ids`: set to `true` if you only want the IDs of the related records to be
+      returned.
+
+    Example
+
+    ```javascript
+    var post = store.createRecord('post', { title: 'Hello World', comments: [2, 3] });
+    var snapshot = post._createSnapshot();
+
+    snapshot.hasMany('comments'); // => [DS.Snapshot, DS.Snapshot]
+    snapshot.hasMany('comments', { ids: true }); // => ['2', '3']
+    ```
+
+    Note: Relationships are loaded lazily and cached upon first access.
+
+    @method hasMany
+    @param {String} keyName
+    @param {Object} [options]
+    @return {Array} An array of snapshots or IDs of a hasMany relationship
+  */
+  hasMany: function(keyName, options) {
+    var ids = options && options.ids;
+    var results = [];
+    var relationship, members;
+
+    if (ids && keyName in this._hasManyIds) {
+      return this._hasManyIds[keyName];
+    }
+
+    if (!ids && keyName in this._hasManyRelationships) {
+      return this._hasManyRelationships[keyName];
+    }
+
+    relationship = this.record._relationships[keyName];
+    if (!(relationship && relationship.relationshipMeta.kind === 'hasMany')) {
+      throw new Ember.Error("Model '" + Ember.inspect(this.record) + "' has no hasMany relationship named '" + keyName + "' defined.");
+    }
+
+    members = get(relationship, 'members');
+
+    if (ids) {
+      members.forEach(function(member) {
+        results.push(get(member, 'id'));
+      });
+      this._hasManyIds[keyName] = results;
+    } else {
+      members.forEach(function(member) {
+        results.push(member._createSnapshot());
+      });
+      this._hasManyRelationships[keyName] = results;
+    }
+
+    return results;
+  },
+
+  /**
+    Iterates through all the attributes of the model, calling the passed
+    function on each attribute.
+
+    Example
+
+    ```javascript
+    snapshot.eachAttribute(function(name, meta) {
+      // ...
+    });
+    ```
+
+    @method eachAttribute
+    @param {Function} callback the callback to execute
+    @param {Object} [binding] the value to which the callback's `this` should be bound
+  */
+  eachAttribute: function(callback, binding) {
+    this.record.eachAttribute(callback, binding);
+  },
+
+  /**
+    Iterates through all the relationships of the model, calling the passed
+    function on each relationship.
+
+    Example
+
+    ```javascript
+    snapshot.eachRelationship(function(name, relationship) {
+      // ...
+    });
+    ```
+
+    @method eachRelationship
+    @param {Function} callback the callback to execute
+    @param {Object} [binding] the value to which the callback's `this` should be bound
+  */
+  eachRelationship: function(callback, binding) {
+    this.record.eachRelationship(callback, binding);
+  },
+
+  /**
+    @method get
+    @param {String} keyName
+    @return {Object} The property value
+    @deprecated Use [attr](#method_attr), [belongsTo](#method_belongsTo) or [hasMany](#method_hasMany) instead
+  */
+  get: function(keyName) {
+    Ember.deprecate('Using DS.Snapshot.get() is deprecated. Use .attr(), .belongsTo() or .hasMany() instead.');
+
+    if (keyName === 'id') {
+      return this.id;
+    }
+
+    if (keyName in this._attributes) {
+      return this.attr(keyName);
+    }
+
+    var relationship = this.record._relationships[keyName];
+
+    if (relationship && relationship.relationshipMeta.kind === 'belongsTo') {
+      return this.belongsTo(keyName);
+    }
+    if (relationship && relationship.relationshipMeta.kind === 'hasMany') {
+      return this.hasMany(keyName);
+    }
+
+    return get(this.record, keyName);
+  },
+
+  /**
+    @method unknownProperty
+    @param {String} keyName
+    @return {Object} The property value
+    @deprecated Use [attr](#method_attr), [belongsTo](#method_belongsTo) or [hasMany](#method_hasMany) instead
+  */
+  unknownProperty: function(keyName) {
+    return this.get(keyName);
+  }
+};
+
+export default Snapshot;

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -221,7 +221,8 @@ Store = Ember.Object.extend({
     @param {Object} options an options hash
   */
   serialize: function(record, options) {
-    return this.serializerFor(record.constructor.typeKey).serialize(record, options);
+    var snapshot = record._createSnapshot();
+    return this.serializerFor(snapshot.typeKey).serialize(snapshot, options);
   },
 
   /**

--- a/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
@@ -567,7 +567,7 @@ test("serialize supports serialize:false on non-relationship properties", functi
   var serializer, json;
   run(function() {
     serializer = env.container.lookup("serializer:superVillain");
-    json = serializer.serialize(tom);
+    json = serializer.serialize(tom._createSnapshot());
   });
 
   deepEqual(json, {
@@ -594,7 +594,7 @@ test("serialize with embedded objects (hasMany relationship)", function() {
   run(function() {
     serializer = env.container.lookup("serializer:homePlanet");
 
-    json = serializer.serialize(league);
+    json = serializer.serialize(league._createSnapshot());
   });
 
   deepEqual(json, {
@@ -624,7 +624,7 @@ test("serialize with embedded objects (hasMany relationship) supports serialize:
   run(function() {
     serializer = env.container.lookup("serializer:homePlanet");
 
-    json = serializer.serialize(league);
+    json = serializer.serialize(league._createSnapshot());
   });
 
   deepEqual(json, {
@@ -647,7 +647,7 @@ test("serialize with (new) embedded objects (hasMany relationship)", function() 
   run(function() {
     serializer = env.container.lookup("serializer:homePlanet");
 
-    json = serializer.serialize(league);
+    json = serializer.serialize(league._createSnapshot());
   });
   deepEqual(json, {
     name: "Villain League",
@@ -679,7 +679,7 @@ test("serialize with embedded objects (hasMany relationships, including related 
   run(function() {
     serializer = env.container.lookup("serializer:superVillain");
 
-    json = serializer.serialize(superVillain);
+    json = serializer.serialize(superVillain._createSnapshot());
   });
   deepEqual(json, {
     first_name: get(superVillain, "firstName"),
@@ -769,7 +769,7 @@ test("serialize with embedded object (belongsTo relationship)", function() {
   });
 
   run(function() {
-    json = serializer.serialize(tom);
+    json = serializer.serialize(tom._createSnapshot());
   });
 
   deepEqual(json, {
@@ -812,7 +812,7 @@ test("serialize with embedded object (belongsTo relationship) works with differe
   });
 
   run(function() {
-    json = serializer.serialize(tom);
+    json = serializer.serialize(tom._createSnapshot());
   });
 
   deepEqual(json, {
@@ -851,7 +851,7 @@ test("serialize with embedded object (belongsTo relationship, new no id)", funct
   });
 
   run(function() {
-    json = serializer.serialize(tom);
+    json = serializer.serialize(tom._createSnapshot());
   });
 
   deepEqual(json, {
@@ -888,7 +888,7 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
   });
 
   run(function() {
-    json = serializer.serialize(tom);
+    json = serializer.serialize(tom._createSnapshot());
   });
 
   deepEqual(json, {
@@ -923,7 +923,7 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
   });
 
   run(function() {
-    json = serializer.serialize(tom);
+    json = serializer.serialize(tom._createSnapshot());
   });
 
   deepEqual(json, {
@@ -956,7 +956,7 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
   });
 
   run(function() {
-    json = serializer.serialize(tom);
+    json = serializer.serialize(tom._createSnapshot());
   });
 
   deepEqual(json, {
@@ -986,7 +986,7 @@ test("serialize with embedded object (belongsTo relationship) serializes the id 
   });
 
   run(function() {
-    json = serializer.serialize(tom);
+    json = serializer.serialize(tom._createSnapshot());
   });
 
   deepEqual(json, {
@@ -1017,7 +1017,7 @@ test("when related record is not present, serialize embedded record (with a belo
   });
 
   run(function() {
-    json = serializer.serialize(tom);
+    json = serializer.serialize(tom._createSnapshot());
   });
 
   deepEqual(json, {
@@ -1200,7 +1200,7 @@ test("Mixin can be used with RESTSerializer which does not define keyForAttribut
   var json;
 
   run(function() {
-    json = serializer.serialize(superVillain);
+    json = serializer.serialize(superVillain._createSnapshot());
   });
 
   deepEqual(json, {
@@ -1273,19 +1273,19 @@ test("serializing relationships with an embedded and without calls super when no
   var calledSerializeHasMany = false;
 
   var Serializer = DS.RESTSerializer.extend({
-    serializeBelongsTo: function(record, json, relationship) {
+    serializeBelongsTo: function(snapshot, json, relationship) {
       calledSerializeBelongsTo = true;
-      return this._super(record, json, relationship);
+      return this._super(snapshot, json, relationship);
     },
-    serializeHasMany: function(record, json, relationship) {
+    serializeHasMany: function(snapshot, json, relationship) {
       calledSerializeHasMany = true;
       var key = relationship.key;
       var payloadKey = this.keyForRelationship ? this.keyForRelationship(key, "hasMany") : key;
-      var relationshipType = record.constructor.determineRelationshipType(relationship);
+      var relationshipType = snapshot.type.determineRelationshipType(relationship);
       // "manyToOne" not supported in DS.RESTSerializer.prototype.serializeHasMany
       var relationshipTypes = Ember.String.w('manyToNone manyToMany manyToOne');
       if (indexOf(relationshipTypes, relationshipType) > -1) {
-        json[payloadKey] = get(record, key).mapBy('id');
+        json[payloadKey] = snapshot.hasMany(key, { ids: true });
       }
     }
   });
@@ -1302,7 +1302,7 @@ test("serializing relationships with an embedded and without calls super when no
 
   var json;
   run(function() {
-    json = serializer.serialize(superVillain);
+    json = serializer.serialize(superVillain._createSnapshot());
   });
 
   deepEqual(json, {

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -1,4 +1,3 @@
-var get = Ember.get;
 var Post, post, Comment, comment, Favorite, favorite, env;
 var run = Ember.run;
 
@@ -436,7 +435,6 @@ test("Calling normalize should normalize the payload (only the passed keys)", fu
 });
 
 test('serializeBelongsTo with async polymorphic', function() {
-  var post, favorite;
   var json = {};
   var expected = { post: '1', postTYPE: 'post' };
 

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -436,13 +436,14 @@ test("Calling normalize should normalize the payload (only the passed keys)", fu
 });
 
 test('serializeBelongsTo with async polymorphic', function() {
-  var json = {},
-      expectedJSON = { post: '1', postTYPE: 'post' };
+  var post, favorite;
+  var json = {};
+  var expected = { post: '1', postTYPE: 'post' };
 
   env.container.register('serializer:favorite', DS.JSONSerializer.extend({
-    serializePolymorphicType: function(record, json, relationship) {
+    serializePolymorphicType: function(snapshot, json, relationship) {
       var key = relationship.key;
-      json[relationship.key + 'TYPE'] = record.constructor.typeKey;
+      json[key + 'TYPE'] = snapshot.belongsTo(key).typeKey;
     }
   }));
 
@@ -451,11 +452,7 @@ test('serializeBelongsTo with async polymorphic', function() {
     favorite = env.store.createRecord(Favorite, { post: post, id: '3' });
   });
 
-  env.container.lookup('serializer:favorite').serializeBelongsTo(favorite, json, { key: 'post', options: { polymorphic: true, async: true } });
+  env.container.lookup('serializer:favorite').serializeBelongsTo(favorite._createSnapshot(), json, { key: 'post', options: { polymorphic: true, async: true } });
 
-  deepEqual(
-    json,
-    expectedJSON,
-    'Expected: ' + JSON.stringify(expectedJSON) + ', Got: ' + JSON.stringify(json)
-  );
+  deepEqual(json, expected, 'returned JSON is correct');
 });

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -275,7 +275,7 @@ test("serialize polymorphicType", function() {
     ray = env.store.createRecord(DoomsdayDevice, { evilMinion: tom, name: "DeathRay" });
   });
 
-  var json = env.restSerializer.serialize(ray);
+  var json = env.restSerializer.serialize(ray._createSnapshot());
 
   deepEqual(json, {
     name:  "DeathRay",
@@ -292,7 +292,7 @@ test("serialize polymorphicType with decamelized typeKey", function() {
     ray = env.store.createRecord(DoomsdayDevice, { evilMinion: tom, name: "DeathRay" });
   });
 
-  var json = env.restSerializer.serialize(ray);
+  var json = env.restSerializer.serialize(ray._createSnapshot());
 
   deepEqual(json["evilMinionType"], "yellowMinion");
 });
@@ -327,7 +327,7 @@ test("serialize polymorphic when associated object is null", function() {
     ray = env.store.createRecord(DoomsdayDevice, { name: "DeathRay" });
   });
 
-  var json = env.restSerializer.serialize(ray);
+  var json = env.restSerializer.serialize(ray._createSnapshot());
 
   deepEqual(json["evilMinionType"], null);
 });
@@ -515,7 +515,7 @@ test("serializeIntoHash", function() {
   });
   var json = {};
 
-  env.restSerializer.serializeIntoHash(json, HomePlanet, league);
+  env.restSerializer.serializeIntoHash(json, HomePlanet, league._createSnapshot());
 
   deepEqual(json, {
     homePlanet: {
@@ -531,7 +531,7 @@ test("serializeIntoHash with decamelized typeKey", function() {
   });
   var json = {};
 
-  env.restSerializer.serializeIntoHash(json, HomePlanet, league);
+  env.restSerializer.serializeIntoHash(json, HomePlanet, league._createSnapshot());
 
   deepEqual(json, {
     homePlanet: {

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -539,3 +539,18 @@ test("serializeIntoHash with decamelized typeKey", function() {
     }
   });
 });
+
+test('serializeBelongsTo with async polymorphic', function() {
+  var evilMinion, doomsdayDevice;
+  var json = {};
+  var expected = { evilMinion: '1', evilMinionType: 'evilMinion' };
+
+  run(function() {
+    evilMinion = env.store.createRecord('evilMinion', { id: 1, name: 'Tomster' });
+    doomsdayDevice = env.store.createRecord('doomsdayDevice', { id: 2, name: 'Yehuda', evilMinion: evilMinion });
+  });
+
+  env.restSerializer.serializeBelongsTo(doomsdayDevice._createSnapshot(), json, { key: 'evilMinion', options: { polymorphic: true, async: true } });
+
+  deepEqual(json, expected, 'returned JSON is correct');
+});

--- a/packages/ember-data/tests/integration/snapshot_test.js
+++ b/packages/ember-data/tests/integration/snapshot_test.js
@@ -1,0 +1,340 @@
+var run = Ember.run;
+var env, Post, Comment;
+
+module("integration/snapshot - DS.Snapshot", {
+  setup: function() {
+    Post = DS.Model.extend({
+      author: DS.attr(),
+      title: DS.attr(),
+      comments: DS.hasMany({ async: true })
+    });
+    Comment = DS.Model.extend({
+      body: DS.attr(),
+      post: DS.belongsTo({ async: true })
+    });
+
+    env = setupStore({
+      post: Post,
+      comment: Comment
+    });
+  },
+
+  teardown: function() {
+    run(function() {
+      env.store.destroy();
+    });
+  }
+});
+
+test("record._createSnapshot() returns a snapshot", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    ok(snapshot instanceof DS.Snapshot, 'snapshot is an instance of DS.Snapshot');
+  });
+});
+
+test("snapshot.id, snapshot.type and snapshot.typeKey returns correctly", function() {
+  expect(3);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    equal(snapshot.id, '1', 'id is correct');
+    ok(DS.Model.detect(snapshot.type), 'type is correct');
+    equal(snapshot.typeKey, 'post', 'typeKey is correct');
+  });
+});
+
+test("snapshot.constructor is unique and deprecated", function() {
+  expect(4);
+
+  run(function() {
+    var comment = env.store.push('comment', { id: 1, body: 'This is comment' });
+    var post = env.store.push('post', { id: 2, title: 'Hello World' });
+    var commentSnapshot = comment._createSnapshot();
+    var postSnapshot = post._createSnapshot();
+
+    expectDeprecation(function() {
+      equal(commentSnapshot.constructor.typeKey, 'comment', 'constructor.typeKey is unique per type');
+    });
+
+    expectDeprecation(function() {
+      equal(postSnapshot.constructor.typeKey, 'post', 'constructor.typeKey is unique per type');
+    });
+  });
+});
+
+test("snapshot.attr() does not change when record changes", function() {
+  expect(2);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    equal(snapshot.attr('title'), 'Hello World', 'snapshot title is correct');
+    post.set('title', 'Tomster');
+    equal(snapshot.attr('title'), 'Hello World', 'snapshot title is still correct');
+  });
+});
+
+test("snapshot.attributes() returns a copy of all attributes for the current snapshot", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    var attributes = snapshot.attributes();
+
+    deepEqual(attributes, { author: undefined, title: 'Hello World' }, 'attributes are returned correctly');
+  });
+});
+
+test("snapshot.belongsTo() returns undefined if relationship is undefined", function() {
+  expect(1);
+
+  run(function() {
+    var comment = env.store.push('comment', { id: 1, body: 'This is comment' });
+    var snapshot = comment._createSnapshot();
+    var relationship = snapshot.belongsTo('post');
+
+    equal(relationship, undefined, 'relationship is undefined');
+  });
+});
+
+test("snapshot.belongsTo() returns a snapshot if relationship is set", function() {
+  expect(3);
+
+  run(function() {
+    env.store.push('post', { id: 1, title: 'Hello World' });
+    var comment = env.store.push('comment', { id: 2, body: 'This is comment', post: 1 });
+    var snapshot = comment._createSnapshot();
+    var relationship = snapshot.belongsTo('post');
+
+    ok(relationship instanceof DS.Snapshot, 'snapshot is an instance of DS.Snapshot');
+    equal(relationship.id, '1', 'post id is correct');
+    equal(relationship.attr('title'), 'Hello World', 'post title is correct');
+  });
+});
+
+test("snapshot.hasMany() returns ID if option.id is set", function() {
+  expect(1);
+
+  run(function() {
+    env.store.push('post', { id: 1, title: 'Hello World' });
+    var comment = env.store.push('comment', { id: 2, body: 'This is comment', post: 1 });
+    var snapshot = comment._createSnapshot();
+    var relationship = snapshot.belongsTo('post', { id: true });
+
+    equal(relationship, '1', 'relationship ID correctly returned');
+  });
+});
+
+test("snapshot.hasMany() returns empty array if relationship is undefined", function() {
+  expect(2);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+    var relationship = snapshot.hasMany('comments');
+
+    ok(relationship instanceof Array, 'relationship is an instance of Array');
+    equal(relationship.length, 0, 'relationship is empty');
+  });
+});
+
+test("snapshot.hasMany() returns array of snapshots if relationship is set", function() {
+  expect(5);
+
+  run(function() {
+    env.store.push('comment', { id: 1, body: 'This is the first comment' });
+    env.store.push('comment', { id: 2, body: 'This is the second comment' });
+    var post = env.store.push('post', { id: 3, title: 'Hello World', comments: [1, 2] });
+    var snapshot = post._createSnapshot();
+    var relationship = snapshot.hasMany('comments');
+
+    ok(relationship instanceof Array, 'relationship is an instance of Array');
+    equal(relationship.length, 2, 'relationship has two items');
+
+    var relationship1 = relationship[0];
+
+    ok(relationship1 instanceof DS.Snapshot, 'relationship item is an instance of DS.Snapshot');
+
+    equal(relationship1.id, '1', 'relationship item id is correct');
+    equal(relationship1.attr('body'), 'This is the first comment', 'relationship item body is correct');
+  });
+});
+
+test("snapshot.hasMany() returns array of IDs if option.ids is set", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World', comments: [2, 3] });
+    var snapshot = post._createSnapshot();
+    var relationship = snapshot.hasMany('comments', { ids: true });
+
+    deepEqual(relationship, ['2', '3'], 'relationship IDs correctly returned');
+  });
+});
+
+test("snapshot.eachAttribute() proxies to record", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    var attributes = [];
+    snapshot.eachAttribute(function(name) {
+      attributes.push(name);
+    });
+    deepEqual(attributes, ['author', 'title'], 'attributes are iterated correctly');
+  });
+});
+
+test("snapshot.eachRelationship() proxies to record", function() {
+  expect(2);
+
+  var getRelationships = function(snapshot) {
+    var relationships = [];
+    snapshot.eachRelationship(function(name) {
+      relationships.push(name);
+    });
+    return relationships;
+  };
+
+  run(function() {
+    var comment = env.store.push('comment', { id: 1, body: 'This is the first comment' });
+    var post = env.store.push('post', { id: 2, title: 'Hello World' });
+    var snapshot;
+
+    snapshot = comment._createSnapshot();
+    deepEqual(getRelationships(snapshot), ['post'], 'relationships are iterated correctly');
+
+    snapshot = post._createSnapshot();
+    deepEqual(getRelationships(snapshot), ['comments'], 'relationships are iterated correctly');
+  });
+});
+
+test("snapshot.belongsTo() does not trigger a call to store.scheduleFetch", function() {
+  expect(0);
+
+  env.store.scheduleFetch = function() {
+    ok(false, 'store.scheduleFetch should not be called');
+  };
+
+  run(function() {
+    var comment = env.store.push('comment', { id: 2, body: 'This is comment', post: 1 });
+    var snapshot = comment._createSnapshot();
+
+    snapshot.belongsTo('post');
+  });
+});
+
+test("snapshot.hasMany() does not trigger a call to store.scheduleFetch", function() {
+  expect(0);
+
+  env.store.scheduleFetch = function() {
+    ok(false, 'store.scheduleFetch should not be called');
+  };
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World', comments: [2, 3] });
+    var snapshot = post._createSnapshot();
+
+    snapshot.hasMany('comments');
+  });
+});
+
+test("snapshot.get() is deprecated", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    expectDeprecation(function() {
+      snapshot.get('title');
+    }, 'Using DS.Snapshot.get() is deprecated. Use .attr(), .belongsTo() or .hasMany() instead.');
+  });
+});
+
+test("snapshot.get() returns id", function() {
+  expect(2);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    expectDeprecation(function() {
+      equal(snapshot.get('id'), '1', 'snapshot id is correct');
+    });
+  });
+});
+
+test("snapshot.get() returns attribute", function() {
+  expect(2);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    expectDeprecation(function() {
+      equal(snapshot.get('title'), 'Hello World', 'snapshot title is correct');
+    });
+  });
+});
+
+test("snapshot.get() returns belongsTo", function() {
+  expect(3);
+
+  run(function() {
+    var comment = env.store.push('comment', { id: 1, body: 'This is a comment', post: 2 });
+    var snapshot = comment._createSnapshot();
+    var relationship;
+
+    expectDeprecation(function() {
+      relationship = snapshot.get('post');
+    });
+
+    ok(relationship instanceof DS.Snapshot, 'relationship is an instance of DS.Snapshot');
+    equal(relationship.id, '2', 'relationship id is correct');
+  });
+});
+
+test("snapshot.get() returns hasMany", function() {
+  expect(3);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World', comments: [2, 3] });
+    var snapshot = post._createSnapshot();
+    var relationship;
+
+    expectDeprecation(function() {
+      relationship = snapshot.get('comments');
+    });
+
+    ok(relationship instanceof Array, 'relationship is an instance of Array');
+    equal(relationship.length, 2, 'relationship has two items');
+  });
+});
+
+test("snapshot.get() proxies property to record unless identified as id, attribute or relationship", function() {
+  expect(2);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    post.set('category', 'Ember.js'); // category is not defined as an DS.attr()
+
+    expectDeprecation(function() {
+      equal(snapshot.get('category'), 'Ember.js', 'snapshot proxies unknown property correctly');
+    });
+  });
+});


### PR DESCRIPTION
This is a first stab at the new Snapshot API, `serializer.serialize()` now receives a Snapshot instead of a record instance.

- **Caching** - Right now, attributes are cached eagerly (on instantiation) and relationships are cached on first access. Is this the design we want?
- **snapshot.belongsTo()** - Returns a new snapshot (with at least an ID) or undefined. Is this what we want or should we always return a new snapshot?
- **snapshot.hasMany()** - Always returns an array.
- **snapshot.get() deprecated** - ~~To only use `attr()`, `belongsTo()` and `hasMany()` would require some work in serializers. Should that be done in the scope of this PR or separately?~~ Done in this PR.

[@sly7-7]: Just to clean issues when that awesome work is merged: 
Closes #2551, Fixes #2385, Fixes #2508, Closes #1491 

Fixes #2750, Closes #2739