### PR TITLE
Display the correct doc block for the model header.

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -92,12 +92,9 @@ function belongsTo(type, options) {
   }).meta(meta);
 }
 
-/**
+/*
   These observers observe all `belongsTo` relationships on the record. See
   `relationships/ext` to see how these observers get their dependencies.
-
-  @class Model
-  @namespace DS
 */
 Model.reopen({
   notifyBelongsToChanged: function(key) {


### PR DESCRIPTION
#### Before
![screen shot 2015-01-15 at 10 00 31 am](https://cloud.githubusercontent.com/assets/54056/5759710/83eab91c-9c9d-11e4-8269-da8accaa0c20.png)
#### After
![screen shot 2015-01-15 at 10 00 15 am](https://cloud.githubusercontent.com/assets/54056/5759708/830fad36-9c9d-11e4-8ab2-98699eb200cb.png)