### PR TITLE
Ember.copy() resolved value for ajaxResponse

### DIFF
--- a/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -36,7 +36,7 @@ function ajaxResponse(value) {
   adapter.ajax = function(url, verb, hash) {
     passedUrl = url;
 
-    return run(Ember.RSVP, 'resolve', value);
+    return run(Ember.RSVP, 'resolve', Ember.copy(value, true));
   };
 }
 

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -38,7 +38,7 @@ function ajaxResponse(value) {
     passedVerb = verb;
     passedHash = hash;
 
-    return run(Ember.RSVP, 'resolve', value);
+    return run(Ember.RSVP, 'resolve', Ember.copy(value, true));
   };
 }
 

--- a/packages/ember-data/tests/integration/store-test.js
+++ b/packages/ember-data/tests/integration/store-test.js
@@ -192,7 +192,7 @@ function ajaxResponse(value) {
     passedVerb = verb;
     passedHash = hash;
 
-    return Ember.RSVP.resolve(value);
+    return run(Ember.RSVP, 'resolve', Ember.copy(value, true));
   };
 }
 


### PR DESCRIPTION
This prevents the original hash provided to ajaxResponse to be modified between multiple adapter runs for the same payload.