### PR TITLE
Always use dasherized modelName to fetch serializer

### DIFF
--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -596,7 +596,7 @@ var RESTSerializer = JSONSerializer.extend({
         continue;
       }
       var type = store.modelFor(typeName);
-      var typeSerializer = store.serializerFor(type);
+      var typeSerializer = store.serializerFor(type.modelName);
       var isPrimary = (!forcedSecondary && this.isPrimaryType(store, typeName, primaryTypeClass));
 
       /*jshint loopfunc:true*/
@@ -1051,7 +1051,7 @@ function _newPushPayload(store, rawPayload) {
       continue;
     }
     var type = store.modelFor(modelName);
-    var typeSerializer = store.serializerFor(type);
+    var typeSerializer = store.serializerFor(type.modelName);
 
     /*jshint loopfunc:true*/
     forEach.call(Ember.makeArray(payload[prop]), (hash) => {


### PR DESCRIPTION
Found two more instances of https://github.com/emberjs/data/issues/3231

This brings the deprecations that come up when running the tests from 70 to 3 :smiley: 