### PR TITLE
Don't include Handlebars in the tests

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -30,14 +30,6 @@
       // Close the script tag to make sure document.write happens
     </script>
 
-    <script type="text/javascript">
-      var emberChannel = QUnit.urlParams.emberchannel || "release";
-      if (emberChannel === 'canary' || emberChannel === 'beta') {
-        window.Handlebars = null;
-        loadScript("http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v2.0.0.js");
-      }
-    </script>
-
     <script src="ember-configuration.js"></script>
 
     <script type="text/javascript">


### PR DESCRIPTION
This is a followup cleanup to #3356, which removes no more needed Handlebars.js in `tests/index.html` (see https://github.com/emberjs/data/pull/3356#issuecomment-112247792).