### PR TITLE
Cleanup unneeded if after  ManyArray refactor

### DIFF
--- a/packages/ember-data/lib/system/record-arrays/record-array.js
+++ b/packages/ember-data/lib/system/record-arrays/record-array.js
@@ -206,10 +206,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
   */
   _unregisterFromManager: function() {
     var manager = get(this, 'manager');
-    //We will stop needing this stupid if statement soon, once manyArray are refactored to not be RecordArrays
-    if (manager) {
-      manager.unregisterFilteredRecordArray(this);
-    }
+    manager.unregisterFilteredRecordArray(this);
   },
 
   willDestroy: function() {


### PR DESCRIPTION
Was familiarizing myself with the record array manager while looking into the memory leak issue with filter. This condition looks like it can be removed now that `ManyArray` isn't a `RecordArray`, and all possible traffic through that method should be derived from `RecordArray` and therefore have a `manager`.