### PR TITLE
Introduce relationship.hasData

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -15,6 +15,7 @@ var Relationship = function(store, record, inverseKey, relationshipMeta) {
   //multiple possible typeKeys
   this.inverseKeyForImplicit = this.store.modelFor(this.record.constructor).typeKey + this.key;
   this.linkPromise = null;
+  this.hasData = false;
 };
 
 Relationship.prototype = {
@@ -230,7 +231,11 @@ Relationship.prototype = {
   },
 
   notifyRecordRelationshipAdded: Ember.K,
-  notifyRecordRelationshipRemoved: Ember.K
+  notifyRecordRelationshipRemoved: Ember.K,
+
+  setHasData: function() {
+    this.hasData = true;
+  }
 };
 
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -331,6 +331,10 @@ Store = Service.extend({
     // Set the properties specified on the record.
     record.setProperties(properties);
 
+    record.eachRelationship(function(key, descriptor) {
+      record._relationships[key].setHasData(true);
+    });
+
     return record;
   },
 
@@ -2057,13 +2061,13 @@ function setupRelationships(store, record, data) {
       relationship.updateLink(data.links[key]);
     }
 
-    if (kind === 'belongsTo') {
-      if (value === undefined) {
-        return;
+    if (value !== undefined) {
+      if (kind === 'belongsTo') {
+        relationship.setCanonicalRecord(value);
+      } else if (kind === 'hasMany') {
+        relationship.updateRecordsFromAdapter(value);
       }
-      relationship.setCanonicalRecord(value);
-    } else if (kind === 'hasMany' && value) {
-      relationship.updateRecordsFromAdapter(value);
+      relationship.setHasData(true);
     }
   });
 }


### PR DESCRIPTION
**This is a first stab at making relationships aware if data exists for the relationship or not.**

There's currently no way of knowing if the contents of a relationship is _unknown_, _empty_ or _set_ just by looking at a snapshot (which is what serializers must do). This PR lays the groundwork of having snapshots returning an _unknown_ state for calls to `.belongsTo()` and `.hasMany()` when we don't know the contents of the relationship yet.

_This should most likely be reviewed and thought through at least once before we merge it._