### PR TITLE
Adds support for using mixins in polymorphic relationships

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs_to.js
@@ -61,13 +61,13 @@ BelongsToRelationship.prototype.addRecord = function(newRecord) {
   if (this.members.has(newRecord)) { return;}
   var type = this.relationshipMeta.type;
   Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", (function () {
-    if (newRecord instanceof type) {
-      return true;
-    } else if (Ember.MODEL_FACTORY_INJECTIONS) {
-      return newRecord instanceof type.superclass;
+    if (type.__isMixin) {
+      return type.__mixin.detect(newRecord);
     }
-
-    return false;
+    if (Ember.MODEL_FACTORY_INJECTIONS) {
+      type = type.superclass;
+    }
+    return newRecord instanceof type;
   })());
 
   if (this.inverseRecord) {

--- a/packages/ember-data/lib/system/relationships/state/has_many.js
+++ b/packages/ember-data/lib/system/relationships/state/has_many.js
@@ -86,13 +86,13 @@ ManyRelationship.prototype.removeRecordFromOwn = function(record, idx) {
 ManyRelationship.prototype.notifyRecordRelationshipAdded = function(record, idx) {
   var type = this.relationshipMeta.type;
   Ember.assert("You cannot add '" + record.constructor.typeKey + "' records to the " + this.record.constructor.typeKey + "." + this.key + " relationship (only '" + this.belongsToType.typeKey + "' allowed)", (function () {
-    if (record instanceof type) {
-      return true;
-    } else if (Ember.MODEL_FACTORY_INJECTIONS) {
-      return record instanceof type.superclass;
+    if (type.__isMixin) {
+      return type.__mixin.detect(record);
     }
-
-    return false;
+    if (Ember.MODEL_FACTORY_INJECTIONS) {
+      type = type.superclass;
+    }
+    return record instanceof type;
   })());
 
   this.record.notifyHasManyAdded(this.key, record, idx);

--- a/packages/ember-data/tests/integration/relationships/polymorphic_mixins_belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/polymorphic_mixins_belongs_to_test.js
@@ -1,0 +1,149 @@
+var env, store, User, Message, Video, NotMessage;
+var run = Ember.run;
+
+var attr = DS.attr;
+var belongsTo = DS.belongsTo;
+
+function stringify(string) {
+  return function() { return string; };
+}
+
+module('integration/relationships/polymorphic_mixins_belongs_to_test - Polymorphic belongsTo relationships with mixins', {
+  setup: function() {
+    User = DS.Model.extend({
+      name: attr('string'),
+      bestMessage: belongsTo('message', { async: true, polymorphic: true })
+    });
+    User.toString = stringify('User');
+
+    Message = Ember.Mixin.create({
+      title: attr('string'),
+      user: belongsTo('user', { async: true })
+    });
+    Message.toString = stringify('Message');
+
+    NotMessage = DS.Model.extend({
+      video: attr()
+    });
+
+    Video = DS.Model.extend(Message, {
+      video: attr()
+    });
+
+    env = setupStore({
+      user: User,
+      video: Video,
+      notMessage: NotMessage
+    });
+
+    env.container.register('mixin:message', Message);
+    store = env.store;
+  },
+
+  teardown: function() {
+    run(env.container, 'destroy');
+  }
+});
+
+/*
+  Server loading tests
+*/
+
+test("Relationship is available from the belongsTo side even if only loaded from the inverse side - async", function () {
+  var user, video;
+  run(function() {
+    user = store.push('user', { id: 1, name: 'Stanley', bestMessage: 2, bestMessageType: 'video' });
+    video = store.push('video', { id: 2, video: 'Here comes Youtube' });
+  });
+  run(function() {
+    user.get('bestMessage').then(function(message) {
+      equal(message, video, 'The message was loaded correctly');
+      message.get('user').then(function(fetchedUser) {
+        equal(fetchedUser, user, 'The inverse was setup correctly');
+      });
+    });
+  });
+});
+
+/*
+  Local edits
+*/
+test("Setting the polymorphic belongsTo gets propagated to the inverse side - async", function () {
+  var user, video;
+  run(function() {
+    user = store.push('user', { id: 1, name: 'Stanley' });
+    video = store.push('video', { id: 2, video: 'Here comes Youtube' });
+  });
+
+  run(function() {
+    user.set('bestMessage', video);
+    video.get('user').then(function(fetchedUser) {
+      equal(fetchedUser, user, "user got set correctly");
+    });
+    user.get('bestMessage').then(function(message) {
+      equal(message, video, 'The message was set correctly');
+    });
+  });
+});
+
+test("Setting the polymorphic belongsTo with an object that does not implement the mixin errors out", function () {
+  var user, video;
+  run(function() {
+    user = store.push('user', { id: 1, name: 'Stanley' });
+    video = store.push('notMessage', { id: 2, video: 'Here comes Youtube' });
+  });
+
+  run(function() {
+    expectAssertion(function() {
+      user.set('bestMessage', video);
+    }, /You can only add a 'message' record to this relationship/);
+  });
+});
+
+
+test("Setting the polymorphic belongsTo gets propagated to the inverse side - model injections true", function () {
+  expect(2);
+  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
+  Ember.MODEL_FACTORY_INJECTIONS = true;
+
+  try {
+    var user, video;
+    run(function() {
+      user = store.push('user', { id: 1, name: 'Stanley' });
+      video = store.push('video', { id: 2, video: 'Here comes Youtube' });
+    });
+
+    run(function() {
+      user.set('bestMessage', video);
+      video.get('user').then(function(fetchedUser) {
+        equal(fetchedUser, user, "user got set correctly");
+      });
+      user.get('bestMessage').then(function(message) {
+        equal(message, video, 'The message was set correctly');
+      });
+    });
+  } finally {
+    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+  }
+});
+
+test("Setting the polymorphic belongsTo with an object that does not implement the mixin errors out - model injections true", function () {
+  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
+  Ember.MODEL_FACTORY_INJECTIONS = true;
+
+  try {
+    var user, video;
+    run(function() {
+      user = store.push('user', { id: 1, name: 'Stanley' });
+      video = store.push('notMessage', { id: 2, video: 'Here comes Youtube' });
+    });
+
+    run(function() {
+      expectAssertion(function() {
+        user.set('bestMessage', video);
+      }, /You can only add a 'message' record to this relationship/);
+    });
+  } finally {
+    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+  }
+});

--- a/packages/ember-data/tests/integration/relationships/polymorphic_mixins_has_many_test.js
+++ b/packages/ember-data/tests/integration/relationships/polymorphic_mixins_has_many_test.js
@@ -1,0 +1,157 @@
+var env, store, User, Message, NotMessage, Video;
+var run = Ember.run;
+
+var attr = DS.attr;
+var hasMany = DS.hasMany;
+var belongsTo = DS.belongsTo;
+
+function stringify(string) {
+  return function() { return string; };
+}
+
+module('integration/relationships/polymorphic_mixins_has_many_test - Polymorphic hasMany relationships with mixins', {
+  setup: function() {
+    User = DS.Model.extend({
+      name: attr('string'),
+      messages: hasMany('message', { async: true, polymorphic: true })
+    });
+    User.toString = stringify('User');
+
+    Message = Ember.Mixin.create({
+      title: attr('string'),
+      user: belongsTo('user', { async: true })
+    });
+    Message.toString = stringify('Message');
+
+    Video = DS.Model.extend(Message, {
+      video: attr()
+    });
+
+    NotMessage = DS.Model.extend({
+      video: attr()
+    });
+
+    env = setupStore({
+      user: User,
+      video: Video,
+      notMessage: NotMessage
+    });
+
+    env.container.register('mixin:message', Message);
+    store = env.store;
+  },
+
+  teardown: function() {
+    run(env.container, 'destroy');
+  }
+});
+
+/*
+  Server loading tests
+*/
+
+test("Relationship is available from the belongsTo side even if only loaded from the hasMany side - async", function () {
+  var user, video;
+  run(function() {
+    user = store.push('user', { id: 1, name: 'Stanley', messages: [{ id: 2, type: 'video' }] });
+    video = store.push('video', { id: 2, video: 'Here comes Youtube' });
+  });
+  run(function() {
+    user.get('messages').then(function(messages) {
+      equal(messages.objectAt(0), video, 'The hasMany has loaded correctly');
+      messages.objectAt(0).get('user').then(function(fetchedUser) {
+        equal(fetchedUser, user, 'The inverse was setup correctly');
+      });
+    });
+  });
+});
+
+/*
+  Local edits
+*/
+test("Pushing to the hasMany reflects the change on the belongsTo side - async", function () {
+  var user, video;
+  run(function() {
+    user = store.push('user', { id: 1, name: 'Stanley', messages: [] });
+    video = store.push('video', { id: 2, video: 'Here comes Youtube' });
+  });
+
+  run(function() {
+    user.get('messages').then(function(fetchedMessages) {
+      fetchedMessages.pushObject(video);
+      video.get('user').then(function(fetchedUser) {
+        equal(fetchedUser, user, "user got set correctly");
+      });
+    });
+  });
+});
+
+/*
+  Local edits
+*/
+test("Pushing a an object that does not implement the mixin to the mixin accepting array errors out", function () {
+  var user,notMessage;
+  run(function() {
+    user = store.push('user', { id: 1, name: 'Stanley', messages: [] });
+    notMessage = store.push('notMessage', { id: 2, video: 'Here comes Youtube' });
+  });
+
+  run(function() {
+    user.get('messages').then(function(fetchedMessages) {
+      expectAssertion(function() {
+        fetchedMessages.pushObject(notMessage);
+      }, /You cannot add 'notMessage' records to the user\.messages relationship \(only 'message' allowed\)/);
+    });
+  });
+});
+
+test("Pushing to the hasMany reflects the change on the belongsTo side - model injections true", function () {
+  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
+  Ember.MODEL_FACTORY_INJECTIONS = true;
+
+  try {
+    var user, video;
+    run(function() {
+      user = store.push('user', { id: 1, name: 'Stanley', messages: [] });
+      video = store.push('video', { id: 2, video: 'Here comes Youtube' });
+    });
+
+    run(function() {
+      user.get('messages').then(function(fetchedMessages) {
+        fetchedMessages.pushObject(video);
+        video.get('user').then(function(fetchedUser) {
+          equal(fetchedUser, user, "user got set correctly");
+        });
+      });
+    });
+  } finally {
+    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+  }
+});
+
+/*
+  Local edits
+*/
+test("Pushing a an object that does not implement the mixin to the mixin accepting array errors out - model injections true", function () {
+  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
+  Ember.MODEL_FACTORY_INJECTIONS = true;
+
+  try {
+    var user,notMessage;
+    run(function() {
+      user = store.push('user', { id: 1, name: 'Stanley', messages: [] });
+      notMessage = store.push('notMessage', { id: 2, video: 'Here comes Youtube' });
+    });
+
+    run(function() {
+      user.get('messages').then(function(fetchedMessages) {
+        expectAssertion(function() {
+          fetchedMessages.pushObject(notMessage);
+        }, /You cannot add 'notMessage' records to the user\.messages relationship \(only 'message' allowed\)/);
+      });
+    });
+  } finally {
+    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+  }
+});
+

--- a/tests/index.html
+++ b/tests/index.html
@@ -43,8 +43,11 @@
 
     <script type="text/javascript">
       var emberChannel = QUnit.urlParams.emberchannel || "release", emberPath;
-      var emberPath = 'https://s3.amazonaws.com/builds.emberjs.com/' + emberChannel + '/ember.js';
-
+      if (emberChannel === "release") {
+        emberPath = "/bower_components/ember/ember.js";
+      } else {
+        emberPath = 'https://s3.amazonaws.com/builds.emberjs.com/' + emberChannel + '/ember.js';
+      }
       loadScript(emberPath);
     </script>
     <!--[if lte IE 8]>


### PR DESCRIPTION
Now it's possible to reference mixins in polymorphic relationships.

For example:

 ```
  var Comment = DS.Model.extend({
     owner: belongsTo('commentable'. { polymorphic: true })
  });
  var Commentable = Ember.Mixin.create({
    comments: hasMany('comment')
  });
```