### PR TITLE
Treat empty strings in ids the same as null or undefined

### DIFF
--- a/packages/ember-data/lib/system/coerce-id.js
+++ b/packages/ember-data/lib/system/coerce-id.js
@@ -5,5 +5,5 @@
 // ID into the URL, and if we later try to deserialize that URL and find the
 // corresponding record, we will not know if it is a string or a number.
 export default function coerceId(id) {
-  return id == null ? null : id+'';
+  return id == null || id === '' ? null : id+'';
 }


### PR DESCRIPTION
Treats empty strings in ids the same as null or undefined.

---

This is the rebased version of #2352