### PR TITLE
Deprecation test: pathForType -> typeForRoot

### DIFF
--- a/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
@@ -575,7 +575,7 @@ test('serializeIntoHash uses payloadKeyFromModelName to normalize the payload ro
   });
 });
 
-test('pathForType is deprecated', function() {
+test('typeForRoot is deprecated', function() {
   expect(1);
 
   expectDeprecation(function() {


### PR DESCRIPTION
Just a test name fix, but it is currently quite confusing given that `pathForType` hasn't been deprecated.