### PR TITLE
Ensure snapshot.belongsTo() and hasMany() do not return deleted records

### DIFF
--- a/packages/ember-data/lib/system/snapshot.js
+++ b/packages/ember-data/lib/system/snapshot.js
@@ -232,7 +232,7 @@ Snapshot.prototype = {
     inverseRecord = get(relationship, 'inverseRecord');
 
     if (hasData) {
-      if (inverseRecord) {
+      if (inverseRecord && !inverseRecord.isDeleted()) {
         if (id) {
           result = get(inverseRecord, 'id');
         } else {
@@ -305,10 +305,12 @@ Snapshot.prototype = {
     if (hasData) {
       results = [];
       members.forEach(function(member) {
-        if (ids) {
-          results.push(member.id);
-        } else {
-          results.push(member.createSnapshot());
+        if (!member.isDeleted()) {
+          if (ids) {
+            results.push(member.id);
+          } else {
+            results.push(member.createSnapshot());
+          }
         }
       });
     }

--- a/packages/ember-data/tests/integration/snapshot-test.js
+++ b/packages/ember-data/tests/integration/snapshot-test.js
@@ -166,6 +166,22 @@ test("snapshot.belongsTo() returns a snapshot if relationship is set", function(
   });
 });
 
+test("snapshot.belongsTo() returns null if relationship is deleted", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var comment = env.store.push('comment', { id: 2, body: 'This is comment', post: 1 });
+
+    post.deleteRecord();
+
+    var snapshot = comment._createSnapshot();
+    var relationship = snapshot.belongsTo('post');
+
+    equal(relationship, null, 'relationship unset after deleted');
+  });
+});
+
 test("snapshot.belongsTo() returns undefined if relationship is a link", function() {
   expect(1);
 
@@ -246,7 +262,7 @@ test("snapshot.belongsTo() and snapshot.hasMany() returns correctly when setting
   });
 });
 
-test("snapshot.hasMany() returns ID if option.id is set", function() {
+test("snapshot.belongsTo() returns ID if option.id is set", function() {
   expect(1);
 
   run(function() {
@@ -256,6 +272,22 @@ test("snapshot.hasMany() returns ID if option.id is set", function() {
     var relationship = snapshot.belongsTo('post', { id: true });
 
     equal(relationship, '1', 'relationship ID correctly returned');
+  });
+});
+
+test("snapshot.belongsTo() returns null if option.id is set but relationship was deleted", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var comment = env.store.push('comment', { id: 2, body: 'This is comment', post: 1 });
+
+    post.deleteRecord();
+
+    var snapshot = comment._createSnapshot();
+    var relationship = snapshot.belongsTo('post', { id: true });
+
+    equal(relationship, null, 'relationship unset after deleted');
   });
 });
 
@@ -306,6 +338,25 @@ test("snapshot.hasMany() returns array of snapshots if relationship is set", fun
   });
 });
 
+test("snapshot.hasMany() returns empty array if relationship records are deleted", function() {
+  expect(2);
+
+  run(function() {
+    var comment1 = env.store.push('comment', { id: 1, body: 'This is the first comment' });
+    var comment2 = env.store.push('comment', { id: 2, body: 'This is the second comment' });
+    var post = env.store.push('post', { id: 3, title: 'Hello World', comments: [1, 2] });
+
+    comment1.deleteRecord();
+    comment2.deleteRecord();
+
+    var snapshot = post._createSnapshot();
+    var relationship = snapshot.hasMany('comments');
+
+    ok(relationship instanceof Array, 'relationship is an instance of Array');
+    equal(relationship.length, 0, 'relationship is empty');
+  });
+});
+
 test("snapshot.hasMany() returns array of IDs if option.ids is set", function() {
   expect(1);
 
@@ -315,6 +366,25 @@ test("snapshot.hasMany() returns array of IDs if option.ids is set", function() 
     var relationship = snapshot.hasMany('comments', { ids: true });
 
     deepEqual(relationship, ['2', '3'], 'relationship IDs correctly returned');
+  });
+});
+
+test("snapshot.hasMany() returns empty array of IDs if option.ids is set but relationship records were deleted", function() {
+  expect(2);
+
+  run(function() {
+    var comment1 = env.store.push('comment', { id: 1, body: 'This is the first comment' });
+    var comment2 = env.store.push('comment', { id: 2, body: 'This is the second comment' });
+    var post = env.store.push('post', { id: 3, title: 'Hello World', comments: [1, 1] });
+
+    comment1.deleteRecord();
+    comment2.deleteRecord();
+
+    var snapshot = post._createSnapshot();
+    var relationship = snapshot.hasMany('comments', { ids: true });
+
+    ok(relationship instanceof Array, 'relationship is an instance of Array');
+    equal(relationship.length, 0, 'relationship is empty');
   });
 });
 


### PR DESCRIPTION
Even though we remove records from their opposite relationships once they are deleted, this commit places this functionality under test and ensures that only non deleted records are returned from snapshot.belongsTo() and snapshot.hasMany().

Closes #3081