### PR TITLE
Do not prepend a `/` if namespace is absolute.

### DIFF
--- a/packages/ember-data/lib/adapters/build-url-mixin.js
+++ b/packages/ember-data/lib/adapters/build-url-mixin.js
@@ -67,7 +67,9 @@ export default Ember.Mixin.create({
     if (prefix) { url.unshift(prefix); }
 
     url = url.join('/');
-    if (!host && url) { url = '/' + url; }
+    if (!host && url && url.charAt(0) !== '/') {
+      url = '/' + url;
+    }
 
     return url;
   },

--- a/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -291,3 +291,16 @@ test('buildURL - buildURL takes a record from delete', function() {
   });
 });
 
+test('buildURL - with absolute namespace', function() {
+  run(function() {
+    adapter.setProperties({
+      namespace: '/api/v1'
+    });
+  });
+
+  ajaxResponse({ posts: [{ id: 1 }] });
+
+  run(store, 'find', 'post', 1).then(async(function(post) {
+    equal(passedUrl, "/api/v1/posts/1");
+  }));
+});


### PR DESCRIPTION
If you provide `namespace` as `/api/v1` it will end up using `//api/v1`.

As of this change, if `namespace` is absolute it will not prepend a slash.