### PR TITLE
[refactor] Prune code that does nothing

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -2032,8 +2032,6 @@ function _commit(adapter, store, operation, record) {
     store._adapterRun(function() {
       if (adapterPayload) {
         payload = serializer.extract(store, type, adapterPayload, get(record, 'id'), operation);
-      } else {
-        payload = adapterPayload;
       }
       store.didSaveRecord(record, payload);
     });


### PR DESCRIPTION
Original intent of the code is in commit 42d966e43f9ea13d94e61f62fa72b7b8ffe33178.
It was changed in fbabbda32cccf43d79782bbcaa3192fbeecaeb18.

If there is no adapterPayload, why set payload = adapterPayload? Just let it stay empty.