### PR TITLE
Add fullMessages property to DS.Errors

### DIFF
--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -1,6 +1,8 @@
+var capitalize = Ember.String.capitalize;
 var get = Ember.get;
 var isEmpty = Ember.isEmpty;
 var map = Ember.EnumerableUtils.map;
+var underscore = Ember.String.underscore;
 
 import {
   MapWithDefault
@@ -155,6 +157,16 @@ export default Ember.Object.extend(Ember.Enumerable, Ember.Evented, {
     An array containing all of the error messages for this
     record. This is useful for displaying all errors to the user.
 
+    ```javascript
+    user.get('errors').add('firstName', 'is required');
+    user.get('errors').add('lastName', 'is required');
+
+    user.get('errors.messages');
+    // ["is required", "is required"]
+    ```
+
+    This is useful for displaying all errors to the user.
+
     ```handlebars
     {{#each model.errors.messages as |message|}}
       <div class="error">
@@ -167,6 +179,41 @@ export default Ember.Object.extend(Ember.Enumerable, Ember.Evented, {
     @type {Array}
   */
   messages: Ember.computed.mapBy('content', 'message'),
+
+  /**
+    An array containing all of the error messages, capitalized and prefixed
+    with their attribute, for this record.
+
+    ```javascript
+    user.get('errors').add('firstName', 'is required');
+    user.get('errors').add('lastName', 'is required');
+
+    user.get('errors.fullMessages');
+    // ["First name is required", "Last name is required"]
+    ```
+
+    This is useful for displaying all errors to the user.
+
+    ```handlebars
+    {{#each model.errors.fullMessages as |message|}}
+      <div class="error">
+        {{message}}
+      </div>
+    {{/each}}
+    ```
+
+    @property fullMessages
+    @type {Array}
+  */
+  fullMessages: Ember.computed('content', function() {
+    var errors = get(this, 'content');
+
+    return map(errors, function(error) {
+      var attribute = underscore(error.attribute).replace('_', ' ');
+
+      return capitalize(attribute) + ' ' + error.message;
+    });
+  }),
 
   /**
     @property content

--- a/packages/ember-data/tests/unit/model/errors-test.js
+++ b/packages/ember-data/tests/unit/model/errors-test.js
@@ -45,7 +45,7 @@ test("add error", function() {
 });
 
 test("get error", function() {
-  expect(8);
+  expect(9);
   ok(errors.get('firstObject') === undefined, 'returns undefined');
   errors.trigger = becameInvalid;
   errors.add('firstName', 'error');
@@ -65,6 +65,11 @@ test("get error", function() {
     { attribute: 'firstName', message: 'error2' }
   ]);
   deepEqual(errors.get('messages'), ['error', 'error2', 'error3']);
+  deepEqual(errors.get('fullMessages'), [
+    'First name error',
+    'First name error2',
+    'Last name error3'
+  ]);
 });
 
 test("remove error", function() {


### PR DESCRIPTION
This adds a `fullMessages` property to a model's `errors` object, similar to the [#full_messages](http://apidock.com/rails/ActiveModel/Errors/full_messages) that Rails provides.

This is similar to the `errors.messages` that already exists but makes the error messages more useful by prefixing the error messages with the name of the attribute that it's for.

```javascript
user.get('errors').add('firstName', 'is required');
user.get('errors').add('lastName', 'is required');

user.get('errors.fullMessages');
// ["First name is required", "Last name is required"]
```

```handlebars
{{#each model.errors.fullMessages as |message|}}
  <p>{{message}}</p>
{{/each}}
```