### PR TITLE
[BUGFIX release] Sideloaded records are not pushed when saving

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -2292,6 +2292,9 @@ function _commit(adapter, store, operation, snapshot) {
       var payload, data;
       if (adapterPayload) {
         payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, snapshot.id, operation);
+        if (payload.included) {
+          store.push({ data: payload.included });
+        }
         data = convertResourceObject(payload.data);
       }
       store.didSaveRecord(internalModel, _normalizeSerializerPayload(internalModel.type, data));


### PR DESCRIPTION
Before the new Serializer API the serializers pushed sideloaded records to the store. Now sideloaded records are returned in `included` and it's the store's responsibility to push them.

Fixes #3406