### PR TITLE
Deprecate the preload argument to `find`/`fetchById` and move in into the `…

### DIFF
--- a/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -178,7 +178,7 @@ test('buildURL - buildURL takes a record from find', function() {
   });
 
   run(function() {
-    store.find('comment', 1, { post: post }).then(async(function(post) {
+    store.find('comment', 1, { preload: { post: post } }).then(async(function(post) {
       equal(passedUrl, "/posts/2/comments/1");
     }));
   });

--- a/packages/ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/ember-data/tests/unit/store/adapter-interop-test.js
@@ -391,7 +391,7 @@ test("initial values of attributes can be passed in as the third argument to fin
   });
 
   run(function() {
-    store.find('test', 1, { name: 'Test' });
+    store.find('test', 1, { preload: { name: 'Test' } });
   });
 });
 
@@ -419,7 +419,7 @@ test("initial values of belongsTo can be passed in as the third argument to find
 
   run(function() {
     tom = store.push('person', { id: 2, name: 'Tom' });
-    store.find('person', 1, { friend: tom });
+    store.find('person', 1, { preload: { friend: tom } });
   });
 });
 
@@ -445,7 +445,7 @@ test("initial values of belongsTo can be passed in as the third argument to find
   env.registry.register('model:person', Person);
 
   run(function() {
-    store.find('person', 1, { friend: 2 }).then(async(function() {
+    store.find('person', 1, { preload: { friend: 2 } }).then(async(function() {
       store.getById('person', 1).get('friend').then(async(function(friend) {
         equal(friend.get('id'), '2', 'Preloaded belongsTo set');
       }));
@@ -477,7 +477,7 @@ test("initial values of hasMany can be passed in as the third argument to find a
 
   run(function() {
     tom = store.push('person', { id: 2, name: 'Tom' });
-    store.find('person', 1, { friends: [tom] });
+    store.find('person', 1, { preload: { friends: [tom] } });
   });
 });
 
@@ -504,7 +504,7 @@ test("initial values of hasMany can be passed in as the third argument to find a
   env.registry.register('model:person', Person);
 
   run(function() {
-    store.find('person', 1, { friends: [2] });
+    store.find('person', 1, { preload: { friends: [2] } });
   });
 });
 
@@ -813,4 +813,67 @@ test("store.fetchRecord reject records that were not found, even when those requ
       }));
     });
   }, /expected to find records with the following ids in the adapter response but they were missing/);
+});
+
+module("unit/store/adapter_interop - find preload deprecations", {
+  setup: function() {
+    var Person = DS.Model.extend({
+      name: DS.attr('string')
+    });
+
+    var TestAdapter = DS.Adapter.extend({
+      find: function(store, type, id, snapshot) {
+        equal(snapshot.attr('name'), 'Tom');
+        return Ember.RSVP.resolve({ id: id });
+      }
+    });
+    store = createStore({
+      adapter: TestAdapter,
+      person: Person
+    });
+  },
+  teardown: function() {
+    run(function() {
+      if (store) { store.destroy(); }
+    });
+  }
+});
+
+test("Using store#find with preload is deprecated", function() {
+  expect(2);
+
+  expectDeprecation(
+    function() {
+      run(function() {
+        store.find('person', 1, { name: 'Tom' });
+      });
+    },
+    /Passing a preload argument to `store.find` is deprecated./
+  );
+});
+
+test("Using store#fetchById with preload is deprecated", function() {
+  expect(2);
+
+  expectDeprecation(
+    function() {
+      run(function() {
+        store.fetchById('person', 1, { name: 'Tom' });
+      });
+    },
+    /Passing a preload argument to `store.fetchById` is deprecated./
+  );
+});
+
+test("Using store#findById with preload is deprecated", function() {
+  expect(2);
+
+  expectDeprecation(
+    function() {
+      run(function() {
+        store.findById('person', 1, { name: 'Tom' });
+      });
+    },
+    /Passing a preload argument to `store.findById` is deprecated/
+  );
 });


### PR DESCRIPTION
…preload` key on the options argument.

Closes https://github.com/emberjs/data/issues/3248