### PR TITLE
[DOC] Use block params style {{#each}}

### DIFF
--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -57,14 +57,14 @@ import {
 
   ```handlebars
   <label>Username: {{input value=username}} </label>
-  {{#each error in model.errors.username}}
+  {{#each model.errors.username as |error|}}
     <div class="error">
       {{error.message}}
     </div>
   {{/each}}
 
   <label>Email: {{input value=email}} </label>
-  {{#each error in model.errors.email}}
+  {{#each model.errors.email as |error|}}
     <div class="error">
       {{error.message}}
     </div>
@@ -75,7 +75,7 @@ import {
   object to get an array of all the error strings.
 
   ```handlebars
-  {{#each message in model.errors.messages}}
+  {{#each model.errors.messages as |message|}}
     <div class="error">
       {{message}}
     </div>
@@ -156,7 +156,7 @@ export default Ember.Object.extend(Ember.Enumerable, Ember.Evented, {
     record. This is useful for displaying all errors to the user.
 
     ```handlebars
-    {{#each message in model.errors.messages}}
+    {{#each model.errors.messages as |message|}}
       <div class="error">
         {{message}}
       </div>

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -367,13 +367,13 @@ var Model = Ember.Object.extend(Ember.Evented, {
 
     ```handlebars
     <label>Username: {{input value=username}} </label>
-    {{#each error in model.errors.username}}
+    {{#each model.errors.username as |error|}}
       <div class="error">
         {{error.message}}
       </div>
     {{/each}}
     <label>Email: {{input value=email}} </label>
-    {{#each error in model.errors.email}}
+    {{#each model.errors.email as |error|}}
       <div class="error">
         {{error.message}}
       </div>
@@ -385,7 +385,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     object to get an array of all the error strings.
 
     ```handlebars
-    {{#each message in model.errors.messages}}
+    {{#each model.errors.messages as |message|}}
       <div class="error">
         {{message}}
       </div>


### PR DESCRIPTION
Replaces  `{{#each ... in ...}}` syntax with block params style `{{#each ... as |...|}}`.