### PR TITLE
DirtyState.invalid handle pushedData event

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -345,7 +345,7 @@ var DirtyState = {
 
     rolledBack: function(record) {
       get(record, 'errors').clear();
-      record.triggerLater('ready');
+      record.transitionTo('loaded.saved');
     },
 
     becameValid: function(record) {

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -336,6 +336,8 @@ var DirtyState = {
 
     becomeDirty: Ember.K,
 
+    pushedData: Ember.K,
+
     willCommit: function(record) {
       get(record, 'errors').clear();
       record.transitionTo('inFlight');

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -345,7 +345,13 @@ var DirtyState = {
 
     rolledBack: function(record) {
       get(record, 'errors').clear();
-      record.transitionTo('loaded.saved');
+
+      if (record.get('isNew')) {
+        DirtyState.uncommitted.rollback.apply(this, arguments);
+        record.transitionTo('deleted.saved');
+      } else {
+        record.transitionTo('loaded.saved');
+      }
     },
 
     becameValid: function(record) {

--- a/packages/ember-data/tests/unit/model/merge-test.js
+++ b/packages/ember-data/tests/unit/model/merge-test.js
@@ -102,6 +102,31 @@ test("When a record is dirty, pushes are overridden by local changes", function(
   equal(person.get('city'), "Portland", "if there are no local changes, the new data applied");
 });
 
+test("When a record is invalid, pushes are overridden by local changes", function() {
+  var store = createStore({ adapter: DS.Adapter });
+  var person;
+
+  run(function() {
+    person = store.push(Person, { id: 1, name: "Brendan McLoughlin", city: "Boston" });
+    person.set('name', "Brondan McLoughlin");
+    person.send('becameInvalid');
+  });
+
+  equal(person.get('isDirty'), true, "the person is currently dirty");
+  equal(person.get('isValid'), false, "the person is currently invalid");
+  equal(person.get('name'), "Brondan McLoughlin", "the update was effective");
+  equal(person.get('city'), "Boston", "the original data applies");
+
+  run(function() {
+    store.push(Person, { id: 1, name: "bmac", city: "Prague" });
+  });
+
+  equal(person.get('isDirty'), true, "the local changes are reapplied");
+  equal(person.get('isValid'), false, "record is still invalid");
+  equal(person.get('name'), "Brondan McLoughlin", "the local changes are reapplied");
+  equal(person.get('city'), "Prague", "if there are no local changes, the new data applied");
+});
+
 test("A record with no changes can still be saved", function() {
   expect(1);
 

--- a/packages/ember-data/tests/unit/model/rollback-test.js
+++ b/packages/ember-data/tests/unit/model/rollback-test.js
@@ -215,10 +215,12 @@ test("invalid record can be rollbacked", function() {
 
   run(function() {
     dog.save().then(null, async(function() {
+      equal(dog.get('isValid'), false);
       dog.rollback();
 
       equal(dog.get('name'), "Pluto");
       ok(dog.get('isValid'));
+      equal(dog.get('isDirty'), false);
     }));
   });
 });

--- a/packages/ember-data/tests/unit/model/rollback-test.js
+++ b/packages/ember-data/tests/unit/model/rollback-test.js
@@ -331,3 +331,49 @@ test("when destroying a record setup the record state to invalid, the record can
     }));
   });
 });
+
+test("invalid new record can be rollbacked", function() {
+  var person;
+  var adapter = DS.RESTAdapter.extend({
+    ajax: function(url, type, hash) {
+      var adapter = this;
+
+      return new Ember.RSVP.Promise(function(resolve, reject) {
+        /* If InvalidError is passed back in the reject it will throw the
+           exception which will bubble up the call stack (crashing the test)
+           instead of hitting the failure route of the promise.
+           So wrapping the reject in an Ember.run.next makes it so save
+           completes without failure and the failure hits the failure route
+           of the promise instead of crashing the save. */
+        Ember.run.next(function() {
+            reject(adapter.ajaxError({ name: 'is invalid' }));
+        });
+      });
+    },
+
+    ajaxError: function(jqXHR) {
+      return new DS.InvalidError(jqXHR);
+    }
+  });
+
+  env = setupStore({ person: Person, adapter: adapter });
+
+  run(function() {
+    person = env.store.createRecord('person', { id: 1 });
+  });
+
+  equal(person.get('isNew'), true, "must be new");
+  equal(person.get('isDirty'), true, "must be dirty");
+
+  run(function() {
+    person.save().then(null, async(function() {
+      equal(person.get('isValid'), false);
+      Ember.run(person, 'rollback');
+
+      // assertions taken from the test 'new record can be rollbacked' http://git.io/vTsKR
+      equal(person.get('isNew'), false, "must not be new");
+      equal(person.get('isDirty'), false, "must not be dirty");
+      equal(person.get('isDeleted'), true, "must be deleted");
+    }));
+  });
+});

--- a/packages/ember-data/tests/unit/model/rollback-test.js
+++ b/packages/ember-data/tests/unit/model/rollback-test.js
@@ -346,7 +346,7 @@ test("invalid new record can be rollbacked", function() {
            completes without failure and the failure hits the failure route
            of the promise instead of crashing the save. */
         Ember.run.next(function() {
-            reject(adapter.ajaxError({ name: 'is invalid' }));
+          reject(adapter.ajaxError({ name: 'is invalid' }));
         });
       });
     },


### PR DESCRIPTION
I think that this should by handled similar as in uncommited.
It's currently causing this error:

```javascript
route: xz Attempted to handle event `pushedData` on <app@model:class::instance> while in state root.loaded.updated.invalid.
```