### PR TITLE
Fix bug where record rejected via `find` stayed in loading state

### DIFF
--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -29,13 +29,11 @@ export function _find(adapter, store, typeClass, id, record) {
       return store.push(typeClass, payload);
     });
   }, function(error) {
-    var record = store.getById(typeClass, id);
-    if (record) {
-      record.notFound();
-      if (get(record, 'isEmpty')) {
-        store.unloadRecord(record);
-      }
+    record.notFound();
+    if (get(record, 'isEmpty')) {
+      store.unloadRecord(record);
     }
+
     throw error;
   }, "DS: Extract payload of '" + typeClass + "'");
 }

--- a/packages/ember-data/tests/integration/records/load-test.js
+++ b/packages/ember-data/tests/integration/records/load-test.js
@@ -1,0 +1,39 @@
+var hasMany = DS.hasMany;
+var Post, Comment, env;
+var run = Ember.run;
+
+module("integration/load - Loading Records", {
+  setup: function() {
+    Post = DS.Model.extend({
+      comments: hasMany({ async: true })
+    });
+
+    Comment = DS.Model.extend();
+
+    Post.toString = function() { return "Post"; };
+    Comment.toString = function() { return "Comment"; };
+
+    env = setupStore({ post: Post, comment: Comment });
+  },
+
+  teardown: function() {
+    run(env.container, 'destroy');
+  }
+});
+
+test("When loading a record fails, the isLoading is set to false", function() {
+  env.adapter.find = function(store, type, id, snapshot) {
+    return Ember.RSVP.reject();
+  };
+
+  run(function() {
+    env.store.find('post', 1).then(null, function() {
+      // store.recordForId is private, but there is currently no other way to
+      // get the specific record instance, since it is not passed to this
+      // rejection handler
+      var post = env.store.recordForId('post', 1);
+
+      equal(post.get("isLoading"), false, "post is not loading anymore");
+    });
+  });
+});


### PR DESCRIPTION
`store.getById(typeClass, id)` is used inside the rejection handler of
`find` to get the record and invoke the corresponding hooks. This is
buggy since the record is not loaded yet into the store - a successful
`find` would mark it as such - and hence the `store.getById` returned
`null`. That's why the hooks are not called and the record stays in the
`loading` state, having the `isLoaded` flag still being set to `false`.

The fix is to reuse the `record` parameter, which is passed to the
`find` method. By this, the hooks are invoked and the record is passed
transitioned out of the `loading` state.

---

This partially addresses #3013 