### PR TITLE
introduce modelNameFromPayloadKey and deprecate typeForRoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `typeKey` on Snapshots and Model classes has been deprecated. Use
   `modelName` instead.
+- `RESTSerializer#typeForRoot` has been deprecated. You can use
+`RESTSerializeer#modelNameFromPayloadKey` instead.
+- Added `RESTSerializer#payloadKeyFromModelName`. This allows you to
+specify the outgoing root key for a JSON payload.
 
 ### Release 1.0.0-beta.17 (May 10, 2015)
 

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -712,13 +712,13 @@ response to be camelized.
 ```
 
 If your server uses underscored root objects you can define the
-`typeForRoot` method in your `ApplicationSerializer`.
+`modelNameFromPayloadKey` method in your `ApplicationSerializer`.
 
 ```js
 App.ApplicationSerializer = DS.RESTSerializer.extend({
-  typeForRoot: function(root) {
-    var camelized = Ember.String.camelize(root);
-    return Ember.String.singularize(camelized);
+  modelNameFromPayloadKey: function(root) {
+    var dasherize = Ember.String.dasherize(root);
+    return Ember.String.singularize(dasherize);
   }
 });
 ```

--- a/packages/activemodel-adapter/lib/system/active-model-serializer.js
+++ b/packages/activemodel-adapter/lib/system/active-model-serializer.js
@@ -138,17 +138,14 @@ var ActiveModelSerializer = RESTSerializer.extend({
   serializeHasMany: Ember.K,
 
   /**
-    Underscores the JSON root keys when serializing.
+   Underscores the JSON root keys when serializing.
 
-    @method serializeIntoHash
-    @param {Object} hash
-    @param {subclass of DS.Model} typeClass
-    @param {DS.Snapshot} snapshot
-    @param {Object} options
+    @method payloadKeyFromModelName
+    @param {String} modelName
+    @returns {String}
   */
-  serializeIntoHash: function(data, typeClass, snapshot, options) {
-    var root = underscore(decamelize(typeClass.modelName));
-    data[root] = this.serialize(snapshot, options);
+  payloadKeyFromModelName: function(modelName) {
+    return underscore(decamelize(modelName));
   },
 
   /**
@@ -269,11 +266,11 @@ var ActiveModelSerializer = RESTSerializer.extend({
           payloadKey = this.keyForAttribute(key, "deserialize");
           payload = hash[payloadKey];
           if (payload && payload.type) {
-            payload.type = this.typeForRoot(payload.type);
+            payload.type = this.modelNameFromPayloadKey(payload.type);
           } else if (payload && relationship.kind === "hasMany") {
             var self = this;
             forEach(payload, function(single) {
-              single.type = self.typeForRoot(single.type);
+              single.type = self.modelNameFromPayloadKey(single.type);
             });
           }
         } else {
@@ -290,7 +287,7 @@ var ActiveModelSerializer = RESTSerializer.extend({
       }, this);
     }
   },
-  typeForRoot: function(key) {
+  modelNameFromPayloadKey: function(key) {
     var convertedFromRubyModule = camelize(singularize(key)).replace(/(^|\:)([A-Z])/g, function(match, separator, chr) {
       return match.toLowerCase();
     }).replace('::', '/');


### PR DESCRIPTION
Introduced in this commit is payloadKeyFromModelName, which allows you
to specify the outgoing root key for a model name in the JSON payload.

For example:

```javascript
RESTSerializer.extend({modelNameFromPayloadKey: underscore});
```

```json
{
  "taco-party": { }
}
```

becomes

```json
{
  "taco_party": {}
}
```

For symmetry, modelNameFromPayloadKey has been introduced to
look up the ember data record in the store given a JSON root
key. This used to be called pathForType, which has been deprecated.

Part of the refactor stuff covered in https://github.com/emberjs/data/pull/2821#issuecomment-79183508