### PR TITLE
[BUGFIX] Fetching an empty record should run find instead of reload

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -771,7 +771,8 @@ Store = Ember.Object.extend({
   hasRecordForId: function(typeName, inputId) {
     var type = this.modelFor(typeName);
     var id = coerceId(inputId);
-    return !!this.typeMapFor(type).idToRecord[id];
+    var record = this.typeMapFor(type).idToRecord[id];
+    return !!record && !get(record, 'isEmpty');
   },
 
   /**

--- a/packages/ember-data/tests/integration/store_test.js
+++ b/packages/ember-data/tests/integration/store_test.js
@@ -246,3 +246,32 @@ test("Using store#fetch on non existing record calls find", function() {
     });
   });
 });
+
+test("Using store#fetch on an empty record calls find", function() {
+  expect(2);
+
+  ajaxResponse({
+    cars: [{
+      id: 20,
+      make: 'BMCW',
+      model: 'Mini'
+    }]
+  });
+
+  run(function() {
+    store.push('person', {
+      id: 1,
+      name: 'Tom Dale',
+      cars: [20]
+    });
+  });
+
+  var car = store.recordForId('car', 20);
+  ok(car.get('isEmpty'), 'Car with id=20 should be empty');
+
+  run(function() {
+    store.fetch('car', 20).then(function (car) {
+      equal(car.get('make'), 'BMCW', 'Car with id=20 is now loaded');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2569

When you run `reload` on an empty record, such as one being created from a reference, you get an error about not being able to call `reloadRecord` on a record that is in state `root.empty`. This checks for that and calls `store.find` instead.

For more details on the issue, see #2569.