### PR TITLE
Fix: `flushCanonical` could be executed when the manyArray is destroyed

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/has_many.js
+++ b/packages/ember-data/lib/system/relationships/state/has_many.js
@@ -65,7 +65,9 @@ ManyRelationship.prototype.removeCanonicalRecordFromOwn = function(record, idx) 
 
 ManyRelationship.prototype._super$flushCanonical = Relationship.prototype.flushCanonical;
 ManyRelationship.prototype.flushCanonical = function() {
-  this.manyArray.flushCanonical();
+  if (!this.manyArray.get('isDestroyed')) {
+    this.manyArray.flushCanonical();
+  }
   this._super$flushCanonical();
 };
 


### PR DESCRIPTION
`flushCanonical` could have been scheduled and executed when the manyArray has been destroyed, therefore it will raise an exception. 
When the `flushCanonical` is not called on a destroyed `ManyArray`, the exception is not thrown.


I am not sure but this may be related to #2662 which is likely executing a scheduled `flushCanonical`. 
@aortbals could try to check if this different changes fixes its issue:

```js
  if (!this.manyArray.get('isDestroyed')) {
    this.manyArray.flushCanonical();
    this._super$flushCanonical();
  }
```