### PR TITLE
[CLEANUP beta] Use Object.keys/Object.create instead of Ember.keys/Ember.create

### DIFF
--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -984,7 +984,7 @@ var RESTAdapter =  Adapter.extend(BuildURLMixin, {
 });
 
 function parseResponseHeaders(headerStr) {
-  var headers = Ember.create(null);
+  var headers = Object.create(null);
   if (!headerStr) { return headers; }
 
   var headerPairs = headerStr.split('\u000d\u000a');

--- a/packages/ember-data/lib/system/model/internal-model.js
+++ b/packages/ember-data/lib/system/model/internal-model.js
@@ -667,7 +667,7 @@ InternalModel.prototype = {
   },
 
   _saveWasRejected: function() {
-    var keys = Ember.keys(this._inFlightAttributes);
+    var keys = Object.keys(this._inFlightAttributes);
     for (var i=0; i < keys.length; i++) {
       if (this._attributes[keys[i]] === undefined) {
         this._attributes[keys[i]] = this._inFlightAttributes[keys[i]];

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -807,7 +807,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
   // rely on the data property.
   willMergeMixin: function(props) {
     var constructor = this.constructor;
-    Ember.assert('`' + intersection(Ember.keys(props), RESERVED_MODEL_PROPS)[0] + '` is a reserved property name on DS.Model objects. Please choose a different property name for ' + constructor.toString(), !intersection(Ember.keys(props), RESERVED_MODEL_PROPS)[0]);
+    Ember.assert('`' + intersection(Object.keys(props), RESERVED_MODEL_PROPS)[0] + '` is a reserved property name on DS.Model objects. Please choose a different property name for ' + constructor.toString(), !intersection(Object.keys(props), RESERVED_MODEL_PROPS)[0]);
   },
 
   attr: function() {

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -354,7 +354,7 @@ var DirtyState = {
     },
 
     exit: function(internalModel) {
-      internalModel._inFlightAttributes = Ember.create(null);
+      internalModel._inFlightAttributes = Object.create(null);
     }
   }
 };
@@ -546,7 +546,7 @@ var RootState = {
     saved: {
       setup: function(internalModel) {
         var attrs = internalModel._attributes;
-        var isDirty = Ember.keys(attrs).length > 0;
+        var isDirty = Object.keys(attrs).length > 0;
 
         if (isDirty) {
           internalModel.adapterDidDirty();

--- a/packages/ember-data/tests/integration/records/unload-test.js
+++ b/packages/ember-data/tests/integration/records/unload-test.js
@@ -105,7 +105,7 @@ test("can unload all records", function () {
 test("Unloading all records for a given type clears saved meta data.", function () {
 
   function metadataKeys(type) {
-    return Ember.keys(env.store.metadataFor(type));
+    return Object.keys(env.store.metadataFor(type));
   }
 
   run(function() {

--- a/packages/ember-data/tests/unit/model-test.js
+++ b/packages/ember-data/tests/unit/model-test.js
@@ -210,7 +210,7 @@ test("changedAttributes() return correct values", function() {
     mascot = store.push('mascot', { id: 1, likes: 'JavaScript', isMascot: true });
   });
 
-  equal(Ember.keys(mascot.changedAttributes()).length, 0, 'there are no initial changes');
+  equal(Object.keys(mascot.changedAttributes()).length, 0, 'there are no initial changes');
   run(function() {
     mascot.set('name', 'Tomster');   // new value
     mascot.set('likes', 'Ember.js'); // changed value
@@ -223,7 +223,7 @@ test("changedAttributes() return correct values", function() {
   run(function() {
     mascot.rollbackAttributes();
   });
-  equal(Ember.keys(mascot.changedAttributes()).length, 0, 'after rollback attributes there are no changes');
+  equal(Object.keys(mascot.changedAttributes()).length, 0, 'after rollback attributes there are no changes');
 });
 
 test("a DS.Model does not require an attribute type", function() {

--- a/packages/ember-data/tests/unit/model/rollback-attributes-test.js
+++ b/packages/ember-data/tests/unit/model/rollback-attributes-test.js
@@ -104,7 +104,7 @@ test("a record's changes can be made if it fails to save", function() {
 
       equal(person.get('firstName'), "Tom");
       equal(person.get('isError'), false);
-      equal(Ember.keys(person.changedAttributes()).length, 0);
+      equal(Object.keys(person.changedAttributes()).length, 0);
     });
   });
 });

--- a/packages/ember-data/tests/unit/store/metadata-for-test.js
+++ b/packages/ember-data/tests/unit/store/metadata-for-test.js
@@ -29,7 +29,7 @@ test("metadataFor and setMetadataFor should return and set correct metadata", fu
   expect(7);
 
   function metadataKeys(type) {
-    return Ember.keys(store.metadataFor(type));
+    return Object.keys(store.metadataFor(type));
   }
 
   // Currently not using QUnit.deepEqual due to the way deepEqual


### PR DESCRIPTION
Since Ember.create and Ember.keys have been deprecated, ember-data has become the cause of quite a few deprecation warnings in the console.