### PR TITLE
Suppress deprecation warnings for Ember.reduceComputed

### DIFF
--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -110,6 +110,8 @@ export default Ember.Object.extend(Ember.Enumerable, Ember.Evented, {
     @private
   */
   errorsByAttributeName: Ember.reduceComputed("content", {
+    _suppressDeprecation: true,
+
     initialValue: function() {
       return MapWithDefault.create({
         defaultValue: function() {


### PR DESCRIPTION
This suppresses the deprecation warnings reported in #3327 (originally reported in emberjs/ember.js#11435), by using the same fix as in emberjs/ember.js#11428.