### PR TITLE
Refactor the ember initializers to use instanceInitializer

### DIFF
--- a/packages/ember-data/lib/ember-initializer.js
+++ b/packages/ember-data/lib/ember-initializer.js
@@ -1,4 +1,5 @@
-import setupContainer from 'ember-data/setup-container';
+import { initializeInjects } from 'ember-data/setup-container';
+import initializeStore from 'ember-data/initializers/store';
 
 var K = Ember.K;
 
@@ -40,9 +41,17 @@ var K = Ember.K;
 
 Ember.onLoad('Ember.Application', function(Application) {
 
+  var instanceInitializer = Application.instanceInitializer || Application.initializer;
+  instanceInitializer = instanceInitializer.bind(Application);
+
   Application.initializer({
     name:       "ember-data",
-    initialize: setupContainer
+    initialize: initializeInjects
+  });
+
+  instanceInitializer({
+    name:       "ember-data-instance-initializer",
+    initialize: initializeStore
   });
 
   // Deprecated initializers to satisfy old code that depended on them

--- a/packages/ember-data/lib/initializers/store.js
+++ b/packages/ember-data/lib/initializers/store.js
@@ -11,14 +11,22 @@ import Store from "ember-data/system/store";
   @param {Ember.Registry} registry
   @param {Object} [application] an application namespace
 */
-export default function initializeStore(registry, application) {
+export default function initializeStore(paramOne, paramTwo) {
+  // initializerStore be called by an Ember.initializer
+  // when used with ember 1.11.0 or below.
+  var params = getRegistryAndContainer(paramOne, paramTwo);
+  var application = params.application;
+  var registry = params.registry;
+  var container = params.container;
+
   Ember.deprecate('Specifying a custom Store for Ember Data on your global namespace as `App.Store` ' +
                   'has been deprecated. Please use `App.ApplicationStore` instead.', !(application && application.Store));
 
   registry.optionsForType('serializer', { singleton: false });
   registry.optionsForType('adapter', { singleton: false });
 
-  registry.register('store:main', registry.lookupFactory('store:application') || (application && application.Store) || Store);
+  // Change to `application.register` once we drop support for Ember pre 1.12
+  registry.register('store:main', container.lookupFactory('store:application') || (application && application.Store) || Store);
 
   // allow older names to be looked up
 
@@ -36,6 +44,26 @@ export default function initializeStore(registry, application) {
 
   // Eagerly generate the store so defaultStore is populated.
   // TODO: Do this in a finisher hook
-  var store = registry.lookup('store:main');
+  var store = container.lookup('store:main');
   registry.register('service:store', store, { instantiate: false });
+}
+
+function getRegistryAndContainer(registry, application) {
+  // Ember 1.12.0 the first argument is the application
+  // There is no second argument
+  if (registry.registry && registry.container) {
+    application = registry;
+    return {
+      application: application,
+      registry: application.registry,
+      container: application.container
+    };
+  } else {
+    // Ember 1.11.0 or below
+    return {
+      application: application,
+      registry: registry,
+      container: registry
+    };
+  }
 }

--- a/packages/ember-data/lib/setup-container.js
+++ b/packages/ember-data/lib/setup-container.js
@@ -4,14 +4,18 @@ import initializeStoreInjections from 'ember-data/initializers/store-injections'
 import initializeDataAdapter from 'ember-data/initializers/data-adapter';
 import setupActiveModelContainer from 'activemodel-adapter/setup-container';
 
-export default function setupContainer(container, application) {
+export default function setupContainer(registry, application) {
   // application is not a required argument. This ensures
   // testing setups can setup a container without booting an
   // entire ember application.
 
-  initializeDataAdapter(container, application);
-  initializeTransforms(container, application);
-  initializeStoreInjections(container, application);
-  initializeStore(container, application);
-  setupActiveModelContainer(container, application);
+  initializeInjects(registry, application);
+  initializeStore(registry, application);
+}
+
+export function initializeInjects(registry, application) {
+  initializeDataAdapter(registry, application);
+  initializeTransforms(registry, application);
+  initializeStoreInjections(registry, application);
+  setupActiveModelContainer(registry, application);
 }


### PR DESCRIPTION
This fixes deprecation warnings with Ember 1.12. (https://github.com/emberjs/data/issues/3069)


This pr is currently blocked on https://github.com/emberjs/ember.js/issues/11172.