### PR TITLE
Snapshots unknown relationships

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs-to.js
@@ -22,6 +22,7 @@ BelongsToRelationship.prototype.setRecord = function(newRecord) {
   } else if (this.inverseRecord) {
     this.removeRecord(this.inverseRecord);
   }
+  this.setHasData(true);
 };
 
 BelongsToRelationship.prototype.setCanonicalRecord = function(newRecord) {
@@ -30,6 +31,7 @@ BelongsToRelationship.prototype.setCanonicalRecord = function(newRecord) {
   } else if (this.inverseRecord) {
     this.removeCanonicalRecord(this.inverseRecord);
   }
+  this.setHasData(true);
 };
 
 BelongsToRelationship.prototype._super$addCanonicalRecord = Relationship.prototype.addCanonicalRecord;

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -85,6 +85,7 @@ Relationship.prototype = {
       }
     }
     this.flushCanonicalLater();
+    this.setHasData(true);
   },
 
   removeCanonicalRecords: function(records, idx) {
@@ -125,6 +126,7 @@ Relationship.prototype = {
       }
       this.record.updateRecordArraysLater();
     }
+    this.setHasData(true);
   },
 
   removeRecord: function(record) {
@@ -228,13 +230,14 @@ Relationship.prototype = {
     var self = this;
     //TODO Once we have adapter support, we need to handle updated and canonical changes
     self.computeChanges(records);
+    self.setHasData(true);
   },
 
   notifyRecordRelationshipAdded: Ember.K,
   notifyRecordRelationshipRemoved: Ember.K,
 
-  setHasData: function() {
-    this.hasData = true;
+  setHasData: function(value) {
+    this.hasData = value;
   }
 };
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -2070,7 +2070,6 @@ function setupRelationships(store, record, data) {
       } else if (kind === 'hasMany') {
         relationship.updateRecordsFromAdapter(value);
       }
-      relationship.setHasData(true);
     }
   });
 }

--- a/packages/ember-data/tests/integration/snapshot-test.js
+++ b/packages/ember-data/tests/integration/snapshot-test.js
@@ -124,6 +124,19 @@ test("snapshot.belongsTo() returns undefined if relationship is undefined", func
   });
 });
 
+test("snapshot.belongsTo() returns null if relationship is unset", function() {
+  expect(1);
+
+  run(function() {
+    env.store.push('post', { id: 1, title: 'Hello World' });
+    var comment = env.store.push('comment', { id: 2, body: 'This is comment', post: null });
+    var snapshot = comment._createSnapshot();
+    var relationship = snapshot.belongsTo('post');
+
+    equal(relationship, null, 'relationship is unset');
+  });
+});
+
 test("snapshot.belongsTo() returns a snapshot if relationship is set", function() {
   expect(3);
 
@@ -136,6 +149,86 @@ test("snapshot.belongsTo() returns a snapshot if relationship is set", function(
     ok(relationship instanceof DS.Snapshot, 'snapshot is an instance of DS.Snapshot');
     equal(relationship.id, '1', 'post id is correct');
     equal(relationship.attr('title'), 'Hello World', 'post title is correct');
+  });
+});
+
+test("snapshot.belongsTo() returns undefined if relationship is a link", function() {
+  expect(1);
+
+  run(function() {
+    var comment = env.store.push('comment', { id: 2, body: 'This is comment', links: { post: 'post' } });
+    var snapshot = comment._createSnapshot();
+    var relationship = snapshot.belongsTo('post');
+
+    equal(relationship, undefined, 'relationship is undefined');
+  });
+});
+
+test("snapshot.belongsTo() returns a snapshot if relationship link has been fetched", function() {
+  expect(2);
+
+  env.adapter.findBelongsTo = function(store, snapshot, link, relationship) {
+    return Ember.RSVP.resolve({ id: 1, title: 'Hello World' });
+  };
+
+  run(function() {
+    var comment = env.store.push('comment', { id: 2, body: 'This is comment', links: { post: 'post' } });
+
+    comment.get('post').then(function(post) {
+      var snapshot = comment._createSnapshot();
+      var relationship = snapshot.belongsTo('post');
+
+      ok(relationship instanceof DS.Snapshot, 'snapshot is an instance of DS.Snapshot');
+      equal(relationship.id, '1', 'post id is correct');
+    });
+  });
+});
+
+test("snapshot.belongsTo() and snapshot.hasMany() returns correctly when adding an object to a hasMany relationship", function() {
+  expect(4);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var comment = env.store.push('comment', { id: 2, body: 'blabla' });
+
+    post.get('comments').then(function(comments) {
+      comments.addObject(comment);
+
+      var postSnapshot = post._createSnapshot();
+      var commentSnapshot = comment._createSnapshot();
+
+      var hasManyRelationship = postSnapshot.hasMany('comments');
+      var belongsToRelationship = commentSnapshot.belongsTo('post');
+
+      ok(hasManyRelationship instanceof Array, 'hasMany relationship is an instance of Array');
+      equal(hasManyRelationship.length, 1, 'hasMany relationship contains related object');
+
+      ok(belongsToRelationship instanceof DS.Snapshot, 'belongsTo relationship is an instance of DS.Snapshot');
+      equal(belongsToRelationship.attr('title'), 'Hello World', 'belongsTo relationship contains related object');
+    });
+  });
+});
+
+test("snapshot.belongsTo() and snapshot.hasMany() returns correctly when setting an object to a belongsTo relationship", function() {
+  expect(4);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var comment = env.store.push('comment', { id: 2, body: 'blabla' });
+
+    comment.set('post', post);
+
+    var postSnapshot = post._createSnapshot();
+    var commentSnapshot = comment._createSnapshot();
+
+    var hasManyRelationship = postSnapshot.hasMany('comments');
+    var belongsToRelationship = commentSnapshot.belongsTo('post');
+
+    ok(hasManyRelationship instanceof Array, 'hasMany relationship is an instance of Array');
+    equal(hasManyRelationship.length, 1, 'hasMany relationship contains related object');
+
+    ok(belongsToRelationship instanceof DS.Snapshot, 'belongsTo relationship is an instance of DS.Snapshot');
+    equal(belongsToRelationship.attr('title'), 'Hello World', 'belongsTo relationship contains related object');
   });
 });
 
