### PR TITLE
[REGRESSION release] Make meta available with new Serializer API

### DIFF
--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -1523,7 +1523,7 @@ var JSONSerializer = Serializer.extend({
     }
 
     if (payload && payload.meta) {
-      store.setMetadataFor(typeClass, payload.meta);
+      store._setMetadataFor(typeClass, payload.meta);
       delete payload.meta;
     }
   },

--- a/packages/ember-data/lib/system/record-arrays/adapter-populated-record-array.js
+++ b/packages/ember-data/lib/system/record-arrays/adapter-populated-record-array.js
@@ -48,7 +48,7 @@ export default RecordArray.extend({
     var store = get(this, 'store');
     var type = get(this, 'type');
     var modelName = type.modelName;
-    var meta = store.metadataFor(modelName);
+    var meta = store._metadataFor(modelName);
 
     //TODO Optimize
     var internalModels = Ember.A(records).mapBy('_internalModel');

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1388,8 +1388,20 @@ Store = Service.extend({
     @method metadataFor
     @param {String} modelName
     @return {object}
+    @deprecated
   */
   metadataFor: function(modelName) {
+    Ember.deprecate("`store.metadataFor()` has been deprecated. You can use `.get('meta')` on relationships and arrays returned from `store.query()`.");
+    return this._metadataFor(modelName);
+  },
+
+  /**
+    @method _metadataFor
+    @param {String} modelName
+    @return {object}
+    @private
+  */
+  _metadataFor: function(modelName) {
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     return this.typeMapFor(typeClass).metadata;
@@ -1402,8 +1414,20 @@ Store = Service.extend({
     @param {String} modelName
     @param {Object} metadata metadata to set
     @return {object}
+    @deprecated
   */
   setMetadataFor: function(modelName, metadata) {
+    Ember.deprecate("`store.setMetadataFor()` has been deprecated. Please return meta from your serializer's `extractMeta` hook.");
+    this._setMetadataFor(modelName, metadata);
+  },
+
+  /**
+    @method _setMetadataFor
+    @param {String} modelName
+    @param {Object} metadata metadata to set
+    @private
+  */
+  _setMetadataFor: function(modelName, metadata) {
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     Ember.merge(this.typeMapFor(typeClass).metadata, metadata);

--- a/packages/ember-data/lib/system/store/serializer-response.js
+++ b/packages/ember-data/lib/system/store/serializer-response.js
@@ -21,7 +21,12 @@ const get = Ember.get;
 */
 export function normalizeResponseHelper(serializer, store, modelClass, payload, id, requestType) {
   if (serializer.get('isNewSerializerAPI')) {
-    return serializer.normalizeResponse(store, modelClass, payload, id, requestType);
+    let normalizedResponse = serializer.normalizeResponse(store, modelClass, payload, id, requestType);
+    // TODO: Remove after metadata refactor
+    if (normalizedResponse.meta) {
+      store._setMetadataFor(modelClass.modelName, normalizedResponse.meta);
+    }
+    return normalizedResponse;
   } else {
     Ember.deprecate('Your custom serializer uses the old version of the Serializer API, with `extract` hooks. Please upgrade your serializers to the new Serializer API using `normalizeResponse` hooks instead.');
     let serializerPayload = serializer.extract(store, modelClass, payload, id, requestType);

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-new-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-new-test.js
@@ -1,0 +1,61 @@
+var env, store, adapter, Post, Comment, SuperUser;
+var passedUrl, passedVerb, passedHash;
+var run = Ember.run;
+//var get = Ember.get;
+
+module("integration/adapter/rest_adapter - REST Adapter (new API)", {
+  setup: function() {
+    Post = DS.Model.extend({
+      name: DS.attr("string")
+    });
+
+    Post.toString = function() {
+      return "Post";
+    };
+
+    Comment = DS.Model.extend({
+      name: DS.attr("string")
+    });
+
+    SuperUser = DS.Model.extend();
+
+    env = setupStore({
+      post: Post,
+      comment: Comment,
+      superUser: SuperUser,
+      adapter: DS.RESTAdapter.extend({
+        defaultSerializer: '-rest-new'
+      })
+    });
+
+    store = env.store;
+    adapter = env.adapter;
+
+    passedUrl = passedVerb = passedHash = null;
+  }
+});
+
+function ajaxResponse(value) {
+  adapter.ajax = function(url, verb, hash) {
+    passedUrl = url;
+    passedVerb = verb;
+    passedHash = hash;
+
+    return run(Ember.RSVP, 'resolve', Ember.copy(value, true));
+  };
+}
+
+test("metadata is accessible", function() {
+  ajaxResponse({
+    meta: { offset: 5 },
+    posts: [{ id: 1, name: "Rails is very expensive sushi" }]
+  });
+
+  store.findAll('post').then(async(function(posts) {
+    equal(
+      store.metadataFor('post').offset,
+      5,
+      "Metadata can be accessed with metadataFor."
+    );
+  }));
+});


### PR DESCRIPTION
We forgot to deprecate `store.metadataFor` and `store.setMetadataFor` when releasing 1.13. We also failed to keep backwards compatibility with metadata for users that are preparing for 2.0 and switches over to the new Serializer API.

This PR fixes that regression and correctly deprecates `store.metadataFor` and `store.setMetadataFor`.

Fixes #3391