### PR TITLE
Fix: remove self reference

### DIFF
--- a/packages/ember/lib/main.js
+++ b/packages/ember/lib/main.js
@@ -1,2 +1,2 @@
 // Shim Ember module
-export default self.Ember;
+export default Ember;


### PR DESCRIPTION
The reference to `self` is breaking FastBoot. 

The issue was outlined here: https://github.com/tildeio/ember-cli-fastboot/issues/11


