### PR TITLE
[Bug] Fixed the test "create - relationships are not duplicated".

### DIFF
--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -470,7 +470,7 @@ test("create - relationships are not duplicated", function() {
 
   run(function(){
     post = store.createRecord('post', { name: "Tomtomhuda" });
-    comment = store.createRecord('comment', { id: 2, name: "Comment title" });
+    comment = store.createRecord('comment', { name: "Comment title" });
   });
 
   ajaxResponse({ post: [{ id: 1, name: "Rails is omakase", comments: [] }] });


### PR DESCRIPTION
Fixed the test "create - relationships are not duplicated". Since you will not predefine the id of a comment created on the client side, it does not make very much sense.

It seems like a good idea to add this failing test so it can be fixed. I am not very deep involved in ember data so I did not manage to solve it myself.

For example in ticket #1829 they describe the same problem. Also in this discussion: http://discuss.emberjs.com/t/two-ember-objects-created-for-single-backend-object/3891.