### PR TITLE
Correct modelFor model not found errors

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1391,8 +1391,10 @@ Store = Ember.Object.extend({
       this.container.register('model:' + key, DS.Model.extend(mixin));
     }
     var factory = this.modelFactoryFor(key);
-    factory.__isMixin = true;
-    factory.__mixin = mixin;
+    if (factory) {
+      factory.__isMixin = true;
+      factory.__mixin = mixin;
+    }
 
     return factory;
   },

--- a/packages/ember-data/tests/unit/store/model_for_test.js
+++ b/packages/ember-data/tests/unit/store/model_for_test.js
@@ -49,3 +49,9 @@ test("when returning passed factory without typeKey, allows it", function() {
   var factory = { typeKey: undefined };
   equal(store.modelFor(factory).typeKey, undefined, "typeKey is undefined");
 });
+
+test("when fetching something that doesn't exist, throws error", function() {
+  throws(function() {
+    store.modelFor('wild-stuff');
+  }, /No model was found/);
+});


### PR DESCRIPTION
`modelFor` is throwing an incorrect error when it cannot find a model. Corrects it.