### PR TITLE
Pass snapshots to adapters instead of records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ### Master
 
+#### Breaking Changes
+
+##### The store now passes snapshots instead of records to adapter methods
+
+In 1.0.0-beta.15 serializers were updated to be passed snapshots instead of
+records to prevent side-effects like fetching data when inspecting
+relationships. This has now been extended to also include adapters methods.
+
+The following adapter methods are now passed snapshots instead of records:
+
+- `find(store, type, id, snapshot)`
+- `findMany(store, type, ids, snapshots)`
+- `findHasMany(store, snapshot, url, relationship)`
+- `findBelongsTo(store, snapshot, url, relationship)`
+- `createRecord(store, type, snapshot)`
+- `updateRecord(store, type, snapshot)`
+- `deleteRecord(store, type, snapshot)`
+
+The signature of `buildURL(type, id, snapshot)` has also been updated to receive
+snapshots instead of records.
+
+This change removes the need for adapters to create snapshots manually using the
+private API `record._createSnapshot()` to be able to pass snapshots to
+serializers.
+
+Snapshots are backwards-compatible with records (with deprecation warnings) and
+it should be pretty straight forward to update current code to the public
+Snapshot API:
+
+```js
+post.get('id')           => postSnapshot.id
+post.get('title')        => postSnapshot.attr('title')
+post.get('author')       => postSnapshot.belongsTo('author')
+post.get('comments')     => postSnapshot.hasMany('comments')
+post.constructor         => postSnapshot.type;
+post.constructor.typeKey => postSnapshot.typeKey
+```
+
+If you need to access the underlying record of a snapshot you can do so by
+accessing `snapshot.record`.
+
+The full API reference of `DS.Snapshot` can be found [here](http://emberjs.com/api/data/classes/DS.Snapshot.html).
+
+
 ### Release 1.0.0-beta.15 (February 14, 2015)
 
 #### Breaking Changes

--- a/packages/ember-data/lib/adapters/build-url-mixin.js
+++ b/packages/ember-data/lib/adapters/build-url-mixin.js
@@ -13,8 +13,8 @@ var get = Ember.get;
 
   ```javascript
   export default DS.Adapter.extend(BuildURLMixin, {
-    find: function(store, type, id, record) {
-      var url = this.buildURL(type.typeKey, id, record);
+    find: function(store, type, id, snapshot) {
+      var url = this.buildURL(type.typeKey, id, snapshot);
       return this.ajax(url, 'GET');
     }
   });
@@ -38,13 +38,16 @@ export default Ember.Mixin.create({
     If an ID is specified, it adds the ID to the path generated
     for the type, separated by a `/`.
 
+    When called by RESTAdapter.findMany() the `id` and `snapshot` parameters
+    will be arrays of ids and snapshots.
+
     @method buildURL
     @param {String} type
-    @param {String} id
-    @param {DS.Model} record
+    @param {String|Array} id single id or array of ids
+    @param {DS.Snapshot|Array} snapshot single snapshot or array of snapshots
     @return {String} url
   */
-  buildURL: function(type, id, record) {
+  buildURL: function(type, id, snapshot) {
     var url = [];
     var host = get(this, 'host');
     var prefix = this.urlPrefix();

--- a/packages/ember-data/lib/adapters/fixture-adapter.js
+++ b/packages/ember-data/lib/adapters/fixture-adapter.js
@@ -114,10 +114,9 @@ export default Adapter.extend({
     @method mockJSON
     @param {DS.Store} store
     @param {Subclass of DS.Model} type
-    @param {DS.Model} record
+    @param {DS.Snapshot} snapshot
   */
-  mockJSON: function(store, type, record) {
-    var snapshot = record._createSnapshot();
+  mockJSON: function(store, type, snapshot) {
     return store.serializerFor(snapshot.typeKey).serialize(snapshot, { includeId: true });
   },
 
@@ -136,9 +135,10 @@ export default Adapter.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {String} id
+    @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
-  find: function(store, type, id) {
+  find: function(store, type, id, snapshot) {
     var fixtures = this.fixturesForType(type);
     var fixture;
 
@@ -160,9 +160,10 @@ export default Adapter.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Array} ids
+    @param {Array} snapshots
     @return {Promise} promise
   */
-  findMany: function(store, type, ids) {
+  findMany: function(store, type, ids, snapshots) {
     var fixtures = this.fixturesForType(type);
 
     Ember.assert("Unable to find fixtures for model type "+type.toString(), fixtures);
@@ -225,11 +226,11 @@ export default Adapter.extend({
     @method createRecord
     @param {DS.Store} store
     @param {subclass of DS.Model} type
-    @param {DS.Model} record
+    @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
-  createRecord: function(store, type, record) {
-    var fixture = this.mockJSON(store, type, record);
+  createRecord: function(store, type, snapshot) {
+    var fixture = this.mockJSON(store, type, snapshot);
 
     this.updateFixtures(type, fixture);
 
@@ -242,11 +243,11 @@ export default Adapter.extend({
     @method updateRecord
     @param {DS.Store} store
     @param {subclass of DS.Model} type
-    @param {DS.Model} record
+    @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
-  updateRecord: function(store, type, record) {
-    var fixture = this.mockJSON(store, type, record);
+  updateRecord: function(store, type, snapshot) {
+    var fixture = this.mockJSON(store, type, snapshot);
 
     this.updateFixtures(type, fixture);
 
@@ -259,11 +260,11 @@ export default Adapter.extend({
     @method deleteRecord
     @param {DS.Store} store
     @param {subclass of DS.Model} type
-    @param {DS.Model} record
+    @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
-  deleteRecord: function(store, type, record) {
-    this.deleteLoadedFixture(type, record);
+  deleteRecord: function(store, type, snapshot) {
+    this.deleteLoadedFixture(type, snapshot);
 
     return this.simulateRemoteCall(function() {
       // no payload in a deletion
@@ -275,10 +276,10 @@ export default Adapter.extend({
     @method deleteLoadedFixture
     @private
     @param type
-    @param record
+    @param snapshot
   */
-  deleteLoadedFixture: function(type, record) {
-    var existingFixture = this.findExistingFixture(type, record);
+  deleteLoadedFixture: function(type, snapshot) {
+    var existingFixture = this.findExistingFixture(type, snapshot);
 
     if (existingFixture) {
       var index = indexOf(type.FIXTURES, existingFixture);
@@ -291,11 +292,11 @@ export default Adapter.extend({
     @method findExistingFixture
     @private
     @param type
-    @param record
+    @param snapshot
   */
-  findExistingFixture: function(type, record) {
+  findExistingFixture: function(type, snapshot) {
     var fixtures = this.fixturesForType(type);
-    var id = get(record, 'id');
+    var id = snapshot.id;
 
     return this.findFixtureById(fixtures, id);
   },

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -181,7 +181,7 @@ var Adapter = Ember.Object.extend({
 
     ```javascript
     App.ApplicationAdapter = DS.Adapter.extend({
-      find: function(store, type, id) {
+      find: function(store, type, id, snapshot) {
         var url = [type.typeKey, id].join('/');
 
         return new Ember.RSVP.Promise(function(resolve, reject) {
@@ -200,6 +200,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {String} id
+    @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
   find: null,
@@ -305,8 +306,8 @@ var Adapter = Ember.Object.extend({
 
     ```javascript
     App.ApplicationAdapter = DS.Adapter.extend({
-      createRecord: function(store, type, record) {
-        var data = this.serialize(record, { includeId: true });
+      createRecord: function(store, type, snapshot) {
+        var data = this.serialize(snapshot, { includeId: true });
         var url = type;
 
         // ...
@@ -334,8 +335,8 @@ var Adapter = Ember.Object.extend({
 
     ```javascript
     App.ApplicationAdapter = DS.Adapter.extend({
-      createRecord: function(store, type, record) {
-        var data = this.serialize(record, { includeId: true });
+      createRecord: function(store, type, snapshot) {
+        var data = this.serialize(snapshot, { includeId: true });
         var url = type;
 
         return new Ember.RSVP.Promise(function(resolve, reject) {
@@ -358,7 +359,7 @@ var Adapter = Ember.Object.extend({
     @method createRecord
     @param {DS.Store} store
     @param {subclass of DS.Model} type   the DS.Model class of the record
-    @param {DS.Model} record
+    @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
   createRecord: null,
@@ -373,9 +374,9 @@ var Adapter = Ember.Object.extend({
 
     ```javascript
     App.ApplicationAdapter = DS.Adapter.extend({
-      updateRecord: function(store, type, record) {
-        var data = this.serialize(record, { includeId: true });
-        var id = record.get('id');
+      updateRecord: function(store, type, snapshot) {
+        var data = this.serialize(snapshot, { includeId: true });
+        var id = snapshot.id;
         var url = [type, id].join('/');
 
         return new Ember.RSVP.Promise(function(resolve, reject) {
@@ -398,7 +399,7 @@ var Adapter = Ember.Object.extend({
     @method updateRecord
     @param {DS.Store} store
     @param {subclass of DS.Model} type   the DS.Model class of the record
-    @param {DS.Model} record
+    @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
   updateRecord: null,
@@ -413,9 +414,9 @@ var Adapter = Ember.Object.extend({
 
     ```javascript
     App.ApplicationAdapter = DS.Adapter.extend({
-      deleteRecord: function(store, type, record) {
-        var data = this.serialize(record, { includeId: true });
-        var id = record.get('id');
+      deleteRecord: function(store, type, snapshot) {
+        var data = this.serialize(snapshot, { includeId: true });
+        var id = snapshot.id;
         var url = [type, id].join('/');
 
         return new Ember.RSVP.Promise(function(resolve, reject) {
@@ -438,7 +439,7 @@ var Adapter = Ember.Object.extend({
     @method deleteRecord
     @param {DS.Store} store
     @param {subclass of DS.Model} type   the DS.Model class of the record
-    @param {DS.Model} record
+    @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
   deleteRecord: null,
@@ -461,7 +462,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type   the DS.Model class of the records
     @param {Array}    ids
-    @param {Array} records
+    @param {Array} snapshots
     @return {Promise} promise
   */
 
@@ -476,12 +477,12 @@ var Adapter = Ember.Object.extend({
 
     @method groupRecordsForFindMany
     @param {DS.Store} store
-    @param {Array} records
+    @param {Array} snapshots
     @return {Array}  an array of arrays of records, each of which is to be
                       loaded separately by `findMany`.
   */
-  groupRecordsForFindMany: function (store, records) {
-    return [records];
+  groupRecordsForFindMany: function(store, snapshots) {
+    return [snapshots];
   }
 });
 

--- a/packages/ember-data/lib/system/snapshot.js
+++ b/packages/ember-data/lib/system/snapshot.js
@@ -65,10 +65,9 @@ Snapshot.prototype = {
     Example
 
     ```javascript
-    var post = store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
-    var snapshot = post._createSnapshot();
+    // store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
 
-    snapshot.id; // => '1'
+    postSnapshot.id; // => '1'
     ```
 
     @property id
@@ -113,11 +112,10 @@ Snapshot.prototype = {
     Example
 
     ```javascript
-    var post = store.createRecord('post', { author: 'Tomster', title: 'Ember.js rocks' });
-    var snapshot = post._createSnapshot();
+    // store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
 
-    snapshot.attr('author'); // => 'Tomster'
-    snapshot.attr('title'); // => 'Ember.js rocks'
+    postSnapshot.attr('author'); // => 'Tomster'
+    postSnapshot.attr('title'); // => 'Ember.js rocks'
     ```
 
     Note: Values are loaded eagerly and cached when the snapshot is created.
@@ -139,10 +137,9 @@ Snapshot.prototype = {
     Example
 
     ```javascript
-    var post = store.createRecord('post', { author: 'Tomster', title: 'Ember.js rocks' });
-    var snapshot = post._createSnapshot();
+    // store.push('post', { id: 1, author: 'Tomster', title: 'Hello World' });
 
-    snapshot.attributes(); // => { author: 'Tomster', title: 'Ember.js rocks' }
+    postSnapshot.attributes(); // => { author: 'Tomster', title: 'Ember.js rocks' }
     ```
 
     @method attributes
@@ -164,12 +161,11 @@ Snapshot.prototype = {
     Example
 
     ```javascript
-    var post = store.push('post', { id: 1, title: 'Hello World' });
-    var comment = store.createRecord('comment', { body: 'Lorem ipsum', post: post });
-    var snapshot = comment._createSnapshot();
+    // store.push('post', { id: 1, title: 'Hello World' });
+    // store.createRecord('comment', { body: 'Lorem ipsum', post: post });
 
-    snapshot.belongsTo('post'); // => DS.Snapshot of post
-    snapshot.belongsTo('post', { id: true }); // => '1'
+    commentSnapshot.belongsTo('post'); // => DS.Snapshot
+    commentSnapshot.belongsTo('post', { id: true }); // => '1'
     ```
 
     Calling `belongsTo` will return a new Snapshot as long as there's any
@@ -229,11 +225,10 @@ Snapshot.prototype = {
     Example
 
     ```javascript
-    var post = store.createRecord('post', { title: 'Hello World', comments: [2, 3] });
-    var snapshot = post._createSnapshot();
+    // store.push('post', { id: 1, title: 'Hello World', comments: [2, 3] });
 
-    snapshot.hasMany('comments'); // => [DS.Snapshot, DS.Snapshot]
-    snapshot.hasMany('comments', { ids: true }); // => ['2', '3']
+    postSnapshot.hasMany('comments'); // => [DS.Snapshot, DS.Snapshot]
+    postSnapshot.hasMany('comments', { ids: true }); // => ['2', '3']
     ```
 
     Note: Relationships are loaded lazily and cached upon first access.

--- a/packages/ember-data/lib/system/snapshot.js
+++ b/packages/ember-data/lib/system/snapshot.js
@@ -355,6 +355,15 @@ Snapshot.prototype = {
   */
   unknownProperty: function(keyName) {
     return this.get(keyName);
+  },
+
+  /**
+    @method _createSnapshot
+    @private
+  */
+  _createSnapshot: function() {
+    Ember.deprecate("You called _createSnapshot on what's already a DS.Snapshot. You shouldn't manually create snapshots in your adapter since the store passes snapshots to adapters by default.");
+    return this;
   }
 };
 

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -13,7 +13,8 @@ var get = Ember.get;
 var Promise = Ember.RSVP.Promise;
 
 export function _find(adapter, store, type, id, record) {
-  var promise = adapter.find(store, type, id, record);
+  var snapshot = record._createSnapshot();
+  var promise = adapter.find(store, type, id, snapshot);
   var serializer = serializerForAdapter(store, adapter, type);
   var label = "DS: Handle Adapter#find of " + type + " with id: " + id;
 
@@ -41,7 +42,8 @@ export function _find(adapter, store, type, id, record) {
 
 
 export function _findMany(adapter, store, type, ids, records) {
-  var promise = adapter.findMany(store, type, ids, records);
+  var snapshots = Ember.A(records).invoke('_createSnapshot');
+  var promise = adapter.findMany(store, type, ids, snapshots);
   var serializer = serializerForAdapter(store, adapter, type);
   var label = "DS: Handle Adapter#findMany of " + type;
 
@@ -64,7 +66,8 @@ export function _findMany(adapter, store, type, ids, records) {
 }
 
 export function _findHasMany(adapter, store, record, link, relationship) {
-  var promise = adapter.findHasMany(store, record, link, relationship);
+  var snapshot = record._createSnapshot();
+  var promise = adapter.findHasMany(store, snapshot, link, relationship);
   var serializer = serializerForAdapter(store, adapter, relationship.type);
   var label = "DS: Handle Adapter#findHasMany of " + record + " : " + relationship.type;
 
@@ -85,7 +88,8 @@ export function _findHasMany(adapter, store, record, link, relationship) {
 }
 
 export function _findBelongsTo(adapter, store, record, link, relationship) {
-  var promise = adapter.findBelongsTo(store, record, link, relationship);
+  var snapshot = record._createSnapshot();
+  var promise = adapter.findBelongsTo(store, snapshot, link, relationship);
   var serializer = serializerForAdapter(store, adapter, relationship.type);
   var label = "DS: Handle Adapter#findBelongsTo of " + record + " : " + relationship.type;
 

--- a/packages/ember-data/tests/integration/adapter/find-test.js
+++ b/packages/ember-data/tests/integration/adapter/find-test.js
@@ -42,7 +42,7 @@ test("When a single record is requested, the adapter's find method should be cal
   var count = 0;
 
   store = createStore({ adapter: DS.Adapter.extend({
-      find: function(store, type, id) {
+      find: function(store, type, id, snapshot) {
         equal(type, Person, "the find method is called with the correct type");
         equal(count, 0, "the find method is only called once");
 
@@ -62,7 +62,7 @@ test("When a single record is requested multiple times, all .find() calls are re
   var deferred = Ember.RSVP.defer();
 
   store = createStore({ adapter: DS.Adapter.extend({
-      find:  function(store, type, id) {
+      find: function(store, type, id, snapshot) {
         return deferred.promise;
       }
     })
@@ -108,7 +108,7 @@ test("When a single record is requested multiple times, all .find() calls are re
 
 test("When a single record is requested, and the promise is rejected, .find() is rejected.", function() {
   store = createStore({ adapter: DS.Adapter.extend({
-      find: function(store, type, id) {
+      find: function(store, type, id, snapshot) {
         return Ember.RSVP.reject();
       }
     })
@@ -125,7 +125,7 @@ test("When a single record is requested, and the promise is rejected, the record
   expect(2);
 
   store = createStore({ adapter: DS.Adapter.extend({
-      find: function(store, type, id) {
+      find: function(store, type, id, snapshot) {
         return Ember.RSVP.reject();
       }
     })

--- a/packages/ember-data/tests/integration/adapter/fixture-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/fixture-adapter-test.js
@@ -284,7 +284,7 @@ asyncTest("copies fixtures instead of passing the direct reference", function() 
   }];
 
   var PersonAdapter = DS.FixtureAdapter.extend({
-    find: function(store, type, id) {
+    find: function(store, type, id, snapshot) {
       return this._super(store, type, id).then(function(fixture) {
         return returnedFixture = fixture;
       });

--- a/packages/ember-data/tests/integration/adapter/record-persistence-test.js
+++ b/packages/ember-data/tests/integration/adapter/record-persistence-test.js
@@ -37,9 +37,9 @@ module("integration/adapter/record_persistence - Persisting Records", {
 test("When a store is committed, the adapter's `commit` method should be called with records that have been changed.", function() {
   expect(2);
 
-  env.adapter.updateRecord = function(store, type, record) {
+  env.adapter.updateRecord = function(store, type, snapshot) {
     equal(type, Person, "the type is correct");
-    equal(record, tom, "the record is correct");
+    equal(snapshot.record, tom, "the record is correct");
 
     return run(Ember.RSVP, 'resolve');
   };
@@ -61,9 +61,9 @@ test("When a store is committed, the adapter's `commit` method should be called 
   expect(2);
   var tom;
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     equal(type, Person, "the type is correct");
-    equal(record, tom, "the record is correct");
+    equal(snapshot.record, tom, "the record is correct");
 
     return Ember.RSVP.resolve({ id: 1, name: "Tom Dale" });
   };
@@ -78,7 +78,7 @@ test("After a created record has been assigned an ID, finding a record by that I
   expect(1);
   var tom;
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     return Ember.RSVP.resolve({ id: 1, name: "Tom Dale" });
   };
 
@@ -91,9 +91,9 @@ test("After a created record has been assigned an ID, finding a record by that I
 });
 
 test("when a store is committed, the adapter's `commit` method should be called with records that have been deleted.", function() {
-  env.adapter.deleteRecord = function(store, type, record) {
+  env.adapter.deleteRecord = function(store, type, snapshot) {
     equal(type, Person, "the type is correct");
-    equal(record, tom, "the record is correct");
+    equal(snapshot.record, tom, "the record is correct");
 
     return run(Ember.RSVP, 'resolve');
   };
@@ -117,7 +117,7 @@ test("An adapter can notify the store that records were updated by calling `didS
 
   var tom, yehuda;
 
-  env.adapter.updateRecord = function(store, type, record) {
+  env.adapter.updateRecord = function(store, type, snapshot) {
     return Ember.RSVP.resolve();
   };
 
@@ -148,10 +148,10 @@ test("An adapter can notify the store that records were updated by calling `didS
 });
 
 test("An adapter can notify the store that records were updated and provide new data by calling `didSaveRecords`.", function() {
-  env.adapter.updateRecord = function(store, type, record) {
-    if (record.get('id') === "1") {
+  env.adapter.updateRecord = function(store, type, snapshot) {
+    if (snapshot.id === "1") {
       return Ember.RSVP.resolve({ id: 1, name: "Tom Dale", updatedAt: "now" });
-    } else if (record.get('id') === "2") {
+    } else if (snapshot.id === "2") {
       return Ember.RSVP.resolve({ id: 2, name: "Yehuda Katz", updatedAt: "now!" });
     }
   };
@@ -175,7 +175,7 @@ test("An adapter can notify the store that records were updated and provide new 
 });
 
 test("An adapter can notify the store that a record was updated by calling `didSaveRecord`.", function() {
-  env.adapter.updateRecord = function(store, type, record) {
+  env.adapter.updateRecord = function(store, type, snapshot) {
     return Ember.RSVP.resolve();
   };
 
@@ -198,8 +198,8 @@ test("An adapter can notify the store that a record was updated by calling `didS
 });
 
 test("An adapter can notify the store that a record was updated and provide new data by calling `didSaveRecord`.", function() {
-  env.adapter.updateRecord = function(store, type, record) {
-    switch (record.get('id')) {
+  env.adapter.updateRecord = function(store, type, snapshot) {
+    switch (snapshot.id) {
       case "1":
         return Ember.RSVP.resolve({ id: 1, name: "Tom Dale", updatedAt: "now" });
       case "2":
@@ -227,7 +227,7 @@ test("An adapter can notify the store that a record was updated and provide new 
 });
 
 test("An adapter can notify the store that records were deleted by calling `didSaveRecords`.", function() {
-  env.adapter.deleteRecord = function(store, type, record) {
+  env.adapter.deleteRecord = function(store, type, snapshot) {
     return Ember.RSVP.resolve();
   };
 

--- a/packages/ember-data/tests/integration/client-id-generation-test.js
+++ b/packages/ember-data/tests/integration/client-id-generation-test.js
@@ -34,12 +34,12 @@ test("If an adapter implements the `generateIdForRecord` method, the store shoul
     return "id-" + idCount++;
   };
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     if (type === Comment) {
-      equal(get(record, 'id'), 'id-1', "Comment passed to `createRecord` has 'id-1' assigned");
+      equal(snapshot.id, 'id-1', "Comment passed to `createRecord` has 'id-1' assigned");
       return Ember.RSVP.resolve();
     } else {
-      equal(get(record, 'id'), 'id-2', "Post passed to `createRecord` has 'id-2' assigned");
+      equal(snapshot.id, 'id-2', "Post passed to `createRecord` has 'id-2' assigned");
       return Ember.RSVP.resolve();
     }
   };

--- a/packages/ember-data/tests/integration/filter-test.js
+++ b/packages/ember-data/tests/integration/filter-test.js
@@ -170,7 +170,7 @@ test("a filtered record array includes created elements", function() {
 test("a Record Array can update its filter", function() {
   run(function() {
     set(store, 'adapter', DS.Adapter.extend({
-      deleteRecord: function(store, type, record) {
+      deleteRecord: function(store, type, snapshot) {
         return Ember.RSVP.resolve();
       }
     }));
@@ -229,7 +229,7 @@ test("a Record Array can update its filter", function() {
 test("a Record Array can update its filter and notify array observers", function() {
   run(function() {
     set(store, 'adapter', DS.Adapter.extend({
-      deleteRecord: function(store, type, record) {
+      deleteRecord: function(store, type, snapshot) {
         return Ember.RSVP.resolve();
       }
     }));
@@ -395,7 +395,7 @@ test("it is possible to filter by state flags", function() {
   var filter;
   run(function() {
     set(store, 'adapter', DS.Adapter.extend({
-      find: function(store, type, id) {
+      find: function(store, type, id, snapshot) {
         return Ember.RSVP.resolve({ id: id, name: "Tom Dale" });
       }
     }));
@@ -491,7 +491,7 @@ test("it is possible to filter created records by dirtiness", function() {
 
 test("it is possible to filter created records by isReloading", function() {
   set(store, 'adapter', DS.Adapter.extend({
-    find: function() {
+    find: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({
         id: 1,
         name: "Tom Dalle"
@@ -564,7 +564,7 @@ var setup = function(serverCallbacks) {
 
 test("a Record Array can update its filter after server-side updates one record", function() {
   setup({
-    updateRecord: function(store, type, record) {
+    updateRecord: function(store, type, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Scumbag Server-side Dale" });
     }
   });
@@ -578,8 +578,8 @@ test("a Record Array can update its filter after server-side updates one record"
 
 test("a Record Array can update its filter after server-side updates multiple records", function() {
   setup({
-    updateRecord: function(store, type, record) {
-      switch (record.get('id')) {
+    updateRecord: function(store, type, snapshot) {
+      switch (snapshot.id) {
         case "1":
           return Ember.RSVP.resolve({ id: 1, name: "Scumbag Server-side Dale" });
         case "2":
@@ -597,7 +597,7 @@ test("a Record Array can update its filter after server-side updates multiple re
 
 test("a Record Array can update its filter after server-side creates one record", function() {
   setup({
-    createRecord: function(store, type, record) {
+    createRecord: function(store, type, snapshot) {
       return Ember.RSVP.resolve({ id: 4, name: "Scumbag Server-side Tim" });
     }
   });
@@ -611,8 +611,8 @@ test("a Record Array can update its filter after server-side creates one record"
 
 test("a Record Array can update its filter after server-side creates multiple records", function() {
   setup({
-    createRecord: function(store, type, record) {
-      switch (record.get('name')) {
+    createRecord: function(store, type, snapshot) {
+      switch (snapshot.attr('name')) {
         case "Client-side Mike":
           return Ember.RSVP.resolve({ id: 4, name: "Scumbag Server-side Mike" });
         case "Client-side David":
@@ -630,8 +630,8 @@ test("a Record Array can update its filter after server-side creates multiple re
 
 test("a Record Array can update its filter after server-side creates multiple records", function() {
   setup({
-    createRecord: function(store, type, record) {
-      switch (record.get('name')) {
+    createRecord: function(store, type, snapshot) {
+      switch (snapshot.attr('name')) {
         case "Client-side Mike":
           return Ember.RSVP.resolve({ id: 4, name: "Scumbag Server-side Mike" });
         case "Client-side David":

--- a/packages/ember-data/tests/integration/lifecycle-hooks-test.js
+++ b/packages/ember-data/tests/integration/lifecycle-hooks-test.js
@@ -22,7 +22,7 @@ module("integration/lifecycle_hooks - Lifecycle Hooks", {
 asyncTest("When the adapter acknowledges that a record has been created, a `didCreate` event is triggered.", function() {
   expect(3);
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     return resolve({ id: 99, name: "Yehuda Katz" });
   };
   var person;
@@ -44,7 +44,7 @@ asyncTest("When the adapter acknowledges that a record has been created, a `didC
 test("When the adapter acknowledges that a record has been created without a new data payload, a `didCreate` event is triggered.", function() {
   expect(3);
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     return Ember.RSVP.resolve();
   };
   var person;

--- a/packages/ember-data/tests/integration/records/collection-save-test.js
+++ b/packages/ember-data/tests/integration/records/collection-save-test.js
@@ -26,7 +26,7 @@ test("Collection will resolve save on success", function() {
 
   var posts = env.store.all('post');
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     return Ember.RSVP.resolve({ id: 123 });
   };
 
@@ -45,7 +45,7 @@ test("Collection will reject save on error", function() {
 
   var posts = env.store.all('post');
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     return Ember.RSVP.reject();
   };
 
@@ -66,7 +66,7 @@ test("Retry is allowed in a failure handler", function() {
 
   var count = 0;
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     if (count++ === 0) {
       return Ember.RSVP.reject();
     } else {
@@ -74,7 +74,7 @@ test("Retry is allowed in a failure handler", function() {
     }
   };
 
-  env.adapter.updateRecord = function(store, type, record) {
+  env.adapter.updateRecord = function(store, type, snapshot) {
     return Ember.RSVP.resolve({ id: 123 });
   };
 
@@ -96,7 +96,7 @@ test("Collection will reject save on invalid", function() {
 
   var posts = env.store.all('post');
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     return Ember.RSVP.reject({ title: 'invalid' });
   };
 

--- a/packages/ember-data/tests/integration/records/reload-test.js
+++ b/packages/ember-data/tests/integration/records/reload-test.js
@@ -25,7 +25,7 @@ module("integration/reload - Reloading Records", {
 test("When a single record is requested, the adapter's find method should be called unless it's loaded.", function() {
   var count = 0;
 
-  env.adapter.find = function(store, type, id) {
+  env.adapter.find = function(store, type, id, snapshot) {
     if (count === 0) {
       count++;
       return Ember.RSVP.resolve({ id: id, name: "Tom Dale" });
@@ -58,7 +58,7 @@ test("When a record is reloaded and fails, it can try again", function() {
   });
 
   var count = 0;
-  env.adapter.find = function(store, type, id) {
+  env.adapter.find = function(store, type, id, snapshot) {
     if (count++ === 0) {
       return Ember.RSVP.reject();
     } else {
@@ -114,7 +114,7 @@ test("When a record is reloaded, its async hasMany relationships still work", fu
 
   var tags = { 1: "hipster", 2: "hair" };
 
-  env.adapter.find = function(store, type, id) {
+  env.adapter.find = function(store, type, id, snapshot) {
     switch (type.typeKey) {
       case 'person':
         return Ember.RSVP.resolve({ id: 1, name: "Tom", tags: [1, 2] });

--- a/packages/ember-data/tests/integration/records/save-test.js
+++ b/packages/ember-data/tests/integration/records/save-test.js
@@ -24,7 +24,7 @@ test("Will resolve save on success", function() {
     post = env.store.createRecord('post', { title: 'toto' });
   });
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     return Ember.RSVP.resolve({ id: 123 });
   };
 
@@ -41,7 +41,7 @@ test("Will reject save on error", function() {
     post = env.store.createRecord('post', { title: 'toto' });
   });
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     return Ember.RSVP.reject();
   };
 
@@ -60,7 +60,7 @@ test("Retry is allowed in a failure handler", function() {
 
   var count = 0;
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     if (count++ === 0) {
       return Ember.RSVP.reject();
     } else {
@@ -85,7 +85,7 @@ test("Repeated failed saves keeps the record in uncommited state", function() {
     post = env.store.createRecord('post', { title: 'toto' });
   });
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     return Ember.RSVP.reject();
   };
 
@@ -107,7 +107,7 @@ test("Will reject save on invalid", function() {
     post = env.store.createRecord('post', { title: 'toto' });
   });
 
-  env.adapter.createRecord = function(store, type, record) {
+  env.adapter.createRecord = function(store, type, snapshot) {
     return Ember.RSVP.reject({ title: 'invalid' });
   };
 

--- a/packages/ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs-to-test.js
@@ -91,7 +91,7 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
     })
   });
 
-  env.adapter.find = function(store, type, id) {
+  env.adapter.find = function(store, type, id, snapshot) {
     ok(true, "The adapter's find method should be called");
     return Ember.RSVP.resolve({
       id: 1
@@ -214,11 +214,11 @@ test("A serializer can materialize a belongsTo as a link that gets sent back to 
     store.push('person', { id: 1, links: { group: '/people/1/group' } });
   });
 
-  env.adapter.find = function() {
+  env.adapter.find = function(store, type, id, snapshot) {
     throw new Error("Adapter's find method should not be called");
   };
 
-  env.adapter.findBelongsTo = async(function(store, record, link, relationship) {
+  env.adapter.findBelongsTo = async(function(store, snapshot, link, relationship) {
     equal(relationship.type, Group);
     equal(relationship.key, 'group');
     equal(link, "/people/1/group");
@@ -252,11 +252,11 @@ test('A record with an async belongsTo relationship always returns a promise for
     store.push('person', { id: 1, links: { seat: '/people/1/seat' } });
   });
 
-  env.adapter.find = function() {
+  env.adapter.find = function(store, type, id, snapshot) {
     throw new Error("Adapter's find method should not be called");
   };
 
-  env.adapter.findBelongsTo = async(function(store, record, link, relationship) {
+  env.adapter.findBelongsTo = async(function(store, snapshot, link, relationship) {
     return Ember.RSVP.resolve({ id: 1 });
   });
 
@@ -290,11 +290,11 @@ test("A record with an async belongsTo relationship returning null should resolv
     store.push('person', { id: 1, links: { group: '/people/1/group' } });
   });
 
-  env.adapter.find = function() {
+  env.adapter.find = function(store, type, id, snapshot) {
     throw new Error("Adapter's find method should not be called");
   };
 
-  env.adapter.findBelongsTo = async(function(store, record, link, relationship) {
+  env.adapter.findBelongsTo = async(function(store, snapshot, link, relationship) {
     return Ember.RSVP.resolve(null);
   });
 
@@ -472,13 +472,13 @@ test("relationship changes shouldn’t cause async fetches", function() {
     });
   });
 
-  env.adapter.deleteRecord = function(store, type, record) {
-    ok(record instanceof type);
-    equal(record.id, 1, 'should first comment');
-    return record.toJSON({ includeId: true });
+  env.adapter.deleteRecord = function(store, type, snapshot) {
+    ok(snapshot.record instanceof type);
+    equal(snapshot.id, 1, 'should first comment');
+    return snapshot.record.toJSON({ includeId: true });
   };
 
-  env.adapter.findMany = function(store, type, ids, records) {
+  env.adapter.findMany = function(store, type, ids, snapshots) {
     ok(false, 'should not need to findMay more comments, but attempted to anyways');
   };
 
@@ -509,13 +509,13 @@ test("Destroying a record with an unloaded aync belongsTo association does not f
     });
   });
 
-  env.adapter.find = function() {
+  env.adapter.find = function(store, type, id, snapshot) {
     throw new Error("Adapter's find method should not be called");
   };
 
-  env.adapter.deleteRecord = function(store, type, record) {
-    ok(record instanceof type);
-    equal(record.id, 1, 'should first post');
+  env.adapter.deleteRecord = function(store, type, snapshot) {
+    ok(snapshot.record instanceof type);
+    equal(snapshot.id, 1, 'should first post');
     return {
       id: "1",
       title: null,

--- a/packages/ember-data/tests/integration/relationships/one-to-one-test.js
+++ b/packages/ember-data/tests/integration/relationships/one-to-one-test.js
@@ -208,7 +208,7 @@ test("Setting a BelongsTo to a promise multiple times is resistant to race condi
     igor = store.push('user', { id: 3, name: "Igor", bestFriend: 5 });
     newFriend = store.push('user', { id: 7, name: "New friend" });
   });
-  env.adapter.find = function(store, type, id) {
+  env.adapter.find = function(store, type, id, snapshot) {
     if (id === '5') {
       return Ember.RSVP.resolve({ id: 5, name: "Igor's friend" });
     } else if (id === '2') {

--- a/packages/ember-data/tests/integration/snapshot-test.js
+++ b/packages/ember-data/tests/integration/snapshot-test.js
@@ -37,6 +37,23 @@ test("record._createSnapshot() returns a snapshot", function() {
   });
 });
 
+test("snapshot._createSnapshot() returns a snapshot (self) but is deprecated", function() {
+  expect(2);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot1 = post._createSnapshot();
+    var snapshot2;
+
+    expectDeprecation(function() {
+      snapshot2 = snapshot1._createSnapshot();
+    }, /You called _createSnapshot on what's already a DS.Snapshot. You shouldn't manually create snapshots in your adapter since the store passes snapshots to adapters by default./);
+
+    ok(snapshot2 === snapshot1, 'snapshot._createSnapshot() returns self');
+  });
+
+});
+
 test("snapshot.id, snapshot.type and snapshot.typeKey returns correctly", function() {
   expect(3);
 

--- a/packages/ember-data/tests/integration/store-test.js
+++ b/packages/ember-data/tests/integration/store-test.js
@@ -54,7 +54,7 @@ asyncTest("destroying record during find doesn't cause error", function() {
   expect(0);
 
   var TestAdapter = DS.FixtureAdapter.extend({
-    find: function() {
+    find: function(store, type, id, snapshot) {
       return new Ember.RSVP.Promise(function(resolve, reject) {
         Ember.run.next(function() {
           store.unloadAll(type);
@@ -82,7 +82,7 @@ asyncTest("find calls do not resolve when the store is destroyed", function() {
   expect(0);
 
   var TestAdapter = DS.FixtureAdapter.extend({
-    find: function() {
+    find: function(store, type, id, snapshot) {
       store.destroy();
       Ember.RSVP.resolve(null);
     }

--- a/packages/ember-data/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
+++ b/packages/ember-data/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
@@ -8,7 +8,7 @@ module("unit/adapters/rest_adapter/group_records_for_find_many_test - DS.RESTAda
 
       coalesceFindRequests: true,
 
-      find: function(store, type, id) {
+      find: function(store, type, id, snapshot) {
         return Ember.RSVP.Promise.resolve({ id: id });
       },
 

--- a/packages/ember-data/tests/unit/model-test.js
+++ b/packages/ember-data/tests/unit/model-test.js
@@ -666,7 +666,7 @@ test("ensure model exits loading state, materializes data and fulfills promise o
 
   var store = createStore({
     adapter: DS.Adapter.extend({
-      find: function(store, type, id) {
+      find: function(store, type, id, snapshot) {
         return Ember.RSVP.resolve({ id: 1, name: "John" });
       }
     })

--- a/packages/ember-data/tests/unit/model/lifecycle-callbacks-test.js
+++ b/packages/ember-data/tests/unit/model/lifecycle-callbacks-test.js
@@ -14,7 +14,7 @@ test("a record receives a didLoad callback when it has finished loading", functi
   });
 
   var adapter = DS.Adapter.extend({
-    find: function(store, type, id) {
+    find: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Foo" });
     }
   });
@@ -48,11 +48,11 @@ test("a record receives a didUpdate callback when it has finished updating", fun
   });
 
   var adapter = DS.Adapter.extend({
-    find: function(store, type, id) {
+    find: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Foo" });
     },
 
-    updateRecord: function(store, type, record) {
+    updateRecord: function(store, type, snapshot) {
       equal(callCount, 0, "didUpdate callback was not called until didSaveRecord is called");
 
       return Ember.RSVP.resolve();
@@ -95,7 +95,7 @@ test("a record receives a didCreate callback when it has finished updating", fun
   });
 
   var adapter = DS.Adapter.extend({
-    createRecord: function(store, type, record) {
+    createRecord: function(store, type, snapshot) {
       equal(callCount, 0, "didCreate callback was not called until didSaveRecord is called");
 
       return Ember.RSVP.resolve();
@@ -139,11 +139,11 @@ test("a record receives a didDelete callback when it has finished deleting", fun
   });
 
   var adapter = DS.Adapter.extend({
-    find: function(store, type, id) {
+    find: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Foo" });
     },
 
-    deleteRecord: function(store, type, record) {
+    deleteRecord: function(store, type, snapshot) {
       equal(callCount, 0, "didDelete callback was not called until didSaveRecord is called");
 
       return Ember.RSVP.resolve();
@@ -225,11 +225,11 @@ test("a record receives a becameInvalid callback when it became invalid", functi
   });
 
   var adapter = DS.Adapter.extend({
-    find: function(store, type, id) {
+    find: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Foo" });
     },
 
-    updateRecord: function(store, type, record) {
+    updateRecord: function(store, type, snapshot) {
       equal(callCount, 0, "becameInvalid callback was not called until recordWasInvalid is called");
 
       return Ember.RSVP.reject(new DS.InvalidError({ bar: 'error' }));

--- a/packages/ember-data/tests/unit/model/merge-test.js
+++ b/packages/ember-data/tests/unit/model/merge-test.js
@@ -14,7 +14,7 @@ test("When a record is in flight, changes can be made", function() {
   expect(3);
 
   var adapter = DS.Adapter.extend({
-    createRecord: function(store, type, record) {
+    createRecord: function(store, type, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Tom Dale" });
     }
   });
@@ -44,7 +44,7 @@ test("When a record is in flight, pushes are applied underneath the in flight ch
   expect(6);
 
   var adapter = DS.Adapter.extend({
-    updateRecord: function(store, type, record) {
+    updateRecord: function(store, type, snapshot) {
     // Make sure saving isn't resolved synchronously
       return new Ember.RSVP.Promise(function(resolve, reject) {
         run.next(null, resolve, { id: 1, name: "Senor Thomas Dale, Esq.", city: "Portland" });
@@ -106,7 +106,7 @@ test("A record with no changes can still be saved", function() {
   expect(1);
 
   var adapter = DS.Adapter.extend({
-    updateRecord: function(store, type, record) {
+    updateRecord: function(store, type, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Thomas Dale" });
     }
   });
@@ -129,7 +129,7 @@ test("A dirty record can be reloaded", function() {
   expect(3);
 
   var adapter = DS.Adapter.extend({
-    find: function(store, type, id) {
+    find: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Thomas Dale", city: "Portland" });
     }
   });

--- a/packages/ember-data/tests/unit/model/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/belongs-to-test.js
@@ -54,7 +54,7 @@ test("async belongsTo relationships work when the data hash has not been loaded"
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;
 
-  env.adapter.find = function(store, type, id) {
+  env.adapter.find = function(store, type, id, snapshot) {
     if (type === Person) {
       equal(id, 1, "id should be 1");
 
@@ -158,8 +158,8 @@ test("When finding a hasMany relationship the inverse belongsTo relationship is 
   var env = setupStore({ occupation: Occupation, person: Person });
   var store = env.store;
 
-  env.adapter.findMany = function(store, type, ids, records) {
-    equal(records[0].get('person.id'), '1');
+  env.adapter.findMany = function(store, type, ids, snapshots) {
+    equal(snapshots[0].belongsTo('person').id, '1');
     return Ember.RSVP.resolve([{ id: 5, description: "fifth" }, { id: 2, description: "second" }]);
   };
 
@@ -204,8 +204,8 @@ test("When finding a belongsTo relationship the inverse belongsTo relationship i
   var env = setupStore({ occupation: Occupation, person: Person });
   var store = env.store;
 
-  env.adapter.find = function(store, type, id, record) {
-    equal(record.get('person.id'), '1');
+  env.adapter.find = function(store, type, id, snapshot) {
+    equal(snapshot.belongsTo('person').id, '1');
     return Ember.RSVP.resolve({ id: 5, description: "fifth" });
   };
 

--- a/packages/ember-data/tests/unit/model/relationships/has-many-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/has-many-test.js
@@ -31,7 +31,7 @@ test("hasMany handles pre-loaded relationships", function() {
   env.registry.register('model:pet', Pet);
   env.registry.register('model:person', Person);
 
-  env.adapter.find = function(store, type, id) {
+  env.adapter.find = function(store, type, id, snapshot) {
     if (type === Tag && id === '12') {
       return Ember.RSVP.resolve({ id: 12, name: "oohlala" });
     } else {
@@ -118,7 +118,7 @@ test("hasMany lazily loads async relationships", function() {
   env.registry.register('model:pet', Pet);
   env.registry.register('model:person', Person);
 
-  env.adapter.find = function(store, type, id) {
+  env.adapter.find = function(store, type, id, snapshot) {
     if (type === Tag && id === '12') {
       return Ember.RSVP.resolve({ id: 12, name: "oohlala" });
     } else {
@@ -280,14 +280,14 @@ test("hasMany relationships work when the data hash has not been loaded", functi
   var store = env.store;
 
   env.adapter.coalesceFindRequests = true;
-  env.adapter.findMany = function(store, type, ids) {
+  env.adapter.findMany = function(store, type, ids, snapshots) {
     equal(type, Tag, "type should be Tag");
     deepEqual(ids, ['5', '2'], "ids should be 5 and 2");
 
     return Ember.RSVP.resolve([{ id: 5, name: "friendly" }, { id: 2, name: "smarmy" }]);
   };
 
-  env.adapter.find = function(store, type, id) {
+  env.adapter.find = function(store, type, id, snapshot) {
     equal(type, Person, "type should be Person");
     equal(id, 1, "id should be 1");
 

--- a/packages/ember-data/tests/unit/model/rollback-test.js
+++ b/packages/ember-data/tests/unit/model/rollback-test.js
@@ -48,7 +48,7 @@ test("changes to unassigned attributes can be rolled back", function() {
 });
 
 test("changes to attributes made after a record is in-flight only rolls back the local changes", function() {
-  env.adapter.updateRecord = function(store, type, record) {
+  env.adapter.updateRecord = function(store, type, snapshot) {
     // Make sure the save is async
     return new Ember.RSVP.Promise(function(resolve, reject) {
       Ember.run.later(null, resolve, 15);
@@ -83,7 +83,7 @@ test("changes to attributes made after a record is in-flight only rolls back the
 });
 
 test("a record's changes can be made if it fails to save", function() {
-  env.adapter.updateRecord = function(store, type, record) {
+  env.adapter.updateRecord = function(store, type, snapshot) {
     return Ember.RSVP.reject();
   };
   var person;
@@ -111,7 +111,7 @@ test("a record's changes can be made if it fails to save", function() {
 
 test("a deleted record can be rollbacked if it fails to save, record arrays are updated accordingly", function() {
   expect(6);
-  env.adapter.deleteRecord = function(store, type, record) {
+  env.adapter.deleteRecord = function(store, type, snapshot) {
     return Ember.RSVP.reject();
   };
   var person, people;

--- a/packages/ember-data/tests/unit/store/unload-test.js
+++ b/packages/ember-data/tests/unit/store/unload-test.js
@@ -5,7 +5,7 @@ var store, tryToFind, Record;
 module("unit/store/unload - Store unloading records", {
   setup: function() {
     store = createStore({ adapter: DS.Adapter.extend({
-        find: function(store, type, id) {
+        find: function(store, type, id, snapshot) {
           tryToFind = true;
           return Ember.RSVP.resolve({ id: id, wasFetched: true });
         }
@@ -97,10 +97,10 @@ test("can commit store after unload record with relationships", function() {
 
   var store = createStore({
     adapter: DS.Adapter.extend({
-      find: function() {
+      find: function(store, type, id, snapshot) {
         return Ember.RSVP.resolve({ id: 1, description: 'cuisinart', brand: 1 });
       },
-      createRecord: function(store, type, record) {
+      createRecord: function(store, type, snapshot) {
         return Ember.RSVP.resolve();
       }
     }),


### PR DESCRIPTION
- [x] Add tests to make sure the store pass snapshots to adapter methods (createRecord, updateRecord, deleteRecord, find, findMany, findHasMany, findBelongsTo)
- [x] Write release notes/breaking change guide. There are deprecation warnings for using `.get()` but a heads-up seems appropriate.
- [X] ~~Go through website/guides and update as needed~~ Couldn't find any related guides
