### PR TITLE
Copy the attr's defaultValue before assigning it.

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -211,7 +211,7 @@ function getDefaultValue(record, options, key) {
   if (typeof options.defaultValue === "function") {
     return options.defaultValue.apply(null, arguments);
   } else {
-    return options.defaultValue;
+    return Ember.copy(options.defaultValue);
   }
 }
 

--- a/packages/ember-data/tests/unit/model_test.js
+++ b/packages/ember-data/tests/unit/model_test.js
@@ -283,6 +283,20 @@ test("a DS.Model can have a defaultValue", function() {
   equal(get(tag, 'name'), null, "null doesn't shadow defaultValue");
 });
 
+test("a DS.Model copies the defaultValue", function() {
+  var Tag = DS.Model.extend({
+    name: DS.attr('string', { defaultValue: [] })
+  });
+  var tag1, tag2;
+
+  run(function() {
+    tag1 = store.createRecord(Tag);
+    tag2 = store.createRecord(Tag);
+  });
+
+  notEqual(get(tag1, 'name'), get(tag2, 'name'), "The default value is copied");
+});
+
 test("a DS.model can define 'setUnknownProperty'", function() {
   var tag;
   var Tag = DS.Model.extend({
@@ -318,6 +332,8 @@ test("a defaultValue for an attribute can be a function", function() {
   });
   equal(get(tag, 'createdAt'), "le default value", "the defaultValue function is evaluated");
 });
+
+
 
 test("a defaultValue function gets the record, options, and key", function() {
   expect(2);


### PR DESCRIPTION
Closes #2833 

This is a breaking change for anyone relying on the old behavior. Also this pr just performs a shallow copy. Should ED make a deep copy or simply require users to define their own function if they want a deep copy?