### PR TITLE
Remove logic for camelCase-ing error keys in ActiveModelAdapter

### DIFF
--- a/packages/activemodel-adapter/lib/system/active-model-adapter.js
+++ b/packages/activemodel-adapter/lib/system/active-model-adapter.js
@@ -6,7 +6,6 @@ import {pluralize} from "ember-inflector";
   @module ember-data
 */
 
-var camelize = Ember.String.camelize;
 var decamelize = Ember.String.decamelize;
 var underscore = Ember.String.underscore;
 
@@ -144,15 +143,6 @@ var ActiveModelAdapter = RESTAdapter.extend({
     if (jqXHR && jqXHR.status === 422) {
       var response = Ember.$.parseJSON(jqXHR.responseText);
       var errors = response.errors ? response.errors : response;
-
-      for (var underscoredError in errors) {
-        var camelizedError = camelize(underscoredError);
-
-        if (camelizedError !== underscoredError) {
-          errors[camelizedError] = errors[underscoredError];
-          delete errors[underscoredError];
-        }
-      }
 
       return new InvalidError(errors);
     } else {

--- a/packages/activemodel-adapter/tests/integration/active-model-adapter-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-adapter-test.js
@@ -42,17 +42,6 @@ test('ajaxError - accepts any kind of json on 422', function() {
   equal(adapter.ajaxError(jqXHR), error.toString());
 });
 
-test('ajaxError - invalid error has camelized keys', function() {
-  var error = new DS.InvalidError({ firstName: "can't be blank" });
-
-  var jqXHR = {
-    status: 422,
-    responseText: JSON.stringify({ errors: { first_name: "can't be blank" } })
-  };
-
-  equal(adapter.ajaxError(jqXHR), error.toString());
-});
-
 test('ajaxError - returns ajax response if not 422 response', function() {
   var jqXHR = {
     status: 500,

--- a/packages/activemodel-adapter/tests/integration/active-model-serializer-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-serializer-test.js
@@ -325,3 +325,19 @@ test("extractPolymorphic does not break hasMany relationships", function() {
     "evilMinions": []
   });
 });
+
+test("extractErrors camelizes keys", function() {
+  var payload = {
+    errors: {
+      first_name: ["firstName not evil enough"]
+    }
+  };
+
+  run(function() {
+    payload = env.amsSerializer.extractErrors(env.store, SuperVillain, payload);
+  });
+
+  deepEqual(payload, {
+    firstName: ["firstName not evil enough"]
+  });
+});

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -477,3 +477,30 @@ test('extractErrors respects custom key mappings', function() {
     comments: ["comments errors"]
   });
 });
+
+test('extractErrors expects error information located on the errors property of payload', function() {
+  env.registry.register('serializer:post', DS.JSONSerializer.extend());
+
+  var payload = {
+    attributeWhichWillBeRemovedinExtractErrors: ["true"],
+    errors: {
+      title: ["title errors"]
+    }
+  };
+
+  var errors = env.container.lookup('serializer:post').extractErrors(env.store, Post, payload);
+
+  deepEqual(errors, { title: ["title errors"] });
+});
+
+test('extractErrors leaves payload untouched if it has no errors property', function() {
+  env.registry.register('serializer:post', DS.JSONSerializer.extend());
+
+  var payload = {
+    untouchedSinceNoErrorsSiblingPresent: ["true"]
+  };
+
+  var errors = env.container.lookup('serializer:post').extractErrors(env.store, Post, payload);
+
+  deepEqual(errors, { untouchedSinceNoErrorsSiblingPresent: ["true"] });
+});


### PR DESCRIPTION
This addresses my comment made in https://github.com/emberjs/data/pull/3030#issuecomment-98396379, where I stated that the made changes of camelCase-ing the error keys are a serializer concern:

Since c947e25 (introduced in #3030) the keys of the error object are camelCased in the adapter, which is actually a serializer concern. The JSONSerializer, from which the ActiveModelSerializer extends, does a normalization of the errors object in the `extractErrors` hook (see http://git.io/vJ0A6 & http://git.io/vJ0AS) and this hook gets called by the store when the adapter rejects (see http://git.io/vJ0AI), the camelCase can be removed from inside the adapter.

cc @fivetanley @bdvholmes