### PR TITLE
Implement ES6-compliant Date string parsing

### DIFF
--- a/packages/ember-data/lib/ext/date.js
+++ b/packages/ember-data/lib/ext/date.js
@@ -39,11 +39,17 @@ Ember.Date.parse = function (date) {
         struct[2] = (+struct[2] || 1) - 1;
         struct[3] = +struct[3] || 1;
 
-        if (struct[8] !== 'Z' && struct[9] !== undefined) {
-            minutesOffset = struct[10] * 60 + struct[11];
+        if (struct[8] !== 'Z') {
+            if (struct[9] !== undefined) {
+                minutesOffset = struct[10] * 60 + struct[11];
 
-            if (struct[9] === '+') {
-                minutesOffset = 0 - minutesOffset;
+                if (struct[9] === '+') {
+                    minutesOffset = 0 - minutesOffset;
+                }
+            // ES6 §20.3.1.15 states "If the time zone offset is absent, the date-time is interpreted as a
+            // local time."
+            } else {
+                minutesOffset = new Date().getTimezoneOffset();
             }
         }
 

--- a/packages/ember-data/tests/unit/transform/date_test.js
+++ b/packages/ember-data/tests/unit/transform/date_test.js
@@ -1,6 +1,8 @@
 module("unit/transform - DS.DateTransform");
 
 var dateString = "2015-01-01T00:00:00.000Z";
+var dateStringNoTz = "2015-01-01";
+var localNewYear = new Date(2015, 0, 1).toISOString();
 var dateInMillis = Ember.Date.parse(dateString);
 var date = new Date(dateInMillis);
 
@@ -18,6 +20,8 @@ test("#deserialize", function() {
 
   // from String
   equal(transform.deserialize(dateString).toISOString(),        dateString);
+
+  equal(transform.deserialize(dateStringNoTz).toISOString(),    localNewYear);
 
   // from Number
   equal(transform.deserialize(dateInMillis).valueOf(),          dateInMillis);


### PR DESCRIPTION
As noted in the changeset, the ECMAScript 6 specification interprets
timezone-less Date strings according to the local system's time zone.
This is in direct opposition to ECMAScript 5 specification and the
currently-implemented behavior. From section 15.9.1.15 of the ES5
specification:

> the time zone offset specified as “Z” (for UTC) [...] The value of an
> absent time zone offset is “Z”.

Update Ember Data's Date string parsing logic to comply with the latest
specification.