### PR TITLE
Change _normalizeTypeKey to defer normalization to the container

### DIFF
--- a/packages/ember-data/lib/serializers/embedded_records_mixin.js
+++ b/packages/ember-data/lib/serializers/embedded_records_mixin.js
@@ -478,7 +478,7 @@ function extractEmbeddedBelongsToPolymorphic(store, key, hash) {
   store.push(embeddedType, embeddedRecord);
 
   hash[key] = embeddedRecord[primaryKey];
-  hash[key + 'Type'] = embeddedType.typeKey;
+  hash[key + 'Type'] = embeddedSerializer.typeForPayload(embeddedType.typeKey);
   return hash;
 }
 

--- a/packages/ember-data/lib/serializers/embedded_records_mixin.js
+++ b/packages/ember-data/lib/serializers/embedded_records_mixin.js
@@ -437,14 +437,13 @@ function extractEmbeddedHasManyPolymorphic(store, key, hash) {
   var ids = [];
 
   forEach(hash[key], function(data) {
-    var typeKey = data.type;
-    var embeddedSerializer = store.serializerFor(typeKey);
-    var embeddedType = store.modelFor(typeKey);
+    var embeddedType = store.modelFor(data.type);
+    var embeddedSerializer = store.serializerFor(embeddedType.typeKey);
     var primaryKey = get(embeddedSerializer, 'primaryKey');
 
     var embeddedRecord = embeddedSerializer.normalize(embeddedType, data, null);
     store.push(embeddedType, embeddedRecord);
-    ids.push({ id: embeddedRecord[primaryKey], type: typeKey });
+    ids.push({ id: embeddedRecord[primaryKey], type: embeddedType.typeKey });
   });
 
   hash[key] = ids;
@@ -471,16 +470,15 @@ function extractEmbeddedBelongsToPolymorphic(store, key, hash) {
   }
 
   var data = hash[key];
-  var typeKey = data.type;
-  var embeddedSerializer = store.serializerFor(typeKey);
-  var embeddedType = store.modelFor(typeKey);
+  var embeddedType = store.modelFor(data.type);
+  var embeddedSerializer = store.serializerFor(embeddedType.typeKey);
   var primaryKey = get(embeddedSerializer, 'primaryKey');
 
   var embeddedRecord = embeddedSerializer.normalize(embeddedType, data, null);
   store.push(embeddedType, embeddedRecord);
 
   hash[key] = embeddedRecord[primaryKey];
-  hash[key + 'Type'] = typeKey;
+  hash[key + 'Type'] = embeddedType.typeKey;
   return hash;
 }
 

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -487,17 +487,32 @@ export default Serializer.extend({
   },
 
   /**
-    You can use this method to customize how a serialized record is added to the complete
-    JSON hash to be sent to the server. By default the JSON Serializer does not namespace
-    the payload and just sends the raw serialized JSON object.
-    If your server expects namespaced keys, you should consider using the RESTSerializer.
-    Otherwise you can override this method to customize how the record is added to the hash.
+    Serialize a model snapshot into a server request payload.
 
-    For example, your server may expect underscored root objects.
+    By default the JSON Serializer does not namespace
+    payloads, instead a "raw" serialized object is sent. For example:
+
+    ```js
+    {
+      id: 'car-one',
+      speed: 'fast'
+    }
+    ```
+
+    Note the lack of a namespace, and of any information about what
+    model this payload refers to.
+
+    If your server expects namespaced payloads, you should consider using the RESTSerializer.
+
+    You can also override this method to customize serialization behavior.
+    For example, your server may expect underscored model namespaces:
 
     ```js
     App.ApplicationSerializer = DS.RESTSerializer.extend({
       serializeIntoHash: function(data, type, snapshot, options) {
+        // type.typeKey is a model name with formatting decided by your
+        // application container. In globals mode, ususally camelCase. In
+        // Ember-CLI, usually dasherize-case.
         var root = Ember.String.decamelize(type.typeKey);
         data[root] = this.serialize(snapshot, options);
       }
@@ -678,7 +693,10 @@ export default Serializer.extend({
         }
       }
     });
-   ```
+    ```
+
+    The default behavior of this method is to not serialize
+    type data for polymorphic relationships.
 
     @method serializePolymorphicType
     @param {DS.Snapshot} snapshot

--- a/packages/ember-data/lib/serializers/json_serializer.js
+++ b/packages/ember-data/lib/serializers/json_serializer.js
@@ -1,4 +1,6 @@
 import Serializer from "ember-data/system/serializer";
+var camelize = Ember.String.camelize;
+import { singularize } from "ember-inflector/system/string";
 
 var get = Ember.get;
 var isNone = Ember.isNone;
@@ -1100,5 +1102,38 @@ export default Serializer.extend({
     var transform = this.container.lookup('transform:' + attributeType);
     Ember.assert("Unable to find transform for '" + attributeType + "'", skipAssertion || !!transform);
     return transform;
+  },
+
+  /**
+    Convert an Ember-Data model type string into a type string for a request
+    payload. For example, your server may expect types to be camelCased:
+
+    ```js
+    // a request payload
+    {
+      "fastCar": {
+        "id": "1",
+        "name": "corvette"
+      }
+    }
+    ```
+
+    The default behavior is to camelCase and singularize model keys.
+    This method is used in `serializeIntoHash`, `serializePolymorphicType`
+    and in the embedded records mixin.
+
+    If you customize this behavior, keep in mind that Model naming
+    conventions may vary between applications and environements, but
+    will most often follow these standards:
+
+    * Ember-CLI applications will follow the pattern: `dasherized-model-name`.
+    * Globals-mode Ember applications will follow the pattern `camelCaseName`.
+
+    @method typeForPayload
+    @param {String} key
+    @return {String} the model's name in your request payloads
+  */
+  typeForPayload: function(key) {
+    return camelize(singularize(key));
   }
 });

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1423,7 +1423,7 @@ Store = Service.extend({
     if (typeof key === 'string') {
       factory = this.modelFactoryFor(key);
       if (!factory) {
-        //Support looking up mixins as base types for polymorphic relationships
+        // Support looking up mixins as base types for polymorphic relationships
         factory = this._modelForMixin(key);
       }
       if (!factory) {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -9,7 +9,6 @@ import {
   InvalidError,
   Adapter
 } from "ember-data/system/adapter";
-import { singularize } from "ember-inflector/system/string";
 import {
   Map
 } from "ember-data/system/map";
@@ -96,8 +95,6 @@ var map = Ember.EnumerableUtils.map;
 var Promise = Ember.RSVP.Promise;
 var copy = Ember.copy;
 var Store;
-
-var camelize = Ember.String.camelize;
 
 var Service = Ember.Service;
 if (!Service) {
@@ -1864,7 +1861,11 @@ Store = Service.extend({
     @return {String} if the adapter can generate one, an ID
   */
   _normalizeTypeKey: function(key) {
-    return camelize(singularize(key));
+    // Delegate to the container for normalization. The container
+    // requires a ':' to normalize so we add `model:` then slice off
+    // the first 6 characters to remove the `model:` in the return
+    // value
+    return this.container.normalize('model:' + key).slice(6);
   }
 });
 

--- a/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
+++ b/packages/ember-data/tests/integration/adapter/rest_adapter_test.js
@@ -1,4 +1,4 @@
-var env, store, adapter, Post, Comment, SuperUser;
+var env, store, adapter, Post, Comment, SuperUser, EmberCliUser;
 var passedUrl, passedVerb, passedHash;
 var run = Ember.run;
 
@@ -16,12 +16,17 @@ module("integration/adapter/rest_adapter - REST Adapter", {
       name: DS.attr("string")
     });
 
+    EmberCliUser = DS.Model.extend({
+      name: DS.attr("string")
+    });
+
     SuperUser = DS.Model.extend();
 
     env = setupStore({
       post: Post,
       comment: Comment,
       superUser: SuperUser,
+      'ember-cli-user': EmberCliUser,
       adapter: DS.RESTAdapter
     });
 
@@ -165,6 +170,22 @@ test("create - an empty payload is a basic success if an id was specified", func
 
       equal(post.get('isDirty'), false, "the post isn't dirty anymore");
       equal(post.get('name'), "The Parley Letter", "the post was updated");
+    }));
+  });
+});
+
+test("create dasherized model name is a basic success", function() {
+  ajaxResponse();
+  var emberCliUser;
+
+  run(function() {
+    emberCliUser = store.createRecord('ember-cli-user', { name: "The Parley Letter" });
+    emberCliUser.save().then(async(function(post) {
+      equal(passedUrl, "/emberCliUsers");
+      equal(passedVerb, "POST");
+
+      equal(post.get('isDirty'), false, "the ember-cli-user isn't dirty anymore");
+      equal(post.get('name'), "The Parley Letter", "the ember-cli-user was updated");
     }));
   });
 });

