### PR TITLE
Metadata for hasmany

### DIFF
--- a/packages/ember-data/lib/system/clone-null.js
+++ b/packages/ember-data/lib/system/clone-null.js
@@ -1,0 +1,7 @@
+export default function cloneNull(source) {
+  var clone = Ember.create(null);
+  for (var key in source) {
+    clone[key] = source[key];
+  }
+  return clone;
+}

--- a/packages/ember-data/lib/system/many-array.js
+++ b/packages/ember-data/lib/system/many-array.js
@@ -115,6 +115,46 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
   */
   relationship: null,
 
+  /**
+    Metadata associated with the request for async hasMany relationships.
+
+    Example
+
+    Given that the server returns the following JSON payload when fetching a
+    hasMany relationship:
+
+    ```js
+    {
+      "comments": [{
+        "id": 1,
+        "comment": "This is the first comment",
+      }, {
+        // ...
+      }],
+
+      "meta": {
+        "page": 1,
+        "total": 5
+      }
+    }
+    ```
+
+    You can then access the metadata via the `meta` property:
+
+    ```js
+    post.get('comments').then(function(comments) {
+      var meta = comments.get('meta');
+
+      // meta.page => 1
+      // meta.total => 5
+    });
+    ```
+
+    @property {Object} meta
+    @public
+  */
+  meta: null,
+
   internalReplace: function(idx, amt, objects) {
     if (!objects) {
       objects = [];

--- a/packages/ember-data/lib/system/record-arrays/adapter-populated-record-array.js
+++ b/packages/ember-data/lib/system/record-arrays/adapter-populated-record-array.js
@@ -1,17 +1,11 @@
 import RecordArray from "ember-data/system/record-arrays/record-array";
+import cloneNull from "ember-data/system/clone-null";
+
 /**
   @module ember-data
 */
 
 var get = Ember.get;
-
-function cloneNull(source) {
-  var clone = Ember.create(null);
-  for (var key in source) {
-    clone[key] = source[key];
-  }
-  return clone;
-}
 
 /**
   Represents an ordered list of records whose order and membership is

--- a/packages/ember-data/lib/system/relationships/state/has-many.js
+++ b/packages/ember-data/lib/system/relationships/state/has-many.js
@@ -2,6 +2,7 @@ import { PromiseManyArray } from "ember-data/system/promise-proxies";
 import Relationship from "ember-data/system/relationships/state/relationship";
 import OrderedSet from "ember-data/system/ordered-set";
 import ManyArray from "ember-data/system/many-array";
+import cloneNull from "ember-data/system/clone-null";
 
 var map = Ember.EnumerableUtils.map;
 
@@ -146,6 +147,9 @@ ManyRelationship.prototype.computeChanges = function(records) {
 ManyRelationship.prototype.fetchLink = function() {
   var self = this;
   return this.store.findHasMany(this.record, this.link, this.relationshipMeta).then(function(records) {
+    var meta = self.store.metadataFor(self.relationshipMeta.type);
+    self.manyArray.set('meta', cloneNull(meta));
+
     self.store._backburner.join(function() {
       self.updateRecordsFromAdapter(records);
     });

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -15,6 +15,7 @@ function Relationship(store, record, inverseKey, relationshipMeta) {
   //multiple possible modelNames
   this.inverseKeyForImplicit = this.record.constructor.modelName + this.key;
   this.linkPromise = null;
+  this.meta = null;
   this.hasData = false;
 }
 
@@ -22,6 +23,10 @@ Relationship.prototype = {
   constructor: Relationship,
 
   destroy: Ember.K,
+
+  updateMeta: function(meta) {
+    this.meta = meta;
+  },
 
   clear: function() {
     var members = this.members.list;

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -2139,6 +2139,11 @@ function setupRelationships(store, record, data) {
       relationship.updateLink(data.links[key]);
     }
 
+    if (data.meta && data.meta.hasOwnProperty(key)) {
+      relationship = record._relationships.get(key);
+      relationship.updateMeta(data.meta[key]);
+    }
+
     if (value !== undefined) {
       if (kind === 'belongsTo') {
         relationship = record._relationships.get(key);

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -83,7 +83,11 @@ export function _findHasMany(adapter, store, internalModel, link, relationship) 
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findHasMany');
       //TODO Use a non record creating push
       var records = pushPayload(store, payload);
-      return map(records, function(record) { return record._internalModel; });
+      var recordArray = map(records, function(record) { return record._internalModel; });
+      if (Ember.FEATURES.isEnabled('ds-new-serializer-api') && serializer.get('isNewSerializerAPI')) {
+        recordArray.meta = payload.meta;
+      }
+      return recordArray;
     });
   }, null, "DS: Extract payload of " + internalModel + " : hasMany " + relationship.type);
 }

--- a/packages/ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/has-many-test.js
@@ -1443,5 +1443,33 @@ test("Model's belongsTo relationship should be created during 'get' method", fun
     user = env.store.createRecord('user');
     user.get('messages');
     ok(user._internalModel._relationships.has('messages'), "Newly created record with relationships in params passed in its constructor should have relationships");
+});
+
+test("metadata is accessible", function() {
+  expect(1);
+
+  env.adapter.findHasMany = function() {
+    return resolve({
+      meta: {
+        foo: 'bar'
+      },
+      chapters: [
+        { id: '2' },
+        { id: '3' }
+      ]
+    });
+  };
+
+  var book;
+
+  run(function() {
+    book = env.store.push('book', { id: 1, title: 'Sailing the Seven Seas', links: { chapters: '/chapters' } });
+  });
+
+  run(function() {
+    book.get('chapters').then(function(chapters) {
+      var meta = chapters.get('meta');
+      equal(get(meta, 'foo'), 'bar', 'metadata is available');
+    });
   });
 });


### PR DESCRIPTION
Happy birthday @wecc 
Copied commit message:

Rebased #2878 and added a test from #2996
Added metadata support behind a feature flag, for hasMany relationships.
For now, until we refactor the internals, the store internally pushes hasMany
metadata around in the `meta` key next to `links` and `data`.
This might lead to overriding meta attribtues with meta relationships,
but will be solved by the upcoming change of the internals to JSONAPI format
