### PR TITLE
Add test for error on model.create()

### DIFF
--- a/packages/ember-data/tests/unit/model-test.js
+++ b/packages/ember-data/tests/unit/model-test.js
@@ -773,3 +773,9 @@ test("Pushing a record into the store should transition it to the loaded state",
     equal(person.get('isNew'), false, 'push should put records into the loaded state');
   });
 });
+
+test("A subclass of DS.Model throws an error when calling create() directly", function() {
+  throws(function() {
+    Person.create();
+  }, /You should not call `create` on a model/, "Throws an error when calling create() on model");
+});


### PR DESCRIPTION
Fixes #3159 

Add a test to ensure that an error is thrown when calling `.create()` on a model directly