--- a/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
@@ -1476,7 +1476,7 @@ test("extractSingle with polymorphic belongsTo", function() {
     firstName: "Tom",
     lastName: "Dale",
     secretLab: "1",
-    secretLabType: "bat-cave"
+    secretLabType: "batCave"
   }, "Primary has was correct");
 
   equal( env.store.recordForId("bat-cave", "1").get("infiltrated"), true,

--- a/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
@@ -1388,7 +1388,7 @@ test("extractSingle with polymorphic hasMany", function() {
     attrs: {
       secretWeapons: { embedded: 'always' }
     },
-    typeForRoot: function(type){
+    typeForRoot: function(type) {
       return Ember.String.dasherize(type);
     }
   }));
@@ -1429,10 +1429,10 @@ test("extractSingle with polymorphic hasMany", function() {
     ]
   }, "Primary hash was correct");
 
-  equal( env.store.recordForId("secret-weapon", "1").get("name"), "The Death Star",
-         "Embedded polymorphic SecretWeapon found" );
-  equal( env.store.recordForId("light-saber", "1").get("name"), "Tom's LightSaber",
-         "Embedded polymorphic LightSaber found" );
+  equal(env.store.recordForId("secret-weapon", "1").get("name"), "The Death Star",
+        "Embedded polymorphic SecretWeapon found" );
+  equal(env.store.recordForId("light-saber", "1").get("name"), "Tom's LightSaber",
+        "Embedded polymorphic LightSaber found" );
 
 });
 
