### PR TITLE
[DOC] Deprecate store.pushMany in documentation

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1962,6 +1962,7 @@ Store = Service.extend({
     @param {String} modelName
     @param {Array} datas
     @return {Array}
+    @deprecated Use [push](#method_push) instead
   */
   pushMany: function(modelName, datas) {
     Ember.assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');


### PR DESCRIPTION
When I pushed up the deprecation for the `store.pushMany` function, I missed adding the deprecation in the comments (and thus the documentation).

This just adds that deprecation to the documents. I'm assuming it's just the `@deprecation` line that will fix this.