### PR TITLE
[CLEANUP] Remove ember-new-computed dependency

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -88,7 +88,6 @@ function packageAddon(packagePath, vendorPath) {
 
 var packages = merge([
   packageAddon('ember-inflector', 'node_modules/'),
-  packageAddon('ember-new-computed', 'node_modules/'),
   package('ember-data'),
   package('activemodel-adapter'),
   package('ember')

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "defeatureify": "~0.1.4",
     "ejs": "^1.0.0",
     "ember-cli": "^0.1.15",
-    "ember-new-computed": "1.0.1",
     "ember-inflector": "^1.6.2",
     "ember-publisher": "0.0.7",
     "es6-module-transpiler": "^0.9.5",

--- a/packages/ember-data/lib/system/model/attributes.js
+++ b/packages/ember-data/lib/system/model/attributes.js
@@ -3,8 +3,6 @@ import {
   Map
 } from "ember-data/system/map";
 
-import computedPolyfill from "ember-new-computed";
-
 /**
   @module ember-data
 */
@@ -315,7 +313,7 @@ export default function attr(type, options) {
     options: options
   };
 
-  return computedPolyfill({
+  return Ember.computed({
     get: function(key) {
       var internalModel = this._internalModel;
       if (hasValue(internalModel, key)) {

--- a/packages/ember-data/lib/system/relationships/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/belongs-to.js
@@ -1,5 +1,4 @@
 import Model from 'ember-data/system/model';
-import computedPolyfill from "ember-new-computed";
 import normalizeModelName from "ember-data/system/normalize-model-name";
 
 /**
@@ -106,7 +105,7 @@ function belongsTo(modelName, options) {
     shouldWarnAsync: shouldWarnAsync
   };
 
-  return computedPolyfill({
+  return Ember.computed({
     get: function(key) {
       Ember.warn('You provided a serialize option on the "' + key + '" property in the "' + this._internalModel.modelName + '" class, this belongs in the serializer. See DS.Serializer and it\'s implementations http://emberjs.com/api/data/classes/DS.Serializer.html', !opts.hasOwnProperty('serialize'));
       Ember.warn('You provided an embedded option on the "' + key + '" property in the "' + this._internalModel.modelName + '" class, this belongs in the serializer. See DS.EmbeddedRecordsMixin http://emberjs.com/api/data/classes/DS.EmbeddedRecordsMixin.html', !opts.hasOwnProperty('embedded'));

--- a/packages/ember-data/lib/system/relationships/has-many.js
+++ b/packages/ember-data/lib/system/relationships/has-many.js
@@ -2,7 +2,6 @@
   @module ember-data
 */
 
-import computedPolyfill from "ember-new-computed";
 import Model from "ember-data/system/model";
 import normalizeModelName from "ember-data/system/normalize-model-name";
 
@@ -144,7 +143,7 @@ function hasMany(type, options) {
     shouldWarnAsync: shouldWarnAsync
   };
 
-  return computedPolyfill({
+  return Ember.computed({
     get: function(key) {
       if (meta.shouldWarnAsync) {
         Ember.deprecate(`In Ember Data 2.0, relationships will be asynchronous by default. You must set \`${key}: DS.hasMany('${type}', { async: false })\` if you wish for a relationship remain synchronous.`);


### PR DESCRIPTION
Since v1.13.0 we use Ember.js-v1.13.0, so this addon is no more needed
since the new computed property syntax is supported out of the box with
this Ember.js version.