### PR TITLE
Replace calls to `container` with `registry`

### DIFF
--- a/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
+++ b/packages/activemodel-adapter/tests/integration/active_model_serializer_test.js
@@ -41,9 +41,9 @@ module("integration/active_model - ActiveModelSerializer", {
     env.store.modelFor('yellowMinion');
     env.store.modelFor('doomsdayDevice');
     env.store.modelFor('mediocreVillain');
-    env.container.register('serializer:application', DS.ActiveModelSerializer);
-    env.container.register('serializer:-active-model', DS.ActiveModelSerializer);
-    env.container.register('adapter:-active-model', DS.ActiveModelAdapter);
+    env.registry.register('serializer:application', DS.ActiveModelSerializer);
+    env.registry.register('serializer:-active-model', DS.ActiveModelSerializer);
+    env.registry.register('adapter:-active-model', DS.ActiveModelAdapter);
     env.amsSerializer = env.container.lookup("serializer:-active-model");
     env.amsAdapter    = env.container.lookup("adapter:-active-model");
   },
@@ -132,7 +132,7 @@ test("normalize links", function() {
 });
 
 test("extractSingle", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
 
   var json_hash = {
     home_planet:   { id: "1", name: "Umber", super_villain_ids: [1] },
@@ -163,7 +163,7 @@ test("extractSingle", function() {
 });
 
 test("extractArray", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
   var array;
 
   var json_hash = {
@@ -228,7 +228,7 @@ test("serialize polymorphic when associated object is null", function() {
 });
 
 test("extractPolymorphic hasMany", function() {
-  env.container.register('adapter:yellowMinion', DS.ActiveModelAdapter);
+  env.registry.register('adapter:yellowMinion', DS.ActiveModelAdapter);
   MediocreVillain.toString   = function() { return "MediocreVillain"; };
   YellowMinion.toString = function() { return "YellowMinion"; };
 
@@ -253,7 +253,7 @@ test("extractPolymorphic hasMany", function() {
 });
 
 test("extractPolymorphic", function() {
-  env.container.register('adapter:yellowMinion', DS.ActiveModelAdapter);
+  env.registry.register('adapter:yellowMinion', DS.ActiveModelAdapter);
   EvilMinion.toString   = function() { return "EvilMinion"; };
   YellowMinion.toString = function() { return "YellowMinion"; };
 

--- a/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/fixture_adapter_test.js
@@ -290,7 +290,7 @@ asyncTest("copies fixtures instead of passing the direct reference", function() 
   });
 
   Ember.run(function() {
-    env.container.register('adapter:person', PersonAdapter);
+    env.registry.register('adapter:person', PersonAdapter);
   });
 
   env.store.find('person', 1).then(function() {

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -111,7 +111,7 @@ test("find - payload with sideloaded records of a different type", function() {
 
 
 test("find - payload with an serializer-specified primary key", function() {
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primaryKey: '_ID_'
   }));
 
@@ -128,7 +128,7 @@ test("find - payload with an serializer-specified primary key", function() {
 });
 
 test("find - payload with a serializer-specified attribute mapping", function() {
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     attrs: {
       'name': '_NAME_',
       'createdAt': { key: '_CREATED_AT_', someOtherOption: 'option' }
@@ -234,7 +234,7 @@ test("create - findMany doesn't overwrite owner", function() {
 
 test("create - a serializer's primary key and attributes are consulted when building the payload", function() {
   var post;
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primaryKey: '_id_',
 
     attrs: {
@@ -255,7 +255,7 @@ test("create - a serializer's primary key and attributes are consulted when buil
 
 test("create - a serializer's attributes are consulted when building the payload if no id is pre-defined", function() {
   var post;
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primarykey: '_id_',
 
     attrs: {
@@ -275,7 +275,7 @@ test("create - a serializer's attributes are consulted when building the payload
 });
 
 test("create - a serializer's attribute mapping takes precdence over keyForAttribute when building the payload", function() {
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     attrs: {
       name: 'given_name'
     },
@@ -297,7 +297,7 @@ test("create - a serializer's attribute mapping takes precdence over keyForAttri
 });
 
 test("create - a serializer's attribute mapping takes precedence over keyForRelationship (belongsTo) when building the payload", function() {
-  env.container.register('serializer:comment', DS.RESTSerializer.extend({
+  env.registry.register('serializer:comment', DS.RESTSerializer.extend({
     attrs: {
       post: 'article'
     },
@@ -322,7 +322,7 @@ test("create - a serializer's attribute mapping takes precedence over keyForRela
 });
 
 test("create - a serializer's attribute mapping takes precedence over keyForRelationship (hasMany) when building the payload", function() {
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     attrs: {
       comments: 'opinions'
     },
@@ -601,7 +601,7 @@ test("update - a payload with sideloaded updates pushes the updates", function()
 });
 
 test("update - a serializer's primary key and attributes are consulted when building the payload", function() {
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primaryKey: '_id_',
 
     attrs: {
@@ -761,7 +761,7 @@ test("findAll - returning sideloaded data loads the data", function() {
 });
 
 test("findAll - data is normalized through custom serializers", function() {
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primaryKey: '_ID_',
     attrs: { name: '_NAME_' }
   }));
@@ -985,7 +985,7 @@ test("findQuery - returning sideloaded data loads the data", function() {
 });
 
 test("findQuery - data is normalized through custom serializers", function() {
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primaryKey: '_ID_',
     attrs: { name: '_NAME_' }
   }));
@@ -1139,12 +1139,12 @@ test("findMany - returning sideloaded data loads the data", function() {
 });
 
 test("findMany - a custom serializer is used if present", function() {
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primaryKey: '_ID_',
     attrs: { name: '_NAME_' }
   }));
 
-  env.container.register('serializer:comment', DS.RESTSerializer.extend({
+  env.registry.register('serializer:comment', DS.RESTSerializer.extend({
     primaryKey: '_ID_',
     attrs: { name: '_NAME_' }
   }));
@@ -1258,12 +1258,12 @@ test("findMany - returning sideloaded data loads the data", function() {
 });
 
 test("findMany - a custom serializer is used if present", function() {
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primaryKey: '_ID_',
     attrs: { name: '_NAME_' }
   }));
 
-  env.container.register('serializer:comment', DS.RESTSerializer.extend({
+  env.registry.register('serializer:comment', DS.RESTSerializer.extend({
     primaryKey: '_ID_',
     attrs: { name: '_NAME_' }
   }));
@@ -1617,7 +1617,7 @@ test('groupRecordsForFindMany groups records correctly when singular URLs are en
 });
 
 test('normalizeKey - to set up _ids and _id', function() {
-  env.container.register('serializer:application', DS.RESTSerializer.extend({
+  env.registry.register('serializer:application', DS.RESTSerializer.extend({
     keyForAttribute: function(attr) {
       return Ember.String.underscore(attr);
     },
@@ -1636,19 +1636,19 @@ test('normalizeKey - to set up _ids and _id', function() {
     }
   }));
 
-  env.container.register('model:post', DS.Model.extend({
+  env.registry.register('model:post', DS.Model.extend({
     name: DS.attr(),
     authorName: DS.attr(),
     author: DS.belongsTo('user'),
     comments: DS.hasMany('comment')
   }));
 
-  env.container.register('model:user', DS.Model.extend({
+  env.registry.register('model:user', DS.Model.extend({
     createdAt: DS.attr(),
     name: DS.attr()
   }));
 
-  env.container.register('model:comment', DS.Model.extend({
+  env.registry.register('model:comment', DS.Model.extend({
     body: DS.attr()
   }));
 

--- a/packages/ember-data/tests/integration/record_array_manager_test.js
+++ b/packages/ember-data/tests/integration/record_array_manager_test.js
@@ -27,8 +27,8 @@ module("integration/record_array_manager- destroy", {
 
     manager = store.recordArrayManager;
 
-    env.container.register('model:car', Car);
-    env.container.register('model:person', Person);
+    env.registry.register('model:car', Car);
+    env.registry.register('model:person', Person);
   }
 });
 

--- a/packages/ember-data/tests/integration/records/reload_test.js
+++ b/packages/ember-data/tests/integration/records/reload_test.js
@@ -103,12 +103,12 @@ test("When a record is loaded a second time, isLoaded stays true", function() {
 });
 
 test("When a record is reloaded, its async hasMany relationships still work", function() {
-  env.container.register('model:person', DS.Model.extend({
+  env.registry.register('model:person', DS.Model.extend({
     name: DS.attr(),
     tags: DS.hasMany('tag', { async: true })
   }));
 
-  env.container.register('model:tag', DS.Model.extend({
+  env.registry.register('model:tag', DS.Model.extend({
     name: DS.attr()
   }));
 

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -63,7 +63,7 @@ module("integration/relationship/belongs_to Belongs-To Relationships", {
       author: Author
     });
 
-    env.container.register('serializer:user', DS.JSONSerializer.extend({
+    env.registry.register('serializer:user', DS.JSONSerializer.extend({
       attrs: {
         favouriteMessage: { embedded: 'always' }
       }
@@ -201,8 +201,8 @@ test("A serializer can materialize a belongsTo as a link that gets sent back to 
     group: DS.belongsTo({ async: true })
   });
 
-  env.container.register('model:group', Group);
-  env.container.register('model:person', Person);
+  env.registry.register('model:group', Group);
+  env.registry.register('model:person', Person);
 
   run(function() {
     store.push('person', { id: 1, links: { group: '/people/1/group' } });
@@ -239,8 +239,8 @@ test('A record with an async belongsTo relationship always returns a promise for
     seat: DS.belongsTo('seat', { async: true })
   });
 
-  env.container.register('model:seat', Seat);
-  env.container.register('model:person', Person);
+  env.registry.register('model:seat', Seat);
+  env.registry.register('model:person', Person);
 
   run(function() {
     store.push('person', { id: 1, links: { seat: '/people/1/seat' } });
@@ -277,8 +277,8 @@ test("A record with an async belongsTo relationship returning null should resolv
     group: DS.belongsTo({ async: true })
   });
 
-  env.container.register('model:group', Group);
-  env.container.register('model:person', Person);
+  env.registry.register('model:group', Group);
+  env.registry.register('model:person', Person);
 
   run(function() {
     store.push('person', { id: 1, links: { group: '/people/1/group' } });

--- a/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
@@ -61,9 +61,9 @@ module("integration/embedded_records_mixin - EmbeddedRecordsMixin", {
     env.store.modelFor('lightSaber');
     env.store.modelFor('evilMinion');
     env.store.modelFor('comment');
-    env.container.register('serializer:application', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
-    env.container.register('serializer:-active-model', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
-    env.container.register('adapter:-active-model', DS.ActiveModelAdapter);
+    env.registry.register('serializer:application', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
+    env.registry.register('serializer:-active-model', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
+    env.registry.register('adapter:-active-model', DS.ActiveModelAdapter);
     env.amsSerializer = env.container.lookup("serializer:-active-model");
     env.amsAdapter    = env.container.lookup("adapter:-active-model");
   },
@@ -74,8 +74,8 @@ module("integration/embedded_records_mixin - EmbeddedRecordsMixin", {
 });
 
 test("extractSingle with embedded objects", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
@@ -112,13 +112,13 @@ test("extractSingle with embedded objects", function() {
 });
 
 test("extractSingle with embedded objects inside embedded objects", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
   }));
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       evilMinions: { embedded: 'always' }
     }
@@ -164,8 +164,8 @@ test("extractSingle with embedded objects inside embedded objects", function() {
 });
 
 test("extractSingle with embedded objects of same type", function() {
-  env.container.register('adapter:comment', DS.ActiveModelAdapter);
-  env.container.register('serializer:comment', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:comment', DS.ActiveModelAdapter);
+  env.registry.register('serializer:comment', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       children: { embedded: 'always' }
     }
@@ -205,8 +205,8 @@ test("extractSingle with embedded objects of same type", function() {
 });
 
 test("extractSingle with embedded objects inside embedded objects of same type", function() {
-  env.container.register('adapter:comment', DS.ActiveModelAdapter);
-  env.container.register('serializer:comment', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:comment', DS.ActiveModelAdapter);
+  env.registry.register('serializer:comment', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       children: { embedded: 'always' }
     }
@@ -258,8 +258,8 @@ test("extractSingle with embedded objects of same type, but from separate attrib
     reformedVillains: DS.hasMany('superVillain', { inverse: null })
   });
 
-  env.container.register('adapter:home_planet', DS.ActiveModelAdapter);
-  env.container.register('serializer:home_planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:home_planet', DS.ActiveModelAdapter);
+  env.registry.register('serializer:home_planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' },
       reformedVillains: { embedded: 'always' }
@@ -306,8 +306,8 @@ test("extractSingle with embedded objects of same type, but from separate attrib
 });
 
 test("extractArray with embedded objects", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
@@ -347,11 +347,11 @@ test("extractArray with embedded objects", function() {
 
 test("extractArray with embedded objects with custom primary key", function() {
   expect(2);
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend({
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend({
     primaryKey: 'villain_id'
   }));
-  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
@@ -391,8 +391,8 @@ test("extractArray with embedded objects with custom primary key", function() {
 });
 test("extractArray with embedded objects with identical relationship and attribute key ", function() {
   expect(2);
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     },
@@ -434,8 +434,8 @@ test("extractArray with embedded objects with identical relationship and attribu
   });
 });
 test("extractArray with embedded objects of same type as primary type", function() {
-  env.container.register('adapter:comment', DS.ActiveModelAdapter);
-  env.container.register('serializer:comment', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:comment', DS.ActiveModelAdapter);
+  env.registry.register('serializer:comment', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       children: { embedded: 'always' }
     }
@@ -482,8 +482,8 @@ test("extractArray with embedded objects of same type, but from separate attribu
     reformedVillains: DS.hasMany('superVillain')
   });
 
-  env.container.register('adapter:homePlanet', DS.ActiveModelAdapter);
-  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:homePlanet', DS.ActiveModelAdapter);
+  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' },
       reformedVillains: { embedded: 'always' }
@@ -559,7 +559,7 @@ test("serialize supports serialize:false on non-relationship properties", functi
     tom = env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", id: '1' });
   });
 
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       firstName: { serialize: false }
     }
@@ -584,7 +584,7 @@ test("serialize with embedded objects (hasMany relationship)", function() {
     tom = env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
   });
 
-  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
@@ -615,7 +615,7 @@ test("serialize with embedded objects (hasMany relationship) supports serialize:
     env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
   });
 
-  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { serialize: false }
     }
@@ -638,7 +638,7 @@ test("serialize with (new) embedded objects (hasMany relationship)", function() 
     env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league });
   });
 
-  env.container.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
@@ -669,7 +669,7 @@ test("serialize with embedded objects (hasMany relationships, including related 
     superVillain.get('secretWeapons').pushObject(secretWeapon);
   });
 
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       evilMinions: { serialize: 'records', deserialize: 'records' },
       secretWeapons: { serialize: 'ids' }
@@ -697,8 +697,8 @@ test("serialize with embedded objects (hasMany relationships, including related 
 
 test("extractSingle with embedded object (belongsTo relationship)", function() {
   expect(4);
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { embedded: 'always' }
     }
@@ -747,8 +747,8 @@ test("extractSingle with embedded object (belongsTo relationship)", function() {
 });
 
 test("serialize with embedded object (belongsTo relationship)", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { embedded: 'always' }
     }
@@ -785,14 +785,14 @@ test("serialize with embedded object (belongsTo relationship)", function() {
 });
 
 test("serialize with embedded object (belongsTo relationship) works with different primaryKeys", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     primaryKey: '_id',
     attrs: {
       secretLab: { embedded: 'always' }
     }
   }));
-  env.container.register('serializer:secretLab', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:secretLab', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     primaryKey: 'crazy_id'
   }));
 
@@ -828,8 +828,8 @@ test("serialize with embedded object (belongsTo relationship) works with differe
 });
 
 test("serialize with embedded object (belongsTo relationship, new no id)", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { embedded: 'always' }
     }
@@ -866,8 +866,8 @@ test("serialize with embedded object (belongsTo relationship, new no id)", funct
 });
 
 test("serialize with embedded object (belongsTo relationship) supports serialize:ids", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { serialize: 'ids' }
     }
@@ -900,8 +900,8 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
 });
 
 test("serialize with embedded object (belongsTo relationship) supports serialize:id", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { serialize: 'id' }
     }
@@ -935,8 +935,8 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
 });
 
 test("serialize with embedded object (belongsTo relationship) supports serialize:false", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { serialize: false }
     }
@@ -967,8 +967,8 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
 });
 
 test("serialize with embedded object (belongsTo relationship) serializes the id by default if no option specified", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
   var serializer = env.container.lookup("serializer:superVillain");
 
   // records with an id, persisted
@@ -998,8 +998,8 @@ test("serialize with embedded object (belongsTo relationship) serializes the id 
 });
 
 test("when related record is not present, serialize embedded record (with a belongsTo relationship) as null", function() {
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { embedded: 'always' }
     }
@@ -1029,13 +1029,13 @@ test("when related record is not present, serialize embedded record (with a belo
 });
 
 test("extractSingle with multiply-nested belongsTo", function() {
-  env.container.register('adapter:evilMinion', DS.ActiveModelAdapter);
-  env.container.register('serializer:evilMinion', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:evilMinion', DS.ActiveModelAdapter);
+  env.registry.register('serializer:evilMinion', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       superVillain: { embedded: 'always' }
     }
   }));
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       homePlanet: { embedded: 'always' }
     }
@@ -1080,8 +1080,8 @@ test("extractSingle with polymorphic hasMany", function() {
     secretWeapons: DS.hasMany("secretWeapon", { polymorphic: true })
   });
 
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretWeapons: { embedded: 'always' }
     }
@@ -1137,8 +1137,8 @@ test("extractSingle with polymorphic belongsTo", function() {
     secretLab: DS.belongsTo("secretLab", { polymorphic: true })
   });
 
-  env.container.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { embedded: 'always' }
     }
@@ -1189,9 +1189,9 @@ test("Mixin can be used with RESTSerializer which does not define keyForAttribut
     superVillain.get('evilMinions').pushObject(evilMinion);
   });
 
-  env.container.register('serializer:evilMinion', DS.RESTSerializer);
-  env.container.register('serializer:secretWeapon', DS.RESTSerializer);
-  env.container.register('serializer:superVillain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:evilMinion', DS.RESTSerializer);
+  env.registry.register('serializer:secretWeapon', DS.RESTSerializer);
+  env.registry.register('serializer:superVillain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       evilMinions: { serialize: 'records', deserialize: 'records' }
     }
@@ -1219,13 +1219,13 @@ test("Mixin can be used with RESTSerializer which does not define keyForAttribut
 });
 
 test("normalize with custom belongsTo primary key", function() {
-  env.container.register('adapter:evilMinion', DS.ActiveModelAdapter);
-  env.container.register('serializer:evilMinion', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:evilMinion', DS.ActiveModelAdapter);
+  env.registry.register('serializer:evilMinion', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       superVillain: { embedded: 'always' }
     }
   }));
-  env.container.register('serializer:superVillain', DS.ActiveModelSerializer.extend({
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend({
     primaryKey: 'custom'
   }));
 
@@ -1289,9 +1289,9 @@ test("serializing relationships with an embedded and without calls super when no
       }
     }
   });
-  env.container.register('serializer:evilMinion', Serializer);
-  env.container.register('serializer:secretWeapon', Serializer);
-  env.container.register('serializer:superVillain', Serializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:evilMinion', Serializer);
+  env.registry.register('serializer:secretWeapon', Serializer);
+  env.registry.register('serializer:superVillain', Serializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       evilMinions: { serialize: 'records', deserialize: 'records' }
       // some relationships are not listed here, so super should be called on those

--- a/packages/ember-data/tests/integration/serializers/json_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/json_serializer_test.js
@@ -39,7 +39,7 @@ test("serializeAttribute", function() {
 });
 
 test("serializeAttribute respects keyForAttribute", function() {
-  env.container.register('serializer:post', DS.JSONSerializer.extend({
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
     keyForAttribute: function(key) {
       return key.toUpperCase();
     }
@@ -99,7 +99,7 @@ test("async serializeBelongsTo with null", function() {
 });
 
 test("serializeBelongsTo respects keyForRelationship", function() {
-  env.container.register('serializer:post', DS.JSONSerializer.extend({
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
     keyForRelationship: function(key, type) {
       return key.toUpperCase();
     }
@@ -118,7 +118,7 @@ test("serializeBelongsTo respects keyForRelationship", function() {
 });
 
 test("serializeHasMany respects keyForRelationship", function() {
-  env.container.register('serializer:post', DS.JSONSerializer.extend({
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
     keyForRelationship: function(key, type) {
       return key.toUpperCase();
     }
@@ -154,7 +154,7 @@ test("serializeIntoHash", function() {
 });
 
 test("serializePolymorphicType", function() {
-  env.container.register('serializer:comment', DS.JSONSerializer.extend({
+  env.registry.register('serializer:comment', DS.JSONSerializer.extend({
     serializePolymorphicType: function(record, json, relationship) {
       var key = relationship.key;
       var belongsTo = get(record, key);
@@ -184,7 +184,7 @@ test("extractArray normalizes each record in the array", function() {
     { title: "Another Post" }
   ];
 
-  env.container.register('serializer:post', DS.JSONSerializer.extend({
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
     normalize: function () {
       postNormalizeCount++;
       return this._super.apply(this, arguments);
@@ -198,7 +198,7 @@ test("extractArray normalizes each record in the array", function() {
 });
 
 test('Serializer should respect the attrs hash when extracting records', function() {
-  env.container.register("serializer:post", DS.JSONSerializer.extend({
+  env.registry.register("serializer:post", DS.JSONSerializer.extend({
     attrs: {
       title: "title_payload_key",
       comments: { key: 'my_comments' }
@@ -220,7 +220,7 @@ test('Serializer should respect the attrs hash when serializing records', functi
   Post.reopen({
     parentPost: DS.belongsTo('post')
   });
-  env.container.register("serializer:post", DS.JSONSerializer.extend({
+  env.registry.register("serializer:post", DS.JSONSerializer.extend({
     attrs: {
       title: "title_payload_key",
       parentPost: { key: "my_parent" }
@@ -241,7 +241,7 @@ test('Serializer should respect the attrs hash when serializing records', functi
 
 test('Serializer respects `serialize: false` on the attrs hash', function() {
   expect(2);
-  env.container.register("serializer:post", DS.JSONSerializer.extend({
+  env.registry.register("serializer:post", DS.JSONSerializer.extend({
     attrs: {
       title: { serialize: false }
     }
@@ -259,7 +259,7 @@ test('Serializer respects `serialize: false` on the attrs hash', function() {
 
 test('Serializer respects `serialize: false` on the attrs hash for a `hasMany` property', function() {
   expect(1);
-  env.container.register("serializer:post", DS.JSONSerializer.extend({
+  env.registry.register("serializer:post", DS.JSONSerializer.extend({
     attrs: {
       comments: { serialize: false }
     }
@@ -279,7 +279,7 @@ test('Serializer respects `serialize: false` on the attrs hash for a `hasMany` p
 
 test('Serializer respects `serialize: false` on the attrs hash for a `belongsTo` property', function() {
   expect(1);
-  env.container.register("serializer:comment", DS.JSONSerializer.extend({
+  env.registry.register("serializer:comment", DS.JSONSerializer.extend({
     attrs: {
       post: { serialize: false }
     }
@@ -298,7 +298,7 @@ test('Serializer respects `serialize: false` on the attrs hash for a `belongsTo`
 });
 
 test("Serializer should respect the primaryKey attribute when extracting records", function() {
-  env.container.register('serializer:post', DS.JSONSerializer.extend({
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
     primaryKey: '_ID_'
   }));
 
@@ -313,7 +313,7 @@ test("Serializer should respect the primaryKey attribute when extracting records
 });
 
 test("Serializer should respect the primaryKey attribute when serializing records", function() {
-  env.container.register('serializer:post', DS.JSONSerializer.extend({
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
     primaryKey: '_ID_'
   }));
 
@@ -327,7 +327,7 @@ test("Serializer should respect the primaryKey attribute when serializing record
 });
 
 test("Serializer should respect keyForAttribute when extracting records", function() {
-  env.container.register('serializer:post', DS.JSONSerializer.extend({
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
     keyForAttribute: function(key) {
       return key.toUpperCase();
     }
@@ -342,7 +342,7 @@ test("Serializer should respect keyForAttribute when extracting records", functi
 });
 
 test("Serializer should respect keyForRelationship when extracting records", function() {
-  env.container.register('serializer:post', DS.JSONSerializer.extend({
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
     keyForRelationship: function(key, type) {
       return key.toUpperCase();
     }
@@ -356,7 +356,7 @@ test("Serializer should respect keyForRelationship when extracting records", fun
 });
 
 test("normalizePayload is called during extractSingle", function() {
-  env.container.register('serializer:post', DS.JSONSerializer.extend({
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
     normalizePayload: function(payload) {
       return payload.response;
     }
@@ -382,14 +382,14 @@ test("Calling normalize should normalize the payload (only the passed keys)", fu
   var Person = DS.Model.extend({
     posts: DS.hasMany('post')
   });
-  env.container.register('serializer:post', DS.JSONSerializer.extend({
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
     attrs: {
       notInHash: 'aCustomAttrNotInHash',
       inHash: 'aCustomAttrInHash'
     }
   }));
 
-  env.container.register('model:person', Person);
+  env.registry.register('model:person', Person);
 
   Post.reopen({
     content: DS.attr('string'),

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -170,7 +170,7 @@ test("pushPayload - single record payload - warning with custom typeForRoot", fu
     }
   });
 
-  env.container.register("serializer:homePlanet", HomePlanetRestSerializer);
+  env.registry.register("serializer:homePlanet", HomePlanetRestSerializer);
 
   var jsonHash = {
     home_planet: { id: "1", name: "Umber", superVillains: [1] },
@@ -226,7 +226,7 @@ test("pushPayload - multiple record payload (extractArray) - warning with custom
     }
   });
 
-  env.container.register("serializer:homePlanet", HomePlanetRestSerializer);
+  env.registry.register("serializer:homePlanet", HomePlanetRestSerializer);
 
   var jsonHash = {
     home_planets: [{ id: "1", name: "Umber", superVillains: [1] }],
@@ -298,7 +298,7 @@ test("serialize polymorphicType with decamelized typeKey", function() {
 });
 
 test("normalizePayload is called during extractSingle", function() {
-  env.container.register('serializer:application', DS.RESTSerializer.extend({
+  env.registry.register('serializer:application', DS.RESTSerializer.extend({
     normalizePayload: function(payload) {
       return payload.response;
     }
@@ -362,7 +362,7 @@ test("extractArray can load secondary records of the same type without affecting
 test("extractSingle loads secondary records with correct serializer", function() {
   var superVillainNormalizeCount = 0;
 
-  env.container.register('serializer:superVillain', DS.RESTSerializer.extend({
+  env.registry.register('serializer:superVillain', DS.RESTSerializer.extend({
     normalize: function() {
       superVillainNormalizeCount++;
       return this._super.apply(this, arguments);
@@ -399,7 +399,7 @@ test("extractSingle returns null if payload contains null", function() {
 test("extractArray loads secondary records with correct serializer", function() {
   var superVillainNormalizeCount = 0;
 
-  env.container.register('serializer:superVillain', DS.RESTSerializer.extend({
+  env.registry.register('serializer:superVillain', DS.RESTSerializer.extend({
     normalize: function() {
       superVillainNormalizeCount++;
       return this._super.apply(this, arguments);
@@ -419,7 +419,7 @@ test("extractArray loads secondary records with correct serializer", function() 
 });
 
 test('normalizeHash normalizes specific parts of the payload', function() {
-  env.container.register('serializer:application', DS.RESTSerializer.extend({
+  env.registry.register('serializer:application', DS.RESTSerializer.extend({
     normalizeHash: {
       homePlanets: function(hash) {
         hash.id = hash._id;
@@ -446,7 +446,7 @@ test('normalizeHash normalizes specific parts of the payload', function() {
 });
 
 test('normalizeHash works with transforms', function() {
-  env.container.register('serializer:application', DS.RESTSerializer.extend({
+  env.registry.register('serializer:application', DS.RESTSerializer.extend({
     normalizeHash: {
       evilMinions: function(hash) {
         hash.condition = hash._condition;
@@ -456,7 +456,7 @@ test('normalizeHash works with transforms', function() {
     }
   }));
 
-  env.container.register('transform:condition', DS.Transform.extend({
+  env.registry.register('transform:condition', DS.Transform.extend({
     deserialize: function(serialized) {
       if (serialized === 1) {
         return "healing";
@@ -488,7 +488,7 @@ test('normalizeHash works with transforms', function() {
 });
 
 test('normalize should allow for different levels of normalization', function() {
-  env.container.register('serializer:application', DS.RESTSerializer.extend({
+  env.registry.register('serializer:application', DS.RESTSerializer.extend({
     attrs: {
       superVillain: 'is_super_villain'
     },

--- a/packages/ember-data/tests/unit/model/relationships/has_many_test.js
+++ b/packages/ember-data/tests/unit/model/relationships/has_many_test.js
@@ -27,9 +27,9 @@ test("hasMany handles pre-loaded relationships", function() {
     pets: DS.hasMany('pet')
   });
 
-  env.container.register('model:tag', Tag);
-  env.container.register('model:pet', Pet);
-  env.container.register('model:person', Person);
+  env.registry.register('model:tag', Tag);
+  env.registry.register('model:pet', Pet);
+  env.registry.register('model:person', Person);
 
   env.adapter.find = function(store, type, id) {
     if (type === Tag && id === '12') {
@@ -114,9 +114,9 @@ test("hasMany lazily loads async relationships", function() {
     pets: DS.hasMany('pet')
   });
 
-  env.container.register('model:tag', Tag);
-  env.container.register('model:pet', Pet);
-  env.container.register('model:person', Person);
+  env.registry.register('model:tag', Tag);
+  env.registry.register('model:pet', Pet);
+  env.registry.register('model:person', Person);
 
   env.adapter.find = function(store, type, id) {
     if (type === Tag && id === '12') {

--- a/packages/ember-data/tests/unit/store/push_test.js
+++ b/packages/ember-data/tests/unit/store/push_test.js
@@ -38,7 +38,7 @@ module("unit/store/push - DS.Store#push", {
 
     store = env.store;
 
-    env.container.register('serializer:post', DS.ActiveModelSerializer);
+    env.registry.register('serializer:post', DS.ActiveModelSerializer);
   },
 
   teardown: function() {
@@ -72,7 +72,7 @@ test("Supplying a model class for `push` is the same as supplying a string", fun
   expect(1);
 
   var Programmer = Person.extend();
-  env.container.register('model:programmer', Programmer);
+  env.registry.register('model:programmer', Programmer);
 
   run(function() {
     store.push(Programmer, {
@@ -144,7 +144,7 @@ test("Calling push with partial records updates just those attributes", function
 });
 
 test("Calling push on normalize allows partial updates with raw JSON", function () {
-  env.container.register('serializer:person', DS.RESTSerializer);
+  env.registry.register('serializer:person', DS.RESTSerializer);
   var person;
 
   run(function() {
@@ -323,13 +323,13 @@ test("Calling pushPayload allows pushing singular payload properties", function 
 
 test("Calling pushPayload should use the type's serializer for normalizing", function () {
   expect(4);
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     normalize: function(store, payload) {
       ok(true, "normalized is called on Post serializer");
       return this._super(store, payload);
     }
   }));
-  env.container.register('serializer:person', DS.RESTSerializer.extend({
+  env.registry.register('serializer:person', DS.RESTSerializer.extend({
     normalize: function(store, payload) {
       ok(true, "normalized is called on Person serializer");
       return this._super(store, payload);
@@ -361,7 +361,7 @@ test("Calling pushPayload should use the type's serializer for normalizing", fun
 test("Calling pushPayload without a type uses application serializer's pushPayload method", function () {
   expect(1);
 
-  env.container.register('serializer:application', DS.RESTSerializer.extend({
+  env.registry.register('serializer:application', DS.RESTSerializer.extend({
     pushPayload: function(store, payload) {
       ok(true, "pushPayload is called on Application serializer");
       return this._super(store, payload);
@@ -378,14 +378,14 @@ test("Calling pushPayload without a type uses application serializer's pushPaylo
 test("Calling pushPayload without a type should use a model's serializer when normalizing", function () {
   expect(4);
 
-  env.container.register('serializer:post', DS.RESTSerializer.extend({
+  env.registry.register('serializer:post', DS.RESTSerializer.extend({
     normalize: function(store, payload) {
       ok(true, "normalized is called on Post serializer");
       return this._super(store, payload);
     }
   }));
 
-  env.container.register('serializer:application', DS.RESTSerializer.extend({
+  env.registry.register('serializer:application', DS.RESTSerializer.extend({
     normalize: function(store, payload) {
       ok(true, "normalized is called on Application serializer");
       return this._super(store, payload);
@@ -415,7 +415,7 @@ test("Calling pushPayload without a type should use a model's serializer when no
 });
 
 test("Calling pushPayload allows partial updates with raw JSON", function () {
-  env.container.register('serializer:person', DS.RESTSerializer);
+  env.registry.register('serializer:person', DS.RESTSerializer);
 
   var person;
 


### PR DESCRIPTION
`Ember.Registry` has not yet landed on `stable`, but floods the console
with deprecation warnings for `beta` and `canary`.

This PR replaces all calls of `env.container.register` with
`env.registry.register` throughout the test suite.

When the Registry is available, it will handle registration. Otherwise,
it will defer to the Container.