### PR TITLE
Mutating a `DS.attr()` array causes dirtying

### DIFF
--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -10,7 +10,8 @@ module("unit/model - DS.Model", {
 
     Person = DS.Model.extend({
       name: DS.attr('string'),
-      isDrugAddict: DS.attr('boolean')
+      isDrugAddict: DS.attr('boolean'),
+      addictions: DS.attr({ defaultValue: [] })
     });
   },
 
@@ -45,6 +46,21 @@ test("setting a property on a record that has not changed does not cause it to b
       person.set('isDrugAddict', true);
 
       equal(person.get('isDirty'), false, "record does not become dirty after setting property to old value");
+    });
+  });
+});
+
+test("mutating an array property on a record causes it to become dirty", function() {
+  expect(2);
+
+  run(function() {
+    store.push(Person, { id: 1, addictions: [] });
+    store.find(Person, 1).then(function(person) {
+      equal(person.get("isDirty"), false, "precond - person record should not be dirty");
+
+      person.get(addictions).pushObjects(["drugs"]);
+
+      equal(person.get("isDirty"), true, "record becomes dirty after mutating an array property");
     });
   });
 });


### PR DESCRIPTION
This is currently a failing test case.

Is this missing behavior a bug, or is it deliberate, since the attribute is
arbitrary?

The canonical use case:

```js
App.Post = DS.Model.extend({
 tags: DS.attr({ defaultValue: [] })
});

// current behavior var post = this.store.createRecord("post");

post.get("tags").pushObject("emberjs"); post.get("isDirty") // false

post.get("tags").setObjects(["ember-data"]); post.get("isDirty") // false

post.set("tags", ["emberconf"]); post.get("isDirty") // true

// new behavior var post = this.store.createRecord("post");

post.get("tags").pushObject("emberjs"); post.get("isDirty") // true

post.get("tags").setObjects(["ember-data"]); post.get("isDirty") // true

post.set("tags", ["emberconf"]); post.get("isDirty") // true
```