### PR TITLE
Namespace query

### DIFF
--- a/packages/ember-data/lib/adapters/build-url-mixin.js
+++ b/packages/ember-data/lib/adapters/build-url-mixin.js
@@ -46,17 +46,17 @@ export default Ember.Mixin.create({
     @param {(String|Array|Object)} id single id or array of ids or query
     @param {(DS.Snapshot|Array)} snapshot single snapshot or array of snapshots
     @param {String} requestType
-    @param {Object} query object of query parameters to send for query requests.
+    @param {Object} options object containing query parameters to send for query requests.
     @return {String} url
   */
-  buildURL: function(modelName, id, snapshot, requestType, query) {
+  buildURL: function(modelName, id, snapshot, requestType, options) {
     switch (requestType) {
       case 'findRecord':
         return this.urlForFindRecord(id, modelName, snapshot);
       case 'findAll':
         return this.urlForFindAll(modelName);
       case 'query':
-        return this.urlForQuery(query, modelName);
+        return this.urlForQuery(options, modelName);
       case 'findMany':
         return this.urlForFindMany(id, modelName, snapshot);
       case 'findHasMany':
@@ -125,7 +125,7 @@ export default Ember.Mixin.create({
 
   /**
    * @method urlForQuery
-   * @param {Object} query
+   * @param {Object} options
    * @param {String} modelName
    * @return {String} url
    */

--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -225,22 +225,22 @@ var RESTAdapter =  Adapter.extend(BuildURLMixin, {
     ```
 
     @method sortQueryParams
-    @param {Object} obj
+    @param {Object} passedQueryParams
     @return {Object}
   */
-  sortQueryParams: function(obj) {
-    var keys = Object.keys(obj);
+  sortQueryParams: function(passedQueryParams) {
+    var keys = Object.keys(passedQueryParams);
     var len = keys.length;
     if (len < 2) {
-      return obj;
+      return { query: passedQueryParams };
     }
     var newQueryParams = {};
     var sortedKeys = keys.sort();
 
     for (var i = 0; i < len; i++) {
-      newQueryParams[sortedKeys[i]] = obj[sortedKeys[i]];
+      newQueryParams[sortedKeys[i]] = passedQueryParams[sortedKeys[i]];
     }
-    return newQueryParams;
+    return { query: newQueryParams };
   },
 
   /**
@@ -413,14 +413,14 @@ var RESTAdapter =  Adapter.extend(BuildURLMixin, {
     @param {Object} query
     @return {Promise} promise
   */
-  query: function(store, type, query) {
-    var url = this.buildURL(type.modelName, null, null, 'query', query);
+  query: function(store, type, options) {
+    var url = this.buildURL(type.modelName, null, null, 'query', options.query);
 
     if (this.sortQueryParams) {
-      query = this.sortQueryParams(query);
+      options.query = this.sortQueryParams(options.query);
     }
 
-    return this.ajax(url, 'GET', { data: query });
+    return this.ajax(url, 'GET', { data: options.query });
   },
 
   /**

--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -232,7 +232,7 @@ var RESTAdapter =  Adapter.extend(BuildURLMixin, {
     var keys = Object.keys(passedQueryParams);
     var len = keys.length;
     if (len < 2) {
-      return { query: passedQueryParams };
+      return passedQueryParams;
     }
     var newQueryParams = {};
     var sortedKeys = keys.sort();
@@ -240,7 +240,7 @@ var RESTAdapter =  Adapter.extend(BuildURLMixin, {
     for (var i = 0; i < len; i++) {
       newQueryParams[sortedKeys[i]] = passedQueryParams[sortedKeys[i]];
     }
-    return { query: newQueryParams };
+    return newQueryParams;
   },
 
   /**
@@ -420,7 +420,7 @@ var RESTAdapter =  Adapter.extend(BuildURLMixin, {
       options.query = this.sortQueryParams(options.query);
     }
 
-    return this.ajax(url, 'GET', { data: options.query });
+    return this.ajax(url, 'GET', { data: options });
   },
 
   /**

--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -414,13 +414,13 @@ var RESTAdapter =  Adapter.extend(BuildURLMixin, {
     @return {Promise} promise
   */
   query: function(store, type, options) {
-    var url = this.buildURL(type.modelName, null, null, 'query', options.query);
+    var url = this.buildURL(type.modelName, null, null, 'query', options);
 
     if (this.sortQueryParams) {
       options.query = this.sortQueryParams(options.query);
     }
 
-    return this.ajax(url, 'GET', { data: options });
+    return this.ajax(url, 'GET', { data: options.query });
   },
 
   /**

--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -163,10 +163,10 @@ var Adapter = Ember.Object.extend({
     import DS from 'ember-data';
 
     export default DS.Adapter.extend({
-      query: function(store, type, query) {
+      query: function(store, type, options) {
         var url = type;
         return new Ember.RSVP.Promise(function(resolve, reject) {
-          jQuery.getJSON(url, query).then(function(data) {
+          jQuery.getJSON(url, options.query).then(function(data) {
             Ember.run(null, resolve, data);
           }, function(jqXHR) {
             jqXHR.then = null; // tame jQuery's ill mannered promises
@@ -201,11 +201,11 @@ var Adapter = Ember.Object.extend({
 
     ```javascript
     App.ApplicationAdapter = DS.Adapter.extend({
-      queryRecord: function(store, typeClass, query) {
+      queryRecord: function(store, typeClass, options) {
         var url = [type.typeKey, id].join('/');
 
         return new Ember.RSVP.Promise(function(resolve, reject) {
-          jQuery.getJSON(url, query).then(function(data) {
+          jQuery.getJSON(url, options.query).then(function(data) {
             Ember.run(null, resolve, data);
           }, function(jqXHR) {
             jqXHR.then = null; // tame jQuery's ill mannered promises

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -252,7 +252,7 @@ Store = Service.extend({
     @method serialize
     @private
     @param {DS.Model} record the record to serialize
-    @param {Object} options an options hash
+    @param {Object} options an options object
   */
   serialize: function(record, options) {
     var snapshot = record._internalModel.createSnapshot();
@@ -312,7 +312,7 @@ Store = Service.extend({
 
     @method createRecord
     @param {String} modelName
-    @param {Object} inputProperties a hash of properties to set on the
+    @param {Object} inputProperties a object of properties to set on the
       newly created record.
     @return {DS.Model} record
   */
@@ -955,11 +955,11 @@ Store = Service.extend({
 
     @method query
     @param {String} modelName
-    @param {Hash} options, query an opaque query of the form {query: { any }} to be used by the adapter
+    @param {Object} options, query an opaque query of the form {query: { any }} to be used by the adapter
     @return {Promise} promise
   */
   query: function(modelName, options) {
-    Ember.deprecate("You need to pass a query hash in the options hash of the store's query method", options && options.query);
+    Ember.deprecate("You need to pass a query object in the options object of the store's query method", options && options.query);
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     var array = this.recordArrayManager
@@ -986,12 +986,12 @@ Store = Service.extend({
 
     @method queryRecord
     @param {String} modelName
-    @param {Hash} options, query an opaque query of the form {query: { any }} to be used by the adapter
+    @param {Object} options, query an opaque query of the form {query: { any }} to be used by the adapter
     @return {Promise} promise
   */
   queryRecord: function(modelName, options) {
     options = options || {};
-    Ember.deprecate("You need to pass a query hash in the options hash of the store's queryRecord method", options && options.query);
+    Ember.deprecate("You need to pass a query object in the options object of the store's queryRecord method", options && options.query);
     Ember.assert("You need to pass a type to the store's queryRecord method", modelName);
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
 

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -959,7 +959,7 @@ Store = Service.extend({
     @return {Promise} promise
   */
   query: function(modelName, options) {
-    Ember.assert("You need to pass a namespaced query hash to the store's query method", options && options.query);
+    Ember.assert("You need to pass a query hash in the options hash of the store's query method", options && options.query);
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     var array = this.recordArrayManager
@@ -992,7 +992,7 @@ Store = Service.extend({
   queryRecord: function(modelName, options) {
     options = options || {};
     Ember.assert("You need to pass a type to the store's queryRecord method", modelName);
-    Ember.assert("You need to pass a namespaced query hash to the store's queryRecord method", options && options.query);
+    Ember.assert("You need to pass a query hash in the options hash of the store's queryRecord method", options && options.query);
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
 
     var typeClass = this.modelFor(modelName);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -959,7 +959,7 @@ Store = Service.extend({
     @return {Promise} promise
   */
   query: function(modelName, options) {
-    Ember.assert("You need to pass a query hash in the options hash of the store's query method", options && options.query);
+    Ember.deprecate("You need to pass a query hash in the options hash of the store's query method", options && options.query);
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     var array = this.recordArrayManager
@@ -991,8 +991,8 @@ Store = Service.extend({
   */
   queryRecord: function(modelName, options) {
     options = options || {};
+    Ember.deprecate("You need to pass a query hash in the options hash of the store's queryRecord method", options && options.query);
     Ember.assert("You need to pass a type to the store's queryRecord method", modelName);
-    Ember.assert("You need to pass a query hash in the options hash of the store's queryRecord method", options && options.query);
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
 
     var typeClass = this.modelFor(modelName);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -991,8 +991,8 @@ Store = Service.extend({
   */
   queryRecord: function(modelName, options) {
     options = options || {};
-    Ember.deprecate("You need to pass a query object in the options object of the store's queryRecord method", options && options.query);
     Ember.assert("You need to pass a type to the store's queryRecord method", modelName);
+    Ember.deprecate("You need to pass a query object in the options object of the store's queryRecord method", options && options.query);
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
 
     var typeClass = this.modelFor(modelName);

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -955,21 +955,22 @@ Store = Service.extend({
 
     @method query
     @param {String} modelName
-    @param {any} query an opaque query to be used by the adapter
+    @param {Hash} options, query an opaque query of the form {query: { any }} to be used by the adapter
     @return {Promise} promise
   */
-  query: function(modelName, query) {
+  query: function(modelName, options) {
+    Ember.assert("You need to pass a namespaced query hash to the store's query method", options && options.query);
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     var array = this.recordArrayManager
-      .createAdapterPopulatedRecordArray(typeClass, query);
+      .createAdapterPopulatedRecordArray(typeClass, options);
 
     var adapter = this.adapterFor(modelName);
 
     Ember.assert("You tried to load a query but you have no adapter (for " + typeClass + ")", adapter);
     Ember.assert("You tried to load a query but your adapter does not implement `query`", typeof adapter.query === 'function' || typeof adapter.findQuery === 'function');
 
-    return promiseArray(_query(adapter, this, typeClass, query, array));
+    return promiseArray(_query(adapter, this, typeClass, options, array));
   },
 
   /**
@@ -984,13 +985,14 @@ Store = Service.extend({
     once the server returns.
 
     @method queryRecord
-    @param {String or subclass of DS.Model} type
-    @param {any} query an opaque query to be used by the adapter
+    @param {String} modelName
+    @param {Hash} options, query an opaque query of the form {query: { any }} to be used by the adapter
     @return {Promise} promise
   */
-  queryRecord: function(modelName, query) {
+  queryRecord: function(modelName, options) {
+    options = options || {};
     Ember.assert("You need to pass a type to the store's queryRecord method", modelName);
-    Ember.assert("You need to pass a query hash to the store's queryRecord method", query);
+    Ember.assert("You need to pass a namespaced query hash to the store's queryRecord method", options && options.query);
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
 
     var typeClass = this.modelFor(modelName);
@@ -999,7 +1001,7 @@ Store = Service.extend({
     Ember.assert("You tried to make a query but you have no adapter (for " + typeClass + ")", adapter);
     Ember.assert("You tried to make a query but your adapter does not implement `queryRecord`", typeof adapter.queryRecord === 'function');
 
-    return promiseObject(_queryRecord(adapter, this, typeClass, query));
+    return promiseObject(_queryRecord(adapter, this, typeClass, options));
   },
 
   /**

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -137,10 +137,9 @@ export function _findAll(adapter, store, typeClass, sinceToken, options) {
   }, null, "DS: Extract payload of findAll " + typeClass);
 }
 
-export function _query(adapter, store, typeClass, query, recordArray) {
+export function _query(adapter, store, typeClass, options, recordArray) {
   var modelName = typeClass.modelName;
   var promise = adapter.query(store, typeClass, query, recordArray);
-
   var serializer = serializerForAdapter(store, adapter, modelName);
   var label = "DS: Handle Adapter#findQuery of " + typeClass;
 
@@ -161,9 +160,9 @@ export function _query(adapter, store, typeClass, query, recordArray) {
   }, null, "DS: Extract payload of findQuery " + typeClass);
 }
 
-export function _queryRecord(adapter, store, typeClass, query) {
+export function _queryRecord(adapter, store, typeClass, options) {
   var modelName = typeClass.modelName;
-  var promise = adapter.queryRecord(store, typeClass, query);
+  var promise = adapter.queryRecord(store, typeClass, options);
   var serializer = serializerForAdapter(store, adapter, modelName);
   var label = "DS: Handle Adapter#queryRecord of " + typeClass;
 

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -139,7 +139,7 @@ export function _findAll(adapter, store, typeClass, sinceToken, options) {
 
 export function _query(adapter, store, typeClass, options, recordArray) {
   var modelName = typeClass.modelName;
-  var promise = adapter.query(store, typeClass, query, recordArray);
+  var promise = adapter.query(store, typeClass, options, recordArray);
   var serializer = serializerForAdapter(store, adapter, modelName);
   var label = "DS: Handle Adapter#findQuery of " + typeClass;
 

--- a/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -204,9 +204,9 @@ test('find many records', function() {
   }]);
 
   run(function() {
-    store.query('post', { filter: { id: 1 } }).then(function(posts) {
+    store.query('post', { query: { filter: { id: 1 } } }).then(function(posts) {
       equal(passedUrl[0], '/posts');
-      deepEqual(passedHash[0], { data: { filter: { id: 1 } } });
+      deepEqual(passedHash[0], { data: { query: { filter: { id: 1 } } } });
 
       equal(posts.get('length'), '1');
       equal(posts.get('firstObject.title'), 'Ember.js rocks');

--- a/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -206,7 +206,7 @@ test('find many records', function() {
   run(function() {
     store.query('post', { query: { filter: { id: 1 } } }).then(function(posts) {
       equal(passedUrl[0], '/posts');
-      deepEqual(passedHash[0], { data: { query: { filter: { id: 1 } } } });
+      deepEqual(passedHash[0], { data: { filter: { id: 1 } } });
 
       equal(posts.get('length'), '1');
       equal(posts.get('firstObject.title'), 'Ember.js rocks');

--- a/packages/ember-data/tests/integration/adapter/queries-test.js
+++ b/packages/ember-data/tests/integration/adapter/queries-test.js
@@ -22,13 +22,13 @@ module("integration/adapter/queries - Queries", {
 });
 
 test("When a query is made, the adapter should receive a record array it can populate with the results of the query.", function() {
-  adapter.query = function(store, type, query, recordArray) {
+  adapter.query = function(store, type, options, recordArray) {
     equal(type, Person, "the find method is called with the correct type");
 
     return Ember.RSVP.resolve([{ id: 1, name: "Peter Wagenet" }, { id: 2, name: "Brohuda Katz" }]);
   };
 
-  store.query('person', { page: 1 }).then(async(function(queryResults) {
+  store.query('person', { query: { page: 1 } }).then(async(function(queryResults) {
     equal(get(queryResults, 'length'), 2, "the record array has a length of 2 after the results are loaded");
     equal(get(queryResults, 'isLoaded'), true, "the record array's `isLoaded` property should be true");
 

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -956,12 +956,12 @@ test("findQuery - if `sortQueryParams` option is not provided, query params are 
     passedVerb = verb;
     passedHash = hash;
 
-    deepEqual(Object.keys(hash.data), ["in", "order", "params", "wrong"], 'query params are received in alphabetical order');
+    deepEqual(Object.keys(hash.data.query), ["in", "order", "params", "wrong"], 'query params are received in alphabetical order');
 
     return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
   };
 
-  store.query('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(async(function() {
+  store.query('post', { query: { "params": 1, "in": 2, "wrong": 3, "order": 4 } }).then(async(function() {
     // Noop
   }));
 });
@@ -977,7 +977,7 @@ test("findQuery - passes buildURL the requestType", function() {
     return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
   };
 
-  store.query('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(async(function() {
+  store.query('post', { query: { "params": 1, "in": 2, "wrong": 3, "order": 4 } }).then(async(function() {
     // NOOP
   }));
 });
@@ -995,7 +995,7 @@ test("findQuery - if `sortQueryParams` is falsey, query params are not sorted at
 
   adapter.sortQueryParams = null;
 
-  store.query('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(async(function() {
+  store.query('post', { query: { "params": 1, "in": 2, "wrong": 3, "order": 4 } }).then(async(function() {
     // Noop
   }));
 });
@@ -1022,7 +1022,7 @@ test("findQuery - if `sortQueryParams` is a custom function, query params passed
     return newQueryParams;
   };
 
-  store.query('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(async(function() {
+  store.query('post', { query: { "params": 1, "in": 2, "wrong": 3, "order": 4 } }).then(async(function() {
     // Noop
   }));
 });
@@ -1033,7 +1033,7 @@ test("findQuery - payload 'meta' is accessible on the record array", function() 
     posts: [{ id: 1, name: "Rails is very expensive sushi" }]
   });
 
-  store.query('post', { page: 2 }).then(async(function(posts) {
+  store.query('post', { query: { page: 2 } }).then(async(function(posts) {
     equal(
       posts.get('meta.offset'),
       5,
@@ -1042,13 +1042,13 @@ test("findQuery - payload 'meta' is accessible on the record array", function() 
   }));
 });
 
-test("findQuery - each record array can have it's own meta object", function() {
+test("findQuery - each record array can have its own meta object", function() {
   ajaxResponse({
     meta: { offset: 5 },
     posts: [{ id: 1, name: "Rails is very expensive sushi" }]
   });
 
-  store.query('post', { page: 2 }).then(async(function(posts) {
+  store.query('post', { query: { page: 2 } }).then(async(function(posts) {
     equal(
       posts.get('meta.offset'),
       5,
@@ -1058,7 +1058,7 @@ test("findQuery - each record array can have it's own meta object", function() {
       meta: { offset: 1 },
       posts: [{ id: 1, name: "Rails is very expensive sushi" }]
     });
-    store.query('post', { page: 1 }).then(async(function(newPosts) {
+    store.query('post', { query: { page: 1 } }).then(async(function(newPosts) {
       equal(newPosts.get('meta.offset'), 1, 'new array has correct metadata');
       equal(posts.get('meta.offset'), 5, 'metadata on the old array hasnt been clobbered');
     }));
@@ -1073,10 +1073,10 @@ test("findQuery - returning an array populates the array", function() {
       { id: 2, name: "The Parley Letter" }]
   });
 
-  store.query('post', { page: 1 }).then(async(function(posts) {
+  store.query('post', { query: { page: 1 } }).then(async(function(posts) {
     equal(passedUrl, '/posts');
     equal(passedVerb, 'GET');
-    deepEqual(passedHash.data, { page: 1 });
+    deepEqual(passedHash.data, { query: { page: 1 } });
 
     var post1 = store.peekRecord('post', 1);
     var post2 = store.peekRecord('post', 2);
@@ -1111,7 +1111,7 @@ test("findQuery - returning sideloaded data loads the data", function() {
     comments: [{ id: 1, name: "FIRST" }]
   });
 
-  store.query('post', { page: 1 }).then(async(function(posts) {
+  store.query('post', { query: { page: 1 } }).then(async(function(posts) {
     var comment = store.peekRecord('comment', 1);
 
     deepEqual(comment.getProperties('id', 'name'), { id: "1", name: "FIRST" });
@@ -1129,7 +1129,7 @@ test("findQuery - data is normalized through custom serializers", function() {
             { _ID_: 2, _NAME_: "The Parley Letter" }]
   });
 
-  store.query('post', { page: 1 }).then(async(function(posts) {
+  store.query('post', { query: { page: 1 } }).then(async(function(posts) {
     var post1 = store.peekRecord('post', 1);
     var post2 = store.peekRecord('post', 2);
 

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -950,7 +950,7 @@ test("metadata is accessible", function() {
   }));
 });
 
-test("findQuery - if `sortQueryParams` option is not provided, query params are sorted alphabetically", function() {
+test("query - if `sortQueryParams` option is not provided, query params are sorted alphabetically", function() {
   adapter.ajax = function(url, verb, hash) {
     passedUrl = url;
     passedVerb = verb;
@@ -966,7 +966,7 @@ test("findQuery - if `sortQueryParams` option is not provided, query params are 
   }));
 });
 
-test("findQuery - passes buildURL the requestType", function() {
+test("query - passes buildURL the requestType", function() {
   adapter.buildURL = function(type, id, snapshot, requestType) {
     return "/" + requestType + "/posts";
   };
@@ -982,7 +982,7 @@ test("findQuery - passes buildURL the requestType", function() {
   }));
 });
 
-test("findQuery - if `sortQueryParams` is falsey, query params are not sorted at all", function() {
+test("query - if `sortQueryParams` is falsey, query params are not sorted at all", function() {
   adapter.ajax = function(url, verb, hash) {
     passedUrl = url;
     passedVerb = verb;
@@ -1000,7 +1000,7 @@ test("findQuery - if `sortQueryParams` is falsey, query params are not sorted at
   }));
 });
 
-test("findQuery - if `sortQueryParams` is a custom function, query params passed through that function", function() {
+test("query - if `sortQueryParams` is a custom function, query params passed through that function", function() {
   adapter.ajax = function(url, verb, hash) {
     passedUrl = url;
     passedVerb = verb;
@@ -1027,7 +1027,7 @@ test("findQuery - if `sortQueryParams` is a custom function, query params passed
   }));
 });
 
-test("findQuery - payload 'meta' is accessible on the record array", function() {
+test("query - payload 'meta' is accessible on the record array", function() {
   ajaxResponse({
     meta: { offset: 5 },
     posts: [{ id: 1, name: "Rails is very expensive sushi" }]
@@ -1042,7 +1042,7 @@ test("findQuery - payload 'meta' is accessible on the record array", function() 
   }));
 });
 
-test("findQuery - each record array can have its own meta object", function() {
+test("query - each record array can have its own meta object", function() {
   ajaxResponse({
     meta: { offset: 5 },
     posts: [{ id: 1, name: "Rails is very expensive sushi" }]
@@ -1066,7 +1066,7 @@ test("findQuery - each record array can have its own meta object", function() {
 });
 
 
-test("findQuery - returning an array populates the array", function() {
+test("query - returning an array populates the array", function() {
   ajaxResponse({
     posts: [
       { id: 1, name: "Rails is omakase" },
@@ -1102,7 +1102,7 @@ test("findQuery - returning an array populates the array", function() {
   }));
 });
 
-test("findQuery - returning sideloaded data loads the data", function() {
+test("query - returning sideloaded data loads the data", function() {
   ajaxResponse({
     posts: [
       { id: 1, name: "Rails is omakase" },
@@ -1118,7 +1118,7 @@ test("findQuery - returning sideloaded data loads the data", function() {
   }));
 });
 
-test("findQuery - data is normalized through custom serializers", function() {
+test("query - data is normalized through custom serializers", function() {
   env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primaryKey: '_ID_',
     attrs: { name: '_NAME_' }

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -988,7 +988,7 @@ test("findQuery - if `sortQueryParams` is falsey, query params are not sorted at
     passedVerb = verb;
     passedHash = hash;
 
-    deepEqual(Object.keys(hash.data), ["params", "in", "wrong", "order"], 'query params are received in their original order');
+    deepEqual(Object.keys(hash.data.query), ["params", "in", "wrong", "order"], 'query params are received in their original order');
 
     return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
   };
@@ -1006,7 +1006,7 @@ test("findQuery - if `sortQueryParams` is a custom function, query params passed
     passedVerb = verb;
     passedHash = hash;
 
-    deepEqual(Object.keys(hash.data), ["wrong", "params", "order", "in"], 'query params are received in reverse alphabetical order');
+    deepEqual(Object.keys(hash.data.query), ["wrong", "params", "order", "in"], 'query params are received in reverse alphabetical order');
 
     return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
   };

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -956,7 +956,7 @@ test("query - if `sortQueryParams` option is not provided, query params are sort
     passedVerb = verb;
     passedHash = hash;
 
-    deepEqual(Object.keys(hash.data.query), ["in", "order", "params", "wrong"], 'query params are received in alphabetical order');
+    deepEqual(Object.keys(hash.data), ["in", "order", "params", "wrong"], 'query params are received in alphabetical order');
 
     return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
   };
@@ -988,7 +988,7 @@ test("query - if `sortQueryParams` is falsey, query params are not sorted at all
     passedVerb = verb;
     passedHash = hash;
 
-    deepEqual(Object.keys(hash.data.query), ["params", "in", "wrong", "order"], 'query params are received in their original order');
+    deepEqual(Object.keys(hash.data), ["params", "in", "wrong", "order"], 'query params are received in their original order');
 
     return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
   };
@@ -1006,7 +1006,7 @@ test("query - if `sortQueryParams` is a custom function, query params passed thr
     passedVerb = verb;
     passedHash = hash;
 
-    deepEqual(Object.keys(hash.data.query), ["wrong", "params", "order", "in"], 'query params are received in reverse alphabetical order');
+    deepEqual(Object.keys(hash.data), ["wrong", "params", "order", "in"], 'query params are received in reverse alphabetical order');
 
     return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
   };
@@ -1023,7 +1023,7 @@ test("query - if `sortQueryParams` is a custom function, query params passed thr
   };
 
   store.query('post', { query: { "params": 1, "in": 2, "wrong": 3, "order": 4 } }).then(async(function() {
-    // Noop
+    // Noopf
   }));
 });
 
@@ -1076,7 +1076,7 @@ test("query - returning an array populates the array", function() {
   store.query('post', { query: { page: 1 } }).then(async(function(posts) {
     equal(passedUrl, '/posts');
     equal(passedVerb, 'GET');
-    deepEqual(passedHash.data, { query: { page: 1 } });
+    deepEqual(passedHash, { data: { page: 1 } });
 
     var post1 = store.peekRecord('post', 1);
     var post2 = store.peekRecord('post', 2);

--- a/packages/ember-data/tests/integration/adapter/store-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/store-adapter-test.js
@@ -40,7 +40,7 @@ module("integration/adapter/store_adapter - DS.Store and DS.Adapter integration 
 });
 
 test("Records loaded multiple times and retrieved in recordArray are ready to send state events", function() {
-  adapter.query = function(store, type, query, recordArray) {
+  adapter.query = function(store, type, options, recordArray) {
     return Ember.RSVP.resolve([{
       id: 1,
       name: "Mickael Ramírez"
@@ -50,8 +50,8 @@ test("Records loaded multiple times and retrieved in recordArray are ready to se
     }]);
   };
 
-  run(store, 'query', 'person', { q: 'bla' }).then(async(function(people) {
-    var people2 = store.query('person', { q: 'bla2' });
+  run(store, 'query', 'person', { query: { q: 'bla' } }).then(async(function(people) {
+    var people2 = store.query('person', { query: { q: 'bla2' } });
 
     return Ember.RSVP.hash({ people: people, people2: people2 });
   })).then(async(function(results) {
@@ -697,7 +697,7 @@ test("the filter method can optionally take a server query as well", function() 
     ]);
   };
 
-  var asyncFilter = store.filter('person', { page: 1 }, function(data) {
+  var asyncFilter = store.filter('person', { query: { page: 1 } }, function(data) {
     return data.get('name') === "Tom Dale";
   });
 

--- a/packages/ember-data/tests/integration/filter-test.js
+++ b/packages/ember-data/tests/integration/filter-test.js
@@ -465,14 +465,14 @@ test("filter with query persists query on the resulting filteredRecordArray", fu
   var filter;
 
   run(function() {
-    filter = store.filter('person', { foo: 1 }, function(person) {
+    filter = store.filter('person', { query: { foo: 1 } }, function(person) {
       return true;
     });
   });
 
   Ember.run(function() {
     filter.then(function(array) {
-      deepEqual(get(array, 'query'), { foo: 1 }, 'has expected query');
+      deepEqual(get(array, 'query'), { query: { foo: 1 } }, 'has expected query');
     });
   });
 });

--- a/packages/ember-data/tests/integration/store-test.js
+++ b/packages/ember-data/tests/integration/store-test.js
@@ -140,9 +140,8 @@ test("destroying the store correctly cleans everything up", function() {
   var adapterPopulatedPeople, filterdPeople;
 
   run(function() {
-    adapterPopulatedPeople = store.query('person', {
-      someCrazy: 'query'
-    });
+    let query = { someCrazy: 'query' };
+    adapterPopulatedPeople = store.query('person', { query });
   });
 
   run(function() {

--- a/packages/ember-data/tests/integration/store-test.js
+++ b/packages/ember-data/tests/integration/store-test.js
@@ -140,7 +140,7 @@ test("destroying the store correctly cleans everything up", function() {
   var adapterPopulatedPeople, filterdPeople;
 
   run(function() {
-    let query = { someCrazy: 'query' };
+    const query = { someCrazy: 'query' };
     adapterPopulatedPeople = store.query('person', { query });
   });
 

--- a/packages/ember-data/tests/integration/store/queries-test.js
+++ b/packages/ember-data/tests/integration/store/queries-test.js
@@ -2,7 +2,7 @@ var get = Ember.get;
 var Person, env, store, adapter;
 var run = Ember.run;
 
-module("integration/adapter/queries - Queries", {
+module("integration/store/queries - Queries", {
   setup: function() {
     Person = DS.Model.extend({
       updatedAt: DS.attr('string'),

--- a/packages/ember-data/tests/integration/store/query-record-test.js
+++ b/packages/ember-data/tests/integration/store/query-record-test.js
@@ -30,7 +30,7 @@ test("It raises an assertion when no type is passed", function() {
 test("It raises an assertion when the query is not namespaced in a hash", function() {
   expectAssertion(function() {
     store.queryRecord('person', { withRelated: 'posts' });
-  }, "You need to pass a namespaced query hash to the store's queryRecord method");
+  }, "You need to pass a query hash in the options hash of the store's queryRecord method");
 });
 
 test("When a record is requested, the adapter's queryRecord method should be called.", function() {

--- a/packages/ember-data/tests/integration/store/query-record-test.js
+++ b/packages/ember-data/tests/integration/store/query-record-test.js
@@ -27,9 +27,17 @@ test("It raises an assertion when no type is passed", function() {
   }, "You need to pass a type to the store's queryRecord method");
 });
 
-test("It raises an assertion when the query is not namespaced in a hash", function() {
-  expectAssertion(function() {
-    store.queryRecord('person', { withRelated: 'posts' });
+test("It raises a deprecation when the query is not namespaced in a hash", function() {
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    queryRecord: function() {
+      return Ember.RSVP.resolve({ id: 1 });
+    }
+  }));
+
+  expectDeprecation(function() {
+    run(function() {
+      store.queryRecord('person', { withRelated: 'posts' });
+    });
   }, "You need to pass a query hash in the options hash of the store's queryRecord method");
 });
 

--- a/packages/ember-data/tests/integration/store/query-record-test.js
+++ b/packages/ember-data/tests/integration/store/query-record-test.js
@@ -87,6 +87,6 @@ test("When a record is requested, the serializer's normalizeQueryRecordResponse 
   }));
 
   run(function() {
-    store.queryRecord('person', { query: { related: 'posts' }});
+    store.queryRecord('person', { query: { related: 'posts' } });
   });
 });

--- a/packages/ember-data/tests/integration/store/query-record-test.js
+++ b/packages/ember-data/tests/integration/store/query-record-test.js
@@ -27,10 +27,10 @@ test("It raises an assertion when no type is passed", function() {
   }, "You need to pass a type to the store's queryRecord method");
 });
 
-test("It raises an assertion when no query hash is passed", function() {
+test("It raises an assertion when the query is not namespaced in a hash", function() {
   expectAssertion(function() {
-    store.queryRecord('person');
-  }, "You need to pass a query hash to the store's queryRecord method");
+    store.queryRecord('person', { withRelated: 'posts' });
+  }, "You need to pass a namespaced query hash to the store's queryRecord method");
 });
 
 test("When a record is requested, the adapter's queryRecord method should be called.", function() {
@@ -44,7 +44,7 @@ test("When a record is requested, the adapter's queryRecord method should be cal
   }));
 
   run(function() {
-    store.queryRecord('person', { related: 'posts' });
+    store.queryRecord('person', { query: { related: 'posts' } });
   });
 });
 
@@ -56,7 +56,7 @@ test("When a record is requested, and the promise is rejected, .queryRecord() is
   }));
 
   run(function() {
-    store.queryRecord('person', {}).then(null, async(function(reason) {
+    store.queryRecord('person', { query : {} }).then(null, async(function(reason) {
       ok(true, "The rejection handler was called");
     }));
   });
@@ -87,6 +87,6 @@ test("When a record is requested, the serializer's normalizeQueryRecordResponse 
   }));
 
   run(function() {
-    store.queryRecord('person', { related: 'posts' });
+    store.queryRecord('person', { query: { related: 'posts' }});
   });
 });

--- a/packages/ember-data/tests/integration/store/query-record-test.js
+++ b/packages/ember-data/tests/integration/store/query-record-test.js
@@ -1,7 +1,7 @@
 var Person, store, env;
 var run = Ember.run;
 
-module("integration/store/query-record - Query one record with a query hash", {
+module("integration/store/query-record - Query one record with a query object", {
   setup: function() {
     Person = DS.Model.extend({
       updatedAt: DS.attr('string'),
@@ -27,7 +27,7 @@ test("It raises an assertion when no type is passed", function() {
   }, "You need to pass a type to the store's queryRecord method");
 });
 
-test("It raises a deprecation when the query is not namespaced in a hash", function() {
+test("It raises a deprecation when the query is not namespaced in a object", function() {
   env.registry.register('adapter:person', DS.Adapter.extend({
     queryRecord: function() {
       return Ember.RSVP.resolve({ id: 1 });
@@ -38,7 +38,7 @@ test("It raises a deprecation when the query is not namespaced in a hash", funct
     run(function() {
       store.queryRecord('person', { withRelated: 'posts' });
     });
-  }, "You need to pass a query hash in the options hash of the store's queryRecord method");
+  }, "You need to pass a query object in the options object of the store's queryRecord method");
 });
 
 test("When a record is requested, the adapter's queryRecord method should be called.", function() {

--- a/packages/ember-data/tests/unit/record-array-test.js
+++ b/packages/ember-data/tests/unit/record-array-test.js
@@ -263,7 +263,7 @@ test("an AdapterPopulatedRecordArray knows if it's loaded or not", function() {
   };
 
   run(function() {
-    store.query('person', { page: 1 }).then(function(people) {
+    store.query('person', { query: { page: 1 } }).then(function(people) {
       equal(get(people, 'isLoaded'), true, "The array is now loaded");
     });
   });

--- a/packages/ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/ember-data/tests/unit/store/adapter-interop-test.js
@@ -195,16 +195,16 @@ test("pushMany extracts ids from an Array of hashes if no ids are specified", fu
 test("loadMany takes an optional Object and passes it on to the Adapter", function() {
   expect(2);
 
-  var passedQuery = { page: 1 };
+  var passedQuery = { query: { page: 1 } };
 
   var Person = DS.Model.extend({
     name: DS.attr('string')
   });
 
   var adapter = TestAdapter.extend({
-    query: function(store, type, query) {
+    query: function(store, type, options) {
       equal(type, store.modelFor('person'), 'The type was Person');
-      equal(query, passedQuery, "The query was passed in");
+      equal(options, passedQuery, "The query was passed in");
       return Ember.RSVP.resolve([]);
     }
   });
@@ -220,7 +220,7 @@ test("loadMany takes an optional Object and passes it on to the Adapter", functi
 });
 
 test("Find with query calls the correct normalizeResponse", function() {
-  var passedQuery = { page: 1 };
+  var passedQuery = { query: { page: 1 } };
 
   var Person = DS.Model.extend({
     name: DS.attr('string')


### PR DESCRIPTION
@igorT a few questions :

**1/ Tests directory**
Should I move the "integration/adapter/queries - Queries” test module to "integration/store/query” (alongside "integration/store/queryRecord”)

**2/ Function param `(modelName, query)` => `(modelName, options)`**
Does that make sense ? Writing `options.query` seems better than `query.query`, what do you think ?

3/ In "integration/adapter/rest_adapter" Rename `findQuery` to `query` in tests ?

It is still a WIP, I need to read myself again to catch any typo/non-up-to-date comments 