### PR TITLE
getter metod for record's relationships

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/belongs-to.js
@@ -82,13 +82,13 @@ function belongsTo(type, options) {
         value = null;
       }
       if (value && value.then) {
-        this._relationships[key].setRecordPromise(value);
+        this._relationships.get(key).setRecordPromise(value);
       } else {
-        this._relationships[key].setRecord(value);
+        this._relationships.get(key).setRecord(value);
       }
     }
 
-    return this._relationships[key].getRecord();
+    return this._relationships.get(key).getRecord();
   }).meta(meta);
 }
 

--- a/packages/ember-data/lib/system/relationships/has-many.js
+++ b/packages/ember-data/lib/system/relationships/has-many.js
@@ -116,7 +116,7 @@ function hasMany(type, options) {
   };
 
   return Ember.computed(function(key) {
-    var relationship = this._relationships[key];
+    var relationship = this._relationships.get(key);
     return relationship.getRecords();
   }).meta(meta).readOnly();
 }

--- a/packages/ember-data/lib/system/relationships/state/create.js
+++ b/packages/ember-data/lib/system/relationships/state/create.js
@@ -1,6 +1,8 @@
 import ManyRelationship from "ember-data/system/relationships/state/has-many";
 import BelongsToRelationship from "ember-data/system/relationships/state/belongs-to";
 
+var get = Ember.get;
+
 var createRelationshipFor = function(record, relationshipMeta, store) {
   var inverseKey;
   var inverse = record.constructor.inverseFor(relationshipMeta.key);
@@ -16,4 +18,22 @@ var createRelationshipFor = function(record, relationshipMeta, store) {
   }
 };
 
