### PR TITLE
refactor store managed instances

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -83,6 +83,7 @@ var Adapter = Ember.Object.extend({
     @property defaultSerializer
     @type {String}
   */
+  defaultSerializer: '-default',
 
   /**
     The `find()` method is invoked when the store is asked for a record that

--- a/packages/ember-data/lib/system/store/container-instance-cache.js
+++ b/packages/ember-data/lib/system/store/container-instance-cache.js
@@ -1,0 +1,86 @@
+import Ember from 'ember';
+
+/**
+ * The `ContainerInstanceCache` serves as a lazy cache for looking up
+ * instances of serializers and adapters. It has some additional logic for
+ * finding the 'fallback' adapter or serializer.
+ *
+ * The 'fallback' adapter or serializer is an adapter or serializer that is looked up
+ * when the preferred lookup fails. For example, say you try to look up `adapter:post`,
+ * but there is no entry (app/adapters/post.js in EmberCLI) for `adapter:post` in the registry.
+ *
+ * The `fallbacks` array passed will then be used; the first entry in the fallbacks array
+ * that exists in the container will then be cached for `adapter:post`. So, the next time you
+ * look up `adapter:post`, you'll get the `adapter:application` instance (or whatever the fallback
+ * was if `adapter:application` doesn't exist).
+ *
+ * @private
+ * @class ContainerInstanceCache
+ *
+*/
+function ContainerInstanceCache(container) {
+  this._container  = container;
+  this._cache      = Ember.create(null);
+}
+
+ContainerInstanceCache.prototype = Ember.create(null);
+
+Ember.merge(ContainerInstanceCache.prototype, {
+  get: function(type, preferredKey, fallbacks) {
+    let cache = this._cache;
+    let preferredLookupKey = `${type}:${preferredKey}`;
+
+    if (!(preferredLookupKey in cache)) {
+      let instance = this.instanceFor(preferredLookupKey) || this._findInstance(type, fallbacks);
+      if (instance) {
+        cache[preferredLookupKey] = instance;
+      }
+    }
+    return cache[preferredLookupKey];
+  },
+
+  _findInstance: function(type, fallbacks) {
+    for (let i = 0, length = fallbacks.length; i < length; i++) {
+      let fallback = fallbacks[i];
+      let lookupKey = `${type}:${fallback}`;
+      let instance = this.instanceFor(lookupKey);
+
+      if (instance) {
+        return instance;
+      }
+    }
+  },
+
+  instanceFor: function(key) {
+    let cache = this._cache;
+    if (!cache[key]) {
+      let instance = this._container.lookup(key);
+      if (instance) {
+        cache[key] = instance;
+      }
+    }
+    return cache[key];
+  },
+
+  destroy: function() {
+    let cache = this._cache;
+    let cacheEntries = Ember.keys(cache);
+
+    for (let i = 0, length = cacheEntries.length; i < length; i++) {
+      let cacheKey = cacheEntries[i];
+      let cacheEntry = cache[cacheKey];
+      if (cacheEntry) {
+        cacheEntry.destroy();
+      }
+    }
+    this._container = null;
+  },
+
+  constructor: ContainerInstanceCache,
+
+  toString: function() {
+    return 'ContainerInstanceCache';
+  }
+});
+
+export default ContainerInstanceCache;

--- a/packages/ember-data/tests/helpers/custom-adapter.js
+++ b/packages/ember-data/tests/helpers/custom-adapter.js
@@ -1,0 +1,10 @@
+
+export default function(env, adapterDefinition) {
+  var adapter = adapterDefinition;
+  if (!DS.Adapter.detect(adapterDefinition)) {
+    adapter = DS.Adapter.extend(adapterDefinition);
+  }
+  var store = env.store;
+  env.registry.register('adapter:-custom', adapter);
+  Ember.run(() => store.set('adapter', '-custom'));
+}

--- a/packages/ember-data/tests/integration/filter-test.js
+++ b/packages/ember-data/tests/integration/filter-test.js
@@ -1,3 +1,5 @@
+import customAdapter from 'ember-data/tests/helpers/custom-adapter';
+
 var get = Ember.get;
 var set = Ember.set;
 var forEach = Ember.EnumerableUtils.forEach;
@@ -168,13 +170,11 @@ test("a filtered record array includes created elements", function() {
 });
 
 test("a Record Array can update its filter", function() {
-  run(function() {
-    set(store, 'adapter', DS.Adapter.extend({
-      deleteRecord: function(store, type, snapshot) {
-        return Ember.RSVP.resolve();
-      }
-    }));
-  });
+  customAdapter(env, DS.Adapter.extend({
+    deleteRecord: function(store, type, snapshot) {
+      return Ember.RSVP.resolve();
+    }
+  }));
 
   run(function() {
     store.pushMany('person', array);
@@ -227,13 +227,11 @@ test("a Record Array can update its filter", function() {
 });
 
 test("a Record Array can update its filter and notify array observers", function() {
-  run(function() {
-    set(store, 'adapter', DS.Adapter.extend({
-      deleteRecord: function(store, type, snapshot) {
-        return Ember.RSVP.resolve();
-      }
-    }));
-  });
+  customAdapter(env, DS.Adapter.extend({
+    deleteRecord: function(store, type, snapshot) {
+      return Ember.RSVP.resolve();
+    }
+  }));
 
   run(function() {
     store.pushMany('person', array);
@@ -367,7 +365,7 @@ test("a filter created after a record is already loaded works", function() {
 });
 
 test("filter with query persists query on the resulting filteredRecordArray", function() {
-  set(store, 'adapter', DS.Adapter.extend({
+  customAdapter(env, DS.Adapter.extend({
     findQuery: function(store, type, id) {
       return Ember.RSVP.resolve([{
         id: id,
@@ -375,6 +373,7 @@ test("filter with query persists query on the resulting filteredRecordArray", fu
       }]);
     }
   }));
+
   var filter;
 
   run(function() {
@@ -393,13 +392,14 @@ test("filter with query persists query on the resulting filteredRecordArray", fu
 
 test("it is possible to filter by state flags", function() {
   var filter;
-  run(function() {
-    set(store, 'adapter', DS.Adapter.extend({
-      find: function(store, type, id, snapshot) {
-        return Ember.RSVP.resolve({ id: id, name: "Tom Dale" });
-      }
-    }));
 
+  customAdapter(env, DS.Adapter.extend({
+    find: function(store, type, id, snapshot) {
+      return Ember.RSVP.resolve({ id: id, name: "Tom Dale" });
+    }
+  }));
+
+  run(function() {
     filter = store.filter('person', function(person) {
       return person.get('isLoaded');
     });
@@ -423,7 +423,7 @@ test("it is possible to filter by state flags", function() {
 });
 
 test("it is possible to filter loaded records by dirtiness", function() {
-  set(store, 'adapter', DS.Adapter.extend({
+  customAdapter(env, DS.Adapter.extend({
     updateRecord: function() {
       return Ember.RSVP.resolve();
     }
@@ -456,7 +456,7 @@ test("it is possible to filter loaded records by dirtiness", function() {
 
 test("it is possible to filter created records by dirtiness", function() {
   run(function() {
-    set(store, 'adapter', DS.Adapter.extend({
+    customAdapter(env, DS.Adapter.extend({
       createRecord: function() {
         return Ember.RSVP.resolve();
       }
@@ -490,7 +490,7 @@ test("it is possible to filter created records by dirtiness", function() {
 });
 
 test("it is possible to filter created records by isReloading", function() {
-  set(store, 'adapter', DS.Adapter.extend({
+  customAdapter(env, DS.Adapter.extend({
     find: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({
         id: 1,
@@ -550,7 +550,7 @@ var serverResponds = function() {
 
 var setup = function(serverCallbacks) {
   run(function() {
-    set(store, 'adapter', DS.Adapter.extend(serverCallbacks));
+    customAdapter(env, DS.Adapter.extend(serverCallbacks));
 
     store.pushMany('person', array);
 

--- a/packages/ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/ember-data/tests/unit/store/adapter-interop-test.js
@@ -28,15 +28,12 @@ test('Adapter can be set as a name', function() {
 });
 
 test('Adapter can not be set as an instance', function() {
-  expect(5);
+  expect(1);
 
   store = DS.Store.create({
     adapter: DS.Adapter.create()
   });
-  var assert = Ember.assert;
-  Ember.assert = function() { ok(true, "raises an error when passing in an instance"); };
-  store.get('defaultAdapter');
-  Ember.assert = assert;
+  expectAssertion(() => store.get('defaultAdapter'));
 });
 
 test("Calling Store#find invokes its adapter#find", function() {

--- a/packages/ember-data/tests/unit/store/lookup-test.js
+++ b/packages/ember-data/tests/unit/store/lookup-test.js
@@ -1,0 +1,135 @@
+var store, env, applicationAdapter, applicationSerializer, Person;
+const run = Ember.run;
+
+function resetStore() {
+  if (store) {
+    run(store, 'destroy');
+  }
+  env = setupStore({
+    adapter: '-rest',
+    person: Person
+  });
+
+  env.registry.unregister('adapter:application');
+  env.registry.unregister('serializer:application');
+
+  env.registry.optionsForType('serializer', { singleton: true });
+  env.registry.optionsForType('adapter', { singleton: true });
+
+  store = env.store;
+}
+
+function lookupAdapter(adapterName) {
+  return run(store, 'adapterFor', adapterName);
+}
+
+function lookupSerializer(serializerName) {
+  return run(store, 'serializerFor', serializerName);
+}
+
+function registerAdapter(adapterName, adapter) {
+  env.registry.register(`adapter:${adapterName}`, adapter);
+}
+
+function registerSerializer(serializerName, serializer) {
+  env.registry.register(`serializer:${serializerName}`, serializer);
+}
+
+module('unit/store/lookup - Managed Instance lookups', {
+  setup() {
+    Person = DS.Model.extend();
+    resetStore();
+    env.registry.register('adapter:application', DS.Adapter.extend());
+    env.registry.register('adapter:serializer', DS.Adapter.extend());
+
+    applicationAdapter = run(store, 'adapterFor', 'application');
+    applicationSerializer = run(store, 'serializerFor', 'application');
+  },
+
+  teardown() {
+    run(store, 'destroy');
+  }
+});
+
+test('when the adapter does not exist for a type, the fallback is returned', () => {
+  let personAdapter = lookupAdapter('person');
+
+  strictEqual(personAdapter, applicationAdapter);
+});
+
+test('when the adapter for a type exists, returns that instead of the fallback', () => {
+  registerAdapter('person', DS.Adapter.extend());
+  let personAdapter = lookupAdapter('person');
+
+  ok(personAdapter !== applicationAdapter);
+});
+
+test('when the serializer does not exist for a type, the fallback is returned', () => {
+  let personSerializer = lookupSerializer('person');
+
+  strictEqual(personSerializer, applicationSerializer);
+});
+
+test('when the serializer does exist for a type, the serializer is returned', () => {
+  registerSerializer('person', DS.Serializer.extend());
+
+  let personSerializer = lookupSerializer('person');
+
+  ok(personSerializer !== applicationSerializer);
+});
+
+test('adapter lookup order', () => {
+  expect(3);
+
+  resetStore();
+
+  let personAdapter = lookupAdapter('person');
+
+  strictEqual(personAdapter, lookupAdapter('-rest'), 'looks up the RESTAdapter first');
+  resetStore();
+
+  registerAdapter('application', DS.ActiveModelSerializer.extend());
+  personAdapter = lookupAdapter('person');
+
+  strictEqual(personAdapter, lookupAdapter('application'), 'looks up application adapter before RESTAdapter if it exists');
+
+  resetStore();
+
+  registerAdapter('application', DS.ActiveModelSerializer.extend());
+  registerAdapter('person', DS.ActiveModelSerializer.extend({ customThingy: true }));
+
+  ok(lookupAdapter('person').get('customThingy'), 'looks up type serializer before application');
+});
+
+test('serializer lookup order', () => {
+  resetStore();
+
+  let personSerializer = lookupSerializer('person');
+
+  strictEqual(personSerializer, lookupSerializer('-rest'));
+
+  resetStore();
+
+  registerSerializer('application', DS.ActiveModelSerializer.extend());
+  personSerializer = lookupSerializer('person');
+  strictEqual(personSerializer, lookupSerializer('application'), 'looks up application before default');
+
+  resetStore();
+  registerAdapter('person', DS.Adapter.extend({
+    defaultSerializer: '-active-model'
+  }));
+  personSerializer = lookupSerializer('person');
+
+  strictEqual(personSerializer, lookupSerializer('-active-model'), 'uses defaultSerializer on adapterFor("model") if application not defined');
+
+  resetStore();
+  registerAdapter('person', DS.Adapter.extend({
+    defaultSerializer: '-active-model'
+  }));
+  registerSerializer('application', DS.ActiveModelSerializer.extend());
+  registerSerializer('person', DS.JSONSerializer.extend({ customThingy: true }));
+  personSerializer = lookupSerializer('person');
+
+  ok(personSerializer.get('customThingy'), 'uses the person serializer before any fallbacks if it is defined');
+});
+

--- a/tests/ember-configuration.js
+++ b/tests/ember-configuration.js
@@ -67,8 +67,13 @@
       }
     };
 
-    var adapter = env.adapter = (options.adapter || DS.Adapter);
+    var adapter = env.adapter = (options.adapter || '-default');
     delete options.adapter;
+
+    if (typeof adapter !== 'string') {
+      env.registry.register('adapter:-ember-data-test-custom', adapter);
+      adapter = '-ember-data-test-custom';
+    }
 
     for (var prop in options) {
       registry.register('model:' + Ember.String.dasherize(prop), options[prop]);
@@ -80,9 +85,12 @@
 
     registry.optionsForType('serializer', { singleton: false });
     registry.optionsForType('adapter', { singleton: false });
+    registry.register('adapter:-default', DS.Adapter);
 
     registry.register('serializer:-default', DS.JSONSerializer);
     registry.register('serializer:-rest', DS.RESTSerializer);
+    registry.register('adapter:-active-model', DS.ActiveModelAdapter);
+    registry.register('serializer:-active-model', DS.ActiveModelSerializer);
     registry.register('adapter:-rest', DS.RESTAdapter);
 
     registry.injection('serializer', 'store', 'store:main');


### PR DESCRIPTION
In this commit, we refactor store managed instance lookups to have its
own class that takes the store's container. This moves a large portion
of code out of the store and instead uses delegation.

There's also a performance benefit:

If you look up `adapter:post` and fallback to `adapter:application`,
this lookup is cached. So, if you look up `adapter:post` again, that
instance will actually be cached. Previously, we did the lookup for
`adapter:post` every time.

This also removes passing factories as the `adapter` property to
DS.Store.

closes #3050