### PR TITLE
Implement adapter reload hooks from RFC #61

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -448,6 +448,85 @@ var Adapter = Ember.Object.extend({
   */
   groupRecordsForFindMany: function(store, snapshots) {
     return [snapshots];
+  },
+
+
+  /**
+    This method is used by the store to determine if the store should
+    reload a record from the adapter when a record is requested by
+    `store.findRecord`.
+
+    If this method returns true the store will re fetch a record form
+    the adapter. If is method returns false the store will resolve
+    immediately using the cached record.
+
+    @method shouldReloadRecord
+    @param {DS.Store} store
+    @param {DS.Snapshot} snapshot
+    @return {Boolean}
+  */
+  shouldReloadRecord: function(store, snapshot) {
+    return false;
+  },
+
+  /**
+    This method is used by the store to determine if the store should
+    reload all records from the adapter when records are requested by
+    `store.findAll`.
+
+    If this method returns true the store will re fetch all records form
+    the adapter. If is method returns false the store will resolve
+    immediately using the cached record.
+
+    @method shouldReloadRecord
+    @param {DS.Store} store
+    @param {DS.SnapshotRecordArray} snapshotRecordArray
+    @return {Boolean}
+  */
+  shouldReloadAll: function(store, snapshotRecordArray) {
+    Ember.deprecate('The default behavior of `shouldBackgroundReloadAll` will change in Ember Data 2.0 to always return false. If you would like to preserve the current behavior please override `shouldReloadAll` in you adapter:application and return true.');
+    return true;
+  },
+
+  /**
+    This method is used by the store to determine if the store should
+    reload a record after the `store.findRecord` method resolves a
+    chached record.
+
+    This method is *only* checked by the store when the store is
+    returning a cached record.
+
+    If this method returns true the store will re-fetch a record form
+    the adapter.
+
+    @method shouldBackgroundReloadRecord
+    @param {DS.Store} store
+    @param {DS.Snapshot} snapshot
+    @return {Boolean}
+  */
+  shouldBackgroundReloadRecord: function(store, snapshot) {
+    Ember.deprecate('The default behavior of `shouldBackgroundReloadRecord` will change in Ember Data 2.0 to always return true. If you would like to preserve the current behavior please override `shouldBackgroundReloadRecord` in you adapter:application and return false.');
+    return false;
+  },
+
+  /**
+    This method is used by the store to determine if the store should
+    reload a record array after the `store.findAll` method resolves
+    with a chached record array.
+
+    This method is *only* checked by the store when the store is
+    returning a cached record array.
+
+    If this method returns true the store will re-fetch all records
+    form the adapter.
+
+    @method shouldBackgroundReloadAll
+    @param {DS.Store} store
+    @param {DS.SnapshotRecordArray} snapshotRecordArray
+    @return {Boolean}
+  */
+  shouldBackgroundReloadAll: function(store, snapshotRecordArray) {
+    return true;
   }
 });
 

--- a/packages/ember-data/lib/system/record-arrays/record-array.js
+++ b/packages/ember-data/lib/system/record-arrays/record-array.js
@@ -3,6 +3,8 @@
 */
 
 import { PromiseArray } from "ember-data/system/promise-proxies";
+import SnapshotRecordArray from "ember-data/system/snapshot-record-array";
+
 var get = Ember.get;
 var set = Ember.set;
 
@@ -198,5 +200,11 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     this._dissociateFromOwnRecords();
     set(this, 'content', undefined);
     this._super.apply(this, arguments);
+  },
+
+  createSnapshot(options) {
+    var adapterOptions = options && options.adapterOptions;
+    var meta = this.get('meta');
+    return new SnapshotRecordArray(this, meta, adapterOptions);
   }
 });

--- a/packages/ember-data/lib/system/snapshot-record-array.js
+++ b/packages/ember-data/lib/system/snapshot-record-array.js
@@ -18,19 +18,6 @@ function SnapshotRecordArray(recordArray, meta, adapterOptions) {
   this.adapterOptions = adapterOptions;
 }
 
-/**
-  @method fromRecordArray
-  @private
-  @static
-  @param {DS.RecordArray} recordArray
-  @param {Object} adapterOptions
-  @return SnapshotRecordArray
-*/
-SnapshotRecordArray.fromRecordArray = function(recordArray, adapterOptions) {
-  var meta = recordArray.get('meta');
-  return new SnapshotRecordArray(recordArray, meta, adapterOptions);
-};
-
 SnapshotRecordArray.prototype.snapshots = function() {
   if (this._snapshots) {
     return this._snapshots;

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -13,8 +13,6 @@ import {
   serializerForAdapter
 } from "ember-data/system/store/serializers";
 
-import SnapshotRecordArray from "ember-data/system/snapshot-record-array";
-
 var Promise = Ember.RSVP.Promise;
 var map = Ember.EnumerableUtils.map;
 
@@ -121,9 +119,9 @@ export function _findBelongsTo(adapter, store, internalModel, link, relationship
 }
 
 export function _findAll(adapter, store, typeClass, sinceToken, options) {
-  var adapterOptions = options && options.adapterOptions;
   var modelName = typeClass.modelName;
-  var snapshotArray = SnapshotRecordArray.fromRecordArray(store.peekAll(modelName), adapterOptions);
+  var recordArray = store.peekAll(modelName);
+  var snapshotArray = recordArray.createSnapshot(options);
   var promise = adapter.findAll(store, typeClass, sinceToken, snapshotArray);
   var serializer = serializerForAdapter(store, adapter, modelName);
   var label = "DS: Handle Adapter#findAll of " + typeClass;


### PR DESCRIPTION
This pr implements `shouldReloadRecord` and `shouldBackgroundReloadRecord` hooks from https://github.com/emberjs/rfcs/pull/61.

It is built on top of the changes made in pr https://github.com/emberjs/data/pull/3312