### PR TITLE
use typeKey and typeClass instead of using `type` inconsistently

### DIFF
--- a/packages/activemodel-adapter/lib/system/active-model-adapter.js
+++ b/packages/activemodel-adapter/lib/system/active-model-adapter.js
@@ -112,11 +112,11 @@ var ActiveModelAdapter = RESTAdapter.extend({
     ```
 
     @method pathForType
-    @param {String} type
+    @param {String} typeKey
     @return String
   */
-  pathForType: function(type) {
-    var decamelized = decamelize(type);
+  pathForType: function(typeKey) {
+    var decamelized = decamelize(typeKey);
     var underscored = underscore(decamelized);
     return pluralize(underscored);
   },

--- a/packages/activemodel-adapter/lib/system/active-model-serializer.js
+++ b/packages/activemodel-adapter/lib/system/active-model-serializer.js
@@ -116,12 +116,12 @@ var ActiveModelSerializer = RESTSerializer.extend({
     relationship keys.
 
     @method keyForRelationship
-    @param {String} key
+    @param {String} relationshipTypeKey
     @param {String} kind
     @return String
   */
-  keyForRelationship: function(rawKey, kind) {
-    var key = decamelize(rawKey);
+  keyForRelationship: function(relationshipTypeKey, kind) {
+    var key = decamelize(relationshipTypeKey);
     if (kind === "belongsTo") {
       return key + "_id";
     } else if (kind === "hasMany") {
@@ -141,12 +141,12 @@ var ActiveModelSerializer = RESTSerializer.extend({
 
     @method serializeIntoHash
     @param {Object} hash
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {DS.Snapshot} snapshot
     @param {Object} options
   */
-  serializeIntoHash: function(data, type, snapshot, options) {
-    var root = underscore(decamelize(type.typeKey));
+  serializeIntoHash: function(data, typeClass, snapshot, options) {
+    var root = underscore(decamelize(typeClass.typeKey));
     data[root] = this.serialize(snapshot, options);
   },
 
@@ -200,16 +200,16 @@ var ActiveModelSerializer = RESTSerializer.extend({
     ```
 
     @method normalize
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} hash
     @param {String} prop
     @return Object
   */
 
-  normalize: function(type, hash, prop) {
+  normalize: function(typeClass, hash, prop) {
     this.normalizeLinks(hash);
 
-    return this._super(type, hash, prop);
+    return this._super(typeClass, hash, prop);
   },
 
   /**
@@ -253,13 +253,14 @@ var ActiveModelSerializer = RESTSerializer.extend({
       }
     ```
 
+    @param {Subclass of DS.Model} typeClass
     @method normalizeRelationships
     @private
   */
-  normalizeRelationships: function(type, hash) {
+  normalizeRelationships: function(typeClass, hash) {
 
     if (this.keyForRelationship) {
-      type.eachRelationship(function(key, relationship) {
+      typeClass.eachRelationship(function(key, relationship) {
         var payloadKey, payload;
         if (relationship.options.polymorphic) {
           payloadKey = this.keyForAttribute(key, "deserialize");

--- a/packages/ember-data/lib/adapters/build-url-mixin.js
+++ b/packages/ember-data/lib/adapters/build-url-mixin.js
@@ -42,52 +42,52 @@ export default Ember.Mixin.create({
     will be arrays of ids and snapshots.
 
     @method buildURL
-    @param {String} type
+    @param {String} typeKey
     @param {String|Array|Object} id single id or array of ids or query
     @param {DS.Snapshot|Array} snapshot single snapshot or array of snapshots
     @param {String} requestType
     @return {String} url
   */
-  buildURL: function(type, id, snapshot, requestType) {
+  buildURL: function(typeKey, id, snapshot, requestType) {
     switch (requestType) {
       case 'find':
-        return this.urlForFind(id, type, snapshot);
+        return this.urlForFind(id, typeKey, snapshot);
       case 'findAll':
-        return this.urlForFindAll(type);
+        return this.urlForFindAll(typeKey);
       case 'findQuery':
-        return this.urlForFindQuery(id, type);
+        return this.urlForFindQuery(id, typeKey);
       case 'findMany':
-        return this.urlForFindMany(id, type, snapshot);
+        return this.urlForFindMany(id, typeKey, snapshot);
       case 'findHasMany':
-        return this.urlForFindHasMany(id, type);
+        return this.urlForFindHasMany(id, typeKey);
       case 'findBelongsTo':
-        return this.urlForFindBelongsTo(id, type);
+        return this.urlForFindBelongsTo(id, typeKey);
       case 'createRecord':
-        return this.urlForCreateRecord(type, snapshot);
+        return this.urlForCreateRecord(typeKey, snapshot);
       case 'updateRecord':
-        return this.urlForUpdateRecord(id, type, snapshot);
+        return this.urlForUpdateRecord(id, typeKey, snapshot);
       case 'deleteRecord':
-        return this.urlForDeleteRecord(id, type, snapshot);
+        return this.urlForDeleteRecord(id, typeKey, snapshot);
       default:
-        return this._buildURL(type, id);
+        return this._buildURL(typeKey, id);
     }
   },
 
   /**
     @method _buildURL
     @private
-    @param {String} type
+    @param {String} typeKey
     @param {String} id
     @return {String} url
   */
-  _buildURL: function(type, id) {
+  _buildURL: function(typeKey, id) {
     var url = [];
     var host = get(this, 'host');
     var prefix = this.urlPrefix();
     var path;
 
-    if (type) {
-      path = this.pathForType(type);
+    if (typeKey) {
+      path = this.pathForType(typeKey);
       if (path) { url.push(path); }
     }
 
@@ -105,31 +105,31 @@ export default Ember.Mixin.create({
   /**
    * @method urlForFind
    * @param {String} id
-   * @param {String} type
+   * @param {String} typeKey
    * @param {DS.Snapshot} snapshot
    * @return {String} url
    */
-  urlForFind: function(id, type, snapshot) {
-    return this._buildURL(type, id);
+  urlForFind: function(id, typeKey, snapshot) {
+    return this._buildURL(typeKey, id);
   },
 
   /**
    * @method urlForFindAll
-   * @param {String} type
+   * @param {String} typeKey
    * @return {String} url
    */
-  urlForFindAll: function(type) {
-    return this._buildURL(type);
+  urlForFindAll: function(typeKey) {
+    return this._buildURL(typeKey);
   },
 
   /**
    * @method urlForFindQuery
    * @param {Object} query
-   * @param {String} type
+   * @param {String} typeKey
    * @return {String} url
    */
-  urlForFindQuery: function(query, type) {
-    return this._buildURL(type);
+  urlForFindQuery: function(query, typeKey) {
+    return this._buildURL(typeKey);
   },
 
   /**
@@ -139,60 +139,60 @@ export default Ember.Mixin.create({
    * @param {Array} snapshots
    * @return {String} url
    */
-  urlForFindMany: function(ids, type, snapshots) {
-    return this._buildURL(type);
+  urlForFindMany: function(ids, typeKey, snapshots) {
+    return this._buildURL(typeKey);
   },
 
   /**
    * @method urlForFindHasMany
    * @param {String} id
-   * @param {String} type
+   * @param {String} typeKey
    * @return {String} url
    */
-  urlForFindHasMany: function(id, type) {
-    return this._buildURL(type, id);
+  urlForFindHasMany: function(id, typeKey) {
+    return this._buildURL(typeKey, id);
   },
 
   /**
    * @method urlForFindBelongTo
    * @param {String} id
-   * @param {String} type
+   * @param {String} typeKey
    * @return {String} url
    */
-  urlForFindBelongsTo: function(id, type) {
-    return this._buildURL(type, id);
+  urlForFindBelongsTo: function(id, typeKey) {
+    return this._buildURL(typeKey, id);
   },
 
   /**
    * @method urlForCreateRecord
-   * @param {String} type
+   * @param {String} typeKey
    * @param {DS.Snapshot} snapshot
    * @return {String} url
    */
-  urlForCreateRecord: function(type, snapshot) {
-    return this._buildURL(type);
+  urlForCreateRecord: function(typeKey, snapshot) {
+    return this._buildURL(typeKey);
   },
 
   /**
    * @method urlForUpdateRecord
    * @param {String} id
-   * @param {String} type
+   * @param {String} typeKey
    * @param {DS.Snapshot} snapshot
    * @return {String} url
    */
-  urlForUpdateRecord: function(id, type, snapshot) {
-    return this._buildURL(type, id);
+  urlForUpdateRecord: function(id, typeKey, snapshot) {
+    return this._buildURL(typeKey, id);
   },
 
   /**
    * @method urlForDeleteRecord
    * @param {String} id
-   * @param {String} type
+   * @param {String} typeKey
    * @param {DS.Snapshot} snapshot
    * @return {String} url
    */
-  urlForDeleteRecord: function(id, type, snapshot) {
-    return this._buildURL(type, id);
+  urlForDeleteRecord: function(id, typeKey, snapshot) {
+    return this._buildURL(typeKey, id);
   },
 
   /**
@@ -251,19 +251,19 @@ export default Ember.Mixin.create({
 
     ```js
     App.ApplicationAdapter = DS.RESTAdapter.extend({
-      pathForType: function(type) {
-        var decamelized = Ember.String.decamelize(type);
+      pathForType: function(typeKey) {
+        var decamelized = Ember.String.decamelize(typeKey);
         return Ember.String.pluralize(decamelized);
       }
     });
     ```
 
     @method pathForType
-    @param {String} type
+    @param {String} typeKey
     @return {String} path
   **/
-  pathForType: function(type) {
-    var camelized = Ember.String.camelize(type);
+  pathForType: function(typeKey) {
+    var camelized = Ember.String.camelize(typeKey);
     return Ember.String.pluralize(camelized);
   }
 });

--- a/packages/ember-data/lib/adapters/fixture-adapter.js
+++ b/packages/ember-data/lib/adapters/fixture-adapter.js
@@ -60,12 +60,12 @@ export default Adapter.extend({
     Implement this method in order to provide data associated with a type
 
     @method fixturesForType
-    @param {Subclass of DS.Model} type
+    @param {Subclass of DS.Model} typeClass
     @return {Array}
   */
-  fixturesForType: function(type) {
-    if (type.FIXTURES) {
-      var fixtures = Ember.A(type.FIXTURES);
+  fixturesForType: function(typeClass) {
+    if (typeClass.FIXTURES) {
+      var fixtures = Ember.A(typeClass.FIXTURES);
       return fixtures.map(function(fixture) {
         var fixtureIdType = typeof fixture.id;
         if (fixtureIdType !== "number" && fixtureIdType !== "string") {
@@ -84,26 +84,26 @@ export default Adapter.extend({
     @method queryFixtures
     @param {Array} fixture
     @param {Object} query
-    @param {Subclass of DS.Model} type
+    @param {Subclass of DS.Model} typeClass
     @return {Promise|Array}
   */
-  queryFixtures: function(fixtures, query, type) {
+  queryFixtures: function(fixtures, query, typeClass) {
     Ember.assert('Not implemented: You must override the DS.FixtureAdapter::queryFixtures method to support querying the fixture store.');
   },
 
   /**
     @method updateFixtures
-    @param {Subclass of DS.Model} type
+    @param {Subclass of DS.Model} typeClass
     @param {Array} fixture
   */
-  updateFixtures: function(type, fixture) {
-    if (!type.FIXTURES) {
-      type.FIXTURES = [];
+  updateFixtures: function(typeClass, fixture) {
+    if (!typeClass.FIXTURES) {
+      typeClass.FIXTURES = [];
     }
 
-    var fixtures = type.FIXTURES;
+    var fixtures = typeClass.FIXTURES;
 
-    this.deleteLoadedFixture(type, fixture);
+    this.deleteLoadedFixture(typeClass, fixture);
 
     fixtures.push(fixture);
   },
@@ -113,10 +113,10 @@ export default Adapter.extend({
 
     @method mockJSON
     @param {DS.Store} store
-    @param {Subclass of DS.Model} type
+    @param {Subclass of DS.Model} typeClass
     @param {DS.Snapshot} snapshot
   */
-  mockJSON: function(store, type, snapshot) {
+  mockJSON: function(store, typeClass, snapshot) {
     return store.serializerFor(snapshot.typeKey).serialize(snapshot, { includeId: true });
   },
 
@@ -133,16 +133,16 @@ export default Adapter.extend({
   /**
     @method find
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {String} id
     @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
-  find: function(store, type, id, snapshot) {
-    var fixtures = this.fixturesForType(type);
+  find: function(store, typeClass, id, snapshot) {
+    var fixtures = this.fixturesForType(typeClass);
     var fixture;
 
-    Ember.assert("Unable to find fixtures for model type "+type.toString() +". If you're defining your fixtures using `Model.FIXTURES = ...`, please change it to `Model.reopenClass({ FIXTURES: ... })`.", fixtures);
+    Ember.assert("Unable to find fixtures for model type "+typeClass.toString() +". If you're defining your fixtures using `Model.FIXTURES = ...`, please change it to `Model.reopenClass({ FIXTURES: ... })`.", fixtures);
 
     if (fixtures) {
       fixture = Ember.A(fixtures).findBy('id', id);
@@ -158,15 +158,15 @@ export default Adapter.extend({
   /**
     @method findMany
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Array} ids
     @param {Array} snapshots
     @return {Promise} promise
   */
-  findMany: function(store, type, ids, snapshots) {
-    var fixtures = this.fixturesForType(type);
+  findMany: function(store, typeClass, ids, snapshots) {
+    var fixtures = this.fixturesForType(typeClass);
 
-    Ember.assert("Unable to find fixtures for model type "+type.toString(), fixtures);
+    Ember.assert("Unable to find fixtures for model type "+typeClass.toString(), fixtures);
 
     if (fixtures) {
       fixtures = fixtures.filter(function(item) {
@@ -185,14 +185,14 @@ export default Adapter.extend({
     @private
     @method findAll
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {String} sinceToken
     @return {Promise} promise
   */
-  findAll: function(store, type) {
-    var fixtures = this.fixturesForType(type);
+  findAll: function(store, typeClass) {
+    var fixtures = this.fixturesForType(typeClass);
 
-    Ember.assert("Unable to find fixtures for model type "+type.toString(), fixtures);
+    Ember.assert("Unable to find fixtures for model type "+typeClass.toString(), fixtures);
 
     return this.simulateRemoteCall(function() {
       return fixtures;
@@ -203,17 +203,17 @@ export default Adapter.extend({
     @private
     @method findQuery
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} query
     @param {DS.AdapterPopulatedRecordArray} recordArray
     @return {Promise} promise
   */
-  findQuery: function(store, type, query, array) {
-    var fixtures = this.fixturesForType(type);
+  findQuery: function(store, typeClass, query, array) {
+    var fixtures = this.fixturesForType(typeClass);
 
-    Ember.assert("Unable to find fixtures for model type " + type.toString(), fixtures);
+    Ember.assert("Unable to find fixtures for model type " + typeClass.toString(), fixtures);
 
-    fixtures = this.queryFixtures(fixtures, query, type);
+    fixtures = this.queryFixtures(fixtures, query, typeClass);
 
     if (fixtures) {
       return this.simulateRemoteCall(function() {
@@ -225,14 +225,14 @@ export default Adapter.extend({
   /**
     @method createRecord
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
-  createRecord: function(store, type, snapshot) {
-    var fixture = this.mockJSON(store, type, snapshot);
+  createRecord: function(store, typeClass, snapshot) {
+    var fixture = this.mockJSON(store, typeClass, snapshot);
 
-    this.updateFixtures(type, fixture);
+    this.updateFixtures(typeClass, fixture);
 
     return this.simulateRemoteCall(function() {
       return fixture;
@@ -246,10 +246,10 @@ export default Adapter.extend({
     @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
-  updateRecord: function(store, type, snapshot) {
-    var fixture = this.mockJSON(store, type, snapshot);
+  updateRecord: function(store, typeClass, snapshot) {
+    var fixture = this.mockJSON(store, typeClass, snapshot);
 
-    this.updateFixtures(type, fixture);
+    this.updateFixtures(typeClass, fixture);
 
     return this.simulateRemoteCall(function() {
       return fixture;
@@ -259,12 +259,12 @@ export default Adapter.extend({
   /**
     @method deleteRecord
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
-  deleteRecord: function(store, type, snapshot) {
-    this.deleteLoadedFixture(type, snapshot);
+  deleteRecord: function(store, typeClass, snapshot) {
+    this.deleteLoadedFixture(typeClass, snapshot);
 
     return this.simulateRemoteCall(function() {
       // no payload in a deletion
@@ -275,15 +275,15 @@ export default Adapter.extend({
   /*
     @method deleteLoadedFixture
     @private
-    @param type
+    @param typeClass
     @param snapshot
   */
-  deleteLoadedFixture: function(type, snapshot) {
-    var existingFixture = this.findExistingFixture(type, snapshot);
+  deleteLoadedFixture: function(typeClass, snapshot) {
+    var existingFixture = this.findExistingFixture(typeClass, snapshot);
 
     if (existingFixture) {
-      var index = indexOf(type.FIXTURES, existingFixture);
-      type.FIXTURES.splice(index, 1);
+      var index = indexOf(typeClass.FIXTURES, existingFixture);
+      typeClass.FIXTURES.splice(index, 1);
       return true;
     }
   },
@@ -291,11 +291,11 @@ export default Adapter.extend({
   /*
     @method findExistingFixture
     @private
-    @param type
+    @param typeClass
     @param snapshot
   */
-  findExistingFixture: function(type, snapshot) {
-    var fixtures = this.fixturesForType(type);
+  findExistingFixture: function(typeClass, snapshot) {
+    var fixtures = this.fixturesForType(typeClass);
     var id = snapshot.id;
 
     return this.findFixtureById(fixtures, id);

--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -108,15 +108,15 @@ export default Serializer.extend({
 
    @method applyTransforms
    @private
-   @param {subclass of DS.Model} type
+   @param {subclass of DS.Model} typeClass
    @param {Object} data The data to transform
    @return {Object} data The transformed data object
   */
-  applyTransforms: function(type, data) {
-    type.eachTransformedAttribute(function applyTransform(key, type) {
+  applyTransforms: function(typeClass, data) {
+    typeClass.eachTransformedAttribute(function applyTransform(key, typeClass) {
       if (!data.hasOwnProperty(key)) { return; }
 
-      var transform = this.transformFor(type);
+      var transform = this.transformFor(typeClass);
       data[key] = transform.deserialize(data[key]);
     }, this);
 
@@ -139,8 +139,8 @@ export default Serializer.extend({
 
     ```javascript
     App.ApplicationSerializer = DS.JSONSerializer.extend({
-      normalize: function(type, hash) {
-        var fields = Ember.get(type, 'fields');
+      normalize: function(typeClass, hash) {
+        var fields = Ember.get(typeClass, 'fields');
         fields.forEach(function(field) {
           var payloadField = Ember.String.underscore(field);
           if (field === payloadField) { return; }
@@ -154,19 +154,19 @@ export default Serializer.extend({
     ```
 
     @method normalize
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} hash
     @return {Object}
   */
-  normalize: function(type, hash) {
+  normalize: function(typeClass, hash) {
     if (!hash) { return hash; }
 
     this.normalizeId(hash);
-    this.normalizeAttributes(type, hash);
-    this.normalizeRelationships(type, hash);
+    this.normalizeAttributes(typeClass, hash);
+    this.normalizeRelationships(typeClass, hash);
 
-    this.normalizeUsingDeclaredMapping(type, hash);
-    this.applyTransforms(type, hash);
+    this.normalizeUsingDeclaredMapping(typeClass, hash);
+    this.applyTransforms(typeClass, hash);
     return hash;
   },
 
@@ -198,11 +198,11 @@ export default Serializer.extend({
     @method normalizeAttributes
     @private
   */
-  normalizeAttributes: function(type, hash) {
+  normalizeAttributes: function(typeClass, hash) {
     var payloadKey;
 
     if (this.keyForAttribute) {
-      type.eachAttribute(function(key) {
+      typeClass.eachAttribute(function(key) {
         payloadKey = this.keyForAttribute(key, 'deserialize');
         if (key === payloadKey) { return; }
         if (!hash.hasOwnProperty(payloadKey)) { return; }
@@ -217,11 +217,11 @@ export default Serializer.extend({
     @method normalizeRelationships
     @private
   */
-  normalizeRelationships: function(type, hash) {
+  normalizeRelationships: function(typeClass, hash) {
     var payloadKey;
 
     if (this.keyForRelationship) {
-      type.eachRelationship(function(key, relationship) {
+      typeClass.eachRelationship(function(key, relationship) {
         payloadKey = this.keyForRelationship(key, relationship.kind, 'deserialize');
         if (key === payloadKey) { return; }
         if (!hash.hasOwnProperty(payloadKey)) { return; }
@@ -236,7 +236,7 @@ export default Serializer.extend({
     @method normalizeUsingDeclaredMapping
     @private
   */
-  normalizeUsingDeclaredMapping: function(type, hash) {
+  normalizeUsingDeclaredMapping: function(typeClass, hash) {
     var attrs = get(this, 'attrs');
     var payloadKey, key;
 
@@ -270,10 +270,10 @@ export default Serializer.extend({
     @method normalizeErrors
     @private
   */
-  normalizeErrors: function(type, hash) {
+  normalizeErrors: function(typeClass, hash) {
     this.normalizeId(hash);
-    this.normalizeAttributes(type, hash);
-    this.normalizeRelationships(type, hash);
+    this.normalizeAttributes(typeClass, hash);
+    this.normalizeRelationships(typeClass, hash);
   },
 
   /**
@@ -508,11 +508,11 @@ export default Serializer.extend({
 
     @method serializeIntoHash
     @param {Object} hash
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {DS.Snapshot} snapshot
     @param {Object} options
   */
-  serializeIntoHash: function(hash, type, snapshot, options) {
+  serializeIntoHash: function(hash, typeClass, snapshot, options) {
     merge(hash, this.serialize(snapshot, options));
   },
 
@@ -710,9 +710,9 @@ export default Serializer.extend({
     ```javascript
     socket.on('message', function(message) {
       var data = message.data;
-      var type = store.modelFor(message.modelName);
-      var serializer = store.serializerFor(type.typeKey);
-      var record = serializer.extract(store, type, data, data.id, 'single');
+      var typeClass = store.modelFor(message.modelName);
+      var serializer = store.serializerFor(typeClass.typeKey);
+      var record = serializer.extract(store, typeClass, data, data.id, 'single');
 
       store.push(message.modelName, record);
     });
@@ -720,17 +720,17 @@ export default Serializer.extend({
 
     @method extract
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extract: function(store, type, payload, id, requestType) {
-    this.extractMeta(store, type, payload);
+  extract: function(store, typeClass, payload, id, requestType) {
+    this.extractMeta(store, typeClass, payload);
 
     var specificExtract = "extract" + requestType.charAt(0).toUpperCase() + requestType.substr(1);
-    return this[specificExtract](store, type, payload, id, requestType);
+    return this[specificExtract](store, typeClass, payload, id, requestType);
   },
 
   /**
@@ -740,14 +740,14 @@ export default Serializer.extend({
 
     @method extractFindAll
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Array} array An array of deserialized objects
   */
-  extractFindAll: function(store, type, payload, id, requestType) {
-    return this.extractArray(store, type, payload, id, requestType);
+  extractFindAll: function(store, typeClass, payload, id, requestType) {
+    return this.extractArray(store, typeClass, payload, id, requestType);
   },
   /**
     `extractFindQuery` is a hook into the extract method used when a
@@ -762,8 +762,8 @@ export default Serializer.extend({
     @param {String} requestType
     @return {Array} array An array of deserialized objects
   */
-  extractFindQuery: function(store, type, payload, id, requestType) {
-    return this.extractArray(store, type, payload, id, requestType);
+  extractFindQuery: function(store, typeClass, payload, id, requestType) {
+    return this.extractArray(store, typeClass, payload, id, requestType);
   },
   /**
     `extractFindMany` is a hook into the extract method used when a
@@ -772,14 +772,14 @@ export default Serializer.extend({
 
     @method extractFindMany
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Array} array An array of deserialized objects
   */
-  extractFindMany: function(store, type, payload, id, requestType) {
-    return this.extractArray(store, type, payload, id, requestType);
+  extractFindMany: function(store, typeClass, payload, id, requestType) {
+    return this.extractArray(store, typeClass, payload, id, requestType);
   },
   /**
     `extractFindHasMany` is a hook into the extract method used when a
@@ -788,14 +788,14 @@ export default Serializer.extend({
 
     @method extractFindHasMany
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Array} array An array of deserialized objects
   */
-  extractFindHasMany: function(store, type, payload, id, requestType) {
-    return this.extractArray(store, type, payload, id, requestType);
+  extractFindHasMany: function(store, typeClass, payload, id, requestType) {
+    return this.extractArray(store, typeClass, payload, id, requestType);
   },
 
   /**
@@ -805,14 +805,14 @@ export default Serializer.extend({
 
     @method extractCreateRecord
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractCreateRecord: function(store, type, payload, id, requestType) {
-    return this.extractSave(store, type, payload, id, requestType);
+  extractCreateRecord: function(store, typeClass, payload, id, requestType) {
+    return this.extractSave(store, typeClass, payload, id, requestType);
   },
   /**
     `extractUpdateRecord` is a hook into the extract method used when
@@ -821,14 +821,14 @@ export default Serializer.extend({
 
     @method extractUpdateRecord
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractUpdateRecord: function(store, type, payload, id, requestType) {
-    return this.extractSave(store, type, payload, id, requestType);
+  extractUpdateRecord: function(store, typeClass, payload, id, requestType) {
+    return this.extractSave(store, typeClass, payload, id, requestType);
   },
   /**
     `extractDeleteRecord` is a hook into the extract method used when
@@ -837,14 +837,14 @@ export default Serializer.extend({
 
     @method extractDeleteRecord
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractDeleteRecord: function(store, type, payload, id, requestType) {
-    return this.extractSave(store, type, payload, id, requestType);
+  extractDeleteRecord: function(store, typeClass, payload, id, requestType) {
+    return this.extractSave(store, typeClass, payload, id, requestType);
   },
 
   /**
@@ -854,14 +854,14 @@ export default Serializer.extend({
 
     @method extractFind
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractFind: function(store, type, payload, id, requestType) {
-    return this.extractSingle(store, type, payload, id, requestType);
+  extractFind: function(store, typeClass, payload, id, requestType) {
+    return this.extractSingle(store, typeClass, payload, id, requestType);
   },
   /**
     `extractFindBelongsTo` is a hook into the extract method used when
@@ -870,14 +870,14 @@ export default Serializer.extend({
 
     @method extractFindBelongsTo
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractFindBelongsTo: function(store, type, payload, id, requestType) {
-    return this.extractSingle(store, type, payload, id, requestType);
+  extractFindBelongsTo: function(store, typeClass, payload, id, requestType) {
+    return this.extractSingle(store, typeClass, payload, id, requestType);
   },
   /**
     `extractSave` is a hook into the extract method used when a call
@@ -892,8 +892,8 @@ export default Serializer.extend({
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractSave: function(store, type, payload, id, requestType) {
-    return this.extractSingle(store, type, payload, id, requestType);
+  extractSave: function(store, typeClass, payload, id, requestType) {
+    return this.extractSingle(store, typeClass, payload, id, requestType);
   },
 
   /**
@@ -904,26 +904,26 @@ export default Serializer.extend({
 
     ```javascript
     App.PostSerializer = DS.JSONSerializer.extend({
-      extractSingle: function(store, type, payload) {
+      extractSingle: function(store, typeClass, payload) {
         payload.comments = payload._embedded.comment;
         delete payload._embedded;
 
-        return this._super(store, type, payload);
+        return this._super(store, typeClass, payload);
       },
     });
     ```
 
     @method extractSingle
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Object} json The deserialized payload
   */
-  extractSingle: function(store, type, payload, id, requestType) {
-    payload = this.normalizePayload(payload);
-    return this.normalize(type, payload);
+  extractSingle: function(store, typeClass, payload, id, requestType) {
+    var normalizedPayload = this.normalizePayload(payload);
+    return this.normalize(typeClass, normalizedPayload);
   },
 
   /**
@@ -934,9 +934,9 @@ export default Serializer.extend({
 
     ```javascript
     App.PostSerializer = DS.JSONSerializer.extend({
-      extractArray: function(store, type, payload) {
+      extractArray: function(store, typeClass, payload) {
         return payload.map(function(json) {
-          return this.extractSingle(store, type, json);
+          return this.extractSingle(store, typeClass, json);
         }, this);
       }
     });
@@ -944,18 +944,18 @@ export default Serializer.extend({
 
     @method extractArray
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @param {String} requestType
     @return {Array} array An array of deserialized objects
   */
-  extractArray: function(store, type, arrayPayload, id, requestType) {
+  extractArray: function(store, typeClass, arrayPayload, id, requestType) {
     var normalizedPayload = this.normalizePayload(arrayPayload);
     var serializer = this;
 
     return map.call(normalizedPayload, function(singlePayload) {
-      return serializer.normalize(type, singlePayload);
+      return serializer.normalize(typeClass, singlePayload);
     });
   },
 
@@ -968,9 +968,9 @@ export default Serializer.extend({
 
     ```javascript
     App.PostSerializer = DS.JSONSerializer.extend({
-      extractMeta: function(store, type, payload) {
+      extractMeta: function(store, typeClass, payload) {
         if (payload && payload._pagination) {
-          store.setMetadataFor(type, payload._pagination);
+          store.setMetadataFor(typeClass, payload._pagination);
           delete payload._pagination;
         }
       }
@@ -979,12 +979,12 @@ export default Serializer.extend({
 
     @method extractMeta
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
   */
-  extractMeta: function(store, type, payload) {
+  extractMeta: function(store, typeClass, payload) {
     if (payload && payload.meta) {
-      store.setMetadataFor(type, payload.meta);
+      store.setMetadataFor(typeClass, payload.meta);
       delete payload.meta;
     }
   },
@@ -999,10 +999,10 @@ export default Serializer.extend({
 
     ```javascript
     App.PostSerializer = DS.JSONSerializer.extend({
-      extractErrors: function(store, type, payload, id) {
+      extractErrors: function(store, typeClass, payload, id) {
         if (payload && typeof payload === 'object' && payload._problems) {
           payload = payload._problems;
-          this.normalizeErrors(type, payload);
+          this.normalizeErrors(typeClass, payload);
         }
         return payload;
       }
@@ -1011,15 +1011,15 @@ export default Serializer.extend({
 
     @method extractErrors
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String or Number} id
     @return {Object} json The deserialized errors
   */
-  extractErrors: function(store, type, payload, id) {
+  extractErrors: function(store, typeClass, payload, id) {
     if (payload && typeof payload === 'object' && payload.errors) {
       payload = payload.errors;
-      this.normalizeErrors(type, payload);
+      this.normalizeErrors(typeClass, payload);
     }
     return payload;
   },
@@ -1063,11 +1063,11 @@ export default Serializer.extend({
 
    @method keyForRelationship
    @param {String} key
-   @param {String} relationship type
+   @param {String} relationship typeClass
    @return {String} normalized key
   */
 
-  keyForRelationship: function(key, type) {
+  keyForRelationship: function(key, typeClass) {
     return key;
   },
 

--- a/packages/ember-data/lib/system/debug/debug-adapter.js
+++ b/packages/ember-data/lib/system/debug/debug-adapter.js
@@ -23,18 +23,18 @@ export default Ember.DataAdapter.extend({
     ];
   },
 
-  detect: function(klass) {
-    return klass !== Model && Model.detect(klass);
+  detect: function(typeClass) {
+    return typeClass !== Model && Model.detect(typeClass);
   },
 
-  columnsForType: function(type) {
+  columnsForType: function(typeClass) {
     var columns = [{
       name: 'id',
       desc: 'Id'
     }];
     var count = 0;
     var self = this;
-    get(type, 'attributes').forEach(function(meta, name) {
+    get(typeClass, 'attributes').forEach(function(meta, name) {
       if (count++ > self.attributeLimit) { return false; }
       var desc = capitalize(underscore(name).replace('_', ' '));
       columns.push({ name: name, desc: desc });
@@ -42,8 +42,8 @@ export default Ember.DataAdapter.extend({
     return columns;
   },
 
-  getRecords: function(type) {
-    return this.get('store').all(type);
+  getRecords: function(typeKey) {
+    return this.get('store').all(typeKey);
   },
 
   getRecordColumnValues: function(record) {

--- a/packages/ember-data/lib/system/relationship-meta.js
+++ b/packages/ember-data/lib/system/relationship-meta.js
@@ -1,19 +1,19 @@
 import { singularize } from "ember-inflector/lib/system";
 
 export function typeForRelationshipMeta(store, meta) {
-  var typeKey, type;
+  var typeKey, typeClass;
 
   typeKey = meta.type || meta.key;
   if (typeof typeKey === 'string') {
     if (meta.kind === 'hasMany') {
       typeKey = singularize(typeKey);
     }
-    type = store.modelFor(typeKey);
+    typeClass = store.modelFor(typeKey);
   } else {
-    type = meta.type;
+    typeClass = meta.type;
   }
 
-  return type;
+  return typeClass;
 }
 
 export function relationshipFromMeta(store, meta) {

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -43,7 +43,7 @@ var relatedTypesDescriptor = Ember.computed(function() {
     relatedTypesDescriptor._cacheable = false;
   }
 
-  var type;
+  var typeKey;
   var types = Ember.A();
 
   // Loop through each computed property on the class,
@@ -52,13 +52,13 @@ var relatedTypesDescriptor = Ember.computed(function() {
   this.eachComputedProperty(function(name, meta) {
     if (meta.isRelationship) {
       meta.key = name;
-      type = typeForRelationshipMeta(this.store, meta);
+      typeKey = typeForRelationshipMeta(this.store, meta);
 
-      Ember.assert("You specified a hasMany (" + meta.type + ") on " + meta.parentType + " but " + meta.type + " was not found.", type);
+      Ember.assert("You specified a hasMany (" + meta.type + ") on " + meta.parentType + " but " + meta.type + " was not found.", typeKey);
 
-      if (!types.contains(type)) {
-        Ember.assert("Trying to sideload " + name + " on " + this.toString() + " but the type doesn't exist.", !!type);
-        types.push(type);
+      if (!types.contains(typeKey)) {
+        Ember.assert("Trying to sideload " + name + " on " + this.toString() + " but the type doesn't exist.", !!typeKey);
+        types.push(typeKey);
       }
     }
   });

--- a/packages/ember-data/lib/system/serializer.js
+++ b/packages/ember-data/lib/system/serializer.js
@@ -40,7 +40,7 @@ var Serializer = Ember.Object.extend({
 
     @method extract
     @param {DS.Store} store
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} payload
     @param {String|Number} id
     @param {String} requestType
@@ -71,11 +71,11 @@ var Serializer = Ember.Object.extend({
     payload.
 
     @method normalize
-    @param {subclass of DS.Model} type
+    @param {subclass of DS.Model} typeClass
     @param {Object} hash
     @return {Object}
   */
-  normalize: function(type, hash) {
+  normalize: function(typeClass, hash) {
     return hash;
   }
 

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -12,24 +12,24 @@ import {
 var get = Ember.get;
 var Promise = Ember.RSVP.Promise;
 
-export function _find(adapter, store, type, id, record) {
+export function _find(adapter, store, typeClass, id, record) {
   var snapshot = record._createSnapshot();
-  var promise = adapter.find(store, type, id, snapshot);
-  var serializer = serializerForAdapter(store, adapter, type);
-  var label = "DS: Handle Adapter#find of " + type + " with id: " + id;
+  var promise = adapter.find(store, typeClass, id, snapshot);
+  var serializer = serializerForAdapter(store, adapter, typeClass);
+  var label = "DS: Handle Adapter#find of " + typeClass + " with id: " + id;
 
   promise = Promise.cast(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    Ember.assert("You made a request for a " + type.typeKey + " with id " + id + ", but the adapter's response did not have any data", adapterPayload);
+    Ember.assert("You made a request for a " + typeClass.typeClassKey + " with id " + id + ", but the adapter's response did not have any data", adapterPayload);
     return store._adapterRun(function() {
-      var payload = serializer.extract(store, type, adapterPayload, id, 'find');
+      var payload = serializer.extract(store, typeClass, adapterPayload, id, 'find');
 
-      return store.push(type, payload);
+      return store.push(typeClass, payload);
     });
   }, function(error) {
-    var record = store.getById(type, id);
+    var record = store.getById(typeClass, id);
     if (record) {
       record.notFound();
       if (get(record, 'isEmpty')) {
@@ -37,15 +37,15 @@ export function _find(adapter, store, type, id, record) {
       }
     }
     throw error;
-  }, "DS: Extract payload of '" + type + "'");
+  }, "DS: Extract payload of '" + typeClass + "'");
 }
 
 
-export function _findMany(adapter, store, type, ids, records) {
+export function _findMany(adapter, store, typeClass, ids, records) {
   var snapshots = Ember.A(records).invoke('_createSnapshot');
-  var promise = adapter.findMany(store, type, ids, snapshots);
-  var serializer = serializerForAdapter(store, adapter, type);
-  var label = "DS: Handle Adapter#findMany of " + type;
+  var promise = adapter.findMany(store, typeClass, ids, snapshots);
+  var serializer = serializerForAdapter(store, adapter, typeClass);
+  var label = "DS: Handle Adapter#findMany of " + typeClass;
 
   if (promise === undefined) {
     throw new Error('adapter.findMany returned undefined, this was very likely a mistake');
@@ -56,13 +56,13 @@ export function _findMany(adapter, store, type, ids, records) {
 
   return promise.then(function(adapterPayload) {
     return store._adapterRun(function() {
-      var payload = serializer.extract(store, type, adapterPayload, null, 'findMany');
+      var payload = serializer.extract(store, typeClass, adapterPayload, null, 'findMany');
 
       Ember.assert("The response from a findMany must be an Array, not " + Ember.inspect(payload), Ember.typeOf(payload) === 'array');
 
-      return store.pushMany(type, payload);
+      return store.pushMany(typeClass, payload);
     });
-  }, null, "DS: Extract payload of " + type);
+  }, null, "DS: Extract payload of " + typeClass);
 }
 
 export function _findHasMany(adapter, store, record, link, relationship) {
@@ -111,32 +111,32 @@ export function _findBelongsTo(adapter, store, record, link, relationship) {
   }, null, "DS: Extract payload of " + record + " : " + relationship.type);
 }
 
-export function _findAll(adapter, store, type, sinceToken) {
-  var promise = adapter.findAll(store, type, sinceToken);
-  var serializer = serializerForAdapter(store, adapter, type);
-  var label = "DS: Handle Adapter#findAll of " + type;
+export function _findAll(adapter, store, typeClass, sinceToken) {
+  var promise = adapter.findAll(store, typeClass, sinceToken);
+  var serializer = serializerForAdapter(store, adapter, typeClass);
+  var label = "DS: Handle Adapter#findAll of " + typeClass;
 
   promise = Promise.cast(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
     store._adapterRun(function() {
-      var payload = serializer.extract(store, type, adapterPayload, null, 'findAll');
+      var payload = serializer.extract(store, typeClass, adapterPayload, null, 'findAll');
 
       Ember.assert("The response from a findAll must be an Array, not " + Ember.inspect(payload), Ember.typeOf(payload) === 'array');
 
-      store.pushMany(type, payload);
+      store.pushMany(typeClass, payload);
     });
 
-    store.didUpdateAll(type);
-    return store.all(type);
-  }, null, "DS: Extract payload of findAll " + type);
+    store.didUpdateAll(typeClass);
+    return store.all(typeClass);
+  }, null, "DS: Extract payload of findAll " + typeClass);
 }
 
-export function _findQuery(adapter, store, type, query, recordArray) {
-  var promise = adapter.findQuery(store, type, query, recordArray);
-  var serializer = serializerForAdapter(store, adapter, type);
-  var label = "DS: Handle Adapter#findQuery of " + type;
+export function _findQuery(adapter, store, typeClass, query, recordArray) {
+  var promise = adapter.findQuery(store, typeClass, query, recordArray);
+  var serializer = serializerForAdapter(store, adapter, typeClass);
+  var label = "DS: Handle Adapter#findQuery of " + typeClass;
 
   promise = Promise.cast(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));
@@ -144,7 +144,7 @@ export function _findQuery(adapter, store, type, query, recordArray) {
   return promise.then(function(adapterPayload) {
     var payload;
     store._adapterRun(function() {
-      payload = serializer.extract(store, type, adapterPayload, null, 'findQuery');
+      payload = serializer.extract(store, typeClass, adapterPayload, null, 'findQuery');
 
       Ember.assert("The response from a findQuery must be an Array, not " + Ember.inspect(payload), Ember.typeOf(payload) === 'array');
     });
@@ -152,5 +152,5 @@ export function _findQuery(adapter, store, type, query, recordArray) {
     recordArray.load(payload);
     return recordArray;
 
-  }, null, "DS: Extract payload of findQuery " + type);
+  }, null, "DS: Extract payload of findQuery " + typeClass);
 }


### PR DESCRIPTION
Before, we exchanged type and typeKey intermittently. Sometimes it
was one or the other. This changes most usages of `type` to
either `typeKey` or `typeClass` for internal consistency.

The API docs were also changed to reflect this.

The Store API docs have been changed to suggest using a string
for a future patchset where we don't take factories to the store
finder methods.