### PR TITLE
initialize lives on the application instance not the Ember namespace

### DIFF
--- a/packages/ember-data/lib/ember-initializer.js
+++ b/packages/ember-data/lib/ember-initializer.js
@@ -53,7 +53,7 @@ Ember.onLoad('Ember.Application', function(Application) {
       initialize: initializeStoreService
     });
   } else {
-    Ember.initializer({
+    Application.initializer({
       name:       "ember-data-store-service",
       after:       "ember-data",
       initialize: initializeStoreService


### PR DESCRIPTION
Fixes Ember Data canary with version of Ember 1.11 or lower. Credit goes to @fivetanley for reporting this issue.