### PR TITLE
JSONAPISerializer only supports the new Serializer API

### DIFF
--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -17,6 +17,16 @@ var map = Ember.EnumerableUtils.map;
 export default JSONSerializer.extend({
 
   /*
+    This is only to be used temporarily during the transition from the old
+    serializer API to the new one.
+
+    `JSONAPISerializer` only supports the new Serializer API.
+
+    @property isNewSerializerAPI
+  */
+  isNewSerializerAPI: true,
+
+  /*
     @method _normalizeRelationshipDataHelper
     @param {Object} relationshipDataHash
     @return {Object}

--- a/tests/ember-configuration.js
+++ b/tests/ember-configuration.js
@@ -98,7 +98,7 @@
     registry.register('adapter:-rest', DS.RESTAdapter);
 
     registry.register('adapter:-json-api', DS.JSONAPIAdapter);
-    registry.register('serializer:-json-api', DS.JSONAPISerializer.extend({ isNewSerializerAPI: true }));
+    registry.register('serializer:-json-api', DS.JSONAPISerializer);
 
     registry.injection('serializer', 'store', 'store:main');
 


### PR DESCRIPTION
Using the `JSONAPISerializer` didn't make it opt in to the new Serializer API. This PR makes `JSONAPISerializer` always use the new Serializer API.