### PR TITLE
Fix changelog script to point to emberjs/data

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -51,7 +51,7 @@ function processPages(res) {
     return a.number > b.number;
   }).map(function(pr) {
     var link   = '[#' + pr.number + ']' +
-                 '(https://github.com/emberjs/ember.js/pull/' + pr.number + ')';
+                 '(https://github.com/emberjs/data/pull/' + pr.number + ')';
     var title  = pr.title;
     var author = '[@' + pr.author + ']' +
                  '(https://github.com/' + pr.author +')';


### PR DESCRIPTION
Looks like a simple typo. It was pointing to the ember.js repo instead.

cc @fivetanley 