### PR TITLE
Fix doc for typeForRoot, should recommend modelNameFromPayloadKey.

### DIFF
--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -791,7 +791,7 @@ var RESTSerializer = JSONSerializer.extend({
   },
 
   /**
-   Deprecated. Use payloadKeyFromModelName instead
+   Deprecated. Use modelNameFromPayloadKey instead
 
     @method typeForRoot
     @param {String} modelName


### PR DESCRIPTION
The inline documentation is currently recommending `payloadKeyFromModelName` instead of `modelNameFromPayloadKey` which is actually used.