### PR TITLE
A new record which is marked as invalid can be rollbacked

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -399,6 +399,9 @@ var createdState = dirtyState({
   isNew: true
 });
 
+createdState.invalid.rolledBack = function(record) {
+  record.transitionTo('deleted.saved');
+};
 createdState.uncommitted.rolledBack = function(record) {
   record.transitionTo('deleted.saved');
 };


### PR DESCRIPTION
Previously rolling back a new record which has been marked as invalid by
the adapter left the record in the `loaded.created.uncommitted` state.

---

This addresses the issues raised in https://github.com/emberjs/data/pull/2943#discussion_r30555588:

> rolling back a new record which is marked as invalid puts the record in the loaded.created.uncommitted state. Is this the intended behavior? There are currently no tests for this case in [`rollback-test.js`](https://github.com/emberjs/data/blob/master/packages/ember-data/tests/unit/model/rollback-test.js) so it needs to be discussed what should be the intended behavior here.