### PR TITLE
fix jshint line numbers

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -93,24 +93,24 @@ var packages = merge([
 
 var globalBuild;
 
-packages = babel(packages, babelOptions);
+var transpiledPackages = babel(packages, babelOptions);
 
 // Bundle formatter for smaller payload
 if (env === 'production') {
-  globalBuild = es6(libTree(packages), {
+  globalBuild = es6(libTree(transpiledPackages), {
     inputFiles: ['ember-data'],
     output: '/ember-data.js',
     resolvers: [PackageResolver],
     formatter: 'bundle'
   });
 
-  var tests = testTree(packages, amdBuild(packages));
+  var tests = testTree(packages, amdBuild(transpiledPackages));
   globalBuild = merge([globalBuild, tests]);
 } else {
 // Use AMD for faster rebuilds in dev
   var bootFile = fileCreator('/boot.js', 'require("ember-data");');
 
-  var compiled = amdBuild(packages);
+  var compiled = amdBuild(transpiledPackages);
   var libFiles = libTree(compiled);
 
   var emberData = merge([bootFile, libFiles]);

--- a/packages/ember-data/tests/integration/snapshot-test.js
+++ b/packages/ember-data/tests/integration/snapshot-test.js
@@ -216,7 +216,7 @@ test("snapshot.belongsTo() throws error if relation doesn't exist", function() {
 
     throws(function() {
       snapshot.belongsTo('unknown');
-    }, /has no belongsTo relationship named 'unknown'/, 'throws error')
+    }, /has no belongsTo relationship named 'unknown'/, 'throws error');
   });
 });
 
@@ -455,7 +455,7 @@ test("snapshot.hasMany() throws error if relation doesn't exist", function() {
 
     throws(function() {
       snapshot.hasMany('unknown');
-    }, /has no hasMany relationship named 'unknown'/, 'throws error')
+    }, /has no hasMany relationship named 'unknown'/, 'throws error');
   });
 });
 
@@ -647,7 +647,7 @@ test("snapshot.serialize() serializes itself", function() {
     post.set('title', 'New Title');
 
     deepEqual(snapshot.serialize(), { author: undefined, title: 'Hello World' }, 'shapshot serializes correctly');
-    deepEqual(snapshot.serialize({ includeId: true }), { id: "1", author: undefined, title: 'Hello World' }, 'serialize takes options')
+    deepEqual(snapshot.serialize({ includeId: true }), { id: "1", author: undefined, title: 'Hello World' }, 'serialize takes options');
   });
 });
 

--- a/packages/ember-data/tests/unit/adapter-populated-record-array-test.js
+++ b/packages/ember-data/tests/unit/adapter-populated-record-array-test.js
@@ -47,5 +47,5 @@ test('recordArray.replace() throws error', function() {
 
   throws(function() {
     recordArray.replace();
-  }, Error("The result of a server query (on (subclass of DS.Model)) is immutable."), 'throws error')
+  }, Error("The result of a server query (on (subclass of DS.Model)) is immutable."), 'throws error');
 });

--- a/packages/ember-data/tests/unit/adapters/rest-adapter/ajax-test.js
+++ b/packages/ember-data/tests/unit/adapters/rest-adapter/ajax-test.js
@@ -52,7 +52,7 @@ test("ajaxOptions() headers are set", function() {
   var receivedHeaders = [];
   var fakeXHR = {
     setRequestHeader: function(key, value) {
-      receivedHeaders.push([key, value])
+      receivedHeaders.push([key, value]);
     }
   };
   ajaxOptions.beforeSend(fakeXHR);

--- a/packages/ember-data/tests/unit/record-arrays/filtered-record-array-test.js
+++ b/packages/ember-data/tests/unit/record-arrays/filtered-record-array-test.js
@@ -2,12 +2,12 @@ var filteredArray;
 
 module("unit/record-arrays/filtered-record-array - DS.FilteredRecordArray", {
   setup: function() {
-    filteredArray = DS.FilteredRecordArray.create({ type: 'recordType' })
+    filteredArray = DS.FilteredRecordArray.create({ type: 'recordType' });
   }
 });
 
 test('recordArray.replace() throws error', function() {
   throws(function() {
     filteredArray.replace();
-  }, Error("The result of a client-side filter (on recordType) is immutable."), 'throws error')
+  }, Error("The result of a client-side filter (on recordType) is immutable."), 'throws error');
 });


### PR DESCRIPTION
It was getting the babel transpiled output, which made it pretty much
impossible to see where the actual lint warnings were coming from. Now, we pass the original source files.