### PR TITLE
Replace Ember.EnumerableUtils with Ember.ArrayPollyfills.

### DIFF
--- a/packages/ember-data/lib/adapters/fixture-adapter.js
+++ b/packages/ember-data/lib/adapters/fixture-adapter.js
@@ -3,7 +3,7 @@
 */
 var get = Ember.get;
 var fmt = Ember.String.fmt;
-var indexOf = Ember.EnumerableUtils.indexOf;
+var indexOf = Ember.ArrayPolyfills.indexOf;
 
 var counter = 0;
 
@@ -169,7 +169,7 @@ export default Adapter.extend({
 
     if (fixtures) {
       fixtures = fixtures.filter(function(item) {
-        return indexOf(ids, item.id) !== -1;
+        return indexOf.call(ids, item.id) !== -1;
       });
     }
 
@@ -280,7 +280,7 @@ export default Adapter.extend({
     var existingFixture = this.findExistingFixture(typeClass, snapshot);
 
     if (existingFixture) {
-      var index = indexOf(typeClass.FIXTURES, existingFixture);
+      var index = indexOf.call(typeClass.FIXTURES, existingFixture);
       typeClass.FIXTURES.splice(index, 1);
       return true;
     }

--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -1,6 +1,6 @@
 var get = Ember.get;
 var set = Ember.set;
-var forEach = Ember.EnumerableUtils.forEach;
+var forEach = Ember.ArrayPolyfills.forEach;
 var camelize = Ember.String.camelize;
 
 /**
@@ -445,7 +445,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     var ids = [];
 
     var embeddedSerializer = store.serializerFor(embeddedTypeClass.modelName);
-    forEach(hash[key], function(data) {
+    forEach.call(hash[key], function(data) {
       var embeddedRecord = embeddedSerializer.normalize(embeddedTypeClass, data, null);
       store.push(embeddedTypeClass.modelName, embeddedRecord);
       ids.push(embeddedRecord.id);
@@ -466,7 +466,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
 
     var ids = [];
 
-    forEach(hash[key], function(data) {
+    forEach.call(hash[key], function(data) {
       var modelName = data.type;
       var embeddedSerializer = store.serializerFor(modelName);
       var embeddedTypeClass = store.modelFor(modelName);

--- a/packages/ember-data/lib/system/many-array.js
+++ b/packages/ember-data/lib/system/many-array.js
@@ -6,7 +6,6 @@ import { PromiseArray } from "ember-data/system/promise-proxies";
 var get = Ember.get;
 var set = Ember.set;
 var filter = Ember.ArrayPolyfills.filter;
-var map = Ember.EnumerableUtils.map;
 
 /**
   A `ManyArray` is a `MutableArray` that represents the contents of a has-many
@@ -193,8 +192,9 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
       records = this.currentState.slice(idx, idx+amt);
       this.get('relationship').removeRecords(records);
     }
+    var map = objects.map || Ember.ArrayPolyfills.map;
     if (objects) {
-      this.get('relationship').addRecords(map(objects, function(obj) { return obj._internalModel; }), idx);
+      this.get('relationship').addRecords(map.call(objects, function(obj) { return obj._internalModel; }), idx);
     }
   },
   /**

--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -1,6 +1,6 @@
 var get = Ember.get;
 var isEmpty = Ember.isEmpty;
-var map = Ember.EnumerableUtils.map;
+var map = Ember.ArrayPolyfills.map;
 
 import {
   MapWithDefault
@@ -237,7 +237,7 @@ export default Ember.Object.extend(Ember.Enumerable, Ember.Evented, {
   _findOrCreateMessages: function(attribute, messages) {
     var errors = this.errorsFor(attribute);
 
-    return map(Ember.makeArray(messages), function(message) {
+    return map.call(Ember.makeArray(messages), function(message) {
       return errors.findBy('message', message) || {
         attribute: attribute,
         message: message

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -5,7 +5,20 @@ import { PromiseObject } from "ember-data/system/promise-proxies";
 */
 
 var get = Ember.get;
-var intersection = Ember.EnumerableUtils.intersection;
+var forEach = Ember.ArrayPolyfills.forEach;
+var indexOf = Ember.ArrayPolyfills.indexOf;
+
+function intersection (array1, array2) {
+  var result = [];
+  forEach.call(array1, (element) => {
+    if (indexOf.call(array2, element) >= 0) {
+      result.push(element);
+    }
+  });
+
+  return result;
+}
+
 var RESERVED_MODEL_PROPS = [
   'currentState', 'data', 'store'
 ];

--- a/packages/ember-data/lib/system/record-array-manager.js
+++ b/packages/ember-data/lib/system/record-array-manager.js
@@ -12,8 +12,8 @@ import {
 } from "ember-data/system/map";
 import OrderedSet from "ember-data/system/ordered-set";
 var get = Ember.get;
-var forEach = Ember.EnumerableUtils.forEach;
-var indexOf = Ember.EnumerableUtils.indexOf;
+var forEach = Ember.ArrayPolyfills.forEach;
+var indexOf = Ember.ArrayPolyfills.indexOf;
 
 /**
   @class RecordArrayManager
@@ -59,7 +59,7 @@ export default Ember.Object.extend({
     @method updateRecordArrays
   */
   updateRecordArrays: function() {
-    forEach(this.changedRecords, function(record) {
+    forEach.call(this.changedRecords, function(record) {
       if (record.isDeleted()) {
         this._recordWasDeleted(record);
       } else {
@@ -87,8 +87,7 @@ export default Ember.Object.extend({
     var typeClass = record.type;
     var recordArrays = this.filteredRecordArrays.get(typeClass);
     var filter;
-
-    forEach(recordArrays, function(array) {
+    forEach.call(recordArrays, function(array) {
       filter = get(array, 'filterFunction');
       this.updateFilterRecordArray(array, filter, typeClass, record);
     }, this);
@@ -100,7 +99,7 @@ export default Ember.Object.extend({
     var recordArrays = this.filteredRecordArrays.get(typeClass);
     var filter;
 
-    forEach(recordArrays, function(array) {
+    forEach.call(recordArrays, function(array) {
       filter = get(array, 'filterFunction');
       this.updateFilterRecordArray(array, filter, typeClass, record);
     }, this);
@@ -122,7 +121,6 @@ export default Ember.Object.extend({
   updateFilterRecordArray: function(array, filter, typeClass, record) {
     var shouldBeInArray = filter(record.getRecord());
     var recordArrays = this.recordArraysForRecord(record);
-
     if (shouldBeInArray) {
       this._addRecordToRecordArray(array, record);
     } else {
@@ -286,7 +284,7 @@ export default Ember.Object.extend({
 
     // unregister filtered record array
     var recordArrays = this.filteredRecordArrays.get(typeClass);
-    var index = indexOf(recordArrays, array);
+    var index = indexOf.call(recordArrays, array);
     if (index !== -1) {
       recordArrays.splice(index, 1);
 
@@ -303,10 +301,10 @@ export default Ember.Object.extend({
     this._super.apply(this, arguments);
 
     this.filteredRecordArrays.forEach(function(value) {
-      forEach(flatten(value), destroy);
+      forEach.call(flatten(value), destroy);
     });
-    forEach(this.liveRecordArrays, destroy);
-    forEach(this._adapterPopulatedRecordArrays, destroy);
+    forEach.call(this.liveRecordArrays, destroy);
+    forEach.call(this._adapterPopulatedRecordArrays, destroy);
   }
 });
 

--- a/packages/ember-data/lib/system/relationships/state/has-many.js
+++ b/packages/ember-data/lib/system/relationships/state/has-many.js
@@ -5,7 +5,8 @@ import ManyArray from "ember-data/system/many-array";
 
 import { assertPolymorphicType } from "ember-data/utils";
 
-var map = Ember.EnumerableUtils.map;
+var map = Ember.ArrayPolyfills.map;
+
 
 var ManyRelationship = function(store, record, inverseKey, relationshipMeta) {
   this._super$constructor(store, record, inverseKey, relationshipMeta);
@@ -157,7 +158,7 @@ ManyRelationship.prototype.fetchLink = function() {
 ManyRelationship.prototype.findRecords = function() {
   var manyArray = this.manyArray;
   //TODO CLEANUP
-  return this.store.findMany(map(manyArray.toArray(), function(rec) { return rec._internalModel; })).then(function() {
+  return this.store.findMany(map.call(manyArray.toArray(), function(rec) { return rec._internalModel; })).then(function() {
     //Goes away after the manyArray refactor
     manyArray.set('isLoaded', true);
     return manyArray;

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -1,6 +1,6 @@
 import OrderedSet from "ember-data/system/ordered-set";
 
-var forEach = Ember.EnumerableUtils.forEach;
+var forEach = Ember.ArrayPolyfills.forEach;
 
 function Relationship(store, record, inverseKey, relationshipMeta) {
   this.members = new OrderedSet();
@@ -52,14 +52,14 @@ Relationship.prototype = {
 
   removeRecords: function(records) {
     var self = this;
-    forEach(records, function(record) {
+    forEach.call(records, function(record) {
       self.removeRecord(record);
     });
   },
 
   addRecords: function(records, idx) {
     var self = this;
-    forEach(records, function(record) {
+    forEach.call(records, function(record) {
       self.addRecord(record, idx);
       if (idx !== undefined) {
         idx++;

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -14,7 +14,7 @@ import {
 } from "ember-data/system/store/serializers";
 
 var Promise = Ember.RSVP.Promise;
-var map = Ember.EnumerableUtils.map;
+var map = Ember.ArrayPolyfills.map;
 var get = Ember.get;
 
 export function _find(adapter, store, typeClass, id, internalModel, options) {
@@ -70,7 +70,7 @@ export function _findMany(adapter, store, typeClass, ids, internalModels) {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findMany');
       //TODO Optimize, no need to materialize here
       var records = pushPayload(store, payload);
-      return map(records, function(record) { return record._internalModel; });
+      return map.call(records, function(record) { return record._internalModel; });
     });
   }, null, "DS: Extract payload of " + typeClass);
 }
@@ -91,7 +91,7 @@ export function _findHasMany(adapter, store, internalModel, link, relationship) 
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findHasMany');
       //TODO Use a non record creating push
       var records = pushPayload(store, payload);
-      var recordArray = map(records, function(record) { return record._internalModel; });
+      var recordArray = map.call(records, function(record) { return record._internalModel; });
       if (serializer.get('isNewSerializerAPI')) {
         recordArray.meta = payload.meta;
       }

--- a/packages/ember-data/lib/system/store/serializer-response.js
+++ b/packages/ember-data/lib/system/store/serializer-response.js
@@ -1,5 +1,5 @@
-var forEach = Ember.EnumerableUtils.forEach;
-var map = Ember.EnumerableUtils.map;
+var forEach = Ember.ArrayPolyfills.forEach;
+var map = Ember.ArrayPolyfills.map;
 
 /**
   This is a helper method that always returns a JSON-API Document.
@@ -43,7 +43,7 @@ export function _normalizeSerializerPayload(modelClass, payload) {
 
   if (payload) {
     if (Ember.isArray(payload)) {
-      data = map(payload, (payload) => {
+      data = map.call(payload, (payload) => {
         return _normalizeSerializerPayloadItem(modelClass, payload);
       });
     } else {
@@ -101,7 +101,7 @@ export function _normalizeSerializerPayloadItem(modelClass, itemPayload) {
       if (relationshipMeta.kind === 'belongsTo') {
         relationship.data = normalizeRelationshipData(value, relationshipMeta);
       } else if (relationshipMeta.kind === 'hasMany') {
-        relationship.data = map(Ember.A(value), function(item) {
+        relationship.data = map.call(Ember.A(value), function(item) {
           return normalizeRelationshipData(item, relationshipMeta);
         });
       }
@@ -155,7 +155,7 @@ export function pushPayloadData(store, payload) {
   var result;
   if (payload && payload.data) {
     if (Ember.isArray(payload.data)) {
-      result = map(payload.data, (item) => {
+      result = map.call(payload.data, (item) => {
         return _pushResourceObject(store, item);
       });
     } else {
@@ -178,7 +178,7 @@ export function pushPayloadData(store, payload) {
 export function pushPayloadIncluded(store, payload) {
   var result;
   if (payload && payload.included && Ember.isArray(payload.included)) {
-    result = map(payload.included, (item) => {
+    result = map.call(payload.included, (item) => {
       return _pushResourceObject(store, item);
     });
   }
@@ -220,14 +220,14 @@ export function convertResourceObject(payload) {
 
   if (payload.attributes) {
     var attributeKeys = Ember.keys(payload.attributes);
-    forEach(attributeKeys, function(key) {
+    forEach.call(attributeKeys, function(key) {
       var attribute = payload.attributes[key];
       data[key] = attribute;
     });
   }
   if (payload.relationships) {
     var relationshipKeys = Ember.keys(payload.relationships);
-    forEach(relationshipKeys, function(key) {
+    forEach.call(relationshipKeys, function(key) {
       var relationship = payload.relationships[key];
       if (relationship.hasOwnProperty('data')) {
         data[key] = relationship.data;

--- a/packages/ember-data/tests/integration/filter-test.js
+++ b/packages/ember-data/tests/integration/filter-test.js
@@ -2,18 +2,18 @@ import customAdapter from 'ember-data/tests/helpers/custom-adapter';
 
 var get = Ember.get;
 var set = Ember.set;
-var forEach = Ember.EnumerableUtils.forEach;
-var indexOf = Ember.EnumerableUtils.indexOf;
+var forEach = Ember.ArrayPolyfills.forEach;
+var indexOf = Ember.ArrayPolyfills.indexOf;
 var run = Ember.run;
 
 var Person, store, env, array, recordArray;
 
 var shouldContain = function(array, item) {
-  ok(indexOf(array, item) !== -1, "array should contain "+item.get('name'));
+  ok(array.indexOf(item) !== -1, "array should contain "+item.get('name'));
 };
 
 var shouldNotContain = function(array, item) {
-  ok(indexOf(array, item) === -1, "array should not contain "+item.get('name'));
+  ok(indexOf.call(array, item) === -1, "array should not contain "+item.get('name'));
 };
 
 module("integration/filter - DS.Model updating", {
@@ -520,7 +520,7 @@ var edited;
 var clientEdits = function(ids) {
   edited = [];
 
-  forEach(ids, function(id) {
+  forEach.call(ids, function(id) {
     // wrap in an Ember.run to guarantee coalescence of the
     // iterated `set` calls and promise resolution.
     Ember.run(function() {
@@ -538,14 +538,14 @@ var clientCreates = function(names) {
   // wrap in an Ember.run to guarantee coalescence of the
   // iterated `set` calls.
   Ember.run(function() {
-    forEach(names, function(name) {
+    forEach.call(names, function(name) {
       edited.push(store.createRecord('person', { name: 'Client-side ' + name }));
     });
   });
 };
 
 var serverResponds = function() {
-  forEach(edited, function(person) { run(person, 'save'); });
+  forEach.call(edited, function(person) { run(person, 'save'); });
 };
 
 var setup = function(serverCallbacks) {

--- a/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
@@ -1,7 +1,7 @@
 var get = Ember.get;
 var HomePlanet, SuperVillain, EvilMinion, SecretLab, SecretWeapon, BatCave, Comment,
   league, superVillain, evilMinion, secretWeapon, homePlanet, secretLab, env;
-var indexOf = Ember.EnumerableUtils.indexOf;
+var indexOf = Ember.ArrayPolyfills.indexOf;
 var run = Ember.run;
 var LightSaber;
 
@@ -1500,7 +1500,7 @@ test("serializing relationships with an embedded and without calls super when no
       var relationshipType = snapshot.type.determineRelationshipType(relationship);
       // "manyToOne" not supported in DS.RESTSerializer.prototype.serializeHasMany
       var relationshipTypes = Ember.String.w('manyToNone manyToMany manyToOne');
-      if (indexOf(relationshipTypes, relationshipType) > -1) {
+      if (indexOf.call(relationshipTypes, relationshipType) > -1) {
         json[payloadKey] = snapshot.hasMany(key, { ids: true });
       }
     }

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -3,6 +3,7 @@ var attr = DS.attr;
 var hasMany = DS.hasMany;
 var belongsTo = DS.belongsTo;
 var run = Ember.run;
+var forEach = Ember.ArrayPolyfills.forEach;
 
 module("unit/store/push - DS.Store#push", {
   setup: function() {
@@ -431,7 +432,7 @@ test('calling push without data argument as an object raises an error', function
 
   expect(invalidValues.length);
 
-  Ember.EnumerableUtils.forEach(invalidValues, function(invalidValue) {
+  forEach.call(invalidValues, function(invalidValue) {
     throws(function() {
       run(function() {
         store.push('person', invalidValue);
@@ -503,7 +504,7 @@ test('calling push with hasMany relationship the value must be an array', functi
 
   expect(invalidValues.length);
 
-  Ember.EnumerableUtils.forEach(invalidValues, function(invalidValue) {
+  forEach.call(invalidValues, function(invalidValue) {
     throws(function() {
       run(function() {
         store.push('person', { id: 1, phoneNumbers: invalidValue });
@@ -521,7 +522,7 @@ test('calling push with missing or invalid `id` throws assertion error', functio
 
   expect(invalidValues.length);
 
-  Ember.EnumerableUtils.forEach(invalidValues, function(invalidValue) {
+  forEach.call(invalidValues, function(invalidValue) {
     throws(function() {
       run(function() {
         store.push('person', invalidValue);


### PR DESCRIPTION
Ember.EnumerableUtils is deprecated. Ember.ArrayPollyfills is
private. They are both going away in Ember 2.0 but
Ember.ArrayPollyfills doesn't introduce console noise in user's code

cc @fivetanley @igorT 

@igorT this would just be for the 1.13 release as I've seen a bunch of confusion in slack about Ember deprecation warnings originating from Ember Data's use of `EnumerableUtils`.