### PR TITLE
make sure deprecate error doesnt get swallowed when using store.push(type, data)

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1773,11 +1773,11 @@ Store = Service.extend({
     if (Ember.typeOf(modelNameArg) === 'object' && Ember.typeOf(dataArg) === 'undefined') {
       data = modelNameArg;
     } else {
+      Ember.deprecate('store.push(type, data) has been deprecated. Please provide a JSON-API document object as the first and only argument to store.push.');
       Ember.assert("Expected an object as `data` in a call to `push` for " + modelNameArg + " , but was " + Ember.typeOf(dataArg), Ember.typeOf(dataArg) === 'object');
       Ember.assert("You must include an `id` for " + modelNameArg + " in an object passed to `push`", dataArg.id != null && dataArg.id !== '');
       data = _normalizeSerializerPayload(this.modelFor(modelNameArg), dataArg);
       modelName = modelNameArg;
-      Ember.deprecate('store.push(type, data) has been deprecated. Please provide a JSON-API document object as the first and only argument to store.push.');
       Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string' || typeof data === 'undefined');
     }
 


### PR DESCRIPTION
right now it will get swallowed as it will error out before it gets to the deprecation message which is confusing to users trying to consume the api

```
Assertion Failed: You must include an `id` for author in an object passed to `push` 
```

http://emberjs.jsbin.com/hiludosuza/1/edit?html,js,console,output