### PR TITLE
Fix for deleting from ManyArray

### DIFF
--- a/packages/ember-data/lib/system/many-array.js
+++ b/packages/ember-data/lib/system/many-array.js
@@ -57,11 +57,7 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
   length: 0,
 
   objectAt: function(index) {
-    if (this.currentState[index]) {
-      return this.currentState[index];
-    } else {
-      return this.canonicalState[index];
-    }
+    return this.currentState[index];
   },
 
   flushCanonical: function() {

--- a/packages/ember-data/tests/integration/records/delete-record-test.js
+++ b/packages/ember-data/tests/integration/records/delete-record-test.js
@@ -40,6 +40,7 @@ test("records can be deleted during record array enumeration", function () {
   });
 
   equal(all.get('length'), 0, 'expected 0 records');
+  equal(all.objectAt(0), null, "can't get any records");
 });
 
 test("when deleted records are rolled back, they are still in their previous record arrays", function () {

--- a/packages/ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/has-many-test.js
@@ -821,7 +821,7 @@ test("Only records of the same base type can be added to a polymorphic hasMany r
 });
 
 test("A record can be removed from a polymorphic association", function() {
-  expect(3);
+  expect(4);
 
   run(function() {
     env.store.push('user', { id: 1 , messages: [{ id: 3, type: 'comment' }] });
@@ -845,6 +845,7 @@ test("A record can be removed from a polymorphic association", function() {
 
       equal(removedObject, records.comment, "The message is correctly removed");
       equal(records.messages.get('length'), 0, "The user does not have any messages");
+      equal(records.messages.objectAt(0), null, "No messages can't be fetched");
     });
   });
 });

--- a/packages/ember-data/tests/integration/relationships/many-to-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/many-to-many-test.js
@@ -86,8 +86,10 @@ test("Fetching a hasMany where a record was removed reflects on the other hasMan
   run(function() {
     user.get('topics').then(async(function(fetchedTopics) {
       equal(fetchedTopics.get('length'), 0, 'Topics were removed correctly');
+      equal(fetchedTopics.objectAt(0), null, "Topics can't be fetched");
       topic.get('users').then(async(function(fetchedUsers) {
         equal(fetchedUsers.get('length'), 0, 'Users were removed correctly');
+        equal(fetchedUsers.objectAt(0), null, "User can't be fetched");
       }));
     }));
   });
@@ -148,6 +150,7 @@ test("Removing a record from a hasMany reflects on the other hasMany side - asyn
       fetchedTopics.removeObject(topic);
       topic.get('users').then(async(function(fetchedUsers) {
         equal(fetchedUsers.get('length'), 0, 'Users were removed correctly');
+        equal(fetchedUsers.objectAt(0), null, "User can't be fetched");
       }));
     }));
   });
@@ -184,6 +187,7 @@ test("Deleting a record that has a hasMany relationship removes it from the othe
     }));
     user.get('topics').then(async(function(fetchedTopics) {
       equal(fetchedTopics.get('length'), 0, 'Topic got removed from the user');
+      equal(fetchedTopics.objectAt(0), null, "Topic can't be fetched");
     }));
   });
 });
@@ -249,9 +253,11 @@ test("Rollbacking a created record that has a ManyToMany relationship works corr
       topic.rollback();
       topic.get('users').then(async(function(fetchedUsers) {
         equal(fetchedUsers.get('length'), 0, 'Users got removed');
+        equal(fetchedUsers.objectAt(0), null, "User can't be fetched");
       }));
       user.get('topics').then(async(function(fetchedTopics) {
         equal(fetchedTopics.get('length'), 0, 'Topics got removed');
+        equal(fetchedTopics.objectAt(0), null, "Topic can't be fetched");
       }));
     }));
   });

--- a/packages/ember-data/tests/integration/relationships/one-to-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/one-to-many-test.js
@@ -399,6 +399,7 @@ test("When deleting a record that has a belongsTo it is removed from the hasMany
     });
     user.get('messages').then(function(fetchedMessages) {
       equal(fetchedMessages.get('length'), 0, 'User was removed from the messages');
+      equal(fetchedMessages.get('firstObject'), null, "Message can't be accessed");
     });
   });
 });
@@ -533,6 +534,7 @@ test("Rollbacking a created record works correctly when the hasMany side has bee
     });
     user.get('messages').then(function(fetchedMessages) {
       equal(fetchedMessages.get('length'), 0, message, 'User does not have the message anymore');
+      equal(fetchedMessages.get('firstObject'), null, "User message can't be accessed");
     });
   });
 });
@@ -563,6 +565,7 @@ test("Rollbacking a created record works correctly when the belongsTo side has b
       });
       user.get('messages').then(function(fetchedMessages) {
         equal(fetchedMessages.get('length'), 0, 'User does not have the message anymore');
+        equal(fetchedMessages.get('firstObject'), null, "User message can't be accessed");
       });
     });
   });

--- a/packages/ember-data/tests/unit/model/rollback-test.js
+++ b/packages/ember-data/tests/unit/model/rollback-test.js
@@ -110,7 +110,7 @@ test("a record's changes can be made if it fails to save", function() {
 });
 
 test("a deleted record can be rollbacked if it fails to save, record arrays are updated accordingly", function() {
-  expect(6);
+  expect(7);
   env.adapter.deleteRecord = function(store, type, snapshot) {
     return Ember.RSVP.reject();
   };
@@ -125,6 +125,7 @@ test("a deleted record can be rollbacked if it fails to save, record arrays are 
     person.deleteRecord();
   });
   equal(people.get('length'), 0, "a deleted record does not appear in record array anymore");
+  equal(people.objectAt(0), null, "a deleted record does not appear in record array anymore");
 
   run(function() {
     person.save().then(null, function() {
@@ -168,6 +169,7 @@ test("deleted record can be rollbacked", function() {
   });
 
   equal(people.get('length'), 0, "a deleted record does not appear in record array anymore");
+  equal(people.objectAt(0), null, "a deleted record does not appear in record array anymore");
 
   equal(person.get('isDeleted'), true, "must be deleted");
 


### PR DESCRIPTION
Basically, if you delete the final object from a ManyArray elsewhere the following will happen:

* The ManyArray will report the correct length of 0.
* The ManyArray's `objectAt(0)` will still return a value.

The issue appears to be that the `currentState` is correctly empty, but the `canonicalState` still retains the deleted item. Because `objectAt` has a fallback, we incorrectly use the value from the `canonicalState`.