### PR TITLE
Rollback Relationships

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -397,6 +397,26 @@ var Adapter = Ember.Object.extend({
   */
   groupRecordsForFindMany: function(store, snapshots) {
     return [snapshots];
+  },
+
+  dirtyRecordForAttrChange: function (record, context) {
+    return context.value !== context.originalValue;
+  },
+
+  dirtyRecordForBelongsToChange: function (record, context) {
+    return context.value !== context.originalValue;
+  },
+
+  dirtyRecordForHasManyChange: function (record, context) {
+    var relationshipType = record.constructor.determineRelationshipType({ key: context.key, kind: context.kind });
+
+    if (relationshipType === 'manyToMany' || relationshipType === 'manyToNone') {
+      if (context.recordAdded) {
+        return !context.originalValue.has(context.recordAdded);
+      }
+      return context.originalValue.has(context.recordRemoved);
+    }
+    return false;
   }
 });
 

--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -292,7 +292,9 @@ export default function attr(type, options) {
 
   var meta = {
     type: type,
+    kind: 'attr',
     isAttribute: true,
+    key: null,
     options: options
   };
 
@@ -307,8 +309,9 @@ export default function attr(type, options) {
         this._attributes[key] = value;
 
         this.send('didSetProperty', {
-          name: key,
-          oldValue: oldValue,
+          key: key,
+          kind: 'attr',
+          isAttribute: true,
           originalValue: this._data[key],
           value: value
         });

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -767,6 +767,15 @@ var Model = Ember.Object.extend(Ember.Evented, {
     });
   },
 
+  rollbackRelationships: function() {
+    this.eachRelationship(function(name, relationship) {
+      this._relationships[name].rollback();
+    }, this);
+    var model = this;
+    forEach.call(Ember.keys(this._implicitRelationships), function(key) {
+      model._implicitRelationships[key].rollback();
+    });
+  },
 
   /**
     @method updateRecordArrays
@@ -1002,15 +1011,14 @@ var Model = Ember.Object.extend(Ember.Evented, {
       set(this, 'isError', false);
     }
 
-    //Eventually rollback will always work for relationships
-    //For now we support it only out of deleted state, because we
-    //have an explicit way of knowing when the server acked the relationship change
-    if (get(this, 'isDeleted')) {
-      this.reconnectRelationships();
-    }
+    var isDeleted = get(this, 'isDeleted');
+    var isNew = get(this, 'isNew');
 
-    if (get(this, 'isNew')) {
-      this.clearRelationships();
+    if (isDeleted || isNew) {
+      if (isDeleted) { this.reconnectRelationships(); }
+      if (isNew) { this.clearRelationships(); }
+    } else {
+      this.rollbackRelationships();
     }
 
     if (!get(this, 'isValid')) {

--- a/packages/ember-data/lib/system/relationships/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/belongs-to.js
@@ -98,7 +98,15 @@ function belongsTo(type, options) {
 */
 Model.reopen({
   notifyBelongsToChanged: function(key) {
+    var relationship = this._relationships[key];
     this.notifyPropertyChange(key);
+    this.send('didSetProperty', {
+      key: key,
+      kind: 'belongsTo',
+      isRelationship: true,
+      originalValue: relationship.canonicalState,
+      value: relationship.inverseRecord
+    });
   }
 });
 

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -134,7 +134,7 @@ Model.reopen({
       // populated by the `DS.belongsTo` helper when it is creating
       // the computed property.
       var meta = value.meta();
-
+      meta.key = key;
       meta.parentType = proto.constructor;
     }
   }

--- a/packages/ember-data/lib/system/relationships/has-many.js
+++ b/packages/ember-data/lib/system/relationships/has-many.js
@@ -122,13 +122,28 @@ function hasMany(type, options) {
 }
 
 Model.reopen({
-  notifyHasManyAdded: function(key) {
+  notifyHasManyAdded: function(key, record) {
     //We need to notifyPropertyChange in the adding case because we need to make sure
     //we fetch the newly added record in case it is unloaded
     //TODO(Igor): Consider whether we could do this only if the record state is unloaded
-
-    //Goes away once hasMany is double promisified
     this.notifyPropertyChange(key);
+    this.send('didSetProperty', {
+      key: key,
+      kind: 'hasMany',
+      isRelationship: true,
+      originalValue: this._relationships[key].canonicalMembers,
+      recordAdded: record
+    });
+  },
+
+  notifyHasManyRemoved: function(key, record) {
+    this.send('didSetProperty', {
+      key: key,
+      kind: 'hasMany',
+      isRelationship: true,
+      originalValue: this._relationships[key].canonicalMembers,
+      recordRemoved: record
+    });
   }
 });
 

--- a/packages/ember-data/lib/system/relationships/state/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs-to.js
@@ -141,4 +141,8 @@ BelongsToRelationship.prototype.getRecord = function() {
   }
 };
 
+BelongsToRelationship.prototype.rollback = function() {
+  this.setRecord(this.canonicalState);
+};
+
 export default BelongsToRelationship;

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -16,6 +16,7 @@ var Relationship = function(store, record, inverseKey, relationshipMeta) {
   this.inverseKeyForImplicit = this.store.modelFor(this.record.constructor).typeKey + this.key;
   this.linkPromise = null;
   this.hasData = false;
+  this.isDirty = false;
 };
 
 Relationship.prototype = {
@@ -44,6 +45,8 @@ Relationship.prototype = {
       this.addRecordToInverse(member);
     }, this);
   },
