### PR TITLE
Deprecate `store:application` and `store:main` in favor of `service:store` 

### DIFF
--- a/packages/ember-data/lib/ember-initializer.js
+++ b/packages/ember-data/lib/ember-initializer.js
@@ -13,7 +13,7 @@ var K = Ember.K;
   This code initializes Ember-Data onto an Ember application.
 
   If an Ember.js developer defines a subclass of DS.Store on their application,
-  as `App.ApplicationStore` (or via a module system that resolves to `store:application`)
+  as `App.StoreService` (or via a module system that resolves to `service:store`)
   this code will automatically instantiate it and make it available on the
   router.
 
@@ -22,7 +22,7 @@ var K = Ember.K;
 
   For example, imagine an Ember.js application with the following classes:
 
-  App.ApplicationStore = DS.Store.extend({
+  App.StoreService = DS.Store.extend({
     adapter: 'custom'
   });
 

--- a/packages/ember-data/lib/initializers/store-injections.js
+++ b/packages/ember-data/lib/initializers/store-injections.js
@@ -6,7 +6,7 @@
   @param {Ember.Registry} registry
 */
 export default function initializeStoreInjections(registry) {
-  registry.injection('controller', 'store', 'store:main');
-  registry.injection('route', 'store', 'store:main');
-  registry.injection('data-adapter', 'store', 'store:main');
+  registry.injection('controller', 'store', 'service:store');
+  registry.injection('route', 'store', 'service:store');
+  registry.injection('data-adapter', 'store', 'service:store');
 }

--- a/packages/ember-data/lib/initializers/store.js
+++ b/packages/ember-data/lib/initializers/store.js
@@ -17,6 +17,9 @@ export default function initializeStore(registry, application) {
   registry.optionsForType('serializer', { singleton: false });
   registry.optionsForType('adapter', { singleton: false });
 
+  // This will get deprecated later in the instace
+  // initializer. However we register it here so we have access to
+  // application.Store in the instance initializer.
   if (application && application.Store) {
     registry.register('store:application', application.Store);
   }

--- a/packages/ember-data/lib/instance-initializers/initialize-store-service.js
+++ b/packages/ember-data/lib/instance-initializers/initialize-store-service.js
@@ -1,4 +1,6 @@
 import Store from "ember-data/system/store";
+import ContainerProxy from "ember-data/system/container-proxy";
+
 /**
  Configures a registry for use with an Ember-Data
  store.
@@ -25,14 +27,32 @@ export default function initializeStoreService(applicationOrRegistry) {
       container = registry;
     }
   }
-  if (registry.has('store:application')) {
-    var customStoreFactory = container.lookupFactory('store:application');
-    registry.register('store:main', customStoreFactory);
-  } else {
-    registry.register('store:main', Store);
-  }
 
   // Eagerly generate the store so defaultStore is populated.
-  var store = container.lookup('store:main');
-  registry.register('service:store', store, { instantiate: false });
+  var store;
+  if (registry.has('store:main')) {
+    Ember.deprecate('Registering a custom store as `store:main` or defining a store in app/store.js has been deprecated. Please move you store to `service:store` or define your custom store in `app/services/store.js`');
+    store = container.lookup('store:main');
+  } else {
+    var storeMainProxy = new ContainerProxy(registry);
+    storeMainProxy.registerDeprecations([
+      { deprecated: 'store:main', valid: 'service:store' }
+    ]);
+  }
+
+  if (registry.has('store:application')) {
+    Ember.deprecate('Registering a custom store as `store:application` or defining a store in app/stores/application.js has been deprecated. Please move you store to `service:store` or define your custom store in `app/services/store.js`');
+    store = container.lookup('store:application');
+  } else {
+    var storeApplicationProxy = new ContainerProxy(registry);
+    storeApplicationProxy.registerDeprecations([
+      { deprecated: 'store:application', valid: 'service:store' }
+    ]);
+  }
+
+  if (store) {
+    registry.register('service:store', store, { instantiate: false });
+  } else {
+    registry.register('service:store', Store);
+  }
 }

--- a/packages/ember-data/tests/integration/application-test.js
+++ b/packages/ember-data/tests/integration/application-test.js
@@ -13,7 +13,7 @@ var app, App, container;
 */
 
 function getStore() {
-  return lookup('store:main');
+  return lookup('service:store');
 }
 
 function lookup(thing) {
@@ -69,7 +69,7 @@ test("registering App.Store is deprecated but functional", function() {
      'has been deprecated. Please use `App.ApplicationStore` instead.');
 
   run(function() {
-    ok(lookup('store:main').get('isCustomButDeprecated'), "the custom store was instantiated");
+    ok(lookup('service:store').get('isCustomButDeprecated'), "the custom store was instantiated");
   });
 
   var fooController = lookup('controller:foo');

--- a/packages/ember-data/tests/integration/backwards-compat/non-dasherized-lookups.js
+++ b/packages/ember-data/tests/integration/backwards-compat/non-dasherized-lookups.js
@@ -9,7 +9,7 @@ module('integration/backwards-compat/non-dasherized-lookups - non dasherized loo
         name: DS.attr()
       });
     });
-    store = App.__container__.lookup('store:main');
+    store = App.__container__.lookup('service:store');
   },
   teardown: function() {
     run(App, 'destroy');
@@ -67,7 +67,7 @@ module('integration/backwards-compat/non-dasherized-lookups - non dasherized loo
         postNotes: DS.hasMany('post_note')
       });
     });
