### PR TITLE
Checking superclass type for equality in addCanonicalRecord method for a belongsTo relationship

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs_to.js
@@ -35,8 +35,6 @@ BelongsToRelationship.prototype.setCanonicalRecord = function(newRecord) {
 BelongsToRelationship.prototype._super$addCanonicalRecord = Relationship.prototype.addCanonicalRecord;
 BelongsToRelationship.prototype.addCanonicalRecord = function(newRecord) {
   if (this.canonicalMembers.has(newRecord)){ return;}
-  var type = this.relationshipMeta.type;
-  Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", newRecord instanceof type);
 
   if (this.canonicalState) {
     this.removeCanonicalRecord(this.canonicalState);

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -312,6 +312,24 @@ test("polymorphic belongsTo type-checks check the superclass when MODEL_FACTORY_
   }
 });
 
+test("the subclass in a polymorphic belongsTo relationship is an instanceof its superclass", function() {
+  expect(1);
+
+  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
+  Ember.MODEL_FACTORY_INJECTIONS = true;
+
+  try {
+    run(function () {
+      var message = env.store.createRecord('message', { id: 1 });
+      var comment = env.store.createRecord('comment', { id: 2, message: message });
+      ok(comment instanceof Message, 'a comment is an instance of a message');
+    });
+
+  } finally {
+    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+  }
+});
+
 test("relationshipsByName does not cache a factory", function() {
 
   // The model is loaded up via a container. It has relationshipsByName


### PR DESCRIPTION
When using polymorphic models in an ember app, the `addCanonicalRecord` method does not check for a model's superclass when comparing equality of a `newRecord` to the expected `type`

Because there previously was no check for a type's super class, this assertion pops up: `Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", newRecord instanceof type);`

My solution to this is to add a check for `Ember.MODEL_FACTORY_INJECTIONS` like in the `addRecord` method inside the `belongs_to` class:
```
Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", (function () {
    if (newRecord instanceof type) {
      return true;
    } else if (Ember.MODEL_FACTORY_INJECTIONS) {
      return newRecord instanceof type.superclass;
    }

    return false;
  })());
```