### PR TITLE
Test warnings cleanup

### DIFF
--- a/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
@@ -233,8 +233,7 @@ test("extractPolymorphic hasMany", function() {
   YellowMinion.toString = function() { return "YellowMinion"; };
 
   var json_hash = {
-    mediocre_villain: {id: 1, name: "Dr Horrible", evil_minions: [{ type: "yellow_minion", id: 12}] },
-    evil_minions:    [{id: 12, name: "Alex", doomsday_device_ids: [1] }]
+    mediocre_villain: { id: 1, name: "Dr Horrible", evil_minions: [{ type: "yellow_minion", id: 12 }] }
   };
   var json;
 
@@ -258,8 +257,7 @@ test("extractPolymorphic", function() {
   YellowMinion.toString = function() { return "YellowMinion"; };
 
   var json_hash = {
-    doomsday_device: {id: 1, name: "DeathRay", evil_minion: { type: "yellow_minion", id: 12}},
-    evil_minions:    [{id: 12, name: "Alex", doomsday_device_ids: [1] }]
+    doomsday_device: { id: 1, name: "DeathRay", evil_minion: { type: "yellow_minion", id: 12 } }
   };
   var json;
 
@@ -279,8 +277,7 @@ test("extractPolymorphic", function() {
 
 test("extractPolymorphic when the related data is not specified", function() {
   var json = {
-    doomsday_device: {id: 1, name: "DeathRay"},
-    evil_minions:    [{id: 12, name: "Alex", doomsday_device_ids: [1] }]
+    doomsday_device: { id: 1, name: "DeathRay" }
   };
 
   run(function(){

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -1167,8 +1167,16 @@ test("Passing a model as type to hasMany should not work", function () {
 test("Relationship.clear removes all records correctly", function(){
   var post;
 
+  Comment.reopen({
+    post: DS.belongsTo('post')
+  });
+
+  Post.reopen({
+    comments: DS.hasMany('comment', { inverse: 'post' })
+  });
+
   run(function(){
-    post = env.store.push('post', { id: 2, title: 'Sailing the Seven Seas', comments: [1,2] });
+    post = env.store.push('post', { id: 2, title: 'Sailing the Seven Seas', comments: [1, 2] });
     env.store.pushMany('comment', [
       {
         id: 1,
@@ -1188,7 +1196,7 @@ test("Relationship.clear removes all records correctly", function(){
   run(function(){
     post._relationships['comments'].clear();
     var comments = Em.A(env.store.all('comment'));
-    deepEqual(comments.mapBy('post'), [undefined, undefined, undefined]);
+    deepEqual(comments.mapBy('post'), [null, null, null]);
   });
 
 });
@@ -1196,6 +1204,14 @@ test("Relationship.clear removes all records correctly", function(){
 
 test('unloading a record with associated records does not prevent the store from tearing down', function(){
   var post;
+
+  Comment.reopen({
+    post: DS.belongsTo('post')
+  });
+
+  Post.reopen({
+    comments: DS.hasMany('comment', { inverse: 'post' })
+  });
 
   run(function(){
     post = env.store.push('post', { id: 2, title: 'Sailing the Seven Seas', comments: [1,2] });

--- a/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
@@ -1054,7 +1054,7 @@ test("extractSingle with multiply-nested belongsTo", function() {
         home_planet: {
           id: "1",
           name: "Umber",
-          super_villain_ids: ["1"]
+          villain_ids: ["1"]
         }
       }
     }

--- a/packages/ember-data/tests/unit/model/lifecycle_callbacks_test.js
+++ b/packages/ember-data/tests/unit/model/lifecycle_callbacks_test.js
@@ -34,6 +34,7 @@ test("a record receives a didUpdate callback when it has finished updating", fun
 
   var Person = DS.Model.extend({
     bar: DS.attr('string'),
+    name: DS.attr('string'),
 
     didUpdate: function() {
       callCount++;
@@ -119,6 +120,7 @@ test("a record receives a didDelete callback when it has finished deleting", fun
 
   var Person = DS.Model.extend({
     bar: DS.attr('string'),
+    name: DS.attr('string'),
 
     didDelete: function() {
       callCount++;
@@ -168,6 +170,7 @@ test("a record receives a becameInvalid callback when it became invalid", functi
 
   var Person = DS.Model.extend({
     bar: DS.attr('string'),
+    name: DS.attr('string'),
 
     becameInvalid: function() {
       callCount++;

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -100,7 +100,7 @@ test("a record's id is included in its toString representation", function() {
 test("trying to set an `id` attribute should raise", function() {
   Person = DS.Model.extend({
     id: DS.attr('number'),
-    name: "Scumdale"
+    name: DS.attr('string'),
   });
 
   expectAssertion(function() {
@@ -575,7 +575,7 @@ test("ensure model exits loading state, materializes data and fulfills promise o
   var store = createStore({
     adapter: DS.Adapter.extend({
       find: function(store, type, id) {
-        return Ember.RSVP.resolve({ id: 1, name: "John", isDrugAddict: false });
+        return Ember.RSVP.resolve({ id: 1, name: "John" });
       }
     })
   });
@@ -604,7 +604,8 @@ test("A DS.Model can be JSONified", function() {
 
 test("A subclass of DS.Model can not use the `data` property", function() {
   var Person = DS.Model.extend({
-    data: DS.attr('string')
+    data: DS.attr('string'),
+    name: DS.attr('string')
   });
 
   var store = createStore({ person: Person });

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -102,7 +102,7 @@ test("Calling push triggers `didLoad` even if the record hasn't been requested f
 test("Calling update should be deprecated", function() {
   expectDeprecation(function() {
     run(function() {
-      store.update('person', { id: '1', name: 'Tomster' });
+      store.update('person', { id: '1', firstName: 'Yehuda', lastName: 'Katz' });
     });
   });
 });
@@ -467,6 +467,10 @@ test('Calling push with a link for a non async relationship should warn', functi
 });
 
 test('Calling push with a link containing an object throws an assertion error', function() {
+  Person.reopen({
+    phoneNumbers: hasMany('phone-number', { async: true })
+  });
+
   expectAssertion(function() {
     run(function(){
       store.push('person', {

--- a/packages/ember-data/tests/unit/store/unload_test.js
+++ b/packages/ember-data/tests/unit/store/unload_test.js
@@ -13,7 +13,8 @@ module("unit/store/unload - Store unloading records", {
     });
 
     Record = DS.Model.extend({
-      title: DS.attr('string')
+      title: DS.attr('string'),
+      wasFetched: DS.attr('boolean')
     });
   },
 


### PR DESCRIPTION
Cleaned up some tests to remove all warnings when running the test suit. The only warnings left are two of these:

```
WARNING: The payload for 'comment' contains these unknown keys: [messageType]. Make sure they've been defined in your model.
```

..but they will disappear when/if #2677 is merged.