### PR TITLE
Run Travis-CI with Docker / Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 ---
 language: node_js
+sudo: false
+cache:
+  directories:
+    - node_modules
 node_js:
   - "0.10"
 before_install:


### PR DESCRIPTION
http://docs.travis-ci.com/user/workers/container-based-infrastructure/

Running CI in docker container should be more performant. This is already
being done in
[ember/ember.js](https://github.com/emberjs/ember.js/blob/dca9c74de7136deff79b9cb2f2de4f6b6b8237c7/.travis.yml#L6-L10)