### PR TITLE
JSONSerializer#extractErrors respects custom key mappings

### DIFF
--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -274,6 +274,7 @@ export default Serializer.extend({
     this.normalizeId(hash);
     this.normalizeAttributes(typeClass, hash);
     this.normalizeRelationships(typeClass, hash);
+    this.normalizeUsingDeclaredMapping(typeClass, hash);
   },
 
   /**

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -454,3 +454,26 @@ test('serializeBelongsTo with async polymorphic', function() {
 
   deepEqual(json, expected, 'returned JSON is correct');
 });
+
+test('extractErrors respects custom key mappings', function() {
+  env.registry.register('serializer:post', DS.JSONSerializer.extend({
+    attrs: {
+      title: 'le_title',
+      comments: { key: 'my_comments' }
+    }
+  }));
+
+  var payload = {
+    errors: {
+      le_title: ["title errors"],
+      my_comments: ["comments errors"]
+    }
+  };
+
+  var errors = env.container.lookup('serializer:post').extractErrors(env.store, Post, payload);
+
+  deepEqual(errors, {
+    title: ["title errors"],
+    comments: ["comments errors"]
+  });
+});


### PR DESCRIPTION
Custom key mappings defined in the `attrs` hash of the JSONSerializer
are now considered when extracting errors.