### PR TITLE
Rely on active model serializer to handle error logic

### DIFF
--- a/packages/activemodel-adapter/lib/system/active-model-adapter.js
+++ b/packages/activemodel-adapter/lib/system/active-model-adapter.js
@@ -142,9 +142,7 @@ var ActiveModelAdapter = RESTAdapter.extend({
 
     if (jqXHR && jqXHR.status === 422) {
       var response = Ember.$.parseJSON(jqXHR.responseText);
-      var errors = response.errors ? response.errors : response;
-
-      return new InvalidError(errors);
+      return new InvalidError(response);
     } else {
       return error;
     }

--- a/packages/activemodel-adapter/tests/integration/active-model-adapter-serializer-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-adapter-serializer-test.js
@@ -1,0 +1,54 @@
+var env, store, adapter, User;
+var originalAjax;
+
+module("integration/active_model_adapter_serializer - AMS Adapter and Serializer", {
+  setup: function() {
+    originalAjax = Ember.$.ajax;
+
+    User = DS.Model.extend({
+      firstName: DS.attr()
+    });
+
+    env = setupStore({
+      user: User,
+      adapter: DS.ActiveModelAdapter
+    });
+
+    store = env.store;
+    adapter = env.adapter;
+
+    env.registry.register('serializer:application', DS.ActiveModelSerializer);
+  },
+
+  teardown: function() {
+    Ember.$.ajax = originalAjax;
+  }
+});
+
+test('errors are camelCased and are expected under the `errors` property of the payload', function() {
+  var jqXHR = {
+    status: 422,
+    responseText: JSON.stringify({
+      errors: {
+        first_name: ["firstName error"]
+      }
+    })
+  };
+
+  Ember.$.ajax = function(hash) {
+    hash.error(jqXHR);
+  };
+
+  var user;
+  Ember.run(function() {
+    user = store.push('user', { id: 1 });
+  });
+
+  Ember.run(function() {
+    user.save().then(null, function() {
+      var errors = user.get('errors');
+      ok(errors.has('firstName'), "there are errors for the firstName attribute");
+      deepEqual(errors.errorsFor('firstName').getEach('message'), ['firstName error']);
+    });
+  });
+});

--- a/packages/activemodel-adapter/tests/integration/active-model-adapter-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-adapter-test.js
@@ -21,25 +21,13 @@ test('buildURL - decamelizes names', function() {
 });
 
 test('ajaxError - returns invalid error if 422 response', function() {
-  var error = new DS.InvalidError({ name: "can't be blank" });
-
-  var jqXHR = {
-    status: 422,
-    responseText: JSON.stringify({ errors: { name: "can't be blank" } })
-  };
-
-  equal(adapter.ajaxError(jqXHR), error.toString());
-});
-
-test('ajaxError - accepts any kind of json on 422', function() {
-  var error = new DS.InvalidError({ name: "can't be blank" });
 
   var jqXHR = {
     status: 422,
     responseText: JSON.stringify({ name: "can't be blank" })
   };
 
-  equal(adapter.ajaxError(jqXHR), error.toString());
+  equal(adapter.ajaxError(jqXHR).errors.name, "can't be blank");
 });
 
 test('ajaxError - returns ajax response if not 422 response', function() {


### PR DESCRIPTION
This pull request reverts the changes in #3030, I'd overlooked the role AMS played in error handling and got distracted by some broken tests. Sorry guys.

Kudos to @pangratz for putting together an integration test to make sure the errors hash does indeed get passed through correctly and camelized as expected.

Fixes #3067, cc @fivetanley 