### PR TITLE
Use new getter/setter for computed if available

### DIFF
--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -3,6 +3,8 @@ import {
   Map
 } from "ember-data/system/map";
 
+import computedPolyfill from "ember-data/utils/computed-polyfill";
+
 /**
   @module ember-data
 */
@@ -296,8 +298,15 @@ export default function attr(type, options) {
     options: options
   };
 
-  return Ember.computed(function(key, value) {
-    if (arguments.length > 1) {
+  return computedPolyfill({
+    get: function(key) {
+      if (hasValue(this, key)) {
+        return getValue(this, key);
+      } else {
+        return getDefaultValue(this, options, key);
+      }
+    },
+    set: function(key, value) {
       Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.constructor.toString(), key !== 'id');
       var oldValue = getValue(this, key);
 
@@ -315,14 +324,6 @@ export default function attr(type, options) {
       }
 
       return value;
-    } else if (hasValue(this, key)) {
-      return getValue(this, key);
-    } else {
-      return getDefaultValue(this, options, key);
     }
-
-    // `data` is never set directly. However, it may be
-    // invalidated from the state manager's setData
-    // event.
   }).meta(meta);
 }

--- a/packages/ember-data/lib/system/relationships/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/belongs-to.js
@@ -1,5 +1,7 @@
 import Model from 'ember-data/system/model';
 
+import computedPolyfill from "ember-data/utils/computed-polyfill";
+
 /**
   `DS.belongsTo` is used to define One-To-One and One-To-Many
   relationships on a [DS.Model](/api/data/classes/DS.Model.html).
@@ -76,9 +78,12 @@ function belongsTo(type, options) {
     key: null
   };
 
-  return Ember.computed(function(key, value) {
-    if (arguments.length>1) {
-      if ( value === undefined ) {
+  return computedPolyfill({
+    get: function(key) {
+      return this._relationships[key].getRecord();
+    },
+    set: function(key, value) {
+      if (value === undefined) {
         value = null;
       }
       if (value && value.then) {
@@ -86,9 +91,9 @@ function belongsTo(type, options) {
       } else {
         this._relationships[key].setRecord(value);
       }
-    }
 
-    return this._relationships[key].getRecord();
+      return this._relationships[key].getRecord();
+    }
   }).meta(meta);
 }
 

--- a/packages/ember-data/lib/utils/computed-polyfill.js
+++ b/packages/ember-data/lib/utils/computed-polyfill.js
@@ -1,0 +1,35 @@
+import supportsComputedGetterSetter from './supports-computed-getter-setter';
+
+var computed = Ember.computed;
+
+export default function() {
+  var polyfillArguments = [];
+  var config = arguments[arguments.length - 1];
+
+  if (typeof config === 'function' || supportsComputedGetterSetter) {
+    return computed.apply(null, arguments);
+  }
+
+  for (var i = 0, l = arguments.length - 1; i < l; i++) {
+    polyfillArguments.push(arguments[i]);
+  }
+
+  var func;
+  if (config.set) {
+    func = function(key, value) {
+      if (arguments.length > 1) {
+        return config.set.call(this, key, value);
+      } else {
+        return config.get.call(this, key);
+      }
+    };
+  } else {
+    func = function(key) {
+      return config.get.call(this, key);
+    };
+  }
+
+  polyfillArguments.push(func);
+
+  return computed.apply(null, polyfillArguments);
+}

--- a/packages/ember-data/lib/utils/supports-computed-getter-setter.js
+++ b/packages/ember-data/lib/utils/supports-computed-getter-setter.js
@@ -1,0 +1,13 @@
+var supportsComputedGetterSetter;
+
+try {
+  Ember.computed({
+    get: function() { },
+    set: function() { }
+  });
+  supportsComputedGetterSetter = true;
+} catch(e) {
+  supportsComputedGetterSetter = false;
+}
+
+export default supportsComputedGetterSetter;


### PR DESCRIPTION
This fixes the ~3400 deprecation warnings `Using the same function as getter and setter is deprecated` for beta and canary builds.