### PR TITLE
Fire didDelete event/callback when in uncommited state

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -410,6 +410,7 @@ var updatedState = dirtyState({
 createdState.uncommitted.deleteRecord = function(record) {
   record.disconnectRelationships();
   record.transitionTo('deleted.saved');
+  record.send('invokeLifecycleCallbacks');
 };
 
 createdState.uncommitted.rollback = function(record) {

--- a/packages/ember-data/tests/unit/model/lifecycle_callbacks_test.js
+++ b/packages/ember-data/tests/unit/model/lifecycle_callbacks_test.js
@@ -173,6 +173,40 @@ test("a record receives a didDelete callback when it has finished deleting", fun
   });
 });
 
+test("an uncommited record also receives a didDelete callback when it is deleted", function() {
+  expect(4);
+
+  var callCount = 0;
+
+  var Person = DS.Model.extend({
+    bar: DS.attr('string'),
+    name: DS.attr('string'),
+
+    didDelete: function() {
+      callCount++;
+      equal(get(this, 'isSaving'), false, "record should not be saving");
+      equal(get(this, 'isDirty'), false, "record should not be dirty");
+    }
+  });
+
+  var store = createStore({
+    adapter: DS.Adapter.extend()
+  });
+
+  var person;
+  run(function() {
+    person = store.createRecord(Person, { name: 'Tomster' });
+  });
+
+  equal(callCount, 0, "precond - didDelete callback was not called yet");
+
+  run(function() {
+    person.deleteRecord();
+  });
+
+  equal(callCount, 1, "didDelete called after delete");
+});
+
 test("a record receives a becameInvalid callback when it became invalid", function() {
   expect(5);
 


### PR DESCRIPTION
Now newly created and uncommited records will fire its livecycle events
when deleted.