-    store = App.__container__.lookup('store:main');
+    store = App.__container__.lookup('service:store');
   },
 
   teardown: function() {

--- a/packages/ember-data/tests/integration/debug-adapter-test.js
+++ b/packages/ember-data/tests/integration/debug-adapter-test.js
@@ -23,7 +23,7 @@ module("DS.DebugAdapter", {
 
     });
 
-    store = App.__container__.lookup('store:main');
+    store = App.__container__.lookup('service:store');
     debugAdapter = App.__container__.lookup('data-adapter:main');
 
     debugAdapter.reopen({

--- a/packages/ember-data/tests/integration/multiple_stores_test.js
+++ b/packages/ember-data/tests/integration/multiple_stores_test.js
@@ -118,7 +118,7 @@ test("embedded records should be created in multiple stores", function() {
 
   run(function() {
     json_main = serializer_main.extractSingle(env.store, env.store.modelFor('home-planet'), json_hash_main);
-    equal(env.store.hasRecordForId('super-villain', "1"), true, "superVillain should exist in store:main");
+    equal(env.store.hasRecordForId('super-villain', "1"), true, "superVillain should exist in service:store");
   });
 
   run(function() {

--- a/packages/ember-data/tests/integration/setup-container-test.js
+++ b/packages/ember-data/tests/integration/setup-container-test.js
@@ -30,7 +30,7 @@ module("integration/setup-container - Setting up a container", {
 });
 
 test("The store should be registered into a container.", function() {
-  ok(container.lookup('store:main') instanceof Store, "the custom store is instantiated");
+  ok(container.lookup('service:store') instanceof Store, "the custom store is instantiated");
 });
 
 test("The store should be registered into the container as a service.", function() {
@@ -84,6 +84,26 @@ test("serializers are not returned as singletons - each lookup should return a d
   serializer1 = container.lookup('serializer:-rest');
   serializer2 = container.lookup('serializer:-rest');
   notEqual(serializer1, serializer2);
+});
+
+test("the deprecated store:main is resolved as service:store", function() {
+  var deprecated;
+  var valid = container.lookup('service:store');
+  expectDeprecation(function() {
+    deprecated = container.lookup('store:main');
+  });
+
+  ok(deprecated.constructor === valid.constructor, "they should resolve to the same thing");
+});
+
+test("the deprecated store:application is resolved as service:store", function() {
+  var deprecated;
+  var valid = container.lookup('service:store');
+  expectDeprecation(function() {
+    deprecated = container.lookup('store:application');
+  });
+
+  ok(deprecated.constructor === valid.constructor, "they should resolve to the same thing");
 });
 
 test("adapters are not returned as singletons - each lookup should return a different instance", function() {


### PR DESCRIPTION
Right now Ember Data supports 3 namespaces where you can define the store `store:main`, `store:application` and `service:store`. I want to reduce this to 1 place for Ember Data 2.0 because it simplifies our initializer code and if a user were to define a custom store for more then 1 of those namespaces it can result in multiple stores instances in their app which is confusing to debug.

I'd like to recommend defining a custom store as `service:store` (`app/services/store.js`) as the path going forward. Is this a good idea/bad idea?

I would also like to see this pr become a beta-19.2 patch release to help people upgrading who currently have a custom store defined in `app/store.js`. Let me know what you think about this change?

