### PR TITLE
Only trigger changes for changed properties

### DIFF
--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -153,7 +153,7 @@ test("Calling push on normalize allows partial updates with raw JSON", function 
   equal(person.get('lastName'), "Jackson", "existing fields are untouched");
 });
 
-test("Calling push with partial records triggers observers for just those attributes", function() {
+test("Calling push with partial records triggers observers for just those attributes that changed", function() {
   expect(1);
   var person;
 
@@ -176,7 +176,8 @@ test("Calling push with partial records triggers observers for just those attrib
   run(function(){
     store.push('person', {
       id: 'wat',
-      lastName: "Katz!"
+      firstName: 'Yehuda',
+      lastName: 'Katz!'
     });
   });
 });


### PR DESCRIPTION
Previously, if your payload sent "firstName", but the value of "firstName" did not change, your observers would fire anyway. It seems like if we are going to do observers we should not cause observers to fire when they wouldn't if the underlying `_data` object were an `Ember.Object`. This also helps reduce zalgo when you are developing an app and wondering why observers are firing when they shouldn't be.

cc @rwjblue