### PR TITLE
[WIP] errors object with sources

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -1,3 +1,5 @@
+import { ADAPTER_SOURCE } from "ember-data/system/model/errors";
+
 /**
   @module ember-data
 */
@@ -329,7 +331,7 @@ var DirtyState = {
     },
 
     didSetProperty: function(record, context) {
-      get(record, 'errors').remove(context.name);
+      get(record, 'errors').remove(context.name, ADAPTER_SOURCE);
 
       didSetProperty(record, context);
     },
@@ -337,12 +339,12 @@ var DirtyState = {
     becomeDirty: Ember.K,
 
     willCommit: function(record) {
-      get(record, 'errors').clear();
+      get(record, 'errors').clear(ADAPTER_SOURCE);
       record.transitionTo('inFlight');
     },
 
     rolledBack: function(record) {
-      get(record, 'errors').clear();
+      get(record, 'errors').clear(ADAPTER_SOURCE);
       record.triggerLater('ready');
     },
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1291,9 +1291,10 @@ Store = Ember.Object.extend({
     @method recordWasError
     @private
     @param {DS.Model} record
+    @param {Error} error
   */
-  recordWasError: function(record) {
-    record.adapterDidError();
+  recordWasError: function(record, error) {
+    record.adapterDidError(error);
   },
 
   /**

--- a/packages/ember-data/tests/unit/model/errors_test.js
+++ b/packages/ember-data/tests/unit/model/errors_test.js
@@ -1,4 +1,5 @@
 var errors;
+var ADAPTER_SOURCE = "ember-data:adapter";
 
 module("unit/model/errors", {
   setup: function() {
@@ -32,9 +33,9 @@ function unexpectedSend(eventName) {
 test("add error", function() {
   expect(6);
   errors.trigger = becameInvalid;
-  errors.add('firstName', 'error');
+  errors.add('firstName', 'error', ADAPTER_SOURCE);
   errors.trigger = unexpectedSend;
-  ok(errors.has('firstName'), 'it has firstName errors');
+  ok(errors.has('firstName', ADAPTER_SOURCE), 'it has firstName errors');
   equal(errors.get('length'), 1, 'it has 1 error');
   errors.add('firstName', ['error1', 'error2']);
   equal(errors.get('length'), 3, 'it has 3 errors');
@@ -48,21 +49,20 @@ test("get error", function() {
   expect(8);
   ok(errors.get('firstObject') === undefined, 'returns undefined');
   errors.trigger = becameInvalid;
-  errors.add('firstName', 'error');
+  errors.add('firstName', 'error', ADAPTER_SOURCE);
   errors.trigger = unexpectedSend;
   ok(errors.get('firstName').length === 1, 'returns errors');
-  deepEqual(errors.get('firstObject'), { attribute: 'firstName', message: 'error' });
-  errors.add('firstName', 'error2');
+  deepEqual(errors.get('firstObject'), { attribute: 'firstName', message: 'error', source: ADAPTER_SOURCE });
+  errors.add('firstName', 'error2', ADAPTER_SOURCE);
   ok(errors.get('firstName').length === 2, 'returns errors');
-  errors.add('lastName', 'error3');
+  errors.add('lastName', 'error3', ADAPTER_SOURCE);
   deepEqual(errors.toArray(), [
-    { attribute: 'firstName', message: 'error' },
-    { attribute: 'firstName', message: 'error2' },
-    { attribute: 'lastName', message: 'error3' }
+    { attribute: 'firstName', message: 'error', source: ADAPTER_SOURCE },
+    { attribute: 'firstName', message: 'error2', source: ADAPTER_SOURCE },
+    { attribute: 'lastName', message: 'error3', source: ADAPTER_SOURCE }
   ]);
   deepEqual(errors.get('firstName'), [
-    { attribute: 'firstName', message: 'error' },
-    { attribute: 'firstName', message: 'error2' }
+    'error', 'error2'
   ]);
   deepEqual(errors.get('messages'), ['error', 'error2', 'error3']);
 });
@@ -70,11 +70,11 @@ test("get error", function() {
 test("remove error", function() {
   expect(5);
   errors.trigger = becameInvalid;
-  errors.add('firstName', 'error');
+  errors.add('firstName', 'error', ADAPTER_SOURCE);
   errors.trigger = becameValid;
-  errors.remove('firstName');
+  errors.remove('firstName', ADAPTER_SOURCE);
   errors.trigger = unexpectedSend;
-  ok(!errors.has('firstName'), 'it has no firstName errors');
+  ok(!errors.has('firstName', ADAPTER_SOURCE), 'it has no firstName errors');
   equal(errors.get('length'), 0, 'it has 0 error');
   ok(errors.get('isEmpty'), 'it is empty');
   errors.remove('firstName');
@@ -83,21 +83,35 @@ test("remove error", function() {
 test("remove same errors from different attributes", function() {
   expect(5);
   errors.trigger = becameInvalid;
-  errors.add('firstName', 'error');
-  errors.add('lastName', 'error');
+  errors.add('firstName', 'error', ADAPTER_SOURCE);
+  errors.add('lastName', 'error', ADAPTER_SOURCE);
   errors.trigger = unexpectedSend;
   equal(errors.get('length'), 2, 'it has 2 error');
-  errors.remove('firstName');
+  errors.remove('firstName', ADAPTER_SOURCE);
   equal(errors.get('length'), 1, 'it has 1 error');
   errors.trigger = becameValid;
-  errors.remove('lastName');
+  errors.remove('lastName', ADAPTER_SOURCE);
   ok(errors.get('isEmpty'), 'it is empty');
+});
+
+test("remove errors from given source only", function() {
+  expect(4);
+  errors.trigger = becameInvalid;
+  errors.add('firstName', 'error', ADAPTER_SOURCE);
+  errors.add('lastName', 'error 1', 'another-source');
+  errors.add('lastName', 'error 2', ADAPTER_SOURCE);
+  errors.trigger = unexpectedSend;
+  equal(errors.get('length'), 3, 'it has 3 error');
+  errors.remove('lastName', 'another-source');
+  equal(errors.get('length'), 2, 'it has 2 error');
+  errors.trigger = becameValid;
+  equal(errors.get('lastName.firstObject'), 'error 2', 'lastName has error');
 });
 
 test("clear errors", function() {
   expect(5);
   errors.trigger = becameInvalid;
-  errors.add('firstName', ['error', 'error1']);
+  errors.add('firstName', ['error', 'error1'], ADAPTER_SOURCE);
   equal(errors.get('length'), 2, 'it has 2 errors');
   errors.trigger = becameValid;
   errors.clear();
@@ -105,4 +119,16 @@ test("clear errors", function() {
   ok(!errors.has('firstName'), 'it has no firstName errors');
   equal(errors.get('length'), 0, 'it has 0 error');
   errors.clear();
+});
+
+test("clear errors from given source", function() {
+  expect(4);
+  errors.trigger = becameInvalid;
+  errors.add('firstName', 'error', ADAPTER_SOURCE);
+  errors.add('lastName', 'error', 'another-source');
+  errors.trigger = unexpectedSend;
+  equal(errors.get('length'), 2, 'it has 2 error');
+  errors.clear('another-source');
+  equal(errors.get('length'), 1, 'it has 1 error');
+  equal(errors.get('firstName.firstObject'), 'error', 'firstName has error');
 });


### PR DESCRIPTION
In this PR I am trying to address a few limitations of `errors` object.

- fix enumerable subclassing by using `Ember.Array` instead
- allow for several sources for errors
- this should also allow for per validator `remove` / `clear` (each validator can be a different source)

This should make it easier to integrate with third partie libraries like `ember-validations` by only triggering invalid state for internal `adapter` source. Proposed changes should also allow for per-validator errors. It should make it easier to implement live client validations, as requested by @bcardarella.

Finally, I know @bcardarella, you are not the biggest fan of how things gone in the past regarding `errors`. I really hope we can iron things out and make it work for core and third party libraries. I am looking forward to work with you on making `ember-validations` play nice with `ember-data`.

I will add some examples and use cases tomorrow. It is getting late around here and I had enough headache with this for tonight :) Any feedback is welcome, but if something is really unclear, hang tight for tomorrow, for more examples and tests.

cc @igorT 