### PR TITLE
Add deprecation to relationships without { async: false }

### DIFF
--- a/packages/ember-data/lib/system/relationships/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/belongs-to.js
@@ -92,6 +92,10 @@ function belongsTo(modelName, options) {
 
   opts = opts || {};
 
+  if (typeof opts.async === 'undefined') {
+    Ember.deprecate('In the future, relationships will be asynchronous by default. You must set { async: false } if you wish for a relationship remain synchronous.');
+  }
+
   var meta = {
     type: userEnteredModelName,
     isRelationship: true,

--- a/packages/ember-data/lib/system/relationships/has-many.js
+++ b/packages/ember-data/lib/system/relationships/has-many.js
@@ -122,6 +122,10 @@ function hasMany(type, options) {
 
   options = options || {};
 
+  if (typeof options.async === 'undefined') {
+    Ember.deprecate('In the future, relationships will be asynchronous by default. You must set { async: false } if you wish for a relationship remain synchronous.');
+  }
+
   if (typeof type === 'string') {
     type = normalizeModelName(type);
   }

--- a/packages/ember-data/tests/unit/model/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/belongs-to-test.js
@@ -311,3 +311,22 @@ test("belongsTo gives a warning when provided with an embedded option", function
     });
   }, /You provided an embedded option on the "hobby" property in the "person" class, this belongs in the serializer. See DS.EmbeddedRecordsMixin/);
 });
+
+module("unit/model/relationships - DS.belongsTo async by default deprecations", {
+  setup: function() {
+    setupStore();
+  }
+});
+
+test("setting DS.belongsTo without async false triggers deprecation", function() {
+  expectDeprecation(
+    function() {
+      run(function() {
+        DS.Model.extend({
+          post: DS.belongsTo('post')
+        });
+      });
+    },
+    'In the future, relationships will be asynchronous by default. You must set { async: false } if you wish for a relationship remain synchronous.'
+  );
+});

--- a/packages/ember-data/tests/unit/model/relationships/has-many-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/has-many-test.js
@@ -466,3 +466,22 @@ test("it is possible to add an item to a relationship, remove it, then add it ag
   equal(tags.objectAt(1), tag1);
   equal(tags.objectAt(2), tag3);
 });
+
+module("unit/model/relationships - DS.hasMany async by default deprecations", {
+  setup: function() {
+    env = setupStore();
+  }
+});
+
+test("setting DS.hasMany without async false triggers deprecation", function() {
+  expectDeprecation(
+    function() {
+      run(function() {
+        DS.Model.extend({
+          comments: DS.hasMany('comment')
+        });
+      });
+    },
+    'In the future, relationships will be asynchronous by default. You must set { async: false } if you wish for a relationship remain synchronous.'
+  );
+});


### PR DESCRIPTION
closes https://github.com/emberjs/data/issues/3220

Adds a deprecation to relationships defined without `{ async: false }` that warns to add `{ async: false }` if you wish for the relationship to remain synchronous.