### PR TITLE
Use MapWithDefault forEach instead of Array#forEach

### DIFF
--- a/packages/ember-data/lib/system/record-array-manager.js
+++ b/packages/ember-data/lib/system/record-array-manager.js
@@ -303,7 +303,7 @@ export default Ember.Object.extend({
     this.filteredRecordArrays.forEach(function(value) {
       forEach.call(flatten(value), destroy);
     });
-    forEach.call(this.liveRecordArrays, destroy);
+    this.liveRecordArrays.forEach(destroy);
     forEach.call(this._adapterPopulatedRecordArrays, destroy);
   }
 });


### PR DESCRIPTION
This fixes a deprecation warning that was introduces in https://github.com/emberjs/data/pull/3354