### PR TITLE
fix bower publishing

### DIFF
--- a/bin/bower-ember-data-build
+++ b/bin/bower-ember-data-build
@@ -12,12 +12,25 @@ USER="rwjblue"
 # This ensure that no directories within dist will be copied when script is run.
 INCLUDED_FILES=`find dist -maxdepth 1 -type f`
 
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
 echo -e "COMPONENTS_EMBER_REPO_SLUG: ${COMPONENTS_EMBER_REPO_SLUG}\n"
 echo -e "INCLUDED_FILES: ${INCLUDED_FILES}\n"
-echo -e "CURRENT_BRANCH: ${TRAVIS_BRANCH}\n"
+echo -e "CURRENT_BRANCH: ${CURRENT_BRANCH}\n"
+
+if [[ -z $GH_TOKEN ]]; then
+  echo "secure environment variables not detected."
+  echo "not a repo owner, exiting."
+  exit 0
+fi
+
+if [[ $TRAVIS_PULL_REQUEST ]]; then
+  echo "not publishing because this is a pull request."
+  exit 0
+fi
 
 # Set channel to publish to.  If no suitable branch is found exit successfully.
-case $TRAVIS_BRANCH in
+case $CURRENT_BRANCH in
   "master" )
     CHANNEL="canary" ;;
   "beta" )


### PR DESCRIPTION
From the Travis CI docs:

http://docs.travis-ci.com/user/ci-environment/

For builds not triggered by a pull request this is the name of the
branch currently being built; whereas for builds triggered by a pull
request this is the name of the branch targeted by the pull request (in
many cases this will be master).

This was building for branches not intended to be published because they
were opened as a pull request against master. As Ember Data core
contributors frequently work off the main repository this is an unwanted
side effect.