### PR TITLE
Make _stripIDFromURL() understand URLs like something/:id.format

### DIFF
--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -591,6 +591,13 @@ export default Adapter.extend(BuildURLMixin, {
     } else if (endsWith(lastSegment, '?id=' + id)) {
       //Case when the url is of the format ...something?id=:id
       expandedURL[expandedURL.length - 1] = lastSegment.substring(0, lastSegment.length - id.length - 1);
+    } else if (expandedURL.length > 1) {
+      // Case when the url is of the format ...something/:id.format
+      var pattern = '^' + id + '\\.\\w+$';
+      if (new RegExp(pattern).test(lastSegment)) {
+        expandedURL[expandedURL.length - 1] = "";
+        expandedURL[expandedURL.length - 2] += lastSegment.substring(id.length, lastSegment.length);
+      }
     }
 
     return expandedURL.join('/');

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -1665,6 +1665,41 @@ test('groupRecordsForFindMany groups records correctly when singular URLs are en
   });
 });
 
+test('groupRecordsForFindMany groups records correctly when singular URLs contains a format', function() {
+  expect(2);
+
+  Comment.reopen({ post: DS.belongsTo('post') });
+  Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
+  adapter.coalesceFindRequests = true;
+
+  adapter.buildURL = function(type, id, record) {
+    if (id === '1') {
+      return '/comments/1.json';
+    } else {
+      return '/other_comments/' + id + '.xml';
+    }
+  };
+
+  adapter.find = function(store, type, id, record ) {
+    equal(id, '1');
+    return Ember.RSVP.resolve({ comments: { id: 1 } });
+  };
+
+  adapter.findMany = function(store, type, ids, records ) {
+    deepEqual(ids, ['2', '3']);
+    return Ember.RSVP.resolve({ comments: [{ id: 2 }, { id: 3 }] });
+  };
+  var post;
+
+  run(function() {
+    post = store.push('post', { id: 2, comments: [1, 2, 3] });
+  });
+
+  run(function() {
+    post.get('comments');
+  });
+});
+
 test('normalizeKey - to set up _ids and _id', function() {
   env.registry.register('serializer:application', DS.RESTSerializer.extend({
     keyForAttribute: function(attr) {


### PR DESCRIPTION
Having URLs like `/posts/1.json` is not an uncommon scenario. This PR makes `_stripIDFromURL()` understand these URLs so coalesced requests can be grouped correctly.

Unsure if RegExp is the right way to go, feedback welcome.

- [ ] Add more asserts to check the actual URLs

Fixes #2690