### PR TITLE
Remove non-breaking spaces

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/belongs_to.js
@@ -64,7 +64,7 @@ function belongsTo(type, options) {
     type = undefined;
   }
 
-  Ember.assert("The first argument to DS.belongsTo must be a string representing a model type key, not an instance of " + Ember.inspect(type) + ". E.g., to define a relation to the Person model, use DS.belongsTo('person')", typeof type === 'string' || typeof type === 'undefined');
+  Ember.assert("The first argument to DS.belongsTo must be a string representing a model type key, not an instance of " + Ember.inspect(type) + ". E.g., to define a relation to the Person model, use DS.belongsTo('person')", typeof type === 'string' || typeof type === 'undefined');
 
   options = options || {};
 

--- a/packages/ember-data/lib/system/relationships/has_many.js
+++ b/packages/ember-data/lib/system/relationships/has_many.js
@@ -99,7 +99,7 @@ function hasMany(type, options) {
     type = undefined;
   }
 
-  Ember.assert("The first argument to DS.hasMany must be a string representing a model type key, not an instance of " + Ember.inspect(type) + ". E.g., to define a relation to the Comment model, use DS.hasMany('comment')", typeof type === 'string' || typeof type === 'undefined');
+  Ember.assert("The first argument to DS.hasMany must be a string representing a model type key, not an instance of " + Ember.inspect(type) + ". E.g., to define a relation to the Comment model, use DS.hasMany('comment')", typeof type === 'string' || typeof type === 'undefined');
 
   options = options || {};
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1434,10 +1434,10 @@ Store = Ember.Object.extend({
     if (Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS) {
       Ember.warn("The payload for '" + type.typeKey + "' contains these unknown keys: " +
         Ember.inspect(filter(Ember.keys(data), function(key) {
-          return !(key === 'id' || key === 'links' || get(type, 'fields').has(key) || key.match(/Type$/));
+          return !(key === 'id' || key === 'links' || get(type, 'fields').has(key) || key.match(/Type$/));
         })) + ". Make sure they've been defined in your model.",
         filter(Ember.keys(data), function(key) {
-          return !(key === 'id' || key === 'links' || get(type, 'fields').has(key) || key.match(/Type$/));
+          return !(key === 'id' || key === 'links' || get(type, 'fields').has(key) || key.match(/Type$/));
         }).length === 0
       );
     }

--- a/packages/ember-data/tests/integration/relationships/has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/has_many_test.js
@@ -895,7 +895,7 @@ test("a records ASYNC HM relationship property is readOnly", function() {
   }, 'Cannot Set: comments on: ' + Ember.inspect(post));
 });
 
-test("When a record is saved, its unsaved hasMany records should be kept", function () {
+test("When a record is saved, its unsaved hasMany records should be kept", function () {
   expect(1);
 
   var post, comment;


### PR DESCRIPTION
I think this is my bad to begin with, sometimes I'm not letting go of the alt key fast enough after writing a `|` followed by a space. This results in a non-breaking space being inserted instead of a regular space. Fixes #2716.