### PR TITLE
Fix doc for Snapshot.attributes()

### DIFF
--- a/packages/ember-data/lib/system/snapshot.js
+++ b/packages/ember-data/lib/system/snapshot.js
@@ -143,7 +143,7 @@ Snapshot.prototype = {
     ```
 
     @method attributes
-    @return {Array} All attributes for the current snapshot
+    @return {Object} All attributes of the current snapshot
   */
   attributes: function() {
     return Ember.copy(this._attributes);


### PR DESCRIPTION
Method returns an object, not an array.

This will fix #2923