### PR TITLE
Rename store.findByRecord to store.findRecord

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -534,7 +534,7 @@ Store = Service.extend({
       return this.findQuery(modelName, id);
     }
 
-    return this.findByRecord(modelName, coerceId(id), preload);
+    return this.findRecord(modelName, coerceId(id), preload);
   },
 
   /**
@@ -614,21 +614,20 @@ Store = Service.extend({
     @return {Promise} promise
   */
   findById: function(modelName, id, preload) {
-    Ember.deprecate('Using store.findById() has been deprecated. Use store.findByRecord() to return a record for a given type and id combination.');
-    return this.findByRecord(modelName, id, preload);
+    Ember.deprecate('Using store.findById() has been deprecated. Use store.findRecord() to return a record for a given type and id combination.');
+    return this.findRecord(modelName, id, preload);
   },
 
   /**
     This method returns a record for a given type and id combination.
 
-    @method findByRecord
-    @private
+    @method findRecord
     @param {String} modelName
     @param {(String|Integer)} id
     @param {Object} preload - optional set of attributes and relationships passed in either as IDs or as actual models
     @return {Promise} promise
   */
-  findByRecord: function(modelName, id, preload) {
+  findRecord: function(modelName, id, preload) {
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var internalModel = this._internalModelForId(modelName, id);
 
@@ -649,7 +648,7 @@ Store = Service.extend({
       fetchedInternalModel = internalModel._loadingPromise;
     }
 
-    return promiseRecord(fetchedInternalModel || internalModel, "DS: Store#findByRecord " + internalModel.typeKey + " with id: " + get(internalModel, 'id'));
+    return promiseRecord(fetchedInternalModel || internalModel, "DS: Store#findRecord " + internalModel.typeKey + " with id: " + get(internalModel, 'id'));
   },
   /**
     This method makes a series of requests to the adapter's `find` method
@@ -666,12 +665,12 @@ Store = Service.extend({
     var store = this;
 
     return promiseArray(Ember.RSVP.all(map(ids, function(id) {
-      return store.findByRecord(modelName, id);
+      return store.findRecord(modelName, id);
     })).then(Ember.A, null, "DS: Store#findByIds of " + modelName + " complete"));
   },
 
   /**
-    This method is called by `findByRecord` if it discovers that a particular
+    This method is called by `findRecord` if it discovers that a particular
     type/id pair hasn't been loaded yet to kick off a request to the
     adapter.
 

--- a/packages/ember-data/tests/integration/store-test.js
+++ b/packages/ember-data/tests/integration/store-test.js
@@ -193,7 +193,7 @@ test("store.findById() is deprecated", function() {
         store.findById('person', 1);
       });
     },
-    'Using store.findById() has been deprecated. Use store.findByRecord() to return a record for a given type and id combination.'
+    'Using store.findById() has been deprecated. Use store.findRecord() to return a record for a given type and id combination.'
   );
 });
 

--- a/packages/ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/ember-data/tests/unit/store/adapter-interop-test.js
@@ -60,7 +60,7 @@ test("Calling Store#find invokes its adapter#find", function() {
   });
 });
 
-test("Calling Store#findByRecord multiple times coalesces the calls into a adapter#findMany call", function() {
+test("Calling Store#findRecord multiple times coalesces the calls into a adapter#findMany call", function() {
   expect(2);
 
   var adapter = TestAdapter.extend({


### PR DESCRIPTION
fixes #3228

- renames `store.findByRecord` to `store.findRecord`
- makes `store.findRecord` public