### PR TITLE
jspm support

### DIFF
--- a/config/package-manager-files/package.json
+++ b/config/package-manager-files/package.json
@@ -8,5 +8,12 @@
   "main": "./ember-data.js",
   "dependencies": {
     "ember": ">= 1.8.1 < 2.0.0"
+  },
+  "jspm": {
+    "main": "ember-data",
+    "shim": {
+      "ember-data": { "deps": ["ember"], "exports": "DS" },
+      "ember-data.prod": { "deps": ["ember"], "exports": "DS" }
+    }
   }
 }


### PR DESCRIPTION
Currently it's possible to install ember via jspm, now this adds jspm support to ember-data.