### PR TITLE
url-templates inital implementation

### DIFF
--- a/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -304,3 +304,51 @@ test('buildURL - with absolute namespace', function() {
     equal(passedUrl, "/api/v1/posts/1");
   }));
 });
+
+
+test('buildURL - with a url template', function() {
+  run(function() {
+    adapter.setProperties({
+      host: 'http://example.com',
+      urlTemplate: '{host}/api/v1/{pathForType}/{id}'
+    });
+  });
+
+  ajaxResponse({ posts: [{ id: 1 }] });
+
+  run(store, 'find', 'post', 1).then(async(function(post) {
+    equal(passedUrl, "http://example.com/api/v1/posts/1");
+  }));
+});
+
+test('buildURL - with a url and urlSegment overrides', function() {
+  run(function() {
+
+    var CustomAdapter = DS.RESTAdapter.extend({
+      host: 'http://example.com',
+      urlTemplate: '{+host}/api/v1/{pathForType}/{id}',
+      urlSegments: {
+        host: 'https://example.com',
+        id: function(type, id, record) {
+          return id + "-foo";
+        }
+      }
+    });
+
+    env = setupStore({
+      post: Post,
+      comment: Comment,
+      superUser: SuperUser,
+      adapter: CustomAdapter
+    });
+
+    store = env.store;
+    adapter = env.adapter;
+  });
+
+  ajaxResponse({ posts: [{ id: 1 }] });
+
+  run(store, 'find', 'post', 1).then(async(function(post) {
+    equal(passedUrl, "https://example.com/api/v1/posts/1-foo");
+  }));
+});


### PR DESCRIPTION
This is an initial implementation for https://github.com/emberjs/rfcs/pull/4

Currently
---------

* This is fully backwards compatible with `buildURL`.
* The template is compiled with a very incomplete inline implementation
  that does not handle lists or reserved words, and only supports the
  `/`, `?`, and `+` operators.
* A context for filling in the templates is created using `urlSegments`,
  which is defined on the adapter.

Example Usage
-------------

```javascript
// adapters/invoice
extend default Adapter.extend({
  urlTemplate: '/api/users/{userId}/invoices{/id}',

  urlSegments: {
    userId: function(type, id, snapshot, requestType) {
      return snapshot.belongsTo('user', { id: true });
    }
  }
});
```

TODO
----

* [x] Create an ember-cli addon with this functionality to get it out there and
  get feedback.
* [ ] Either use a 3rd-party url-template library, or support a larger subset
  of the rfc6570 spec. Possibly create an adapter layer so that a
  lightweight version can be included in ember-data and users can include
  a more full-featured library if they want.
* [ ] Allow for defining a template for specific `requestType`s.
* [ ] Support `findBelongsTo` and `findHasMany` without using `urlPrefix`.
  These methods use `buildURL` and then `urlPrefix` to generate a prefix
  suitable for prepending to the value from `links`. This seems
  unnecessary with url-templates, but needs to be backwards compatible.