### PR TITLE
[DOCS]Update about defining application's store

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -113,7 +113,7 @@ function coerceId(id) {
   Define your application's store like this:
 
   ```javascript
-  MyApp.Store = DS.Store.extend();
+  MyApp.ApplicationStore = DS.Store.extend();
   ```
 
   Most Ember.js applications will only have a single `DS.Store` that is


### PR DESCRIPTION
Previously, when you've defined application's store, like outdated documentation suggested:
~~~~
MyApp.Store = DS.Store.extend();
~~~~
It raised deprecation warning:
~~~~
 DEPRECATION: Specifying a custom Store for Ember Data on your global namespace as `App.Store` has been deprecated. Please use `App.ApplicationStore` instead.
        at ember$data$lib$initializers$store$$initializeStore (http://builds.emberjs.com/canary/ember-data.js:10308:13)
        at ember$data$lib$setup$container$$setupContainer (http://builds.emberjs.com/canary/ember-data.js:10621:7)
        at http://builds.emberjs.com/tags/v1.9.1/ember.js:3079:11
        at visit (http://builds.emberjs.com/tags/v1.9.1/ember.js:2002:7)
        at visit (http://builds.emberjs.com/tags/v1.9.1/ember.js:2000:9)
        at DAG.topsort (http://builds.emberjs.com/tags/v1.9.1/ember.js:2114:11)
        at Namespace.extend.runInitializers (http://builds.emberjs.com/tags/v1.9.1/ember.js:3076:15)
        at Namespace.extend._initialize (http://builds.emberjs.com/tags/v1.9.1/ember.js:2961:14)
        at Object.Backburner.run (http://builds.emberjs.com/tags/v1.9.1/ember.js:194:27)
~~~~
This is the correct way:
~~~~
MyApp.ApplicationStore = DS.Store.extend();
~~~~