### PR TITLE
Declare `store` property on DS.Model

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -74,6 +74,9 @@ function mergeAndReturnChangedKeys(original, updates) {
 var Model = Ember.Object.extend(Ember.Evented, {
   _recordArrays: undefined,
   _relationships: undefined,
+
+  store: null,
+
   /**
     If this property is `true` the record is in the `empty`
     state. Empty is the first state all records enter after they have

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -283,6 +283,26 @@ test("a DS.Model can have a defaultValue", function() {
   equal(get(tag, 'name'), null, "null doesn't shadow defaultValue");
 });
 
+test("a DS.model can define 'setUnknownProperty'", function() {
+  var tag;
+  var Tag = DS.Model.extend({
+    name: DS.attr("string"),
+
+    setUnknownProperty: function(key, value) {
+      if (key === "title") {
+        this.set("name", value);
+      }
+    }
+  });
+
+  run(function() {
+    tag = store.createRecord(Tag, { name: "old" });
+    set(tag, "title", "new");
+  });
+
+  equal(get(tag, "name"), "new", "setUnknownProperty not triggered");
+});
+
 test("a defaultValue for an attribute can be a function", function() {
   var Tag = DS.Model.extend({
     createdAt: DS.attr('string', {


### PR DESCRIPTION
Without explicitly declaring `store` on a `DS.Model` instance,
[`setUnknownProperty`][unknown] will be invoked, breaking any
user-overridden behavior.

[unknown]: https://github.com/emberjs/ember.js/blob/c9af09524a191ba155d98de8b9bbabaf802245e2/packages/ember-runtime/lib/system/core_object.js#L157-L159