### PR TITLE
Fix JSCS rule and unlock v1.11.0

### DIFF
--- a/lib/jscs-rules/require-spaces-after-closing-parenthesis-in-function-declaration.js
+++ b/lib/jscs-rules/require-spaces-after-closing-parenthesis-in-function-declaration.js
@@ -25,20 +25,10 @@ module.exports.prototype = {
   check: function(file, errors) {
     var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
     var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-    var tokens = file.getTokens();
 
     file.iterateNodesByType(['FunctionDeclaration'], function(node) {
-      var nodeBeforeRoundBrace = node;
-      // named function
-      if (node.id) {
-        nodeBeforeRoundBrace = node.id;
-      }
-
-      var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-      var functionToken = tokens[functionTokenPos];
-
-      var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-      var nextToken = tokens[nextTokenPos];
+      var functionToken = file.getFirstNodeToken(node.id || node);
+      var nextToken = file.getNextToken(functionToken);
 
       if (beforeOpeningRoundBrace) {
         if (nextToken) {
@@ -56,8 +46,8 @@ module.exports.prototype = {
         }
       }
 
-      var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-      var tokenBeforeBody = tokens[tokenBeforeBodyPos];
+      // errors if no token is found unless `includeComments` is passed
+      var tokenBeforeBody = file.getPrevToken(node.body, { includeComments: true });
 
       if (beforeOpeningCurlyBrace) {
         if (tokenBeforeBody) {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "es6-module-transpiler-amd-formatter": "^0.2.4",
     "es6-module-transpiler-package-resolver": "^1.0.1",
     "git-repo-version": "0.0.2",
-    "jscs": "1.11.0",
+    "jscs": "^1.12.0",
     "testem": "^0.6.19",
     "yuidocjs": "~0.3.46"
   }

--- a/packages/ember-data/lib/system/many-array.js
+++ b/packages/ember-data/lib/system/many-array.js
@@ -100,12 +100,12 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
   */
   isLoaded: false,
 
-   /**
-     The relationship which manages this array.
+  /**
+    The relationship which manages this array.
 
-     @property {ManyRelationship} relationship
-     @private
-   */
+    @property {ManyRelationship} relationship
+    @private
+  */
   relationship: null,
 
   internalReplace: function(idx, amt, objects) {

--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -321,8 +321,8 @@ export default function attr(type, options) {
       return getDefaultValue(this, options, key);
     }
 
-  // `data` is never set directly. However, it may be
-  // invalidated from the state manager's setData
-  // event.
+    // `data` is never set directly. However, it may be
+    // invalidated from the state manager's setData
+    // event.
   }).meta(meta);
 }

--- a/packages/ember-data/tests/integration/adapter/find-all-test.js
+++ b/packages/ember-data/tests/integration/adapter/find-all-test.js
@@ -57,8 +57,9 @@ test("When all records for a type are requested, a rejection should reject the p
   expect(5);
 
   var count = 0;
-  store = createStore({ adapter: DS.Adapter.extend({
-    findAll: function(store, type, since) {
+  store = createStore({
+    adapter: DS.Adapter.extend({
+      findAll: function(store, type, since) {
         // this will get called twice
         ok(true, "the adapter's findAll method should be invoked");
 

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -88,7 +88,7 @@ test("serializeBelongsTo with null", function() {
 test("async serializeBelongsTo with null", function() {
   Comment.reopen({
     post: DS.belongsTo('post', { async: true })
-   });
+  });
   run(function() {
     comment = env.store.createRecord(Comment, { body: "Omakase is delicious", post: null });
   });

--- a/packages/ember-data/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
+++ b/packages/ember-data/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
@@ -32,7 +32,7 @@ module("unit/adapters/rest_adapter/group_records_for_find_many_test - DS.RESTAda
     Store = createStore({
       adapter: GroupsAdapter,
       testRecord: DS.Model.extend()
-     });
+    });
 
   }
 });

--- a/packages/ember-data/tests/unit/model/merge-test.js
+++ b/packages/ember-data/tests/unit/model/merge-test.js
@@ -45,7 +45,7 @@ test("When a record is in flight, pushes are applied underneath the in flight ch
 
   var adapter = DS.Adapter.extend({
     updateRecord: function(store, type, snapshot) {
-    // Make sure saving isn't resolved synchronously
+      // Make sure saving isn't resolved synchronously
       return new Ember.RSVP.Promise(function(resolve, reject) {
         run.next(null, resolve, { id: 1, name: "Senor Thomas Dale, Esq.", city: "Portland" });
       });


### PR DESCRIPTION
The jscs package was locked to 1.11.0 in #2945 due to failing builds. The build failed because `getTokenPosByRangeStart()` was removed in 1.12.0.

This PR implements the same changes as https://github.com/emberjs/ember.js/pull/10747 and unlocks the version of jscs in package.json.