@@ -152,11 +245,23 @@ test("snapshot.hasMany() returns ID if option.id is set", function() {
   });
 });
 
-test("snapshot.hasMany() returns empty array if relationship is undefined", function() {
-  expect(2);
+test("snapshot.hasMany() returns undefined if relationship is undefined", function() {
+  expect(1);
 
   run(function() {
     var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+    var relationship = snapshot.hasMany('comments');
+
+    equal(relationship, undefined, 'relationship is undefined');
+  });
+});
+
+test("snapshot.hasMany() returns empty array if relationship is unset", function() {
+  expect(2);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World', comments: null });
     var snapshot = post._createSnapshot();
     var relationship = snapshot.hasMany('comments');
 
@@ -196,6 +301,38 @@ test("snapshot.hasMany() returns array of IDs if option.ids is set", function() 
     var relationship = snapshot.hasMany('comments', { ids: true });
 
     deepEqual(relationship, ['2', '3'], 'relationship IDs correctly returned');
+  });
+});
+
+test("snapshot.hasMany() returns undefined if relationship is a link", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World', links: { comments: 'comments' } });
+    var snapshot = post._createSnapshot();
+    var relationship = snapshot.hasMany('comments');
+
+    equal(relationship, undefined, 'relationship is undefined');
+  });
+});
+
+test("snapshot.hasMany() returns array of snapshots if relationship link has been fetched", function() {
+  expect(2);
+
+  env.adapter.findHasMany = function(store, snapshot, link, relationship) {
+    return Ember.RSVP.resolve([{ id: 2, body: 'This is comment' }]);
+  };
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World', links: { comments: 'comments' } });
+
+    post.get('comments').then(function(comments) {
+      var snapshot = post._createSnapshot();
+      var relationship = snapshot.hasMany('comments');
+
+      ok(relationship instanceof Array, 'relationship is an instance of Array');
+      equal(relationship.length, 1, 'relationship has one item');
+    });
   });
 });
 


### PR DESCRIPTION
This is the second part of solving the problem described in #2936.

Snapshots are now aware of unknown relationships and can return `undefined` from `belongsTo()` and `hasMany()` if that is the case.

~~Ping @igorT re: f67ab9c13cd4cf20deb494a85826aa2468636a28~~