### PR TITLE
Sort query params in ajax calls.

### DIFF
--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -832,6 +832,67 @@ test("metadata is accessible", function() {
   }));
 });
 
+test("findQuery - if `sortQueryParams` option is not provided, query params are sorted alphabetically", function() {
+  adapter.ajax = function(url, verb, hash) {
+    passedUrl = url;
+    passedVerb = verb;
+    passedHash = hash;
+
+    deepEqual(Object.keys(hash.data), ["in", "order", "params", "wrong"], 'query params are received in alphabetical order');
+
+    return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
+  };
+
+  store.findQuery('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(async(function() {
+    // Noop
+  }));
+});
+
+test("findQuery - if `sortQueryParams` is falsey, query params are not sorted at all", function() {
+  adapter.ajax = function(url, verb, hash) {
+    passedUrl = url;
+    passedVerb = verb;
+    passedHash = hash;
+
+    deepEqual(Object.keys(hash.data), ["params", "in", "wrong", "order"], 'query params are received in their original order');
+
+    return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
+  };
+
+  adapter.sortQueryParams = null;
+
+  store.findQuery('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(async(function() {
+    // Noop
+  }));
+});
+
+test("findQuery - if `sortQueryParams` is a custom function, query params passed through that function", function() {
+  adapter.ajax = function(url, verb, hash) {
+    passedUrl = url;
+    passedVerb = verb;
+    passedHash = hash;
+
+    deepEqual(Object.keys(hash.data), ["wrong", "params", "order", "in"], 'query params are received in reverse alphabetical order');
+
+    return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
+  };
+
+  adapter.sortQueryParams = function(obj) {
+    var sortedKeys = Object.keys(obj).sort().reverse();
+    var len = sortedKeys.length;
+    var newQueryParams = {};
+
+    for (var i = 0; i < len; i++) {
+      newQueryParams[sortedKeys[i]] = obj[sortedKeys[i]];
+    }
+    return newQueryParams;
+  };
+
+  store.findQuery('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(async(function() {
+    // Noop
+  }));
+});
+
 test("findQuery - payload 'meta' is accessible on the record array", function() {
   ajaxResponse({
     meta: { offset: 5 },


### PR DESCRIPTION
When developing APIs, is pretty common to place a high level cachingmechanism, like Varnish, to cache requests to public API endpoints, and those tools use the URL string to determine if they have a cached
response.

As an example, if one user requests `/posts?sort=price&category=pets` and another requests `/posts?category=pets&sort=price`, the cached request won't be used in the second call.

Varnish by example has some modules to sort query parameters when caching, but it's not the default behavior and requires custom config.

Although the URL specification does not say that the order of the query parameters is meaningless, in the bast mayority (read: all) of the APIs I've seen, 2 requests are considered identical regardless of the the order.

Because of that, sorting the query params consistently is considered a good practice, so this PR introduces a `sortQueryParams` key in the RESTAdapter class, that defaults to a function to sort query params alphabetically. I decided to make this the default. I doubt this will be a breaking change for anyone.

In case you don't want this behavior, setting that property to a falsey value in the ApplicationAdapter will respect the original order.

```js
export default DS.RESTAdapter.extend({
  namespace: 'api/v1',
  sortQueryParams: false
});
```

In case you want a different order, you can pass a function that does the sorting your way.

```js
export default DS.RESTAdapter.extend({
  namespace: 'api/v1',
  sortQueryParams: function(params) {
    var sortedKeys = Object.keys(params).sort().reverse();
    var len = keys.length, newParams = {};

    for (var i = 0; i < len; i++) {
      newParams[sortedKeys[i]] = params[sortedKeys[i]];
    }
    return newParams;
  }
});
```
As other customization in ED, this can be customized on a per resource level, in case the order matters in only a few endpoints.

EDIT:

As @bakura10 mentions, this also has the side effect of improving the number of requests when working with CORS, since preflight OPTIONS requests are only valid for a given URL, so sending several requests with the query parameters in different order will require additional requests.