### PR TITLE
dasherize ALL the things: use dasherized model names everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Master
 
+- `typeKey` on Snapshots and Model classes has been deprecated. Use
+  `modelName` instead.
+
 ### Release 1.0.0-beta.17 (May 10, 2015)
 
 - [#2898](https://github.com/emberjs/data/pull/2898) Pass requestType to buildURL [@amiel](https://github.com/amiel)

--- a/packages/activemodel-adapter/lib/system/active-model-adapter.js
+++ b/packages/activemodel-adapter/lib/system/active-model-adapter.js
@@ -112,11 +112,11 @@ var ActiveModelAdapter = RESTAdapter.extend({
     ```
 
     @method pathForType
-    @param {String} typeKey
+    @param {String} modelName
     @return String
   */
-  pathForType: function(typeKey) {
-    var decamelized = decamelize(typeKey);
+  pathForType: function(modelName) {
+    var decamelized = decamelize(modelName);
     var underscored = underscore(decamelized);
     return pluralize(underscored);
   },

--- a/packages/activemodel-adapter/lib/system/active-model-serializer.js
+++ b/packages/activemodel-adapter/lib/system/active-model-serializer.js
@@ -1,5 +1,6 @@
 import { singularize } from "ember-inflector";
 import RESTSerializer from "ember-data/serializers/rest-serializer";
+import normalizeModelName from "ember-data/system/normalize-model-name";
 /**
   @module ember-data
 */
@@ -146,7 +147,7 @@ var ActiveModelSerializer = RESTSerializer.extend({
     @param {Object} options
   */
   serializeIntoHash: function(data, typeClass, snapshot, options) {
-    var root = underscore(decamelize(typeClass.typeKey));
+    var root = underscore(decamelize(typeClass.modelName));
     data[root] = this.serialize(snapshot, options);
   },
 
@@ -166,7 +167,7 @@ var ActiveModelSerializer = RESTSerializer.extend({
     if (Ember.isNone(belongsTo)) {
       json[jsonKey] = null;
     } else {
-      json[jsonKey] = classify(belongsTo.typeKey).replace(/(\/)([a-z])/g, function(match, separator, chr) {
+      json[jsonKey] = classify(belongsTo.modelName).replace(/(\/)([a-z])/g, function(match, separator, chr) {
         return match.toUpperCase();
       }).replace('/', '::');
     }
@@ -290,9 +291,10 @@ var ActiveModelSerializer = RESTSerializer.extend({
     }
   },
   typeForRoot: function(key) {
-    return camelize(singularize(key)).replace(/(^|\:)([A-Z])/g, function(match, separator, chr) {
+    var convertedFromRubyModule = camelize(singularize(key)).replace(/(^|\:)([A-Z])/g, function(match, separator, chr) {
       return match.toLowerCase();
     }).replace('::', '/');
+    return normalizeModelName(convertedFromRubyModule);
   }
 });
 

--- a/packages/activemodel-adapter/tests/integration/active-model-serializer-namespaced-modelname-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-serializer-namespaced-modelname-test.js
@@ -63,7 +63,7 @@ test("serialize polymorphic", function() {
 });
 
 test("serialize polymorphic when type key is not camelized", function() {
-  YellowMinion.typeKey = 'evil-minions/yellow-minion';
+  YellowMinion.modelName = 'evil-minions/yellow-minion';
   var tom, ray;
   run(function() {
     tom = env.store.createRecord(YellowMinion, { name: "Alex", id: "124" });
@@ -90,7 +90,7 @@ test("extractPolymorphic hasMany", function() {
     "id": 1,
     "name": "Dr Horrible",
     "evilMinions": [{
-      type: "evilMinions/yellowMinion",
+      type: "evil-minions/yellow-minion",
       id: 12
     }]
   });
@@ -111,7 +111,7 @@ test("extractPolymorphic", function() {
     "id": 1,
     "name": "DeathRay",
     "evilMinion": {
-      type: "evilMinions/yellowMinion",
+      type: "evil-minions/yellow-minion",
       id: 12
     }
   });

--- a/packages/activemodel-adapter/tests/integration/active-model-serializer-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-serializer-test.js
@@ -85,7 +85,7 @@ test("serializeIntoHash", function() {
 });
 
 test("serializeIntoHash with decamelized types", function() {
-  HomePlanet.typeKey = 'home-planet';
+  HomePlanet.modelName = 'home-planet';
   run(function() {
     league = env.store.createRecord(HomePlanet, { name: "Umber", id: "123" });
   });
@@ -205,7 +205,7 @@ test("serialize polymorphic", function() {
 });
 
 test("serialize polymorphic when type key is not camelized", function() {
-  YellowMinion.typeKey = 'yellow-minion';
+  YellowMinion.modelName = 'yellow-minion';
   var tom, ray;
   run(function() {
     tom = env.store.createRecord(YellowMinion, { name: "Alex", id: "124" });
@@ -246,7 +246,7 @@ test("extractPolymorphic hasMany", function() {
     "id": 1,
     "name": "Dr Horrible",
     "evilMinions": [{
-      type: "yellowMinion",
+      type: "yellow-minion",
       id: 12
     }]
   });
@@ -271,7 +271,7 @@ test("extractPolymorphic", function() {
     "id": 1,
     "name": "DeathRay",
     "evilMinion": {
-      type: "yellowMinion",
+      type: "yellow-minion",
       id: 12
     }
   });

--- a/packages/ember-data/lib/adapters/build-url-mixin.js
+++ b/packages/ember-data/lib/adapters/build-url-mixin.js
@@ -14,7 +14,7 @@ var get = Ember.get;
   ```javascript
   export default DS.Adapter.extend(BuildURLMixin, {
     find: function(store, type, id, snapshot) {
-      var url = this.buildURL(type.typeKey, id, snapshot, 'find');
+      var url = this.buildURL(type.modelName, id, snapshot, 'find');
       return this.ajax(url, 'GET');
     }
   });
@@ -42,52 +42,52 @@ export default Ember.Mixin.create({
     will be arrays of ids and snapshots.
 
     @method buildURL
-    @param {String} typeKey
+    @param {String} modelName
     @param {String|Array|Object} id single id or array of ids or query
     @param {DS.Snapshot|Array} snapshot single snapshot or array of snapshots
     @param {String} requestType
     @return {String} url
   */
-  buildURL: function(typeKey, id, snapshot, requestType) {
+  buildURL: function(modelName, id, snapshot, requestType) {
     switch (requestType) {
       case 'find':
-        return this.urlForFind(id, typeKey, snapshot);
+        return this.urlForFind(id, modelName, snapshot);
       case 'findAll':
-        return this.urlForFindAll(typeKey);
+        return this.urlForFindAll(modelName);
       case 'findQuery':
-        return this.urlForFindQuery(id, typeKey);
+        return this.urlForFindQuery(id, modelName);
       case 'findMany':
-        return this.urlForFindMany(id, typeKey, snapshot);
+        return this.urlForFindMany(id, modelName, snapshot);
       case 'findHasMany':
-        return this.urlForFindHasMany(id, typeKey);
+        return this.urlForFindHasMany(id, modelName);
       case 'findBelongsTo':
-        return this.urlForFindBelongsTo(id, typeKey);
+        return this.urlForFindBelongsTo(id, modelName);
       case 'createRecord':
-        return this.urlForCreateRecord(typeKey, snapshot);
+        return this.urlForCreateRecord(modelName, snapshot);
       case 'updateRecord':
-        return this.urlForUpdateRecord(id, typeKey, snapshot);
+        return this.urlForUpdateRecord(id, modelName, snapshot);
       case 'deleteRecord':
-        return this.urlForDeleteRecord(id, typeKey, snapshot);
+        return this.urlForDeleteRecord(id, modelName, snapshot);
       default:
-        return this._buildURL(typeKey, id);
+        return this._buildURL(modelName, id);
     }
   },
 
   /**
     @method _buildURL
     @private
-    @param {String} typeKey
+    @param {String} modelName
     @param {String} id
     @return {String} url
   */
-  _buildURL: function(typeKey, id) {
+  _buildURL: function(modelName, id) {
     var url = [];
     var host = get(this, 'host');
     var prefix = this.urlPrefix();
     var path;
 
-    if (typeKey) {
-      path = this.pathForType(typeKey);
+    if (modelName) {
+      path = this.pathForType(modelName);
       if (path) { url.push(path); }
     }
 
@@ -105,31 +105,31 @@ export default Ember.Mixin.create({
   /**
    * @method urlForFind
    * @param {String} id
-   * @param {String} typeKey
+   * @param {String} modelName
    * @param {DS.Snapshot} snapshot
    * @return {String} url
    */
-  urlForFind: function(id, typeKey, snapshot) {
-    return this._buildURL(typeKey, id);
+  urlForFind: function(id, modelName, snapshot) {
+    return this._buildURL(modelName, id);
   },
 
   /**
    * @method urlForFindAll
-   * @param {String} typeKey
+   * @param {String} modelName
    * @return {String} url
    */
-  urlForFindAll: function(typeKey) {
-    return this._buildURL(typeKey);
+  urlForFindAll: function(modelName) {
+    return this._buildURL(modelName);
   },
 
   /**
    * @method urlForFindQuery
    * @param {Object} query
-   * @param {String} typeKey
+   * @param {String} modelName
    * @return {String} url
    */
-  urlForFindQuery: function(query, typeKey) {
-    return this._buildURL(typeKey);
+  urlForFindQuery: function(query, modelName) {
+    return this._buildURL(modelName);
   },
 
   /**
@@ -139,60 +139,60 @@ export default Ember.Mixin.create({
    * @param {Array} snapshots
    * @return {String} url
    */
-  urlForFindMany: function(ids, typeKey, snapshots) {
-    return this._buildURL(typeKey);
+  urlForFindMany: function(ids, modelName, snapshots) {
+    return this._buildURL(modelName);
   },
 
   /**
    * @method urlForFindHasMany
    * @param {String} id
-   * @param {String} typeKey
+   * @param {String} modelName
    * @return {String} url
    */
-  urlForFindHasMany: function(id, typeKey) {
-    return this._buildURL(typeKey, id);
+  urlForFindHasMany: function(id, modelName) {
+    return this._buildURL(modelName, id);
   },
 
   /**
    * @method urlForFindBelongTo
    * @param {String} id
-   * @param {String} typeKey
+   * @param {String} modelName
    * @return {String} url
    */
-  urlForFindBelongsTo: function(id, typeKey) {
-    return this._buildURL(typeKey, id);
+  urlForFindBelongsTo: function(id, modelName) {
+    return this._buildURL(modelName, id);
   },
 
   /**
    * @method urlForCreateRecord
-   * @param {String} typeKey
+   * @param {String} modelName
    * @param {DS.Snapshot} snapshot
    * @return {String} url
    */
-  urlForCreateRecord: function(typeKey, snapshot) {
-    return this._buildURL(typeKey);
+  urlForCreateRecord: function(modelName, snapshot) {
+    return this._buildURL(modelName);
   },
 
   /**
    * @method urlForUpdateRecord
    * @param {String} id
-   * @param {String} typeKey
+   * @param {String} modelName
    * @param {DS.Snapshot} snapshot
    * @return {String} url
    */
-  urlForUpdateRecord: function(id, typeKey, snapshot) {
-    return this._buildURL(typeKey, id);
+  urlForUpdateRecord: function(id, modelName, snapshot) {
+    return this._buildURL(modelName, id);
   },
 
   /**
    * @method urlForDeleteRecord
    * @param {String} id
-   * @param {String} typeKey
+   * @param {String} modelName
    * @param {DS.Snapshot} snapshot
    * @return {String} url
    */
-  urlForDeleteRecord: function(id, typeKey, snapshot) {
-    return this._buildURL(typeKey, id);
+  urlForDeleteRecord: function(id, modelName, snapshot) {
+    return this._buildURL(modelName, id);
   },
 
   /**
@@ -251,19 +251,19 @@ export default Ember.Mixin.create({
 
     ```js
     App.ApplicationAdapter = DS.RESTAdapter.extend({
-      pathForType: function(typeKey) {
-        var decamelized = Ember.String.decamelize(typeKey);
+      pathForType: function(modelName) {
+        var decamelized = Ember.String.decamelize(modelName);
         return Ember.String.pluralize(decamelized);
       }
     });
     ```
 
     @method pathForType
-    @param {String} typeKey
+    @param {String} modelName
     @return {String} path
   **/
-  pathForType: function(typeKey) {
-    var camelized = Ember.String.camelize(typeKey);
+  pathForType: function(modelName) {
+    var camelized = Ember.String.camelize(modelName);
     return Ember.String.pluralize(camelized);
   }
 });

--- a/packages/ember-data/lib/adapters/fixture-adapter.js
+++ b/packages/ember-data/lib/adapters/fixture-adapter.js
@@ -117,7 +117,7 @@ export default Adapter.extend({
     @param {DS.Snapshot} snapshot
   */
   mockJSON: function(store, typeClass, snapshot) {
-    return store.serializerFor(snapshot.typeKey).serialize(snapshot, { includeId: true });
+    return store.serializerFor(snapshot.modelName).serialize(snapshot, { includeId: true });
   },
 
   /**

--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -344,7 +344,7 @@ export default Adapter.extend(BuildURLMixin, {
     @return {Promise} promise
   */
   find: function(store, type, id, snapshot) {
-    return this.ajax(this.buildURL(type.typeKey, id, snapshot, 'find'), 'GET');
+    return this.ajax(this.buildURL(type.modelName, id, snapshot, 'find'), 'GET');
   },
 
   /**
@@ -368,7 +368,7 @@ export default Adapter.extend(BuildURLMixin, {
       query = { since: sinceToken };
     }
 
-    url = this.buildURL(type.typeKey, null, null, 'findAll');
+    url = this.buildURL(type.modelName, null, null, 'findAll');
 
     return this.ajax(url, 'GET', { data: query });
   },
@@ -391,7 +391,7 @@ export default Adapter.extend(BuildURLMixin, {
     @return {Promise} promise
   */
   findQuery: function(store, type, query) {
-    var url = this.buildURL(type.typeKey, query, null, 'findQuery');
+    var url = this.buildURL(type.modelName, query, null, 'findQuery');
 
     if (this.sortQueryParams) {
       query = this.sortQueryParams(query);
@@ -434,7 +434,7 @@ export default Adapter.extend(BuildURLMixin, {
     @return {Promise} promise
   */
   findMany: function(store, type, ids, snapshots) {
-    var url = this.buildURL(type.typeKey, ids, snapshots, 'findMany');
+    var url = this.buildURL(type.modelName, ids, snapshots, 'findMany');
     return this.ajax(url, 'GET', { data: { ids: ids } });
   },
 
@@ -467,7 +467,7 @@ export default Adapter.extend(BuildURLMixin, {
   */
   findHasMany: function(store, snapshot, url, relationship) {
     var id   = snapshot.id;
-    var type = snapshot.typeKey;
+    var type = snapshot.modelName;
 
     url = this.urlPrefix(url, this.buildURL(type, id, null, 'findHasMany'));
 
@@ -503,7 +503,7 @@ export default Adapter.extend(BuildURLMixin, {
   */
   findBelongsTo: function(store, snapshot, url, relationship) {
     var id   = snapshot.id;
-    var type = snapshot.typeKey;
+    var type = snapshot.modelName;
 
     url = this.urlPrefix(url, this.buildURL(type, id, null, 'findBelongsTo'));
     return this.ajax(url, 'GET');
@@ -527,8 +527,8 @@ export default Adapter.extend(BuildURLMixin, {
   */
   createRecord: function(store, type, snapshot) {
     var data = {};
-    var serializer = store.serializerFor(type.typeKey);
-    var url = this.buildURL(type.typeKey, null, snapshot, 'createRecord');
+    var serializer = store.serializerFor(type.modelName);
+    var url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
 
     serializer.serializeIntoHash(data, type, snapshot, { includeId: true });
 
@@ -553,12 +553,12 @@ export default Adapter.extend(BuildURLMixin, {
   */
   updateRecord: function(store, type, snapshot) {
     var data = {};
-    var serializer = store.serializerFor(type.typeKey);
+    var serializer = store.serializerFor(type.modelName);
 
     serializer.serializeIntoHash(data, type, snapshot);
 
     var id = snapshot.id;
-    var url = this.buildURL(type.typeKey, id, snapshot, 'updateRecord');
+    var url = this.buildURL(type.modelName, id, snapshot, 'updateRecord');
 
     return this.ajax(url, "PUT", { data: data });
   },
@@ -577,11 +577,11 @@ export default Adapter.extend(BuildURLMixin, {
   deleteRecord: function(store, type, snapshot) {
     var id = snapshot.id;
 
-    return this.ajax(this.buildURL(type.typeKey, id, snapshot, 'deleteRecord'), "DELETE");
+    return this.ajax(this.buildURL(type.modelName, id, snapshot, 'deleteRecord'), "DELETE");
   },
 
   _stripIDFromURL: function(store, snapshot) {
-    var url = this.buildURL(snapshot.typeKey, snapshot.id, snapshot);
+    var url = this.buildURL(snapshot.modelName, snapshot.id, snapshot);
 
     var expandedURL = url.split('/');
     //Case when the url is of the format ...something/:id

--- a/packages/ember-data/lib/main.js
+++ b/packages/ember-data/lib/main.js
@@ -18,6 +18,8 @@ Ember.runInDebug(function() {
 import DS from "ember-data/core";
 import "ember-data/ext/date";
 
+import normalizeModelName from "ember-data/system/normalize-model-name";
+
 import {
   PromiseArray,
   PromiseObject,
@@ -125,6 +127,13 @@ DS.Relationship  = Relationship;
 DS.ContainerProxy = ContainerProxy;
 
 DS._setupContainer = setupContainer;
+
+Ember.defineProperty(DS, 'normalizeModelName', {
+  enumerable: true,
+  writable: false,
+  configurable: false,
+  value: normalizeModelName
+});
 
 Ember.lookup.DS = DS;
 

--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -391,7 +391,7 @@ function extractEmbeddedRecords(serializer, store, typeClass, partial) {
 
   typeClass.eachRelationship(function(key, relationship) {
     if (serializer.hasDeserializeRecordsOption(key)) {
-      var embeddedTypeClass = store.modelFor(relationship.type.typeKey);
+      var embeddedTypeClass = store.modelFor(relationship.type.modelName);
       if (relationship.kind === "hasMany") {
         if (relationship.options.polymorphic) {
           extractEmbeddedHasManyPolymorphic(store, key, partial);
@@ -420,7 +420,7 @@ function extractEmbeddedHasMany(store, key, embeddedTypeClass, hash) {
 
   var ids = [];
 
-  var embeddedSerializer = store.serializerFor(embeddedTypeClass.typeKey);
+  var embeddedSerializer = store.serializerFor(embeddedTypeClass.modelName);
   forEach(hash[key], function(data) {
     var embeddedRecord = embeddedSerializer.normalize(embeddedTypeClass, data, null);
     store.push(embeddedTypeClass, embeddedRecord);
@@ -439,14 +439,14 @@ function extractEmbeddedHasManyPolymorphic(store, key, hash) {
   var ids = [];
 
   forEach(hash[key], function(data) {
-    var typeKey = data.type;
-    var embeddedSerializer = store.serializerFor(typeKey);
-    var embeddedTypeClass = store.modelFor(typeKey);
+    var modelName = data.type;
+    var embeddedSerializer = store.serializerFor(modelName);
+    var embeddedTypeClass = store.modelFor(modelName);
     var primaryKey = get(embeddedSerializer, 'primaryKey');
 
     var embeddedRecord = embeddedSerializer.normalize(embeddedTypeClass, data, null);
     store.push(embeddedTypeClass, embeddedRecord);
-    ids.push({ id: embeddedRecord[primaryKey], type: typeKey });
+    ids.push({ id: embeddedRecord[primaryKey], type: modelName });
   });
 
   hash[key] = ids;
@@ -458,7 +458,7 @@ function extractEmbeddedBelongsTo(store, key, embeddedTypeClass, hash) {
     return hash;
   }
 
-  var embeddedSerializer = store.serializerFor(embeddedTypeClass.typeKey);
+  var embeddedSerializer = store.serializerFor(embeddedTypeClass.modelName);
   var embeddedRecord = embeddedSerializer.normalize(embeddedTypeClass, hash[key], null);
   store.push(embeddedTypeClass, embeddedRecord);
 
@@ -473,16 +473,16 @@ function extractEmbeddedBelongsToPolymorphic(store, key, hash) {
   }
 
   var data = hash[key];
-  var typeKey = data.type;
-  var embeddedSerializer = store.serializerFor(typeKey);
-  var embeddedTypeClass = store.modelFor(typeKey);
+  var modelName = data.type;
+  var embeddedSerializer = store.serializerFor(modelName);
+  var embeddedTypeClass = store.modelFor(modelName);
   var primaryKey = get(embeddedSerializer, 'primaryKey');
 
   var embeddedRecord = embeddedSerializer.normalize(embeddedTypeClass, data, null);
   store.push(embeddedTypeClass, embeddedRecord);
 
   hash[key] = embeddedRecord[primaryKey];
-  hash[key + 'Type'] = typeKey;
+  hash[key + 'Type'] = modelName;
   return hash;
 }
 

--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -502,7 +502,7 @@ export default Serializer.extend({
     ```js
     App.ApplicationSerializer = DS.RESTSerializer.extend({
       serializeIntoHash: function(data, type, snapshot, options) {
-        var root = Ember.String.decamelize(type.typeKey);
+        var root = Ember.String.decamelize(type.modelName);
         data[root] = this.serialize(snapshot, options);
       }
     });
@@ -678,7 +678,7 @@ export default Serializer.extend({
         if (Ember.isNone(belongsTo)) {
           json[key + "_type"] = null;
         } else {
-          json[key + "_type"] = belongsTo.typeKey;
+          json[key + "_type"] = belongsTo.modelName;
         }
       }
     });
@@ -713,7 +713,7 @@ export default Serializer.extend({
     socket.on('message', function(message) {
       var data = message.data;
       var typeClass = store.modelFor(message.modelName);
-      var serializer = store.serializerFor(typeClass.typeKey);
+      var serializer = store.serializerFor(typeClass.modelName);
       var record = serializer.extract(store, typeClass, data, data.id, 'single');
 
       store.push(message.modelName, record);

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -96,7 +96,7 @@ var Adapter = Ember.Object.extend({
     ```javascript
     App.ApplicationAdapter = DS.Adapter.extend({
       find: function(store, type, id, snapshot) {
-        var url = [type.typeKey, id].join('/');
+        var url = [type.modelName, id].join('/');
 
         return new Ember.RSVP.Promise(function(resolve, reject) {
           jQuery.getJSON(url).then(function(data) {
@@ -235,7 +235,7 @@ var Adapter = Ember.Object.extend({
     @return {Object} serialized snapshot
   */
   serialize: function(snapshot, options) {
-    return get(snapshot.record, 'store').serializerFor(snapshot.typeKey).serialize(snapshot, options);
+    return get(snapshot.record, 'store').serializerFor(snapshot.modelName).serialize(snapshot, options);
   },
 
   /**

--- a/packages/ember-data/lib/system/debug/debug-adapter.js
+++ b/packages/ember-data/lib/system/debug/debug-adapter.js
@@ -42,8 +42,8 @@ export default Ember.DataAdapter.extend({
     return columns;
   },
 
-  getRecords: function(typeKey) {
-    return this.get('store').all(typeKey);
+  getRecords: function(modelName) {
+    return this.get('store').all(modelName);
   },
 
   getRecordColumnValues: function(record) {

--- a/packages/ember-data/lib/system/many-array.js
+++ b/packages/ember-data/lib/system/many-array.js
@@ -226,7 +226,7 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
     var type = get(this, 'type');
     var record;
 
-    Ember.assert("You cannot add '" + type.typeKey + "' records to this polymorphic relationship.", !get(this, 'isPolymorphic'));
+    Ember.assert("You cannot add '" + type.modelName + "' records to this polymorphic relationship.", !get(this, 'isPolymorphic'));
 
     record = store.createRecord(type, hash);
     this.pushObject(record);

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -1252,7 +1252,35 @@ Model.reopenClass({
   */
   create: function() {
     throw new Ember.Error("You should not call `create` on a model. Instead, call `store.createRecord` with the attributes you would like to set.");
-  }
+  },
+
+  /**
+   Represents the model's class name as a string. This can be used to look up the model through
+   DS.Store's modelFor method.
+
+   `modelName` is generated for you by Ember Data. It will be a lowercased, dasherized string.
+   For example:
+
+   ```javascript
+   store.modelFor('post').modelName; // 'post'
+   store.modelFor('blog-post').modelName; // 'blog-post'
+   ```
+
+   The most common place you'll want to access `modelName` is in your serializer's `payloadKeyFromModelName` method. For example, to change payload
+   keys to underscore (instead of dasherized), you might use the following code:
+
+   ```javascript
+   export default var PostSerializer = DS.RESTSerializer.extend({
+     payloadKeyFromModelName: function(modelName) {
+       return Ember.String.underscore(modelName);
+     }
+   });
+   ```
+   @property
+   @type String
+   @readonly
+  */
+  modelName: null
 });
 
 export default Model;

--- a/packages/ember-data/lib/system/normalize-model-name.js
+++ b/packages/ember-data/lib/system/normalize-model-name.js
@@ -1,0 +1,12 @@
+/**
+  All modelNames are dasherized internally. Changing this function may
+  require changes to other normalization hooks (such as typeForRoot).
+  @method normalizeModelName
+  @public
+  @param {String} type
+  @return {String} if the adapter can generate one, an ID
+  @for DS
+*/
+export default function normalizeModelName(modelName) {
+  return Ember.String.dasherize(modelName);
+}

--- a/packages/ember-data/lib/system/record-array-manager.js
+++ b/packages/ember-data/lib/system/record-array-manager.js
@@ -142,11 +142,11 @@ export default Ember.Object.extend({
 
     @method updateFilter
     @param {Array} array
-    @param {String} typeKey
+    @param {String} modelName
     @param {Function} filter
   */
-  updateFilter: function(array, typeKey, filter) {
-    var typeMap = this.store.typeMapFor(typeKey);
+  updateFilter: function(array, modelName, filter) {
+    var typeMap = this.store.typeMapFor(modelName);
     var records = typeMap.records;
     var record;
 
@@ -154,7 +154,7 @@ export default Ember.Object.extend({
       record = records[i];
 
       if (!get(record, 'isDeleted') && !get(record, 'isEmpty')) {
-        this.updateRecordArray(array, filter, typeKey, record);
+        this.updateRecordArray(array, filter, modelName, record);
       }
     }
   },

--- a/packages/ember-data/lib/system/relationship-meta.js
+++ b/packages/ember-data/lib/system/relationship-meta.js
@@ -1,14 +1,14 @@
-import { singularize } from "ember-inflector/lib/system";
+import {singularize} from 'ember-inflector/lib/system/string';
 
 export function typeForRelationshipMeta(store, meta) {
-  var typeKey, typeClass;
+  var modelName, typeClass;
 
-  typeKey = meta.type || meta.key;
-  if (typeof typeKey === 'string') {
+  modelName = meta.type || meta.key;
+  if (typeof modelName === 'string') {
     if (meta.kind === 'hasMany') {
-      typeKey = singularize(typeKey);
+      modelName = singularize(modelName);
     }
-    typeClass = store.modelFor(typeKey);
+    typeClass = store.modelFor(modelName);
   } else {
     typeClass = meta.type;
   }

--- a/packages/ember-data/lib/system/relationships/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/belongs-to.js
@@ -1,6 +1,7 @@
 import Model from 'ember-data/system/model';
 
 import computedPolyfill from "ember-data/utils/computed-polyfill";
+import normalizeModelName from "ember-data/system/normalize-model-name";
 
 /**
   `DS.belongsTo` is used to define One-To-One and One-To-Many
@@ -56,24 +57,32 @@ import computedPolyfill from "ember-data/utils/computed-polyfill";
   @namespace
   @method belongsTo
   @for DS
-  @param {String} type (optional) type of the relationship
+  @param {String} modelName (optional) type of the relationship
   @param {Object} options (optional) a hash of options
   @return {Ember.computed} relationship
 */
-function belongsTo(type, options) {
-  if (typeof type === 'object') {
-    options = type;
-    type = undefined;
+function belongsTo(modelName, options) {
+  var opts, userEnteredModelName;
+  if (typeof modelName === 'object') {
+    opts = modelName;
+    userEnteredModelName = undefined;
+  } else {
+    opts = options;
+    userEnteredModelName = modelName;
   }
 
-  Ember.assert("The first argument to DS.belongsTo must be a string representing a model type key, not an instance of " + Ember.inspect(type) + ". E.g., to define a relation to the Person model, use DS.belongsTo('person')", typeof type === 'string' || typeof type === 'undefined');
+  if (typeof userEnteredModelName === 'string') {
+    userEnteredModelName = normalizeModelName(userEnteredModelName);
+  }
 
-  options = options || {};
+  Ember.assert("The first argument to DS.belongsTo must be a string representing a model type key, not an instance of " + Ember.inspect(userEnteredModelName) + ". E.g., to define a relation to the Person model, use DS.belongsTo('person')", typeof userEnteredModelName === 'string' || typeof userEnteredModelName === 'undefined');
+
+  opts = opts || {};
 
   var meta = {
-    type: type,
+    type: userEnteredModelName,
     isRelationship: true,
-    options: options,
+    options: opts,
     kind: 'belongsTo',
     key: null
   };

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -43,7 +43,7 @@ var relatedTypesDescriptor = Ember.computed(function() {
     relatedTypesDescriptor._cacheable = false;
   }
 
-  var typeKey;
+  var modelName;
   var types = Ember.A();
 
   // Loop through each computed property on the class,
@@ -52,13 +52,13 @@ var relatedTypesDescriptor = Ember.computed(function() {
   this.eachComputedProperty(function(name, meta) {
     if (meta.isRelationship) {
       meta.key = name;
-      typeKey = typeForRelationshipMeta(this.store, meta);
+      modelName = typeForRelationshipMeta(this.store, meta);
 
-      Ember.assert("You specified a hasMany (" + meta.type + ") on " + meta.parentType + " but " + meta.type + " was not found.", typeKey);
+      Ember.assert("You specified a hasMany (" + meta.type + ") on " + meta.parentType + " but " + meta.type + " was not found.", modelName);
 
-      if (!types.contains(typeKey)) {
-        Ember.assert("Trying to sideload " + name + " on " + this.toString() + " but the type doesn't exist.", !!typeKey);
-        types.push(typeKey);
+      if (!types.contains(modelName)) {
+        Ember.assert("Trying to sideload " + name + " on " + this.toString() + " but the type doesn't exist.", !!modelName);
+        types.push(modelName);
       }
     }
   });
@@ -235,14 +235,14 @@ Model.reopenClass({
 
     var inverseName, inverseKind, inverse;
 
-    Ember.warn("Detected a reflexive relationship by the name of '" + name + "' without an inverse option. Look at http://emberjs.com/guides/models/defining-models/#toc_reflexive-relation for how to explicitly specify inverses.", options.inverse || propertyMeta.type !== propertyMeta.parentType.typeKey);
+    Ember.warn("Detected a reflexive relationship by the name of '" + name + "' without an inverse option. Look at http://emberjs.com/guides/models/defining-models/#toc_reflexive-relation for how to explicitly specify inverses.", options.inverse || propertyMeta.type !== propertyMeta.parentType.modelName);
 
     //If inverse is specified manually, return the inverse
     if (options.inverse) {
       inverseName = options.inverse;
       inverse = Ember.get(inverseType, 'relationshipsByName').get(inverseName);
 
-      Ember.assert("We found no inverse relationships by the name of '" + inverseName + "' on the '" + inverseType.typeKey +
+      Ember.assert("We found no inverse relationships by the name of '" + inverseName + "' on the '" + inverseType.modelName +
         "' model. This is most likely due to a missing attribute on your model definition.", !Ember.isNone(inverse));
 
       inverseKind = inverse.kind;

--- a/packages/ember-data/lib/system/relationships/has-many.js
+++ b/packages/ember-data/lib/system/relationships/has-many.js
@@ -3,6 +3,7 @@
 */
 
 import Model from "ember-data/system/model";
+import normalizeModelName from "ember-data/system/normalize-model-name";
 
 /**
   `DS.hasMany` is used to define One-To-Many and Many-To-Many
@@ -102,6 +103,10 @@ function hasMany(type, options) {
   Ember.assert("The first argument to DS.hasMany must be a string representing a model type key, not an instance of " + Ember.inspect(type) + ". E.g., to define a relation to the Comment model, use DS.hasMany('comment')", typeof type === 'string' || typeof type === 'undefined');
 
   options = options || {};
+
+  if (typeof type === 'string') {
+    type = normalizeModelName(type);
+  }
 
   // Metadata about relationships is stored on the meta of
   // the relationship. This is used for introspection and

--- a/packages/ember-data/lib/system/relationships/state/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs-to.js
@@ -62,7 +62,7 @@ BelongsToRelationship.prototype._super$addRecord = Relationship.prototype.addRec
 BelongsToRelationship.prototype.addRecord = function(newRecord) {
   if (this.members.has(newRecord)) { return;}
   var type = this.relationshipMeta.type;
-  Ember.assert("You cannot add a '" + newRecord.constructor.typeKey + "' record to the '" + this.record.constructor.typeKey + "." + this.key +"'. " + "You can only add a '" + type.typeKey + "' record to this relationship.", (function () {
+  Ember.assert("You cannot add a '" + newRecord.constructor.modelName + "' record to the '" + this.record.constructor.modelName + "." + this.key +"'. " + "You can only add a '" + type.modelName + "' record to this relationship.", (function () {
     if (type.__isMixin) {
       return type.__mixin.detect(newRecord);
     }
@@ -138,7 +138,7 @@ BelongsToRelationship.prototype.getRecord = function() {
       content: this.inverseRecord
     });
   } else {
-    Ember.assert("You looked up the '" + this.key + "' relationship on a '" + this.record.constructor.typeKey + "' with id " + this.record.get('id') +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.belongsTo({ async: true })`)", this.inverseRecord === null || !this.inverseRecord.get('isEmpty'));
+    Ember.assert("You looked up the '" + this.key + "' relationship on a '" + this.record.constructor.modelName + "' with id " + this.record.get('id') +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.belongsTo({ async: true })`)", this.inverseRecord === null || !this.inverseRecord.get('isEmpty'));
     return this.inverseRecord;
   }
 };

--- a/packages/ember-data/lib/system/relationships/state/has-many.js
+++ b/packages/ember-data/lib/system/relationships/state/has-many.js
@@ -85,7 +85,7 @@ ManyRelationship.prototype.removeRecordFromOwn = function(record, idx) {
 
 ManyRelationship.prototype.notifyRecordRelationshipAdded = function(record, idx) {
   var type = this.relationshipMeta.type;
-  Ember.assert("You cannot add '" + record.constructor.typeKey + "' records to the " + this.record.constructor.typeKey + "." + this.key + " relationship (only '" + this.belongsToType.typeKey + "' allowed)", (function () {
+  Ember.assert("You cannot add '" + record.constructor.modelName + "' records to the " + this.record.constructor.modelName + "." + this.key + " relationship (only '" + this.belongsToType.modelName + "' allowed)", (function () {
     if (type.__isMixin) {
       return type.__mixin.detect(record);
     }
@@ -180,7 +180,7 @@ ManyRelationship.prototype.getRecords = function() {
       promise: promise
     });
   } else {
-    Ember.assert("You looked up the '" + this.key + "' relationship on a '" + this.record.constructor.typeKey + "' with id " + this.record.get('id') +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", this.manyArray.isEvery('isEmpty', false));
+    Ember.assert("You looked up the '" + this.key + "' relationship on a '" + this.record.constructor.modelName + "' with id " + this.record.get('id') +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", this.manyArray.isEvery('isEmpty', false));
 
     //TODO(Igor) WTF DO I DO HERE?
     if (!this.manyArray.get('isDestroyed')) {

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -12,8 +12,8 @@ var Relationship = function(store, record, inverseKey, relationshipMeta) {
   this.isAsync = relationshipMeta.options.async;
   this.relationshipMeta = relationshipMeta;
   //This probably breaks for polymorphic relationship in complex scenarios, due to
-  //multiple possible typeKeys
-  this.inverseKeyForImplicit = this.store.modelFor(this.record.constructor).typeKey + this.key;
+  //multiple possible modelNames
+  this.inverseKeyForImplicit = this.store.modelFor(this.record.constructor).modelName + this.key;
   this.linkPromise = null;
   this.hasData = false;
 };
@@ -204,8 +204,8 @@ Relationship.prototype = {
   },
 
   updateLink: function(link) {
-    Ember.warn("You have pushed a record of type '" + this.record.constructor.typeKey + "' with '" + this.key + "' as a link, but the association is not an async relationship.", this.isAsync);
-    Ember.assert("You have pushed a record of type '" + this.record.constructor.typeKey + "' with '" + this.key + "' as a link, but the value of that link is not a string.", typeof link === 'string' || link === null);
+    Ember.warn("You have pushed a record of type '" + this.record.constructor.modelName + "' with '" + this.key + "' as a link, but the association is not an async relationship.", this.isAsync);
+    Ember.assert("You have pushed a record of type '" + this.record.constructor.modelName + "' with '" + this.key + "' as a link, but the value of that link is not a string.", typeof link === 'string' || link === null);
     if (link !== this.link) {
       this.link = link;
       this.linkPromise = null;

--- a/packages/ember-data/lib/system/snapshot.js
+++ b/packages/ember-data/lib/system/snapshot.js
@@ -25,7 +25,7 @@ function Snapshot(record) {
   this.id = get(record, 'id');
   this.record = record;
   this.type = record.constructor;
-  this.typeKey = record.constructor.typeKey;
+  this.modelName = record.constructor.modelName;
 
   // The following code is here to keep backwards compatibility when accessing
   // `constructor` directly.
@@ -100,10 +100,10 @@ Snapshot.prototype = {
   /**
     The name of the type of the underlying record for this snapshot, as a string.
 
-    @property typeKey
+    @property modelName
     @type {String}
   */
-  typeKey: null,
+  modelName: null,
 
   /**
     Returns the value of an attribute.
@@ -381,5 +381,16 @@ Snapshot.prototype = {
     return this;
   }
 };
+
+Ember.defineProperty(Snapshot.prototype, 'typeKey', {
+  enumerable: false,
+  get: function() {
+    Ember.deprecate('Snapshot.typeKey is deprecated. Use snapshot.modelName instead.');
+    return this.modelName;
+  },
+  set: function() {
+    Ember.assert('Setting snapshot.typeKey is not supported. In addition, Snapshot.typeKey has been deprecated for Snapshot.modelName.');
+  }
+});
 
 export default Snapshot;

--- a/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -147,7 +147,7 @@ test('buildURL - with camelized names', function() {
   adapter.setProperties({
     pathForType: function(type) {
       var decamelized = Ember.String.decamelize(type);
-      return Ember.String.pluralize(decamelized);
+      return Ember.String.underscore(Ember.String.pluralize(decamelized));
     }
   });
 

--- a/packages/ember-data/tests/integration/backwards-compat/deprecate-type-key-test.js
+++ b/packages/ember-data/tests/integration/backwards-compat/deprecate-type-key-test.js
@@ -1,0 +1,24 @@
+var Post, env;
+module('integration/backwards-compat/deprecate-type-key', {
+  setup: function() {
+    env = setupStore({
+      post: DS.Model.extend()
+    });
+    Post = env.store.modelFor('post');
+  },
+
+  teardown: function() {
+  }
+});
+
+test('typeKey is deprecated', function() {
+  expectDeprecation(function() {
+    return Post.typeKey;
+  });
+});
+
+test('setting typeKey is not allowed', function() {
+  throws(function() {
+    Post.typeKey = 'hello';
+  });
+});

--- a/packages/ember-data/tests/integration/backwards-compat/non-dasherized-lookups.js
+++ b/packages/ember-data/tests/integration/backwards-compat/non-dasherized-lookups.js
@@ -1,0 +1,121 @@
+var App, store;
+
+var run = Ember.run;
+module('integration/backwards-compat/non-dasherized-lookups - non dasherized lookups in application code finders', {
+  setup: function() {
+    run(function() {
+      App = Ember.Application.create();
+      App.PostNote = DS.Model.extend({
+        name: DS.attr()
+      });
+    });
+    store = App.__container__.lookup('store:main');
+  },
+  teardown: function() {
+    run(App, 'destroy');
+    App = null;
+  }
+});
+
+test('can lookup models using camelCase strings', function() {
+  expect(1);
+  run(function() {
+    store.pushPayload('postNote', {
+      postNote: {
+        id: 1,
+        name: 'Ember Data'
+      }
+    });
+  });
+
+  run(function() {
+    store.find('postNote', 1).then(async(function(postNote) {
+      equal(postNote.get('id'), 1);
+    }));
+  });
+});
+
+test('can lookup models using underscored strings', function() {
+  run(function() {
+    store.pushPayload('post_note', {
+      postNote: {
+        id: 1,
+        name: 'Ember Data'
+      }
+    });
+
+    run(function() {
+      store.find('post_note', 1).then(async(function(postNote) {
+        equal(postNote.get('id'), 1);
+      }));
+    });
+  });
+});
+
+module('integration/backwards-compat/non-dasherized-lookups - non dasherized lookups in application code relationship macros', {
+  setup: function() {
+    run(function() {
+      App = Ember.Application.create();
+      App.PostNote = DS.Model.extend({
+        notePost: DS.belongsTo('notePost'),
+        name: DS.attr()
+      });
+      App.NotePost = DS.Model.extend({
+        name: DS.attr()
+      });
+      App.LongModelName = DS.Model.extend({
+        postNotes: DS.hasMany('post_note')
+      });
+    });
+    store = App.__container__.lookup('store:main');
+  },
+
+  teardown: function() {
+    run(App, 'destroy');
+    App = null;
+  }
+});
+
+test('looks up using camelCase string', function() {
+  expect(1);
+
+  run(function() {
+    store.push('postNote', {
+      id: 1,
+      notePost: 1
+    });
+    store.push('notePost', {
+      id: 1,
+      name: 'Inverse'
+    });
+  });
+
+  run(function() {
+    store.find('postNote', 1).then(function(postNote) {
+      equal(postNote.get('notePost'), store.getById('notePost', 1));
+    });
+  });
+});
+
+test('looks up using under_score string', function() {
+  expect(1);
+
+  run(function() {
+    store.push('long_model_name', {
+      id: 1,
+      name: 'Inverse',
+      postNotes: ['1']
+    });
+    store.push('postNote', {
+      id: 1,
+      name: 'Underscore'
+    });
+  });
+
+  run(function() {
+    store.find('long_model_name', 1).then(function(longModelName) {
+      deepEqual(longModelName.get('postNotes').toArray(), [store.getById('postNote', 1)]);
+    });
+  });
+
+});

--- a/packages/ember-data/tests/integration/multiple_stores_test.js
+++ b/packages/ember-data/tests/integration/multiple_stores_test.js
@@ -42,8 +42,8 @@ module("integration/multiple_stores - Multiple Stores Tests", {
 });
 
 test("should be able to push into multiple stores", function() {
-  env.registry.register('adapter:homePlanet', DS.ActiveModelAdapter);
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer);
+  env.registry.register('adapter:home-planet', DS.ActiveModelAdapter);
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer);
 
   var home_planet_main = { id: '1', name: 'Earth' };
   var home_planet_a = { id: '1', name: 'Mars' };
@@ -68,10 +68,10 @@ test("should be able to push into multiple stores", function() {
 });
 
 test("embedded records should be created in multiple stores", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('adapter:homePlanet', DS.ActiveModelAdapter);
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('adapter:home-planet', DS.ActiveModelAdapter);
 
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }

--- a/packages/ember-data/tests/integration/records/reload-test.js
+++ b/packages/ember-data/tests/integration/records/reload-test.js
@@ -118,7 +118,7 @@ test("When a record is reloaded, its async hasMany relationships still work", fu
   var tags = { 1: "hipster", 2: "hair" };
 
   env.adapter.find = function(store, type, id, snapshot) {
-    switch (type.typeKey) {
+    switch (type.modelName) {
       case 'person':
         return Ember.RSVP.resolve({ id: 1, name: "Tom", tags: [1, 2] });
       case 'tag':

--- a/packages/ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/has-many-test.js
@@ -150,7 +150,7 @@ test("A serializer can materialize a hasMany as an opaque token that can be lazi
 
   env.adapter.findHasMany = function(store, snapshot, link, relationship) {
     equal(link, "/posts/1/comments", "findHasMany link was /posts/1/comments");
-    equal(relationship.type.typeKey, "comment", "relationship was passed correctly");
+    equal(relationship.type.modelName, "comment", "relationship was passed correctly");
 
     return Ember.RSVP.resolve([
       { id: 1, body: "First" },
@@ -570,7 +570,7 @@ test("An updated `links` value should invalidate a relationship cache", function
   });
 
   env.adapter.findHasMany = function(store, snapshot, link, relationship) {
-    equal(relationship.type.typeKey, "comment", "relationship was passed correctly");
+    equal(relationship.type.modelName, "comment", "relationship was passed correctly");
 
     if (link === '/first') {
       return Ember.RSVP.resolve([

--- a/packages/ember-data/tests/integration/relationships/polymorphic-mixins-has-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/polymorphic-mixins-has-many-test.js
@@ -100,7 +100,7 @@ test("Pushing a an object that does not implement the mixin to the mixin accepti
     user.get('messages').then(function(fetchedMessages) {
       expectAssertion(function() {
         fetchedMessages.pushObject(notMessage);
-      }, /You cannot add 'notMessage' records to the user\.messages relationship \(only 'message' allowed\)/);
+      }, /You cannot add 'not-message' records to the user\.messages relationship \(only 'message' allowed\)/);
     });
   });
 });
@@ -147,7 +147,7 @@ test("Pushing a an object that does not implement the mixin to the mixin accepti
       user.get('messages').then(function(fetchedMessages) {
         expectAssertion(function() {
           fetchedMessages.pushObject(notMessage);
-        }, /You cannot add 'notMessage' records to the user\.messages relationship \(only 'message' allowed\)/);
+        }, /You cannot add 'not-message' records to the user\.messages relationship \(only 'message' allowed\)/);
       });
     });
   } finally {

--- a/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
@@ -74,14 +74,14 @@ module("integration/embedded_records_mixin - EmbeddedRecordsMixin", {
 });
 
 test("extractSingle with embedded objects", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:homePlanet");
+  var serializer = env.container.lookup("serializer:home-planet");
   var json_hash = {
     home_planet: {
       id: "1",
@@ -112,19 +112,19 @@ test("extractSingle with embedded objects", function() {
 });
 
 test("extractSingle with embedded objects inside embedded objects", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
   }));
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       evilMinions: { embedded: 'always' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:homePlanet");
+  var serializer = env.container.lookup("serializer:home-planet");
   var json_hash = {
     home_planet: {
       id: "1",
@@ -152,14 +152,14 @@ test("extractSingle with embedded objects inside embedded objects", function() {
     villains: ["1"]
   });
   run(function() {
-    env.store.find("superVillain", 1).then(function(villain) {
+    env.store.find("superVillain", 1).then(async(function(villain) {
       equal(villain.get('firstName'), "Tom");
       equal(villain.get('evilMinions.length'), 1, "Should load the embedded child");
       equal(villain.get('evilMinions.firstObject.name'), "Alex", "Should load the embedded child");
-    });
-    env.store.find("evilMinion", 1).then(function(minion) {
+    }));
+    env.store.find("evilMinion", 1).then(async(function(minion) {
       equal(minion.get('name'), "Alex");
-    });
+    }));
   });
 });
 
@@ -258,15 +258,15 @@ test("extractSingle with embedded objects of same type, but from separate attrib
     reformedVillains: DS.hasMany('superVillain', { inverse: null })
   });
 
-  env.registry.register('adapter:home_planet', DS.ActiveModelAdapter);
-  env.registry.register('serializer:home_planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:home-planet', DS.ActiveModelAdapter);
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' },
       reformedVillains: { embedded: 'always' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:home_planet");
+  var serializer = env.container.lookup("serializer:home-planet");
   var json_hash = {
     home_planet: {
       id: "1",
@@ -306,14 +306,14 @@ test("extractSingle with embedded objects of same type, but from separate attrib
 });
 
 test("extractArray with embedded objects", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:homePlanet");
+  var serializer = env.container.lookup("serializer:home-planet");
 
   var json_hash = {
     home_planets: [{
@@ -347,17 +347,17 @@ test("extractArray with embedded objects", function() {
 
 test("extractArray with embedded objects with custom primary key", function() {
   expect(2);
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend({
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend({
     primaryKey: 'villain_id'
   }));
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:homePlanet");
+  var serializer = env.container.lookup("serializer:home-planet");
 
   var json_hash = {
     home_planets: [{
@@ -384,15 +384,15 @@ test("extractArray with embedded objects with custom primary key", function() {
 
   run(function() {
     return env.store.find("superVillain", 1).then(function(minion) {
-      env.registry.unregister('serializer:superVillain');
+      env.registry.unregister('serializer:super-villain');
       equal(minion.get('firstName'), "Alex");
     });
   });
 });
 test("extractArray with embedded objects with identical relationship and attribute key ", function() {
   expect(2);
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     },
@@ -402,7 +402,7 @@ test("extractArray with embedded objects with identical relationship and attribu
     }
   }));
 
-  var serializer = env.container.lookup("serializer:homePlanet");
+  var serializer = env.container.lookup("serializer:home-planet");
 
   var json_hash = {
     home_planets: [{
@@ -482,15 +482,15 @@ test("extractArray with embedded objects of same type, but from separate attribu
     reformedVillains: DS.hasMany('superVillain')
   });
 
-  env.registry.register('adapter:homePlanet', DS.ActiveModelAdapter);
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:home-planet', DS.ActiveModelAdapter);
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' },
       reformedVillains: { embedded: 'always' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:homePlanet");
+  var serializer = env.container.lookup("serializer:home-planet");
   var json_hash = {
     home_planets: [{
       id: "1",
@@ -559,14 +559,14 @@ test("serialize supports serialize:false on non-relationship properties", functi
     tom = env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", id: '1' });
   });
 
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       firstName: { serialize: false }
     }
   }));
   var serializer, json;
   run(function() {
-    serializer = env.container.lookup("serializer:superVillain");
+    serializer = env.container.lookup("serializer:super-villain");
     json = serializer.serialize(tom._createSnapshot());
   });
 
@@ -584,7 +584,7 @@ test("serialize with embedded objects (hasMany relationship)", function() {
     tom = env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
   });
 
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
@@ -592,7 +592,7 @@ test("serialize with embedded objects (hasMany relationship)", function() {
 
   var serializer, json;
   run(function() {
-    serializer = env.container.lookup("serializer:homePlanet");
+    serializer = env.container.lookup("serializer:home-planet");
 
     json = serializer.serialize(league._createSnapshot());
   });
@@ -615,14 +615,14 @@ test("serialize with embedded objects (hasMany relationship) supports serialize:
     env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
   });
 
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { serialize: false }
     }
   }));
   var serializer, json;
   run(function() {
-    serializer = env.container.lookup("serializer:homePlanet");
+    serializer = env.container.lookup("serializer:home-planet");
 
     json = serializer.serialize(league._createSnapshot());
   });
@@ -638,14 +638,14 @@ test("serialize with (new) embedded objects (hasMany relationship)", function() 
     env.store.createRecord(SuperVillain, { firstName: "Tom", lastName: "Dale", homePlanet: league });
   });
 
-  env.registry.register('serializer:homePlanet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:home-planet', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       villains: { embedded: 'always' }
     }
   }));
   var serializer, json;
   run(function() {
-    serializer = env.container.lookup("serializer:homePlanet");
+    serializer = env.container.lookup("serializer:home-planet");
 
     json = serializer.serialize(league._createSnapshot());
   });
@@ -669,7 +669,7 @@ test("serialize with embedded objects (hasMany relationships, including related 
     superVillain.get('secretWeapons').pushObject(secretWeapon);
   });
 
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       evilMinions: { serialize: 'records', deserialize: 'records' },
       secretWeapons: { serialize: 'ids' }
@@ -677,7 +677,7 @@ test("serialize with embedded objects (hasMany relationships, including related 
   }));
   var serializer, json;
   run(function() {
-    serializer = env.container.lookup("serializer:superVillain");
+    serializer = env.container.lookup("serializer:super-villain");
 
     json = serializer.serialize(superVillain._createSnapshot());
   });
@@ -697,14 +697,14 @@ test("serialize with embedded objects (hasMany relationships, including related 
 
 test("extractSingle with embedded object (belongsTo relationship)", function() {
   expect(4);
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { embedded: 'always' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
 
   var json_hash = {
     super_villain: {
@@ -747,15 +747,15 @@ test("extractSingle with embedded object (belongsTo relationship)", function() {
 });
 
 test("serialize with embedded object (belongsTo relationship)", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { embedded: 'always' }
     }
   }));
   var serializer, json, tom;
   run(function() {
-    serializer = env.container.lookup("serializer:superVillain");
+    serializer = env.container.lookup("serializer:super-villain");
 
     // records with an id, persisted
 
@@ -785,18 +785,18 @@ test("serialize with embedded object (belongsTo relationship)", function() {
 });
 
 test("serialize with embedded object (belongsTo relationship) works with different primaryKeys", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     primaryKey: '_id',
     attrs: {
       secretLab: { embedded: 'always' }
     }
   }));
-  env.registry.register('serializer:secretLab', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:secret-lab', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     primaryKey: 'crazy_id'
   }));
 
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
 
   // records with an id, persisted
   var tom, json;
@@ -805,8 +805,8 @@ test("serialize with embedded object (belongsTo relationship) works with differe
     tom = env.store.createRecord(
       SuperVillain,
       { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord(SecretLab, { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" })
+        secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
       }
     );
   });
@@ -828,14 +828,14 @@ test("serialize with embedded object (belongsTo relationship) works with differe
 });
 
 test("serialize with embedded object (belongsTo relationship, new no id)", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { embedded: 'always' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
 
   // records without ids, new
   var tom, json;
@@ -866,13 +866,13 @@ test("serialize with embedded object (belongsTo relationship, new no id)", funct
 });
 
 test("serialize with embedded object (belongsTo relationship) supports serialize:ids", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { serialize: 'ids' }
     }
   }));
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
 
   // records with an id, persisted
   var tom, json;
@@ -900,14 +900,14 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
 });
 
 test("serialize with embedded object (belongsTo relationship) supports serialize:id", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { serialize: 'id' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
 
   // records with an id, persisted
   var tom, json;
@@ -935,14 +935,14 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
 });
 
 test("serialize with embedded object (belongsTo relationship) supports serialize:id in conjunction with deserialize:records", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { serialize: 'id', deserialize: 'records' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
 
   // records with an id, persisted
   var tom, json;
@@ -951,8 +951,8 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
     tom = env.store.createRecord(
       SuperVillain,
       { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord(SecretLab, { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord(HomePlanet, { name: "Villain League", id: "123" })
+        secretLab: env.store.createRecord('secretLab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+        homePlanet: env.store.createRecord('homePlanet', { name: "Villain League", id: "123" })
       }
     );
   });
@@ -970,13 +970,13 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
 });
 
 test("serialize with embedded object (belongsTo relationship) supports serialize:false", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { serialize: false }
     }
   }));
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
 
   // records with an id, persisted
   var tom, json;
@@ -1002,9 +1002,9 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
 });
 
 test("serialize with embedded object (belongsTo relationship) serializes the id by default if no option specified", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
-  var serializer = env.container.lookup("serializer:superVillain");
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin));
+  var serializer = env.container.lookup("serializer:super-villain");
 
   // records with an id, persisted
 
@@ -1033,13 +1033,13 @@ test("serialize with embedded object (belongsTo relationship) serializes the id 
 });
 
 test("when related record is not present, serialize embedded record (with a belongsTo relationship) as null", function() {
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { embedded: 'always' }
     }
   }));
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
   var tom, json;
 
   run(function() {
@@ -1064,19 +1064,19 @@ test("when related record is not present, serialize embedded record (with a belo
 });
 
 test("extractSingle with multiply-nested belongsTo", function() {
-  env.registry.register('adapter:evilMinion', DS.ActiveModelAdapter);
-  env.registry.register('serializer:evilMinion', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:evil-minion', DS.ActiveModelAdapter);
+  env.registry.register('serializer:evil-minion', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       superVillain: { embedded: 'always' }
     }
   }));
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       homePlanet: { embedded: 'always' }
     }
   }));
 
-  var serializer = env.container.lookup("serializer:evilMinion");
+  var serializer = env.container.lookup("serializer:evil-minion");
   var json_hash = {
     evil_minion: {
       id: "1",
@@ -1115,13 +1115,13 @@ test("extractSingle with polymorphic hasMany", function() {
     secretWeapons: DS.hasMany("secretWeapon", { polymorphic: true })
   });
 
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretWeapons: { embedded: 'always' }
     }
   }));
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
 
   var json_hash = {
     super_villain: {
@@ -1154,8 +1154,8 @@ test("extractSingle with polymorphic hasMany", function() {
     firstName: "Tom",
     lastName: "Dale",
     secretWeapons: [
-      { id: "1", type: "lightSaber" },
-      { id: "1", type: "secretWeapon" }
+      { id: "1", type: "light-saber" },
+      { id: "1", type: "secret-weapon" }
     ]
   }, "Primary hash was correct");
 
@@ -1172,13 +1172,13 @@ test("extractSingle with polymorphic belongsTo", function() {
     secretLab: DS.belongsTo("secretLab", { polymorphic: true })
   });
 
-  env.registry.register('adapter:superVillain', DS.ActiveModelAdapter);
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:super-villain', DS.ActiveModelAdapter);
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       secretLab: { embedded: 'always' }
     }
   }));
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
 
   var json_hash = {
     super_villain: {
@@ -1187,7 +1187,7 @@ test("extractSingle with polymorphic belongsTo", function() {
       last_name: "Dale",
       secret_lab: {
         id: "1",
-        type: "BatCave",
+        type: "bat-cave",
         infiltrated: true
       }
     }
@@ -1204,7 +1204,7 @@ test("extractSingle with polymorphic belongsTo", function() {
     firstName: "Tom",
     lastName: "Dale",
     secretLab: "1",
-    secretLabType: "batCave"
+    secretLabType: "bat-cave"
   }, "Primary has was correct");
 
   equal(env.store.recordForId("batCave", "1").get("infiltrated"), true, "Embedded polymorphic BatCave was found");
@@ -1224,14 +1224,14 @@ test("Mixin can be used with RESTSerializer which does not define keyForAttribut
     superVillain.get('evilMinions').pushObject(evilMinion);
   });
 
-  env.registry.register('serializer:evilMinion', DS.RESTSerializer);
-  env.registry.register('serializer:secretWeapon', DS.RESTSerializer);
-  env.registry.register('serializer:superVillain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:evil-minion', DS.RESTSerializer);
+  env.registry.register('serializer:secret-weapon', DS.RESTSerializer);
+  env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       evilMinions: { serialize: 'records', deserialize: 'records' }
     }
   }));
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
   var json;
 
   run(function() {
@@ -1254,17 +1254,17 @@ test("Mixin can be used with RESTSerializer which does not define keyForAttribut
 });
 
 test("normalize with custom belongsTo primary key", function() {
-  env.registry.register('adapter:evilMinion', DS.ActiveModelAdapter);
-  env.registry.register('serializer:evilMinion', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('adapter:evil-minion', DS.ActiveModelAdapter);
+  env.registry.register('serializer:evil-minion', DS.ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       superVillain: { embedded: 'always' }
     }
   }));
-  env.registry.register('serializer:superVillain', DS.ActiveModelSerializer.extend({
+  env.registry.register('serializer:super-villain', DS.ActiveModelSerializer.extend({
     primaryKey: 'custom'
   }));
 
-  var serializer = env.container.lookup("serializer:evilMinion");
+  var serializer = env.container.lookup("serializer:evil-minion");
   var json_hash = {
     evil_minion: {
       id: "1",
@@ -1324,16 +1324,16 @@ test("serializing relationships with an embedded and without calls super when no
       }
     }
   });
-  env.registry.register('serializer:evilMinion', Serializer);
-  env.registry.register('serializer:secretWeapon', Serializer);
-  env.registry.register('serializer:superVillain', Serializer.extend(DS.EmbeddedRecordsMixin, {
+  env.registry.register('serializer:evil-minion', Serializer);
+  env.registry.register('serializer:secret-weapon', Serializer);
+  env.registry.register('serializer:super-villain', Serializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
       evilMinions: { serialize: 'records', deserialize: 'records' }
       // some relationships are not listed here, so super should be called on those
       // e.g. secretWeapons: { serialize: 'ids' }
     }
   }));
-  var serializer = env.container.lookup("serializer:superVillain");
+  var serializer = env.container.lookup("serializer:super-villain");
 
   var json;
   run(function() {

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -163,7 +163,7 @@ test("serializePolymorphicType sync", function() {
     serializePolymorphicType: function(record, json, relationship) {
       var key = relationship.key;
       var belongsTo = record.belongsTo(key);
-      json[relationship.key + "TYPE"] = belongsTo.typeKey;
+      json[relationship.key + "TYPE"] = belongsTo.modelName;
 
       ok(true, 'serializePolymorphicType is called when serialize a polymorphic belongsTo');
     }
@@ -472,7 +472,7 @@ test('serializeBelongsTo with async polymorphic', function() {
   env.registry.register('serializer:favorite', DS.JSONSerializer.extend({
     serializePolymorphicType: function(snapshot, json, relationship) {
       var key = relationship.key;
-      json[key + 'TYPE'] = snapshot.belongsTo(key).typeKey;
+      json[key + 'TYPE'] = snapshot.belongsTo(key).modelName;
     }
   }));
 

--- a/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
@@ -49,10 +49,10 @@ module("integration/serializer/rest - RESTSerializer", {
   }
 });
 
-test("typeForRoot returns always same typeKey even for uncountable multi words keys", function() {
+test("typeForRoot returns always same modelName even for uncountable multi words keys", function() {
   expect(2);
   Ember.Inflector.inflector.uncountable('words');
-  var expectedTypeKey = 'multiWords';
+  var expectedTypeKey = 'multi-words';
   equal(env.restSerializer.typeForRoot('multi_words'), expectedTypeKey);
   equal(env.restSerializer.typeForRoot('multiWords'), expectedTypeKey);
 });
@@ -170,7 +170,7 @@ test("pushPayload - single record payload - warning with custom typeForRoot", fu
     }
   });
 
-  env.registry.register("serializer:homePlanet", HomePlanetRestSerializer);
+  env.registry.register("serializer:home-planet", HomePlanetRestSerializer);
 
   var jsonHash = {
     home_planet: { id: "1", name: "Umber", superVillains: [1] },
@@ -226,7 +226,7 @@ test("pushPayload - multiple record payload (extractArray) - warning with custom
     }
   });
 
-  env.registry.register("serializer:homePlanet", HomePlanetRestSerializer);
+  env.registry.register("serializer:home-planet", HomePlanetRestSerializer);
 
   var jsonHash = {
     home_planets: [{ id: "1", name: "Umber", superVillains: [1] }],
@@ -284,8 +284,8 @@ test("serialize polymorphicType", function() {
   });
 });
 
-test("serialize polymorphicType with decamelized typeKey", function() {
-  YellowMinion.typeKey = 'yellow-minion';
+test("serialize polymorphicType with decamelized modelName", function() {
+  YellowMinion.modelName = 'yellow-minion';
   var tom, ray;
   run(function() {
     tom = env.store.createRecord(YellowMinion, { name: "Alex", id: "124" });
@@ -362,7 +362,7 @@ test("extractArray can load secondary records of the same type without affecting
 test("extractSingle loads secondary records with correct serializer", function() {
   var superVillainNormalizeCount = 0;
 
-  env.registry.register('serializer:superVillain', DS.RESTSerializer.extend({
+  env.registry.register('serializer:super-villain', DS.RESTSerializer.extend({
     normalize: function() {
       superVillainNormalizeCount++;
       return this._super.apply(this, arguments);
@@ -399,7 +399,7 @@ test("extractSingle returns null if payload contains null", function() {
 test("extractArray loads secondary records with correct serializer", function() {
   var superVillainNormalizeCount = 0;
 
-  env.registry.register('serializer:superVillain', DS.RESTSerializer.extend({
+  env.registry.register('serializer:super-villain', DS.RESTSerializer.extend({
     normalize: function() {
       superVillainNormalizeCount++;
       return this._super.apply(this, arguments);
@@ -524,8 +524,8 @@ test("serializeIntoHash", function() {
   });
 });
 
-test("serializeIntoHash with decamelized typeKey", function() {
-  HomePlanet.typeKey = 'home-planet';
+test("serializeIntoHash with decamelized modelName", function() {
+  HomePlanet.modelName = 'home-planet';
   run(function() {
     league = env.store.createRecord(HomePlanet, { name: "Umber", id: "123" });
   });

--- a/packages/ember-data/tests/integration/snapshot-test.js
+++ b/packages/ember-data/tests/integration/snapshot-test.js
@@ -54,7 +54,7 @@ test("snapshot._createSnapshot() returns a snapshot (self) but is deprecated", f
 
 });
 
-test("snapshot.id, snapshot.type and snapshot.typeKey returns correctly", function() {
+test("snapshot.id, snapshot.type and snapshot.modelName returns correctly", function() {
   expect(3);
 
   run(function() {
@@ -63,7 +63,7 @@ test("snapshot.id, snapshot.type and snapshot.typeKey returns correctly", functi
 
     equal(snapshot.id, '1', 'id is correct');
     ok(DS.Model.detect(snapshot.type), 'type is correct');
-    equal(snapshot.typeKey, 'post', 'typeKey is correct');
+    equal(snapshot.modelName, 'post', 'modelName is correct');
   });
 });
 
@@ -77,11 +77,11 @@ test("snapshot.constructor is unique and deprecated", function() {
     var postSnapshot = post._createSnapshot();
 
     expectDeprecation(function() {
-      equal(commentSnapshot.constructor.typeKey, 'comment', 'constructor.typeKey is unique per type');
+      equal(commentSnapshot.constructor.modelName, 'comment', 'constructor.modelName is unique per type');
     });
 
     expectDeprecation(function() {
-      equal(postSnapshot.constructor.typeKey, 'post', 'constructor.typeKey is unique per type');
+      equal(postSnapshot.constructor.modelName, 'post', 'constructor.modelName is unique per type');
     });
   });
 });
@@ -512,4 +512,18 @@ test("snapshot.get() proxies property to record unless identified as id, attribu
       equal(snapshot.get('category'), 'Ember.js', 'snapshot proxies unknown property correctly');
     });
   });
+});
+
+test('snapshot.typeKey is deprecated', function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    expectDeprecation(function() {
+      return snapshot.typeKey;
+    });
+  });
+
 });

--- a/packages/ember-data/tests/unit/adapters/rest-adapter/ajax.js
+++ b/packages/ember-data/tests/unit/adapters/rest-adapter/ajax.js
@@ -3,8 +3,8 @@ var run = Ember.run;
 
 module("integration/adapter/ajax - building requests", {
   setup: function() {
-    Person = { typeKey: 'person' };
-    Place = { typeKey: 'place' };
+    Person = { modelName: 'person' };
+    Place = { modelName: 'place' };
     env = setupStore({ adapter: DS.RESTAdapter, person: Person, place: Place });
     store = env.store;
     adapter = env.adapter;

--- a/packages/ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/ember-data/tests/unit/store/adapter-interop-test.js
@@ -80,7 +80,7 @@ test("Calling Store#findById multiple times coalesces the calls into a adapter#f
 
   var currentStore = createStore({ adapter: adapter });
   var currentType = DS.Model.extend();
-  currentType.typeKey = "test";
+  currentType.modelName = "test";
   stop();
   run(function() {
     currentStore.find(currentType, 1);

--- a/packages/ember-data/tests/unit/store/create-record-test.js
+++ b/packages/ember-data/tests/unit/store/create-record-test.js
@@ -24,13 +24,10 @@ test("doesn't modify passed in properties hash", function() {
 module("unit/store/createRecord - Store with models by dash", {
   setup: function() {
     var env = setupStore({
-      'some-thing': DS.Model.extend({ foo: DS.attr('string') })
+      someThing: DS.Model.extend({ foo: DS.attr('string') })
     });
     store = env.store;
     container = env.container;
-    env.replaceContainerNormalize(function(key) {
-      return Ember.String.dasherize(key);
-    });
   }
 });
 test("creating a record by camel-case string finds the model", function() {
@@ -42,7 +39,7 @@ test("creating a record by camel-case string finds the model", function() {
   });
 
   equal(record.get('foo'), attributes.foo, "The record is created");
-  equal(store.modelFor('someThing').typeKey, 'someThing');
+  equal(store.modelFor('someThing').modelName, 'some-thing');
 });
 
 test("creating a record by dasherize string finds the model", function() {
@@ -54,7 +51,7 @@ test("creating a record by dasherize string finds the model", function() {
   });
 
   equal(record.get('foo'), attributes.foo, "The record is created");
-  equal(store.modelFor('some-thing').typeKey, 'someThing');
+  equal(store.modelFor('some-thing').modelName, 'some-thing');
 });
 
 module("unit/store/createRecord - Store with models by camelCase", {
@@ -64,7 +61,6 @@ module("unit/store/createRecord - Store with models by camelCase", {
     });
     store = env.store;
     container = env.container;
-    env.replaceContainerNormalize(Ember.String.camelize);
   }
 });
 
@@ -77,7 +73,7 @@ test("creating a record by camel-case string finds the model", function() {
   });
 
   equal(record.get('foo'), attributes.foo, "The record is created");
-  equal(store.modelFor('someThing').typeKey, 'someThing');
+  equal(store.modelFor('someThing').modelName, 'some-thing');
 });
 
 test("creating a record by dasherize string finds the model", function() {
@@ -89,5 +85,5 @@ test("creating a record by dasherize string finds the model", function() {
   });
 
   equal(record.get('foo'), attributes.foo, "The record is created");
-  equal(store.modelFor('some-thing').typeKey, 'someThing');
+  equal(store.modelFor('some-thing').modelName, 'some-thing');
 });

--- a/packages/ember-data/tests/unit/store/model-for-test.js
+++ b/packages/ember-data/tests/unit/store/model-for-test.js
@@ -10,7 +10,7 @@ module("unit/store/model_for - DS.Store#modelFor", {
   setup: function() {
     env = setupStore({
       blogPost: DS.Model.extend(),
-      "blog-post": DS.Model.extend()
+      "blog.post": DS.Model.extend()
     });
     store = env.store;
     container = store.container;
@@ -25,30 +25,31 @@ module("unit/store/model_for - DS.Store#modelFor", {
   }
 });
 
-test("when fetching factory from string, sets a normalized key as typeKey", function() {
-  env.replaceContainerNormalize(camelize);
-
-  equal(registry.normalize('some.post'), 'somePost', 'precond - container camelizes');
-  equal(store.modelFor("blog.post").typeKey, "blogPost", "typeKey is normalized to camelCase");
-});
-
-test("when fetching factory from string and dashing normalizer, sets a normalized key as typeKey", function() {
-  env.replaceContainerNormalize(function(fullName) {
-    return dasherize(camelize(fullName));
+test("when fetching factory from string, sets a normalized key as modelName", function() {
+  env.replaceContainerNormalize(function(key) {
+    return dasherize(camelize(key));
   });
 
+  equal(registry.normalize('some.post'), 'some-post', 'precond - container camelizes');
+  equal(store.modelFor("blog.post").modelName, "blog.post", "modelName is normalized to dasherized");
+});
+
+test("when fetching factory from string and dashing normalizer, sets a normalized key as modelName", function() {
+  env.replaceContainerNormalize(function(key) {
+    return dasherize(camelize(key));
+  });
   equal(registry.normalize('some.post'), 'some-post', 'precond - container dasherizes');
-  equal(store.modelFor("blog.post").typeKey, "blogPost", "typeKey is normalized to camelCase");
+  equal(store.modelFor("blog.post").modelName, "blog.post", "modelName is normalized to dasherized");
 });
 
-test("when returning passed factory, sets a normalized key as typeKey", function() {
-  var factory = { typeKey: 'some-thing' };
-  equal(store.modelFor(factory).typeKey, "someThing", "typeKey is normalized to camelCase");
+test("when returning passed factory, sets a normalized key as modelName", function() {
+  var factory = { modelName: 'some-thing' };
+  equal(store.modelFor(factory).modelName, "some-thing", "modelName is normalized to dasherized");
 });
 
-test("when returning passed factory without typeKey, allows it", function() {
-  var factory = { typeKey: undefined };
-  equal(store.modelFor(factory).typeKey, undefined, "typeKey is undefined");
+test("when returning passed factory without modelName, allows it", function() {
+  var factory = { modelName: undefined };
+  equal(store.modelFor(factory).modelName, undefined, "modelName is undefined");
 });
 
 test("when fetching something that doesn't exist, throws error", function() {

--- a/tests/ember-configuration.js
+++ b/tests/ember-configuration.js
@@ -71,7 +71,7 @@
     delete options.adapter;
 
     for (var prop in options) {
-      registry.register('model:' + prop, options[prop]);
+      registry.register('model:' + Ember.String.dasherize(prop), options[prop]);
     }
 
     registry.register('store:main', DS.Store.extend({


### PR DESCRIPTION
use dasherized model names everywhere / change typeKey -> modelName

Previously, we allowed container keys to be loosy-goosy and normalized
them in several places. This commit consolidates those efforts into
one place `normalizeTypeKey`.

typeKey is now referred to as modelName on snapshot instances and Model
classes. typeKey remains on both of these but is deprecated.

modelName is now a dasherized string, where previously it was
camelCased.
