### PR TITLE
Assert of the user specifies a reflexive relationship without explicitly...

### DIFF
--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -228,11 +228,14 @@ Model.reopenClass({
       return null;
     }
 
+    var propertyMeta = this.metaForProperty(name);
     //If inverse is manually specified to be null, like  `comments: DS.hasMany('message', {inverse: null})`
-    var options = this.metaForProperty(name).options;
+    var options = propertyMeta.options;
     if (options.inverse === null) { return null; }
 
     var inverseName, inverseKind, inverse;
+
+    Ember.warn("Detected a reflexive relationship by the name of '" + name + "' without an inverse option. Look at http://emberjs.com/guides/models/defining-models/#toc_reflexive-relation for how to explicitly specify inverses.", options.inverse || propertyMeta.type !== propertyMeta.parentType.typeKey);
 
     //If inverse is specified manually, return the inverse
     if (options.inverse) {

--- a/packages/ember-data/tests/integration/filter_test.js
+++ b/packages/ember-data/tests/integration/filter_test.js
@@ -17,7 +17,7 @@ var shouldNotContain = function(array, item) {
 module("integration/filter - DS.Model updating", {
   setup: function() {
     array = [{ id: 1, name: "Scumbag Dale", bestFriend: 2 }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];
-    Person = DS.Model.extend({ name: DS.attr('string'), bestFriend: DS.belongsTo('person') });
+    Person = DS.Model.extend({ name: DS.attr('string'), bestFriend: DS.belongsTo('person', { inverse: null }) });
 
     env = setupStore({ person: Person });
     store = env.store;

--- a/packages/ember-data/tests/integration/inverse_test.js
+++ b/packages/ember-data/tests/integration/inverse_test.js
@@ -1,4 +1,4 @@
-var env, store, User, Job;
+var env, store, User, Job, ReflexiveModel;
 
 var attr = DS.attr;
 var belongsTo = DS.belongsTo;
@@ -12,7 +12,7 @@ module('integration/inverse_test - inverseFor', {
   setup: function() {
     User = DS.Model.extend({
       name: attr('string'),
-      bestFriend: belongsTo('user', { async: true }),
+      bestFriend: belongsTo('user', { async: true, inverse: null }),
       job: belongsTo('job')
     });
 
@@ -25,9 +25,16 @@ module('integration/inverse_test - inverseFor', {
 
     Job.toString = stringify('job');
 
+    ReflexiveModel = DS.Model.extend({
+      reflexiveProp: belongsTo('reflexiveModel')
+    });
+
+    ReflexiveModel.toString = stringify('reflexiveModel');
+
     env = setupStore({
       user: User,
-      job: Job
+      job: Job,
+      reflexiveModel: ReflexiveModel
     });
 
     store = env.store;
@@ -128,4 +135,15 @@ test("Caches findInverseFor return value", function () {
   };
 
   equal(inverseForUser, Job.inverseFor('user'), 'Inverse cached succesfully');
+});
+
+test("Errors out if you do not define an inverse for a reflexive relationship", function () {
+
+  //Maybe store is evaluated lazily, so we need this :(
+  warns(function() {
+    var reflexiveModel;
+    run(function() {
+      reflexiveModel = store.push('reflexiveModel', { id: 1 });
+    });
+  }, /Detected a reflexive relationship by the name of 'reflexiveProp'/);
 });

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -17,7 +17,7 @@ module("integration/relationships/has_many - Has-Many Relationships", {
     User = DS.Model.extend({
       name: attr('string'),
       messages: hasMany('message', { polymorphic: true }),
-      contacts: hasMany()
+      contacts: hasMany('user', { inverse: null })
     });
 
     Contact = DS.Model.extend({

--- a/packages/ember-data/tests/integration/relationships/one_to_one_test.js
+++ b/packages/ember-data/tests/integration/relationships/one_to_one_test.js
@@ -12,7 +12,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', {
   setup: function() {
     User = DS.Model.extend({
       name: attr('string'),
-      bestFriend: belongsTo('user', { async: true }),
+      bestFriend: belongsTo('user', { async: true, inverse: 'bestFriend' }),
       job: belongsTo('job')
     });
     User.toString = stringify('User');

--- a/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
@@ -41,7 +41,7 @@ module("integration/embedded_records_mixin - EmbeddedRecordsMixin", {
     Comment = DS.Model.extend({
       body:            DS.attr('string'),
       root:            DS.attr('boolean'),
-      children:        DS.hasMany('comment')
+      children:        DS.hasMany('comment', { inverse: null })
     });
     env = setupStore({
       superVillain:    SuperVillain,

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -218,7 +218,7 @@ test('Serializer should respect the attrs hash when extracting records', functio
 
 test('Serializer should respect the attrs hash when serializing records', function() {
   Post.reopen({
-    parentPost: DS.belongsTo('post')
+    parentPost: DS.belongsTo('post', { inverse: null })
   });
   env.container.register("serializer:post", DS.JSONSerializer.extend({
     attrs: {

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -26,7 +26,7 @@ module("integration/serializer/rest - RESTSerializer", {
     Comment = DS.Model.extend({
       body: DS.attr('string'),
       root: DS.attr('boolean'),
-      children: DS.hasMany('comment')
+      children: DS.hasMany('comment', { inverse: null })
     });
     env = setupStore({
       superVillain:   SuperVillain,

--- a/packages/ember-data/tests/unit/model/relationships_test.js
+++ b/packages/ember-data/tests/unit/model/relationships_test.js
@@ -12,7 +12,7 @@ test("exposes a hash of the relationships on a model", function() {
 
   Person.reopen({
     people: DS.hasMany('person', { inverse: 'parent' }),
-    parent: DS.belongsTo('person')
+    parent: DS.belongsTo('person', { inverse: 'people' })
   });
 
   var store = createStore({

--- a/packages/ember-data/tests/unit/store/adapter_interop_test.js
+++ b/packages/ember-data/tests/unit/store/adapter_interop_test.js
@@ -389,7 +389,7 @@ test("initial values of belongsTo can be passed in as the third argument to find
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
-    friend: DS.belongsTo('person')
+    friend: DS.belongsTo('person', { inverse: null })
   });
 
   store.container.register('model:person', Person);
@@ -418,7 +418,7 @@ test("initial values of belongsTo can be passed in as the third argument to find
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
-    friend: DS.belongsTo('person', { async: true })
+    friend: DS.belongsTo('person', { async: true, inverse: null })
   });
 
   store.container.register('model:person', Person);
@@ -445,7 +445,7 @@ test("initial values of hasMany can be passed in as the third argument to find a
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
-    friends: DS.hasMany('person')
+    friends: DS.hasMany('person', { inverse: null })
   });
 
   store.container.register('model:person', Person);
@@ -474,7 +474,7 @@ test("initial values of hasMany can be passed in as the third argument to find a
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
-    friends: DS.hasMany('person', { async: true })
+    friends: DS.hasMany('person', { async: true, inverse: null })
   });
 
   store.container.register('model:person', Person);


### PR DESCRIPTION
... defining the inverse


Currently if a user specifies a reflexive belongsTo relationship in Ember Data without providing a `inverse` key Ember Data will assume the relationship is a 1 to 1 relationship. This can be confusing (see https://github.com/emberjs/data/issues/2272 and https://github.com/emberjs/data/issues/2405) since in practice 1 to 1 relationships are rarely used. 

This pr forces the user to specify a inverse key if they define a reflexive relationship. 1 to 1 relationships are still possible you just need to specify the relationship as its own inverse.

