### PR TITLE
rename Reference to Ghost

### DIFF
--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -116,7 +116,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
    @method normalize
    @param {subclass of DS.Model} typeClass
    @param {Object} hash to be normalized
-   @param {String} key the hash has been referenced by
+   @param {String} key the hash has been ghostd by
    @return {Object} the normalized hash
   **/
   normalize: function(typeClass, hash, prop) {
@@ -463,7 +463,7 @@ function extractEmbeddedBelongsTo(store, key, embeddedTypeClass, hash) {
   store.push(embeddedTypeClass, embeddedRecord);
 
   hash[key] = embeddedRecord.id;
-  //TODO Need to add a reference to the parent later so relationship works between both `belongsTo` records
+  //TODO Need to add a ghost to the parent later so relationship works between both `belongsTo` records
   return hash;
 }
 

--- a/packages/ember-data/lib/system/ghost.js
+++ b/packages/ember-data/lib/system/ghost.js
@@ -32,7 +32,7 @@ function retrieveFromCurrentState(key) {
   };
 }
 
-var Reference = function(type, id, store, container, data) {
+var Ghost = function(type, id, store, container, data) {
   this.type = type;
   this.id = id;
   this.store = store;
@@ -75,7 +75,7 @@ var Reference = function(type, id, store, container, data) {
   });
 };
 
