### PR TITLE
Extract polymorphic check

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs-to.js
@@ -2,6 +2,8 @@ import {
   PromiseObject
 } from "ember-data/system/promise-proxies";
 
+import { assertPolymorphicType } from "ember-data/utils";
+
 import Relationship from "ember-data/system/relationships/state/relationship";
 
 var BelongsToRelationship = function(store, record, inverseKey, relationshipMeta) {
@@ -61,18 +63,8 @@ BelongsToRelationship.prototype.flushCanonical = function() {
 BelongsToRelationship.prototype._super$addRecord = Relationship.prototype.addRecord;
 BelongsToRelationship.prototype.addRecord = function(newRecord) {
   if (this.members.has(newRecord)) { return;}
-  var typeClass = this.store.modelFor(this.relationshipMeta.type);
-  Ember.assert("You cannot add a '" + newRecord.type.modelName + "' record to the '" + this.record.type.modelName + "." + this.key +"'. " + "You can only add a '" + typeClass.modelName + "' record to this relationship.", (function () {
-    if (typeClass.__isMixin) {
-      //TODO Need to do this in order to support mixins, should convert to public api
-      //once it exists in Ember
-      return typeClass.__mixin.detect(newRecord.type.PrototypeMixin);
-    }
-    if (Ember.MODEL_FACTORY_INJECTIONS) {
-      typeClass = typeClass.superclass;
-    }
-    return typeClass.detect(newRecord.type);
-  })());
+
+  assertPolymorphicType(this.record, this.relationshipMeta, newRecord);
 
   if (this.inverseRecord) {
     this.removeRecord(this.inverseRecord);

--- a/packages/ember-data/lib/system/relationships/state/has-many.js
+++ b/packages/ember-data/lib/system/relationships/state/has-many.js
@@ -3,6 +3,8 @@ import Relationship from "ember-data/system/relationships/state/relationship";
 import OrderedSet from "ember-data/system/ordered-set";
 import ManyArray from "ember-data/system/many-array";
 
+import { assertPolymorphicType } from "ember-data/utils";
+
 var map = Ember.EnumerableUtils.map;
 
 var ManyRelationship = function(store, record, inverseKey, relationshipMeta) {
@@ -92,16 +94,7 @@ ManyRelationship.prototype.removeRecordFromOwn = function(record, idx) {
 };
 
 ManyRelationship.prototype.notifyRecordRelationshipAdded = function(record, idx) {
-  var typeClass = this.store.modelFor(this.relationshipMeta.type);
-  Ember.assert("You cannot add '" + record.type.modelName + "' records to the " + this.record.type.modelName + "." + this.key + " relationship (only '" + typeClass.modelName + "' allowed)", (function () {
-    if (typeClass.__isMixin) {
-      return typeClass.__mixin.detect(record.type.PrototypeMixin);
-    }
-    if (Ember.MODEL_FACTORY_INJECTIONS) {
-      typeClass = typeClass.superclass;
-    }
-    return typeClass.detect(record.type);
-  })());
+  assertPolymorphicType(this.record, this.relationshipMeta, record);
 
   this.record.notifyHasManyAdded(this.key, record, idx);
 };

--- a/packages/ember-data/lib/utils.js
+++ b/packages/ember-data/lib/utils.js
@@ -1,0 +1,46 @@
+import Ember from 'ember';
+
+/**
+  Assert that `addedRecord` has a valid type so it can be added to the
+  relationship of the `record`.
+
+  The assert basically checks if the `addedRecord` can be added to the
+  relationship (specified via `relationshipMeta`) of the `record`.
+
+  This utility should only be used internally, as both record parameters must
+  be an InternalModel and the `relationshipMeta` needs to be the meta
+  information about the relationship, retrieved via
+  `record.relationshipFor(key)`.
+
+  @param {InternalModel} record
+  @param {RelationshipMeta} relationshipMeta retrieved via
+         `record.relationshipFor(key)`
+  @param {InternalModel} addedRecord record which
+         should be added/set for the relationship
+*/
+var assertPolymorphicType = function(record, relationshipMeta, addedRecord) {
+  var addedType = addedRecord.type.modelName;
+  var recordType = record.type.modelName;
+  var key = relationshipMeta.key;
+  var typeClass = record.store.modelFor(relationshipMeta.type);
+
+  var assertionMessage = `You cannot add a record of type '${addedType}' to the '${recordType}.${key}' relationship (only '${typeClass.modelName}' allowed)`;
+
+  Ember.assert(assertionMessage, checkPolymorphic(typeClass, addedRecord));
+};
+
+function checkPolymorphic(typeClass, addedRecord) {
+  if (typeClass.__isMixin) {
+    //TODO Need to do this in order to support mixins, should convert to public api
+    //once it exists in Ember
+    return typeClass.__mixin.detect(addedRecord.type.PrototypeMixin);
+  }
+  if (Ember.MODEL_FACTORY_INJECTIONS) {
+    typeClass = typeClass.superclass;
+  }
+  return typeClass.detect(addedRecord.type);
+}
+
+export {
+  assertPolymorphicType
+};

--- a/packages/ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs-to-test.js
@@ -142,7 +142,7 @@ test("Only a record of the same type can be used with a monomorphic belongsTo re
     }).then(function(records) {
       expectAssertion(function() {
         records.post.set('user', records.comment);
-      }, /You can only add a 'user' record to this relationship/);
+      }, /You cannot add a record of type 'comment' to the 'post.user' relationship/);
     });
   });
 });
