### PR TITLE
Improve property change notifications for records

### DIFF
--- a/packages/ember-data/tests/integration/records/property-changes-test.js
+++ b/packages/ember-data/tests/integration/records/property-changes-test.js
@@ -1,0 +1,115 @@
+var env, store, Person;
+var attr = DS.attr;
+var run = Ember.run;
+
+module('integration/records/property-changes - Property changes', {
+  setup: function() {
+    Person = DS.Model.extend({
+      firstName: attr('string'),
+      lastName: attr('string')
+    });
+    Person.toString = function() { return 'Person'; };
+
+    env = setupStore({
+      person: Person
+    });
+    store = env.store;
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      env.container.destroy();
+    });
+  }
+});
+
+test('Calling push with partial records trigger observers for just those attributes that changed', function() {
+  expect(1);
+  var person;
+
+  run(function() {
+    person = store.push('person', {
+      id: 'wat',
+      firstName: 'Yehuda',
+      lastName: 'Katz'
+    });
+  });
+
+  person.addObserver('firstName', function() {
+    ok(false, 'firstName observer should not be triggered');
+  });
+
+  person.addObserver('lastName', function() {
+    ok(true, 'lastName observer should be triggered');
+  });
+
+  run(function() {
+    store.push('person', {
+      id: 'wat',
+      firstName: 'Yehuda',
+      lastName: 'Katz!'
+    });
+  });
+});
+
+test('Calling push does not trigger observers for locally changed attributes with the same value', function() {
+  expect(0);
+  var person;
+
+  run(function() {
+    person = store.push('person', {
+      id: 'wat',
+      firstName: 'Yehuda',
+      lastName: 'Katz'
+    });
+
+    person.set('lastName', 'Katz!');
+  });
+
+  person.addObserver('firstName', function() {
+    ok(false, 'firstName observer should not be triggered');
+  });
+
+  person.addObserver('lastName', function() {
+    ok(false, 'lastName observer should not be triggered');
+  });
+
+  run(function() {
+    store.push('person', {
+      id: 'wat',
+      firstName: 'Yehuda',
+      lastName: 'Katz!'
+    });
+  });
+});
+
+test('Saving a record trigger observers for locally changed attributes with the same canonical value', function() {
+  expect(1);
+  var person;
+
+  env.adapter.updateRecord = function(store, type, snapshot) {
+    return Ember.RSVP.resolve({ id: 'wat', lastName: 'Katz' });
+  };
+
+  run(function() {
+    person = store.push('person', {
+      id: 'wat',
+      firstName: 'Yehuda',
+      lastName: 'Katz'
+    });
+
+    person.set('lastName', 'Katz!');
+  });
+
+  person.addObserver('firstName', function() {
+    ok(false, 'firstName observer should not be triggered');
+  });
+
+  person.addObserver('lastName', function() {
+    ok(true, 'lastName observer should be triggered');
+  });
+
+  run(function() {
+    person.save();
+  });
+});

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -164,35 +164,6 @@ test("Calling push on normalize allows partial updates with raw JSON", function 
   equal(person.get('lastName'), "Jackson", "existing fields are untouched");
 });
 
-test("Calling push with partial records triggers observers for just those attributes that changed", function() {
-  expect(1);
-  var person;
-
-  run(function() {
-    person = store.push('person', {
-      id: 'wat',
-      firstName: "Yehuda",
-      lastName: "Katz"
-    });
-  });
-
-  person.addObserver('firstName', function() {
-    ok(false, 'firstName observer should not be triggered');
-  });
-
-  person.addObserver('lastName', function() {
-    ok(true, 'lastName observer should be triggered');
-  });
-
-  run(function() {
-    store.push('person', {
-      id: 'wat',
-      firstName: 'Yehuda',
-      lastName: 'Katz!'
-    });
-  });
-});
-
 test("Calling push with a normalized hash containing related records returns a record", function() {
   var number1, number2, person;
   run(function() {


### PR DESCRIPTION
This PR improves how we trigger property changes when pushing data to the store/a record.

Previously we only cared about comparing new data with `model._data`, this resulted in weird behavior in a couple of scenarios:

1. If you modify an attribute locally and push new canonical data that matched the current local attribute we got a false trigger.
2. If you modify an attribute locally and save, and the server return new canonical data that matches the existing canonical data, we did not get a trigger (hence the old locally changed value stayed).

Fixes #2937, fixes #2900