### PR TITLE
generateIdForRecord gets type & object properties passed to it

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -289,7 +289,7 @@ Store = Ember.Object.extend({
     // to avoid conflicts.
 
     if (isNone(properties.id)) {
-      properties.id = this._generateId(type);
+      properties.id = this._generateId(type, properties);
     }
 
     // Coerce ID to a string
@@ -314,13 +314,14 @@ Store = Ember.Object.extend({
     @method _generateId
     @private
     @param {String} type
+    @param {Object} properties from the new record
     @return {String} if the adapter can generate one, an ID
   */
-  _generateId: function(type) {
+  _generateId: function(type, properties) {
     var adapter = this.adapterFor(type);
 
     if (adapter && adapter.generateIdForRecord) {
-      return adapter.generateIdForRecord(this);
+      return adapter.generateIdForRecord(this, type, properties);
     }
 
     return null;


### PR DESCRIPTION
This is for #2516 

The documentation should also be updated to reflect the actual parameters being passed