@@ -173,7 +173,7 @@ test("Only a record of the same base type can be used with a polymorphic belongs
 
       expectAssertion(function() {
         comment.set('message', records.user);
-      }, /You cannot add a 'user' record to the 'comment.message'. You can only add a 'message' record to this relationship./);
+      }, /You cannot add a record of type 'user' to the 'comment.message' relationship \(only 'message' allowed\)/);
     });
   });
 });

--- a/packages/ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/has-many-test.js
@@ -782,7 +782,7 @@ test("Only records of the same type can be added to a monomorphic hasMany relati
     ]).then(function(records) {
       expectAssertion(function() {
         records[0].get('comments').pushObject(records[1]);
-      }, /You cannot add 'post' records to the post.comments relationship \(only 'comment' allowed\)/);
+      }, /You cannot add a record of type 'post' to the 'post.comments' relationship \(only 'comment' allowed\)/);
     });
   });
 });
@@ -815,7 +815,7 @@ test("Only records of the same base type can be added to a polymorphic hasMany r
 
       expectAssertion(function() {
         records.messages.pushObject(records.anotherUser);
-      }, /You cannot add 'user' records to the user.messages relationship \(only 'message' allowed\)/);
+      }, /You cannot add a record of type 'user' to the 'user.messages' relationship \(only 'message' allowed\)/);
     });
   });
 });

--- a/packages/ember-data/tests/integration/relationships/polymorphic-mixins-belongs-to-test.js
+++ b/packages/ember-data/tests/integration/relationships/polymorphic-mixins-belongs-to-test.js
@@ -96,7 +96,7 @@ test("Setting the polymorphic belongsTo with an object that does not implement t
   run(function() {
     expectAssertion(function() {
       user.set('bestMessage', video);
-    }, /You can only add a 'message' record to this relationship/);
+    }, /You cannot add a record of type 'not-message' to the 'user.bestMessage' relationship \(only 'message' allowed\)/);
   });
 });
 
@@ -141,7 +141,7 @@ test("Setting the polymorphic belongsTo with an object that does not implement t
     run(function() {
       expectAssertion(function() {
         user.set('bestMessage', video);
-      }, /You can only add a 'message' record to this relationship/);
+      }, /You cannot add a record of type 'not-message' to the 'user.bestMessage' relationship \(only 'message' allowed\)/);
     });
   } finally {
     Ember.MODEL_FACTORY_INJECTIONS = injectionValue;

--- a/packages/ember-data/tests/integration/relationships/polymorphic-mixins-has-many-test.js
+++ b/packages/ember-data/tests/integration/relationships/polymorphic-mixins-has-many-test.js
@@ -100,7 +100,7 @@ test("Pushing a an object that does not implement the mixin to the mixin accepti
     user.get('messages').then(function(fetchedMessages) {
       expectAssertion(function() {
         fetchedMessages.pushObject(notMessage);
-      }, /You cannot add 'not-message' records to the user\.messages relationship \(only 'message' allowed\)/);
+      }, /You cannot add a record of type 'not-message' to the 'user.messages' relationship \(only 'message' allowed\)/);
     });
   });
 });
