### PR TITLE
Fix: a record in state deleted.invalid can be rollbacked

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -658,6 +658,11 @@ var RootState = {
       becameError: function(record) {
         record.transitionTo('uncommitted');
         record.triggerLater('becameError', record);
+      },
+
+      becameInvalid: function(record) {
+        record.transitionTo('invalid');
+        record.triggerLater('becameInvalid', record);
       }
     },
 
@@ -681,6 +686,32 @@ var RootState = {
       willCommit: Ember.K,
 
       didCommit: Ember.K
+    },
+
+    invalid: {
+      isValid: false,
+
+      didSetProperty: function(record, context) {
+        get(record, 'errors').remove(context.name);
+
+        didSetProperty(record, context);
+      },
+
+      deleteRecord: Ember.K,
+      becomeDirty: Ember.K,
+      willCommit: Ember.K,
+
+
+      rolledBack: function(record) {
+        get(record, 'errors').clear();
+        record.transitionTo('loaded.saved');
+        record.triggerLater('ready');
+      },
+
+      becameValid: function(record) {
+        record.transitionTo('uncommitted');
+      }
+
     }
   },
 

--- a/packages/ember-data/tests/unit/model/rollback_test.js
+++ b/packages/ember-data/tests/unit/model/rollback_test.js
@@ -281,3 +281,49 @@ test("invalid record is rolled back to correct state after set", function() {
     }));
   });
 });
+
+test("when destroying a record setup the record state to invalid, the record can be rollbacked", function() {
+  Dog = DS.Model.extend({
+    name: DS.attr()
+  });
+
+  var adapter = DS.RESTAdapter.extend({
+    ajax: function(url, type, hash) {
+      var adapter = this;
+
+      return new Ember.RSVP.Promise(function(resolve, reject) {
+        Ember.run.next(function(){
+          reject(adapter.ajaxError({name: 'is invalid'}));
+        });
+      });
+    },
+
+    ajaxError: function(jqXHR) {
+      return new DS.InvalidError(jqXHR);
+    }
+  });
+
+  env = setupStore({ dog: Dog, adapter: adapter});
+  var dog;
+  run(function(){
+    dog = env.store.push('dog', { id: 1, name: "Pluto" });
+  });
+
+  run(function(){
+    dog.destroyRecord().then(null, async(function() {
+
+
+      equal(dog.get('isError'), false, "must not be error");
+      equal(dog.get('isDeleted'), true, "must be deleted");
+      equal(dog.get('isValid'), false, "must not be valid");
+      ok(dog.get('errors.length') > 0, "must have errors");
+
+      dog.rollback();
+
+      equal(dog.get('isError'), false, "must not be error after `rollback`");
+      equal(dog.get('isDeleted'), false, "must not be deleted after `rollback`");
+      equal(dog.get('isValid'), true, "must be valid after `rollback`");
+      ok(dog.get('errors.length') === 0, "must not have errors");
+    }));
+  });
+});


### PR DESCRIPTION
Fix #2126, #2169, #2708 

Defines the `root.deleted.invalid` state and its different events. 

Now  a record which has been invalidated during its `deletion` can be rollbacked on the same way that if it would receive an error response.

