### PR TITLE
Add `expect` calls when async is involved

### DIFF
--- a/packages/ember-data/tests/unit/model/lifecycle_callbacks_test.js
+++ b/packages/ember-data/tests/unit/model/lifecycle_callbacks_test.js
@@ -4,6 +4,8 @@ var run = Ember.run;
 module("unit/model/lifecycle_callbacks - Lifecycle Callbacks");
 
 test("a record receives a didLoad callback when it has finished loading", function() {
+  expect(3);
+
   var Person = DS.Model.extend({
     name: DS.attr(),
     didLoad: function() {
@@ -30,6 +32,8 @@ test("a record receives a didLoad callback when it has finished loading", functi
 });
 
 test("a record receives a didUpdate callback when it has finished updating", function() {
+  expect(5);
+
   var callCount = 0;
 
   var Person = DS.Model.extend({
@@ -77,6 +81,8 @@ test("a record receives a didUpdate callback when it has finished updating", fun
 });
 
 test("a record receives a didCreate callback when it has finished updating", function() {
+  expect(5);
+
   var callCount = 0;
 
   var Person = DS.Model.extend({
@@ -115,6 +121,8 @@ test("a record receives a didCreate callback when it has finished updating", fun
 });
 
 test("a record receives a didDelete callback when it has finished deleting", function() {
+  expect(5);
+
   var callCount = 0;
 
   var Person = DS.Model.extend({
@@ -164,6 +172,8 @@ test("a record receives a didDelete callback when it has finished deleting", fun
 });
 
 test("a record receives a becameInvalid callback when it became invalid", function() {
+  expect(5);
+
   var callCount = 0;
 
   var Person = DS.Model.extend({

--- a/packages/ember-data/tests/unit/model/merge_test.js
+++ b/packages/ember-data/tests/unit/model/merge_test.js
@@ -7,21 +7,18 @@ module("unit/model/merge - Merging", {
       name: DS.attr(),
       city: DS.attr()
     });
-  },
-
-  teardown: function() {
-
   }
 });
 
 test("When a record is in flight, changes can be made", function() {
+  expect(3);
+
   var adapter = DS.Adapter.extend({
     createRecord: function(store, type, record) {
       return Ember.RSVP.resolve({ id: 1, name: "Tom Dale" });
     }
   });
   var person;
-
   var store = createStore({ adapter: adapter });
 
   run(function(){
@@ -29,7 +26,7 @@ test("When a record is in flight, changes can be made", function() {
   });
 
   // Make sure saving isn't resolved synchronously
-  Ember.run(function() {
+  run(function() {
     var promise = person.save();
 
     equal(person.get('name'), "Tom Dale");
@@ -44,11 +41,13 @@ test("When a record is in flight, changes can be made", function() {
 });
 
 test("When a record is in flight, pushes are applied underneath the in flight changes", function() {
+  expect(6);
+
   var adapter = DS.Adapter.extend({
     updateRecord: function(store, type, record) {
     // Make sure saving isn't resolved synchronously
       return new Ember.RSVP.Promise(function(resolve, reject){
-        Ember.run.next(null, resolve, { id: 1, name: "Senor Thomas Dale, Esq.", city: "Portland" });
+        run.next(null, resolve, { id: 1, name: "Senor Thomas Dale, Esq.", city: "Portland" });
       });
     }
   });
@@ -61,7 +60,7 @@ test("When a record is in flight, pushes are applied underneath the in flight ch
     person.set('name', "Thomas Dale");
   });
 
-  Ember.run(function() {
+  run(function() {
     var promise = person.save();
 
     equal(person.get('name'), "Thomas Dale");
@@ -104,6 +103,8 @@ test("When a record is dirty, pushes are overridden by local changes", function(
 });
 
 test("A record with no changes can still be saved", function() {
+  expect(1);
+
   var adapter = DS.Adapter.extend({
     updateRecord: function(store, type, record) {
       return Ember.RSVP.resolve({ id: 1, name: "Thomas Dale" });
@@ -125,6 +126,8 @@ test("A record with no changes can still be saved", function() {
 });
 
 test("A dirty record can be reloaded", function() {
+  expect(3);
+
   var adapter = DS.Adapter.extend({
     find: function(store, type, id) {
       return Ember.RSVP.resolve({ id: 1, name: "Thomas Dale", city: "Portland" });

--- a/packages/ember-data/tests/unit/model/relationships_test.js
+++ b/packages/ember-data/tests/unit/model/relationships_test.js
@@ -44,6 +44,8 @@ module("unit/model/relationships - DS.hasMany", {
 });
 
 test("hasMany handles pre-loaded relationships", function() {
+  expect(13);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     person: DS.belongsTo('person')
@@ -118,7 +120,7 @@ test("hasMany handles pre-loaded relationships", function() {
       equal(get(pets, 'length'), 1, "the list of pets should have the correct length");
       equal(get(pets.objectAt(0), 'name'), "fluffy", "the first pet should be correct");
 
-      Ember.run(function() {
+      run(function() {
         store.push(Person, { id: 4, name: "Cyvid Hamluck", pets: [4, 12] });
       });
 
@@ -129,6 +131,8 @@ test("hasMany handles pre-loaded relationships", function() {
 });
 
 test("hasMany lazily loads async relationships", function() {
+  expect(5);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     person: DS.belongsTo('person')
@@ -259,6 +263,8 @@ test("should be able to retrieve the type for a belongsTo relationship specified
 });
 
 test("relationships work when declared with a string path", function() {
+  expect(2);
+
   window.App = {};
 
   var Person = DS.Model.extend({
@@ -289,6 +295,8 @@ test("relationships work when declared with a string path", function() {
 });
 
 test("hasMany relationships work when the data hash has not been loaded", function() {
+  expect(8);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     person: DS.belongsTo('person')
@@ -337,6 +345,8 @@ test("hasMany relationships work when the data hash has not been loaded", functi
 });
 
 test("it is possible to add a new item to a relationship", function() {
+  expect(2);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     people: DS.belongsTo('person')
@@ -374,6 +384,8 @@ test("it is possible to add a new item to a relationship", function() {
 });
 
 test("possible to replace items in a relationship using setObjects w/ Ember Enumerable Array/Object as the argument (GH-2533)", function(){
+  expect(2);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     person: DS.belongsTo('person')
@@ -386,9 +398,8 @@ test("possible to replace items in a relationship using setObjects w/ Ember Enum
 
   var env   = setupStore({ tag: Tag, person: Person });
   var store = env.store;
-  var run   = Ember.run;
 
-  Ember.run(function(){
+  run(function(){
     store.push('person', { id: 1, name: "Tom Dale", tags: [ 1 ] });
     store.push('person', { id: 2, name: "Sylvain Mina", tags: [ 2 ] });
     store.push('tag', { id: 1, name: "ember" });
@@ -410,6 +421,8 @@ test("possible to replace items in a relationship using setObjects w/ Ember Enum
 });
 
 test("it is possible to remove an item from a relationship", function() {
+  expect(2);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     person: DS.belongsTo('person')
@@ -517,6 +530,8 @@ test("updating the content of a RecordArray updates its content", function() {
 });
 
 test("can create child record from a hasMany relationship", function() {
+  expect(3);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     person: DS.belongsTo('person')
@@ -548,6 +563,8 @@ test("can create child record from a hasMany relationship", function() {
 module("unit/model/relationships - DS.belongsTo");
 
 test("belongsTo lazily loads relationships as needed", function() {
+  expect(5);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     people: DS.hasMany('person')
@@ -582,6 +599,8 @@ test("belongsTo lazily loads relationships as needed", function() {
 });
 
 test("async belongsTo relationships work when the data hash has not been loaded", function() {
+  expect(5);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string')
   });
@@ -621,6 +640,8 @@ test("async belongsTo relationships work when the data hash has not been loaded"
 });
 
 test("async belongsTo relationships work when the data hash has already been loaded", function() {
+  expect(3);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string')
   });
@@ -652,6 +673,8 @@ test("async belongsTo relationships work when the data hash has already been loa
 });
 
 test("calling createRecord and passing in an undefined value for a relationship should be treated as if null", function () {
+  expect(1);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     person: DS.belongsTo('person')
@@ -722,6 +745,7 @@ test("When finding a hasMany relationship the inverse belongsTo relationship is 
 
 test("When finding a belongsTo relationship the inverse belongsTo relationship is available immediately", function() {
   expect(1);
+
   var Occupation = DS.Model.extend({
     description: DS.attr('string'),
     person: DS.belongsTo('person')
@@ -754,6 +778,8 @@ test("When finding a belongsTo relationship the inverse belongsTo relationship i
 });
 
 test("belongsTo supports relationships to models with id 0", function() {
+  expect(5);
+
   var Tag = DS.Model.extend({
     name: DS.attr('string'),
     people: DS.hasMany('person')

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -1,7 +1,8 @@
-var get = Ember.get, set = Ember.set;
+var get = Ember.get;
+var set = Ember.set;
+var run = Ember.run;
 
 var Person, store, array;
-var run = Ember.run;
 
 module("unit/model - DS.Model", {
   setup: function() {
@@ -33,6 +34,8 @@ test("can have a property set on it", function() {
 });
 
 test("setting a property on a record that has not changed does not cause it to become dirty", function() {
+  expect(2);
+
   run(function(){
     store.push(Person, { id: 1, name: "Peter", isDrugAddict: true });
     store.find(Person, 1).then(function(person) {
@@ -47,6 +50,8 @@ test("setting a property on a record that has not changed does not cause it to b
 });
 
 test("resetting a property on a record cause it to become clean again", function() {
+  expect(3);
+
   run(function(){
     store.push(Person, { id: 1, name: "Peter", isDrugAddict: true });
     store.find(Person, 1).then(function(person) {
@@ -60,6 +65,8 @@ test("resetting a property on a record cause it to become clean again", function
 });
 
 test("a record becomes clean again only if all changed properties are reset", function() {
+  expect(5);
+
   run(function(){
     store.push(Person, { id: 1, name: "Peter", isDrugAddict: true });
     store.find(Person, 1).then(function(person) {
@@ -77,6 +84,8 @@ test("a record becomes clean again only if all changed properties are reset", fu
 });
 
 test("a record reports its unique id via the `id` property", function() {
+  expect(1);
+
   run(function(){
     store.push(Person, { id: 1 });
     store.find(Person, 1).then(function(record) {
@@ -86,13 +95,12 @@ test("a record reports its unique id via the `id` property", function() {
 });
 
 test("a record's id is included in its toString representation", function() {
+  expect(1);
+
   run(function(){
     store.push(Person, { id: 1 });
-
-    run(function(){
-      store.find(Person, 1).then(function(record) {
-        equal(record.toString(), '<(subclass of DS.Model):'+Ember.guidFor(record)+':1>', "reports id in toString");
-      });
+    store.find(Person, 1).then(function(record) {
+      equal(record.toString(), '<(subclass of DS.Model):'+Ember.guidFor(record)+':1>', "reports id in toString");
     });
   });
 });
@@ -112,6 +120,8 @@ test("trying to set an `id` attribute should raise", function() {
 });
 
 test("a collision of a record's id with object function's name", function() {
+  expect(1);
+
   var hasWatchMethod = Object.prototype.watch;
   try {
     if (!hasWatchMethod) {
@@ -131,6 +141,8 @@ test("a collision of a record's id with object function's name", function() {
 });
 
 test("it should use `_reference` and not `reference` to store its reference", function() {
+  expect(1);
+
   run(function(){
     store.push(Person, { id: 1 });
 
@@ -141,6 +153,8 @@ test("it should use `_reference` and not `reference` to store its reference", fu
 });
 
 test("it should cache attributes", function() {
+  expect(2);
+
   var store = createStore();
 
   var Post = DS.Model.extend({
@@ -240,6 +254,8 @@ module("unit/model - DS.Model updating", {
 });
 
 test("a DS.Model can update its attributes", function() {
+  expect(1);
+
   run(function(){
     store.find(Person, 2).then(function(person) {
       set(person, 'name', "Brohuda Katz");
@@ -312,11 +328,7 @@ test("setting a property to undefined on a newly created record should not impac
 
   run(function(){
     tag = store.createRecord(Tag);
-  });
-  run(function(){
     set(tag, 'name', 'testing');
-  });
-  run(function(){
     set(tag, 'name', undefined);
   });
 
@@ -332,6 +344,8 @@ test("setting a property to undefined on a newly created record should not impac
 // NOTE: this is a 'backdoor' test that ensures internal consistency, and should be
 // thrown out if/when the current `_attributes` hash logic is removed.
 test("setting a property back to its original value removes the property from the `_attributes` hash", function() {
+  expect(3);
+
   run(function(){
     store.find(Person, 1).then(function(person) {
       equal(person._attributes.name, undefined, "the `_attributes` hash is clean");
@@ -349,7 +363,11 @@ test("setting a property back to its original value removes the property from th
 
 module("unit/model - with a simple Person model", {
   setup: function() {
-    array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];
+    array = [
+      { id: 1, name: "Scumbag Dale" },
+      { id: 2, name: "Scumbag Katz" },
+      { id: 3, name: "Scumbag Bryn" }
+    ];
     Person = DS.Model.extend({
       name: DS.attr('string')
     });
@@ -498,6 +516,8 @@ var convertsWhenSet = function(type, provided, expected) {
 };
 
 test("a DS.Model can describe String attributes", function() {
+  expect(6);
+
   converts('string', "Scumbag Tom", "Scumbag Tom");
   converts('string', 1, "1");
   converts('string', "", "");
@@ -507,6 +527,8 @@ test("a DS.Model can describe String attributes", function() {
 });
 
 test("a DS.Model can describe Number attributes", function() {
+  expect(9);
+
   converts('number', "1", 1);
   converts('number', "0", 0);
   converts('number', 1, 1);
@@ -519,6 +541,8 @@ test("a DS.Model can describe Number attributes", function() {
 });
 
 test("a DS.Model can describe Boolean attributes", function() {
+  expect(7);
+
   converts('boolean', "1", true);
   converts('boolean', "", false);
   converts('boolean', 1, true);
@@ -529,6 +553,8 @@ test("a DS.Model can describe Boolean attributes", function() {
 });
 
 test("a DS.Model can describe Date attributes", function() {
+  expect(5);
+
   converts('date', null, null);
   converts('date', undefined, undefined);
 
@@ -572,6 +598,8 @@ test("don't allow setting", function(){
 });
 
 test("ensure model exits loading state, materializes data and fulfills promise only after data is available", function () {
+  expect(2);
+
   var store = createStore({
     adapter: DS.Adapter.extend({
       find: function(store, type, id) {

--- a/packages/ember-data/tests/unit/record_array_test.js
+++ b/packages/ember-data/tests/unit/record_array_test.js
@@ -14,6 +14,8 @@ module("unit/record_array - DS.RecordArray", {
 });
 
 test("a record array is backed by records", function() {
+  expect(3);
+
   var store = createStore();
   run(function(){
     store.pushMany(Person, array);
@@ -67,6 +69,8 @@ test("stops updating when destroyed", function() {
 
 
 test("a loaded record is removed from a record array when it is deleted", function() {
+  expect(4);
+
   var Tag = DS.Model.extend({
     people: DS.hasMany('person')
   });
@@ -223,6 +227,8 @@ test("a record array should be able to be enumerated in any order", function() {
 });
 
 test("an AdapterPopulatedRecordArray knows if it's loaded or not", function() {
+  expect(1);
+
   var env = setupStore({ person: Person }),
       store = env.store;
 

--- a/packages/ember-data/tests/unit/store/adapter_interop_test.js
+++ b/packages/ember-data/tests/unit/store/adapter_interop_test.js
@@ -15,7 +15,7 @@ module("unit/store/adapter_interop - DS.Store working with a DS.Adapter", {
 });
 
 test("Adapter can be set as a factory", function() {
-  store = createStore({adapter: TestAdapter});
+  store = createStore({ adapter: TestAdapter });
 
   ok(store.get('defaultAdapter') instanceof TestAdapter);
 });
@@ -27,6 +27,8 @@ test('Adapter can be set as a name', function() {
 });
 
 test('Adapter can not be set as an instance', function() {
+  expect(5);
+
   store = DS.Store.create({
     adapter: DS.Adapter.create()
   });
@@ -79,13 +81,15 @@ test("Calling Store#findById multiple times coalesces the calls into a adapter#f
   var currentType = DS.Model.extend();
   currentType.typeKey = "test";
   stop();
-  Ember.run(function(){
+  run(function(){
     currentStore.find(currentType, 1);
     currentStore.find(currentType, 2);
   });
 });
 
 test("Returning a promise from `find` asynchronously loads data", function() {
+  expect(1);
+
   var adapter = TestAdapter.extend({
     find: function(store, type, id) {
       return resolve({ id: 1, name: "Scumbag Dale" });
@@ -105,6 +109,8 @@ test("Returning a promise from `find` asynchronously loads data", function() {
 });
 
 test("IDs provided as numbers are coerced to strings", function() {
+  expect(4);
+
   var adapter = TestAdapter.extend({
     find: function(store, type, id) {
       equal(typeof id, 'string', "id has been normalized to a string");
@@ -135,6 +141,8 @@ test("IDs provided as numbers are coerced to strings", function() {
 var array = [{ id: "1", name: "Scumbag Dale" }, { id: "2", name: "Scumbag Katz" }, { id: "3", name: "Scumbag Bryn" }];
 
 test("can load data for the same record if it is not dirty", function() {
+  expect(3);
+
   var store = createStore();
   var Person = DS.Model.extend({
     name: DS.attr('string')
@@ -166,6 +174,8 @@ test("DS.Store loads individual records without explicit IDs with a custom prima
 */
 
 test("pushMany extracts ids from an Array of hashes if no ids are specified", function() {
+  expect(1);
+
   var store = createStore();
 
   var Person = DS.Model.extend({ name: DS.attr('string') });
@@ -179,6 +189,8 @@ test("pushMany extracts ids from an Array of hashes if no ids are specified", fu
 });
 
 test("loadMany takes an optional Object and passes it on to the Adapter", function() {
+  expect(2);
+
   var passedQuery = { page: 1 };
 
   var Person = DS.Model.extend({
@@ -323,6 +335,8 @@ test("an initial data hash can be provided via store.createRecord(type, hash)", 
 });
 
 test("if an id is supplied in the initial data hash, it can be looked up using `store.find`", function() {
+  expect(1);
+
   var store = createStore();
   var Person = DS.Model.extend({
     name: DS.attr('string')
@@ -338,6 +352,8 @@ test("if an id is supplied in the initial data hash, it can be looked up using `
 });
 
 test("initial values of attributes can be passed in as the third argument to find", function() {
+  expect(1);
+
   var adapter = TestAdapter.extend({
     find: function(store, type, query) {
       return Ember.RSVP.resolve({id: '1', name: 'Test'});
@@ -388,6 +404,7 @@ test("initial values of belongsTo can be passed in as the third argument to find
 
 test("initial values of belongsTo can be passed in as the third argument to find as ids", function() {
   expect(1);
+
   var adapter = TestAdapter.extend({
     find: function(store, type, id) {
       return Ember.RSVP.Promise.resolve({id: id});
@@ -470,6 +487,8 @@ test("initial values of hasMany can be passed in as the third argument to find a
 });
 
 test("records should have their ids updated when the adapter returns the id data", function() {
+  expect(2);
+
   var Person = DS.Model.extend();
 
   var idCounter = 1;
@@ -501,6 +520,8 @@ test("records should have their ids updated when the adapter returns the id data
 });
 
 test("store.fetchMany should always return a promise", function() {
+  expect(3);
+
   var Person = DS.Model.extend();
   var store = createStore({
     adapter: TestAdapter.extend()
@@ -522,7 +543,9 @@ test("store.fetchMany should always return a promise", function() {
   }));
 });
 
-test("store.scheduleFetchMany should not resolve until all the records are resolve", function() {
+test("store.scheduleFetchMany should not resolve until all the records are resolved", function() {
+  expect(1);
+
   var Person = DS.Model.extend();
   var Phone = DS.Model.extend();
 
@@ -533,7 +556,7 @@ test("store.scheduleFetchMany should not resolve until all the records are resol
       var record = { id: id };
 
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        Ember.run.later(function() {
+        run.later(function() {
           resolve(record);
         }, wait);
       });
@@ -547,7 +570,7 @@ test("store.scheduleFetchMany should not resolve until all the records are resol
       });
 
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        Ember.run.later(function() {
+        run.later(function() {
           resolve(records);
         }, wait);
       });
@@ -627,6 +650,7 @@ test("the store calls adapter.findMany according to groupings returned by adapte
 
 test("the promise returned by `scheduleFetch`, when it resolves, does not depend on the promises returned to other calls to `scheduleFetch` that are in the same run loop, but different groups", function() {
   expect(2);
+
   var Person = DS.Model.extend();
   var davidResolved = false;
 
@@ -645,7 +669,7 @@ test("the promise returned by `scheduleFetch`, when it resolves, does not depend
         if (id === 'igor') {
           resolve(record);
         } else {
-          Ember.run.later(function () {
+          run.later(function () {
             davidResolved = true;
             resolve(record);
           }, 5);
@@ -658,7 +682,7 @@ test("the promise returned by `scheduleFetch`, when it resolves, does not depend
     adapter: adapter
   });
 
-  Ember.run(function () {
+  run(function () {
     var davidPromise = store.find(Person, 'david');
     var igorPromise = store.find(Person, 'igor');
 
@@ -674,6 +698,7 @@ test("the promise returned by `scheduleFetch`, when it resolves, does not depend
 
 test("the promise returned by `scheduleFetch`, when it rejects, does not depend on the promises returned to other calls to `scheduleFetch` that are in the same run loop, but different groups", function() {
   expect(2);
+
   var Person = DS.Model.extend();
   var davidResolved = false;
 
@@ -692,7 +717,7 @@ test("the promise returned by `scheduleFetch`, when it rejects, does not depend 
         if (id === 'igor') {
           reject(record);
         } else {
-          Ember.run.later(function () {
+          run.later(function () {
             davidResolved = true;
             resolve(record);
           }, 5);
@@ -705,7 +730,7 @@ test("the promise returned by `scheduleFetch`, when it rejects, does not depend 
     adapter: adapter
   });
 
-  Ember.run(function () {
+  run(function () {
     var davidPromise = store.find(Person, 'david');
     var igorPromise = store.find(Person, 'igor');
 
@@ -721,6 +746,7 @@ test("the promise returned by `scheduleFetch`, when it rejects, does not depend 
 
 test("store.fetchRecord reject records that were not found, even when those requests were coalesced with records that were found", function() {
   expect(2);
+
   var Person = DS.Model.extend();
 
   var adapter = TestAdapter.extend({
@@ -741,7 +767,7 @@ test("store.fetchRecord reject records that were not found, even when those requ
     adapter: adapter
   });
 
-  Ember.run(function () {
+  run(function () {
     var davidPromise = store.find(Person, 'david');
     var igorPromise = store.find(Person, 'igor');
 

--- a/packages/ember-data/tests/unit/store/create_record_test.js
+++ b/packages/ember-data/tests/unit/store/create_record_test.js
@@ -60,7 +60,7 @@ test("creating a record by dasherize string finds the model", function(){
 module("unit/store/createRecord - Store with models by camelCase", {
   setup: function() {
     var env = setupStore({
-      'someThing': DS.Model.extend({ foo: DS.attr('string') })
+      someThing: DS.Model.extend({ foo: DS.attr('string') })
     });
     store = env.store;
     container = env.container;

--- a/packages/ember-data/tests/unit/store/metadata_for_test.js
+++ b/packages/ember-data/tests/unit/store/metadata_for_test.js
@@ -27,9 +27,9 @@ test("metaForType should be deprecated", function() {
 
 test("metadataFor and setMetadataFor should return and set correct metadata", function() {
   expect(7);
-  var keys = Ember.keys;
+
   function metadataKeys(type){
-    return keys(store.metadataFor(type));
+    return Ember.keys(store.metadataFor(type));
   }
 
   // Currently not using QUnit.deepEqual due to the way deepEqual

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -1,5 +1,7 @@
 var env, store, Person, PhoneNumber, Post;
-var attr = DS.attr, hasMany = DS.hasMany, belongsTo = DS.belongsTo;
+var attr = DS.attr;
+var hasMany = DS.hasMany;
+var belongsTo = DS.belongsTo;
 var run = Ember.run;
 
 module("unit/store/push - DS.Store#push", {
@@ -38,13 +40,15 @@ module("unit/store/push - DS.Store#push", {
   },
 
   teardown: function() {
-    Ember.run(function() {
+    run(function() {
       store.destroy();
     });
   }
 });
 
 test("Calling push with a normalized hash returns a record", function() {
+  expect(2);
+
   run(function(){
     var person = store.push('person', {
       id: 'wat',
@@ -63,6 +67,8 @@ test("Calling push with a normalized hash returns a record", function() {
 });
 
 test("Supplying a model class for `push` is the same as supplying a string", function () {
+  expect(1);
+
   var Programmer = Person.extend();
   env.container.register('model:programmer', Programmer);
 
@@ -84,6 +90,8 @@ test("Supplying a model class for `push` is the same as supplying a string", fun
 });
 
 test("Calling push triggers `didLoad` even if the record hasn't been requested from the adapter", function() {
+  expect(1);
+
   Person.reopen({
     didLoad: async(function() {
       ok(true, "The didLoad callback was called");
@@ -108,9 +116,10 @@ test("Calling update should be deprecated", function() {
 });
 
 test("Calling push with partial records updates just those attributes", function() {
-  var person;
+  expect(2);
+
   run(function(){
-    person = store.push('person', {
+    var person = store.push('person', {
       id: 'wat',
       firstName: "Yehuda",
       lastName: "Katz"
@@ -210,6 +219,8 @@ test("Calling push with a normalized hash containing related records returns a r
 });
 
 test("Calling push with a normalized hash containing IDs of related records returns a record", function() {
+  expect(1);
+
   Person.reopen({
     phoneNumbers: hasMany('phone-number', { async: true })
   });
@@ -558,7 +569,7 @@ test('calling push with an embedded relationship throws a useful error', functio
 });
 
 test("Ember.ENV.DS_NO_WARN_ON_UNUSED_KEYS suppresses unknown keys warning", function() {
-  Ember.run(function(){
+  run(function(){
     try {
       Ember.ENV.DS_NO_WARN_ON_UNUSED_KEYS = true;
         noWarns(function() {

--- a/packages/ember-data/tests/unit/store/unload_test.js
+++ b/packages/ember-data/tests/unit/store/unload_test.js
@@ -1,6 +1,6 @@
 var get = Ember.get;
-var store, tryToFind, Record;
 var run = Ember.run;
+var store, tryToFind, Record;
 
 module("unit/store/unload - Store unloading records", {
   setup: function() {
@@ -23,6 +23,8 @@ module("unit/store/unload - Store unloading records", {
 });
 
 test("unload a dirty record", function() {
+  expect(2);
+
   run(function(){
     store.push(Record, {
       id: 1,
@@ -48,6 +50,8 @@ test("unload a dirty record", function() {
 });
 
 test("unload a record", function() {
+  expect(5);
+
   run(function(){
     store.push(Record, {id: 1, title: 'toto'});
     store.find(Record, 1).then(function(record) {
@@ -73,6 +77,8 @@ module("DS.Store - unload record with relationships");
 
 
 test("can commit store after unload record with relationships", function() {
+  expect(1);
+
   var like, product;
 
   var Brand = DS.Model.extend({


### PR DESCRIPTION
`expect` calls within callbacks ensure that all expectations are invoked
and passing.