### PR TITLE
[BUGFIX release] Use typeOf instead of isArray in _normalizeSerializerPayload

### DIFF
--- a/packages/ember-data/lib/system/store/serializer-response.js
+++ b/packages/ember-data/lib/system/store/serializer-response.js
@@ -45,7 +45,7 @@ export function _normalizeSerializerPayload(modelClass, payload) {
   let data = null;
 
   if (payload) {
-    if (Ember.isArray(payload)) {
+    if (Ember.typeOf(payload) === 'array') {
       data = map.call(payload, (payload) => {
         return _normalizeSerializerPayloadItem(modelClass, payload);
       });


### PR DESCRIPTION
Because of `Ember.isArray({ length: 1 }) => true`.

`Array.isArray()` used in master is not affected by this.

Fixes #3387