@@ -1448,7 +1448,7 @@ test("extractSingle with polymorphic belongsTo", function() {
     attrs: {
       secretLab: { embedded: 'always' }
     },
-    typeForRoot: function(type){
+    typeForRoot: function(type) {
       return Ember.String.dasherize(type);
     }
   }));
@@ -1479,6 +1479,6 @@ test("extractSingle with polymorphic belongsTo", function() {
     secretLabType: "batCave"
   }, "Primary has was correct");
 
-  equal( env.store.recordForId("bat-cave", "1").get("infiltrated"), true,
-         "Embedded polymorphic BatCave was found" );
+  equal(env.store.recordForId("bat-cave", "1").get("infiltrated"), true,
+        "Embedded polymorphic BatCave was found" );
 });

--- a/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded_records_mixin_test.js
@@ -1321,3 +1321,164 @@ test("serializing relationships with an embedded and without calls super when no
   ok(calledSerializeBelongsTo);
   ok(calledSerializeHasMany);
 });
+
+module("integration/embedded_records_mixin - EmbeddedRecordsMixin with dasherized model names in container", {
+  setup: function() {
+    SuperVillain = DS.Model.extend({
+      firstName:       DS.attr('string'),
+      lastName:        DS.attr('string'),
+      homePlanet:      DS.belongsTo("home-planet", { inverse: 'villains' }),
+      secretLab:       DS.belongsTo("secret-lab"),
+      secretWeapons:   DS.hasMany("secret-weapon"),
+      evilMinions:     DS.hasMany("evil-minion")
+    });
+    HomePlanet = DS.Model.extend({
+      name:            DS.attr('string'),
+      villains:        DS.hasMany('super-villain', { inverse: 'homePlanet' })
+    });
+    SecretLab = DS.Model.extend({
+      minionCapacity:  DS.attr('number'),
+      vicinity:        DS.attr('string'),
+      superVillain:    DS.belongsTo('super-villain')
+    });
+    BatCave = SecretLab.extend({
+      infiltrated:     DS.attr('boolean')
+    });
+    SecretWeapon = DS.Model.extend({
+      name:            DS.attr('string'),
+      superVillain:    DS.belongsTo('super-villain')
+    });
+    LightSaber = SecretWeapon.extend({
+      color:           DS.attr('string')
+    });
+    EvilMinion = DS.Model.extend({
+      superVillain:    DS.belongsTo('super-villain'),
+      name:            DS.attr('string')
+    });
+    env = setupStore({
+      'super-villain': SuperVillain,
+      'home-planet':   HomePlanet,
+      'secret-lab':    SecretLab,
+      'bat-cave':      BatCave,
+      'secret-weapon': SecretWeapon,
+      'light-saber':   LightSaber,
+      'evil-minion':   EvilMinion
+    });
+    env.store.modelFor('super-villain');
+    env.store.modelFor('home-planet');
+    env.store.modelFor('secret-lab');
+    env.store.modelFor('bat-cave');
+    env.store.modelFor('secret-weapon');
+    env.store.modelFor('light-saber');
+    env.store.modelFor('evil-minion');
+  },
+
+  teardown: function() {
+    run(env.store, 'destroy');
+  }
+});
+
+test("extractSingle with polymorphic hasMany", function() {
+  SuperVillain.reopen({
+    secretWeapons: DS.hasMany("secret-weapon", { polymorphic: true })
+  });
+
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretWeapons: { embedded: 'always' }
+    },
+    typeForRoot: function(type){
+      return Ember.String.dasherize(type);
+    }
+  }));
+  var serializer = env.container.lookup("serializer:super-villain");
+
+  var json_hash = {
+    super_villain: {
+      id: "1",
+      first_name: "Tom",
+      last_name: "Dale",
+      secret_weapons: [
+        {
+          id: "1",
+          type: "LightSaber",
+          name: "Tom's LightSaber",
+          color: "Red"
+        },
+        {
+          id: "1",
+          type: "SecretWeapon",
+          name: "The Death Star"
+        }
+      ]
+    }
+  };
+
+  var json = run(function() {
+    return serializer.extractSingle(env.store, SuperVillain, json_hash);
+  });
+
+  deepEqual(json, {
+    id: "1",
+    firstName: "Tom",
+    lastName: "Dale",
+    secretWeapons: [
+      { id: "1", type: "light-saber" },
+      { id: "1", type: "secret-weapon" }
+    ]
+  }, "Primary hash was correct");
+
+  equal( env.store.recordForId("secret-weapon", "1").get("name"), "The Death Star",
+         "Embedded polymorphic SecretWeapon found" );
+  equal( env.store.recordForId("light-saber", "1").get("name"), "Tom's LightSaber",
+         "Embedded polymorphic LightSaber found" );
+
+});
+
+test("extractSingle with polymorphic belongsTo", function() {
+  expect(2);
+
+  SuperVillain.reopen({
+    secretLab: DS.belongsTo("secret-lab", { polymorphic: true })
+  });
+
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: { embedded: 'always' }
+    },
+    typeForRoot: function(type){
+      return Ember.String.dasherize(type);
+    }
+  }));
+  var serializer = env.container.lookup("serializer:super-villain");
+
+  var json_hash = {
+    super_villain: {
+      id: "1",
+      first_name: "Tom",
+      last_name: "Dale",
+      secret_lab: {
+        id: "1",
+        type: "BatCave",
+        infiltrated: true
+      }
+    }
+  };
+
+  var json = run(function() {
+    return serializer.extractSingle(env.store, SuperVillain, json_hash);
+  });
+
+  deepEqual(json, {
+    id: "1",
+    firstName: "Tom",
+    lastName: "Dale",
+    secretLab: "1",
+    secretLabType: "bat-cave"
+  }, "Primary has was correct");
+
+  equal( env.store.recordForId("bat-cave", "1").get("infiltrated"), true,
+         "Embedded polymorphic BatCave was found" );
+});

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -284,19 +284,6 @@ test("serialize polymorphicType", function() {
   });
 });
 
