### PR TITLE
Fix docparser warnings, @returns => @return

### DIFF
--- a/packages/activemodel-adapter/lib/system/active-model-serializer.js
+++ b/packages/activemodel-adapter/lib/system/active-model-serializer.js
@@ -142,7 +142,7 @@ var ActiveModelSerializer = RESTSerializer.extend({
 
     @method payloadKeyFromModelName
     @param {String} modelName
-    @returns {String}
+    @return {String}
   */
   payloadKeyFromModelName: function(modelName) {
     return underscore(decamelize(modelName));

--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -784,7 +784,7 @@ var RESTSerializer = JSONSerializer.extend({
 
     @method payloadKeyFromModelName
     @param {String} modelName
-    @returns {String}
+    @return {String}
   */
   payloadKeyFromModelName: function(modelName) {
     return camelize(modelName);
@@ -795,7 +795,7 @@ var RESTSerializer = JSONSerializer.extend({
 
     @method typeForRoot
     @param {String} modelName
-    @returns {String}
+    @return {String}
     @deprecated
   */
   typeForRoot: function(modelName) {


### PR DESCRIPTION
```
warn: (docparser): replacing incorrect tag: returns with return:  packages/activemodel-adapter/lib/system/active-model-serializer.js:140
warn: (docparser): replacing incorrect tag: returns with return:  packages/ember-data/lib/serializers/rest-serializer.js:746
warn: (docparser): replacing incorrect tag: returns with return:  packages/ember-data/lib/serializers/rest-serializer.js:793
```