### PR TITLE
Fix docparser warning

### DIFF
--- a/packages/ember-data/lib/utils.js
+++ b/packages/ember-data/lib/utils.js
@@ -12,6 +12,7 @@ import Ember from 'ember';
   information about the relationship, retrieved via
   `record.relationshipFor(key)`.
 
+  @method assertPolymorphicType
   @param {InternalModel} record
   @param {RelationshipMeta} relationshipMeta retrieved via
          `record.relationshipFor(key)`


### PR DESCRIPTION
`warn: (docparser): Missing item type:  packages\ember-data\lib\utils.js:3`