### PR TITLE
Update JSBin link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ demo should be fully operational with the exception of the bug you want to
 demonstrate. The more pared down, the better. A preconfigured [JSBin][1] |
 [JSFiddle][2] with mocked requests is available.
 
-[1]: http://emberjs.jsbin.com/qovara/1/edit?html,js,output
+[1]: http://emberjs.jsbin.com/qovara/edit?html,js,output
 [2]: http://jsfiddle.net/842xesgc/
 
 4. If possible, submit a Pull Request with a failing test. Better yet, take


### PR DESCRIPTION
- Version 1 was missing ember-template-compiler.js which caused it to error out
- Link to the latest version