### PR TITLE
Use Map.prototype.delete instead of Map.prototype.remove

### DIFF
--- a/packages/ember-data/lib/system/record-array-manager.js
+++ b/packages/ember-data/lib/system/record-array-manager.js
@@ -294,7 +294,7 @@ export default Ember.Object.extend({
     } else if (this.liveRecordArrays.has(typeClass)) {
       var liveRecordArrayForType = this.liveRecordArrayFor(typeClass);
       if (array === liveRecordArrayForType) {
-        this.liveRecordArrays.remove(typeClass);
+        this.liveRecordArrays.delete(typeClass);
       }
     }
   },


### PR DESCRIPTION
`Map.prototype.remove` is deprecated and causes:

```
DEPRECATION: Calling `Map.prototype.remove` has been deprecated, please use `Map.prototype.delete` instead.
```

https://github.com/emberjs/ember.js/commit/39bf8b23a8482eb9fffeda00d8beb914c3b8c444