### PR TITLE
Make store.findAll(type) public

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Server](http://emberjs.com/guides/models/connecting-to-an-http-server/).
 From your route or controller:
 
 ```js
-this.store.find('blogPost');
+this.store.findAll('blogPost');
 ```
 
 This returns a promise that resolves to the collection of records.

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -28,7 +28,7 @@ Ember Data 1.0.beta.1:
 ```js
 App.PostsRoute = Ember.Route.extend({
   model: function() {
-    return this.store.find('post');
+    return this.store.findAll('post');
   }
 });
 
@@ -180,7 +180,7 @@ App.NewPostRoute = Ember.Route.extend({
 });
 ```
 
-You also no longer need transactions to save relationships independently 
+You also no longer need transactions to save relationships independently
 of the model it belongs to, e.g. comments of a post.
 
 Ember Data 0.13:
@@ -295,7 +295,7 @@ function retry(promise, retryCallback, nTimes) {
   });
 }
 
-// try to save the person up to 5 times 
+// try to save the person up to 5 times
 retry(person.save(), function() {
   return person.save();
 }, 5);
@@ -305,7 +305,7 @@ Because all async operations in Ember Data 1.0.beta.1 are promises, you
 can combine them together using normal promise primitives.
 
 ```js
-this.store.find('person').then(function(people) {
+this.store.findAll('person').then(function(people) {
   people.forEach(function(person) {
     person.set('isPaidUp', true);
   });
@@ -533,7 +533,7 @@ App.PostSerializer = DS.RESTSerializer.extend({
     });
 
     post.comments = commentIds;
-    
+
     var post_payload = { post: post, comments: comments };
 
     return this._super(store, type, post_payload, id);
@@ -559,7 +559,7 @@ App.PostSerializer = DS.RESTSerializer.extend({
     // below in `normalizeHash`
     var comments = payload._embedded.comments;
     post.comments = comments.mapBy('ID_');
-    
+
     var post_payload = { post: post, comments: comments };
 
     return this._super(store, type, post_payload, id);
@@ -620,7 +620,7 @@ App.PostSerializer = DS.RESTSerializer.extend({
 
     // normalize the underscored properties
     for (var prop in hash) {
-      json[prop.camelize()] = hash[prop]; 
+      json[prop.camelize()] = hash[prop];
     }
 
     // delegate to any type-specific normalizations
@@ -648,14 +648,14 @@ In 0.13, the REST Adapter automatically camelized incoming keys for
 you. It also expected `belongsTo` relationships to be listed under
 `name_id` and `hasMany` relationships to be listed under `name_ids`.
 
-If your application returns json with underscored attributes and `_id` or `_ids` 
+If your application returns json with underscored attributes and `_id` or `_ids`
 for relation, you can extend `ActiveModelSerializer` and all will work out of the box.
 
 ```js
 App.ApplicationSerializer = DS.ActiveModelSerializer.extend({});
 ```
 
-Note: DS.ActiveModelSerializer is not to be confused with the ActiveModelSerializer gem 
+Note: DS.ActiveModelSerializer is not to be confused with the ActiveModelSerializer gem
 that is part of Rails API project. A conventional Rails API project with produce underscored output
 and the `DS.ActiveModelSerializer` will perform the expected normalization behavior such as camelizing
 property keys in your JSON.

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -124,8 +124,7 @@ var Adapter = Ember.Object.extend({
   find: null,
 
   /**
-    The `findAll()` method is called when you call `find` on the store
-    without an ID (i.e. `store.find('post')`).
+    The `findAll()` method is used to retrieve all records for a given type.
 
     Example
 
@@ -148,7 +147,6 @@ var Adapter = Ember.Object.extend({
     });
     ```
 
