### PR TITLE
Add Deprecation test for store.push with DS.Record in relationship

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -2188,7 +2188,7 @@ function deserializeRecordId(store, data, key, relationship, id) {
 
   //If record objects were given to push directly, uncommon, not sure whether we should actually support
   if (id instanceof Model) {
-    Ember.deprecate("You tried to push a record '" + relationship.parentType + "'' with id '" + Ember.inspect(id) + "' and passed a DS.Model instance as a value for the relationship '" + key + "'. You should instead pass a numerical or string id to represent the record.");
+    Ember.deprecate("You tried to push a record of type '" + relationship.parentType + "' with id '" + id._internalModel._data[relationship.parentType.typeKey] + "' and passed a DS.Model instance as a value for the relationship '" + relationship.key + "'. You should instead pass a numerical or string id to represent the record.");
     data[key] = id._internalModel;
     return;
   }

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -596,3 +596,23 @@ test("Calling pushMany is deprecated", function() {
     });
   }, 'Using store.pushMany() has been deprecated since store.push() now handles multiple items. You should use store.push() instead.');
 });
+
+test("Calling push with a model in the relationship should be deprecated", function() {
+  var number1, person;
+  expectDeprecation(function() {
+    run(function() {
+      number1 = store.push('phone-number', {
+        id: 1,
+        number: '5551212',
+        person: 'someid'
+      });
+
+      person = store.push('person', {
+        id: 'someid',
+        firstName: 'John',
+        lastName: 'Smith',
+        phoneNumbers: [number1]
+      });
+    });
+  }, "You tried to push a record of type 'Person' with id 'someid' and passed a DS.Model instance as a value for the relationship 'phoneNumbers'. You should instead pass a numerical or string id to represent the record.");
+});


### PR DESCRIPTION
Add a test that checks for deprecation message when calling store.push and using a record in a relationship instead of an id.

This tests PR #3279 