### PR TITLE
Delete `Ember.required` (it is deprecated).

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -202,7 +202,7 @@ var Adapter = Ember.Object.extend({
     @param {String} id
     @return {Promise} promise
   */
-  find: Ember.required(Function),
+  find: null,
 
   /**
     The `findAll()` method is called when you call `find` on the store
@@ -361,7 +361,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Model} record
     @return {Promise} promise
   */
-  createRecord: Ember.required(Function),
+  createRecord: null,
 
   /**
     Implement this method in a subclass to handle the updating of
@@ -401,7 +401,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Model} record
     @return {Promise} promise
   */
-  updateRecord: Ember.required(Function),
+  updateRecord: null,
 
   /**
     Implement this method in a subclass to handle the deletion of
@@ -441,7 +441,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Model} record
     @return {Promise} promise
   */
-  deleteRecord: Ember.required(Function),
+  deleteRecord: null,
 
   /**
     By default the store will try to coalesce all `fetchRecord` calls within the same runloop

--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -46,7 +46,7 @@ var Serializer = Ember.Object.extend({
     @param {String} requestType
     @return {Object}
   */
-  extract: Ember.required(Function),
+  extract: null,
 
   /**
     The `serialize` method is used when a record is saved in order to convert
@@ -62,7 +62,7 @@ var Serializer = Ember.Object.extend({
     @param {Object} [options]
     @return {Object}
   */
-  serialize: Ember.required(Function),
+  serialize: null,
 
   /**
     The `normalize` method is used to convert a payload received from your

--- a/packages/ember-data/lib/transforms/base.js
+++ b/packages/ember-data/lib/transforms/base.js
@@ -49,7 +49,7 @@ export default Ember.Object.extend({
     @param {mixed} deserialized The deserialized value
     @return {mixed} The serialized value
   */
-  serialize: Ember.required(),
+  serialize: null,
 
   /**
     When given a serialize value from a JSON object this method must
@@ -67,5 +67,5 @@ export default Ember.Object.extend({
     @param {mixed} serialized The serialized value
     @return {mixed} The deserialized value
   */
-  deserialize: Ember.required()
+  deserialize: null
 });


### PR DESCRIPTION
Fixes #2910.