-    @private
     @method findAll
     @param {DS.Store} store
     @param {DS.Model} type

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -462,10 +462,10 @@ Store = Service.extend({
 
     ---
 
-    To find all records for a type, call `find` with no additional parameters:
+    To find all records for a type, call `findAll`:
 
     ```javascript
-    store.find('person');
+    store.findAll('person');
     ```
 
     This will ask the adapter's `findAll` method to find the records for the
@@ -526,6 +526,7 @@ Store = Service.extend({
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
 
     if (arguments.length === 1) {
+      Ember.deprecate('Using store.find(type) has been deprecated. Use store.findAll(type) to retrieve all records for a given type.');
       return this.findAll(modelName);
     }
 
@@ -997,7 +998,6 @@ Store = Service.extend({
     the array with records of that type.
 
     @method findAll
-    @private
     @param {String} modelName
     @return {DS.AdapterPopulatedRecordArray}
   */

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -584,10 +584,8 @@ Store = Service.extend({
     @return {Promise} promise
   */
   fetchAll: function(modelName) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
-    var typeClass = this.modelFor(modelName);
-
-    return this._fetchAll(typeClass, this.all(modelName));
+    Ember.deprecate('Using store.fetchAll(type) has been deprecated. Use store.findAll(type) to retrieve all records for a given type.');
+    return this.findAll(modelName);
   },
 
   /**
@@ -1003,7 +1001,9 @@ Store = Service.extend({
   */
   findAll: function(modelName) {
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
-    return this.fetchAll(modelName);
+    var typeClass = this.modelFor(modelName);
+
+    return this._fetchAll(typeClass, this.all(modelName));
   },
 
   /**

--- a/packages/ember-data/tests/integration/adapter/find-all-test.js
+++ b/packages/ember-data/tests/integration/adapter/find-all-test.js
@@ -43,7 +43,7 @@ test("When all records for a type are requested, the store should call the adapt
   var allRecords;
 
   run(function() {
-    store.find('person').then(function(all) {
+    store.findAll('person').then(function(all) {
       allRecords = all;
       equal(get(all, 'length'), 1, "the record array's length is 1 after a record is loaded into it");
       equal(all.objectAt(0).get('name'), "Braaaahm Dale", "the first item in the record array is Braaaahm Dale");
@@ -51,7 +51,7 @@ test("When all records for a type are requested, the store should call the adapt
   });
 
   run(function() {
-    store.find('person').then(function(all) {
+    store.findAll('person').then(function(all) {
       // Only one record array per type should ever be created (identity map)
       strictEqual(allRecords, all, "the same record array is returned every time all records of a type are requested");
     });
@@ -78,9 +78,9 @@ test("When all records for a type are requested, a rejection should reject the p
   var allRecords;
 
   run(function() {
-    store.find('person').then(null, function() {
+    store.findAll('person').then(null, function() {
       ok(true, "The rejection should get here");
-      return store.find('person');
+      return store.findAll('person');
     }).then(function(all) {
       allRecords = all;
       equal(get(all, 'length'), 1, "the record array's length is 1 after a record is loaded into it");

--- a/packages/ember-data/tests/integration/adapter/find-test.js
+++ b/packages/ember-data/tests/integration/adapter/find-test.js
@@ -22,14 +22,12 @@ module("integration/adapter/find - Finding Records", {
 });
 
 test("It raises an assertion when no type is passed", function() {
-
   expectAssertion(function() {
     store.find();
   }, "You need to pass a type to the store's find method");
 });
 
 test("It raises an assertion when `undefined` is passed as id (#1705)", function() {
-
   expectAssertion(function() {
     store.find('person', undefined);
   }, "You may not pass `undefined` as id to the store's find method");
@@ -37,6 +35,23 @@ test("It raises an assertion when `undefined` is passed as id (#1705)", function
   expectAssertion(function() {
     store.find('person', null);
   }, "You may not pass `null` as id to the store's find method");
+});
+
+test("store.find(type) is deprecated", function() {
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    findAll: function(store, typeClass) {
+      return [];
+    }
+  }));
+
+  expectDeprecation(
+    function() {
+      run(function() {
+        store.find('person');
+      });
+    },
+    'Using store.find(type) has been deprecated. Use store.findAll(type) to retrieve all records for a given type.'
+  );
 });
 
 test("When a single record is requested, the adapter's find method should be called unless it's loaded.", function() {

--- a/packages/ember-data/tests/integration/store-test.js
+++ b/packages/ember-data/tests/integration/store-test.js
@@ -269,13 +269,28 @@ test("Using store#fetchById on existing record reloads it", function() {
   });
 });
 
-module("integration/store - fetchAll", {
+module("integration/store - findAll", {
   setup: function() {
     initializeStore(DS.RESTAdapter.extend());
   }
 });
 
-test("Using store#fetchAll with no records triggers a query", function() {
+test("store#fetchAll() is deprecated", function() {
+  ajaxResponse({
+    cars: []
+  });
+
+  expectDeprecation(
+    function() {
+      run(function() {
+        store.fetchAll('car');
+      });
+    },
+    'Using store.fetchAll(type) has been deprecated. Use store.findAll(type) to retrieve all records for a given type.'
+  );
+});
+
+test("Using store#findAll with no records triggers a query", function() {
   expect(2);
 
   ajaxResponse({
@@ -295,13 +310,13 @@ test("Using store#fetchAll with no records triggers a query", function() {
   ok(!cars.get('length'), 'There is no cars in the store');
 
   run(function() {
-    store.fetchAll('car').then(function(cars) {
+    store.findAll('car').then(function(cars) {
       equal(cars.get('length'), 2, 'Two car were fetched');
     });
   });
 });
 
-test("Using store#fetchAll with existing records performs a query, updating existing records and returning new ones", function() {
+test("Using store#findAll with existing records performs a query, updating existing records and returning new ones", function() {
   expect(3);
 
   run(function() {
@@ -329,7 +344,7 @@ test("Using store#fetchAll with existing records performs a query, updating exis
   equal(cars.get('length'), 1, 'There is one car in the store');
 
   run(function() {
-    store.fetchAll('car').then(function(cars) {
+    store.findAll('car').then(function(cars) {
       equal(cars.get('length'), 2, 'There is 2 cars in the store now');
       var mini = cars.findBy('id', '1');
       equal(mini.get('model'), 'New Mini', 'Existing records have been updated');
@@ -337,7 +352,7 @@ test("Using store#fetchAll with existing records performs a query, updating exis
   });
 });
 
-test("store#fetchAll should return all known records even if they are not in the adapter response", function() {
+test("store#findAll should return all known records even if they are not in the adapter response", function() {
   expect(4);
 
   run(function() {
@@ -357,7 +372,7 @@ test("store#fetchAll should return all known records even if they are not in the
   equal(cars.get('length'), 2, 'There is two cars in the store');
 
   run(function() {
-    store.fetchAll('car').then(function(cars) {
+    store.findAll('car').then(function(cars) {
       equal(cars.get('length'), 2, 'It returns all cars');
       var mini = cars.findBy('id', '1');
       equal(mini.get('model'), 'New Mini', 'Existing records have been updated');


### PR DESCRIPTION
closes https://github.com/emberjs/data/issues/3227

- [x] Make `store.findAll` public
- [x] Make `adapter.findAll` public
- [x] Deprecate `store.find(type)` in favor of `store.findAll(type)`
- [x] Deprecate `store.fetchAll(type)` in favor of `store.findAll(type)`