### PR TITLE
Clear else branch of RecordArrayManager#filter

### DIFF
--- a/packages/ember-data/lib/system/record-array-manager.js
+++ b/packages/ember-data/lib/system/record-array-manager.js
@@ -143,7 +143,7 @@ export default Ember.Object.extend({
     var recordArrays = this.recordArraysForRecord(record);
     if (shouldBeInArray) {
       this._addRecordToRecordArray(array, record);
-    } else if (!shouldBeInArray) {
+    } else {
       recordArrays.delete(array);
       array.removeInternalModel(record);
     }


### PR DESCRIPTION
The `else if (!shouldBeInArray)` has been replaced with a simple `else`
in during cleanup in b9044fd978c2ff4fc6e6acda1800c57e59351454.

This addresses https://github.com/emberjs/data/pull/3302#discussion_r32233897.