### PR TITLE
Add main entry point for package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "keywords": [
     "ember-addon"
   ],
+  "main": "lib/ember-addon/index.js",
   "ember-addon": {
     "main": "lib/ember-addon/index.js"
   },


### PR DESCRIPTION
Without this change, Ember CLI 0.2.0 will have the following warning for
all ember-data + ember-cli users:

```
% ember s
The package `ember-data` is not a properly formatted package, we have used a fallback lookup
to resolve it at `/some-path/goes/here/node_modules/ember-data`. This is generally caused by
an addon not having a `main` entry point (or `index.js`).
```