### PR TITLE
adapter.serialize receives a snapshot

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -230,13 +230,12 @@ var Adapter = Ember.Object.extend({
     ```
 
     @method serialize
-    @param {DS.Model} record
+    @param {DS.Snapshot} snapshot
     @param {Object}   options
-    @return {Object} serialized record
+    @return {Object} serialized snapshot
   */
-  serialize: function(record, options) {
-    var snapshot = record._createSnapshot();
-    return get(record, 'store').serializerFor(snapshot.typeKey).serialize(snapshot, options);
+  serialize: function(snapshot, options) {
+    return get(snapshot.record, 'store').serializerFor(snapshot.typeKey).serialize(snapshot, options);
   },
 
   /**


### PR DESCRIPTION
Since the beta 16, the serialize method of adapter base class receives a snapshot, not a record. It should not use record._createSnapshot anymore.