### PR TITLE
ActiveModelAdapter camelizes keys for errors on 422

### DIFF
--- a/packages/activemodel-adapter/lib/system/active-model-adapter.js
+++ b/packages/activemodel-adapter/lib/system/active-model-adapter.js
@@ -141,7 +141,8 @@ var ActiveModelAdapter = RESTAdapter.extend({
     var error = this._super.apply(this, arguments);
 
     if (jqXHR && jqXHR.status === 422) {
-      return new InvalidError(Ember.$.parseJSON(jqXHR.responseText));
+      var response = Ember.$.parseJSON(jqXHR.responseText);
+      return new InvalidError(response.errors);
     } else {
       return error;
     }

--- a/packages/activemodel-adapter/lib/system/active-model-adapter.js
+++ b/packages/activemodel-adapter/lib/system/active-model-adapter.js
@@ -6,6 +6,7 @@ import {pluralize} from "ember-inflector";
   @module ember-data
 */
 
+var camelize = Ember.String.camelize;
 var decamelize = Ember.String.decamelize;
 var underscore = Ember.String.underscore;
 
@@ -143,6 +144,16 @@ var ActiveModelAdapter = RESTAdapter.extend({
     if (jqXHR && jqXHR.status === 422) {
       var response = Ember.$.parseJSON(jqXHR.responseText);
       var errors = response.errors ? response.errors : response;
+
+      for (var underscoredError in errors) {
+        var camelizedError = camelize(underscoredError);
+
+        if (camelizedError !== underscoredError) {
+          errors[camelizedError] = errors[underscoredError];
+          delete errors[underscoredError];
+        }
+      }
+
       return new InvalidError(errors);
     } else {
       return error;

--- a/packages/activemodel-adapter/lib/system/active-model-adapter.js
+++ b/packages/activemodel-adapter/lib/system/active-model-adapter.js
@@ -142,7 +142,8 @@ var ActiveModelAdapter = RESTAdapter.extend({
 
     if (jqXHR && jqXHR.status === 422) {
       var response = Ember.$.parseJSON(jqXHR.responseText);
-      return new InvalidError(response.errors);
+      var errors = response.errors ? response.errors : response;
+      return new InvalidError(errors);
     } else {
       return error;
     }

--- a/packages/activemodel-adapter/tests/integration/active-model-adapter-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-adapter-test.js
@@ -21,7 +21,7 @@ test('buildURL - decamelizes names', function() {
 });
 
 test('ajaxError - returns invalid error if 422 response', function() {
-  var error = new DS.InvalidError({ errors: { name: "can't be blank" } });
+  var error = new DS.InvalidError({ name: "can't be blank" });
 
   var jqXHR = {
     status: 422,
@@ -32,7 +32,7 @@ test('ajaxError - returns invalid error if 422 response', function() {
 });
 
 test('ajaxError - invalid error has camelized keys', function() {
-  var error = new DS.InvalidError({ errors: { firstName: "can't be blank" } });
+  var error = new DS.InvalidError({ firstName: "can't be blank" });
 
   var jqXHR = {
     status: 422,

--- a/packages/activemodel-adapter/tests/integration/active-model-adapter-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-adapter-test.js
@@ -31,6 +31,17 @@ test('ajaxError - returns invalid error if 422 response', function() {
   equal(adapter.ajaxError(jqXHR), error.toString());
 });
 
+test('ajaxError - accepts any kind of json on 422', function() {
+  var error = new DS.InvalidError({ name: "can't be blank" });
+
+  var jqXHR = {
+    status: 422,
+    responseText: JSON.stringify({ name: "can't be blank" })
+  };
+
+  equal(adapter.ajaxError(jqXHR), error.toString());
+});
+
 test('ajaxError - invalid error has camelized keys', function() {
   var error = new DS.InvalidError({ firstName: "can't be blank" });
 


### PR DESCRIPTION
Fields are not currently camelized in the model's errors object e.g.

    pilot.errors.first_name

should be

    pilot.errors.firstName

There is already test for this behavior but because of the way `InvalidError` and `Ember.inspect` are implemented the test passes when it shouldn't do.

ActiveModelAdapter now passes the errors hash directly to `InvalidError` as is expected according to the docs. This assumes that the 422 provides JSON of the form

    {
      errors: {
        first_name: ['is too long']
      }
    }

as is standard in active model. If `errors` is not present in the JSON response, active model adapter will continue to behave as it did before.