### PR TITLE
[BUGFIX release] Do not register the service store when it has already been registered

### DIFF
--- a/packages/ember-data/lib/initializers/store.js
+++ b/packages/ember-data/lib/initializers/store.js
@@ -58,7 +58,7 @@ export default function initializeStore(registry, application) {
 
   if (store) {
     registry.register('service:store', store, { instantiate: false });
-  } else {
+  } else if (!registry.has('service:store')) {
     registry.register('service:store', application && application.Store || Store);
   }
 }

--- a/packages/ember-data/tests/integration/application-test.js
+++ b/packages/ember-data/tests/integration/application-test.js
@@ -166,6 +166,30 @@ test("ember-data initializer is run", function() {
   ok(ran, 'ember-data initializer was found');
 });
 
+test("ember-data initializer does not register the store service when it was already registered", function() {
+
+  var AppStore = Store.extend({
+    isCustomStore: true
+  });
+
+  App.initializer({
+    name:       "after-ember-data",
+    before:      "ember-data",
+    initialize: function(registry) {
+      registry.register('service:store', AppStore);
+    }
+  });
+
+  run(function() {
+    app = App.create();
+    container = app.__container__;
+  });
+
+  var store = getStore();
+  ok(store && store.get('isCustomStore'), 'ember-data initializer does not overwrite the previous registered service store');
+
+});
+
 test("store initializer is run (DEPRECATED)", function() {
   var ran = false;
   App.initializer({


### PR DESCRIPTION
The following change remove the need of the `service:store` registration after the `store` initializer like:

```
import ApplicationStore from 'app/data/store';

export default {
  name: 'setup-store',
  after: ['store'],

  initialize: function(registry, application) {
    registry.register('service:store', ApplicationStore);
  }
};
```

Now, the `service:store` could be registered either before or after the store initializer.