### PR TITLE
Remove unused relationship code

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -45,15 +45,12 @@ var set = Ember.set;
 export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
   init: function() {
     this.currentState = Ember.A([]);
-    this.diff = [];
   },
 
   record: null,
 
   canonicalState: null,
   currentState: null,
-
-  diff: null,
 
   length: 0,
 


### PR DESCRIPTION
Found some dead code while tracing the inverseRelationship / ImplicitRelationship code paths.

* ManyArray doesn't appear to use the `diff` array
* Relationship doesn't use addCanonicalRecords