### PR TITLE
Remove the 'container' property from model instances

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -373,7 +373,6 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @return {Object} A JSON representation of the object.
   */
   toJSON: function(options) {
-    // container is for lazy transform lookups
     var serializer = this.store.serializerFor('-default');
     var snapshot = this._internalModel.createSnapshot();
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1813,9 +1813,7 @@ Store = Service.extend({
     Ember.assert('The id ' + id + ' has already been used with another record of type ' + type.toString() + '.', !id || !idToRecord[id]);
     Ember.assert("`" + Ember.inspect(type)+ "` does not appear to be an ember-data model", (typeof type._create === 'function') );
 
-    // lookupFactory should really return an object that creates
-    // instances with the injections applied
-    var internalModel = new InternalModel(type, id, this, this.container, data);
+    var internalModel = new InternalModel(type, id, this, data);
 
     // if we're creating an item, this process will be done
     // later, once the object has been persisted.

--- a/packages/ember-data/tests/unit/model-test.js
+++ b/packages/ember-data/tests/unit/model-test.js
@@ -299,6 +299,16 @@ test("supports pushedData in root.deleted.uncommitted", function() {
   });
 });
 
+test("accessing the `container` property throws an error", function() {
+  run(function() {
+    var record = store.createRecord('person');
+
+    /* jshint expr:true */
+    throws(function() {
+      record.container;
+    }, /Model instances no longer have access to a container./, "Throws an error when accessing `container` on a model");
+  });
+});
 
 module("unit/model - DS.Model updating", {
   setup: function() {


### PR DESCRIPTION
From the commit:

> Models have always been created/managed by a store instance, and
> support for multiple stores makes accessing the container from a model
> inconsistent (and potentially dangerous), given that all adapter/serializer
> instances are looked up through a store's ContainerInstanceCache.

I think this makes sense, but I don't know if removing the `container` property from `DS.Model` instances would be considered a breaking change. If so, I can create a deprecated property accessor. @igorT, @fivetanley thoughts?