### PR TITLE
Add a Serializer base class

### DIFF
--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -36,6 +36,7 @@ import {
   InvalidError,
   Adapter
 } from "ember-data/system/adapter";
+import Serializer from "ember-data/system/serializer";
 import DebugAdapter from "ember-data/system/debug";
 import {
   RecordArray,
@@ -85,6 +86,8 @@ DS.Errors    = Errors;
 
 DS.Adapter      = Adapter;
 DS.InvalidError = InvalidError;
+
+DS.Serializer = Serializer;
 
 DS.DebugAdapter = DebugAdapter;
 

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -1,3 +1,5 @@
+import Serializer from "ember-data/system/serializer";
+
 var get = Ember.get;
 var isNone = Ember.isNone;
 var map = Ember.ArrayPolyfills.map;
@@ -17,8 +19,9 @@ var merge = Ember.merge;
 
   @class JSONSerializer
   @namespace DS
+  @extends DS.Serializer
 */
-export default Ember.Object.extend({
+export default Serializer.extend({
   /**
     The primaryKey is used when serializing and deserializing
     data. Ember Data always uses the `id` property to store the id of

--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -1,0 +1,74 @@
+/**
+  @module ember-data
+*/
+
+/**
+  `DS.Serializer` is an abstract base class that you should override in your
+  application to customize it for your backend. The minimum set of methods
+  that you should implement is:
+
+    * `extract()`
+    * `serialize()`
+
+  And you can optionally override the following methods:
+
+    * `normalize()`
+
+  For an example implementation, see
+  [DS.JSONSerializer](DS.JSONSerializer.html), the included JSON serializer.
+
+  @class Serializer
+  @namespace DS
+  @extends Ember.Object
+*/
+
+var Serializer = Ember.Object.extend({
+
+  /**
+    The `extract` method is used to deserialize the payload received from your
+    data source into the form that Ember Data expects.
+
+    @method extract
+    @param {DS.Store} store
+    @param {subclass of DS.Model} type
+    @param {Object} payload
+    @param {String|Number} id
+    @param {String} requestType
+    @return {Object}
+  */
+  extract: Ember.required(Function),
+
+  /**
+    The `serialize` method is used when a record is saved in order to convert
+    the record into the form that your external data source expects.
+
+    `serialize` takes an optional `options` hash with a single option:
+
+    - `includeId`: If this is `true`, `serialize` should include the ID
+      in the serialized object it builds.
+
+    @method serialize
+    @param {subclass of DS.Model} record
+    @param {Object} [options]
+    @return {Object}
+  */
+  serialize: Ember.required(Function),
+
+  /**
+    The `normalize` method is used to convert a payload received from your
+    external data source into the normalized form `store.push()` expects. You
+    should override this method, munge the hash and return the normalized
+    payload.
+
+    @method normalize
+    @param {subclass of DS.Model} type
+    @param {Object} hash
+    @return {Object}
+  */
+  normalize: function(type, hash) {
+    return hash;
+  }
+
+});
+
+export default Serializer;


### PR DESCRIPTION
`serializer.extract()` and `serializer.serialize()` should be the only methods you need to implement if you're building your own serializer but I've included `serializer.normalize()` since it's used by `store.normalize()` and there's no checking if it exists or not (as opposed to `store.pushPayload()` that asserts that `serializer.pushPayload()` has been implemented).

Closes #1658