### PR TITLE
Warnings for incorrect options in belongsTo, resolves #3187

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/belongs-to.js
@@ -102,6 +102,9 @@ function belongsTo(modelName, options) {
 
   return computedPolyfill({
     get: function(key) {
+      Ember.warn('You provided a serialize option on the "' + key + '" property in the "' + this._internalModel.modelName + '" class, this belongs in the serializer. See DS.Serializer and it\'s implementations http://emberjs.com/api/data/classes/DS.Serializer.html', !opts.hasOwnProperty('serialize'));
+      Ember.warn('You provided an embedded option on the "' + key + '" property in the "' + this._internalModel.modelName + '" class, this belongs in the serializer. See DS.EmbeddedRecordsMixin http://emberjs.com/api/data/classes/DS.EmbeddedRecordsMixin.html', !opts.hasOwnProperty('embedded'));
+
       return this._internalModel._relationships.get(key).getRecord();
     },
     set: function(key, value) {

--- a/packages/ember-data/tests/unit/model/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/belongs-to-test.js
@@ -253,3 +253,61 @@ test("belongsTo supports relationships to models with id 0", function() {
     }));
   });
 });
+
+test("belongsTo gives a warning when provided with a serialize option", function() {
+  var Hobby = DS.Model.extend({
+    name: DS.attr('string')
+  });
+  Hobby.toString = function() { return "Hobby"; };
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    hobby: DS.belongsTo('hobby', { serialize: true })
+  });
+  Person.toString = function() { return "Person"; };
+
+  var env = setupStore({ hobby: Hobby, person: Person });
+  var store = env.store;
+
+  run(function() {
+    store.pushMany('hobby', [{ id: 1, name: "fishing" }, { id: 1, name: "coding" }]);
+    store.push('person', { id: 1, name: "Tom Dale", hobby: 1 });
+  });
+
+  warns(function() {
+    run(function() {
+      store.find('person', 1).then(async(function(person) {
+        get(person, 'hobby');
+      }));
+    });
+  }, /You provided a serialize option on the "hobby" property in the "person" class, this belongs in the serializer. See DS.Serializer and it's implementations/);
+});
+
+test("belongsTo gives a warning when provided with an embedded option", function() {
+  var Hobby = DS.Model.extend({
+    name: DS.attr('string')
+  });
+  Hobby.toString = function() { return "Hobby"; };
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string'),
+    hobby: DS.belongsTo('hobby', { embedded: true })
+  });
+  Person.toString = function() { return "Person"; };
+
+  var env = setupStore({ hobby: Hobby, person: Person });
+  var store = env.store;
+
+  run(function() {
+    store.pushMany('hobby', [{ id: 1, name: "fishing" }, { id: 1, name: "coding" }]);
+    store.push('person', { id: 1, name: "Tom Dale", hobby: 1 });
+  });
+
+  warns(function() {
+    run(function() {
+      store.find('person', 1).then(async(function(person) {
+        get(person, 'hobby');
+      }));
+    });
+  }, /You provided an embedded option on the "hobby" property in the "person" class, this belongs in the serializer. See DS.EmbeddedRecordsMixin/);
+});


### PR DESCRIPTION
Display a warning when the user specifies ```serialize``` or ```embedded``` in the options for ```belongsTo```. These settings belong in the serializer now, I have linked to the relevant documentation pages in order to help the user to do what they meant to do. Resolves #3187.