-Reference.prototype = {
+Ghost.prototype = {
   isEmpty: retrieveFromCurrentState('isEmpty'),
   isLoading: retrieveFromCurrentState('isLoading'),
   isLoaded: retrieveFromCurrentState('isLoaded'),
@@ -86,7 +86,7 @@ Reference.prototype = {
   isValid: retrieveFromCurrentState('isValid'),
   dirtyType: retrieveFromCurrentState('dirtyType'),
 
-  constructor: Reference,
+  constructor: Ghost,
   materializeRecord: function() {
     // lookupFactory should really return an object that creates
     // instances with the injections applied
@@ -95,7 +95,7 @@ Reference.prototype = {
       store: this.store,
       container: this.container
     });
-    this.record.reference = this;
+    this.record._ghost = this;
     //TODO Probably should call deferred triggers here
   },
 
@@ -344,7 +344,7 @@ Reference.prototype = {
   */
   transitionTo: function(name) {
     // POSSIBLE TODO: Remove this code and replace with
-    // always having direct references to state objects
+    // always having direct ghosts to state objects
 
     var pivotName = extractPivotName(name);
     var currentState = get(this, 'currentState');
@@ -523,13 +523,13 @@ Reference.prototype = {
     this._relationships[key].setRecord(recordToSet);
   },
 
-  //TODO Rename to reference
+  //TODO Rename to ghost
   _convertStringOrNumberIntoRecord: function(value, type) {
     if (Ember.typeOf(value) === 'string' || Ember.typeOf(value) === 'number') {
-      return this.store.referenceForId(type, value);
+      return this.store._ghostForId(type, value);
     }
-    if (value.reference) {
-      return value.reference;
+    if (value._ghost) {
+      return value._ghost;
     }
     return value;
   },
@@ -681,4 +681,4 @@ function mergeAndReturnChangedKeys(original, updates) {
   return changedKeys;
 }
 
-export default Reference;
+export default Ghost;

--- a/packages/ember-data/lib/system/many-array.js
+++ b/packages/ember-data/lib/system/many-array.js
@@ -148,7 +148,7 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
       this.get('relationship').removeRecords(records);
     }
     if (objects) {
-      this.get('relationship').addRecords(map(objects, function(obj) { return obj.reference; }), idx);
+      this.get('relationship').addRecords(map(objects, function(obj) { return obj._ghost; }), idx);
     }
   },
   /**

--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -300,27 +300,27 @@ export default function attr(type, options) {
 
   return computedPolyfill({
     get: function(key) {
-      var reference = this.reference;
-      if (hasValue(reference, key)) {
-        return getValue(reference, key);
+      var ghost = this._ghost;
+      if (hasValue(ghost, key)) {
+        return getValue(ghost, key);
       } else {
         return getDefaultValue(this, options, key);
       }
     },
     set: function(key, value) {
       Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.constructor.toString(), key !== 'id');
-      var reference = this.reference;
-      var oldValue = getValue(reference, key);
+      var ghost = this._ghost;
+      var oldValue = getValue(ghost, key);
 
       if (value !== oldValue) {
         // Add the new value to the changed attributes hash; it will get deleted by
         // the 'didSetProperty' handler if it is no different from the original value
-        reference._attributes[key] = value;
+        ghost._attributes[key] = value;
 
-        this.reference.send('didSetProperty', {
+        this._ghost.send('didSetProperty', {
           name: key,
           oldValue: oldValue,
-          originalValue: reference._data[key],
+          originalValue: ghost._data[key],
           value: value
         });
       }

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -12,7 +12,7 @@ var RESERVED_MODEL_PROPS = [
 ];
 
 var retrieveFromCurrentState = Ember.computed('currentState', function(key) {
-  return get(this.reference.currentState, key);
+  return get(this._ghost.currentState, key);
 }).readOnly();
 
 
@@ -337,7 +337,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @type {DS.Errors}
   */
   errors: Ember.computed(function() {
-    return this.reference.getErrors();
+    return this._ghost.getErrors();
   }).readOnly(),
 
   /**
@@ -455,7 +455,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @param {String} name
     @param {Object} context
   send: function(name, context) {
-    return this.reference.send(name, context);
+    return this._ghost.send(name, context);
   },
 
   /**
@@ -463,7 +463,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @private
     @param {String} name
   transitionTo: function(name) {
-    return this.reference.transitionTo(name);
+    return this._ghost.transitionTo(name);
   },
 
 
@@ -523,7 +523,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @method deleteRecord
   */
   deleteRecord: function() {
-    this.reference.deleteRecord();
+    this._ghost.deleteRecord();
   },
 
   /**
@@ -559,7 +559,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
   */
   unloadRecord: function() {
     if (this.isDestroyed) { return; }
-    this.reference.unloadRecord();
+    this._ghost.unloadRecord();
   },
 
   /**
@@ -599,8 +599,8 @@ var Model = Ember.Object.extend(Ember.Evented, {
       and value is an [oldProp, newProp] array.
   */
   changedAttributes: function() {
-    var oldData = get(this.reference, '_data');
-    var newData = get(this.reference, '_attributes');
+    var oldData = get(this._ghost, '_data');
+    var newData = get(this._ghost, '_attributes');
     var diffData = {};
     var prop;
 
@@ -646,7 +646,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @method rollback
   */
   rollback: function() {
-    this.reference.rollback();
+    this._ghost.rollback();
   },
 
 
@@ -656,7 +656,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @private
   */
   _createSnapshot: function() {
-    return this.reference._createSnapshot();
+    return this._ghost._createSnapshot();
   },
 
   toStringExtension: function() {
@@ -683,7 +683,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
   */
   save: function() {
     var model = this;
-    return this.reference.save().then(function() {
+    return this._ghost.save().then(function() {
       return model;
     });
   },
@@ -717,7 +717,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
   reload: function() {
     var model = this;
     return PromiseObject.create({
-      promise: this.reference.reload().then(function() {
+      promise: this._ghost.reload().then(function() {
         return model;
       })
     });
@@ -747,10 +747,10 @@ var Model = Ember.Object.extend(Ember.Evented, {
 
   willDestroy: function() {
     //TODO Move!
-    this.reference.clearRelationships();
-    this.reference.recordObjectWillDestroy();
+    this._ghost.clearRelationships();
+    this._ghost.recordObjectWillDestroy();
     this._super.apply(this, arguments);
-    //TODO should we set reference to null here?
+    //TODO should we set ghost to null here?
   },
 
   // This is a temporary solution until we refactor DS.Model to not

--- a/packages/ember-data/lib/system/record-arrays/adapter-populated-record-array.js
+++ b/packages/ember-data/lib/system/record-arrays/adapter-populated-record-array.js
@@ -43,7 +43,7 @@ export default RecordArray.extend({
     var meta = store.metadataFor(type);
 
     //TODO Optimize
-    var refs = Ember.A(records).mapBy('reference');
+    var refs = Ember.A(records).mapBy('_ghost');
     this.setProperties({
       content: Ember.A(refs),
       isLoaded: true,

--- a/packages/ember-data/lib/system/reference.js
+++ b/packages/ember-data/lib/system/reference.js
@@ -184,7 +184,7 @@ Reference.prototype = {
     if (this.record) {
       this.record._notifyProperties(changedKeys);
     }
-    this.didIinitalizeData();
+    this.didInitalizeData();
   },
 
   becameReady: function() {
@@ -194,7 +194,7 @@ Reference.prototype = {
     });
   },
 
-  didIinitalizeData: function() {
+  didInitalizeData: function() {
     if (!this.dataHasInitialized) {
       this.becameReady();
       this.dataHasInitialized = true;
@@ -230,7 +230,7 @@ Reference.prototype = {
   */
   loadedData: function() {
     this.send('loadedData');
-    this.didIinitalizeData();
+    this.didInitalizeData();
   },
 
   /**

--- a/packages/ember-data/lib/system/relationships/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/belongs-to.js
@@ -89,21 +89,21 @@ function belongsTo(modelName, options) {
 
   return computedPolyfill({
     get: function(key) {
-      return this.reference._relationships[key].getRecord();
+      return this._ghost._relationships[key].getRecord();
     },
     set: function(key, value) {
       if (value === undefined) {
         value = null;
       }
       if (value && value.then) {
-        this.reference._relationships[key].setRecordPromise(value);
+        this._ghost._relationships[key].setRecordPromise(value);
       } else if (value) {
-        this.reference._relationships[key].setRecord(value.reference);
+        this._ghost._relationships[key].setRecord(value._ghost);
       } else {
-        this.reference._relationships[key].setRecord(value);
+        this._ghost._relationships[key].setRecord(value);
       }
 
-      return this.reference._relationships[key].getRecord();
+      return this._ghost._relationships[key].getRecord();
     }
   }).meta(meta);
 }

--- a/packages/ember-data/lib/system/relationships/has-many.js
+++ b/packages/ember-data/lib/system/relationships/has-many.js
@@ -123,14 +123,14 @@ function hasMany(type, options) {
 
   return computedPolyfill({
     get: function(key) {
-      var relationship = this.reference._relationships[key];
+      var relationship = this._ghost._relationships[key];
       return relationship.getRecords();
     },
     set: function(key, records) {
-      var relationship = this.reference._relationships[key];
+      var relationship = this._ghost._relationships[key];
       relationship.clear();
       Ember.assert("You must pass an array of records to set a hasMany relationship", Ember.isArray(records));
-      relationship.addRecords(Ember.A(records).mapBy('reference'));
+      relationship.addRecords(Ember.A(records).mapBy('_ghost'));
       return relationship.getRecords();
     }
   }).meta(meta);

--- a/packages/ember-data/lib/system/relationships/state/has-many.js
+++ b/packages/ember-data/lib/system/relationships/state/has-many.js
@@ -158,7 +158,7 @@ ManyRelationship.prototype.fetchLink = function() {
 ManyRelationship.prototype.findRecords = function() {
   var manyArray = this.manyArray;
   //TODO CLEANUP
-  return this.store.findMany(map(manyArray.toArray(), function(rec) { return rec.reference; })).then(function() {
+  return this.store.findMany(map(manyArray.toArray(), function(rec) { return rec._ghost; })).then(function() {
     //Goes away after the manyArray refactor
     manyArray.set('isLoaded', true);
     return manyArray;

--- a/packages/ember-data/lib/system/snapshot.js
+++ b/packages/ember-data/lib/system/snapshot.js
@@ -24,7 +24,7 @@ function Snapshot(record) {
   }, this);
 
   this.id = get(record, 'id');
-  this.reference = record;
+  this._ghost = record;
   this.type = record.type;
   this.modelName = record.type.modelName;
 
@@ -195,7 +195,7 @@ Snapshot.prototype = {
       return this._belongsToRelationships[keyName];
     }
 
-    relationship = this.reference._relationships[keyName];
+    relationship = this._ghost._relationships[keyName];
     if (!(relationship && relationship.relationshipMeta.kind === 'belongsTo')) {
       throw new Ember.Error("Model '" + Ember.inspect(this.record) + "' has no belongsTo relationship named '" + keyName + "' defined.");
     }
@@ -266,7 +266,7 @@ Snapshot.prototype = {
       return this._hasManyRelationships[keyName];
     }
 
-    relationship = this.reference._relationships[keyName];
+    relationship = this._ghost._relationships[keyName];
     if (!(relationship && relationship.relationshipMeta.kind === 'hasMany')) {
       throw new Ember.Error("Model '" + Ember.inspect(this.record) + "' has no hasMany relationship named '" + keyName + "' defined.");
     }
@@ -351,7 +351,7 @@ Snapshot.prototype = {
       return this.attr(keyName);
     }
 
-    var relationship = this.reference._relationships[keyName];
+    var relationship = this._ghost._relationships[keyName];
 
     if (relationship && relationship.relationshipMeta.kind === 'belongsTo') {
       return this.belongsTo(keyName);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -40,7 +40,7 @@ import {
 
 import RecordArrayManager from "ember-data/system/record-array-manager";
 
-import Reference from "ember-data/system/reference";
+import Ghost from "ember-data/system/ghost";
 
 import Model from "ember-data/system/model";
 
@@ -88,13 +88,13 @@ if (!Backburner.prototype.join) {
 }
 
 
-function promiseRecord(reference, label) {
+function promiseRecord(ghost, label) {
   //TODO cleanup
-  var toReturn = reference;
-  if (!reference.then) {
-    toReturn = reference.getRecord();
+  var toReturn = ghost;
+  if (!ghost.then) {
+    toReturn = ghost.getRecord();
   } else {
-    toReturn = reference.then(function(ref) {
+    toReturn = ghost.then(function(ref) {
       return ref.getRecord();
     });
   }
@@ -127,7 +127,7 @@ if (!Service) {
 //   * +clientId+ means a transient numerical identifier generated at runtime by
 //     the data store. It is important primarily because newly created objects may
 //     not yet have an externally generated id.
-//   * +reference+ means a record reference object, which holds metadata about a
+//   * +ghost+ means a record ghost object, which holds metadata about a
 //     record, even if it has not yet been fully materialized.
 //   * +type+ means a subclass of DS.Model.
 
@@ -335,19 +335,19 @@ Store = Service.extend({
     // Coerce ID to a string
     properties.id = coerceId(properties.id);
 
-    var reference = this.buildReference(typeClass, properties.id);
-    var record = reference.getRecord();
+    var ghost = this.buildGhost(typeClass, properties.id);
+    var record = ghost.getRecord();
 
     // Move the record out of its initial `empty` state into
     // the `loaded` state.
-    reference.loadedData();
+    ghost.loadedData();
 
     // Set the properties specified on the record.
     record.setProperties(properties);
 
     //TODO Bring baaaaack
-    reference.eachRelationship(function(key, descriptor) {
-      reference._relationships[key].setHasData(true);
+    ghost.eachRelationship(function(key, descriptor) {
+      ghost._relationships[key].setHasData(true);
     });
 
     return record;
@@ -615,26 +615,26 @@ Store = Service.extend({
   findById: function(modelName, id, preload) {
 
     var type = this.modelFor(modelName);
-    var reference = this.referenceForId(type, id);
+    var ghost = this._ghostForId(type, id);
 
-    return this._findByRecord(reference, preload);
+    return this._findByRecord(ghost, preload);
   },
 
-  _findByReference: function(reference, preload) {
-    var fetchedReference;
+  _findByGhost: function(ghost, preload) {
+    var fetchedGhost;
 
     if (preload) {
-      reference._preloadData(preload);
+      ghost._preloadData(preload);
     }
 
-    if (reference.isEmpty()) {
-      fetchedReference = this.scheduleFetch(reference);
+    if (ghost.isEmpty()) {
+      fetchedGhost = this.scheduleFetch(ghost);
       //TODO double check about reloading
-    } else if (reference.isLoading()) {
-      fetchedReference = reference._loadingPromise;
+    } else if (ghost.isLoading()) {
+      fetchedGhost = ghost._loadingPromise;
     }
 
-    return promiseRecord(fetchedReference || reference, "DS: Store#findByRecord " + reference.typeKey + " with id: " + get(reference, 'id'));
+    return promiseRecord(fetchedGhost || ghost, "DS: Store#findByRecord " + ghost.typeKey + " with id: " + get(ghost, 'id'));
   },
 
 
@@ -696,8 +696,8 @@ Store = Service.extend({
   },
 
   scheduleFetchMany: function(records) {
-    var references = map(records, function(record) { return record.reference; });
-    return Promise.all(map(references, this.scheduleFetch, this));
+    var ghosts = map(records, function(record) { return record._ghost; });
+    return Promise.all(map(ghosts, this.scheduleFetch, this));
   },
 
   scheduleFetch: function(record) {
@@ -802,7 +802,7 @@ Store = Service.extend({
       var snapshots = Ember.A(records).invoke('_createSnapshot');
       var groups = adapter.groupRecordsForFindMany(this, snapshots);
       forEach(groups, function (groupOfSnapshots) {
-        var groupOfRecords = Ember.A(groupOfSnapshots).mapBy('record.reference');
+        var groupOfRecords = Ember.A(groupOfSnapshots).mapBy('record._ghost');
         var requestedRecords = Ember.A(groupOfRecords);
         var ids = requestedRecords.mapBy('id');
         if (ids.length > 1) {
@@ -844,7 +844,7 @@ Store = Service.extend({
   */
   getById: function(type, id) {
     if (this.hasRecordForId(type, id)) {
-      return this.referenceForId(type, id).getRecord();
+      return this._ghostForId(type, id).getRecord();
     } else {
       return null;
     }
@@ -900,17 +900,17 @@ Store = Service.extend({
     @return {DS.Model} record
   */
   recordForId: function(modelName, id) {
-    return this.referenceForId(modelName, id).getRecord();
+    return this._ghostForId(modelName, id).getRecord();
   },
 
-  referenceForId: function(typeName, inputId) {
+  _ghostForId: function(typeName, inputId) {
     var typeClass = this.modelFor(typeName);
     var id = coerceId(inputId);
     var idToRecord = this.typeMapFor(typeClass).idToRecord;
     var record = idToRecord[id];
 
     if (!record || !idToRecord[id]) {
-      record = this.buildReference(typeClass, id);
+      record = this.buildGhost(typeClass, id);
     }
 
     return record;
@@ -1445,13 +1445,13 @@ Store = Service.extend({
   */
   _load: function(type, data) {
     var id = coerceId(data.id);
-    var reference = this.referenceForId(type, id);
+    var ghost = this._ghostForId(type, id);
 
-    reference.setupData(data);
+    ghost.setupData(data);
 
-    this.recordArrayManager.recordDidChange(reference);
+    this.recordArrayManager.recordDidChange(ghost);
 
-    return reference;
+    return ghost;
   },
 
   /*
@@ -1633,15 +1633,15 @@ Store = Service.extend({
     }
 
     // Actually load the record into the store.
-    var reference = this._load(type, data);
+    var ghost = this._load(type, data);
 
     var store = this;
 
     this._backburner.join(function() {
-      store._backburner.schedule('normalizeRelationships', store, '_setupRelationships', reference, type, data);
+      store._backburner.schedule('normalizeRelationships', store, '_setupRelationships', ghost, type, data);
     });
 
-    return reference.getRecord();
+    return ghost.getRecord();
   },
 
   _setupRelationships: function(record, type, data) {
@@ -1800,7 +1800,7 @@ Store = Service.extend({
     @param {Object} data
     @return {DS.Model} record
   */
-  buildReference: function(type, id, data) {
+  buildGhost: function(type, id, data) {
     var typeMap = this.typeMapFor(type);
     var idToRecord = typeMap.idToRecord;
 
@@ -1809,17 +1809,17 @@ Store = Service.extend({
 
     // lookupFactory should really return an object that creates
     // instances with the injections applied
-    var reference = new Reference(type, id, this, this.container, data);
+    var ghost = new Ghost(type, id, this, this.container, data);
 
     // if we're creating an item, this process will be done
     // later, once the object has been persisted.
     if (id) {
-      idToRecord[id] = reference;
+      idToRecord[id] = ghost;
     }
 
-    typeMap.records.push(reference);
+    typeMap.records.push(ghost);
 
-    return reference;
+    return ghost;
   },
 
   //Called by the state machine to notify the store that the record is ready to be interacted with
@@ -2019,7 +2019,7 @@ function deserializeRecordId(store, data, key, relationship, id) {
 
   //If record objects were given to push directly, uncommon, not sure whether we should actually support
   if (id instanceof Model) {
-    data[key] = id.reference;
+    data[key] = id._ghost;
     return;
   }
 
@@ -2029,11 +2029,11 @@ function deserializeRecordId(store, data, key, relationship, id) {
 
   if (typeof id === 'number' || typeof id === 'string') {
     type = typeFor(relationship, key, data);
-    data[key] = store.referenceForId(type, id);
+    data[key] = store._ghostForId(type, id);
   } else if (typeof id === 'object') {
     // hasMany polymorphic
     Ember.assert('Ember Data expected a number or string to represent the record(s) in the `' + relationship.key + '` relationship instead it found an object. If this is a polymorphic relationship please specify a `type` key. If this is an embedded relationship please include the `DS.EmbeddedRecordsMixin` and specify the `' + relationship.key +'` property in your serializer\'s attrs object.', id.type);
-    data[key] = store.referenceForId(id.type, id.id);
+    data[key] = store._ghostForId(id.type, id.id);
   }
 }
 

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -28,7 +28,7 @@ export function _find(adapter, store, typeClass, id, record) {
 
       //TODO Optimize
       var record = store.push(typeClass, payload);
-      return record.reference;
+      return record._ghost;
     });
   }, function(error) {
     record.notFound();
@@ -62,7 +62,7 @@ export function _findMany(adapter, store, typeClass, ids, records) {
 
       //TODO Optimize, no need to materialize here
       var records = store.pushMany(typeClass, payload);
-      return map(records, function(record) { return record.reference; });
+      return map(records, function(record) { return record._ghost; });
     });
   }, null, "DS: Extract payload of " + typeClass);
 }
@@ -85,7 +85,7 @@ export function _findHasMany(adapter, store, record, link, relationship) {
 
       //TODO Use a non record creating push
       var records = store.pushMany(relationship.type, payload);
-      return map(records, function(record) { return record.reference; });
+      return map(records, function(record) { return record._ghost; });
     });
   }, null, "DS: Extract payload of " + record + " : hasMany " + relationship.type);
 }
@@ -110,7 +110,7 @@ export function _findBelongsTo(adapter, store, record, link, relationship) {
 
       var record = store.push(relationship.type, payload);
       //TODO Optimize
-      return record.reference;
+      return record._ghost;
     });
   }, null, "DS: Extract payload of " + record + " : " + relationship.type);
 }

--- a/packages/ember-data/lib/transforms/date.js
+++ b/packages/ember-data/lib/transforms/date.js
@@ -20,7 +20,7 @@
 import Transform from "ember-data/transforms/base";
 
 // Date.prototype.toISOString shim
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Ghost/Global_Objects/Date/toISOString
 var toISOString = Date.prototype.toISOString || function() {
   function pad(number) {
     if ( number < 10 ) {

--- a/packages/ember-data/tests/integration/record-array-manager-test.js
+++ b/packages/ember-data/tests/integration/record-array-manager-test.js
@@ -84,17 +84,17 @@ test("destroying the store correctly cleans everything up", function() {
 
   equal(filterd2Summary.called.length, 0);
 
-  equal(person.reference._recordArrays.list.length, 2, 'expected the person to be a member of 2 recordArrays');
+  equal(person._ghost._recordArrays.list.length, 2, 'expected the person to be a member of 2 recordArrays');
 
   Ember.run(filterd2, filterd2.destroy);
 
-  equal(person.reference._recordArrays.list.length, 1, 'expected the person to be a member of 1 recordArrays');
+  equal(person._ghost._recordArrays.list.length, 1, 'expected the person to be a member of 1 recordArrays');
 
   equal(filterd2Summary.called.length, 1);
 
   Ember.run(manager, manager.destroy);
 
-  equal(person.reference._recordArrays.list.length, 0, 'expected the person to be a member of no recordArrays');
+  equal(person._ghost._recordArrays.list.length, 0, 'expected the person to be a member of no recordArrays');
 
   equal(filterd2Summary.called.length, 1);
 

--- a/packages/ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs-to-test.js
@@ -602,7 +602,7 @@ test("belongsTo hasData async loaded", function () {
 
   run(function() {
     store.find('book', 1).then(function(book) {
-      var relationship = book.reference._relationships['author'];
+      var relationship = book._ghost._relationships['author'];
       equal(relationship.hasData, true, 'relationship has data');
     });
   });
@@ -617,7 +617,7 @@ test("belongsTo hasData sync loaded", function () {
 
   run(function() {
     store.find('book', 1).then(function(book) {
-      var relationship = book.reference._relationships['author'];
+      var relationship = book._ghost._relationships['author'];
       equal(relationship.hasData, true, 'relationship has data');
     });
   });
@@ -636,7 +636,7 @@ test("belongsTo hasData async not loaded", function () {
 
   run(function() {
     store.find('book', 1).then(function(book) {
-      var relationship = book.reference._relationships['author'];
+      var relationship = book._ghost._relationships['author'];
       equal(relationship.hasData, false, 'relationship does not have data');
     });
   });
@@ -651,7 +651,7 @@ test("belongsTo hasData sync not loaded", function () {
 
   run(function() {
     store.find('book', 1).then(function(book) {
-      var relationship = book.reference._relationships['author'];
+      var relationship = book._ghost._relationships['author'];
       equal(relationship.hasData, false, 'relationship does not have data');
     });
   });
@@ -666,7 +666,7 @@ test("belongsTo hasData async created", function () {
 
   run(function() {
     var book = store.createRecord('book', { name: 'The Greatest Book' });
-    var relationship = book.reference._relationships['author'];
+    var relationship = book._ghost._relationships['author'];
     equal(relationship.hasData, true, 'relationship has data');
   });
 });
@@ -676,7 +676,7 @@ test("belongsTo hasData sync created", function () {
 
   run(function() {
     var book = store.createRecord('book', { name: 'The Greatest Book' });
-    var relationship = book.reference._relationships['author'];
+    var relationship = book._ghost._relationships['author'];
     equal(relationship.hasData, true, 'relationship has data');
   });
 });

--- a/packages/ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/has-many-test.js
@@ -127,7 +127,7 @@ test("adapter.findMany only gets unique IDs even if duplicate IDs are present in
 });
 
 // This tests the case where a serializer materializes a has-many
-// relationship as a reference that it can fetch lazily. The most
+// relationship as a ghost that it can fetch lazily. The most
 // common use case of this is to provide a URL to a collection that
 // is loaded later.
 test("A serializer can materialize a hasMany as an opaque token that can be lazily fetched via the adapter's findHasMany hook", function() {
@@ -970,7 +970,7 @@ test("dual non-async HM <-> BT", function() {
 
       deepEqual(post, commentPost, 'expect the new comments post, to be the correct post');
       ok(postComments, "comments should exist");
-      equal(postCommentsLength, 2, "comment's post should have a reference back to comment");
+      equal(postCommentsLength, 2, "comment's post should have a ghost back to comment");
       ok(postComments && postComments.indexOf(firstComment) !== -1, 'expect to contain first comment');
       ok(postComments && postComments.indexOf(comment) !== -1, 'expected to contain the new comment');
     });
@@ -1218,7 +1218,7 @@ test("Relationship.clear removes all records correctly", function() {
   });
 
   run(function() {
-    post.reference._relationships['comments'].clear();
+    post._ghost._relationships['comments'].clear();
     var comments = Ember.A(env.store.all('comment'));
     deepEqual(comments.mapBy('post'), [null, null, null]);
   });
@@ -1350,7 +1350,7 @@ test("hasMany hasData async loaded", function () {
 
   run(function() {
     store.find('chapter', 1).then(function(chapter) {
-      var relationship = chapter.reference._relationships['pages'];
+      var relationship = chapter._ghost._relationships['pages'];
       equal(relationship.hasData, true, 'relationship has data');
     });
   });
@@ -1365,7 +1365,7 @@ test("hasMany hasData sync loaded", function () {
 
   run(function() {
     store.find('chapter', 1).then(function(chapter) {
-      var relationship = chapter.reference._relationships['pages'];
+      var relationship = chapter._ghost._relationships['pages'];
       equal(relationship.hasData, true, 'relationship has data');
     });
   });
@@ -1384,7 +1384,7 @@ test("hasMany hasData async not loaded", function () {
 
   run(function() {
     store.find('chapter', 1).then(function(chapter) {
-      var relationship = chapter.reference._relationships['pages'];
+      var relationship = chapter._ghost._relationships['pages'];
       equal(relationship.hasData, false, 'relationship does not have data');
     });
   });
@@ -1399,7 +1399,7 @@ test("hasMany hasData sync not loaded", function () {
 
   run(function() {
     store.find('chapter', 1).then(function(chapter) {
-      var relationship = chapter.reference._relationships['pages'];
+      var relationship = chapter._ghost._relationships['pages'];
       equal(relationship.hasData, false, 'relationship does not have data');
     });
   });
@@ -1414,7 +1414,7 @@ test("hasMany hasData async created", function () {
 
   run(function() {
     var chapter = store.createRecord('chapter', { title: 'The Story Begins' });
-    var relationship = chapter.reference._relationships['pages'];
+    var relationship = chapter._ghost._relationships['pages'];
     equal(relationship.hasData, true, 'relationship has data');
   });
 });
@@ -1424,7 +1424,7 @@ test("hasMany hasData sync created", function () {
 
   run(function() {
     var chapter = store.createRecord('chapter', { title: 'The Story Begins' });
-    var relationship = chapter.reference._relationships['pages'];
+    var relationship = chapter._ghost._relationships['pages'];
     equal(relationship.hasData, true, 'relationship has data');
   });
 });

--- a/packages/ember-data/tests/unit/model-test.js
+++ b/packages/ember-data/tests/unit/model-test.js
@@ -141,14 +141,14 @@ test("a collision of a record's id with object function's name", function() {
 });
 
 /*
-test("it should use `_reference` and not `reference` to store its reference", function() {
+test("it should use `_ghost` and not `ghost` to store its ghost", function() {
   expect(1);
 
   run(function() {
     store.push(Person, { id: 1 });
 
     store.find(Person, 1).then(function(record) {
-      equal(record.get('reference'), undefined, "doesn't shadow reference key");
+      equal(record.get('_ghost'), undefined, "doesn't shadow ghost key");
     });
   });
 });
@@ -409,15 +409,15 @@ test("setting a property back to its original value removes the property from th
 
   run(function() {
     store.find(Person, 1).then(function(person) {
-      equal(person.reference._attributes.name, undefined, "the `_attributes` hash is clean");
+      equal(person._ghost._attributes.name, undefined, "the `_attributes` hash is clean");
 
       set(person, 'name', "Niceguy Dale");
 
-      equal(person.reference._attributes.name, "Niceguy Dale", "the `_attributes` hash contains the changed value");
+      equal(person._ghost._attributes.name, "Niceguy Dale", "the `_attributes` hash contains the changed value");
 
       set(person, 'name', "Scumbag Dale");
 
-      equal(person.reference._attributes.name, undefined, "the `_attributes` hash is reset");
+      equal(person._ghost._attributes.name, undefined, "the `_attributes` hash is reset");
     });
   });
 });

--- a/packages/ember-data/tests/unit/model/relationships/record-array-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/record-array-test.js
@@ -11,19 +11,19 @@ test("updating the content of a RecordArray updates its content", function() {
 
   var env = setupStore({ tag: Tag });
   var store = env.store;
-  var records, tags, references;
+  var records, tags, ghosts;
 
   run(function() {
     records = store.pushMany('tag', [{ id: 5, name: "friendly" }, { id: 2, name: "smarmy" }, { id: 12, name: "oohlala" }]);
-    references = Ember.A(records).mapBy('reference');
-    tags = DS.RecordArray.create({ content: Ember.A(references.slice(0, 2)), store: store, type: Tag });
+    ghosts = Ember.A(records).mapBy('_ghost');
+    tags = DS.RecordArray.create({ content: Ember.A(ghosts.slice(0, 2)), store: store, type: Tag });
   });
 
   var tag = tags.objectAt(0);
   equal(get(tag, 'name'), "friendly", "precond - we're working with the right tags");
 
   run(function() {
-    set(tags, 'content', Ember.A(references.slice(1, 3)));
+    set(tags, 'content', Ember.A(ghosts.slice(1, 3)));
   });
 
   tag = tags.objectAt(0);

--- a/packages/ember-data/tests/unit/store/unload-test.js
+++ b/packages/ember-data/tests/unit/store/unload-test.js
@@ -34,7 +34,7 @@ test("unload a dirty record", function() {
 
     store.find(Record, 1).then(function(record) {
       record.set('title', 'toto2');
-      record.reference.send('willCommit');
+      record._ghost.send('willCommit');
 
       equal(get(record, 'isDirty'), true, "record is dirty");
 
@@ -44,7 +44,7 @@ test("unload a dirty record", function() {
 
       // force back into safe to unload mode.
       run(function() {
-        record.reference.transitionTo('deleted.saved');
+        record._ghost.transitionTo('deleted.saved');
       });
     });
   });


### PR DESCRIPTION
Originally we planned on renaming to `modelDataPOJO`. However, the name
is misleading because it does more than just store data; it has its own
constructor and prototype chain.

I chose Ghost from Martin Fowler's 'Patterns of Enterprise Application
Architecture':

> A ghost is the real object in a partial state. When you load the object
> from the database it contains just its ID. Whenever you try to access a
> field it loads its full state. Think of a ghost as an object, where
> every field is lazy-initialized in one fell swoop, or as a virtual
> proxy, where the object is its own virtual proxy. Of course, there's no
> need to load all the data in one go; you may group it in groups that are
> commonly used together.