### PR TITLE
[DOC] Stop using deprecated `each` helper syntax

### DIFF
--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -54,23 +54,23 @@ import {
   or using the `messages` property to get an array of all errors.
 
   ```handlebars
-  {{#each errors.messages}}
+  {{#each message in errors.messages}}
     <div class="error">
       {{message}}
     </div>
   {{/each}}
 
   <label>Username: {{input value=username}} </label>
-  {{#each errors.username}}
+  {{#each error in errors.username}}
     <div class="error">
-      {{message}}
+      {{error.message}}
     </div>
   {{/each}}
 
   <label>Email: {{input value=email}} </label>
-  {{#each errors.email}}
+  {{#each error in errors.email}}
     <div class="error">
-      {{message}}
+      {{error.message}}
     </div>
   {{/each}}
   ```
@@ -149,7 +149,7 @@ export default Ember.Object.extend(Ember.Enumerable, Ember.Evented, {
     record. This is useful for displaying all errors to the user.
 
     ```handlebars
-    {{#each errors.messages}}
+    {{#each message in errors.messages}}
       <div class="error">
         {{message}}
       </div>


### PR DESCRIPTION
The `each` helper with context switching is deprecated in Ember.js 1.9.
see: http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope
