### PR TITLE
Fix warning message after typeForRoot renaming.

### DIFF
--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -827,8 +827,8 @@ var RESTSerializer = JSONSerializer.extend({
 
 Ember.runInDebug(function() {
   RESTSerializer.reopen({
-    warnMessageNoModelForKey: function(prop, modelName) {
-      return 'Encountered "' + prop + '" in payload, but no model was found for model name "' + modelName + '" (resolved model name using ' + this.constructor.toString() + '.typeForRoot("' + prop + '"))';
+    warnMessageNoModelForKey: function(prop, typeKey) {
+      return 'Encountered "' + prop + '" in payload, but no model was found for model name "' + typeKey + '" (resolved model name using ' + this.constructor.toString() + '.modelNameFromPayloadKey("' + prop + '"))';
     }
   });
 });


### PR DESCRIPTION
Message had still a reference to typeForRoot. I changed that to modelNameFromPayloadKey.