### PR TITLE
Fix references to buildURL in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,7 +150,7 @@ var Post = DS.Model.extend({
 * Expand the package configuration filename glob declaration in `Brocfile.js` into the affected filenames, as the `broccoli-string-replace` plugin doesn't support globbing
 * Clear inverseRecord for deleted belongsTo properly
 * Warn when pushing unknown payload keys into the store
-* RestAdapter's buildUrl from delete can ask for record's relations. closes #534
+* RESTAdapter's buildURL from delete can ask for record's relations. closes #534
 * Ensure production builds do not use require internally.
 * [DOCS] InvalidError docs missing quote
 * Use the model rollback and not state machine for created records rollback

--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -208,7 +208,7 @@ export default Adapter.extend({
 
     will also send a request to: `GET /comments?ids[]=1&ids[]=2`
 
-    Note: Requests coalescing rely on URL building strategy. So if you override `buildUrl` in your app
+    Note: Requests coalescing rely on URL building strategy. So if you override `buildURL` in your app
     `groupRecordsForFindMany` more likely should be overridden as well in order for coalescing to work.
 
     @property coalesceFindRequests


### PR DESCRIPTION
Noticed that the documentation for RESTAdapter on the website refers to `buildUrl` rather than `buildURL`. Fixed the change log, too, but obviously that is less important. Cheers!
