### PR TITLE
bump ember-cli to 2.0 & remove sourcemapping comments in production

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -30,6 +30,7 @@ function minify(tree, name){
     srcFile: name + '.js',
     destFile: '/' + name + '.prod.js'
   });
+  tree = removeSourceMappingURL(tree);
   var uglified = moveFile(uglify(tree, {mangle: true}),{
     srcFile: name + '.prod.js',
     destFile: '/' + name + '.min.js'
@@ -143,12 +144,22 @@ var configurationFiles = pickFiles('config/package-manager-files', {
   files: [ '**/*.json' ]
 });
 
-function versionStamp(tree){
+function versionStamp(tree) {
   return replace(tree, {
     files: ['**/*'],
     patterns: [{
       match: /VERSION_STRING_PLACEHOLDER/g,
       replacement: version
+    }]
+  });
+}
+
+function removeSourceMappingURL(tree) {
+  return replace(tree, {
+    files: ['**/*'],
+    patterns: [{
+      match: /\/\/(.*)sourceMappingURL=(.*)/g,
+      replacement: ''
     }]
   });
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "broccoli-yuidoc": "^1.3.0",
     "defeatureify": "~0.1.4",
     "ejs": "^1.0.0",
-    "ember-cli": "^0.1.4",
+    "ember-cli": "^0.2.0",
     "ember-publisher": "0.0.6",
     "es6-module-transpiler": "^0.9.5",
     "es6-module-transpiler-amd-formatter": "^0.2.4",


### PR DESCRIPTION
fixes #2871, although I think that https://github.com/ember-cli/ember-cli-uglify/issues/4 has not actually been fixed.

cc @stefanpenner @ef4 @bmac