### PR TITLE
Lookup the store using store:application instead of store:main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-data",
   "private": true,
   "dependencies": {
-    "ember": "~1.11.1"
+    "ember": "~1.12.1"
   },
   "devDependencies": {
     "qunit": "~1.17.0",

--- a/packages/ember-data/lib/ember-initializer.js
+++ b/packages/ember-data/lib/ember-initializer.js
@@ -1,4 +1,6 @@
-import setupContainer from 'ember-data/setup-container';
+import { initializeInjects } from 'ember-data/setup-container';
+import initializeStoreService from 'ember-data/instance-initializers/initialize-store-service';
+
 
 var K = Ember.K;
 
@@ -42,11 +44,23 @@ Ember.onLoad('Ember.Application', function(Application) {
 
   Application.initializer({
     name:       "ember-data",
-    initialize: setupContainer
+    initialize: initializeInjects
   });
 
-  // Deprecated initializers to satisfy old code that depended on them
+  if (Application.instanceInitializer) {
+    Application.instanceInitializer({
+      name:       "ember-data",
+      initialize: initializeStoreService
+    });
+  } else {
+    Ember.initializer({
+      name:       "ember-data-store-service",
+      after:       "ember-data",
+      initialize: initializeStoreService
+    });
+  }
 
+  // Deprecated initializers to satisfy old code that depended on them
   Application.initializer({
     name:       "store",
     after:      "ember-data",

--- a/packages/ember-data/lib/initializers/store-injections.js
+++ b/packages/ember-data/lib/initializers/store-injections.js
@@ -6,7 +6,7 @@
   @param {Ember.Registry} registry
 */
 export default function initializeStoreInjections(registry) {
-  registry.injection('controller', 'store', 'store:main');
-  registry.injection('route', 'store', 'store:main');
-  registry.injection('data-adapter', 'store', 'store:main');
+  registry.injection('controller', 'store', 'store:application');
+  registry.injection('route', 'store', 'store:application');
+  registry.injection('data-adapter', 'store', 'store:application');
 }

--- a/packages/ember-data/lib/initializers/store.js
+++ b/packages/ember-data/lib/initializers/store.js
@@ -18,7 +18,7 @@ export default function initializeStore(registry, application) {
   registry.optionsForType('serializer', { singleton: false });
   registry.optionsForType('adapter', { singleton: false });
 
-  registry.register('store:main', registry.lookupFactory('store:application') || (application && application.Store) || Store);
+  registry.register('store:application', application && application.Store || Store);
 
   // allow older names to be looked up
 
@@ -26,16 +26,12 @@ export default function initializeStore(registry, application) {
   proxy.registerDeprecations([
     { deprecated: 'serializer:_default',  valid: 'serializer:-default' },
     { deprecated: 'serializer:_rest',     valid: 'serializer:-rest' },
-    { deprecated: 'adapter:_rest',        valid: 'adapter:-rest' }
+    { deprecated: 'adapter:_rest',        valid: 'adapter:-rest' },
+    { deprecated: 'store:main',        valid: 'store:application' }
   ]);
 
   // new go forward paths
   registry.register('serializer:-default', JSONSerializer);
   registry.register('serializer:-rest', RESTSerializer);
   registry.register('adapter:-rest', RESTAdapter);
-
-  // Eagerly generate the store so defaultStore is populated.
-  // TODO: Do this in a finisher hook
-  var store = registry.lookup('store:main');
-  registry.register('service:store', store, { instantiate: false });
 }

--- a/packages/ember-data/lib/instance-initializers/initialize-store-service.js
+++ b/packages/ember-data/lib/instance-initializers/initialize-store-service.js
@@ -1,0 +1,26 @@
+/**
+ Configures a registry for use with an Ember-Data
+ store.
+
+ @method initializeStore
+ @param {Ember.ApplicationInstance} applicationOrRegistry
+ */
+export default function initializeStoreService(applicationOrRegistry) {
+  var registry, container;
+  if (applicationOrRegistry.registry && applicationOrRegistry.container) {
+    // initializeStoreService was registered with an
+    // instanceInitializer. The first argument is the application
+    // instance.
+    registry = applicationOrRegistry.registry;
+    container = applicationOrRegistry.container;
+  } else {
+    // initializeStoreService was called by an initializer instead of
+    // an instanceInitializer. The first argument is a registy. This
+    // case allows ED to support Ember pre 1.12
+    registry = applicationOrRegistry;
+    container = registry.container();
+  }
+  // Eagerly generate the store so defaultStore is populated.
+  var store = container.lookup('store:application');
+  registry.register('service:store', store, { instantiate: false });
+}

--- a/packages/ember-data/lib/setup-container.js
+++ b/packages/ember-data/lib/setup-container.js
@@ -3,15 +3,22 @@ import initializeTransforms from 'ember-data/initializers/transforms';
 import initializeStoreInjections from 'ember-data/initializers/store-injections';
 import initializeDataAdapter from 'ember-data/initializers/data-adapter';
 import setupActiveModelContainer from 'activemodel-adapter/setup-container';
+import initializeStoreService from 'ember-data/instance-initializers/initialize-store-service';
 
-export default function setupContainer(container, application) {
+export default function setupContainer(registry, application) {
   // application is not a required argument. This ensures
   // testing setups can setup a container without booting an
   // entire ember application.
 
-  initializeDataAdapter(container, application);
-  initializeTransforms(container, application);
-  initializeStoreInjections(container, application);
-  initializeStore(container, application);
-  setupActiveModelContainer(container, application);
+  initializeInjects(registry, application);
+  initializeStoreService(registry);
+}
+
+
+export function initializeInjects(registry, application) {
+  initializeDataAdapter(registry, application);
+  initializeTransforms(registry, application);
+  initializeStoreInjections(registry, application);
+  setupActiveModelContainer(registry, application);
+  initializeStore(registry, application);
 }

--- a/packages/ember-data/tests/integration/application-test.js
+++ b/packages/ember-data/tests/integration/application-test.js
@@ -13,7 +13,7 @@ var app, App, container;
 */
 
 function getStore() {
-  return lookup('store:main');
+  return lookup('store:application');
 }
 
 function lookup(thing) {
@@ -69,7 +69,7 @@ test("registering App.Store is deprecated but functional", function() {
      'has been deprecated. Please use `App.ApplicationStore` instead.');
 
   run(function() {
-    ok(lookup('store:main').get('isCustomButDeprecated'), "the custom store was instantiated");
+    ok(lookup('store:application').get('isCustomButDeprecated'), "the custom store was instantiated");
   });
 
   var fooController = lookup('controller:foo');

--- a/packages/ember-data/tests/integration/backwards-compat/non-dasherized-lookups.js
+++ b/packages/ember-data/tests/integration/backwards-compat/non-dasherized-lookups.js
@@ -9,7 +9,7 @@ module('integration/backwards-compat/non-dasherized-lookups - non dasherized loo
         name: DS.attr()
       });
     });
-    store = App.__container__.lookup('store:main');
+    store = App.__container__.lookup('store:application');
   },
   teardown: function() {
     run(App, 'destroy');
@@ -67,7 +67,7 @@ module('integration/backwards-compat/non-dasherized-lookups - non dasherized loo
         postNotes: DS.hasMany('post_note')
       });
     });
-    store = App.__container__.lookup('store:main');
+    store = App.__container__.lookup('store:application');
   },
 
   teardown: function() {

--- a/packages/ember-data/tests/integration/debug-adapter-test.js
+++ b/packages/ember-data/tests/integration/debug-adapter-test.js
@@ -18,7 +18,7 @@ module("DS.DebugAdapter", {
 
     });
 
-    store = App.__container__.lookup('store:main');
+    store = App.__container__.lookup('store:application');
     debugAdapter = App.__container__.lookup('data-adapter:main');
 
     debugAdapter.reopen({

--- a/packages/ember-data/tests/integration/multiple_stores_test.js
+++ b/packages/ember-data/tests/integration/multiple_stores_test.js
@@ -118,7 +118,7 @@ test("embedded records should be created in multiple stores", function() {
 
   run(function() {
     json_main = serializer_main.extractSingle(env.store, HomePlanet, json_hash_main);
-    equal(env.store.hasRecordForId("superVillain", "1"), true, "superVillain should exist in store:main");
+    equal(env.store.hasRecordForId("superVillain", "1"), true, "superVillain should exist in store:application");
   });
 
   run(function() {

--- a/packages/ember-data/tests/integration/setup-container-test.js
+++ b/packages/ember-data/tests/integration/setup-container-test.js
@@ -30,7 +30,7 @@ module("integration/setup-container - Setting up a container", {
 });
 
 test("The store should be registered into a container.", function() {
-  ok(container.lookup('store:main') instanceof Store, "the custom store is instantiated");
+  ok(container.lookup('store:application') instanceof Store, "the custom store is instantiated");
 });
 
 test("The store should be registered into the container as a service.", function() {
@@ -85,6 +85,17 @@ test("serializers are not returned as singletons - each lookup should return a d
   serializer2 = container.lookup('serializer:-rest');
   notEqual(serializer1, serializer2);
 });
+
+test("the deprecated store:main is resolved as store:application", function() {
+  var deprecated;
+  var valid = container.lookup('store:application');
+  expectDeprecation(function() {
+    deprecated = container.lookup('store:main');
+  });
+
+  ok(deprecated.constructor === valid.constructor, "they should resolve to the same thing");
+});
+
 
 test("adapters are not returned as singletons - each lookup should return a different instance", function() {
   var adapter1, adapter2;


### PR DESCRIPTION
This simplifes the process of registering the store when a user
creates a custom one.  This change also fixes deprecations warning
introduces in Ember 1.12. The store service is now injected as a
instanceInitializer.