-test("serialize polymorphicType with decamelized typeKey", function() {
-  YellowMinion.typeKey = 'yellow-minion';
-  var tom, ray;
-  run(function() {
-    tom = env.store.createRecord(YellowMinion, { name: "Alex", id: "124" });
-    ray = env.store.createRecord(DoomsdayDevice, { evilMinion: tom, name: "DeathRay" });
-  });
-
-  var json = env.restSerializer.serialize(ray._createSnapshot());
-
-  deepEqual(json["evilMinionType"], "yellowMinion");
-});
-
 test("normalizePayload is called during extractSingle", function() {
   env.registry.register('serializer:application', DS.RESTSerializer.extend({
     normalizePayload: function(payload) {
@@ -510,22 +497,6 @@ test('normalize should allow for different levels of normalization', function() 
 });
 
 test("serializeIntoHash", function() {
-  run(function() {
-    league = env.store.createRecord(HomePlanet, { name: "Umber", id: "123" });
-  });
-  var json = {};
-
-  env.restSerializer.serializeIntoHash(json, HomePlanet, league._createSnapshot());
-
-  deepEqual(json, {
-    homePlanet: {
-      name: "Umber"
-    }
-  });
-});
-
-test("serializeIntoHash with decamelized typeKey", function() {
-  HomePlanet.typeKey = 'home-planet';
   run(function() {
     league = env.store.createRecord(HomePlanet, { name: "Umber", id: "123" });
   });

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -511,6 +511,23 @@ test("serializeIntoHash", function() {
   });
 });
 
+test("serializeIntoHash with dasherized model", function() {
+  env.container.register('model:home-planet', HomePlanet);
+  var model = env.store.modelFor('home-planet');
+  run(function() {
+    league = env.store.createRecord(model, { name: "Umber", id: "123" });
+  });
+  var json = {};
+
+  env.restSerializer.serializeIntoHash(json, model, league._createSnapshot());
+
+  deepEqual(json, {
+    homePlanet: {
+      name: "Umber"
+    }
+  });
+});
+
 test('serializeBelongsTo with async polymorphic', function() {
   var evilMinion, doomsdayDevice;
   var json = {};

--- a/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
+++ b/packages/ember-data/tests/integration/serializers/rest_serializer_test.js
@@ -529,7 +529,7 @@ test("serializeIntoHash with dasherized model", function() {
 });
 
 test("serializeIntoHash with and typeForPayload", function() {
-  env.restSerializer.typeForPayload = function(key){
+  env.restSerializer.typeForPayload = function(key) {
     return key.toUpperCase();
   };
   env.container.register('model:home-planet', HomePlanet);
@@ -568,7 +568,7 @@ test('serializeBelongsTo with async polymorphic with typeForPayload', function()
   var json = {};
   var expected = { evilMinion: '1', evilMinionType: 'evil_minion' };
 
-  env.restSerializer.typeForPayload = function(key){
+  env.restSerializer.typeForPayload = function(key) {
     return Ember.String.decamelize(key);
   };
 

--- a/packages/ember-data/tests/unit/store/create_record_test.js
+++ b/packages/ember-data/tests/unit/store/create_record_test.js
@@ -42,7 +42,7 @@ test("creating a record by camel-case string finds the model", function() {
   });
 
   equal(record.get('foo'), attributes.foo, "The record is created");
-  equal(store.modelFor('someThing').typeKey, 'someThing');
+  equal(store.modelFor('someThing').typeKey, 'some-thing');
 });
 
 test("creating a record by dasherize string finds the model", function() {
@@ -54,7 +54,7 @@ test("creating a record by dasherize string finds the model", function() {
   });
 
   equal(record.get('foo'), attributes.foo, "The record is created");
-  equal(store.modelFor('some-thing').typeKey, 'someThing');
+  equal(store.modelFor('some-thing').typeKey, 'some-thing');
 });
 
 module("unit/store/createRecord - Store with models by camelCase", {

--- a/packages/ember-data/tests/unit/store/model_for_test.js
+++ b/packages/ember-data/tests/unit/store/model_for_test.js
@@ -1,16 +1,22 @@
 var container, store;
 
 var camelize  = Ember.String.camelize;
-var dasherize = Ember.String.dasherize;
+var capitalize = Ember.String.capitalize;
 
 var run = Ember.run;
 var env;
 
+function containerNormalize(string) {
+  return container.normalize('model:'+string).slice(6);
+}
+
 module("unit/store/model_for - DS.Store#modelFor", {
   setup: function() {
     env = setupStore({
-      blogPost: DS.Model.extend(),
-      "blog-post": DS.Model.extend()
+      "blog.post": DS.Model.extend(),
+      "blog_post": DS.Model.extend(),
+      "blogPost": DS.Model.extend(),
+      "BlogPost": DS.Model.extend()
     });
     store = env.store;
     container = store.container;
@@ -24,25 +30,37 @@ module("unit/store/model_for - DS.Store#modelFor", {
   }
 });
 
+// In this test, the normalizer is nothing at all. This is the default for
+// containers, most notably in unit tests. Note that the Ember application
+// container *does* have normalization logic, and that is tested in the next
+// test.
 test("when fetching factory from string, sets a normalized key as typeKey", function() {
-  env.replaceContainerNormalize(camelize);
-
-  equal(container.normalize('some.post'), 'somePost', 'precond - container camelizes');
-  equal(store.modelFor("blog.post").typeKey, "blogPost", "typeKey is normalized to camelCase");
+  equal(containerNormalize('some.post'), 'some.post', 'precond - container does nothing to dots');
+  equal(store.modelFor("blog.post").typeKey, "blog.post", "typeKey is normalized");
+  equal(store.modelFor("blog_post").typeKey, "blog_post", "typeKey is normalized");
+  equal(store.modelFor("blogPost").typeKey, "blogPost", "typeKey is normalized");
 });
 
-test("when fetching factory from string and dashing normalizer, sets a normalized key as typeKey", function() {
+// Test a container similar to the Ember application container- one with
+// normalization.
+test("when fetching factory from string and non-default normalizer, sets a normalized key as typeKey", function() {
   env.replaceContainerNormalize(function(fullName) {
-    return dasherize(camelize(fullName));
+    return 'model:'+capitalize(camelize(fullName.slice(6)));
   });
 
-  equal(container.normalize('some.post'), 'some-post', 'precond - container dasherizes');
-  equal(store.modelFor("blog.post").typeKey, "blogPost", "typeKey is normalized to camelCase");
+  equal(containerNormalize('some.post'), 'SomePost', 'precond - container titlizes');
+  equal(store.modelFor("blog.post").typeKey, "BlogPost", "typeKey is normalized");
+  equal(store.modelFor("blog_post").typeKey, "BlogPost", "typeKey is normalized");
+  equal(store.modelFor("blog-post").typeKey, "BlogPost", "typeKey is normalized");
 });
 
 test("when returning passed factory, sets a normalized key as typeKey", function() {
+  env.replaceContainerNormalize(function(fullName) {
+    return 'model:'+capitalize(camelize(fullName.slice(6)));
+  });
+
   var factory = { typeKey: 'some-thing' };
-  equal(store.modelFor(factory).typeKey, "someThing", "typeKey is normalized to camelCase");
+  equal(store.modelFor(factory).typeKey, "SomeThing", "typeKey is normalized");
 });
 
 test("when returning passed factory without typeKey, allows it", function() {


### PR DESCRIPTION
Let's talk about Ember-Data model resolution works in this PR.

First, remember that [isolated containers have no normalization](https://github.com/emberjs/ember.js/blob/5d853cefaec16a58af72f380bbc927474eb88c63/packages/container/lib/registry.js#L314-L323). When testing with isolated containers (unit tests), **the user-entered model name becomes the factory name requested from the container as well as the typeKey**.

For example, in a unit test modelFor works like this:

* `modelFor("SomeItem")`
* Looks for `"model:SomeItem"` in the container
* This is normalized to `"model:SomeItem"` (unit tests have no
  normalization)
* The factory is returned. In Ember-CLI, an error (?). In globals Ember,
  `App.SomeItem`.
* The typeKey is set to the normalized value: `SomeItem`

In an acceptance or app environment the container has a different resolver. In these cases normalization changes things. For example, [with the Ember-CLI resolver](https://github.com/ember-cli/ember-resolver/blob/64fca02c571057a93891a16cc3d20f7b38533e4f/packages/ember-resolver/lib/core.js#L168-L179):

* `modelFor("SomeItem")`
* Looks for `"model:SomeItem"` in the container
* This is normalized to `"model:some-item"` (Ember-CLI is dasherizing)
* The factory is returned. In Ember-CLI, that from `app/models/some-item`.
* The typeKey is set to the normalized value: `some-item`

There are several points of confusion IMO. I'd like to suggest two followup issues:

* Most developers do not realize that unit testing uses a different resolver/normalization than apps and acceptance tests. Acceptance tests are more "forgiving". If you camelCase in an Ember-CLI unit test you will get model-not-found errors. IMO (and I've PR this before, got it merged, and it was ripped out), Ember-Data should normalize model names **before** passing them to the container. This doesn't mean the typeKey should not be based on the container normalization (should not matter, should be an internal anyway), but that an additional normalization step would be introduced at the [beginning of `modelFor`](https://github.com/emberjs/data/blob/f71e90a76f8290f98315a1776a5d158b9c463694/packages/ember-data/lib/system/store.js#L1413). This normalization would ensure that Ember-Data, when there is no normalization provided by the container, always normalizes its own requests to camelCase or some other consistent format instead of blindly trying to trust user input.
* RESTAdapter defers to the `typeKey` for model keys. **If you change your resolver, you will change the requests sent to your server and the way data is parsed**.
  * [serializing a hash presumes the typeKey is the payload key](https://github.com/emberjs/data/blob/f71e90a76f8290f98315a1776a5d158b9c463694/packages/ember-data/lib/serializers/rest_serializer.js#L726). [bmac suggested](https://github.com/emberjs/data/pull/2766/files#diff-e9dfda7f1f589005862728db5d21e6d4R726) using `typeForRoot` here (which is definitely just a happens to work fix, it camelizes) or introducing a `rootForType`. `rootForType` with a default of camelization (based on [other typeKey normalization in that file](https://github.com/emberjs/data/blob/f71e90a76f8290f98315a1776a5d158b9c463694/packages/ember-data/lib/serializers/rest_serializer.js#L746)) is correct and I believe necessary.
  * Embedded records mixin also seems to presume the type can be read from a server response [during extract](https://github.com/emberjs/data/blob/f71e90a76f8290f98315a1776a5d158b9c463694/packages/ember-data/lib/serializers/embedded_records_mixin.js#L440). This should maybe go through `typeForRoot` as well.

See also:

* https://github.com/emberjs/data/pull/2766
* https://github.com/bantic/data/pull/1