### PR TITLE
Add test for normalizing attrs inside links.

### DIFF
--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -237,6 +237,27 @@ test('Serializer should respect the attrs hash when extracting records', functio
   deepEqual(post.comments, [1,2]);
 });
 
+test('Serializer should respect the attrs hash in links', function() {
+  env.registry.register("serializer:post", DS.JSONSerializer.extend({
+    attrs: {
+      title: "title_payload_key",
+      comments: { key: 'my_comments' }
+    }
+  }));
+
+  var jsonHash = {
+    title_payload_key: "Rails is omakase",
+    links: {
+      my_comments: 'posts/1/comments'
+    }
+  };
+
+  var post = env.container.lookup("serializer:post").extractSingle(env.store, Post, jsonHash);
+
+  equal(post.title, "Rails is omakase");
+  equal(post.links.comments, 'posts/1/comments');
+});
+
 test('Serializer should respect the attrs hash when serializing records', function() {
   Post.reopen({
     parentPost: DS.belongsTo('post', { inverse: null })

--- a/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
@@ -509,6 +509,30 @@ test('normalize should allow for different levels of normalization', function() 
   equal(array[0].superVillain, 1);
 });
 
+test('Serializer should respect the attrs hash in links', function() {
+  env.registry.register("serializer:super-villain", DS.RESTSerializer.extend({
+    attrs: {
+      evilMinions: { key: 'my_minions' }
+    }
+  }));
+
+  var jsonHash = {
+    "super-villains": [
+      {
+        firstName: 'Tom',
+        lastName: 'Dale',
+        links: {
+          my_minions: 'me/minions'
+        }
+      }
+    ]
+  };
+
+  var me = env.container.lookup("serializer:super-villain").extractSingle(env.store, SuperVillain, jsonHash);
+
+  equal(me.links.evilMinions, 'me/minions');
+});
+
 test("serializeIntoHash", function() {
   run(function() {
     league = env.store.createRecord('home-planet', { name: "Umber", id: "123" });


### PR DESCRIPTION
This tests checkes that the attrs object in serializers are taking into account
inside the links object too.

Fix #3188