### PR TITLE
Remove unnecessary `toString` overrides

### DIFF
--- a/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
@@ -229,8 +229,6 @@ test("serialize polymorphic when associated object is null", function() {
 
 test("extractPolymorphic hasMany", function() {
   env.container.register('adapter:yellowMinion', DS.ActiveModelAdapter);
-  MediocreVillain.toString   = function() { return "MediocreVillain"; };
-  YellowMinion.toString = function() { return "YellowMinion"; };
 
   var json_hash = {
     mediocre_villain: {id: 1, name: "Dr Horrible", evil_minions: [{ type: "yellow_minion", id: 12}] },
@@ -254,8 +252,6 @@ test("extractPolymorphic hasMany", function() {
 
 test("extractPolymorphic", function() {
   env.container.register('adapter:yellowMinion', DS.ActiveModelAdapter);
-  EvilMinion.toString   = function() { return "EvilMinion"; };
-  YellowMinion.toString = function() { return "YellowMinion"; };
 
   var json_hash = {
     doomsday_device: {id: 1, name: "DeathRay", evil_minion: { type: "yellow_minion", id: 12}},

--- a/packages/ember-data/tests/integration/adapter/record_persistence_test.js
+++ b/packages/ember-data/tests/integration/adapter/record_persistence_test.js
@@ -20,7 +20,6 @@ module("integration/adapter/record_persistence - Persisting Records", {
       firstName: attr('string'),
       lastName: attr('string')
     });
-    Person.toString = function() { return "Person"; };
 
     env = setupStore({ person: Person });
     store = env.store;

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -8,10 +8,6 @@ module("integration/adapter/rest_adapter - REST Adapter", {
       name: DS.attr("string")
     });
 
-    Post.toString = function() {
-      return "Post";
-    };
-
     Comment = DS.Model.extend({
       name: DS.attr("string")
     });

--- a/packages/ember-data/tests/integration/debug_adapter_test.js
+++ b/packages/ember-data/tests/integration/debug_adapter_test.js
@@ -5,7 +5,6 @@ module("DS.DebugAdapter", {
   setup: function() {
     Ember.run(function() {
       App = Ember.Application.create();
-      App.toString = function(){ return 'App'; };
 
       App.ApplicationStore = DS.Store.extend({
         adapter: DS.Adapter.extend()

--- a/packages/ember-data/tests/integration/inverse_test.js
+++ b/packages/ember-data/tests/integration/inverse_test.js
@@ -3,10 +3,6 @@ var env, store, User, Job;
 var attr = DS.attr, belongsTo = DS.belongsTo;
 var run = Ember.run;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module('integration/inverse_test - inverseFor', {
   setup: function() {
     User = DS.Model.extend({
@@ -15,14 +11,10 @@ module('integration/inverse_test - inverseFor', {
       job: belongsTo('job')
     });
 
-    User.toString = stringify('user');
-
     Job = DS.Model.extend({
       isGood: attr(),
       user: belongsTo('user')
     });
-
-    Job.toString = stringify('job');
 
     env = setupStore({
       user: User,
@@ -99,10 +91,12 @@ test("Errors out if you define 2 inverses to the same model", function () {
     user: belongsTo('user', {inverse: 'job'}),
     owner: belongsTo('user', {inverse: 'job'})
   });
+  Job.toString = function() { return "job"; }
 
   User.reopen({
-    job: belongsTo('job')
+    job: belongsTo('job'),
   });
+  User.toString = function() { return "user"; }
 
   //Maybe store is evaluated lazily, so we need this :(
   expectAssertion(function() {

--- a/packages/ember-data/tests/integration/record_array_manager_test.js
+++ b/packages/ember-data/tests/integration/record_array_manager_test.js
@@ -6,15 +6,11 @@ var Person = DS.Model.extend({
   cars: DS.hasMany('car')
 });
 
-Person.toString = function() { return "Person"; };
-
 var Car = DS.Model.extend({
   make: DS.attr('string'),
   model: DS.attr('string'),
   person: DS.belongsTo('person')
 });
-
-Car.toString = function() { return "Car"; };
 
 var manager;
 

--- a/packages/ember-data/tests/integration/records/collection_save_test.js
+++ b/packages/ember-data/tests/integration/records/collection_save_test.js
@@ -7,8 +7,6 @@ module("integration/records/collection_save - Save Collection of Records", {
       title: DS.attr('string')
     });
 
-    Post.toString = function() { return "Post"; };
-
     env = setupStore({ post: Post });
   },
 

--- a/packages/ember-data/tests/integration/records/delete_record_test.js
+++ b/packages/ember-data/tests/integration/records/delete_record_test.js
@@ -8,8 +8,6 @@ module("integration/deletedRecord - Deleting Records", {
       name: attr('string')
     });
 
-    Person.toString = function() { return "Person"; };
-
     env = setupStore({
       person: Person
     });

--- a/packages/ember-data/tests/integration/records/reload_test.js
+++ b/packages/ember-data/tests/integration/records/reload_test.js
@@ -12,8 +12,6 @@ module("integration/reload - Reloading Records", {
       lastName: attr('string')
     });
 
-    Person.toString = function() { return "Person"; };
-
     env = setupStore({ person: Person });
   },
 

--- a/packages/ember-data/tests/integration/records/save_test.js
+++ b/packages/ember-data/tests/integration/records/save_test.js
@@ -7,8 +7,6 @@ module("integration/records/save - Save Record", {
       title: DS.attr('string')
     });
 
-    Post.toString = function() { return "Post"; };
-
     env = setupStore({ post: Post });
   },
 

--- a/packages/ember-data/tests/integration/records/unload_test.js
+++ b/packages/ember-data/tests/integration/records/unload_test.js
@@ -15,8 +15,6 @@ var Car = DS.Model.extend({
   person: belongsTo('person')
 });
 
-Person.toString = function() { return "Person"; };
-
 module("integration/unload - Unloading Records", {
   setup: function() {
    env = setupStore({

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -5,10 +5,6 @@ var run = Ember.run;
 var attr = DS.attr, hasMany = DS.hasMany, belongsTo = DS.belongsTo;
 var hash = Ember.RSVP.hash;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module("integration/relationship/belongs_to Belongs-To Relationships", {
   setup: function() {
     User = DS.Model.extend({
@@ -16,36 +12,30 @@ module("integration/relationship/belongs_to Belongs-To Relationships", {
       messages: hasMany('message', {polymorphic: true}),
       favouriteMessage: belongsTo('message', {polymorphic: true, inverse: null}),
     });
-    User.toString = stringify('User');
 
     Message = DS.Model.extend({
       user: belongsTo('user', { inverse: 'messages' }),
       created_at: attr('date')
     });
-    Message.toString = stringify('Message');
 
     Post = Message.extend({
       title: attr('string'),
       comments: hasMany('comment')
     });
-    Post.toString = stringify('Post');
 
     Comment = Message.extend({
       body: DS.attr('string'),
       message: DS.belongsTo('message', { polymorphic: true })
     });
-    Comment.toString = stringify('Comment');
 
     Book = DS.Model.extend({
       name: attr('string'),
       author: belongsTo('author')
     });
-    Book.toString = stringify('Book');
 
     Author = DS.Model.extend({
       name: attr('string')
     });
-    Author.toString = stringify('Author');
 
     env = setupStore({
       user: User,
@@ -343,7 +333,6 @@ test("relationshipsByName does not cache a factory", function() {
   // A new model for a relationship is created. Note that this may happen
   // due to an extend call internal to MODEL_FACTORY_INJECTIONS.
   NewMessage = Message.extend();
-  NewMessage.toString = stringify('Message');
 
   // A new store is created.
   env = setupStore({

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -6,10 +6,6 @@ var run = Ember.run;
 
 var attr = DS.attr, hasMany = DS.hasMany, belongsTo = DS.belongsTo;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module("integration/relationships/has_many - Has-Many Relationships", {
   setup: function() {
     User = DS.Model.extend({
@@ -34,37 +30,31 @@ module("integration/relationships/has_many - Has-Many Relationships", {
       user: belongsTo('user'),
       created_at: attr('date')
     });
-    Message.toString = stringify('Message');
 
     Post = Message.extend({
       title: attr('string'),
       comments: hasMany('comment')
     });
-    Post.toString = stringify('Post');
 
     Comment = Message.extend({
       body: DS.attr('string'),
       message: DS.belongsTo('post', { polymorphic: true })
     });
-    Comment.toString = stringify('Comment');
 
     Book = DS.Model.extend({
       title: attr(),
       chapters: hasMany('chapter', { async: true })
     });
-    Book.toString = stringify('Book');
 
     Chapter = DS.Model.extend({
       title: attr(),
       pages: hasMany('page')
     });
-    Chapter.toString = stringify('Chapter');
 
     Page = DS.Model.extend({
       number: attr('number'),
       chapter: belongsTo('chapter')
     });
-    Page.toString = stringify('Page');
 
     env = setupStore({
       user: User,

--- a/packages/ember-data/tests/integration/relationships/many_to_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/many_to_many_test.js
@@ -3,10 +3,6 @@ var run = Ember.run;
 
 var attr = DS.attr, hasMany = DS.hasMany;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module('integration/relationships/many_to_many_test - ManyToMany relationships', {
   setup: function() {
     User = DS.Model.extend({
@@ -15,21 +11,15 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
       accounts: hasMany('account')
     });
 
-    User.toString = stringify('User');
-
     Account = DS.Model.extend({
       state: attr(),
       users: hasMany('user')
     });
 
-    Account.toString = stringify('Account');
-
     Topic = DS.Model.extend({
       title: attr('string'),
       users: hasMany('user', {async: true})
     });
-
-    Topic.toString = stringify('Topic');
 
     env = setupStore({
       user: User,

--- a/packages/ember-data/tests/integration/relationships/one_to_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/one_to_many_test.js
@@ -4,10 +4,6 @@ var run = Ember.run;
 
 var attr = DS.attr, hasMany = DS.hasMany, belongsTo = DS.belongsTo;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module('integration/relationships/one_to_many_test - OneToMany relationships', {
   setup: function() {
     User = DS.Model.extend({
@@ -15,19 +11,16 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', {
       messages: hasMany('message', {async: true}),
       accounts: hasMany('account')
     });
-    User.toString = stringify('User');
 
     Account = DS.Model.extend({
       state: attr(),
       user: belongsTo('user')
     });
-    Account.toString = stringify('Account');
 
     Message = DS.Model.extend({
       title: attr('string'),
       user: belongsTo('user', {async: true})
     });
-    Message.toString = stringify('Message');
 
     env = setupStore({
       user: User,

--- a/packages/ember-data/tests/integration/relationships/one_to_one_test.js
+++ b/packages/ember-data/tests/integration/relationships/one_to_one_test.js
@@ -3,10 +3,6 @@ var run = Ember.run;
 
 var attr = DS.attr, belongsTo = DS.belongsTo;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module('integration/relationships/one_to_one_test - OneToOne relationships', {
   setup: function() {
     User = DS.Model.extend({
@@ -14,13 +10,11 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', {
       bestFriend: belongsTo('user', {async: true}),
       job: belongsTo('job')
     });
-    User.toString = stringify('User');
 
     Job = DS.Model.extend({
       isGood: attr(),
       user: belongsTo('user')
     });
-    Job.toString = stringify('Job');
 
     env = setupStore({
       user: User,

--- a/packages/ember-data/tests/integration/store_test.js
+++ b/packages/ember-data/tests/integration/store_test.js
@@ -7,15 +7,11 @@ var Person = DS.Model.extend({
 
 var run = Ember.run;
 
-Person.toString = function() { return "Person"; };
-
 var Car = DS.Model.extend({
   make: DS.attr('string'),
   model: DS.attr('string'),
   person: DS.belongsTo('person')
 });
-
-Car.toString = function() { return "Car"; };
 
 function initializeStore(adapter) {
   env = setupStore({

--- a/packages/ember-data/tests/unit/many_array_test.js
+++ b/packages/ember-data/tests/unit/many_array_test.js
@@ -10,17 +10,11 @@ module("unit/many_array - DS.ManyArray", {
       title: attr('string'),
       tags: hasMany('tag')
     });
-    Post.toString = function() {
-      return 'Post';
-    };
 
     var Tag = DS.Model.extend({
       name: attr('string'),
       post: belongsTo('post')
     });
-    Tag.toString = function() {
-      return 'Tag';
-    };
 
     env = setupStore({
       post: Post,

--- a/packages/ember-data/tests/unit/model/relationships_test.js
+++ b/packages/ember-data/tests/unit/model/relationships_test.js
@@ -302,14 +302,10 @@ test("hasMany relationships work when the data hash has not been loaded", functi
     person: DS.belongsTo('person')
   });
 
-  Tag.toString = function() { return "Tag"; };
-
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     tags: DS.hasMany('tag', { async: true })
   });
-
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ tag: Tag, person: Person }),
       store = env.store;
@@ -467,9 +463,6 @@ test("it is possible to add an item to a relationship, remove it, then add it ag
     tags: DS.hasMany('tag')
   });
 
-  Tag.toString = function() { return "Tag"; };
-  Person.toString = function() { return "Person"; };
-
   var env = setupStore({ tag: Tag, person: Person }),
       store = env.store;
   var person, tag1, tag2, tag3;
@@ -569,13 +562,11 @@ test("belongsTo lazily loads relationships as needed", function() {
     name: DS.attr('string'),
     people: DS.hasMany('person')
   });
-  Tag.toString = function() { return "Tag"; };
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     tag: DS.belongsTo('tag')
   });
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ tag: Tag, person: Person }),
       store = env.store;
@@ -705,14 +696,10 @@ test("When finding a hasMany relationship the inverse belongsTo relationship is 
     person: DS.belongsTo('person')
   });
 
-  Occupation.toString = function() { return "Occupation"; };
-
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     occupations: DS.hasMany('occupation', { async: true })
   });
-
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ occupation: Occupation, person: Person }),
       store = env.store;
@@ -751,14 +738,10 @@ test("When finding a belongsTo relationship the inverse belongsTo relationship i
     person: DS.belongsTo('person')
   });
 
-  Occupation.toString = function() { return "Occupation"; };
-
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     occupation: DS.belongsTo('occupation', { async: true })
   });
-
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ occupation: Occupation, person: Person }),
       store = env.store;
@@ -784,14 +767,10 @@ test("belongsTo supports relationships to models with id 0", function() {
     name: DS.attr('string'),
     people: DS.hasMany('person')
   });
-  Tag.toString = function() { return "Tag"; };
-
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     tag: DS.belongsTo('tag')
   });
-  Person.toString = function() { return "Person"; };
-
   var env = setupStore({ tag: Tag, person: Person }),
       store = env.store;
 

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -11,24 +11,15 @@ module("unit/store/push - DS.Store#push", {
       lastName: attr('string'),
       phoneNumbers: hasMany('phone-number')
     });
-    Person.toString = function() {
-      return 'Person';
-    };
 
     PhoneNumber = DS.Model.extend({
       number: attr('string'),
       person: belongsTo('person')
     });
-    PhoneNumber.toString = function() {
-      return 'PhoneNumber';
-    };
 
     Post = DS.Model.extend({
       postTitle: attr('string')
     });
-    Post.toString = function() {
-      return 'Post';
-    };
 
     env = setupStore({"post": Post,
                       "person": Person,


### PR DESCRIPTION
Only re-define `toString` when the test depends on it. Otherwise, 
re-definitions add to test noise.