### PR TITLE
Add rootModel setting to RESTAdapter

### DIFF
--- a/packages/ember-data/lib/adapters/rest_adapter.js
+++ b/packages/ember-data/lib/adapters/rest_adapter.js
@@ -113,6 +113,18 @@ var forEach = Ember.ArrayPolyfills.forEach;
   });
   ```
 
+  ### Root model customization
+
+  An adapter can scope requests to a root model by setting the rootModel
+  property on the adapter:
+
+  ```js
+  DS.RESTAdapter.reopen({
+    rootModel: 'post'
+  });
+  ```
+  Requests for `App.Comment` would now target `/posts/1/comments/1`
+
   ### Headers customization
 
   Some APIs require HTTP headers, e.g. to provide an API key. Arbitrary
@@ -533,6 +545,9 @@ export default Adapter.extend({
     var url = [];
     var host = get(this, 'host');
     var prefix = this.urlPrefix();
+    var rootModel = get(this, 'rootModel');
+
+    if (rootModel) { url.push(this.pathForRootModel(record, rootModel)); }
 
     if (type) { url.push(this.pathForType(type)); }
 
@@ -698,6 +713,24 @@ export default Adapter.extend({
   pathForType: function(type) {
     var camelized = Ember.String.camelize(type);
     return Ember.String.pluralize(camelized);
+  },
+
+  /**
+    Determines the root model path for a given model and root
+
+    Uses pathForType to build the root model path
+
+    @method pathForRootModel
+    @param {DS.Model} record
+    @param {String} rootModel
+    @return {String} path
+  **/
+
+  pathForRootModel: function(record, rootModel) {
+    return [
+      this.pathForType(rootModel),
+      encodeURIComponent(record.get(rootModel).get('id'))
+    ].join('/');
   },
 
   /**

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -1257,6 +1257,29 @@ test('buildURL - with host and namespace', function() {
   }));
 });
 
+test('buildURL - with parentKey', function() {
+  Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
+  Comment.reopen({ post: DS.belongsTo('post') });
+
+  run(function() {
+    store.push('post', { id: 1, comments: [37], name: "Rails is omakase" });
+  });
+
+  run(function() {
+    adapter.setProperties({
+      rootModel: 'post'
+    });
+  });
+
+  run(function() {
+    ajaxResponse({ comments: [{ id: 37, post_id: 1, name: "Ember Data progress update" }] });
+  });
+
+  run(store, 'find', 'comment', 37).then(async(function(comment) {
+    equal(passedUrl, "/posts/1/comments/37", "Url scoped to root model");
+  }));
+});
+
 test('buildURL - with relative paths in links', function() {
   run(function() {
     adapter.setProperties({


### PR DESCRIPTION
This would add support for REST API's with embedded models:

If post has many comments, then 

```js
# /app/adapters/comments
export default ApplicationAdapter.extend({
  rootModel: 'post'
});
```

would generate ``/posts/:post_id/comments/:id`` as the url

Embedded models often cannot be accessed by id directly (i.e. mongodb) and many API's use something along the lines of:
```ruby
Post.find(params[:post_id]).comments.find(params[:id])
```
To access embedded models.

That's something I use and it seems it's quite widely requested:
- http://stackoverflow.com/questions/21964155/override-buildurl-method-to-include-parent-models-id
- https://github.com/emberjs/data/pull/39
- https://github.com/emberjs/data/pull/57

The alternative is the pathTemplate RFC: https://github.com/emberjs/rfcs/pull/4 

It seems that a single nested nesting covers most cases and is along the lines of how other properties are set on the adapter.
