### PR TITLE
Handle null/empty type paths in build url mixin

### DIFF
--- a/packages/ember-data/lib/adapters/build-url-mixin.js
+++ b/packages/ember-data/lib/adapters/build-url-mixin.js
@@ -52,8 +52,12 @@ export default Ember.Mixin.create({
     var url = [];
     var host = get(this, 'host');
     var prefix = this.urlPrefix();
+    var path;
 
-    if (type) { url.push(this.pathForType(type)); }
+    if (type) {
+      path = this.pathForType(type);
+      if (path) { url.push(path); }
+    }
 
     //We might get passed in an array of ids from findMany
     //in which case we don't want to modify the url, as the

--- a/packages/ember-data/tests/unit/adapters/build-url-mixin/path-for-type-test.js
+++ b/packages/ember-data/tests/unit/adapters/build-url-mixin/path-for-type-test.js
@@ -2,7 +2,16 @@ var env, adapter;
 
 module("unit/adapters/build-url-mixin/path-for-type - DS.BuildURLMixin#pathForType", {
   setup: function() {
-    var Adapter = DS.Adapter.extend(DS.BuildURLMixin);
+
+    // test for overriden pathForType methods which return null path values
+    var customPathForType = {
+      pathForType: function(type) {
+        if (type === 'rootModel') { return ''; }
+        return this._super(type);
+      }
+    };
+
+    var Adapter = DS.Adapter.extend(DS.BuildURLMixin, customPathForType);
 
     env = setupStore({
       adapter: Adapter
@@ -22,4 +31,8 @@ test('pathForType - works with dasherized types', function() {
 
 test('pathForType - works with underscored types', function() {
   equal(adapter.pathForType('super_user'), "superUsers");
+});
+
+test('buildURL - works with empty paths', function() {
+  equal(adapter.buildURL('rootModel', 1), "/1");
 });


### PR DESCRIPTION
handle empty values returned by pathForType in buildURL method of
the build url mixin.

refs emberjs/data#2844