### PR TITLE
Remove value from retrieveFromCurrentState CP

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -20,7 +20,7 @@ var RESERVED_MODEL_PROPS = [
   'currentState', 'data', 'store'
 ];
 
-var retrieveFromCurrentState = Ember.computed('currentState', function(key, value) {
+var retrieveFromCurrentState = Ember.computed('currentState', function(key) {
   return get(get(this, 'currentState'), key);
 }).readOnly();
 


### PR DESCRIPTION
This triggered an assert that readonly CPs are not allowed to have setters (old-style).