### PR TITLE
Unload record instead of dematerialize

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -671,7 +671,7 @@ var RootState = {
 
       setup: function(record) {
         var store = get(record, 'store');
-        store.dematerializeRecord(record);
+        store._dematerializeRecord(record);
       },
 
       invokeLifecycleCallbacks: function(record) {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1912,7 +1912,7 @@ function _find(adapter, store, type, id, record) {
     if (record) {
       record.notFound();
       if (get(record, 'isEmpty')) {
-        store.dematerializeRecord(record);
+        store.unloadRecord(record);
       }
     }
     throw error;

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1678,14 +1678,25 @@ Store = Ember.Object.extend({
   // ...............
 
   /**
-    When a record is destroyed, this un-indexes it and
-    removes it from any record arrays so it can be GCed.
-
     @method dematerializeRecord
     @private
     @param {DS.Model} record
+    @deprecated Use [unloadRecord](#method_unloadRecord) instead
   */
   dematerializeRecord: function(record) {
+    Ember.deprecate('Using store.dematerializeRecord() has been deprecated since it was intended for private use only. You should use store.unloadRecord() instead.');
+    this._dematerializeRecord(record);
+  },
+
+  /**
+    When a record is destroyed, this un-indexes it and
+    removes it from any record arrays so it can be GCed.
+
+    @method _dematerializeRecord
+    @private
+    @param {DS.Model} record
+  */
+  _dematerializeRecord: function(record) {
     var type = record.constructor;
     var typeMap = this.typeMapFor(type);
     var id = get(record, 'id');

--- a/packages/ember-data/tests/integration/adapter/find_test.js
+++ b/packages/ember-data/tests/integration/adapter/find_test.js
@@ -121,7 +121,7 @@ test("When a single record is requested, and the promise is rejected, .find() is
   });
 });
 
-test("When a single record is requested, and the promise is rejected, the record should be dematerialized.", function() {
+test("When a single record is requested, and the promise is rejected, the record should be unloaded.", function() {
   expect(2);
 
   store = createStore({ adapter: DS.Adapter.extend({
@@ -137,5 +137,5 @@ test("When a single record is requested, and the promise is rejected, the record
     }));
   });
 
-  ok(!store.hasRecordForId(Person, 1), "The record has been dematerialized");
+  ok(!store.hasRecordForId(Person, 1), "The record has been unloaded");
 });


### PR DESCRIPTION
- Use store.unloadRecord() in favor of store.dematerializeRecord() (Fixes #2780)
- Deprecate store.dematerializeRecord()