### PR TITLE
use the esperanto module transpiler / vendor backburner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,16 @@ cache:
   directories:
     - node_modules
 node_js:
-  - "0.10"
+  - "iojs-v2.2.1"
 before_install:
   - "npm config set spin false"
   - "npm install -g npm@^2"
 install:
-- "npm install"
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
+  - npm install
 script:
   - ./bin/lint-features
   - npm run-script test

--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "ember": "~1.12.1"
   },
   "devDependencies": {
+    "backburner": "https://github.com/ebryn/backburner.js.git#4a0105a4a0bc4cf73bdf3e554aea14f3f438876c",
     "qunit": "~1.17.0",
     "jquery": "~1.10.x",
     "loader.js": "~1.0.0",

--- a/lib/amd-build.js
+++ b/lib/amd-build.js
@@ -1,30 +1,45 @@
-var es6             = require('broccoli-es6-module-transpiler');
+var ES6             = require('broccoli-es6modules');
 var merge           = require('broccoli-merge-trees');
-var PackageResolver = require('es6-module-transpiler-package-resolver');
-var AMDFormatter    = require('es6-module-transpiler-amd-formatter');
 var replace         = require('broccoli-replace');
+var stew            = require('broccoli-stew');
 
 function amdES6Package(packages, root, outfile) {
-
-  var es6Build = es6(packages, {
-    inputFiles: ['ember-data'],
-    output: '/ember-data/',
-    resolvers: [PackageResolver],
-    formatter: new AMDFormatter(),
-    basePath: '/ember-data/',
-    sourceRoot: '/ember-data/'
+  var amdFiles = new ES6(packages, {
+    format: 'namedAmd',
+    esperantoOptions: {
+      strict: true
+    }
   });
-
-  return replace(es6Build, {
+  var loggedApp = stew.log(amdFiles, { output: 'tree', label: 'my-app-name tree' });
+  var renamedToEmberConvention = replace(amdFiles, {
+    files: ['**/*.js'],
+    patterns: [{
+        match: /lib\//g,
+        replacement: ''
+    }]
+  });
+  return replace(renamedToEmberConvention, {
     files: ['**/*.js'],
     patterns: [
       {
-        match: /\/lib/g,
-        replacement: ''
+        match: /ember-data\/main/g,
+        replacement: 'ember-data'
       },
       {
-        match: /\/main/g,
-        replacement: ''
+        match: /activemodel-adapter\/main/g,
+        replacement: 'activemodel-adapter'
+      },
+      {
+        match: /ember-inflector\/main/g,
+        replacement: 'ember-inflector'
+      },
+      {
+        match: /ember\/main/g,
+        replacement: 'ember'
+      },
+      {
+        match: /ember-new-computed\/main/g,
+        replacement: 'ember-new-computed'
       }
     ]
   });

--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
     "broccoli-concat": "0.0.12",
     "broccoli-defeatureify": "^1.0.0",
     "broccoli-env": "0.0.1",
-    "broccoli-es3-safe-recast": "0.0.8",
-    "broccoli-es6-module-transpiler": "^0.5.0",
-    "broccoli-es6-transpiler": "^0.1.0",
+    "broccoli-es6modules": "^0.6.0",
     "broccoli-file-creator": "^0.1.0",
     "broccoli-file-mover": "~0.2.0",
     "broccoli-jscs": "0.0.22",
@@ -54,20 +52,15 @@
     "broccoli-yuidoc": "^1.3.0",
     "defeatureify": "~0.1.4",
     "ejs": "^1.0.0",
-    "ember-cli": "^0.1.15",
-    "ember-new-computed": "1.0.1",
+    "ember-cli": "^0.2.7",
     "ember-inflector": "^1.5.0",
+    "ember-new-computed": "1.0.1",
     "ember-publisher": "0.0.7",
-    "es6-module-transpiler": "^0.9.5",
-    "es6-module-transpiler-amd-formatter": "^0.2.4",
-    "es6-module-transpiler-package-resolver": "^1.0.1",
     "git-repo-version": "0.0.2",
     "github": "^0.2.4",
     "jscs": "^1.12.0",
     "testem": "^0.6.19",
-    "yuidocjs": "~0.3.46"
-  },
-  "dependencies": {
+    "yuidocjs": "~0.3.46",
     "rsvp": "^3.0.18"
   }
 }

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -13,6 +13,8 @@ import {
   Map
 } from "ember-data/system/map";
 
+import Backburner from 'backburner/backburner';
+
 import {
   promiseArray,
   promiseObject
@@ -50,49 +52,6 @@ import ContainerInstanceCache from 'ember-data/system/store/container-instance-c
 
 import InternalModel from "ember-data/system/model/internal-model";
 import Model from "ember-data/system/model";
-
-var Backburner = Ember._Backburner || Ember.Backburner || Ember.__loader.require('backburner')['default'] || Ember.__loader.require('backburner')['Backburner'];
-
-//Shim Backburner.join
-if (!Backburner.prototype.join) {
-  var isString = function(suspect) {
-    return typeof suspect === 'string';
-  };
-
-  Backburner.prototype.join = function(/*target, method, args */) {
-    var method, target;
-
-    if (this.currentInstance) {
-      var length = arguments.length;
-      if (length === 1) {
-        method = arguments[0];
-        target = null;
-      } else {
-        target = arguments[0];
-        method = arguments[1];
-      }
-
-      if (isString(method)) {
-        method = target[method];
-      }
-
-      if (length === 1) {
-        return method();
-      } else if (length === 2) {
-        return method.call(target);
-      } else {
-        var args = new Array(length - 2);
-        for (var i =0, l = length - 2; i < l; i++) {
-          args[i] = arguments[i + 2];
-        }
-        return method.apply(target, args);
-      }
-    } else {
-      return this.run.apply(this, arguments);
-    }
-  };
-}
-
 
 //Get the materialized model from the internalModel/promise that returns
 //an internal model and return it in a promiseObject. Useful for returning

--- a/tests/index.html
+++ b/tests/index.html
@@ -56,7 +56,7 @@
     <![endif]]-->
 
     <script src="/bower_components/loader.js/loader.js"></script>
-    <script src="/ember-data.js"></script>
+    <script src="/ember-data-for-tests.js"></script>
     <script src="ember-data-setup.js"></script>
     <script src="ember-data-tests.js"></script>
 


### PR DESCRIPTION
**This commit drops support for IE8!**. Esperanto by default uses
Object.defineProperty to support cyclical dependencies.

This allows us to use iojs/node.js v0.12 as well.