### PR TITLE
Add a way to pass options to an adapter 

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -119,6 +119,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Model} type
     @param {String} id
     @param {DS.Snapshot} snapshot
+    @param {Object} adapterOptions
     @return {Promise} promise
   */
   find: null,
@@ -151,6 +152,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {DS.Model} type
     @param {String} sinceToken
+    @param {Object} adapterOptions
     @return {Promise} promise
   */
   findAll: null,
@@ -184,6 +186,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Model} type
     @param {Object} query
     @param {DS.AdapterPopulatedRecordArray} recordArray
+    @param {Object} adapterOptions
     @return {Promise} promise
   */
   findQuery: null,
@@ -282,7 +285,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {DS.Model} type   the DS.Model class of the record
     @param {DS.Snapshot} snapshot
-    @param {Object} options
+    @param {Object} adapterOptions
     @return {Promise} promise
   */
   createRecord: null,
@@ -325,7 +328,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {DS.Model} type   the DS.Model class of the record
     @param {DS.Snapshot} snapshot
-    @param {Object} options
+    @param {Object} adapterOptions
     @return {Promise} promise
   */
   updateRecord: null,
@@ -368,7 +371,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {DS.Model} type   the DS.Model class of the record
     @param {DS.Snapshot} snapshot
-    @param {Object} options
+    @param {Object} adapterOptions
     @return {Promise} promise
   */
   deleteRecord: null,

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -282,6 +282,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {DS.Model} type   the DS.Model class of the record
     @param {DS.Snapshot} snapshot
+    @param {Object} options
     @return {Promise} promise
   */
   createRecord: null,
@@ -324,6 +325,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {DS.Model} type   the DS.Model class of the record
     @param {DS.Snapshot} snapshot
+    @param {Object} options
     @return {Promise} promise
   */
   updateRecord: null,
@@ -366,6 +368,7 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {DS.Model} type   the DS.Model class of the record
     @param {DS.Snapshot} snapshot
+    @param {Object} options
     @return {Promise} promise
   */
   deleteRecord: null,

--- a/packages/ember-data/lib/system/model/internal-model.js
+++ b/packages/ember-data/lib/system/model/internal-model.js
@@ -126,11 +126,11 @@ InternalModel.prototype = {
     this.send('deleteRecord');
   },
 
