### PR TITLE
Make version check for Ember.js strict

### DIFF
--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -8,7 +8,7 @@
 Ember.RSVP.Promise.cast = Ember.RSVP.Promise.cast || Ember.RSVP.resolve;
 
 Ember.runInDebug(function() {
-  if (Ember.VERSION.match(/1\.[0-7]\./)) {
+  if (Ember.VERSION.match(/^1\.[0-7]\./)) {
     throw new Ember.Error("Ember Data requires at least Ember 1.8.0, but you have " +
                           Ember.VERSION +
                           ". Please upgrade your version of Ember, then upgrade Ember Data");


### PR DESCRIPTION
When `Ember.VERSION` contains some version suffix (such as '1.11.0.72d2409e'),
This check will reject this version of Ember unexpectedly.