### PR TITLE
Embedded records mixin should use the correct serialization key when deserialize configuration is set, Fixes #2556

### DIFF
--- a/packages/activemodel-adapter/lib/system/active-model-serializer.js
+++ b/packages/activemodel-adapter/lib/system/active-model-serializer.js
@@ -262,7 +262,7 @@ var ActiveModelSerializer = RESTSerializer.extend({
       type.eachRelationship(function(key, relationship) {
         var payloadKey, payload;
         if (relationship.options.polymorphic) {
-          payloadKey = this.keyForAttribute(key);
+          payloadKey = this.keyForAttribute(key, "deserialize");
           payload = hash[payloadKey];
           if (payload && payload.type) {
             payload.type = this.typeForRoot(payload.type);
@@ -273,7 +273,7 @@ var ActiveModelSerializer = RESTSerializer.extend({
             });
           }
         } else {
-          payloadKey = this.keyForRelationship(key, relationship.kind);
+          payloadKey = this.keyForRelationship(key, relationship.kind, "deserialize");
           if (!hash.hasOwnProperty(payloadKey)) { return; }
           payload = hash[payloadKey];
         }

--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -123,11 +123,11 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     return extractEmbeddedRecords(this, this.store, type, normalizedHash);
   },
 
-  keyForRelationship: function(key, type) {
-    if (this.hasDeserializeRecordsOption(key)) {
-      return this.keyForAttribute(key);
+  keyForRelationship: function(key, type, method) {
+    if ((method === 'serialize' && this.hasSerializeRecordsOption(key)) || (method === 'deserialize' && this.hasDeserializeRecordsOption(key))) {
+      return this.keyForAttribute(key, method);
     } else {
-      return this._super(key, type) || key;
+      return this._super(key, type, method) || key;
     }
   },
 
@@ -191,14 +191,14 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     var embeddedSnapshot = snapshot.belongsTo(attr);
     var key;
     if (includeIds) {
-      key = this.keyForRelationship(attr, relationship.kind);
+      key = this.keyForRelationship(attr, relationship.kind, 'serialize');
       if (!embeddedSnapshot) {
         json[key] = null;
       } else {
         json[key] = embeddedSnapshot.id;
       }
     } else if (includeRecords) {
-      key = this.keyForAttribute(attr);
+      key = this.keyForAttribute(attr, 'serialize');
       if (!embeddedSnapshot) {
         json[key] = null;
       } else {
@@ -299,10 +299,10 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     var includeRecords = this.hasSerializeRecordsOption(attr);
     var key;
     if (includeIds) {
-      key = this.keyForRelationship(attr, relationship.kind);
+      key = this.keyForRelationship(attr, relationship.kind, 'serialize');
       json[key] = snapshot.hasMany(attr, { ids: true });
     } else if (includeRecords) {
-      key = this.keyForAttribute(attr);
+      key = this.keyForAttribute(attr, 'serialize');
       json[key] = snapshot.hasMany(attr).map(function(embeddedSnapshot) {
         var embeddedJson = embeddedSnapshot.record.serialize({ includeId: true });
         this.removeEmbeddedForeignKey(snapshot, embeddedSnapshot, relationship, embeddedJson);
@@ -335,7 +335,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
       if (parentRecord) {
         var name = parentRecord.name;
         var embeddedSerializer = this.store.serializerFor(embeddedSnapshot.type);
-        var parentKey = embeddedSerializer.keyForRelationship(name, parentRecord.kind);
+        var parentKey = embeddedSerializer.keyForRelationship(name, parentRecord.kind, 'deserialize');
         if (parentKey) {
           delete json[parentKey];
         }

--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -201,7 +201,7 @@ export default Serializer.extend({
 
     if (this.keyForAttribute) {
       type.eachAttribute(function(key) {
-        payloadKey = this.keyForAttribute(key);
+        payloadKey = this.keyForAttribute(key, 'deserialize');
         if (key === payloadKey) { return; }
         if (!hash.hasOwnProperty(payloadKey)) { return; }
 
@@ -220,7 +220,7 @@ export default Serializer.extend({
 
     if (this.keyForRelationship) {
       type.eachRelationship(function(key, relationship) {
-        payloadKey = this.keyForRelationship(key, relationship.kind);
+        payloadKey = this.keyForRelationship(key, relationship.kind, 'deserialize');
         if (key === payloadKey) { return; }
         if (!hash.hasOwnProperty(payloadKey)) { return; }
 
@@ -572,7 +572,7 @@ export default Serializer.extend({
 
        var belongsTo = snapshot.belongsTo(key);
 
-       key = this.keyForRelationship ? this.keyForRelationship(key, "belongsTo") : key;
+       key = this.keyForRelationship ? this.keyForRelationship(key, "belongsTo", "serialize") : key;
 
        json[key] = Ember.isNone(belongsTo) ? belongsTo : belongsTo.record.toJSON();
      }
@@ -594,7 +594,7 @@ export default Serializer.extend({
       // the serializer
       var payloadKey = this._getMappedKey(key);
       if (payloadKey === key && this.keyForRelationship) {
-        payloadKey = this.keyForRelationship(key, "belongsTo");
+        payloadKey = this.keyForRelationship(key, "belongsTo", "serialize");
       }
 
       //Need to check whether the id is there for new&async records
@@ -644,7 +644,7 @@ export default Serializer.extend({
       // the serializer
       payloadKey = this._getMappedKey(key);
       if (payloadKey === key && this.keyForRelationship) {
-        payloadKey = this.keyForRelationship(key, "hasMany");
+        payloadKey = this.keyForRelationship(key, "hasMany", "serialize");
       }
 
       var relationshipType = snapshot.type.determineRelationshipType(relationship);

--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -47,8 +47,9 @@ function coerceId(id) {
   ```
 
   You can also implement `keyForRelationship`, which takes the name
-  of the relationship as the first parameter, and the kind of
-  relationship (`hasMany` or `belongsTo`) as the second parameter.
+  of the relationship as the first parameter, the kind of
+  relationship (`hasMany` or `belongsTo`) as the second parameter, and
+  the method (`serialize` or `deserialize`) as the third parameter.
 
   @class RESTSerializer
   @namespace DS
@@ -739,7 +740,7 @@ var RESTSerializer = JSONSerializer.extend({
   serializePolymorphicType: function(snapshot, json, relationship) {
     var key = relationship.key;
     var belongsTo = snapshot.belongsTo(key);
-    key = this.keyForAttribute ? this.keyForAttribute(key) : key;
+    key = this.keyForAttribute ? this.keyForAttribute(key, "serialize") : key;
     if (Ember.isNone(belongsTo)) {
       json[key + "Type"] = null;
     } else {

--- a/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
@@ -934,6 +934,41 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
   });
 });
 
+test("serialize with embedded object (belongsTo relationship) supports serialize:id in conjunction with deserialize:records", function() {
+  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: { serialize: 'id', deserialize: 'records' }
+    }
+  }));
+
+  var serializer = env.container.lookup("serializer:superVillain");
+
+  // records with an id, persisted
+  var tom, json;
+
+  run(function() {
+    tom = env.store.createRecord(
+      SuperVillain,
+      { firstName: "Tom", lastName: "Dale", id: "1",
+        secretLab: env.store.createRecord(SecretLab, { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+        homePlanet: env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" })
+      }
+    );
+  });
+
+  run(function() {
+    json = serializer.serialize(tom._createSnapshot());
+  });
+
+  deepEqual(json, {
+    first_name: get(tom, "firstName"),
+    last_name: get(tom, "lastName"),
+    home_planet_id: get(tom, "homePlanet").get("id"),
+    secret_lab_id: get(tom, "secretLab").get("id")
+  });
+});
+
 test("serialize with embedded object (belongsTo relationship) supports serialize:false", function() {
   env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
   env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {


### PR DESCRIPTION
This is my first attempted contribution to Ember Data, so if I'm approaching anything the wrong way, please let me know!

When extending the `DS.EmbeddedRecordsMixin`, if you configure a `belongsTo` relationship as `{ serialize: 'id', deserialize: 'records' }`, it won't actually pay attention to the `serialize: 'id'` option, but use the `deserialize: 'records'` option. This is because of [`serializeBelongsTo`](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/serializers/embedded_records_mixin.js#L194) and the reimplementation of [`keyForRelationship`](https://github.com/emberjs/data/blob/f1be2af71d7402d034bc034d9502733647cad295/packages/ember-data/lib/serializers/embedded_records_mixin.js#L126-L132), which notices the `deserialize` option instead of the `serialize` option.

Fixes #2556.