-  save: function() {
+  save: function(options) {
     var promiseLabel = "DS: Model#save " + this;
     var resolver = Ember.RSVP.defer(promiseLabel);
 
-    this.store.scheduleSave(this, resolver);
+    this.store.scheduleSave(this, resolver, options);
     return resolver.promise;
   },
 

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -494,8 +494,8 @@ var Model = Ember.Object.extend(Ember.Evented, {
 
     @method deleteRecord
   */
-  deleteRecord: function() {
-    this._internalModel.deleteRecord();
+  deleteRecord: function(options) {
+    this._internalModel.deleteRecord(options);
   },
 
   /**
@@ -519,12 +519,13 @@ var Model = Ember.Object.extend(Ember.Evented, {
     ```
 
     @method destroyRecord
+    @param {Object} options
     @return {Promise} a promise that will be resolved when the adapter returns
     successfully or rejected if the adapter returns with an error.
   */
-  destroyRecord: function() {
+  destroyRecord: function(options) {
     this.deleteRecord();
-    return this.save();
+    return this.save(options);
   },
 
   /**
@@ -653,7 +654,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     });
     ```
     @method save
-    @param {Object} options a hash specifying save options sent to the server.
+    @param {Object} options
     @return {Promise} a promise that will be resolved when the adapter returns
     successfully or rejected if the adapter returns with an error.
   */

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -653,13 +653,14 @@ var Model = Ember.Object.extend(Ember.Evented, {
     });
     ```
     @method save
+    @param {Object} options a hash specifying save options sent to the server.
     @return {Promise} a promise that will be resolved when the adapter returns
     successfully or rejected if the adapter returns with an error.
   */
-  save: function() {
+  save: function(options) {
     var model = this;
     return PromiseObject.create({
-      promise: this._internalModel.save().then(function() {
+      promise: this._internalModel.save(options).then(function() {
         return model;
       })
     });

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -605,7 +605,7 @@ Store = Service.extend({
     }
 
     if (internalModel.isEmpty()) {
-      fetchedInternalModel = this.scheduleFetch(internalModel);
+      fetchedInternalModel = this.scheduleFetch(internalModel, options);
       //TODO double check about reloading
     } else if (internalModel.isLoading()) {
       fetchedInternalModel = internalModel._loadingPromise;
@@ -641,8 +641,9 @@ Store = Service.extend({
     @private
     @param {InternalModel} internalModel model
     @return {Promise} promise
-  */
-  fetchRecord: function(internalModel) {
+   */
+  // TODO rename this to have an underscore
+  fetchRecord: function(internalModel, options) {
     var typeClass = internalModel.type;
     var id = internalModel.id;
     var adapter = this.adapterFor(typeClass.modelName);
@@ -650,7 +651,7 @@ Store = Service.extend({
     Ember.assert("You tried to find a record but you have no adapter (for " + typeClass + ")", adapter);
     Ember.assert("You tried to find a record but your adapter (for " + typeClass + ") does not implement 'find'", typeof adapter.find === 'function');
 
-    var promise = _find(adapter, this, typeClass, id, internalModel);
+    var promise = _find(adapter, this, typeClass, id, internalModel, options);
     return promise;
   },
 
@@ -659,24 +660,25 @@ Store = Service.extend({
     return Promise.all(map(internalModels, this.scheduleFetch, this));
   },
 
-  scheduleFetch: function(internalModel) {
+  scheduleFetch: function(internalModel, options) {
     var typeClass = internalModel.type;
 
     if (internalModel._loadingPromise) { return internalModel._loadingPromise; }
 
     var resolver = Ember.RSVP.defer('Fetching ' + typeClass + 'with id: ' + internalModel.id);
-    var recordResolverPair = {
+    var pendingFetchItem = {
       record: internalModel,
-      resolver: resolver
+      resolver: resolver,
+      options: options
     };
     var promise = resolver.promise;
 
     internalModel.loadingData(promise);
 
     if (!this._pendingFetch.get(typeClass)) {
-      this._pendingFetch.set(typeClass, [recordResolverPair]);
+      this._pendingFetch.set(typeClass, [pendingFetchItem]);
     } else {
-      this._pendingFetch.get(typeClass).push(recordResolverPair);
+      this._pendingFetch.get(typeClass).push(pendingFetchItem);
     }
     Ember.run.scheduleOnce('afterRender', this, this.flushAllPendingFetches);
 
@@ -692,19 +694,19 @@ Store = Service.extend({
     this._pendingFetch = Map.create();
   },
 
-  _flushPendingFetchForType: function (recordResolverPairs, typeClass) {
+  _flushPendingFetchForType: function (pendingFetchItems, typeClass) {
     var store = this;
     var adapter = store.adapterFor(typeClass.modelName);
     var shouldCoalesce = !!adapter.findMany && adapter.coalesceFindRequests;
-    var records = Ember.A(recordResolverPairs).mapBy('record');
+    var records = Ember.A(pendingFetchItems).mapBy('record');
 
     function _fetchRecord(recordResolverPair) {
-      recordResolverPair.resolver.resolve(store.fetchRecord(recordResolverPair.record));
+      recordResolverPair.resolver.resolve(store.fetchRecord(recordResolverPair.record, recordResolverPair.options)); // TODO adapter options
     }
 
     function resolveFoundRecords(records) {
       forEach(records, function(record) {
-        var pair = Ember.A(recordResolverPairs).findBy('record', record);
+        var pair = Ember.A(pendingFetchItems).findBy('record', record);
         if (pair) {
           var resolver = pair.resolver;
           resolver.resolve(record);
@@ -734,7 +736,7 @@ Store = Service.extend({
 
     function rejectRecords(records, error) {
       forEach(records, function(record) {
-        var pair = Ember.A(recordResolverPairs).findBy('record', record);
+        var pair = Ember.A(pendingFetchItems).findBy('record', record);
         if (pair) {
           var resolver = pair.resolver;
           resolver.reject(error);
@@ -742,8 +744,8 @@ Store = Service.extend({
       });
     }
 
-    if (recordResolverPairs.length === 1) {
-      _fetchRecord(recordResolverPairs[0]);
+    if (pendingFetchItems.length === 1) {
+      _fetchRecord(pendingFetchItems[0]);
     } else if (shouldCoalesce) {
 
       // TODO: Improve records => snapshots => records => snapshots
@@ -769,14 +771,14 @@ Store = Service.extend({
             then(makeMissingRecordsRejector(requestedRecords)).
             then(null, makeRecordsRejector(requestedRecords));
         } else if (ids.length === 1) {
-          var pair = Ember.A(recordResolverPairs).findBy('record', groupOfRecords[0]);
+          var pair = Ember.A(pendingFetchItems).findBy('record', groupOfRecords[0]);
           _fetchRecord(pair);
         } else {
           Ember.assert("You cannot return an empty array from adapter's method groupRecordsForFindMany", false);
         }
       });
     } else {
-      forEach(recordResolverPairs, _fetchRecord);
+      forEach(pendingFetchItems, _fetchRecord);
     }
   },
 
@@ -973,9 +975,10 @@ Store = Service.extend({
     @method query
     @param {String} modelName
     @param {any} query an opaque query to be used by the adapter
+    @param {Object} options
     @return {Promise} promise
   */
-  query: function(modelName, query) {
+  query: function(modelName, query, options) {
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     var array = this.recordArrayManager
@@ -986,7 +989,7 @@ Store = Service.extend({
     Ember.assert("You tried to load a query but you have no adapter (for " + typeClass + ")", adapter);
     Ember.assert("You tried to load a query but your adapter does not implement `findQuery`", typeof adapter.findQuery === 'function');
 
-    return promiseArray(_query(adapter, this, typeClass, query, array));
+    return promiseArray(_query(adapter, this, typeClass, query, array, options));
   },
 
   /**
@@ -1018,13 +1021,14 @@ Store = Service.extend({
 
     @method findAll
     @param {String} modelName
+    @param {Object} options
     @return {DS.AdapterPopulatedRecordArray}
   */
-  findAll: function(modelName) {
+  findAll: function(modelName, options) {
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
 
-    return this._fetchAll(typeClass, this.all(modelName));
+    return this._fetchAll(typeClass, this.all(modelName), options);
   },
 
   /**
@@ -1034,7 +1038,7 @@ Store = Service.extend({
     @param {DS.RecordArray} array
     @return {Promise} promise
   */
-  _fetchAll: function(typeClass, array) {
+  _fetchAll: function(typeClass, array, options) {
     var adapter = this.adapterFor(typeClass.modelName);
     var sinceToken = this.typeMapFor(typeClass).metadata.since;
 
@@ -1043,7 +1047,7 @@ Store = Service.extend({
     Ember.assert("You tried to load all records but you have no adapter (for " + typeClass + ")", adapter);
     Ember.assert("You tried to load all records but your adapter does not implement `findAll`", typeof adapter.findAll === 'function');
 
-    return promiseArray(_findAll(adapter, this, typeClass, sinceToken));
+    return promiseArray(_findAll(adapter, this, typeClass, sinceToken, options));
   },
 
   /**
@@ -1304,7 +1308,7 @@ Store = Service.extend({
     internalModel.adapterWillCommit();
     this._pendingSave.push({
       snapshot: snapshot,
-      response: resolver,
+      resolver: resolver,
       options: options
     });
     once(this, 'flushPendingSave');
@@ -2118,7 +2122,8 @@ function _commit(adapter, store, operation, snapshot, options) {
   var record = snapshot._internalModel;
   var modelName = snapshot.modelName;
   var type = store.modelFor(modelName);
-  var promise = adapter[operation](store, type, snapshot, options); // TODO check this out
+  var adapterOptions = options && options.adapterOptions;
+  var promise = adapter[operation](store, type, snapshot, adapterOptions);
   var serializer = serializerForAdapter(store, adapter, modelName);
   var label = "DS: Extract and notify about " + operation + " completion of " + record;
 

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -16,9 +16,10 @@ import {
 var Promise = Ember.RSVP.Promise;
 var map = Ember.EnumerableUtils.map;
 
-export function _find(adapter, store, typeClass, id, internalModel) {
+export function _find(adapter, store, typeClass, id, internalModel, options) {
+  var adapterOptions = options && options.adapterOptions;
   var snapshot = internalModel.createSnapshot();
-  var promise = adapter.find(store, typeClass, id, snapshot);
+  var promise = adapter.find(store, typeClass, id, snapshot, adapterOptions);
   var serializer = serializerForAdapter(store, adapter, internalModel.type.modelName);
   var label = "DS: Handle Adapter#find of " + typeClass + " with id: " + id;
 
@@ -118,8 +119,9 @@ export function _findBelongsTo(adapter, store, internalModel, link, relationship
   }, null, "DS: Extract payload of " + internalModel + " : " + relationship.type);
 }
 
-export function _findAll(adapter, store, typeClass, sinceToken) {
-  var promise = adapter.findAll(store, typeClass, sinceToken);
+export function _findAll(adapter, store, typeClass, sinceToken, options) {
+  var adapterOptions = options && options.adapterOptions;
+  var promise = adapter.findAll(store, typeClass, sinceToken, adapterOptions);
   var modelName = typeClass.modelName;
   var serializer = serializerForAdapter(store, adapter, modelName);
   var label = "DS: Handle Adapter#findAll of " + typeClass;
@@ -139,9 +141,10 @@ export function _findAll(adapter, store, typeClass, sinceToken) {
   }, null, "DS: Extract payload of findAll " + typeClass);
 }
 
-export function _query(adapter, store, typeClass, query, recordArray) {
+export function _query(adapter, store, typeClass, query, recordArray, options) {
   var modelName = typeClass.modelName;
-  var promise = adapter.findQuery(store, typeClass, query, recordArray);
+  var adapterOptions = options && options.adapterOptions;
+  var promise = adapter.findQuery(store, typeClass, query, recordArray, adapterOptions);
   var serializer = serializerForAdapter(store, adapter, modelName);
   var label = "DS: Handle Adapter#findQuery of " + typeClass;
 

--- a/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -178,7 +178,7 @@ test('buildURL - buildURL takes a record from find', function() {
   });
 
   run(function() {
-    store.find('comment', 1, { post: post }).then(async(function(post) {
+    store.find('comment', 1, { preload: { post: post } }).then(async(function(post) {
       equal(passedUrl, "/posts/2/comments/1");
     }));
   });

--- a/packages/ember-data/tests/integration/adapter/store-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/store-adapter-test.js
@@ -947,3 +947,115 @@ test("findBelongsTo receives a snapshot", function() {
     person.get('dog');
   });
 });
+
+test("record.save should pass adapterOptions to the updateRecord method", function() {
+  expect(1);
+
+  env.adapter.updateRecord = async(function(store, type, snapshot, adapterOptions) {
+    deepEqual(adapterOptions, { subscribe: true });
+    return Ember.RSVP.resolve({ id: 1 });
+  });
+
+  run(function() {
+    var person = store.push('person', { id: 1, name: 'Tom' });
+    person.save({ adapterOptions: { subscribe: true } });
+  });
+});
+
+test("record.save should pass adapterOptions to the createRecord method", function() {
+  expect(1);
+
+  env.adapter.createRecord = async(function(store, type, snapshot, adapterOptions) {
+    deepEqual(adapterOptions, { subscribe: true });
+    return Ember.RSVP.resolve({ id: 1 });
+  });
+
+  run(function() {
+    var person = store.createRecord('person', { name: 'Tom' });
+    person.save({ adapterOptions: { subscribe: true } });
+  });
+});
+
+test("record.save should pass adapterOptions to the deleteRecord method", function() {
+  expect(1);
+
+  env.adapter.deleteRecord = async(function(store, type, snapshot, adapterOptions) {
+    deepEqual(adapterOptions, { subscribe: true });
+    return Ember.RSVP.resolve({ id: 1 });
+  });
+
+  run(function() {
+    var person = store.push('person', { id: 1, name: 'Tom' });
+    person.destroyRecord({ adapterOptions: { subscribe: true } });
+  });
+});
+
+
+test("findRecord should pass adapterOptions to the find method", function() {
+  expect(1);
+
+  env.adapter.find = async(function(store, type, id, snapshot, adapterOptions) {
+    deepEqual(adapterOptions, { query: { embed: true } });
+    return Ember.RSVP.resolve({ id: 1 });
+  });
+
+  run(function() {
+    store.findRecord('person', 1, { adapterOptions: { query: { embed: true } } });
+  });
+});
+
+
+test("findRecord should pass adapterOptions to the find method", function() {
+  expect(1);
+
+  env.adapter.find = async(function(store, type, id, snapshot, adapterOptions) {
+    deepEqual(adapterOptions, { query: { embed: true } });
+    return Ember.RSVP.resolve({ id: 1 });
+  });
+
+  run(function() {
+    store.findRecord('person', 1, { adapterOptions: { query: { embed: true } } });
+  });
+});
+
+
+test("findAll should pass adapterOptions to the findAll method", function() {
+  expect(1);
+
+  env.adapter.findAll = async(function(store, type, sinceToken, adapterOptions) {
+    deepEqual(adapterOptions, { query: { embed: true } });
+    return Ember.RSVP.resolve([{ id: 1 }]);
+  });
+
+  run(function() {
+    store.findAll('person', { adapterOptions: { query: { embed: true } } });
+  });
+});
+
+
+test("query should pass adapterOptions to the findQuery method", function() {
+  expect(1);
+
+  env.adapter.findQuery = async(function(store, type, query, recordArray, adapterOptions) {
+    deepEqual(adapterOptions, { subscribe: true });
+    return Ember.RSVP.resolve([{ id: 1 }]);
+  });
+
+  run(function() {
+    store.query('person', {}, { adapterOptions: { subscribe: true } });
+  });
+});
+
+
+// test("queryRecord should pass adapterOptions to the findQueryRecord method", function() {
+//   expect(1);
+
+//   env.adapter.findQueryRecord = async(function(store, type, query, recordArray, adapterOptions) {
+//     deepEqual(adapterOptions, { subscribe: true });
+//     return Ember.RSVP.resolve([{ id: 1 }]);
+//   });
+
+//   run(function() {
+//     store.queryRecord('person', {}, { adapterOptions: { subscribe: true } });
+//   });
+// });

--- a/packages/ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/ember-data/tests/unit/store/adapter-interop-test.js
@@ -391,7 +391,7 @@ test("initial values of attributes can be passed in as the third argument to fin
   });
 
   run(function() {
-    store.find('test', 1, { name: 'Test' });
+    store.find('test', 1, { preload: { name: 'Test' } });
   });
 });
 
@@ -419,7 +419,7 @@ test("initial values of belongsTo can be passed in as the third argument to find
 
   run(function() {
     tom = store.push('person', { id: 2, name: 'Tom' });
-    store.find('person', 1, { friend: tom });
+    store.find('person', 1, { preload: { friend: tom } });
   });
 });
 
@@ -445,7 +445,7 @@ test("initial values of belongsTo can be passed in as the third argument to find
   env.registry.register('model:person', Person);
 
   run(function() {
-    store.find('person', 1, { friend: 2 }).then(async(function() {
+    store.find('person', 1, { preload: { friend: 2 } }).then(async(function() {
       store.getById('person', 1).get('friend').then(async(function(friend) {
         equal(friend.get('id'), '2', 'Preloaded belongsTo set');
       }));
@@ -477,7 +477,7 @@ test("initial values of hasMany can be passed in as the third argument to find a
 
   run(function() {
     tom = store.push('person', { id: 2, name: 'Tom' });
-    store.find('person', 1, { friends: [tom] });
+    store.find('person', 1, { preload: { friends: [tom] } });
   });
 });
 
@@ -504,7 +504,7 @@ test("initial values of hasMany can be passed in as the third argument to find a
   env.registry.register('model:person', Person);
 
   run(function() {
-    store.find('person', 1, { friends: [2] });
+    store.find('person', 1, { preload: { friends: [2] } });
   });
 });
 
@@ -813,4 +813,67 @@ test("store.fetchRecord reject records that were not found, even when those requ
       }));
     });
   }, /expected to find records with the following ids in the adapter response but they were missing/);
+});
+
+module("unit/store/adapter_interop - find preload deprecations", {
+  setup: function() {
+    var Person = DS.Model.extend({
+      name: DS.attr('string')
+    });
+
+    var TestAdapter = DS.Adapter.extend({
+      find: function(store, type, id, snapshot) {
+        equal(snapshot.attr('name'), 'Tom');
+        return Ember.RSVP.resolve({ id: id });
+      }
+    });
+    store = createStore({
+      adapter: TestAdapter,
+      person: Person
+    });
+  },
+  teardown: function() {
+    run(function() {
+      if (store) { store.destroy(); }
+    });
+  }
+});
+
+test("Using store#find with preload is deprecated", function() {
+  expect(2);
+
+  expectDeprecation(
+    function() {
+      run(function() {
+        store.find('person', 1, { name: 'Tom' });
+      });
+    },
+    /Passing a preload argument to `store.find` is deprecated./
+  );
+});
+
+test("Using store#fetchById with preload is deprecated", function() {
+  expect(2);
+
+  expectDeprecation(
+    function() {
+      run(function() {
+        store.fetchById('person', 1, { name: 'Tom' });
+      });
+    },
+    /Passing a preload argument to `store.fetchById` is deprecated./
+  );
+});
+
+test("Using store#findById with preload is deprecated", function() {
+  expect(2);
+
+  expectDeprecation(
+    function() {
+      run(function() {
+        store.findById('person', 1, { name: 'Tom' });
+      });
+    },
+    /Passing a preload argument to `store.findById` is deprecated/
+  );
 });


### PR DESCRIPTION
`DS.Store#findAll`, `DS.Store#findRecord`, `DS.Store#query`, `DS.Model#save` and `DS.Model#destroyRecord` now all take an options parameter. If this `options` parameter has a value on the `adapeterOptions` key it will be passed to the adapter method used to retrieve or update from the backend.

This pr currently include the code from #3264 because that is a prerequisites for this work. I will rebase this pr after #3264 is merged.

This pr is built on top of the work @knownasilya started in pr https://github.com/emberjs/data/pull/2621