### PR TITLE
Raise error on unhandled deprecation warnings

### DIFF
--- a/packages/ember-data/lib/adapters/errors.js
+++ b/packages/ember-data/lib/adapters/errors.js
@@ -79,7 +79,9 @@ AdapterError.prototype = Object.create(EmberError.prototype);
 */
 export function InvalidError(errors) {
   if (!Ember.isArray(errors)) {
-    Ember.deprecate('`InvalidError` expects json-api formatted errors.');
+    Ember.deprecate('`InvalidError` expects json-api formatted errors.', false, {
+      id: 'ember-data-invalidError-expects-json-api-errors'
+    });
     errors = errorsHashToArray(errors);
   }
   AdapterError.call(this, errors, 'The adapter rejected the commit because it was invalid');

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -483,7 +483,9 @@ var Adapter = Ember.Object.extend({
   */
   shouldReloadAll: function(store, snapshotRecordArray) {
     var modelName = snapshotRecordArray.type.modelName;
-    Ember.deprecate(`The default behavior of shouldReloadAll will change in Ember Data 2.0 to always return false when there is at least one "${modelName}" record in the store. If you would like to preserve the current behavior please override shouldReloadAll in your adapter:application and return true.`);
+    Ember.deprecate(`The default behavior of shouldReloadAll will change in Ember Data 2.0 to always return false when there is at least one "${modelName}" record in the store. If you would like to preserve the current behavior please override shouldReloadAll in your adapter:application and return true.`, false, {
+      id: 'ember-data-shouldReloadAll'
+    });
     return true;
   },
 
@@ -504,7 +506,9 @@ var Adapter = Ember.Object.extend({
     @return {Boolean}
   */
   shouldBackgroundReloadRecord: function(store, snapshot) {
-    Ember.deprecate('The default behavior of `shouldBackgroundReloadRecord` will change in Ember Data 2.0 to always return true. If you would like to preserve the current behavior please override `shouldBackgroundReloadRecord` in your adapter:application and return false.');
+    Ember.deprecate('The default behavior of `shouldBackgroundReloadRecord` will change in Ember Data 2.0 to always return true. If you would like to preserve the current behavior please override `shouldBackgroundReloadRecord` in your adapter:application and return false.', false, {
+      id: 'ember-data-shouldBackgroundReloadRecord'
+    });
     return false;
   },
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1284,7 +1284,9 @@ Store = Service.extend({
     @deprecated
   */
   metadataFor: function(modelName) {
-    Ember.deprecate("`store.metadataFor()` has been deprecated. You can use `.get('meta')` on relationships and arrays returned from `store.query()`.");
+    Ember.deprecate("`store.metadataFor()` has been deprecated. You can use `.get('meta')` on relationships and arrays returned from `store.query()`.", false, {
+      id: 'ember-data-metadataFor'
+    });
     return this._metadataFor(modelName);
   },
 
@@ -1310,7 +1312,9 @@ Store = Service.extend({
     @deprecated
   */
   setMetadataFor: function(modelName, metadata) {
-    Ember.deprecate("`store.setMetadataFor()` has been deprecated. Please return meta from your serializer's `extractMeta` hook.");
+    Ember.deprecate("`store.setMetadataFor()` has been deprecated. Please return meta from your serializer's `extractMeta` hook.", false, {
+      id: 'ember-data-setMetadataFor'
+    });
     this._setMetadataFor(modelName, metadata);
   },
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1694,7 +1694,9 @@ Store = Service.extend({
     if (Ember.typeOf(modelNameArg) === 'object' && Ember.typeOf(dataArg) === 'undefined') {
       data = modelNameArg;
     } else {
-      Ember.deprecate('store.push(type, data) has been deprecated. Please provide a JSON-API document object as the first and only argument to store.push.');
+      Ember.deprecate('store.push(type, data) has been deprecated. Please provide a JSON-API document object as the first and only argument to store.push.', false, {
+        id: 'ember-data-store#push(type, data)'
+      });
       Ember.assert("Expected an object as `data` in a call to `push` for " + modelNameArg + " , but was " + Ember.typeOf(dataArg), Ember.typeOf(dataArg) === 'object');
       Ember.assert("You must include an `id` for " + modelNameArg + " in an object passed to `push`", dataArg.id != null && dataArg.id !== '');
       data = _normalizeSerializerPayload(this.modelFor(modelNameArg), dataArg);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1888,7 +1888,10 @@ Store = Service.extend({
   */
   pushMany: function(modelName, datas) {
     Ember.assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
-    Ember.deprecate('Using store.pushMany() has been deprecated since store.push() now handles multiple items. You should use store.push() instead.');
+    Ember.deprecate('Using store.pushMany() has been deprecated since store.push() now handles multiple items. You should use store.push() instead.', false, {
+      id: "ember-data-pushMany"
+    });
+
     var length = datas.length;
     var result = new Array(length);
 

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -184,7 +184,7 @@ test("Calling push on normalize allows partial updates with raw JSON", function 
   equal(person.get('lastName'), "Jackson", "existing fields are untouched");
 });
 
-test("Calling push with a normalized hash containing related records returns a record", function() {
+test("DEPRECATED - Calling push with a normalized hash containing related records returns a record", function() {
   var number1, number2, person;
   run(function() {
     number1 = store.push('phone-number', {
@@ -198,15 +198,18 @@ test("Calling push with a normalized hash containing related records returns a r
       number: '5552121',
       person: 'wat'
     });
-
-    person = store.push('person', {
-      id: 'wat',
-      firstName: 'John',
-      lastName: 'Smith',
-      phoneNumbers: [number1, number2]
-    });
   });
 
+  run(function() {
+    expectDeprecation(function() {
+      person = store.push('person', {
+        id: 'wat',
+        firstName: 'John',
+        lastName: 'Smith',
+        phoneNumbers: [number1, number2]
+      });
+    });
+  });
 
   deepEqual(person.get('phoneNumbers').toArray(), [number1, number2], "phoneNumbers array is correct");
 });

--- a/tests/ember-configuration.js
+++ b/tests/ember-configuration.js
@@ -15,6 +15,7 @@
 
   // Handle testing feature flags
   ENV['ENABLE_OPTIONAL_FEATURES'] = !!QUnit.urlParams.enableoptionalfeatures;
+  ENV['RAISE_ON_DEPRECATION'] = true;
 
   window.async = function(callback, timeout) {
     var timer;

--- a/tests/ember-data-setup.js
+++ b/tests/ember-data-setup.js
@@ -6,6 +6,9 @@
   // logged but they do not result in a failed test.
   Ember.Debug._addDeprecationLevel("ember-data-pushMany", Ember.Debug._deprecationLevels.LOG);
 
+  Ember.Debug._addDeprecationLevel("ember-data-shouldBackgroundReloadRecord", Ember.Debug._deprecationLevels.LOG);
+  Ember.Debug._addDeprecationLevel("ember-data-shouldReloadAll", Ember.Debug._deprecationLevels.LOG);
+
   Ember.RSVP.configure('onerror', function(reason) {
     // only print error messages if they're exceptions;
     // otherwise, let a future turn of the event loop

--- a/tests/ember-data-setup.js
+++ b/tests/ember-data-setup.js
@@ -9,6 +9,9 @@
   Ember.Debug._addDeprecationLevel("ember-data-shouldBackgroundReloadRecord", Ember.Debug._deprecationLevels.LOG);
   Ember.Debug._addDeprecationLevel("ember-data-shouldReloadAll", Ember.Debug._deprecationLevels.LOG);
 
+  Ember.Debug._addDeprecationLevel("ember-data-metadataFor", Ember.Debug._deprecationLevels.LOG);
+  Ember.Debug._addDeprecationLevel("ember-data-setMetadataFor", Ember.Debug._deprecationLevels.LOG);
+
   Ember.Debug._addDeprecationLevel("ember-data-invalidError-expects-json-api-errors", Ember.Debug._deprecationLevels.LOG);
 
   Ember.RSVP.configure('onerror', function(reason) {

--- a/tests/ember-data-setup.js
+++ b/tests/ember-data-setup.js
@@ -6,6 +6,8 @@
   // logged but they do not result in a failed test.
   Ember.Debug._addDeprecationLevel("ember-data-pushMany", Ember.Debug._deprecationLevels.LOG);
 
+  Ember.Debug._addDeprecationLevel("ember-data-store#push(type, data)", Ember.Debug._deprecationLevels.LOG);
+
   Ember.Debug._addDeprecationLevel("ember-data-shouldBackgroundReloadRecord", Ember.Debug._deprecationLevels.LOG);
   Ember.Debug._addDeprecationLevel("ember-data-shouldReloadAll", Ember.Debug._deprecationLevels.LOG);
 

--- a/tests/ember-data-setup.js
+++ b/tests/ember-data-setup.js
@@ -1,5 +1,11 @@
 ;(function() {
 
+  // Since store.pushMany is used pretty heavily inside the tests, fixing all
+  // the deprecation warnings at once would be a big changeset. That's why the
+  // log level for this deprecation is set to LOG, so the deprecations are
+  // logged but they do not result in a failed test.
+  Ember.Debug._addDeprecationLevel("ember-data-pushMany", Ember.Debug._deprecationLevels.LOG);
+
   Ember.RSVP.configure('onerror', function(reason) {
     // only print error messages if they're exceptions;
     // otherwise, let a future turn of the event loop

--- a/tests/ember-data-setup.js
+++ b/tests/ember-data-setup.js
@@ -9,6 +9,8 @@
   Ember.Debug._addDeprecationLevel("ember-data-shouldBackgroundReloadRecord", Ember.Debug._deprecationLevels.LOG);
   Ember.Debug._addDeprecationLevel("ember-data-shouldReloadAll", Ember.Debug._deprecationLevels.LOG);
 
+  Ember.Debug._addDeprecationLevel("ember-data-invalidError-expects-json-api-errors", Ember.Debug._deprecationLevels.LOG);
+
   Ember.RSVP.configure('onerror', function(reason) {
     // only print error messages if they're exceptions;
     // otherwise, let a future turn of the event loop


### PR DESCRIPTION
This is my stab at enabling the `ENV['RAISE_ON_DEPRACATION']` flag when the tests are run. By this, unhandled deprecation messages throw an error and hence it is not possible to use deprecated features  within the tests of `ember-data` (an example being not using the deprecated `Ember.Map.remove` and use `Ember.Map.delete` instead).

Some minor deprecation warnings are fixed in the course of this PR, but there are two areas, which are addressed differently:

- `store.pushMany` is deprecated in favor of `store.push(object)`; since this is used throughout many tests, this deprecation warning is changed to be soft-deprecated, which means that the deprecation warning are logged but they do not result in a failed test/build

- the same is true for `Serializer#extract`, which is deprecated when the `ds-new-serializer-api` feature is enabled.

Soft deprecating those features allows us to migrate the tests step-by-step migrate and make adaptions in smaller chunks.

Changing the log level for deprecations has been implemented in emberjs/ember.js#11419.