### PR TITLE
Fix deprecation warning in store test

### DIFF
--- a/packages/ember-data/tests/integration/store-test.js
+++ b/packages/ember-data/tests/integration/store-test.js
@@ -391,7 +391,7 @@ test("Using store#fetch on an empty record calls find", function() {
   ok(car.get('isEmpty'), 'Car with id=20 should be empty');
 
   run(function() {
-    store.fetch('car', 20).then(function (car) {
+    store.fetchById('car', 20).then(function (car) {
       equal(car.get('make'), 'BMCW', 'Car with id=20 is now loaded');
     });
   });


### PR DESCRIPTION
`Using store.fetch() has been deprecated. Use store.fetchById for fetching individual records or store.fetchAll for collections`