### PR TITLE
Fix unload record

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -455,10 +455,9 @@ var RootState = {
   // you out of the in-flight state.
   rolledBack: Ember.K,
   unloadRecord: function(record) {
-    // clear relationships before moving to deleted state
-    // otherwise it fails
-    record.clearRelationships();
-    record.transitionTo('deleted.saved');
+    record.destroy();
+    var store = get(record, 'store');
+    store._dematerializeRecord(record);
   },
 
 
@@ -573,10 +572,9 @@ var RootState = {
       },
 
       unloadRecord: function(record) {
-        // clear relationships before moving to deleted state
-        // otherwise it fails
-        record.clearRelationships();
-        record.transitionTo('deleted.saved');
+        record.destroy();
+        var store = get(record, 'store');
+        store._dematerializeRecord(record);
       },
 
       didCommit: function(record) {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1049,7 +1049,6 @@ Store = Service.extend({
     for (var i = 0; i < records.length; i++) {
       record = records[i];
       record.unloadRecord();
-      record.destroy(); // maybe within unloadRecord
     }
 
     typeMap.findAllCache = null;

--- a/packages/ember-data/tests/unit/store/unload_test.js
+++ b/packages/ember-data/tests/unit/store/unload_test.js
@@ -63,8 +63,8 @@ test("unload a record", function() {
         store.unloadRecord(record);
       });
 
-      equal(get(record, 'isDirty'), false, "record is not dirty");
-      equal(get(record, 'isDeleted'), true, "record is deleted");
+      equal(get(record, 'isDestroyed'), true, "record is destroyed");
+      equal(store.hasRecordForId(Record, 1), false, "record is dematerialized");
 
       tryToFind = false;
       return store.find(Record, 1).then(function() {


### PR DESCRIPTION
This targets #2859 and #2862. When I started my work on this I only wanted to fix #2859, but both issues are connected and I believe that it's better to fix them at once. You can't easily change transitioning to `deleted.saved` without doing something else that removes record from record arrays, which can be achieved by destroying a record. Additionally, destroying a record on unloading without dematerializing it doesn't really make sense, so I also added that.

One more thing that should be a motivation for this change is that `dematerializeRecord` and it mentions using `unloadRecord`, which isn't an equivalent at the moment.