### PR TITLE
make store.serialize a public method

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -241,7 +241,6 @@ Store = Service.extend({
       the JSON representation
 
     @method serialize
-    @private
     @param {DS.Model} record the record to serialize
     @param {Object} options an options hash
   */


### PR DESCRIPTION
Sometimes, it is useful to have hooks for serializing records for an endpoint that has a custom endpoint that does not match a simple CRUD operation. An example of this is creating bulk records, where you may want to map over a list of records:

```javascript

var records = this.store.all('post');

var array = records.map( (record) => this.store.serialize(record) );

$.ajax({type: 'POST', data: array, url: '/bulk_update_posts'});
```

This seems to me like a necessary escape hatch for people who can't adapt to JSONAPI in the future for some endpoints as well.