### PR TITLE
Add assertion for `store` property on DS.Model subclasses

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -1158,6 +1158,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
   // rely on the data property.
   willMergeMixin: function(props) {
     Ember.assert('`data` is a reserved property name on DS.Model objects. Please choose a different property name for ' + this.constructor.toString(), !props.data);
+    Ember.assert('`store` is a reserved property name on DS.Model objects. Please choose a different property name for '+ this.constructor.toString(), !props.store);
   }
 });
 

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -649,6 +649,20 @@ test("A subclass of DS.Model can not use the `data` property", function() {
   }, /`data` is a reserved property name on DS.Model objects/);
 });
 
+test("A subclass of DS.Model can not use the `store` property", function() {
+  var Retailer = DS.Model.extend({
+    store: DS.attr(),
+    name: DS.attr()
+  });
+
+  var store = createStore({ retailer: Retailer });
+
+  expectAssertion(function() {
+    run(function() {
+      store.createRecord('retailer', { name: "Buy n Large" });
+    });
+  }, /`store` is a reserved property name on DS.Model objects/);
+});
 
 test("Pushing a record into the store should transition it to the loaded state", function() {
   var Person = DS.Model.extend({


### PR DESCRIPTION
Currently, the `store` property is "injected" into each model's record when it is created. This can potentially conflict with a `store` attribute on the model. (E.g. modeling a data set that includes Retailers and Stores.)

Attempting to subclass Model with a `store` attribute *will* produce an error, but it is not instructive as to what went wrong. I was helping a developer who is new to Ember and he was confused/misled by the existing error message:

```
Error while processing route: index Cannot use 'in' operator to search for 'store' in undefined TypeError: Cannot use 'in' operator to search for 'store' in undefined
    at ember$data$lib$system$model$attributes$$getValue
```

I have implemented an assertion and test based on those for the also-protected `data` property. Any feedback on how to implement is appreciated :smiley: 