### PR TITLE
use package.json for ember addon

### DIFF
--- a/lib/ember-addon/blueprints/ember-data/index.js
+++ b/lib/ember-addon/blueprints/ember-data/index.js
@@ -8,6 +8,7 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('ember-data', '1.0.0-beta.14.1');
+    var json = require('../../../../package.json');
+    return this.addBowerPackageToProject('ember-data', json.version);
   }
 };


### PR DESCRIPTION
We should migrate Ember Data to an ember addon soon.
Until then, we remove a step that could be automated in the
release pipeline by using the version in package.json