-export default createRelationshipFor;
+var Relationships = function(record) {
+  this.record = record;
+  this.initializedRelationships = Ember.create(null);
+};
+
+Relationships.prototype.has = function(key) {
+  return !!this.initializedRelationships[key];
+};
+
+Relationships.prototype.get = function(key) {
+  var relationships = this.initializedRelationships;
+  var relationshipsByName = get(this.record.constructor, 'relationshipsByName');
+  if (!relationships[key] && relationshipsByName.get(key)) {
+    relationships[key] = createRelationshipFor(this.record, relationshipsByName.get(key), this.record.store);
+  }
+  return relationships[key];
+};
+
+export default Relationships;

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -75,7 +75,7 @@ Relationship.prototype = {
     if (!this.canonicalMembers.has(record)) {
       this.canonicalMembers.add(record);
       if (this.inverseKey) {
-        record._relationships[this.inverseKey].addCanonicalRecord(this.record);
+        record._relationships.get(this.inverseKey).addCanonicalRecord(this.record);
       } else {
         if (!record._implicitRelationships[this.inverseKeyForImplicit]) {
           record._implicitRelationships[this.inverseKeyForImplicit] = new Relationship(this.store, record, this.key,  { options: {} });
@@ -115,7 +115,7 @@ Relationship.prototype = {
       this.members.addWithIndex(record, idx);
       this.notifyRecordRelationshipAdded(record, idx);
       if (this.inverseKey) {
-        record._relationships[this.inverseKey].addRecord(this.record);
+        record._relationships.get(this.inverseKey).addRecord(this.record);
       } else {
         if (!record._implicitRelationships[this.inverseKeyForImplicit]) {
           record._implicitRelationships[this.inverseKeyForImplicit] = new Relationship(this.store, record, this.key,  { options: {} });
@@ -141,12 +141,12 @@ Relationship.prototype = {
 
   addRecordToInverse: function(record) {
     if (this.inverseKey) {
-      record._relationships[this.inverseKey].addRecord(this.record);
+      record._relationships.get(this.inverseKey).addRecord(this.record);
     }
   },
 
   removeRecordFromInverse: function(record) {
-    var inverseRelationship = record._relationships[this.inverseKey];
+    var inverseRelationship = record._relationships.get(this.inverseKey);
     //Need to check for existence, as the record might unloading at the moment
     if (inverseRelationship) {
       inverseRelationship.removeRecordFromOwn(this.record);
@@ -160,7 +160,7 @@ Relationship.prototype = {
   },
 
   removeCanonicalRecordFromInverse: function(record) {
-    var inverseRelationship = record._relationships[this.inverseKey];
+    var inverseRelationship = record._relationships.get(this.inverseKey);
     //Need to check for existence, as the record might unloading at the moment
     if (inverseRelationship) {
       inverseRelationship.removeCanonicalRecordFromOwn(this.record);

--- a/packages/ember-data/lib/system/snapshot.js
+++ b/packages/ember-data/lib/system/snapshot.js
@@ -196,7 +196,7 @@ Snapshot.prototype = {
       return this._belongsToRelationships[keyName];
     }
 
-    relationship = this.record._relationships[keyName];
+    relationship = this.record._relationships.get(keyName);
     if (!(relationship && relationship.relationshipMeta.kind === 'belongsTo')) {
       throw new Ember.Error("Model '" + Ember.inspect(this.record) + "' has no belongsTo relationship named '" + keyName + "' defined.");
     }
@@ -256,7 +256,7 @@ Snapshot.prototype = {
       return this._hasManyRelationships[keyName];
     }
 
-    relationship = this.record._relationships[keyName];
+    relationship = this.record._relationships.get(keyName);
     if (!(relationship && relationship.relationshipMeta.kind === 'hasMany')) {
       throw new Ember.Error("Model '" + Ember.inspect(this.record) + "' has no hasMany relationship named '" + keyName + "' defined.");
     }
@@ -335,7 +335,7 @@ Snapshot.prototype = {
       return this.attr(keyName);
     }
 
-    var relationship = this.record._relationships[keyName];
+    var relationship = this.record._relationships.get(keyName);
 
     if (relationship && relationship.relationshipMeta.kind === 'belongsTo') {
       return this.belongsTo(keyName);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1973,9 +1973,10 @@ function setupRelationships(store, record, data) {
   type.eachRelationship(function(key, descriptor) {
     var kind = descriptor.kind;
     var value = data[key];
-    var relationship = record._relationships[key];
+    var relationship;
 
     if (data.links && data.links[key]) {
+      relationship = record._relationships.get(key);
       relationship.updateLink(data.links[key]);
     }
 
@@ -1983,8 +1984,10 @@ function setupRelationships(store, record, data) {
       if (value === undefined) {
         return;
       }
+      relationship = record._relationships.get(key);
       relationship.setCanonicalRecord(value);
     } else if (kind === 'hasMany' && value) {
+      relationship = record._relationships.get(key);
       relationship.updateRecordsFromAdapter(value);
     }
   });

--- a/packages/ember-data/tests/integration/inverse-test.js
+++ b/packages/ember-data/tests/integration/inverse-test.js
@@ -144,6 +144,7 @@ test("Errors out if you do not define an inverse for a reflexive relationship", 
     var reflexiveModel;
     run(function() {
       reflexiveModel = store.push('reflexiveModel', { id: 1 });
+      reflexiveModel.get('reflexiveProp');
     });
   }, /Detected a reflexive relationship by the name of 'reflexiveProp'/);
 });

--- a/packages/ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs-to-test.js
@@ -574,3 +574,42 @@ test("Passing a model as type to belongsTo should not work", function () {
     });
   }, /The first argument to DS.belongsTo must be a string/);
 });
+
+test("Model's belongsTo relationship should not be created during model creation", function () {
+  var user;
+  run(function () {
+    user = env.store.createRecord('user');
+    ok(!user._relationships.has('favouriteMessage'), 'Newly created record should not have relationships');
+  });
+});
+
+test("Model's belongsTo relationship should be created during model creation if relationship passed in constructor", function () {
+  var user, message;
+  run(function () {
+    message = env.store.createRecord('message');
+    user = env.store.createRecord('user', {
+      name: 'John Doe',
+      favouriteMessage: message
+    });
+    ok(user._relationships.has('favouriteMessage'), "Newly created record with relationships in params passed in its constructor should have relationships");
+  });
+});
+
+test("Model's belongsTo relationship should be created during 'set' method", function () {
+  var user, message;
+  run(function () {
+    message = env.store.createRecord('message');
+    user = env.store.createRecord('user');
+    user.set('favouriteMessage', message);
+    ok(user._relationships.has('favouriteMessage'), "Newly created record with relationships in params passed in its constructor should have relationships");
+  });
+});
+
+test("Model's belongsTo relationship should be created during 'get' method", function () {
+  var user;
+  run(function () {
+    user = env.store.createRecord('user');
+    user.get('favouriteMessage');
+    ok(user._relationships.has('favouriteMessage'), "Newly created record with relationships in params passed in its constructor should have relationships");
+  });
+});

--- a/packages/ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/has-many-test.js
@@ -1212,7 +1212,7 @@ test("Relationship.clear removes all records correctly", function() {
   });
 
   run(function() {
-    post._relationships['comments'].clear();
+    post._relationships.get('comments').clear();
     var comments = Ember.A(env.store.all('comment'));
     deepEqual(comments.mapBy('post'), [null, null, null]);
   });
@@ -1254,4 +1254,22 @@ test('unloading a record with associated records does not prevent the store from
   } catch (error) {
     ok(false, "store prevented from being destroyed");
   }
+});
+
+
+test("Model's hasMany relationship should not be created during model creation", function () {
+  var user;
+  run(function () {
+    user = env.store.createRecord('user');
+    ok(!user._relationships.has('messages'), 'Newly created record should not have relationships');
+  });
+});
+
+test("Model's belongsTo relationship should be created during 'get' method", function () {
+  var user;
+  run(function () {
+    user = env.store.createRecord('user');
+    user.get('messages');
+    ok(user._relationships.has('messages'), "Newly created record with relationships in params passed in its constructor should have relationships");
+  });
 });

--- a/packages/ember-data/tests/integration/relationships/inverse-relationships-test.js
+++ b/packages/ember-data/tests/integration/relationships/inverse-relationships-test.js
@@ -423,14 +423,15 @@ test("Inverse relationships that don't exist throw a nice error for a hasMany", 
   });
 
   var env = setupStore({ post: Post, comment: Comment, user: User });
-  var comment;
+  var comment, post;
   run(function() {
     comment = env.store.createRecord('comment');
   });
 
   expectAssertion(function() {
     run(function() {
-      env.store.createRecord('post');
+      post = env.store.createRecord('post');
+      post.get('comments');
     });
   }, /We found no inverse relationships by the name of 'testPost' on the 'comment' model/);
 });
@@ -444,14 +445,15 @@ test("Inverse relationships that don't exist throw a nice error for a belongsTo"
   });
 
   var env = setupStore({ post: Post, comment: Comment, user: User });
-  var user;
+  var user, post;
   run(function() {
     user = env.store.createRecord('user');
   });
 
   expectAssertion(function() {
     run(function() {
-      env.store.createRecord('post');
+      post = env.store.createRecord('post');
+      post.get('user');
     });
   }, /We found no inverse relationships by the name of 'testPost' on the 'user' model/);
 });


### PR DESCRIPTION
Creating instances of model with many relationships takes too many time, it happens because all relationships are creating during _setup method. 
I found comment https://github.com/emberjs/data/blob/master/packages/ember-data/lib/system/model/model.js#L504, and decided implement getter method.