### PR TITLE
Rename adapter and serializer methods to match the new store methods

### DIFF
--- a/packages/activemodel-adapter/tests/integration/active-model-serializer-namespaced-model-name-new-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-serializer-namespaced-model-name-new-test.js
@@ -57,7 +57,7 @@ test("extractPolymorphic hasMany", function() {
   var json;
 
   run(function() {
-    json = env.amsSerializer.normalizeResponse(env.store, MediocreVillain, json_hash, '1', 'find');
+    json = env.amsSerializer.normalizeResponse(env.store, MediocreVillain, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -94,7 +94,7 @@ test("extractPolymorphic belongsTo", function() {
   var json;
 
   run(function() {
-    json = env.amsSerializer.normalizeResponse(env.store, DoomsdayDevice, json_hash, '1', 'find');
+    json = env.amsSerializer.normalizeResponse(env.store, DoomsdayDevice, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {

--- a/packages/activemodel-adapter/tests/integration/active-model-serializer-new-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-serializer-new-test.js
@@ -120,7 +120,7 @@ test("normalizeSingleResponse", function() {
 
   var json;
   run(function() {
-    json = env.amsSerializer.normalizeSingleResponse(env.store, HomePlanet, json_hash, '1', 'find');
+    json = env.amsSerializer.normalizeSingleResponse(env.store, HomePlanet, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -210,7 +210,7 @@ test("extractPolymorphic hasMany", function() {
   var json;
 
   run(function() {
-    json = env.amsSerializer.normalizeResponse(env.store, MediocreVillain, json_hash, '1', 'find');
+    json = env.amsSerializer.normalizeResponse(env.store, MediocreVillain, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -251,7 +251,7 @@ test("extractPolymorphic belongsTo", function() {
   var json;
 
   run(function() {
-    json = env.amsSerializer.normalizeResponse(env.store, DoomsdayDevice, json_hash, '1', 'find');
+    json = env.amsSerializer.normalizeResponse(env.store, DoomsdayDevice, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -285,7 +285,7 @@ test("extractPolymorphic when the related data is not specified", function() {
   };
 
   run(function() {
-    json = env.amsSerializer.normalizeResponse(env.store, DoomsdayDevice, json, '1', 'find');
+    json = env.amsSerializer.normalizeResponse(env.store, DoomsdayDevice, json, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -314,7 +314,7 @@ test("extractPolymorphic hasMany when the related data is not specified", functi
   };
 
   run(function() {
-    json = env.amsSerializer.normalizeResponse(env.store, MediocreVillain, json, '1', 'find');
+    json = env.amsSerializer.normalizeResponse(env.store, MediocreVillain, json, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -336,7 +336,7 @@ test("extractPolymorphic does not break hasMany relationships", function() {
   };
 
   run(function () {
-    json = env.amsSerializer.normalizeResponse(env.store, MediocreVillain, json, '1', 'find');
+    json = env.amsSerializer.normalizeResponse(env.store, MediocreVillain, json, '1', 'findRecord');
   });
 
   deepEqual(json, {

--- a/packages/activemodel-adapter/tests/integration/active-model-serializer-test.js
+++ b/packages/activemodel-adapter/tests/integration/active-model-serializer-test.js
@@ -156,7 +156,7 @@ test("extractSingle", function() {
   });
 
   run(function() {
-    env.store.find('super-villain', 1).then(function(minion) {
+    env.store.findRecord('super-villain', 1).then(function(minion) {
       equal(minion.get('firstName'), "Tom");
     });
   });
@@ -182,7 +182,7 @@ test("extractArray", function() {
   }]);
 
   run(function() {
-    env.store.find('super-villain', 1).then(function(minion) {
+    env.store.findRecord('super-villain', 1).then(function(minion) {
       equal(minion.get('firstName'), "Tom");
     });
   });

--- a/packages/ember-data/lib/adapters/build-url-mixin.js
+++ b/packages/ember-data/lib/adapters/build-url-mixin.js
@@ -13,8 +13,8 @@ var get = Ember.get;
 
   ```javascript
   export default DS.Adapter.extend(BuildURLMixin, {
-    find: function(store, type, id, snapshot) {
-      var url = this.buildURL(type.modelName, id, snapshot, 'find');
+    findRecord: function(store, type, id, snapshot) {
+      var url = this.buildURL(type.modelName, id, snapshot, 'findRecord');
       return this.ajax(url, 'GET');
     }
   });
@@ -27,7 +27,7 @@ var get = Ember.get;
   @class BuildURLMixin
   @namespace DS
 */
-export default Ember.Mixin.create({
+var BuildURLMixin = Ember.Mixin.create({
   /**
     Builds a URL for a given type and optional ID.
 
@@ -46,17 +46,23 @@ export default Ember.Mixin.create({
     @param {(String|Array|Object)} id single id or array of ids or query
     @param {(DS.Snapshot|Array)} snapshot single snapshot or array of snapshots
     @param {String} requestType
-    @param {Object} query object of query parameters to send for findQuery requests.
+    @param {Object} query object of query parameters to send for query requests.
     @return {String} url
   */
   buildURL: function(modelName, id, snapshot, requestType, query) {
     switch (requestType) {
       case 'find':
+        // The `find` case is deprecated
         return this.urlForFind(id, modelName, snapshot);
+      case 'findRecord':
+        return this.urlForFindRecord(id, modelName, snapshot);
       case 'findAll':
         return this.urlForFindAll(modelName);
       case 'findQuery':
+        // The `findQuery` case is deprecated
         return this.urlForFindQuery(query, modelName);
+      case 'query':
+        return this.urlForQuery(query, modelName);
       case 'findMany':
         return this.urlForFindMany(id, modelName, snapshot);
       case 'findHasMany':
@@ -109,8 +115,22 @@ export default Ember.Mixin.create({
    * @param {String} modelName
    * @param {DS.Snapshot} snapshot
    * @return {String} url
+   * @deprecated Use [urlForFindRecord](#method_urlForFindRecord) instead
    */
-  urlForFind: function(id, modelName, snapshot) {
+  urlForFind: urlForFind,
+
+  /**
+   * @method urlForFind
+   * @param {String} id
+   * @param {String} modelName
+   * @param {DS.Snapshot} snapshot
+   * @return {String} url
+   */
+  urlForFindRecord: function(id, modelName, snapshot) {
+    if (this.urlForFind !== urlForFind) {
+      Ember.deprecate('BuildURLMixin#urlForFind has been deprecated and renamed to `urlForFindRecord`.');
+      return this.urlForFind(id, modelName, snapshot);
+    }
     return this._buildURL(modelName, id);
   },
 
@@ -128,8 +148,21 @@ export default Ember.Mixin.create({
    * @param {Object} query
    * @param {String} modelName
    * @return {String} url
+   * @deprecated Use [urlForQuery](#method_urlForQuery) instead
    */
-  urlForFindQuery: function(query, modelName) {
+  urlForFindQuery: urlForFindQuery,
+
+  /**
+   * @method urlForQuery
+   * @param {Object} query
+   * @param {String} modelName
+   * @return {String} url
+   */
+  urlForQuery: function(query, modelName) {
+    if (this.urlForFindQuery !== urlForFindQuery) {
+      Ember.deprecate('BuildURLMixin#urlForFindQuery has been deprecated and renamed to `urlForQuery`.');
+      return this.urlForFindQuery(query, modelName);
+    }
     return this._buildURL(modelName);
   },
 
@@ -270,3 +303,15 @@ export default Ember.Mixin.create({
     return Ember.String.pluralize(camelized);
   }
 });
+
+function urlForFind(id, modelName, snapshot) {
+  Ember.deprecate('BuildURLMixin#urlForFind has been deprecated and renamed to `urlForFindRecord`.');
+  return this._buildURL(modelName, id);
+}
+
+function urlForFindQuery(query, modelName) {
+  Ember.deprecate('BuildURLMixin#urlForFindQuery has been deprecated and renamed to `urlForQuery`.');
+  return this._buildURL(modelName);
+}
+
+export default BuildURLMixin;

--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -277,8 +277,8 @@ var RestAdapter = Adapter.extend(BuildURLMixin, {
     relationships accessed within the same runloop. If you set `coalesceFindRequests: true`
 
     ```javascript
-    store.find('comment', 1);
-    store.find('comment', 2);
+    store.findRecord('comment', 1);
+    store.findRecord('comment', 2);
     ```
 
     will also send a request to: `GET /comments?ids[]=1&ids[]=2`
@@ -346,26 +346,45 @@ var RestAdapter = Adapter.extend(BuildURLMixin, {
 
     @property headers
     @type {Object}
-  */
+   */
 
   /**
-    Called by the store in order to fetch the JSON for a given
-    type and ID.
-
-    The `find` method makes an Ajax request to a URL computed by `buildURL`, and returns a
-    promise for the resulting payload.
-
-    This method performs an HTTP `GET` request with the id provided as part of the query string.
-
     @method find
     @param {DS.Store} store
     @param {DS.Model} type
     @param {String} id
     @param {DS.Snapshot} snapshot
     @return {Promise} promise
+    @deprecated Use [findRecord](#method_findRecord) instead
   */
   find: function(store, type, id, snapshot) {
+    Ember.deprecate('RestAdapter#find has been deprecated and renamed to `findRecord`.');
     return this.ajax(this.buildURL(type.modelName, id, snapshot, 'find'), 'GET');
+  },
+
+  /**
+    Called by the store in order to fetch the JSON for a given
+    type and ID.
+
+    The `findRecord` method makes an Ajax request to a URL computed by
+    `buildURL`, and returns a promise for the resulting payload.
+
+    This method performs an HTTP `GET` request with the id provided as part of the query string.
+
+    @method findRecord
+    @param {DS.Store} store
+    @param {DS.Model} type
+    @param {String} id
+    @param {DS.Snapshot} snapshot
+    @return {Promise} promise
+  */
+  findRecord: function(store, type, id, snapshot) {
+    var find = RestAdapter.prototype.find;
+    if (find !== this.find) {
+      Ember.deprecate('RestAdapter#find has been deprecated and renamed to `findRecord`.');
+      return this.find(store, type, id, snapshot);
+    }
+    return this.ajax(this.buildURL(type.modelName, id, snapshot, 'findRecord'), 'GET');
   },
 
   /**
@@ -410,9 +429,44 @@ var RestAdapter = Adapter.extend(BuildURLMixin, {
     @param {DS.Model} type
     @param {Object} query
     @return {Promise} promise
+    @deprecated Use [query](#method_query) instead
   */
   findQuery: function(store, type, query) {
+    Ember.deprecate('RestAdapter#findQuery has been deprecated and renamed to `query`.');
     var url = this.buildURL(type.modelName, null, null, 'findQuery', query);
+
+    if (this.sortQueryParams) {
+      query = this.sortQueryParams(query);
+    }
+
+    return this.ajax(url, 'GET', { data: query });
+  },
+
+  /**
+    Called by the store in order to fetch a JSON array for
+    the records that match a particular query.
+
+    The `findQuery` method makes an Ajax (HTTP GET) request to a URL computed by `buildURL`, and returns a
+    promise for the resulting payload.
+
+    The `query` argument is a simple JavaScript object that will be passed directly
+    to the server as parameters.
+
+    @private
+    @method query
+    @param {DS.Store} store
+    @param {DS.Model} type
+    @param {Object} query
+    @return {Promise} promise
+  */
+  query: function(store, type, query) {
+    var findQuery = RestAdapter.prototype.findQuery;
+    if (findQuery !== this.findQuery) {
+      Ember.deprecate('RestAdapter#findQuery has been deprecated and renamed to `query`.');
+      return this.findQuery(store, type, query);
+    }
+
+    var url = this.buildURL(type.modelName, null, null, 'query', query);
 
     if (this.sortQueryParams) {
       query = this.sortQueryParams(query);

--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -81,7 +81,7 @@ var merge = Ember.merge;
   @namespace DS
   @extends DS.Serializer
 */
-export default Serializer.extend({
+var JSONSerializer = Serializer.extend({
 
   /**
     The primaryKey is used when serializing and deserializing
@@ -231,8 +231,8 @@ export default Serializer.extend({
   */
   normalizeResponse: function(store, primaryModelClass, payload, id, requestType) {
     switch (requestType) {
-      case 'find':
-        return this.normalizeFindResponse(...arguments);
+      case 'findRecord':
+        return this.normalizeFindRecordResponse(...arguments);
       case 'findAll':
         return this.normalizeFindAllResponse(...arguments);
       case 'findBelongsTo':
@@ -241,8 +241,8 @@ export default Serializer.extend({
         return this.normalizeFindHasManyResponse(...arguments);
       case 'findMany':
         return this.normalizeFindManyResponse(...arguments);
-      case 'findQuery':
-        return this.normalizeFindQueryResponse(...arguments);
+      case 'query':
+        return this.normalizeQueryResponse(...arguments);
       case 'createRecord':
         return this.normalizeCreateRecordResponse(...arguments);
       case 'deleteRecord':
@@ -253,7 +253,7 @@ export default Serializer.extend({
   },
 
   /*
-    @method normalizeFindResponse
+    @method normalizeFindRecordResponse
     @param {DS.Store} store
     @param {DS.Model} primaryModelClass
     @param {Object} payload
@@ -261,7 +261,7 @@ export default Serializer.extend({
     @param {String} requestType
     @return {Object} JSON-API Document
   */
-  normalizeFindResponse: function(store, primaryModelClass, payload, id, requestType) {
+  normalizeFindRecordResponse: function(store, primaryModelClass, payload, id, requestType) {
     return this.normalizeSingleResponse(...arguments);
   },
 
@@ -318,7 +318,7 @@ export default Serializer.extend({
   },
 
   /*
-    @method normalizeFindQueryResponse
+    @method normalizeQueryResponse
     @param {DS.Store} store
     @param {DS.Model} primaryModelClass
     @param {Object} payload
@@ -326,7 +326,7 @@ export default Serializer.extend({
     @param {String} requestType
     @return {Object} JSON-API Document
   */
-  normalizeFindQueryResponse: function(store, primaryModelClass, payload, id, requestType) {
+  normalizeQueryResponse: function(store, primaryModelClass, payload, id, requestType) {
     return this.normalizeArrayResponse(...arguments);
   },
 
@@ -1369,6 +1369,7 @@ export default Serializer.extend({
   extractFind: function(store, typeClass, payload, id, requestType) {
     return this.extractSingle(store, typeClass, payload, id, requestType);
   },
+
   /**
     `extractFindBelongsTo` is a hook into the extract method used when
     a call is made to `DS.Store#findBelongsTo`. By default this method is
@@ -1664,3 +1665,5 @@ function _newExtractMeta(store, modelClass, payload) {
     return meta;
   }
 }
+
+export default JSONSerializer;

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -41,12 +41,12 @@ var get = Ember.get;
   application to customize it for your backend. The minimum set of methods
   that you should implement is:
 
-    * `find()`
+    * `findRecord()`
     * `createRecord()`
     * `updateRecord()`
     * `deleteRecord()`
     * `findAll()`
-    * `findQuery()`
+    * `query()`
 
   To improve the network performance of your application, you can optimize
   your adapter by overriding these lower-level methods:
@@ -87,19 +87,19 @@ var Adapter = Ember.Object.extend({
   defaultSerializer: '-default',
 
   /**
-    The `find()` method is invoked when the store is asked for a record that
-    has not previously been loaded. In response to `find()` being called, you
+    The `findRecord()` method is invoked when the store is asked for a record that
+    has not previously been loaded. In response to `findRecord()` being called, you
     should query your persistence layer for a record with the given ID. Once
     found, you can asynchronously call the store's `push()` method to push
     the record into the store.
 
-    Here is an example `find` implementation:
+    Here is an example `findRecord` implementation:
 
     ```app/adapters/application.js
     import DS from 'ember-data';
 
     export default DS.Adapter.extend({
-      find: function(store, type, id, snapshot) {
+      findRecord: function(store, type, id, snapshot) {
         var url = [type.modelName, id].join('/');
 
         return new Ember.RSVP.Promise(function(resolve, reject) {
@@ -114,14 +114,14 @@ var Adapter = Ember.Object.extend({
     });
     ```
 
-    @method find
+    @method findRecord
     @param {DS.Store} store
     @param {DS.Model} type
     @param {String} id
     @param {DS.Snapshot} snapshot
     @return {Promise} promise
   */
-  find: null,
+  findRecord: null,
 
   /**
     The `findAll()` method is used to retrieve all records for a given type.
@@ -165,7 +165,7 @@ var Adapter = Ember.Object.extend({
     import DS from 'ember-data';
 
     export default DS.Adapter.extend({
-      findQuery: function(store, type, query) {
+      query: function(store, type, query) {
         var url = type;
         return new Ember.RSVP.Promise(function(resolve, reject) {
           jQuery.getJSON(url, query).then(function(data) {
@@ -180,14 +180,14 @@ var Adapter = Ember.Object.extend({
     ```
 
     @private
-    @method findQuery
+    @method query
     @param {DS.Store} store
     @param {DS.Model} type
     @param {Object} query
     @param {DS.AdapterPopulatedRecordArray} recordArray
     @return {Promise} promise
   */
-  findQuery: null,
+  query: null,
 
   /**
     The `queryRecord()` method is invoked when the store is asked for a single

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -690,7 +690,7 @@ Store = Service.extend({
     var adapter = this.adapterFor(typeClass.modelName);
 
     Ember.assert("You tried to find a record but you have no adapter (for " + typeClass + ")", adapter);
-    Ember.assert("You tried to find a record but your adapter (for " + typeClass + ") does not implement 'find'", typeof adapter.find === 'function');
+    Ember.assert("You tried to find a record but your adapter (for " + typeClass + ") does not implement 'findRecord'", typeof adapter.findRecord === 'function' || typeof adapter.find === 'function');
 
     var promise = _find(adapter, this, typeClass, id, internalModel, options);
     return promise;
@@ -896,7 +896,7 @@ Store = Service.extend({
 
     Ember.assert("You cannot reload a record without an ID", id);
     Ember.assert("You tried to reload a record but you have no adapter (for " + modelName + ")", adapter);
-    Ember.assert("You tried to reload a record but your adapter does not implement `find`", typeof adapter.find === 'function');
+    Ember.assert("You tried to reload a record but your adapter does not implement `findRecord`", typeof adapter.findRecord === 'function' || typeof adapter.find === 'function');
 
     return this.scheduleFetch(internalModel);
   },
@@ -1052,7 +1052,7 @@ Store = Service.extend({
     var adapter = this.adapterFor(modelName);
 
     Ember.assert("You tried to load a query but you have no adapter (for " + typeClass + ")", adapter);
-    Ember.assert("You tried to load a query but your adapter does not implement `findQuery`", typeof adapter.findQuery === 'function');
+    Ember.assert("You tried to load a query but your adapter does not implement `query`", typeof adapter.query === 'function' || typeof adapter.findQuery === 'function');
 
     return promiseArray(_query(adapter, this, typeClass, query, array));
   },

--- a/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -55,7 +55,7 @@ test('buildURL - with host and namespace', function() {
 
   ajaxResponse({ posts: [{ id: 1 }] });
 
-  run(store, 'find', 'post', 1).then(async(function(post) {
+  run(store, 'findRecord', 'post', 1).then(async(function(post) {
     equal(passedUrl, "http://example.com/api/v1/posts/1");
   }));
 });
@@ -72,7 +72,7 @@ test('buildURL - with relative paths in links', function() {
 
   ajaxResponse({ posts: [{ id: 1, links: { comments: 'comments' } }] });
 
-  run(store, 'find', 'post', '1').then(async(function(post) {
+  run(store, 'findRecord', 'post', '1').then(async(function(post) {
     ajaxResponse({ comments: [{ id: 1 }] });
     return post.get('comments');
   })).then(async(function (comments) {
@@ -92,7 +92,7 @@ test('buildURL - with absolute paths in links', function() {
 
   ajaxResponse({ posts: [{ id: 1, links: { comments: '/api/v1/posts/1/comments' } }] });
 
-  run(store, 'find', 'post', 1).then(async(function(post) {
+  run(store, 'findRecord', 'post', 1).then(async(function(post) {
     ajaxResponse({ comments: [{ id: 1 }] });
     return post.get('comments');
   })).then(async(function (comments) {
@@ -113,7 +113,7 @@ test('buildURL - with absolute paths in links and protocol relative host', funct
 
   ajaxResponse({ posts: [{ id: 1, links: { comments: '/api/v1/posts/1/comments' } }] });
 
-  run(store, 'find', 'post', 1).then(async(function(post) {
+  run(store, 'findRecord', 'post', 1).then(async(function(post) {
     ajaxResponse({ comments: [{ id: 1 }] });
     return post.get('comments');
   })).then(async(function (comments) {
@@ -138,7 +138,7 @@ test('buildURL - with full URLs in links', function() {
   });
 
   run(function() {
-    store.find('post', 1).then(async(function(post) {
+    store.findRecord('post', 1).then(async(function(post) {
       ajaxResponse({ comments: [{ id: 1 }] });
       return post.get('comments');
     })).then(async(function (comments) {
@@ -158,7 +158,7 @@ test('buildURL - with camelized names', function() {
   ajaxResponse({ superUsers: [{ id: 1 }] });
 
   run(function() {
-    store.find('super-user', 1).then(async(function(post) {
+    store.findRecord('super-user', 1).then(async(function(post) {
       equal(passedUrl, "/super_users/1");
     }));
   });
@@ -178,7 +178,7 @@ test('buildURL - buildURL takes a record from find', function() {
   });
 
   run(function() {
-    store.find('comment', 1, { preload: { post: post } }).then(async(function(post) {
+    store.findRecord('comment', 1, { preload: { post: post } }).then(async(function(post) {
       equal(passedUrl, "/posts/2/comments/1");
     }));
   });
@@ -231,7 +231,7 @@ test('buildURL - buildURL takes a record from create to query a resolved async b
   ajaxResponse({ posts: [{ id: 2 }] });
 
   run(function() {
-    store.find('post', 2).then(async(function(post) {
+    store.findRecord('post', 2).then(async(function(post) {
       equal(post.get('id'), 2);
 
       adapter.buildURL = function(type, id, snapshot) {
@@ -304,7 +304,37 @@ test('buildURL - with absolute namespace', function() {
 
   ajaxResponse({ posts: [{ id: 1 }] });
 
-  run(store, 'find', 'post', 1).then(async(function(post) {
+  run(store, 'findRecord', 'post', 1).then(async(function(post) {
     equal(passedUrl, "/api/v1/posts/1");
   }));
+});
+
+
+test('buildURL - urlForFindRecord calls deprecated urlForFind', function() {
+  expect(2);
+
+  var adapter = DS.RESTAdapter.extend({
+    urlForFind: function() {
+      ok(true, 'urlForFind should be called');
+    }
+  }).create();
+
+  expectDeprecation(function() {
+    adapter.buildURL('post', 1, {}, 'findRecord');
+  }, /urlForFindRecord/);
+});
+
+
+test('buildURL - urlForQuery calls deprecated urlForFindQuery', function() {
+  expect(2);
+
+  var adapter = DS.RESTAdapter.extend({
+    urlForFindQuery: function() {
+      ok(true, 'urlForFindQuery should be called');
+    }
+  }).create();
+
+  expectDeprecation(function() {
+    adapter.buildURL('post', 1, {}, 'query');
+  }, /urlForQuery/);
 });

--- a/packages/ember-data/tests/integration/adapter/find-test.js
+++ b/packages/ember-data/tests/integration/adapter/find-test.js
@@ -60,7 +60,7 @@ test("When a single record is requested, the adapter's find method should be cal
   var count = 0;
 
   env.registry.register('adapter:person', DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       equal(type, Person, "the find method is called with the correct type");
       equal(count, 0, "the find method is only called once");
 
@@ -70,8 +70,8 @@ test("When a single record is requested, the adapter's find method should be cal
   }));
 
   run(function() {
-    store.find('person', 1);
-    store.find('person', 1);
+    store.findRecord('person', 1);
+    store.findRecord('person', 1);
   });
 });
 
@@ -79,13 +79,13 @@ test("When a single record is requested multiple times, all .find() calls are re
   var deferred = Ember.RSVP.defer();
 
   env.registry.register('adapter:person', DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return deferred.promise;
     }
   }));
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       equal(person.get('id'), "1");
       equal(person.get('name'), "Braaaahm Dale");
 
@@ -101,7 +101,7 @@ test("When a single record is requested multiple times, all .find() calls are re
   });
 
   run(function() {
-    store.find('person', 1).then(async(function(post) {
+    store.findRecord('person', 1).then(async(function(post) {
       equal(post.get('id'), "1");
       equal(post.get('name'), "Braaaahm Dale");
 
@@ -124,13 +124,13 @@ test("When a single record is requested multiple times, all .find() calls are re
 
 test("When a single record is requested, and the promise is rejected, .find() is rejected.", function() {
   env.registry.register('adapter:person', DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return Ember.RSVP.reject();
     }
   }));
 
   run(function() {
-    store.find('person', 1).then(null, async(function(reason) {
+    store.findRecord('person', 1).then(null, async(function(reason) {
       ok(true, "The rejection handler was called");
     }));
   });
@@ -140,13 +140,13 @@ test("When a single record is requested, and the promise is rejected, the record
   expect(2);
 
   env.registry.register('adapter:person', DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return Ember.RSVP.reject();
     }
   }));
 
   run(function() {
-    store.find('person', 1).then(null, async(function(reason) {
+    store.findRecord('person', 1).then(null, async(function(reason) {
       ok(true, "The rejection handler was called");
     }));
   });

--- a/packages/ember-data/tests/integration/adapter/queries-test.js
+++ b/packages/ember-data/tests/integration/adapter/queries-test.js
@@ -22,7 +22,7 @@ module("integration/adapter/queries - Queries", {
 });
 
 test("When a query is made, the adapter should receive a record array it can populate with the results of the query.", function() {
-  adapter.findQuery = function(store, type, query, recordArray) {
+  adapter.query = function(store, type, query, recordArray) {
     equal(type, Person, "the find method is called with the correct type");
 
     return Ember.RSVP.resolve([{ id: 1, name: "Peter Wagenet" }, { id: 2, name: "Brohuda Katz" }]);

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -57,7 +57,7 @@ test("find - basic payload", function() {
 });
 
 
-test("find - passes buildURL a requestType", function() {
+test("findRecord - passes buildURL a requestType", function() {
   adapter.buildURL = function(type, id, snapshot, requestType) {
     return "/" + requestType + "/post/" + id;
   };
@@ -65,8 +65,8 @@ test("find - passes buildURL a requestType", function() {
   ajaxResponse({ posts: [{ id: 1, name: "Rails is omakase" }] });
 
 
-  run(store, 'find', 'post', 1).then(async(function(post) {
-    equal(passedUrl, "/find/post/1");
+  run(store, 'findRecord', 'post', 1).then(async(function(post) {
+    equal(passedUrl, "/findRecord/post/1");
   }));
 });
 
@@ -972,7 +972,7 @@ test("findQuery - passes buildURL the requestType", function() {
   };
 
   adapter.ajax = function(url, verb, hash) {
-    equal(url, '/findQuery/posts');
+    equal(url, '/query/posts');
 
     return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
   };
@@ -1549,7 +1549,7 @@ test('groupRecordsForFindMany groups records based on their url', function() {
     }
   };
 
-  adapter.find = function(store, type, id, snapshot) {
+  adapter.findRecord = function(store, type, id, snapshot) {
     equal(id, '1');
     return Ember.RSVP.resolve({ comments: { id: 1 } });
   };
@@ -1582,7 +1582,7 @@ test('groupRecordsForFindMany groups records correctly when singular URLs are en
     }
   };
 
-  adapter.find = function(store, type, id, snapshot) {
+  adapter.findRecord = function(store, type, id, snapshot) {
     equal(id, '1');
     return Ember.RSVP.resolve({ comments: { id: 1 } });
   };
@@ -1689,7 +1689,7 @@ test('groupRecordsForFindMany splits up calls for large ids', function() {
 
   adapter.coalesceFindRequests = true;
 
-  adapter.find = function(store, type, id, snapshot) {
+  adapter.findRecord = function(store, type, id, snapshot) {
     if (id === a2000 || id === b2000) {
       ok(true, "Found " + id);
     }
@@ -1727,7 +1727,7 @@ test('groupRecordsForFindMany groups calls for small ids', function() {
 
   adapter.coalesceFindRequests = true;
 
-  adapter.find = function(store, type, id, snapshot) {
+  adapter.findRecord = function(store, type, id, snapshot) {
     ok(false, "find should not be called - we expect 1 call to findMany for a100 and b100");
     return Ember.RSVP.reject();
   };

--- a/packages/ember-data/tests/integration/adapter/store-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/store-adapter-test.js
@@ -40,7 +40,7 @@ module("integration/adapter/store_adapter - DS.Store and DS.Adapter integration 
 });
 
 test("Records loaded multiple times and retrieved in recordArray are ready to send state events", function() {
-  adapter.findQuery = function(store, type, query, recordArray) {
+  adapter.query = function(store, type, query, recordArray) {
     return Ember.RSVP.resolve([{
       id: 1,
       name: "Mickael Ramírez"
@@ -105,8 +105,8 @@ test("by default, createRecords calls createRecord once per record", function() 
     tom = records.tom;
     yehuda = records.yehuda;
 
-    asyncEqual(tom, store.find('person', 1), "Once an ID is in, find returns the same object");
-    asyncEqual(yehuda, store.find('person', 2), "Once an ID is in, find returns the same object");
+    asyncEqual(tom, store.findRecord('person', 1), "Once an ID is in, find returns the same object");
+    asyncEqual(yehuda, store.findRecord('person', 2), "Once an ID is in, find returns the same object");
     equal(get(tom, 'updatedAt'), "now", "The new information is received");
     equal(get(yehuda, 'updatedAt'), "now", "The new information is received");
   }));
@@ -140,8 +140,8 @@ test("by default, updateRecords calls updateRecord once per record", function() 
 
   var promise = run(function() {
     return Ember.RSVP.hash({
-      tom: store.find('person', 1),
-      yehuda: store.find('person', 2)
+      tom: store.findRecord('person', 1),
+      yehuda: store.findRecord('person', 2)
     });
   });
 
@@ -190,8 +190,8 @@ test("calling store.didSaveRecord can provide an optional hash", function() {
 
   var promise = run(function() {
     return Ember.RSVP.hash({
-      tom: store.find('person', 1),
-      yehuda: store.find('person', 2)
+      tom: store.findRecord('person', 1),
+      yehuda: store.findRecord('person', 2)
     });
   });
   promise.then(async(function(records) {
@@ -242,8 +242,8 @@ test("by default, deleteRecord calls deleteRecord once per record", function() {
 
   var promise = run(function() {
     return Ember.RSVP.hash({
-      tom: store.find('person', 1),
-      yehuda: store.find('person', 2)
+      tom: store.findRecord('person', 1),
+      yehuda: store.findRecord('person', 2)
     });
   });
 
@@ -287,8 +287,8 @@ test("by default, destroyRecord calls deleteRecord once per record without requi
 
   var promise = run(function() {
     return Ember.RSVP.hash({
-      tom: store.find('person', 1),
-      yehuda: store.find('person', 2)
+      tom: store.findRecord('person', 1),
+      yehuda: store.findRecord('person', 2)
     });
   });
 
@@ -324,7 +324,7 @@ test("if an existing model is edited then deleted, deleteRecord is called on the
   });
 
   // Retrieve that loaded record and edit it so it becomes dirty
-  run(store, 'find', 'person', 'deleted-record').then(async(function(tom) {
+  run(store, 'findRecord', 'person', 'deleted-record').then(async(function(tom) {
     tom.set('name', "Tom Mothereffin' Dale");
 
     equal(get(tom, 'isDirty'), true, "precond - record should be dirty after editing");
@@ -355,7 +355,7 @@ test("if a deleted record errors, it enters the error state", function() {
   var tom;
 
   run(function() {
-    store.find('person', 'deleted-record').then(async(function(person) {
+    store.findRecord('person', 'deleted-record').then(async(function(person) {
       tom = person;
       person.deleteRecord();
       return person.save();
@@ -529,7 +529,7 @@ test("if an updated record is marked as invalid by the server, it enters an erro
   });
 
   Ember.run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       equal(person, yehuda, "The same object is passed through");
 
       equal(get(yehuda, 'isValid'), true, "precond - the record is valid");
@@ -573,7 +573,7 @@ test("records can have errors on arbitrary properties after update", function() 
   });
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       equal(person, yehuda, "The same object is passed through");
 
       equal(get(yehuda, 'isValid'), true, "precond - the record is valid");
@@ -625,7 +625,7 @@ test("if an updated record is marked as invalid by the server, you can attempt t
   });
 
   Ember.run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       equal(person, yehuda, "The same object is passed through");
 
       equal(get(yehuda, 'isValid'), true, "precond - the record is valid");
@@ -667,7 +667,7 @@ test("if a updated record is marked as erred by the server, it enters an error s
     return store.push('person', { id: 1, name: "John Doe" });
   });
 
-  run(store, 'find', 'person', 1).then(async(function(record) {
+  run(store, 'findRecord', 'person', 1).then(async(function(record) {
     equal(record, person, "The person was resolved");
     person.set('name', "Jonathan Doe");
     return person.save();
@@ -679,18 +679,18 @@ test("if a updated record is marked as erred by the server, it enters an error s
 test("can be created after the DS.Store", function() {
   expect(1);
 
-  adapter.find = function(store, type, id, snapshot) {
+  adapter.findRecord = function(store, type, id, snapshot) {
     equal(type, Person, "the type is correct");
     return Ember.RSVP.resolve({ id: 1 });
   };
 
   run(function() {
-    store.find('person', 1);
+    store.findRecord('person', 1);
   });
 });
 
 test("the filter method can optionally take a server query as well", function() {
-  adapter.findQuery = function(store, type, query, array) {
+  adapter.query = function(store, type, query, array) {
     return Ember.RSVP.resolve([
       { id: 1, name: "Yehuda Katz" },
       { id: 2, name: "Tom Dale" }
@@ -705,7 +705,7 @@ test("the filter method can optionally take a server query as well", function() 
 
   asyncFilter.then(async(function(filter) {
     loadedFilter = filter;
-    return store.find('person', 2);
+    return store.findRecord('person', 2);
   })).then(async(function(tom) {
     equal(get(loadedFilter, 'length'), 1, "The filter has an item in it");
     deepEqual(loadedFilter.toArray(), [tom], "The filter has a single entry in it");
@@ -721,7 +721,7 @@ test("relationships returned via `commit` do not trigger additional findManys", 
     store.push('dog', { id: 1, name: "Scruffy" });
   });
 
-  adapter.find = function(store, type, id, snapshot) {
+  adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.resolve({ id: 1, name: "Tom Dale", dogs: [1] });
   };
 
@@ -738,8 +738,8 @@ test("relationships returned via `commit` do not trigger additional findManys", 
   };
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
-      return Ember.RSVP.hash({ tom: person, dog: store.find('dog', 1) });
+    store.findRecord('person', 1).then(async(function(person) {
+      return Ember.RSVP.hash({ tom: person, dog: store.findRecord('dog', 1) });
     })).then(async(function(records) {
       records.tom.get('dogs');
       return records.dog.save();
@@ -768,7 +768,7 @@ test("relationships don't get reset if the links is the same", function() {
 
   var tom, dogs;
 
-  run(store, 'find', 'person', 1).then(async(function(person) {
+  run(store, 'findRecord', 'person', 1).then(async(function(person) {
     tom = person;
     dogs = tom.get('dogs');
     return dogs;
@@ -867,13 +867,13 @@ test("deleteRecord receives a snapshot", function() {
 test("find receives a snapshot", function() {
   expect(1);
 
-  adapter.find = function(store, type, id, snapshot) {
+  adapter.findRecord = function(store, type, id, snapshot) {
     ok(snapshot instanceof DS.Snapshot, "snapshot is an instance of DS.Snapshot");
     return Ember.RSVP.resolve({ id: 1 });
   };
 
   run(function() {
-    store.find('person', 1);
+    store.findRecord('person', 1);
   });
 });
 

--- a/packages/ember-data/tests/integration/filter-test.js
+++ b/packages/ember-data/tests/integration/filter-test.js
@@ -188,9 +188,9 @@ test("a Record Array can update its filter", function() {
   var asyncDale, asyncKatz, asyncBryn;
 
   run(function() {
-    asyncDale = store.find('person', 1);
-    asyncKatz = store.find('person', 2);
-    asyncBryn = store.find('person', 3);
+    asyncDale = store.findRecord('person', 1);
+    asyncKatz = store.findRecord('person', 2);
+    asyncBryn = store.findRecord('person', 3);
   });
 
   store.filter('person', function(hash) {
@@ -246,9 +246,9 @@ test("a Record Array can update its filter and notify array observers", function
   var asyncDale, asyncKatz, asyncBryn;
 
   run(function() {
-    asyncDale = store.find('person', 1);
-    asyncKatz = store.find('person', 2);
-    asyncBryn = store.find('person', 3);
+    asyncDale = store.findRecord('person', 1);
+    asyncKatz = store.findRecord('person', 2);
+    asyncBryn = store.findRecord('person', 3);
   });
 
   store.filter('person', function(hash) {
@@ -332,7 +332,7 @@ test("it is possible to filter by computed properties", function() {
 
   equal(filter.get('length'), 1, "the filter now has a record in it");
 
-  store.find('person', 1).then(async(function(person) {
+  store.findRecord('person', 1).then(async(function(person) {
     Ember.run(function() {
       person.set('name', "Yehuda Katz");
     });
@@ -361,12 +361,12 @@ test("a filter created after a record is already loaded works", function() {
   });
 
   equal(filter.get('length'), 1, "the filter now has a record in it");
-  asyncEqual(filter.objectAt(0), store.find('person', 1));
+  asyncEqual(filter.objectAt(0), store.findRecord('person', 1));
 });
 
 test("filter with query persists query on the resulting filteredRecordArray", function() {
   customAdapter(env, DS.Adapter.extend({
-    findQuery: function(store, type, id) {
+    query: function(store, type, id) {
       return Ember.RSVP.resolve([{
         id: id,
         name: "Tom Dale"
@@ -394,7 +394,7 @@ test("it is possible to filter by state flags", function() {
   var filter;
 
   customAdapter(env, DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: id, name: "Tom Dale" });
     }
   }));
@@ -408,7 +408,7 @@ test("it is possible to filter by state flags", function() {
   equal(filter.get('length'), 0, "precond - there are no records yet");
 
   Ember.run(function() {
-    var asyncPerson = store.find('person', 1);
+    var asyncPerson = store.findRecord('person', 1);
 
     // Ember.run will block `find` from being synchronously
     // resolved in test mode
@@ -417,7 +417,7 @@ test("it is possible to filter by state flags", function() {
 
     asyncPerson.then(async(function(person) {
       equal(filter.get('length'), 1, "the now-loaded record is in the filter");
-      asyncEqual(filter.objectAt(0), store.find('person', 1));
+      asyncEqual(filter.objectAt(0), store.findRecord('person', 1));
     }));
   });
 });
@@ -437,7 +437,7 @@ test("it is possible to filter loaded records by dirtiness", function() {
     store.push('person', { id: 1, name: "Tom Dale" });
   });
 
-  store.find('person', 1).then(async(function(person) {
+  store.findRecord('person', 1).then(async(function(person) {
     equal(filter.get('length'), 1, "the clean record is in the filter");
 
     // Force synchronous update of the filter, even though
@@ -491,7 +491,7 @@ test("it is possible to filter created records by dirtiness", function() {
 
 test("it is possible to filter created records by isReloading", function() {
   customAdapter(env, DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({
         id: 1,
         name: "Tom Dalle"
@@ -524,7 +524,7 @@ var clientEdits = function(ids) {
     // wrap in an Ember.run to guarantee coalescence of the
     // iterated `set` calls and promise resolution.
     Ember.run(function() {
-      store.find('person', id).then(function(person) {
+      store.findRecord('person', id).then(function(person) {
         edited.push(person);
         person.set('name', 'Client-side ' + id );
       });

--- a/packages/ember-data/tests/integration/records/load-test.js
+++ b/packages/ember-data/tests/integration/records/load-test.js
@@ -22,12 +22,12 @@ module("integration/load - Loading Records", {
 });
 
 test("When loading a record fails, the isLoading is set to false", function() {
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.reject();
   };
 
   run(function() {
-    env.store.find('post', 1).then(null, async(function() {
+    env.store.findRecord('post', 1).then(null, async(function() {
       // store.recordForId is private, but there is currently no other way to
       // get the specific record instance, since it is not passed to this
       // rejection handler

--- a/packages/ember-data/tests/integration/records/reload-test.js
+++ b/packages/ember-data/tests/integration/records/reload-test.js
@@ -25,7 +25,7 @@ module("integration/reload - Reloading Records", {
 test("When a single record is requested, the adapter's find method should be called unless it's loaded.", function() {
   var count = 0;
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     if (count === 0) {
       count++;
       return Ember.RSVP.resolve({ id: id, name: "Tom Dale" });
@@ -38,7 +38,7 @@ test("When a single record is requested, the adapter's find method should be cal
   };
 
   run(function() {
-    env.store.find('person', 1).then(function(person) {
+    env.store.findRecord('person', 1).then(function(person) {
       equal(get(person, 'name'), "Tom Dale", "The person is loaded with the right name");
       equal(get(person, 'isLoaded'), true, "The person is now loaded");
       var promise = person.reload();
@@ -58,7 +58,7 @@ test("When a record is reloaded and fails, it can try again", function() {
   });
 
   var count = 0;
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     equal(tom.get('isReloading'), true, "Tom is reloading");
     if (count++ === 0) {
       return Ember.RSVP.reject();
@@ -87,7 +87,7 @@ test("When a record is loaded a second time, isLoaded stays true", function() {
   });
 
   run(function() {
-    env.store.find('person', 1).then(function(person) {
+    env.store.findRecord('person', 1).then(function(person) {
       equal(get(person, 'isLoaded'), true, "The person is loaded");
       person.addObserver('isLoaded', isLoadedDidChange);
 
@@ -117,7 +117,7 @@ test("When a record is reloaded, its async hasMany relationships still work", fu
 
   var tags = { 1: "hipster", 2: "hair" };
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     switch (type.modelName) {
       case 'person':
         return Ember.RSVP.resolve({ id: 1, name: "Tom", tags: [1, 2] });
@@ -129,7 +129,7 @@ test("When a record is reloaded, its async hasMany relationships still work", fu
   var tom;
 
   run(function() {
-    env.store.find('person', 1).then(function(person) {
+    env.store.findRecord('person', 1).then(function(person) {
       tom = person;
       equal(person.get('name'), "Tom", "precond");
 

--- a/packages/ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs-to-test.js
@@ -106,7 +106,7 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
     })
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     ok(true, "The adapter's find method should be called");
     return Ember.RSVP.resolve({
       id: 1
@@ -121,7 +121,7 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
   });
 
   run(function() {
-    env.store.find('post', 1).then(function(post) {
+    env.store.findRecord('post', 1).then(function(post) {
       post.get('user');
     });
   });
@@ -137,8 +137,8 @@ test("Only a record of the same type can be used with a monomorphic belongsTo re
 
   run(function() {
     hash({
-      post: store.find('post', 1),
-      comment: store.find('comment', 2)
+      post: store.findRecord('post', 1),
+      comment: store.findRecord('comment', 2)
     }).then(function(records) {
       expectAssertion(function() {
         records.post.set('user', records.comment);
@@ -158,10 +158,10 @@ test("Only a record of the same base type can be used with a polymorphic belongs
 
   run(function() {
     var asyncRecords = hash({
-      user: store.find('user', 3),
-      post: store.find('post', 1),
-      comment: store.find('comment', 1),
-      anotherComment: store.find('comment', 2)
+      user: store.findRecord('user', 3),
+      post: store.findRecord('post', 1),
+      comment: store.findRecord('comment', 1),
+      anotherComment: store.findRecord('comment', 2)
     });
 
     asyncRecords.then(function(records) {
@@ -186,8 +186,8 @@ test("The store can load a polymorphic belongsTo association", function() {
 
   run(function() {
     hash({
-      message: store.find('post', 1),
-      comment: store.find('comment', 2)
+      message: store.findRecord('post', 1),
+      comment: store.findRecord('comment', 2)
     }).then(function(records) {
       equal(records.comment.get('message'), records.message);
     });
@@ -205,7 +205,7 @@ test("The store can serialize a polymorphic belongsTo association", function() {
     env.store.push('post', { id: 1 });
     env.store.push('comment', { id: 2, message: 1, messageType: 'post' });
 
-    store.find('comment', 2).then(function(comment) {
+    store.findRecord('comment', 2).then(function(comment) {
       var serialized = store.serialize(comment, { includeId: true });
       equal(serialized['message'], 1);
       equal(serialized['message_type'], 'post');
@@ -229,7 +229,7 @@ test("A serializer can materialize a belongsTo as a link that gets sent back to 
     store.push('person', { id: 1, links: { group: '/people/1/group' } });
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     throw new Error("Adapter's find method should not be called");
   };
 
@@ -242,7 +242,7 @@ test("A serializer can materialize a belongsTo as a link that gets sent back to 
   });
 
   run(function() {
-    env.store.find('person', 1).then(function(person) {
+    env.store.findRecord('person', 1).then(function(person) {
       return person.get('group');
     }).then(function(group) {
       ok(group instanceof Group, "A group object is loaded");
@@ -267,7 +267,7 @@ test('A record with an async belongsTo relationship always returns a promise for
     store.push('person', { id: 1, links: { seat: '/people/1/seat' } });
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     throw new Error("Adapter's find method should not be called");
   };
 
@@ -276,7 +276,7 @@ test('A record with an async belongsTo relationship always returns a promise for
   });
 
   run(function() {
-    env.store.find('person', 1).then(function(person) {
+    env.store.findRecord('person', 1).then(function(person) {
       person.get('seat').then(function(seat) {
         // this assertion fails too
         // ok(seat.get('person') === person, 'parent relationship should be populated');
@@ -305,7 +305,7 @@ test("A record with an async belongsTo relationship returning null should resolv
     store.push('person', { id: 1, links: { group: '/people/1/group' } });
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     throw new Error("Adapter's find method should not be called");
   };
 
@@ -313,7 +313,7 @@ test("A record with an async belongsTo relationship returning null should resolv
     return Ember.RSVP.resolve(null);
   });
 
-  env.store.find('person', 1).then(async(function(person) {
+  env.store.findRecord('person', 1).then(async(function(person) {
     return person.get('group');
   })).then(async(function(group) {
     ok(group === null, "group should be null");
@@ -339,7 +339,7 @@ test("A record can be created with a resolved belongsTo promise", function() {
     group = store.push('group', { id: 1 });
   });
 
-  var groupPromise = store.find('group', 1);
+  var groupPromise = store.findRecord('group', 1);
   groupPromise.then(async(function(group) {
     var person = env.store.createRecord('person', {
       group: groupPromise
@@ -552,7 +552,7 @@ test("Destroying a record with an unloaded aync belongsTo association does not f
     });
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     throw new Error("Adapter's find method should not be called");
   };
 
@@ -631,12 +631,12 @@ test("belongsTo hasData async loaded", function () {
     author: belongsTo('author', { async: true })
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.resolve({ id: 1, name: 'The Greatest Book', author: 2 });
   };
 
   run(function() {
-    store.find('book', 1).then(function(book) {
+    store.findRecord('book', 1).then(function(book) {
       var relationship = book._internalModel._relationships.get('author');
       equal(relationship.hasData, true, 'relationship has data');
     });
@@ -646,12 +646,12 @@ test("belongsTo hasData async loaded", function () {
 test("belongsTo hasData sync loaded", function () {
   expect(1);
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.resolve({ id: 1, name: 'The Greatest Book', author: 2 });
   };
 
   run(function() {
-    store.find('book', 1).then(function(book) {
+    store.findRecord('book', 1).then(function(book) {
       var relationship = book._internalModel._relationships.get('author');
       equal(relationship.hasData, true, 'relationship has data');
     });
@@ -665,12 +665,12 @@ test("belongsTo hasData async not loaded", function () {
     author: belongsTo('author', { async: true })
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.resolve({ id: 1, name: 'The Greatest Book', links: { author: 'author' } });
   };
 
   run(function() {
-    store.find('book', 1).then(function(book) {
+    store.findRecord('book', 1).then(function(book) {
       var relationship = book._internalModel._relationships.get('author');
       equal(relationship.hasData, false, 'relationship does not have data');
     });
@@ -680,12 +680,12 @@ test("belongsTo hasData async not loaded", function () {
 test("belongsTo hasData sync not loaded", function () {
   expect(1);
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.resolve({ id: 1, name: 'The Greatest Book' });
   };
 
   run(function() {
-    store.find('book', 1).then(function(book) {
+    store.findRecord('book', 1).then(function(book) {
       var relationship = book._internalModel._relationships.get('author');
       equal(relationship.hasData, false, 'relationship does not have data');
     });

--- a/packages/ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/has-many-test.js
@@ -99,7 +99,7 @@ test("When a hasMany relationship is accessed, the adapter's findMany method sho
   run(function() {
     env.store.push('post', { id: 1, comments: [1] });
     env.store.push('comment', { id: 1 });
-    env.store.find('post', 1).then(function(post) {
+    env.store.findRecord('post', 1).then(function(post) {
       return post.get('comments');
     });
   });
@@ -120,7 +120,7 @@ test("adapter.findMany only gets unique IDs even if duplicate IDs are present in
 
   run(function() {
     env.store.push('book', { id: 1, chapters: [2, 3, 3] });
-    env.store.find('book', 1).then(function(book) {
+    env.store.findRecord('book', 1).then(function(book) {
       return book.get('chapters');
     });
   });
@@ -137,7 +137,7 @@ test("A serializer can materialize a hasMany as an opaque token that can be lazi
 
   // When the store asks the adapter for the record with ID 1,
   // provide some fake data.
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     equal(type, Post, "find type was Post");
     equal(id, "1", "find id was 1");
 
@@ -159,7 +159,7 @@ test("A serializer can materialize a hasMany as an opaque token that can be lazi
   };
 
   run(function() {
-    env.store.find('post', 1).then(async(function(post) {
+    env.store.findRecord('post', 1).then(async(function(post) {
       return post.get('comments');
     })).then(async(function(comments) {
       equal(comments.get('isLoaded'), true, "comments are loaded");
@@ -332,7 +332,7 @@ test("A hasMany relationship can be reloaded if it was fetched via a link", func
     comments: DS.hasMany('comment', { async: true })
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     equal(type, Post, "find type was Post");
     equal(id, "1", "find id was 1");
 
@@ -351,7 +351,7 @@ test("A hasMany relationship can be reloaded if it was fetched via a link", func
   };
 
   run(function() {
-    run(env.store, 'find', 'post', 1).then(function(post) {
+    run(env.store, 'findRecord', 'post', 1).then(function(post) {
       return post.get('comments');
     }).then(function(comments) {
       equal(comments.get('isLoaded'), true, "comments are loaded");
@@ -381,7 +381,7 @@ test("A sync hasMany relationship can be reloaded if it was fetched via ids", fu
     comments: DS.hasMany('comment')
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     equal(type, Post, "find type was Post");
     equal(id, "1", "find id was 1");
 
@@ -391,7 +391,7 @@ test("A sync hasMany relationship can be reloaded if it was fetched via ids", fu
   run(function() {
     env.store.pushMany('comment', [{ id: 1, body: "First" }, { id: 2, body: "Second" }]);
 
-    env.store.find('post', '1').then(function(post) {
+    env.store.findRecord('post', '1').then(function(post) {
       var comments = post.get('comments');
       equal(comments.get('isLoaded'), true, "comments are loaded");
       equal(comments.get('length'), 2, "comments have a length of 2");
@@ -415,7 +415,7 @@ test("A hasMany relationship can be reloaded if it was fetched via ids", functio
     comments: DS.hasMany('comment', { async: true })
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     equal(type, Post, "find type was Post");
     equal(id, "1", "find id was 1");
 
@@ -430,7 +430,7 @@ test("A hasMany relationship can be reloaded if it was fetched via ids", functio
   };
 
   run(function() {
-    env.store.find('post', 1).then(function(post) {
+    env.store.findRecord('post', 1).then(function(post) {
       return post.get('comments');
     }).then(function(comments) {
       equal(comments.get('isLoaded'), true, "comments are loaded");
@@ -455,7 +455,7 @@ test("A hasMany relationship can be directly reloaded if it was fetched via ids"
     comments: DS.hasMany('comment', { async: true })
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     equal(type, Post, "find type was Post");
     equal(id, "1", "find id was 1");
 
@@ -470,7 +470,7 @@ test("A hasMany relationship can be directly reloaded if it was fetched via ids"
   };
 
   run(function() {
-    env.store.find('post', 1).then(function(post) {
+    env.store.findRecord('post', 1).then(function(post) {
       return post.get('comments').reload().then(function(comments) {
         equal(comments.get('isLoaded'), true, "comments are loaded");
         equal(comments.get('length'), 2, "comments have 2 length");
@@ -620,7 +620,7 @@ test("When a polymorphic hasMany relationship is accessed, the adapter's findMan
   });
 
   run(function() {
-    env.store.find('user', 1).then(function(user) {
+    env.store.findRecord('user', 1).then(function(user) {
       var messages = user.get('messages');
       equal(messages.get('length'), 2, "The messages are correctly loaded");
     });
@@ -632,7 +632,7 @@ test("When a polymorphic hasMany relationship is accessed, the store can call mu
     messages: hasMany('message', { polymorphic: true, async: true })
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     if (type === Post) {
       return Ember.RSVP.resolve({ id: 1 });
     } else if (type === Comment) {
@@ -645,7 +645,7 @@ test("When a polymorphic hasMany relationship is accessed, the store can call mu
   });
 
   run(function() {
-    env.store.find('user', 1).then(function(user) {
+    env.store.findRecord('user', 1).then(function(user) {
       return user.get('messages');
     }).then(function(messages) {
       equal(messages.get('length'), 2, "The messages are correctly loaded");
@@ -682,7 +682,7 @@ test("Type can be inferred from the key of a hasMany relationship", function() {
     env.store.push('contact', { id: 1 });
   });
   run(function() {
-    env.store.find('user', 1).then(function(user) {
+    env.store.findRecord('user', 1).then(function(user) {
       return user.get('contacts');
     }).then(function(contacts) {
       equal(contacts.get('length'), 1, "The contacts relationship is correctly set up");
@@ -701,7 +701,7 @@ test("Type can be inferred from the key of an async hasMany relationship", funct
     env.store.push('contact', { id: 1 });
   });
   run(function() {
-    env.store.find('user', 1).then(function(user) {
+    env.store.findRecord('user', 1).then(function(user) {
       return user.get('contacts');
     }).then(function(contacts) {
       equal(contacts.get('length'), 1, "The contacts relationship is correctly set up");
@@ -721,7 +721,7 @@ test("Polymorphic relationships work with a hasMany whose type is inferred", fun
     env.store.push('phone', { id: 2 });
   });
   run(function() {
-    env.store.find('user', 1).then(function(user) {
+    env.store.findRecord('user', 1).then(function(user) {
       return user.get('contacts');
     }).then(function(contacts) {
       equal(contacts.get('length'), 2, "The contacts relationship is correctly set up");
@@ -758,7 +758,7 @@ test("A record can't be created from a polymorphic hasMany relationship", functi
   });
 
   run(function() {
-    env.store.find('user', 1).then(function(user) {
+    env.store.findRecord('user', 1).then(function(user) {
       return user.get('messages');
     }).then(function(messages) {
       expectAssertion(function() {
@@ -777,8 +777,8 @@ test("Only records of the same type can be added to a monomorphic hasMany relati
 
   run(function() {
     Ember.RSVP.all([
-      env.store.find('post', 1),
-      env.store.find('post', 2)
+      env.store.findRecord('post', 1),
+      env.store.findRecord('post', 2)
     ]).then(function(records) {
       expectAssertion(function() {
         records[0].get('comments').pushObject(records[1]);
@@ -799,10 +799,10 @@ test("Only records of the same base type can be added to a polymorphic hasMany r
 
   run(function() {
     asyncRecords = Ember.RSVP.hash({
-      user: env.store.find('user', 1),
-      anotherUser: env.store.find('user', 2),
-      post: env.store.find('post', 1),
-      comment: env.store.find('comment', 3)
+      user: env.store.findRecord('user', 1),
+      anotherUser: env.store.findRecord('user', 2),
+      post: env.store.findRecord('post', 1),
+      comment: env.store.findRecord('comment', 3)
     });
 
     asyncRecords.then(function(records) {
@@ -831,8 +831,8 @@ test("A record can be removed from a polymorphic association", function() {
 
   run(function() {
     asyncRecords = Ember.RSVP.hash({
-      user: env.store.find('user', 1),
-      comment: env.store.find('comment', 3)
+      user: env.store.findRecord('user', 1),
+      comment: env.store.findRecord('comment', 3)
     });
 
     asyncRecords.then(function(records) {
@@ -986,7 +986,7 @@ test("When an unloaded record is added to the hasMany, it gets fetched once the 
     return resolve([{ id: 1, body: 'first' }, { id: 2, body: 'second' }]);
   };
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     return resolve({ id: 3, body: 'third' });
   };
   var post;
@@ -1307,7 +1307,7 @@ test("adding and removing records from hasMany relationship #2666", function() {
 
   run(function() {
     stop();
-    env.store.find('post', 1).then(function (post) {
+    env.store.findRecord('post', 1).then(function (post) {
       var comments = post.get('comments');
       equal(comments.get('length'), 3, "Initial comments count");
 
@@ -1344,12 +1344,12 @@ test("hasMany hasData async loaded", function () {
     pages: hasMany('pages', { async: true })
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.resolve({ id: 1, title: 'The Story Begins', pages: [2, 3] });
   };
 
   run(function() {
-    store.find('chapter', 1).then(function(chapter) {
+    store.findRecord('chapter', 1).then(function(chapter) {
       var relationship = chapter._internalModel._relationships.get('pages');
       equal(relationship.hasData, true, 'relationship has data');
     });
@@ -1359,12 +1359,12 @@ test("hasMany hasData async loaded", function () {
 test("hasMany hasData sync loaded", function () {
   expect(1);
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.resolve({ id: 1, title: 'The Story Begins', pages: [2, 3] });
   };
 
   run(function() {
-    store.find('chapter', 1).then(function(chapter) {
+    store.findRecord('chapter', 1).then(function(chapter) {
       var relationship = chapter._internalModel._relationships.get('pages');
       equal(relationship.hasData, true, 'relationship has data');
     });
@@ -1378,12 +1378,12 @@ test("hasMany hasData async not loaded", function () {
     pages: hasMany('pages', { async: true })
   });
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.resolve({ id: 1, title: 'The Story Begins', links: { pages: 'pages' } });
   };
 
   run(function() {
-    store.find('chapter', 1).then(function(chapter) {
+    store.findRecord('chapter', 1).then(function(chapter) {
       var relationship = chapter._internalModel._relationships.get('pages');
       equal(relationship.hasData, false, 'relationship does not have data');
     });
@@ -1393,12 +1393,12 @@ test("hasMany hasData async not loaded", function () {
 test("hasMany hasData sync not loaded", function () {
   expect(1);
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.resolve({ id: 1, title: 'The Story Begins' });
   };
 
   run(function() {
-    store.find('chapter', 1).then(function(chapter) {
+    store.findRecord('chapter', 1).then(function(chapter) {
       var relationship = chapter._internalModel._relationships.get('pages');
       equal(relationship.hasData, false, 'relationship does not have data');
     });

--- a/packages/ember-data/tests/integration/relationships/one-to-one-test.js
+++ b/packages/ember-data/tests/integration/relationships/one-to-one-test.js
@@ -208,7 +208,7 @@ test("Setting a BelongsTo to a promise multiple times is resistant to race condi
     igor = store.push('user', { id: 3, name: "Igor", bestFriend: 5 });
     newFriend = store.push('user', { id: 7, name: "New friend" });
   });
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     if (id === '5') {
       return Ember.RSVP.resolve({ id: 5, name: "Igor's friend" });
     } else if (id === '2') {

--- a/packages/ember-data/tests/integration/serializers/embedded-records-mixin-new-test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded-records-mixin-new-test.js
@@ -95,7 +95,7 @@ test("normalizeSingleResponse with embedded objects", function() {
   var json;
 
   run(function() {
-    json = serializer.normalizeSingleResponse(env.store, HomePlanet, json_hash, '1', 'find');
+    json = serializer.normalizeSingleResponse(env.store, HomePlanet, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -160,7 +160,7 @@ test("normalizeSingleResponse with embedded objects inside embedded objects", fu
   var json;
 
   run(function() {
-    json = serializer.normalizeSingleResponse(env.store, HomePlanet, json_hash, '1', 'find');
+    json = serializer.normalizeSingleResponse(env.store, HomePlanet, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -231,7 +231,7 @@ test("normalizeSingleResponse with embedded objects of same type", function() {
   };
   var json;
   run(function() {
-    json = serializer.normalizeSingleResponse(env.store, Comment, json_hash, '1', 'find');
+    json = serializer.normalizeSingleResponse(env.store, Comment, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -304,7 +304,7 @@ test("normalizeSingleResponse with embedded objects inside embedded objects of s
   };
   var json;
   run(function() {
-    json = serializer.normalizeSingleResponse(env.store, Comment, json_hash, '1', 'find');
+    json = serializer.normalizeSingleResponse(env.store, Comment, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -395,7 +395,7 @@ test("normalizeSingleResponse with embedded objects of same type, but from separ
   };
   var json;
   run(function() {
-    json = serializer.normalizeSingleResponse(env.store, HomePlanet, json_hash, '1', 'find');
+    json = serializer.normalizeSingleResponse(env.store, HomePlanet, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -883,7 +883,7 @@ test("normalizeSingleResponse with embedded object (belongsTo relationship)", fu
   var json;
 
   run(function() {
-    json = serializer.normalizeSingleResponse(env.store, SuperVillain, json_hash, '1', 'find');
+    json = serializer.normalizeSingleResponse(env.store, SuperVillain, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -959,7 +959,7 @@ test("normalizeSingleResponse with multiply-nested belongsTo", function() {
   var json;
 
   run(function() {
-    json = serializer.normalizeSingleResponse(env.store, EvilMinion, json_hash, '1', 'find');
+    json = serializer.normalizeSingleResponse(env.store, EvilMinion, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -1113,7 +1113,7 @@ test("normalizeSingleResponse with polymorphic belongsTo", function() {
   var json;
 
   run(function() {
-    json = serializer.normalizeSingleResponse(env.store, SuperVillain, json_hash, '1', 'find');
+    json = serializer.normalizeSingleResponse(env.store, SuperVillain, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {
@@ -1167,7 +1167,7 @@ test("normalize with custom belongsTo primary key", function() {
   var json;
 
   run(function() {
-    json = serializer.normalizeResponse(env.store, EvilMinion, json_hash, '1', 'find');
+    json = serializer.normalizeResponse(env.store, EvilMinion, json_hash, '1', 'findRecord');
   });
 
   deepEqual(json, {

--- a/packages/ember-data/tests/integration/serializers/rest-serializer-new-test.js
+++ b/packages/ember-data/tests/integration/serializers/rest-serializer-new-test.js
@@ -71,7 +71,7 @@ test("normalizeSingleResponse with custom modelNameFromPayloadKey", function() {
   var array;
 
   run(function() {
-    array = env.container.lookup("serializer:application").normalizeSingleResponse(env.store, HomePlanet, jsonHash, '1', 'find');
+    array = env.container.lookup("serializer:application").normalizeSingleResponse(env.store, HomePlanet, jsonHash, '1', 'findRecord');
   });
 
   deepEqual(array, {
@@ -171,7 +171,7 @@ test("normalizeSingleResponse warning with custom modelNameFromPayloadKey", func
 
   warns(Ember.run.bind(null, function() {
     run(function() {
-      env.restNewSerializer.normalizeSingleResponse(env.store, HomePlanet, jsonHash, '1', 'find');
+      env.restNewSerializer.normalizeSingleResponse(env.store, HomePlanet, jsonHash, '1', 'findRecord');
     });
   }), /Encountered "home_planet" in payload, but no model was found for model name "garbage"/);
 
@@ -183,7 +183,8 @@ test("normalizeSingleResponse warning with custom modelNameFromPayloadKey", func
 
   noWarns(function() {
     run(function() {
-      homePlanet = env.restNewSerializer.normalizeSingleResponse(env.store, HomePlanet, jsonHash, 1, 'find');
+
+      homePlanet = env.restNewSerializer.normalizeSingleResponse(env.store, HomePlanet, jsonHash, 1, 'findRecord');
     });
   });
 
@@ -202,7 +203,7 @@ test("normalizeResponse can load secondary records of the same type without affe
   var array;
 
   run(function() {
-    array = env.restNewSerializer.normalizeResponse(env.store, Comment, jsonHash, '1', 'find');
+    array = env.restNewSerializer.normalizeResponse(env.store, Comment, jsonHash, '1', 'findRecord');
   });
 
   deepEqual(array, {
@@ -262,7 +263,7 @@ test("normalizeSingleResponse loads secondary records with correct serializer", 
   };
 
   run(function() {
-    env.restNewSerializer.normalizeSingleResponse(env.store, EvilMinion, jsonHash, '1', 'find');
+    env.restNewSerializer.normalizeSingleResponse(env.store, EvilMinion, jsonHash, '1', 'findRecord');
   });
 
   equal(superVillainNormalizeCount, 1, "superVillain is normalized once");
@@ -277,7 +278,7 @@ test("normalizeSingleResponse returns null if payload contains null", function()
   var value;
 
   run(function() {
-    value = env.restNewSerializer.normalizeSingleResponse(env.store, EvilMinion, jsonHash, null, 'find');
+    value = env.restNewSerializer.normalizeSingleResponse(env.store, EvilMinion, jsonHash, null, 'findRecord');
   });
 
   deepEqual(value, { data: null, included: [] }, "returned value is null");

--- a/packages/ember-data/tests/integration/store-test.js
+++ b/packages/ember-data/tests/integration/store-test.js
@@ -54,7 +54,7 @@ asyncTest("destroying record during find doesn't cause error", function() {
   expect(0);
 
   var TestAdapter = DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return new Ember.RSVP.Promise(function(resolve, reject) {
         Ember.run.next(function() {
           store.unloadAll(type.modelName);
@@ -74,7 +74,7 @@ asyncTest("destroying record during find doesn't cause error", function() {
   }
 
   run(function() {
-    store.find(type, id).then(done, done);
+    store.findRecord(type, id).then(done, done);
   });
 });
 
@@ -82,7 +82,7 @@ asyncTest("find calls do not resolve when the store is destroyed", function() {
   expect(0);
 
   var TestAdapter = DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       store.destroy();
       Ember.RSVP.resolve(null);
     }
@@ -101,7 +101,7 @@ asyncTest("find calls do not resolve when the store is destroyed", function() {
   };
 
   run(function() {
-    store.find(type, id);
+    store.findRecord(type, id);
   });
 
   setTimeout(function() {
@@ -131,7 +131,7 @@ test("destroying the store correctly cleans everything up", function() {
   var carWillDestroy = tap(car, 'willDestroy');
   var carsWillDestroy = tap(car.get('person.cars'), 'willDestroy');
 
-  env.adapter.findQuery = function() {
+  env.adapter.query = function() {
     return [{
       id: 2,
       name: 'Yehuda'
@@ -153,7 +153,7 @@ test("destroying the store correctly cleans everything up", function() {
   var adapterPopulatedPeopleWillDestroy = tap(adapterPopulatedPeople.content, 'willDestroy');
 
   run(function() {
-    store.find('person', 2);
+    store.findRecord('person', 2);
   });
 
   equal(personWillDestroy.called.length, 0, 'expected person.willDestroy to not have been called');

--- a/packages/ember-data/tests/unit/adapters/build-url-mixin/path-for-type-test.js
+++ b/packages/ember-data/tests/unit/adapters/build-url-mixin/path-for-type-test.js
@@ -37,17 +37,17 @@ test('buildURL - works with empty paths', function() {
   equal(adapter.buildURL('rootModel', 1), "/1");
 });
 
-test('buildURL - find requestType delegates to urlForFind', function() {
+test('buildURL - find requestType delegates to urlForFindRecord', function() {
   expect(4);
   var snapshotStub = { snapshot: true };
-  var originalMethod = adapter.urlForFind;
-  adapter.urlForFind = function(id, type, snapshot) {
+  var originalMethod = adapter.urlForFindRecord;
+  adapter.urlForFindRecord = function(id, type, snapshot) {
     equal(id, 1);
     equal(type, 'super-user');
     equal(snapshot, snapshotStub);
     return originalMethod.apply(this, arguments);
   };
-  equal(adapter.buildURL('super-user', 1, snapshotStub, 'find'), '/superUsers/1');
+  equal(adapter.buildURL('super-user', 1, snapshotStub, 'findRecord'), '/superUsers/1');
 });
 
 test('buildURL - findAll requestType delegates to urlForFindAll', function() {
@@ -60,16 +60,16 @@ test('buildURL - findAll requestType delegates to urlForFindAll', function() {
   equal(adapter.buildURL('super-user', null, null, 'findAll'), '/superUsers');
 });
 
-test('buildURL - findQuery requestType delegates to urlForFindQuery', function() {
+test('buildURL - query requestType delegates to urlForQuery', function() {
   expect(3);
-  var originalMethod = adapter.urlForFindQuery;
+  var originalMethod = adapter.urlForQuery;
   var queryStub = { limit: 10 };
-  adapter.urlForFindQuery = function(query, type) {
+  adapter.urlForQuery = function(query, type) {
     equal(query, queryStub);
     equal(type, 'super-user');
     return originalMethod.apply(this, arguments);
   };
-  equal(adapter.buildURL('super-user', null, null, 'findQuery', queryStub), '/superUsers');
+  equal(adapter.buildURL('super-user', null, null, 'query', queryStub), '/superUsers');
 });
 
 test('buildURL - findMany requestType delegates to urlForFindMany', function() {

--- a/packages/ember-data/tests/unit/adapters/rest-adapter/ajax-test.js
+++ b/packages/ember-data/tests/unit/adapters/rest-adapter/ajax-test.js
@@ -28,8 +28,8 @@ test("When an id is searched, the correct url should be generated", function() {
     return Ember.RSVP.resolve();
   };
   run(function() {
-    adapter.find(store, Person, 1);
-    adapter.find(store, Place, 1);
+    adapter.findRecord(store, Person, 1);
+    adapter.findRecord(store, Place, 1);
   });
 });
 
@@ -40,7 +40,7 @@ test("id's should be sanatized", function() {
     return Ember.RSVP.resolve();
   };
   run(function() {
-    adapter.find(store, Person, '../place/1');
+    adapter.findRecord(store, Person, '../place/1');
   });
 });
 

--- a/packages/ember-data/tests/unit/adapters/rest-adapter/deprecated-adapter-methods.js
+++ b/packages/ember-data/tests/unit/adapters/rest-adapter/deprecated-adapter-methods.js
@@ -1,0 +1,35 @@
+var store = {};
+var type = 'post';
+var id = 1;
+var snapshot = {};
+
+module("unit/adapters/rest-adapter/deprecated-adapter-methods - ");
+
+test("`findRecord` delegates to deprecated find method if it is supplied", function() {
+  expect(2);
+
+  var adapter = DS.RESTAdapter.extend({
+    find: function() {
+      ok(true, 'overridden `find` method should be called');
+    }
+  }).create();
+
+  expectDeprecation(function() {
+    adapter.findRecord(store, type, id, snapshot);
+  }, /RestAdapter#find has been deprecated and renamed to `findRecord`./);
+});
+
+
+test("`query` delegates to deprecated findQuery method if it is supplied", function() {
+  expect(2);
+
+  var adapter = DS.RESTAdapter.extend({
+    findQuery: function() {
+      ok(true, 'overridden `findQuery` method should be called');
+    }
+  }).create();
+
+  expectDeprecation(function() {
+    adapter.query(store, type, id, snapshot);
+  }, /RestAdapter#findQuery has been deprecated and renamed to `query`./);
+});

--- a/packages/ember-data/tests/unit/model-test.js
+++ b/packages/ember-data/tests/unit/model-test.js
@@ -41,7 +41,7 @@ test("setting a property on a record that has not changed does not cause it to b
 
   run(function() {
     store.push('person', { id: 1, name: "Peter", isDrugAddict: true });
-    store.find('person', 1).then(function(person) {
+    store.findRecord('person', 1).then(function(person) {
       equal(person.get('isDirty'), false, "precond - person record should not be dirty");
 
       person.set('name', "Peter");
@@ -57,7 +57,7 @@ test("resetting a property on a record cause it to become clean again", function
 
   run(function() {
     store.push('person', { id: 1, name: "Peter", isDrugAddict: true });
-    store.find('person', 1).then(function(person) {
+    store.findRecord('person', 1).then(function(person) {
       equal(person.get('isDirty'), false, "precond - person record should not be dirty");
       person.set('isDrugAddict', false);
       equal(person.get('isDirty'), true, "record becomes dirty after setting property to a new value");
@@ -72,7 +72,7 @@ test("a record becomes clean again only if all changed properties are reset", fu
 
   run(function() {
     store.push('person', { id: 1, name: "Peter", isDrugAddict: true });
-    store.find('person', 1).then(function(person) {
+    store.findRecord('person', 1).then(function(person) {
       equal(person.get('isDirty'), false, "precond - person record should not be dirty");
       person.set('isDrugAddict', false);
       equal(person.get('isDirty'), true, "record becomes dirty after setting one property to a new value");
@@ -91,7 +91,7 @@ test("a record reports its unique id via the `id` property", function() {
 
   run(function() {
     store.push('person', { id: 1 });
-    store.find('person', 1).then(function(record) {
+    store.findRecord('person', 1).then(function(record) {
       equal(get(record, 'id'), 1, "reports id as id by default");
     });
   });
@@ -102,7 +102,7 @@ test("a record's id is included in its toString representation", function() {
 
   run(function() {
     store.push('person', { id: 1 });
-    store.find('person', 1).then(function(record) {
+    store.findRecord('person', 1).then(function(record) {
       equal(record.toString(), '<(subclass of DS.Model):'+Ember.guidFor(record)+':1>', "reports id in toString");
     });
   });
@@ -121,7 +121,7 @@ test("trying to set an `id` attribute should raise", function() {
   expectAssertion(function() {
     run(function() {
       store.push('person', { id: 1, name: "Scumdale" });
-      store.find('person', 1);
+      store.findRecord('person', 1);
     });
   }, /You may not set `id`/);
 });
@@ -136,7 +136,7 @@ test("a collision of a record's id with object function's name", function() {
     }
     run(function() {
       store.push('person', { id: 'watch' });
-      store.find('person', 'watch').then(function(record) {
+      store.findRecord('person', 'watch').then(function(record) {
         equal(get(record, 'id'), 'watch', "record is successfully created and could be found by its id");
       });
     });
@@ -154,7 +154,7 @@ test("it should use `_internalModel` and not `internalModel` to store its intern
   run(function() {
     store.push('person', { id: 1 });
 
-    store.find(Person, 1).then(function(record) {
+    store.findRecord(Person, 1).then(function(record) {
       equal(record.get('_internalModel'), undefined, "doesn't shadow internalModel key");
     });
   });
@@ -177,7 +177,7 @@ test("it should cache attributes", function() {
 
   run(function() {
     store.push('post', { id: 1 });
-    store.find('post', 1).then(function(record) {
+    store.findRecord('post', 1).then(function(record) {
       run(function() {
         record.set('updatedAt', date);
       });
@@ -338,7 +338,7 @@ test("a DS.Model can update its attributes", function() {
   expect(1);
 
   run(function() {
-    store.find('person', 2).then(function(person) {
+    store.findRecord('person', 2).then(function(person) {
       set(person, 'name', "Brohuda Katz");
       equal(get(person, 'name'), "Brohuda Katz", "setting took hold");
     });
@@ -469,7 +469,7 @@ test("setting a property back to its original value removes the property from th
   expect(3);
 
   run(function() {
-    store.find('person', 1).then(function(person) {
+    store.findRecord('person', 1).then(function(person) {
       equal(person._internalModel._attributes.name, undefined, "the `_attributes` hash is clean");
 
       set(person, 'name', "Niceguy Dale");
@@ -601,7 +601,7 @@ var converts = function(type, provided, expected) {
   run(function() {
     testStore.push('model', serializer.normalize(Model, { id: 1, name: provided }));
     testStore.push('model', serializer.normalize(Model, { id: 2 }));
-    testStore.find('model', 1).then(function(record) {
+    testStore.findRecord('model', 1).then(function(record) {
       deepEqual(get(record, 'name'), expected, type + " coerces " + provided + " to " + expected);
     });
   });
@@ -633,7 +633,7 @@ var convertsFromServer = function(type, provided, expected) {
 
   run(function() {
     testStore.push('model', serializer.normalize(Model, { id: "1", name: provided }));
-    testStore.find('model', 1).then(function(record) {
+    testStore.findRecord('model', 1).then(function(record) {
       deepEqual(get(record, 'name'), expected, type + " coerces " + provided + " to " + expected);
     });
   });
@@ -648,7 +648,7 @@ var convertsWhenSet = function(type, provided, expected) {
 
   run(function() {
     testStore.push('model', { id: 2 });
-    testStore.find('model', 2).then(function(record) {
+    testStore.findRecord('model', 2).then(function(record) {
       set(record, 'name', provided);
       deepEqual(record.serialize().name, expected, type + " saves " + provided + " as " + expected);
     });
@@ -712,7 +712,7 @@ test("a DS.Model can describe Date attributes", function() {
 
   run(function() {
     store.push('person', { id: 1 });
-    store.find('person', 1).then(function(record) {
+    store.findRecord('person', 1).then(function(record) {
       run(function() {
         record.set('updatedAt', date);
       });
@@ -747,7 +747,7 @@ test("ensure model exits loading state, materializes data and fulfills promise o
 
   var store = createStore({
     adapter: DS.Adapter.extend({
-      find: function(store, type, id, snapshot) {
+      findRecord: function(store, type, id, snapshot) {
         return Ember.RSVP.resolve({ id: 1, name: "John" });
       }
     }),
@@ -755,7 +755,7 @@ test("ensure model exits loading state, materializes data and fulfills promise o
   });
 
   run(function() {
-    store.find('person', 1).then(function(person) {
+    store.findRecord('person', 1).then(function(person) {
       equal(get(person, 'currentState.stateName'), 'root.loaded.saved', 'model is in loaded state');
       equal(get(person, 'isLoaded'), true, 'model is loaded');
     });

--- a/packages/ember-data/tests/unit/model/lifecycle-callbacks-test.js
+++ b/packages/ember-data/tests/unit/model/lifecycle-callbacks-test.js
@@ -14,7 +14,7 @@ test("a record receives a didLoad callback when it has finished loading", functi
   });
 
   var adapter = DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Foo" });
     }
   });
@@ -25,7 +25,7 @@ test("a record receives a didLoad callback when it has finished loading", functi
   });
 
   run(function() {
-    store.find('person', 1).then(function(person) {
+    store.findRecord('person', 1).then(function(person) {
       equal(person.get('id'), "1", "The person's ID is available");
       equal(person.get('name'), "Foo", "The person's properties are available");
     });
@@ -75,7 +75,7 @@ test("a record receives a didUpdate callback when it has finished updating", fun
   });
 
   var adapter = DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Foo" });
     },
 
@@ -93,7 +93,7 @@ test("a record receives a didUpdate callback when it has finished updating", fun
   var asyncPerson;
 
   run(function() {
-    asyncPerson = store.find('person', 1);
+    asyncPerson = store.findRecord('person', 1);
   });
   equal(callCount, 0, "precond - didUpdate callback was not called yet");
 
@@ -168,7 +168,7 @@ test("a record receives a didDelete callback when it has finished deleting", fun
   });
 
   var adapter = DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Foo" });
     },
 
@@ -186,7 +186,7 @@ test("a record receives a didDelete callback when it has finished deleting", fun
   var asyncPerson;
 
   run(function() {
-    asyncPerson = store.find('person', 1);
+    asyncPerson = store.findRecord('person', 1);
   });
 
   equal(callCount, 0, "precond - didDelete callback was not called yet");
@@ -256,7 +256,7 @@ test("a record receives a becameInvalid callback when it became invalid", functi
   });
 
   var adapter = DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Foo" });
     },
 
@@ -274,7 +274,7 @@ test("a record receives a becameInvalid callback when it became invalid", functi
   var asyncPerson;
 
   run(function() {
-    asyncPerson = store.find('person', 1);
+    asyncPerson = store.findRecord('person', 1);
   });
   equal(callCount, 0, "precond - becameInvalid callback was not called yet");
 

--- a/packages/ember-data/tests/unit/model/merge-test.js
+++ b/packages/ember-data/tests/unit/model/merge-test.js
@@ -204,7 +204,7 @@ test("A dirty record can be reloaded", function() {
   expect(3);
 
   var adapter = DS.Adapter.extend({
-    find: function(store, type, id, snapshot) {
+    findRecord: function(store, type, id, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Thomas Dale", city: "Portland" });
     }
   });

--- a/packages/ember-data/tests/unit/model/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/belongs-to-test.js
@@ -27,14 +27,14 @@ test("belongsTo lazily loads relationships as needed", function() {
   });
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       equal(get(person, 'name'), "Tom Dale", "precond - retrieves person record from store");
 
       equal(get(person, 'tag') instanceof Tag, true, "the tag property should return a tag");
       equal(get(person, 'tag.name'), "friendly", "the tag shuld have name");
 
       strictEqual(get(person, 'tag'), get(person, 'tag'), "the returned object is always the same");
-      asyncEqual(get(person, 'tag'), store.find('tag', 5), "relationship object is the same as object retrieved directly");
+      asyncEqual(get(person, 'tag'), store.findRecord('tag', 5), "relationship object is the same as object retrieved directly");
     }));
   });
 });
@@ -54,7 +54,7 @@ test("async belongsTo relationships work when the data hash has not been loaded"
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     if (type === Person) {
       equal(id, 1, "id should be 1");
 
@@ -67,7 +67,7 @@ test("async belongsTo relationships work when the data hash has not been loaded"
   };
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       equal(get(person, 'name'), "Tom Dale", "The person is now populated");
 
       return run(function() {
@@ -101,7 +101,7 @@ test("async belongsTo relationships work when the data hash has already been loa
   });
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       equal(get(person, 'name'), "Tom Dale", "The person is now populated");
       return run(function() {
         return get(person, 'tag');
@@ -134,7 +134,7 @@ test("calling createRecord and passing in an undefined value for a relationship 
   });
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       strictEqual(person.get('tag'), null, "undefined values should return null relationships");
     }));
   });
@@ -170,7 +170,7 @@ test("When finding a hasMany relationship the inverse belongsTo relationship is 
   });
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       equal(get(person, 'isLoaded'), true, "isLoaded should be true");
       equal(get(person, 'name'), "Tom Dale", "the person is still Tom Dale");
 
@@ -204,7 +204,7 @@ test("When finding a belongsTo relationship the inverse belongsTo relationship i
   var env = setupStore({ occupation: Occupation, person: Person });
   var store = env.store;
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     equal(snapshot.belongsTo('person').id, '1');
     return Ember.RSVP.resolve({ id: 5, description: "fifth" });
   };
@@ -242,14 +242,14 @@ test("belongsTo supports relationships to models with id 0", function() {
   });
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       equal(get(person, 'name'), "Tom Dale", "precond - retrieves person record from store");
 
       equal(get(person, 'tag') instanceof Tag, true, "the tag property should return a tag");
       equal(get(person, 'tag.name'), "friendly", "the tag should have name");
 
       strictEqual(get(person, 'tag'), get(person, 'tag'), "the returned object is always the same");
-      asyncEqual(get(person, 'tag'), store.find('tag', 0), "relationship object is the same as object retrieved directly");
+      asyncEqual(get(person, 'tag'), store.findRecord('tag', 0), "relationship object is the same as object retrieved directly");
     }));
   });
 });

--- a/packages/ember-data/tests/unit/model/relationships/has-many-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/has-many-test.js
@@ -31,11 +31,11 @@ test("hasMany handles pre-loaded relationships", function() {
   env.registry.register('model:pet', Pet);
   env.registry.register('model:person', Person);
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     if (type === Tag && id === '12') {
       return Ember.RSVP.resolve({ id: 12, name: "oohlala" });
     } else {
-      ok(false, "find() should not be called with these values");
+      ok(false, "findRecord() should not be called with these values");
     }
   };
 
@@ -49,7 +49,7 @@ test("hasMany handles pre-loaded relationships", function() {
   });
 
   run(function() {
-    store.find('person', 1).then(function(person) {
+    store.findRecord('person', 1).then(function(person) {
       equal(get(person, 'name'), "Tom Dale", "precond - retrieves person record from store");
 
       var tags = get(person, 'tags');
@@ -64,20 +64,20 @@ test("hasMany handles pre-loaded relationships", function() {
       equal(get(get(person, 'tags'), 'length'), 2, "the length is updated after new data is loaded");
 
       strictEqual(get(person, 'tags').objectAt(0), get(person, 'tags').objectAt(0), "the returned object is always the same");
-      asyncEqual(get(person, 'tags').objectAt(0), store.find('tag', 5), "relationship objects are the same as objects retrieved directly");
+      asyncEqual(get(person, 'tags').objectAt(0), store.findRecord('tag', 5), "relationship objects are the same as objects retrieved directly");
 
       run(function() {
         store.push('person', { id: 3, name: "KSelden" });
       });
 
-      return store.find('person', 3);
+      return store.findRecord('person', 3);
     }).then(function(kselden) {
       equal(get(get(kselden, 'tags'), 'length'), 0, "a relationship that has not been supplied returns an empty array");
 
       run(function() {
         store.push('person', { id: 4, name: "Cyvid Hamluck", pets: [4] });
       });
-      return store.find('person', 4);
+      return store.findRecord('person', 4);
     }).then(function(cyvid) {
       equal(get(cyvid, 'name'), "Cyvid Hamluck", "precond - retrieves person record from store");
 
@@ -118,11 +118,11 @@ test("hasMany lazily loads async relationships", function() {
   env.registry.register('model:pet', Pet);
   env.registry.register('model:person', Person);
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     if (type === Tag && id === '12') {
       return Ember.RSVP.resolve({ id: 12, name: "oohlala" });
     } else {
-      ok(false, "find() should not be called with these values");
+      ok(false, "findRecord() should not be called with these values");
     }
   };
 
@@ -138,7 +138,7 @@ test("hasMany lazily loads async relationships", function() {
   var wycats;
 
   run(function() {
-    store.find('person', 2).then(function(person) {
+    store.findRecord('person', 2).then(function(person) {
       wycats = person;
 
       equal(get(wycats, 'name'), "Yehuda Katz", "precond - retrieves person record from store");
@@ -152,7 +152,7 @@ test("hasMany lazily loads async relationships", function() {
       equal(get(records.tags.objectAt(0), 'name'), "oohlala", "the first tag should be a Tag");
 
       strictEqual(records.tags.objectAt(0), records.tags.objectAt(0), "the returned object is always the same");
-      asyncEqual(records.tags.objectAt(0), store.find('tag', 12), "relationship objects are the same as objects retrieved directly");
+      asyncEqual(records.tags.objectAt(0), store.findRecord('tag', 12), "relationship objects are the same as objects retrieved directly");
 
       return get(wycats, 'tags');
     }).then(function(tags) {
@@ -252,7 +252,7 @@ test("relationships work when declared with a string path", function() {
   });
 
   run(function() {
-    env.store.find('person', 1).then(function(person) {
+    env.store.findRecord('person', 1).then(function(person) {
       equal(get(person, 'name'), "Tom Dale", "precond - retrieves person record from store");
       equal(get(person, 'tags.length'), 2, "the list of tags should have the correct length");
     });
@@ -287,7 +287,7 @@ test("hasMany relationships work when the data hash has not been loaded", functi
     return Ember.RSVP.resolve([{ id: 5, name: "friendly" }, { id: 2, name: "smarmy" }]);
   };
 
-  env.adapter.find = function(store, type, id, snapshot) {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
     equal(type, Person, "type should be Person");
     equal(id, 1, "id should be 1");
 
@@ -295,7 +295,7 @@ test("hasMany relationships work when the data hash has not been loaded", functi
   };
 
   run(function() {
-    store.find('person', 1).then(function(person) {
+    store.findRecord('person', 1).then(function(person) {
       equal(get(person, 'name'), "Tom Dale", "The person is now populated");
 
       return run(function() {
@@ -335,7 +335,7 @@ test("it is possible to add a new item to a relationship", function() {
   });
 
   run(function() {
-    store.find('person', 1).then(function(person) {
+    store.findRecord('person', 1).then(function(person) {
       var tag = get(person, 'tags').objectAt(0);
 
       equal(get(tag, 'name'), "ember", "precond - relationships work");
@@ -407,7 +407,7 @@ test("it is possible to remove an item from a relationship", function() {
   });
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       var tag = get(person, 'tags').objectAt(0);
 
       equal(get(tag, 'name'), "ember", "precond - relationships work");

--- a/packages/ember-data/tests/unit/model/relationships/record-array-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/record-array-test.js
@@ -51,7 +51,7 @@ test("can create child record from a hasMany relationship", function() {
   });
 
   run(function() {
-    store.find('person', 1).then(async(function(person) {
+    store.findRecord('person', 1).then(async(function(person) {
       person.get("tags").createRecord({ name: "cool" });
 
       equal(get(person, 'name'), "Tom Dale", "precond - retrieves person record from store");

--- a/packages/ember-data/tests/unit/record-array-test.js
+++ b/packages/ember-data/tests/unit/record-array-test.js
@@ -103,8 +103,8 @@ test("a loaded record is removed from a record array when it is deleted", functi
 
   run(function() {
     var asyncRecords = Ember.RSVP.hash({
-      scumbag: store.find('person', 1),
-      tag: store.find('tag', 1)
+      scumbag: store.findRecord('person', 1),
+      tag: store.findRecord('tag', 1)
     });
 
     asyncRecords.then(function(records) {
@@ -258,7 +258,7 @@ test("an AdapterPopulatedRecordArray knows if it's loaded or not", function() {
   var env = setupStore({ person: Person });
   var store = env.store;
 
-  env.adapter.findQuery = function(store, type, query, recordArray) {
+  env.adapter.query = function(store, type, query, recordArray) {
     return Ember.RSVP.resolve(array);
   };
 

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -57,8 +57,8 @@ test("Calling push with a normalized hash returns a record", function() {
       firstName: "Yehuda",
       lastName: "Katz"
     });
-    store.find('person', 'wat').then(function(foundPerson) {
-      equal(foundPerson, person, "record returned via load() is the same as the record returned from find()");
+    store.findRecord('person', 'wat').then(function(foundPerson) {
+      equal(foundPerson, person, "record returned via load() is the same as the record returned from findRecord()");
       deepEqual(foundPerson.getProperties('id', 'firstName', 'lastName'), {
         id: 'wat',
         firstName: "Yehuda",
@@ -81,7 +81,7 @@ test("Supplying a model class for `push` is the same as supplying a string", fun
       lastName: "Katz"
     });
 
-    store.find('programmer', 'wat').then(function(foundProgrammer) {
+    store.findRecord('programmer', 'wat').then(function(foundProgrammer) {
       deepEqual(foundProgrammer.getProperties('id', 'firstName', 'lastName'), {
         id: 'wat',
         firstName: "Yehuda",
@@ -132,8 +132,8 @@ test("Calling push with partial records updates just those attributes", function
       lastName: "Katz!"
     });
 
-    store.find('person', 'wat').then(function(foundPerson) {
-      equal(foundPerson, person, "record returned via load() is the same as the record returned from find()");
+    store.findRecord('person', 'wat').then(function(foundPerson) {
+      equal(foundPerson, person, "record returned via load() is the same as the record returned from findRecord()");
       deepEqual(foundPerson.getProperties('id', 'firstName', 'lastName'), {
         id: 'wat',
         firstName: "Yehuda",
@@ -198,7 +198,7 @@ test("Calling push with a normalized hash containing IDs of related records retu
     phoneNumbers: hasMany('phone-number', { async: true })
   });
 
-  env.adapter.find = function(store, type, id) {
+  env.adapter.findRecord = function(store, type, id) {
     if (id === "1") {
       return Ember.RSVP.resolve({
         id: 1,

--- a/packages/ember-data/tests/unit/store/unload-test.js
+++ b/packages/ember-data/tests/unit/store/unload-test.js
@@ -11,7 +11,7 @@ module("unit/store/unload - Store unloading records", {
     });
     store = createStore({
       adapter: DS.Adapter.extend({
-        find: function(store, type, id, snapshot) {
+        findRecord: function(store, type, id, snapshot) {
           tryToFind = true;
           return Ember.RSVP.resolve({ id: id, wasFetched: true });
         }
@@ -34,7 +34,7 @@ test("unload a dirty record", function() {
       title: 'toto'
     });
 
-    store.find('record', 1).then(function(record) {
+    store.findRecord('record', 1).then(function(record) {
       record.set('title', 'toto2');
       record._internalModel.send('willCommit');
 
@@ -57,7 +57,7 @@ test("unload a record", function() {
 
   run(function() {
     store.push('record', { id: 1, title: 'toto' });
-    store.find('record', 1).then(function(record) {
+    store.findRecord('record', 1).then(function(record) {
       equal(get(record, 'id'), 1, "found record with id 1");
       equal(get(record, 'isDirty'), false, "record is not dirty");
 
@@ -69,7 +69,7 @@ test("unload a record", function() {
       equal(get(record, 'isDeleted'), true, "record is deleted");
 
       tryToFind = false;
-      return store.find('record', 1).then(function() {
+      return store.findRecord('record', 1).then(function() {
         equal(tryToFind, true, "not found record with id 1");
       });
     });
@@ -99,7 +99,7 @@ test("can commit store after unload record with relationships", function() {
 
   var store = createStore({
     adapter: DS.Adapter.extend({
-      find: function(store, type, id, snapshot) {
+      findRecord: function(store, type, id, snapshot) {
         return Ember.RSVP.resolve({ id: 1, description: 'cuisinart', brand: 1 });
       },
       createRecord: function(store, type, snapshot) {
@@ -116,8 +116,8 @@ test("can commit store after unload record with relationships", function() {
     store.push('brand', { id: 1, name: 'EmberJS' });
     store.push('product', { id: 1, description: 'toto', brand: 1 });
     asyncRecords = Ember.RSVP.hash({
-      brand: store.find('brand', 1),
-      product: store.find('product', 1)
+      brand: store.findRecord('brand', 1),
+      product: store.findRecord('product', 1)
     });
     asyncRecords.then(function(records) {
       like = store.createRecord('like', { id: 1, product: product });
@@ -125,9 +125,9 @@ test("can commit store after unload record with relationships", function() {
       return Ember.RSVP.hash(records);
     }).then(function(records) {
       store.unloadRecord(records.product);
-      return store.find('product', 1);
+      return store.findRecord('product', 1);
     }).then(function(product) {
-      equal(product.get('description'), 'cuisinart', "The record was unloaded and the adapter's `find` was called");
+      equal(product.get('description'), 'cuisinart', "The record was unloaded and the adapter's `findRecord` was called");
       store.destroy();
     });
   });


### PR DESCRIPTION
`Adapter#find` -> `Adapter#findRecord` and `Adapter#findQuery` -> `Adapter#query`
`BuildURLMixin#urlForFind` -> `BuildURLMixin#urlForFindRecord` and `BuildURLMixin#urlForFindQuery` -> `BuildURLMixin#urlForQuery`
`Serializer#extractFind` -> `Serializer#extractFindRecord` and `Serializer#findQuery` -> `Serializer#extractQuery`