### PR TITLE
Deprecate normalizePayload and normalizeHash

### DIFF
--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -656,6 +656,7 @@ var JSONSerializer = Serializer.extend({
     @method normalizePayload
     @param {Object} payload
     @return {Object} the normalized payload
+    @deprecated
   */
   normalizePayload: function(payload) {
     return payload;
@@ -1459,6 +1460,7 @@ var JSONSerializer = Serializer.extend({
     @return {Object} json The deserialized payload
   */
   extractSingle: function(store, typeClass, payload, id, requestType) {
+    Ember.deprecate('`serializer.normalizePayload` has been deprecated. Please use `serializer.normalizeResponse` with the new Serializer API to modify the payload.', this.normalizePayload === JSONSerializer.prototype.normalizePayload);
     var normalizedPayload = this.normalizePayload(payload);
     return this.normalize(typeClass, normalizedPayload);
   },
@@ -1490,6 +1492,7 @@ var JSONSerializer = Serializer.extend({
     @return {Array} array An array of deserialized objects
   */
   extractArray: function(store, typeClass, arrayPayload, id, requestType) {
+    Ember.deprecate('`serializer.normalizePayload` has been deprecated. Please use `serializer.normalizeResponse` with the new Serializer API to modify the payload.', this.normalizePayload === JSONSerializer.prototype.normalizePayload);
     var normalizedPayload = this.normalizePayload(arrayPayload);
     var serializer = this;
 

--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -107,6 +107,7 @@ var RESTSerializer = JSONSerializer.extend({
     @property normalizeHash
     @type {Object}
     @default undefined
+    @deprecated
   */
 
   /**
@@ -188,6 +189,7 @@ var RESTSerializer = JSONSerializer.extend({
     this.normalizeUsingDeclaredMapping(typeClass, hash);
 
     if (this.normalizeHash && this.normalizeHash[prop]) {
+      Ember.deprecate('`RESTSerializer.normalizeHash` has been deprecated. Please use `serializer.normalize` to modify the payload of single resources.');
       this.normalizeHash[prop](hash);
     }
 
@@ -1045,6 +1047,7 @@ export default RESTSerializer;
 */
 function _newNormalize(modelClass, resourceHash, prop) {
   if (this.normalizeHash && this.normalizeHash[prop]) {
+    Ember.deprecate('`RESTSerializer.normalizeHash` has been deprecated. Please use `serializer.normalize` to modify the payload of single resources.');
     this.normalizeHash[prop](resourceHash);
   }
 }

--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -438,6 +438,7 @@ var RESTSerializer = JSONSerializer.extend({
     @return {Object} the primary response to the original request
   */
   extractSingle: function(store, primaryTypeClass, rawPayload, recordId) {
+    Ember.deprecate('`serializer.normalizePayload` has been deprecated. Please use `serializer.normalizeResponse` with the new Serializer API to modify the payload.', this.normalizePayload === JSONSerializer.prototype.normalizePayload);
     var payload = this.normalizePayload(rawPayload);
     var primaryRecord;
 
@@ -592,6 +593,7 @@ var RESTSerializer = JSONSerializer.extend({
       to the original query.
   */
   extractArray: function(store, primaryTypeClass, rawPayload) {
+    Ember.deprecate('`serializer.normalizePayload` has been deprecated. Please use `serializer.normalizeResponse` with the new Serializer API to modify the payload.', this.normalizePayload === JSONSerializer.prototype.normalizePayload);
     var payload = this.normalizePayload(rawPayload);
     var primaryArray;
 
@@ -670,6 +672,7 @@ var RESTSerializer = JSONSerializer.extend({
       return;
     }
 
+    Ember.deprecate('`serializer.normalizePayload` has been deprecated. Please use `serializer.normalizeResponse` with the new Serializer API to modify the payload.', this.normalizePayload === JSONSerializer.prototype.normalizePayload);
     var payload = this.normalizePayload(rawPayload);
 
     for (var prop in payload) {
@@ -1056,6 +1059,8 @@ function _newPushPayload(store, rawPayload) {
     data: [],
     included: []
   };
+
+  Ember.deprecate('`serializer.normalizePayload` has been deprecated. Please use `serializer.normalizeResponse` with the new Serializer API to modify the payload.', this.normalizePayload === JSONSerializer.prototype.normalizePayload);
   let payload = this.normalizePayload(rawPayload);
 
   for (var prop in payload) {


### PR DESCRIPTION
I've duplicated the `Ember.deprecate` calls for `normalizePayload` to prevent the deprecation from being silent when users override `normalizePayload` and don't call super. The example in the docs doesn't even call super.

`RESTSerializer` does not override `normalizePayload`, that's why it's comparing with `JSONSerializer.prototype.normalizePayload `.

Closes #3428