### PR TITLE
Fixed `@extends` and `@uses` for ManyArray doc

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -38,7 +38,8 @@ var get = Ember.get, set = Ember.set;
 
   @class ManyArray
   @namespace DS
-  @extends DS.RecordArray
+  @extends Ember.Object
+  @uses Ember.MutableArray, Ember.Evented
 */
 export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
   init: function() {


### PR DESCRIPTION
Before: 

    @extends DS.RecordArray

But `DS.ManyArray` does not extend `DS.RecordArray`!

After:

    @extends Ember.Object
    @uses Ember.MutableArray, Ember.Evented