### PR TITLE
Add a test for async polymorphic relationships with lazy type inference

### DIFF
--- a/packages/ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs-to-test.js
@@ -754,3 +754,28 @@ test("Model's belongsTo relationship should be created during 'get' method", fun
     ok(user._internalModel._relationships.has('favouriteMessage'), "Newly created record with relationships in params passed in its constructor should have relationships");
   });
 });
+
+// this depends on unique keys for all the records that can show up in the relationship
+test("Polymorphic relationships with belongsTo, which are materialized as an array of IDs without a type use the parent type until loaded", function () {
+  expect(1);
+
+  env.adapter.find = function(store, type, id, snapshot) {
+    return Ember.RSVP.resolve({ id: 2, type: 'post', title: 'Post' });
+  };
+
+  run(function () {
+    env.store.push('user', {
+      id: 1,
+      favouriteMessage: 2
+    });
+
+    env.store.find('user', 1)
+      .then(function (user) {
+        return user.get('favouriteMessage');
+      })
+      .then(function (message) {
+        equal(message.get('title'), 'Post', "The messages relationship has been set up");
+      });
+  });
+
+});

--- a/packages/ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/has-many-test.js
@@ -1539,4 +1539,44 @@ if (Ember.FEATURES.isEnabled('ds-new-serializer-api')) {
       });
     });
   });
+
+  // this depends on unique keys for all the records that can show up in the relationship
+  test("Polymorphic relationships with hasMany, which are materialized as an array of IDs without a type use the parent type until loaded", function () {
+    expect(4);
+
+    env.adapter.findMany = function (store, type, ids, snapshots) {
+      equal(type, 'message', "The requested type should equal the parent type of the related records");
+      return Ember.RSVP.resolve([
+        {
+          id: 2,
+          type: 'post',
+          title: 'Post'
+        },
+        {
+          id: 3,
+          type: 'comment',
+          body: 'Comment'
+        }
+      ]);
+    };
+
+    run(function () {
+      env.store.push('user', {
+        id: 1,
+        messages: [2, 3]
+      });
+
+      env.store.find('user', 1)
+        .then(function (user) {
+          return user.get('messages');
+        })
+        .then(function (messages) {
+          equal(messages.get('length'), 2, "The messages relationship has been set up");
+          equal(messages.objectAt(0).get('title'), 'Post', "Polymorphic record at index 0 has the correct fields and data");
+          equal(messages.objectAt(1).get('body'), 'Comment', "Polymorphic record at index 1 has the correct fields and data");
+        });
+    });
+
+  });
+
 }


### PR DESCRIPTION
These test describes a situation where an API has polymorphic relationships, but neither embeds the records nor supplies a type alongside the ID. Since we already have a "parent" type for polymorphic relationships, I was wondering if the related record could be known to Ember Data just as the ID and the parent type until it gets fetched from the API. When we finally have the complete information, the type could be recast to the child type.

There would be 2 requirements:

all the polymorphic records have to be accessible on the endpoint of the parent type
all polymorphic records need to have unique IDs
A bit of related discussion:
#2991

I should mention that this comes from a real-world example. I was trying to build an Ember Data integration for the Contentful content management API.
