### PR TITLE
Do not register DS.ActiveModelAdapter for all tests.

### DIFF
--- a/packages/ember-data/tests/unit/store/lookup-test.js
+++ b/packages/ember-data/tests/unit/store/lookup-test.js
@@ -13,6 +13,8 @@ function resetStore() {
   env.registry.unregister('adapter:application');
   env.registry.unregister('serializer:application');
 
+  env.registry.register('serializer:-active-model', DS.ActiveModelSerializer);
+
   env.registry.optionsForType('serializer', { singleton: true });
   env.registry.optionsForType('adapter', { singleton: true });
 

--- a/tests/ember-configuration.js
+++ b/tests/ember-configuration.js
@@ -94,9 +94,6 @@
     registry.register('serializer:-rest', DS.RESTSerializer);
     registry.register('serializer:-rest-new', DS.RESTSerializer.extend({ isNewSerializerAPI: true }));
 
-    registry.register('adapter:-active-model', DS.ActiveModelAdapter);
-    registry.register('serializer:-active-model', DS.ActiveModelSerializer);
-
     registry.register('adapter:-rest', DS.RESTAdapter);
 
     registry.register('adapter:-json-api', DS.JSONAPIAdapter);


### PR DESCRIPTION
This change removes about 2000 deprecation warnings from the console when the tests are run.