### PR TITLE
add tests for error conditions in snapshot methods

### DIFF
--- a/packages/ember-data/tests/integration/snapshot-test.js
+++ b/packages/ember-data/tests/integration/snapshot-test.js
@@ -99,6 +99,19 @@ test("snapshot.attr() does not change when record changes", function() {
   });
 });
 
+test("snapshot.attr() throws an error attribute not found", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    throws(function() {
+      snapshot.attr('unknown');
+    }, /has no attribute named 'unknown' defined/, 'attr throws error');
+  });
+});
+
 test("snapshot.attributes() returns a copy of all attributes for the current snapshot", function() {
   expect(1);
 
@@ -191,6 +204,19 @@ test("snapshot.belongsTo() returns undefined if relationship is a link", functio
     var relationship = snapshot.belongsTo('post');
 
     equal(relationship, undefined, 'relationship is undefined');
+  });
+});
+
+test("snapshot.belongsTo() throws error if relation doesn't exist", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    throws(function() {
+      snapshot.belongsTo('unknown');
+    }, /has no belongsTo relationship named 'unknown'/, 'throws error')
   });
 });
 
@@ -417,6 +443,19 @@ test("snapshot.hasMany() returns array of snapshots if relationship link has bee
       ok(relationship instanceof Array, 'relationship is an instance of Array');
       equal(relationship.length, 1, 'relationship has one item');
     });
+  });
+});
+
+test("snapshot.hasMany() throws error if relation doesn't exist", function() {
+  expect(1);
+
+  run(function() {
+    var post = env.store.push('post', { id: 1, title: 'Hello World' });
+    var snapshot = post._createSnapshot();
+
+    throws(function() {
+      snapshot.hasMany('unknown');
+    }, /has no hasMany relationship named 'unknown'/, 'throws error')
   });
 });
 


### PR DESCRIPTION
* snapshot.attr()
* snapshot.belongsTo()
* snapshot.hasMany()

fixes #3157