### PR TITLE
Don't warn for polymorphic belongsTo type keys

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1400,15 +1400,15 @@ Store = Ember.Object.extend({
     var type = this.modelFor(typeName);
     var filter = Ember.EnumerableUtils.filter;
 
-    // If the payload contains unused keys log a warning.
-    // Adding `Ember.ENV.DS_NO_WARN_ON_UNUSED_KEYS = true` will suppress the warning.
-    if (!Ember.ENV.DS_NO_WARN_ON_UNUSED_KEYS) {
+    // If Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS is set to true and the payload
+    // contains unknown keys, log a warning.
+    if (Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS) {
       Ember.warn("The payload for '" + type.typeKey + "' contains these unknown keys: " +
         Ember.inspect(filter(Ember.keys(data), function(key) {
-          return !get(type, 'fields').has(key) && key !== 'id' && key !== 'links';
+          return !(key === 'id' || key === 'links' || get(type, 'fields').has(key) || key.match(/Type$/));
         })) + ". Make sure they've been defined in your model.",
         filter(Ember.keys(data), function(key) {
-          return !get(type, 'fields').has(key) && key !== 'id' && key !== 'links';
+          return !(key === 'id' || key === 'links' || get(type, 'fields').has(key) || key.match(/Type$/));
         }).length === 0
       );
     }

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -568,11 +568,12 @@ test('calling push with an embedded relationship throws a useful error', functio
     }, /If this is an embedded relationship/);
 });
 
-test("Ember.ENV.DS_NO_WARN_ON_UNUSED_KEYS suppresses unknown keys warning", function() {
+test("Enabling Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS should warn on unknown keys", function() {
   run(function(){
+    var originalFlagValue = Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS;
     try {
-      Ember.ENV.DS_NO_WARN_ON_UNUSED_KEYS = true;
-        noWarns(function() {
+      Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS = true;
+        warns(function() {
           store.push('person', {
             id: '1',
             firstName: 'Tomster',
@@ -581,13 +582,13 @@ test("Ember.ENV.DS_NO_WARN_ON_UNUSED_KEYS suppresses unknown keys warning", func
           });
         });
     } finally {
-      Ember.ENV.DS_NO_WARN_ON_UNUSED_KEYS = null;
+      Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS = originalFlagValue;
     }
   });
 });
 
-test("Calling push with unknown keys in the provided payload should warn", function() {
-  warns(function() {
+test("Calling push with unknown keys should not warn by default", function() {
+  noWarns(function() {
     run(function(){
       store.push('person', {
         id: '1',


### PR DESCRIPTION
This is not pretty but it was the least ugly thing I could come up with. This also allows for regular attributes ending in "Type", like:

```javascript
App.Thing = DS.Model.extend({
  fakeType: DS.attr('string')
});
```

Fixes #2599 