@@ -147,7 +147,7 @@ test("Pushing a an object that does not implement the mixin to the mixin accepti
       user.get('messages').then(function(fetchedMessages) {
         expectAssertion(function() {
           fetchedMessages.pushObject(notMessage);
-        }, /You cannot add 'not-message' records to the user\.messages relationship \(only 'message' allowed\)/);
+        }, /You cannot add a record of type 'not-message' to the 'user.messages' relationship \(only 'message' allowed\)/);
       });
     });
   } finally {

--- a/packages/ember-data/tests/unit/utils-test.js
+++ b/packages/ember-data/tests/unit/utils-test.js
@@ -1,0 +1,107 @@
+// TODO enable import once this is possible
+// import { assertPolymorphicType } from "ember-data/utils";
+
+var env, User, Message, Post, Person, Video, Medium;
+
+module("unit/utils", {
+  setup() {
+    Person = DS.Model.extend();
+    User = DS.Model.extend({
+      messages: DS.hasMany('message')
+    });
+
+    Message = DS.Model.extend();
+    Post = Message.extend({
+      medias: DS.hasMany('medium')
+    });
+
+    Medium = Ember.Mixin.create();
+    Video = DS.Model.extend(Medium);
+
+    env = setupStore({
+      user: User,
+      person: Person,
+      message: Message,
+      post: Post,
+      video: Video
+    });
+
+    env.registry.register('mixin:medium', Medium);
+  },
+
+  teardown() {
+    Ember.run(env.container, 'destroy');
+  }
+});
+
+test("assertPolymorphicType works for subclasses", function() {
+  var user, post, person;
+
+  Ember.run(function() {
+    user = env.store.push('user', { id: 1, messages: [] });
+    post = env.store.push('post', { id: 1 });
+    person = env.store.push('person', { id: 1 });
+  });
+
+  // TODO un-comment once we test the assertPolymorphicType directly
+  // var relationship = user.relationshipFor('messages');
+  // user = user._internalModel;
+  // post = post._internalModel;
+  // person = person._internalModel;
+
+  try {
+    Ember.run(function() {
+      user.get('messages').addObject(post);
+    });
+
+    // TODO enable once we can do "import { assertPolymorphicType } from "ember-data/utils"
+    // assertPolymorphicType(user, relationship, post);
+  } catch (e) {
+    ok(false, "should not throw an error");
+  }
+
+  expectAssertion(function() {
+    Ember.run(function() {
+      user.get('messages').addObject(person);
+    });
+
+    // TODO enable once we can do "import { assertPolymorphicType } from "ember-data/utils"
+    // assertPolymorphicType(user, relationship, person);
+  }, "You cannot add a record of type 'person' to the 'user.messages' relationship (only 'message' allowed)");
+});
+
+test("assertPolymorphicType works for mixins", function() {
+  var post, video, person;
+
+  Ember.run(function() {
+    post = env.store.push('post', { id: 1 });
+    video = env.store.push('video', { id: 1 });
+    person = env.store.push('person', { id: 1 });
+  });
+
+  // TODO un-comment once we test the assertPolymorphicType directly
+  // var relationship = post.relationshipFor('medias');
+  // post = post._internalModel;
+  // video = video._internalModel;
+  // person = person._internalModel;
+
+  try {
+    Ember.run(function() {
+      post.get('medias').addObject(video);
+    });
+
+    // TODO enable once we can do "import { assertPolymorphicType } from "ember-data/utils"
+    // assertPolymorphicType(post, relationship, video);
+  } catch (e) {
+    ok(false, "should not throw an error");
+  }
+
+  expectAssertion(function() {
+    Ember.run(function() {
+      post.get('medias').addObject(person);
+    });
+
+    // TODO enable once we can do "import { assertPolymorphicType } from "ember-data/utils"
+    // assertPolymorphicType(post, relationship, person);
+  }, "You cannot add a record of type 'person' to the 'post.medias' relationship (only 'medium' allowed)");
+});


### PR DESCRIPTION
Currently the logic to check if a record can be added to a (polymorphic) relationship has been duplicated in two places: within [`belongs-to relationship state](http://git.io/vIHxH) and [`has-many relationship state](http://git.io/vIHxh).

This PR extracts the functionality into a `assertPolymorphicType` function, so it can be reused elsewhere. Currently, also the assertion messages are slightly different; by using the same function they are the same for both calls.

---

Caveats: (currently) only the `Ember.assert` within the `assertPolymorphicType` function is stripped for production builds, so a little noise is left. Is this something we can ignore?