### PR TITLE
Wrap the errorThrown in an Error object if it's a string

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -747,7 +747,11 @@ export default Adapter.extend({
     if (isObject) {
       jqXHR.then = null;
       if (!jqXHR.errorThrown) {
-        jqXHR.errorThrown = errorThrown;
+        if (typeof errorThrown === 'string') {
+          jqXHR.errorThrown = new Error(errorThrown);
+        } else {
+          jqXHR.errorThrown = errorThrown;
+        }
       }
     }
 

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -1793,3 +1793,30 @@ test('ajaxError appends errorThrown for sanity', function() {
     Ember.$.ajax = originalAjax;
   }
 });
+
+
+test('ajaxError wraps the error string in an Error object', function() {
+  expect(2);
+
+  var originalAjax = Ember.$.ajax;
+  var jqXHR = {
+    responseText: 'Nope lol'
+  };
+
+  var errorThrown = 'nope!';
+
+  Ember.$.ajax = function(hash) {
+    hash.error(jqXHR, jqXHR.responseText, errorThrown);
+  };
+
+  try {
+    run(function(){
+      store.find('post', '1').catch(function(err){
+        equal(err.errorThrown.message, errorThrown);
+        ok(err, 'promise rejected');
+      });
+    });
+  } finally {
+    Ember.$.ajax = originalAjax;
+  }
+});


### PR DESCRIPTION
Related to #2694 and https://github.com/emberjs/ember.js/pull/10215. This change will make the stack trace in the error object more relevant as its closer to the failed ajax request. Instead of originating from `RSVP.onerrorDefault`