### PR TITLE
[DOC] Clarify when didCreate is fired

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -431,7 +431,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
   didUpdate: Ember.K,
 
   /**
-    Fired when the record is created.
+    Fired when a new record is commited to the server.
 
     @event didCreate
   */


### PR DESCRIPTION
Previous doc was ambiguous and could be interpreted to mean when the record is created using createRecord(). Clarifies that the event is fired when a new record is saved.