### PR TITLE
Remove yuidoc warning

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -602,9 +602,7 @@ export default Adapter.extend({
     return expandedURL.join('/');
   },
 
-  /**
-    http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
-  */
+  // http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
   maxUrlLength: 2048,
 
   /**


### PR DESCRIPTION
Removes this warning from the build:

```
info: (yuidoc): YUIDoc Starting from: packages
warn: (docparser): Missing item type:  packages/ember-data/lib/adapters/rest_adapter.js:605
warn: (docparser):             http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
```