### PR TITLE
Use store.push instead of store.update in test

### DIFF
--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -116,7 +116,7 @@ test("Calling push with partial records updates just those attributes", function
       lastName: "Katz"
     });
 
-    store.update('person', {
+    store.push('person', {
       id: 'wat',
       lastName: "Katz!"
     });


### PR DESCRIPTION
This removes the store.update deprecation warning when running tests