### PR TITLE
stop rebuilding production after successful test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ script:
   - npm run-script test:beta
   - npm run-script test:canary
 after_success:
-- npm run-script publish-build
-- "./bin/bower-ember-data-build"
+  - npm run-script publish-build:prebuilt
+  - "./bin/bower-ember-data-build"
 env:
   global:
   - BROCCOLI_ENV="production"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start": "ember serve",
     "test": "jscs packages && testem -R dot ci",
     "publish-build": "npm run build:production && ./bin/publish-to-s3.js",
+    "publish-build:prebuilt": "./bin/publish-to-s3.js",
     "test:local": "testem -R dot ci",
     "test:beta": "testem -f config/testem-beta.json -R dot ci",
     "test:canary": "testem -f config/testem-canary.json -R dot ci",


### PR DESCRIPTION
The production build is already built at the start of the build due to
the `prepublish` hooks that runs after `npm install`.