### PR TITLE
Register service:store in an initializer instead of an instanceInitia…

### DIFF
--- a/packages/ember-data/lib/instance-initializers/initialize-store-service.js
+++ b/packages/ember-data/lib/instance-initializers/initialize-store-service.js
@@ -1,6 +1,3 @@
-import Store from "ember-data/system/store";
-import ContainerProxy from "ember-data/system/container-proxy";
-
 /**
  Configures a registry for use with an Ember-Data
  store.
@@ -29,30 +26,5 @@ export default function initializeStoreService(applicationOrRegistry) {
   }
 
   // Eagerly generate the store so defaultStore is populated.
-  var store;
-  if (registry.has('store:main')) {
-    Ember.deprecate('Registering a custom store as `store:main` or defining a store in app/store.js has been deprecated. Please move you store to `service:store` or define your custom store in `app/services/store.js`');
-    store = container.lookup('store:main');
-  } else {
-    var storeMainProxy = new ContainerProxy(registry);
-    storeMainProxy.registerDeprecations([
-      { deprecated: 'store:main', valid: 'service:store' }
-    ]);
-  }
-
-  if (registry.has('store:application')) {
-    Ember.deprecate('Registering a custom store as `store:application` or defining a store in app/stores/application.js has been deprecated. Please move you store to `service:store` or define your custom store in `app/services/store.js`');
-    store = container.lookup('store:application');
-  } else {
-    var storeApplicationProxy = new ContainerProxy(registry);
-    storeApplicationProxy.registerDeprecations([
-      { deprecated: 'store:application', valid: 'service:store' }
-    ]);
-  }
-
-  if (store) {
-    registry.register('service:store', store, { instantiate: false });
-  } else {
-    registry.register('service:store', Store);
-  }
+  container.lookup('service:store');
 }


### PR DESCRIPTION
…lizer

This fixes https://github.com/emberjs/data/issues/3342. 

Basically it moves the registering of `service:store` into an initializer so users don't need to worry about making sure their instance initializers are run after the `ember-data` instance initializer.

The reason why we didn't do this initially is because it causes extra deprecation warnings when users try load custom stores from `app/store.js` or `app/stores/application.js`.

#### Custom Store in `app/store.js` (Deprecated Path 1)
![screen shot 2015-06-15 at 4 48 29 pm](https://cloud.githubusercontent.com/assets/54056/8170582/b5d78b7c-137f-11e5-9782-efe498e3ebcc.png)


#### Custom Store in `app/stores/application.js` (Deprecated Path 2)
![screen shot 2015-06-15 at 4 53 07 pm](https://cloud.githubusercontent.com/assets/54056/8170590/c3fa1e54-137f-11e5-99f5-fcdf6a739ede.png)




#### Custom Store in `app/services/store.js` (Happy Path)
![screen shot 2015-06-15 at 4 53 57 pm](https://cloud.githubusercontent.com/assets/54056/8170574/9ef7f0fe-137f-11e5-8328-8b8f0dd5e86f.png)