+
+  rollback: Ember.K,
 
   removeRecords: function(records) {
     var self = this;

--- a/packages/ember-data/tests/integration/relationships/many-to-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/many-to-many-test.js
@@ -257,7 +257,7 @@ test("Rollbacking a created record that has a ManyToMany relationship works corr
   });
 });
 
-test("Deleting a record that has a hasMany relationship removes it from the otherMany array but does not remove the other record from itself - sync", function () {
+test("Creating a record that has a hasMany relationship removes it from the otherMany array but does not remove the other record from itself - sync", function () {
   var account, user;
   run(function() {
     account = store.push('account', { id: 2 , state: 'lonely' });
@@ -269,6 +269,46 @@ test("Deleting a record that has a hasMany relationship removes it from the othe
   });
   equal(account.get('users.length'), 0, 'Users got removed');
   equal(user.get('accounts.length'), undefined, 'Accounts got rolledback correctly');
+});
+
+test("Rollbacking a record that has a ManyToMany relationship works correctly - async", function () {
+  var user, topic1, topic2;
+  run(function() {
+    user = store.push('user', { id: 1, name: 'Stanley', topics: [1] });
+    topic1 = store.push('topic', { id: 1, title: "This year's EmberFest was great" });
+    topic2 = store.push('topic', { id: 2, title: "Last year's EmberFest was great" });
+  });
+  run(function() {
+    topic2.get('users').addObject(user);
+    topic2.rollback();
+  });
+  run(function() {
+    topic1.get('users').then(async(function(fetchedUsers) {
+      deepEqual(fetchedUsers.toArray(), [user], 'Users are still there');
+    }));
+    topic2.get('users').then(async(function(fetchedUsers) {
+      deepEqual(fetchedUsers.toArray(), [], 'Users are still empty');
+    }));
+    user.get('topics').then(async(function(fetchedTopics) {
+      deepEqual(fetchedTopics.toArray(), [topic1], 'Topics are still there');
+    }));
+  });
+});
+
+test("Rollbacking a record that has a ManyToMany relationship works correctly - sync", function () {
+  var user, account1, account2;
+  run(function() {
+    user = store.push('user', { id: 1, name: 'Stanley', accounts: [1] });
+    account1 = store.push('account', { id: 1 , state: 'lonely' });
+    account2 = store.push('account', { id: 2 , state: 'content' });
+  });
+  run(function() {
+    account2.get('users').addObject(user);
+    account2.rollback();
+  });
+  deepEqual(user.get('accounts').toArray(), [account1], 'Accounts are still there');
+  deepEqual(account1.get('users').toArray(), [user], 'Users are still there');
+  deepEqual(account2.get('users').toArray(), [], 'Users are still empty');
 });
 
 


### PR DESCRIPTION
This commit allows relationships to be rolledback and also reintroduces `dirtyRecordFor*Change` hooks on the adapter.