### PR TITLE
Pad single-line objects with white-space

### DIFF
--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -193,7 +193,7 @@ var RestAdapter = Adapter.extend(BuildURLMixin, {
     For example:
 
     ```js
-      store.query('posts', {sort: 'price', category: 'pets'});
+      store.query('posts', { sort: 'price', category: 'pets' });
     ```
 
     will generate a requests like this `/posts?category=pets&sort=price`, even if the

--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -161,7 +161,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
 
     export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
       attrs: {
-        author: {embedded: 'always'}
+        author: { embedded: 'always' }
       }
     })
     ```
@@ -269,8 +269,8 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     serializing. When serializing, an option to embed `ids` or `records` can be set.
     When extracting the only option is `records`.
 
-    So `{embedded: 'always'}` is shorthand for:
-    `{serialize: 'records', deserialize: 'records'}`
+    So `{ embedded: 'always' }` is shorthand for:
+    `{ serialize: 'records', deserialize: 'records' }`
 
     To embed the `ids` for a related object (using a hasMany relationship):
 
@@ -279,7 +279,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
 
     export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
       attrs: {
-        comments: {serialize: 'ids', deserialize: 'records'}
+        comments: { serialize: 'ids', deserialize: 'records' }
       }
     })
     ```

--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -133,7 +133,7 @@ export default Serializer.extend({
     export default DS.JSONSerializer.extend({
       attrs: {
         admin: 'is_admin',
-        occupation: {key: 'career'}
+        occupation: { key: 'career' }
       }
     });
     ```
@@ -149,7 +149,7 @@ export default Serializer.extend({
     export default DS.JSONSerializer.extend({
       attrs: {
         admin: {serialize: false},
-        occupation: {key: 'career'}
+        occupation: { key: 'career' }
       }
     });
     ```
@@ -730,8 +730,8 @@ export default Serializer.extend({
     var mappedKey;
     if (attrs && attrs[key]) {
       mappedKey = attrs[key];
-      //We need to account for both the {title: 'post_title'} and
-      //{title: {key: 'post_title'}} forms
+      //We need to account for both the { title: 'post_title' } and
+      //{ title: { key: 'post_title' }} forms
       if (mappedKey.key) {
         mappedKey = mappedKey.key;
       }
@@ -1117,7 +1117,7 @@ export default Serializer.extend({
   /**
     You can use this method to customize how polymorphic objects are
     serialized. Objects are considered to be polymorphic if
-    `{polymorphic: true}` is pass as the second argument to the
+    `{ polymorphic: true }` is pass as the second argument to the
     `DS.belongsTo` function.
 
     Example

--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -274,7 +274,7 @@ function getValue(record, key) {
   export default DS.Model.extend({
     username: DS.attr('string'),
     email: DS.attr('string'),
-    verified: DS.attr('boolean', {defaultValue: false})
+    verified: DS.attr('boolean', { defaultValue: false })
   });
   ```
 

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -210,8 +210,8 @@ Model.reopenClass({
     });
     ```
 
-    App.Post.inverseFor('comments') -> {type: App.Message, name:'owner', kind:'belongsTo'}
-    App.Message.inverseFor('owner') -> {type: App.Post, name:'comments', kind:'hasMany'}
+    App.Post.inverseFor('comments') -> { type: App.Message, name: 'owner', kind: 'belongsTo' }
+    App.Message.inverseFor('owner') -> { type: App.Post, name: 'comments', kind: 'hasMany' }
 
     @method inverseFor
     @static
@@ -238,7 +238,7 @@ Model.reopenClass({
     }
 
     var propertyMeta = this.metaForProperty(name);
-    //If inverse is manually specified to be null, like  `comments: DS.hasMany('message', {inverse: null})`
+    //If inverse is manually specified to be null, like  `comments: DS.hasMany('message', { inverse: null })`
     var options = propertyMeta.options;
     if (options.inverse === null) { return null; }
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -445,7 +445,7 @@ Store = Service.extend({
     without fetching the post you can pass in the post to the `find` call:
 
     ```javascript
-    store.find('comment', 2, {post: 1});
+    store.find('comment', 2, { post: 1 });
     ```
 
     If you have access to the post model you can also pass the model itself:
@@ -1687,10 +1687,10 @@ Store = Service.extend({
     ```js
     var pushData = {
       posts: [
-        {id: 1, post_title: "Great post", comment_ids: [2]}
+        { id: 1, post_title: "Great post", comment_ids: [2] }
       ],
       comments: [
-        {id: 2, comment_body: "Insightful comment"}
+        { id: 2, comment_body: "Insightful comment" }
       ]
     }
 


### PR DESCRIPTION
https://github.com/emberjs/ember.js/blob/master/STYLEGUIDE.md#objects

I think it's important, especially in the docs/examples, to provide consistency.