### PR TITLE
Merge `attrs` from superclasses into their subclasses.

### DIFF
--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -98,6 +98,7 @@ export default Serializer.extend({
     @property attrs
     @type {Object}
   */
+  mergedProperties: ['attrs'],
 
   /**
    Given a subclass of `DS.Model` and a JSON object this method will

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -318,6 +318,32 @@ test('Serializer respects `serialize: false` on the attrs hash for a `belongsTo`
   ok(!payload.hasOwnProperty(serializedProperty), "Does not add the key to instance");
 });
 
+test("Serializer should merge attrs from superclasses", function() {
+  expect(2);
+  Post.reopen({
+    description: DS.attr('string')
+  });
+  var BaseSerializer = DS.JSONSerializer.extend({
+    attrs: {
+      title: "title_payload_key"
+    }
+  });
+  env.registry.register("serializer:post", BaseSerializer.extend({
+    attrs: {
+      description: "description_payload_key"
+    }
+  }));
+
+  run(function() {
+    post = env.store.createRecord("post", { title: "Rails is omakase", description: "Omakase is delicious" });
+  });
+
+  var payload = env.container.lookup("serializer:post").serialize(post._createSnapshot());
+
+  equal(payload.title_payload_key, "Rails is omakase");
+  equal(payload.description_payload_key, "Omakase is delicious");
+});
+
 test("Serializer should respect the primaryKey attribute when extracting records", function() {
   env.registry.register('serializer:post', DS.JSONSerializer.extend({
     primaryKey: '_ID_'


### PR DESCRIPTION
This PR defines `attrs` as a `mergedProperty`, so it can be inherited from superclasses. This is useful if you have a polymorphic type and want to define a base serializer for common attributes.