### PR TITLE
Don't remove records from record arrays before commiting

### DIFF
--- a/packages/ember-data/lib/system/record_array_manager.js
+++ b/packages/ember-data/lib/system/record_array_manager.js
@@ -56,7 +56,9 @@ export default Ember.Object.extend({
   */
   updateRecordArrays: function() {
     forEach(this.changedRecords, function(record) {
-      if (get(record, 'isDeleted')) {
+      // TODO: it can be refactored after #2862 && #2859 are closed
+      if (get(record, 'isDestroyed') || get(record, 'isDestroying') ||
+          (get(record, 'isDeleted') && !get(record, 'isDirty'))) {
         this._recordWasDeleted(record);
       } else {
         this._recordWasChanged(record);

--- a/packages/ember-data/tests/integration/debug_adapter_test.js
+++ b/packages/ember-data/tests/integration/debug_adapter_test.js
@@ -105,7 +105,7 @@ test("Watching Records", function() {
   deepEqual(record.searchKeywords, ['2', 'New Post']);
   deepEqual(record.color, 'green');
 
-  Ember.run(post, 'deleteRecord');
+  Ember.run(post, 'unloadRecord');
 
   equal(removedIndex, 1);
   equal(removedCount, 1);

--- a/packages/ember-data/tests/integration/records/delete_record_test.js
+++ b/packages/ember-data/tests/integration/records/delete_record_test.js
@@ -22,8 +22,38 @@ module("integration/deletedRecord - Deleting Records", {
   }
 });
 
+test("records should not be removed from record arrays just after deleting, but only after commiting them", function () {
+  var adam, dave;
+
+  env.adapter.deleteRecord = function() {
+    return Ember.RSVP.Promise.resolve();
+  };
+
+  run(function() {
+    adam = env.store.push('person', { id: 1, name: "Adam Sunderland" });
+    dave = env.store.push('person', { id: 2, name: "Dave Sunderland" });
+  });
+  var all  = env.store.all('person');
+
+  // pre-condition
+  equal(all.get('length'), 2, 'expected 2 records');
+
+  Ember.run(adam, 'deleteRecord');
+
+  equal(all.get('length'), 2, 'expected 2 record');
+
+  Ember.run(adam, 'save');
+
+  equal(all.get('length'), 1, 'expected 1 record');
+});
+
 test("records can be deleted during record array enumeration", function () {
   var adam, dave;
+
+  env.adapter.deleteRecord = function() {
+    return Ember.RSVP.Promise.resolve();
+  };
+
   run(function() {
     adam = env.store.push('person', { id: 1, name: "Adam Sunderland" });
     dave = env.store.push('person', { id: 2, name: "Dave Sunderland" });
@@ -35,7 +65,7 @@ test("records can be deleted during record array enumeration", function () {
 
   Ember.run(function() {
     all.forEach(function(record) {
-      record.deleteRecord();
+      record.destroyRecord();
     });
   });
 

--- a/packages/ember-data/tests/unit/model/rollback_test.js
+++ b/packages/ember-data/tests/unit/model/rollback_test.js
@@ -110,7 +110,7 @@ test("a record's changes can be made if it fails to save", function() {
 });
 
 test("a deleted record can be rollbacked if it fails to save, record arrays are updated accordingly", function() {
-  expect(6);
+  expect(5);
   env.adapter.deleteRecord = function(store, type, record) {
     return Ember.RSVP.reject();
   };
@@ -124,7 +124,6 @@ test("a deleted record can be rollbacked if it fails to save, record arrays are 
   run(function() {
     person.deleteRecord();
   });
-  equal(people.get('length'), 0, "a deleted record does not appear in record array anymore");
 
   run(function() {
     person.save().then(null, function() {
@@ -166,8 +165,6 @@ test("deleted record can be rollbacked", function() {
     people = store.all('person');
     person.deleteRecord();
   });
-
-  equal(people.get('length'), 0, "a deleted record does not appear in record array anymore");
 
   equal(person.get('isDeleted'), true, "must be deleted");
 


### PR DESCRIPTION
Before this commit records were deleted from record arrays just after
deleting them, but before they were commited. This can be an issue if
you want to keep records visible in the UI until they're actually
removed.