### PR TITLE
Serializer & Adapter Lookups Preference/Order

### DIFF
--- a/packages/ember-data/lib/initializers/store.js
+++ b/packages/ember-data/lib/initializers/store.js
@@ -32,6 +32,7 @@ export default function initializeStore(registry, application) {
   // new go forward paths
   registry.register('serializer:-default', JSONSerializer);
   registry.register('serializer:-rest', RESTSerializer);
+  registry.register('adapter:-default', RESTAdapter);
   registry.register('adapter:-rest', RESTAdapter);
 
   // Eagerly generate the store so defaultStore is populated.

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -216,19 +216,19 @@ Store = Service.extend({
   /**
     The adapter to use to communicate to a backend server or other persistence layer.
 
-    This can be specified as an instance, class, or string.
+    This must be specified as a string.
 
-    If you want to specify `App.CustomAdapter` as a string, do:
+    If you want to specify `App.CustomAdapter`, do:
 
     ```js
     adapter: 'custom'
     ```
 
     @property adapter
-    @default DS.RESTAdapter
-    @type {DS.Adapter|String}
+    @default null
+    @type {String}
   */
-  adapter: '-rest',
+  adapter: null,
 
   /**
     Returns a JSON representation of the record using a custom
@@ -253,13 +253,6 @@ Store = Service.extend({
     This property returns the adapter, after resolving a possible
     string key.
 
-    If the supplied `adapter` was a class, or a String property
-    path resolved to a class, this property will instantiate the
-    class.
-
-    This property is cacheable, so the same instance of a specified
-    adapter class should be used for the lifetime of the store.
-
     @property defaultAdapter
     @private
     @return DS.Adapter
@@ -267,17 +260,14 @@ Store = Service.extend({
   defaultAdapter: Ember.computed('adapter', function() {
     var adapter = get(this, 'adapter');
 
-    Ember.assert('You tried to set `adapter` property to an instance of `DS.Adapter`, where it should be a name or a factory', !(adapter instanceof Adapter));
+    Ember.assert('You tried to set `adapter` property to an instance of `DS.Adapter`, where it should be a string', !(adapter instanceof Adapter));
 
     if (typeof adapter === 'string') {
-      adapter = this.container.lookup('adapter:' + adapter) || this.container.lookup('adapter:application') || this.container.lookup('adapter:-rest');
+      adapter = this.lookupAdapter(adapter);
     }
 
-    if (DS.Adapter.detect(adapter)) {
-      adapter = adapter.create({
-        container: this.container,
-        store: this
-      });
+    if (isNone(adapter)) {
+      adapter = this.lookupAdapter('application') || this.lookupAdapter('-rest');
     }
 
     return adapter;

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -231,6 +231,23 @@ Store = Service.extend({
   adapter: null,
 
   /**
+    The serializer to use to communicate to a backend server or other persistence layer.
+
+    This must be specified as a string.
+
+    If you want to specify `App.CustomSerializer`, do:
+
+    ```js
+    serializer: 'custom'
+    ```
+
+    @property serializer
+    @default null
+    @type {String}
+  */
+  serializer: null,
+
+  /**
     Returns a JSON representation of the record using a custom
     type-specific serializer, if one exists.
 
@@ -271,6 +288,31 @@ Store = Service.extend({
     }
 
     return adapter;
+  }),
+
+
+  /**
+    This property returns the serializer, after resolving a possible
+    string key.
+
+    @property defaultSerializer
+    @private
+    @return DS.Serializer
+  */
+  defaultSerializer: Ember.computed('serializer', function() {
+    var serializer = get(this, 'serializer');
+
+    Ember.assert('You tried to set `serializer` property to an instance of `DS.Serializer`, where it should be a string', !(serializer instanceof Serializer));
+
+    if (typeof serializer === 'string') {
+      serializer = this.lookupSerializer(serializer);
+    }
+
+    if (isNone(serializer)) {
+      serializer = this.lookupSerializer('application') || this.lookupSerializer('-default');
+    }
+
+    return serializer;
   }),
 
   // .....................

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1934,7 +1934,7 @@ Store = Service.extend({
 
     if (!serializer) {
       var adapter = this.lookupAdapter(type.modelName);
-      serializer = this.lookupSerializer(get(adapter, 'defaultSerializer'));
+      serializer = adapter && this.lookupSerializer(get(adapter, 'defaultSerializer'));
     }
 
     return serializer || get(this, 'defaultSerializer');

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -10,6 +10,7 @@ import {
   InvalidError,
   Adapter
 } from "ember-data/system/adapter";
+import Serializer from "ember-data/system/serializer";
 import {
   Map
 } from "ember-data/system/map";
@@ -278,6 +279,11 @@ Store = Service.extend({
     var adapter = get(this, 'adapter');
 
     Ember.assert('You tried to set `adapter` property to an instance of `DS.Adapter`, where it should be a string', !(adapter instanceof Adapter));
+
+    if (Adapter.detect(adapter)) {
+      Ember.deprecate('Using a class in the store.adapter property is deprecated. Please use string values.');
+      adapter = adapter.create({ container: this.container, store: this });
+    }
 
     if (typeof adapter === 'string') {
       adapter = this.lookupAdapter(adapter);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1887,9 +1887,7 @@ Store = Service.extend({
       type = this.modelFor(type);
     }
 
-    var adapter = this.lookupAdapter(type.modelName) || this.lookupAdapter('application');
-
-    return adapter || get(this, 'defaultAdapter');
+    return this.lookupAdapter(type.modelName) || get(this, 'defaultAdapter');
   },
 
   _adapterRun: function (fn) {

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -10,7 +10,6 @@ import {
   InvalidError,
   Adapter
 } from "ember-data/system/adapter";
-import Serializer from "ember-data/system/serializer";
 import {
   Map
 } from "ember-data/system/map";
@@ -307,8 +306,6 @@ Store = Service.extend({
   */
   defaultSerializer: Ember.computed('serializer', function() {
     var serializer = get(this, 'serializer');
-
-    Ember.assert('You tried to set `serializer` property to an instance of `DS.Serializer`, where it should be a string', !(serializer instanceof Serializer));
 
     if (typeof serializer === 'string') {
       serializer = this.lookupSerializer(serializer);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1924,18 +1924,14 @@ Store = Service.extend({
       type = this.modelFor(type);
     }
 
-    var serializer = this.lookupSerializer(type.modelName) || this.lookupSerializer('application');
+    var serializer = this.lookupSerializer(type.modelName);
 
     if (!serializer) {
-      var adapter = this.adapterFor(type);
+      var adapter = this.lookupAdapter(type.modelName);
       serializer = this.lookupSerializer(get(adapter, 'defaultSerializer'));
     }
 
-    if (!serializer) {
-      serializer = this.lookupSerializer('-default');
-    }
-
-    return serializer;
+    return serializer || get(this, 'defaultSerializer');
   },
 
   /**

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -284,7 +284,7 @@ Store = Service.extend({
     }
 
     if (isNone(adapter)) {
-      adapter = this.lookupAdapter('application') || this.lookupAdapter('-rest');
+      adapter = this.lookupAdapter('application') || this.lookupAdapter('-default');
     }
 
     return adapter;

--- a/packages/ember-data/lib/system/store/serializers.js
+++ b/packages/ember-data/lib/system/store/serializers.js
@@ -1,5 +1,7 @@
+/*globals Ember*/
+
 export function serializerForAdapter(store, adapter, type) {
-  var serializer = adapter.serializer;
+  var serializer = Ember.get(adapter, 'serializer');
 
   if (serializer === undefined) {
     serializer = store.serializerFor(type);

--- a/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -29,10 +29,10 @@ module("integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter", {
     adapter = env.adapter;
     env.registry.register('adapter:post', DS.RESTAdapter);
     env.registry.register('adapter:comment', DS.RESTAdapter);
-    env.registry.register('adapter:superUser', DS.RESTAdapter);
+    env.registry.register('adapter:super-user', DS.RESTAdapter);
     env.registry.register('serializer:post', DS.RESTSerializer);
     env.registry.register('serializer:comment', DS.RESTSerializer);
-    env.registry.register('serializer:superUser', DS.RESTSerializer);
+    env.registry.register('serializer:super-user', DS.RESTSerializer);
 
     passedUrl = null;
   }

--- a/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -27,29 +27,64 @@ module("integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter", {
 
     store = env.store;
     adapter = env.adapter;
+    env.registry.register('adapter:post', DS.RESTAdapter);
+    env.registry.register('adapter:comment', DS.RESTAdapter);
+    env.registry.register('adapter:superUser', DS.RESTAdapter);
+    env.registry.register('serializer:post', DS.RESTSerializer);
+    env.registry.register('serializer:comment', DS.RESTSerializer);
+    env.registry.register('serializer:superUser', DS.RESTSerializer);
 
     passedUrl = null;
   }
 });
 
-function ajaxResponse(value) {
-  adapter.ajax = function(url, verb, hash) {
-    passedUrl = url;
+function adapterSetProperties(properties) {
+  var post_adapter = store.adapterFor('post');
+  var comment_adapter = store.adapterFor('comment');
+  var super_user_adapter = store.adapterFor('superUser');
+  var default_adapter = store.get('defaultAdapter');
 
-    return run(Ember.RSVP, 'resolve', value);
-  };
+  post_adapter.setProperties(properties);
+  comment_adapter.setProperties(properties);
+  super_user_adapter.setProperties(properties);
+  default_adapter.setProperties(properties);
+}
+
+function adapterFix(property, value, store) {
+  var post_adapter = store.adapterFor('post');
+  var comment_adapter = store.adapterFor('comment');
+  var super_user_adapter = store.adapterFor('superUser');
+  var default_adapter = store.get('defaultAdapter');
+
+  post_adapter[property] = value;
+  comment_adapter[property] = value;
+  super_user_adapter[property] = value;
+  default_adapter[property] = value;
+}
+
+function ajaxResponse(value, store) {
+
+  if (typeof value === 'function') {
+    adapterFix('ajax', value, store);
+  } else {
+    adapterFix('ajax', function ajaxResponseFix(url, verb, hash) {
+      passedUrl = url;
+
+      return run(Ember.RSVP, 'resolve', value);
+    }, store);
+  }
 }
 
 
 test('buildURL - with host and namespace', function() {
   run(function() {
-    adapter.setProperties({
+    adapterSetProperties({
       host: 'http://example.com',
       namespace: 'api/v1'
-    });
+    }, store);
   });
 
-  ajaxResponse({ posts: [{ id: 1 }] });
+  ajaxResponse({ posts: [{ id: 1 }] }, store);
 
   run(store, 'find', 'post', 1).then(async(function(post) {
     equal(passedUrl, "http://example.com/api/v1/posts/1");
@@ -58,18 +93,18 @@ test('buildURL - with host and namespace', function() {
 
 test('buildURL - with relative paths in links', function() {
   run(function() {
-    adapter.setProperties({
+    adapterSetProperties({
       host: 'http://example.com',
       namespace: 'api/v1'
-    });
+    }, store);
   });
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
   Comment.reopen({ post: DS.belongsTo('post') });
 
-  ajaxResponse({ posts: [{ id: 1, links: { comments: 'comments' } }] });
+  ajaxResponse({ posts: [{ id: 1, links: { comments: 'comments' } }] }, store);
 
   run(store, 'find', 'post', '1').then(async(function(post) {
-    ajaxResponse({ comments: [{ id: 1 }] });
+    ajaxResponse({ comments: [{ id: 1 }] }, store);
     return post.get('comments');
   })).then(async(function (comments) {
     equal(passedUrl, "http://example.com/api/v1/posts/1/comments");
@@ -78,18 +113,18 @@ test('buildURL - with relative paths in links', function() {
 
 test('buildURL - with absolute paths in links', function() {
   run(function() {
-    adapter.setProperties({
+    adapterSetProperties({
       host: 'http://example.com',
       namespace: 'api/v1'
-    });
+    }, store);
   });
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
   Comment.reopen({ post: DS.belongsTo('post') });
 
-  ajaxResponse({ posts: [{ id: 1, links: { comments: '/api/v1/posts/1/comments' } }] });
+  ajaxResponse({ posts: [{ id: 1, links: { comments: '/api/v1/posts/1/comments' } }] }, store);
 
   run(store, 'find', 'post', 1).then(async(function(post) {
-    ajaxResponse({ comments: [{ id: 1 }] });
+    ajaxResponse({ comments: [{ id: 1 }] }, store);
     return post.get('comments');
   })).then(async(function (comments) {
     equal(passedUrl, "http://example.com/api/v1/posts/1/comments");
@@ -99,18 +134,18 @@ test('buildURL - with absolute paths in links', function() {
 
 test('buildURL - with absolute paths in links and protocol relative host', function() {
   run(function() {
-    adapter.setProperties({
+    adapterSetProperties({
       host: '//example.com',
       namespace: 'api/v1'
-    });
+    }, store);
   });
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
   Comment.reopen({ post: DS.belongsTo('post') });
 
-  ajaxResponse({ posts: [{ id: 1, links: { comments: '/api/v1/posts/1/comments' } }] });
+  ajaxResponse({ posts: [{ id: 1, links: { comments: '/api/v1/posts/1/comments' } }] }, store);
 
   run(store, 'find', 'post', 1).then(async(function(post) {
-    ajaxResponse({ comments: [{ id: 1 }] });
+    ajaxResponse({ comments: [{ id: 1 }] }, store);
     return post.get('comments');
   })).then(async(function (comments) {
     equal(passedUrl, "//example.com/api/v1/posts/1/comments");
@@ -118,10 +153,10 @@ test('buildURL - with absolute paths in links and protocol relative host', funct
 });
 
 test('buildURL - with full URLs in links', function() {
-  adapter.setProperties({
+  adapterSetProperties({
     host: 'http://example.com',
     namespace: 'api/v1'
-  });
+  }, store);
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
   Comment.reopen({ post: DS.belongsTo('post') });
 
@@ -131,11 +166,11 @@ test('buildURL - with full URLs in links', function() {
         links: { comments: 'http://example.com/api/v1/posts/1/comments' }
       }
     ]
-  });
+  }, store);
 
   run(function() {
     store.find('post', 1).then(async(function(post) {
-      ajaxResponse({ comments: [{ id: 1 }] });
+      ajaxResponse({ comments: [{ id: 1 }] }, store);
       return post.get('comments');
     })).then(async(function (comments) {
       equal(passedUrl, "http://example.com/api/v1/posts/1/comments");
@@ -144,14 +179,14 @@ test('buildURL - with full URLs in links', function() {
 });
 
 test('buildURL - with camelized names', function() {
-  adapter.setProperties({
+  adapterSetProperties({
     pathForType: function(type) {
       var decamelized = Ember.String.decamelize(type);
       return Ember.String.underscore(Ember.String.pluralize(decamelized));
     }
-  });
+  }, store);
 
-  ajaxResponse({ superUsers: [{ id: 1 }] });
+  ajaxResponse({ superUsers: [{ id: 1 }] }, store);
 
   run(function() {
     store.find('superUser', 1).then(async(function(post) {
@@ -162,11 +197,11 @@ test('buildURL - with camelized names', function() {
 
 test('buildURL - buildURL takes a record from find', function() {
   Comment.reopen({ post: DS.belongsTo('post') });
-  adapter.buildURL = function(type, id, snapshot) {
+  adapterFix('buildURL', function(type, id, snapshot) {
     return "/posts/" + snapshot.belongsTo('post', { id: true }) + '/comments/' + snapshot.id;
-  };
+  }, store);
 
-  ajaxResponse({ comments: [{ id: 1 }] });
+  ajaxResponse({ comments: [{ id: 1 }] }, store);
 
   var post;
   run(function() {
@@ -184,15 +219,15 @@ test('buildURL - buildURL takes the records from findMany', function() {
   Comment.reopen({ post: DS.belongsTo('post') });
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
 
-  adapter.buildURL = function(type, ids, snapshots) {
+  adapterFix('buildURL', function(type, ids, snapshots) {
     if (Ember.isArray(snapshots)) {
       return "/posts/" + snapshots.get('firstObject').belongsTo('post', { id: true }) + '/comments/';
     }
     return "";
-  };
-  adapter.coalesceFindRequests = true;
+  }, store);
+  adapterFix('coalesceFindRequests', true, store);
 
-  ajaxResponse({ comments: [{ id: 1 }, { id: 2 }, { id: 3 }] });
+  ajaxResponse({ comments: [{ id: 1 }, { id: 2 }, { id: 3 }] }, store);
   var post;
 
   run(function() {
@@ -205,11 +240,11 @@ test('buildURL - buildURL takes the records from findMany', function() {
 
 test('buildURL - buildURL takes a record from create', function() {
   Comment.reopen({ post: DS.belongsTo('post') });
-  adapter.buildURL = function(type, id, snapshot) {
+  adapterFix('buildURL', function(type, id, snapshot) {
     return "/posts/" + snapshot.belongsTo('post', { id: true }) + '/comments/';
-  };
+  }, store);
 
-  ajaxResponse({ comments: [{ id: 1 }] });
+  ajaxResponse({ comments: [{ id: 1 }] }, store);
 
   run(function() {
     var post = store.push('post', { id: 2 });
@@ -224,17 +259,17 @@ test('buildURL - buildURL takes a record from create', function() {
 test('buildURL - buildURL takes a record from create to query a resolved async belongsTo relationship', function() {
   Comment.reopen({ post: DS.belongsTo('post', { async: true }) });
 
-  ajaxResponse({ posts: [{ id: 2 }] });
+  ajaxResponse({ posts: [{ id: 2 }] }, store);
 
   run(function() {
     store.find('post', 2).then(async(function(post) {
       equal(post.get('id'), 2);
 
-      adapter.buildURL = function(type, id, snapshot) {
+      adapterFix('buildURL', function(type, id, snapshot) {
         return "/posts/" + snapshot.belongsTo('post', { id: true }) + '/comments/';
-      };
+      }, store);
 
-      ajaxResponse({ comments: [{ id: 1 }] });
+      ajaxResponse({ comments: [{ id: 1 }] }, store);
 
       var comment = store.createRecord('comment');
       comment.set('post', post);
@@ -248,11 +283,11 @@ test('buildURL - buildURL takes a record from create to query a resolved async b
 
 test('buildURL - buildURL takes a record from update', function() {
   Comment.reopen({ post: DS.belongsTo('post') });
-  adapter.buildURL = function(type, id, snapshot) {
+  adapterFix('buildURL', function(type, id, snapshot) {
     return "/posts/" + snapshot.belongsTo('post', { id: true }) + '/comments/' + snapshot.id;
-  };
+  }, store);
 
-  ajaxResponse({ comments: [{ id: 1 }] });
+  ajaxResponse({ comments: [{ id: 1 }] }, store);
 
   var post, comment;
   run(function() {
@@ -270,11 +305,11 @@ test('buildURL - buildURL takes a record from update', function() {
 test('buildURL - buildURL takes a record from delete', function() {
   Comment.reopen({ post: DS.belongsTo('post') });
   Post.reopen({ comments: DS.hasMany('comment') });
-  adapter.buildURL = function(type, id, snapshot) {
+  adapterFix('buildURL', function(type, id, snapshot) {
     return 'posts/' + snapshot.belongsTo('post', { id: true }) + '/comments/' + snapshot.id;
-  };
+  }, store);
 
-  ajaxResponse({ comments: [{ id: 1 }] });
+  ajaxResponse({ comments: [{ id: 1 }] }, store);
 
   var post, comment;
   run(function() {
@@ -293,12 +328,12 @@ test('buildURL - buildURL takes a record from delete', function() {
 
 test('buildURL - with absolute namespace', function() {
   run(function() {
-    adapter.setProperties({
+    adapterSetProperties({
       namespace: '/api/v1'
-    });
+    }, store);
   });
 
-  ajaxResponse({ posts: [{ id: 1 }] });
+  ajaxResponse({ posts: [{ id: 1 }] }, store);
 
   run(store, 'find', 'post', 1).then(async(function(post) {
     equal(passedUrl, "/api/v1/posts/1");

--- a/packages/ember-data/tests/integration/backwards-compat/non-dasherized-lookups.js
+++ b/packages/ember-data/tests/integration/backwards-compat/non-dasherized-lookups.js
@@ -8,6 +8,8 @@ module('integration/backwards-compat/non-dasherized-lookups - non dasherized loo
       App.PostNote = DS.Model.extend({
         name: DS.attr()
       });
+      App.PostNoteAdapter = DS.RESTAdapater;
+      App.PostNoteSerializer = DS.RESTSerializer;
     });
     store = App.__container__.lookup('store:main');
   },

--- a/tests/ember-configuration.js
+++ b/tests/ember-configuration.js
@@ -83,6 +83,7 @@
 
     registry.register('serializer:-default', DS.JSONSerializer);
     registry.register('serializer:-rest', DS.RESTSerializer);
+    registry.register('adapter:-default', DS.RESTAdapter);
     registry.register('adapter:-rest', DS.RESTAdapter);
 
     registry.injection('serializer', 'store', 'store:main');


### PR DESCRIPTION
I've put together this PR after the discussion in PR #2617. Although nothing was decided I figure if a PR exists and defines something to start with and a place for discussion it can start there?

No tests have broken but thats likely because no tests exist for the purpose of serializer/adapter lookup order/preference..

The commits have been ordered in a particular way and the messages help explain the overall changes in this PR in smaller pieces - so having a look at each commit might give more of an understanding.

## Adapters

### Current Preference/Order

1 `adapterFor`: `'adapter:[typeKey]'`
2 `adapterFor`: `'adapter:application'`
3 `defaultAdapter`: `'adapter:[this.adapter]'` (`this.adapter` default to `'-rest'`)
4 `defaultAdapter`: `'adapter:application'`
5 `defaultAdapter`: `'adapter:-rest'`

### Proposed Preference/Order

1 `adapterFor`: `'adapter:[typeKey]'`
2 `defaultAdapter`: `'adapter:[this.adapter]'` (`this.adapter` default to `null`)
3 `defaultAdapter`: `'adapter:application'`
4 `defaultAdapter`: `'adapter:-default'`

- A `-default` adapter has been added, which is registered on the registry as the RESTAdapter.

Adapters largely retains the same lookup order but in a clearer to understand way. I can see two scenarios that break:

### Breaking Scenarios for Adapters

##### 1. When a user has defined `store.adapter` to something other than `'-rest'` and they have an `application` adapter

By defaulting `store.adapter` to `null` we keep the same order but break users who have explicitly defined `store.adapter` in subclasses.

For example if someone has defined `store.adapter` as `'custom'`, the result of this change would be:

*Current:* `adapter:[typekey]`, `adapter:application`, `adapter:custom`, 

*Proposed:* `adapter:[typekey]`, `adapter:custom`, `adapter:application`


## Serializers

### Current Preference/Order

1 `serializerFor`: `'serializer:[typeKey]'`
2 `serializerFor`: `'serializer:application'`
3 `serializerFor`: `'serializer:[defaultSerializer]'` using the `defaultSerializer` property of the adapter returned in `adapterFor` (could either be: `'adapter:[typeKey]'`, `'adapter:application'` or `'adapter:-rest'`)
4 `serializerFor`: `'serializer:-default'`

### Proposed Preference/Order

1 `serializerFor`: `serializer:[typeKey]`
2 `serializerFor`: `'serializer:[defaultSerializer]'` using the `defaultSerializer` property of `'adapter:[typeKey]'` (if `'adapter:[typeKey]'` exists)
3 `defaultSerializer`: `'serializer:[this.serializer]'` (default to `null`)
4 `defaultSerializer`: `'serializer:application'`
5 `defaultSerializer`: `'serializer:-default'`

Serializers are where the most changes are happening:

- `store.defaultSerializer` and `store.serializer` have been added for consistency with the adapter lookup
- `store.serializerFor` is more explicit in which adapter is used when retrieving the `defaultSerializer` property - it no longer uses `adapterFor` and therefor would not return the 'default' adapters (such as `application` or `-rest`)


### Breaking Scenarios for Serializers

##### 1. Where `serializer:[typeKey]` does not exist, `serializer:application` is defined and the `defaultSerializer` from `adapter:[typeKey]` is defined and is not `serializer:application` 

For example if you have lookup 'superVillain' and you have `serializer:application` and `adapter:superVillain.defaultSerializer` is set to `serializer:aliens`

*Current:* `serializer:superVillain` (fail), `serializer:application` (found), `serializer:aliens` 

*Proposed:* `serializer:superVillain` (fail), `serializer:aliens` (found), `serializer:application`

There are a few others that are quite convoluted and I started typing them out but deleted them. They are mainly around the use of the `defaultSerializer` property on the 'default' adapter (`application` and `-rest`)