### PR TITLE
improve error message for belongsTo

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/belongs_to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs_to.js
@@ -60,7 +60,7 @@ BelongsToRelationship.prototype._super$addRecord = Relationship.prototype.addRec
 BelongsToRelationship.prototype.addRecord = function(newRecord) {
   if (this.members.has(newRecord)) { return;}
   var type = this.relationshipMeta.type;
-  Ember.assert("You can only add a '" + type.typeKey + "' record to this relationship", (function () {
+  Ember.assert("You cannot add a '" + newRecord.constructor.typeKey + "' record to the '" + this.record.constructor.typeKey + "." + this.key +"'. " + "You can only add a '" + type.typeKey + "' record to this relationship.", (function () {
     if (type.__isMixin) {
       return type.__mixin.detect(newRecord);
     }

--- a/packages/ember-data/tests/integration/relationships/belongs_to_test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs_to_test.js
@@ -154,7 +154,7 @@ test("Only a record of the same base type can be used with a polymorphic belongs
 
       expectAssertion(function() {
         comment.set('message', records.user);
-      }, /You can only add a 'message' record to this relationship/);
+      }, /You cannot add a 'user' record to the 'comment.message'. You can only add a 'message' record to this relationship./);
     });
   });
 });


### PR DESCRIPTION
Improved the error message for ensuring belongsTo has proper relationship. 

This is for #2802 