### PR TITLE
Remove workaround for Ember 1.5

### DIFF
--- a/packages/ember-data/tests/integration/debug_adapter_test.js
+++ b/packages/ember-data/tests/integration/debug_adapter_test.js
@@ -22,11 +22,6 @@ module("DS.DebugAdapter", {
 
     debugAdapter.reopen({
       getModelTypes: function() {
-        // Support Ember < 1.5.
-        // TODO: Remove this workaround (if statement) when Ember 1.5 is released.
-        if (!this.get('containerDebugAdapter')) {
-          return Ember.A([App.Post]);
-        }
         return Ember.A([{ klass: App.Post, name: 'App.Post' }]);
       }
     });


### PR DESCRIPTION
Since support for Ember <= 1.7.1 has been removed, I'm guessing it's safe to remove this.