### PR TITLE
Fix relationship being named `belongsTo` instead of `book`

### DIFF
--- a/packages/ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs-to-test.js
@@ -53,7 +53,7 @@ module("integration/relationship/belongs_to Belongs-To Relationships", {
 
     Chapter = DS.Model.extend({
       title: attr('string'),
-      belongsTo: belongsTo('book')
+      book: belongsTo('book')
     });
 
     Author = DS.Model.extend({


### PR DESCRIPTION
Looks like this relationship isn't used in any test though ...