### PR TITLE
Assert if the user tries to redefine a reserved property name.

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -1164,8 +1164,17 @@ var Model = Ember.Object.extend(Ember.Evented, {
   // This is a temporary solution until we refactor DS.Model to not
   // rely on the data property.
   willMergeMixin: function(props) {
-    Ember.assert('`data` is a reserved property name on DS.Model objects. Please choose a different property name for ' + this.constructor.toString(), !props.data);
-    Ember.assert('`store` is a reserved property name on DS.Model objects. Please choose a different property name for '+ this.constructor.toString(), !props.store);
+    var constructor = this.constructor;
+    [
+      'attributes', 'clientId', 'currentState', 'data', 'dirtyType',
+      'errors', 'fields', 'isDeleted', 'isDirty', 'isDestroyed',
+      'isDestroying', 'isEmpty', 'isError', 'isLoaded',
+      'isLoading', 'isNew', 'isReloading', 'isSaving', 'isValid',
+      'relatedTypes', 'relationshipNames', 'relationships',
+      'relationshipsByName', 'transformedAttributes', 'store'
+    ].forEach(function(reservedProperty) {
+      Ember.assert('`' + reservedProperty + '` is a reserved property name on DS.Model objects. Please choose a different property name for ' + constructor.toString(), !props[reservedProperty]);
+    });
   },
 
   attr: function() {

--- a/packages/ember-data/tests/unit/model-test.js
+++ b/packages/ember-data/tests/unit/model-test.js
@@ -710,6 +710,30 @@ test("A subclass of DS.Model can not use the `store` property", function() {
   }, /`store` is a reserved property name on DS.Model objects/);
 });
 
+test("A subclass of DS.Model can not use reserved properties", function() {
+  expect(25);
+  [
+    'attributes', 'clientId', 'currentState', 'data', 'dirtyType',
+    'errors', 'fields', 'isDeleted', 'isDirty', 'isDestroyed',
+    'isDestroying', 'isEmpty', 'isError', 'isLoaded',
+    'isLoading', 'isNew', 'isReloading', 'isSaving', 'isValid',
+    'relatedTypes', 'relationshipNames', 'relationships',
+    'relationshipsByName', 'transformedAttributes', 'store'
+  ].forEach(function(reservedProperty) {
+    var invalidExtendObject = {};
+    invalidExtendObject[reservedProperty] = DS.attr();
+    var Post = DS.Model.extend(invalidExtendObject);
+
+    var store = createStore({ post: Post });
+
+    expectAssertion(function() {
+      run(function() {
+        store.createRecord('post', {});
+      });
+    }, /is a reserved property name on DS.Model objects/);
+  });
+});
+
 test("Pushing a record into the store should transition it to the loaded state", function() {
   var Person = DS.Model.extend({
     name: DS.attr('string')


### PR DESCRIPTION
A better long term solution may be to move attributes off of the Model but for now this will give users a clear warning if they try to do something that will break Ember Data's assumptions about the model.

Closes #602 #2230 #2328