### PR TITLE
ManyArray.flushCanonical should use set method for currentState

### DIFF
--- a/packages/ember-data/lib/system/record_arrays/many_array.js
+++ b/packages/ember-data/lib/system/record_arrays/many_array.js
@@ -76,7 +76,7 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
     toSet = toSet.concat(newRecords);
     this.arrayContentWillChange(0, this.length, this.length);
     this.set('length', toSet.length);
-    this.currentState = toSet;
+    this.set('currentState', toSet);
     this.arrayContentDidChange(0, this.length, this.length);
     //TODO Figure out to notify only on additions and maybe only if unloaded
     this.relationship.notifyHasManyChanged();


### PR DESCRIPTION
I was getting an "should use set" exception from ManyArray's
flushCannonical. This patch fixes the issue and works properly
in my application.