### PR TITLE
Update shouldReload* flags for 2.0

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -482,9 +482,7 @@ var Adapter = Ember.Object.extend({
     @return {Boolean}
   */
   shouldReloadAll: function(store, snapshotRecordArray) {
-    var modelName = snapshotRecordArray.type.modelName;
-    Ember.deprecate(`The default behavior of shouldReloadAll will change in Ember Data 2.0 to always return false when there is at least one "${modelName}" record in the store. If you would like to preserve the current behavior please override shouldReloadAll in your adapter:application and return true.`);
-    return true;
+    return !snapshotRecordArray.length;
   },
 
   /**
@@ -504,8 +502,7 @@ var Adapter = Ember.Object.extend({
     @return {Boolean}
   */
   shouldBackgroundReloadRecord: function(store, snapshot) {
-    Ember.deprecate('The default behavior of `shouldBackgroundReloadRecord` will change in Ember Data 2.0 to always return true. If you would like to preserve the current behavior please override `shouldBackgroundReloadRecord` in your adapter:application and return false.');
-    return false;
+    return true;
   },
 
   /**

--- a/packages/ember-data/tests/integration/adapter/find-test.js
+++ b/packages/ember-data/tests/integration/adapter/find-test.js
@@ -31,18 +31,6 @@ test("It raises an assertion when `undefined` is passed as id (#1705)", function
   }, "You cannot pass `null` as id to the store's find method");
 });
 
-test("store.findAll should trigger a deprecation warning about store.shouldReloadAll", function() {
-  env.adapter.findAll = function() {
-    return Ember.RSVP.resolve([]);
-  };
-
-  run(function() {
-    expectDeprecation(function() {
-      store.findAll('person');
-    }, 'The default behavior of shouldReloadAll will change in Ember Data 2.0 to always return false when there is at least one "person" record in the store. If you would like to preserve the current behavior please override shouldReloadAll in your adapter:application and return true.');
-  });
-});
-
 test("When a single record is requested, the adapter's find method should be called unless it's loaded.", function() {
   expect(2);
 

--- a/packages/ember-data/tests/integration/adapter/record-persistence-test.js
+++ b/packages/ember-data/tests/integration/adapter/record-persistence-test.js
@@ -25,7 +25,12 @@ module("integration/adapter/record_persistence - Persisting Records", {
     });
     Person.toString = function() { return "Person"; };
 
-    env = setupStore({ person: Person });
+    env = setupStore({
+      adapter: DS.Adapter.extend({
+        shouldBackgroundReloadRecord: () => false
+      }),
+      person: Person
+    });
     store = env.store;
   },
 
@@ -58,11 +63,13 @@ test("When a store is committed, the adapter's `commit` method should be called 
 
   var tom;
 
-  env.store.find('person', 1).then(async(function(person) {
-    tom = person;
-    set(tom, "name", "Tom Dale");
-    tom.save();
-  }));
+  run(function() {
+    env.store.findRecord('person', 1).then(async(function(person) {
+      tom = person;
+      set(tom, "name", "Tom Dale");
+      tom.save();
+    }));
+  });
 });
 
 test("When a store is committed, the adapter's `commit` method should be called with records that have been created.", function() {

--- a/packages/ember-data/tests/integration/adapter/store-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/store-adapter-test.js
@@ -69,7 +69,7 @@ test("Records loaded multiple times and retrieved in recordArray are ready to se
 
 test("by default, createRecords calls createRecord once per record", function() {
   var count = 1;
-
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.createRecord = function(store, type, snapshot) {
     equal(type, Person, "the type is correct");
 
@@ -114,7 +114,7 @@ test("by default, createRecords calls createRecord once per record", function() 
 
 test("by default, updateRecords calls updateRecord once per record", function() {
   var count = 0;
-
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.updateRecord = function(store, type, snapshot) {
     equal(type, Person, "the type is correct");
 
@@ -180,7 +180,7 @@ test("by default, updateRecords calls updateRecord once per record", function() 
 
 test("calling store.didSaveRecord can provide an optional hash", function() {
   var count = 0;
-
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.updateRecord = function(store, type, snapshot) {
     equal(type, Person, "the type is correct");
 
@@ -244,7 +244,7 @@ test("by default, deleteRecord calls deleteRecord once per record", function() {
   expect(4);
 
   var count = 0;
-
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.deleteRecord = function(store, type, snapshot) {
     equal(type, Person, "the type is correct");
 
@@ -302,7 +302,7 @@ test("by default, destroyRecord calls deleteRecord once per record without requi
   expect(4);
 
   var count = 0;
-
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.deleteRecord = function(store, type, snapshot) {
     equal(type, Person, "the type is correct");
 
@@ -357,7 +357,7 @@ test("if an existing model is edited then deleted, deleteRecord is called on the
   expect(5);
 
   var count = 0;
-
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.deleteRecord = function(store, type, snapshot) {
     count++;
     equal(snapshot.id, 'deleted-record', "should pass correct record to deleteRecord");
@@ -401,6 +401,7 @@ test("if a deleted record errors, it enters the error state", function() {
   var count = 0;
   var error = new DS.AdapterError();
 
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.deleteRecord = function(store, type, snapshot) {
     if (count++ === 0) {
       return Ember.RSVP.reject(error);
@@ -588,6 +589,7 @@ test("if a created record is marked as erred by the server, it enters an error s
 });
 
 test("if an updated record is marked as invalid by the server, it enters an error state", function() {
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.updateRecord = function(store, type, snapshot) {
     equal(type, Person, "the type is correct");
 
@@ -643,6 +645,7 @@ test("if an updated record is marked as invalid by the server, it enters an erro
 
 
 test("records can have errors on arbitrary properties after update", function() {
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.updateRecord = function(store, type, snapshot) {
     if (snapshot.attr('name').indexOf('Bro') === -1) {
       return Ember.RSVP.reject(new DS.InvalidError({ base: ['is a generally unsavoury character'] }));
@@ -702,6 +705,7 @@ test("records can have errors on arbitrary properties after update", function() 
 
 test("if an updated record is marked as invalid by the server, you can attempt the save again", function() {
   var saveCount = 0;
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.updateRecord = function(store, type, snapshot) {
     equal(type, Person, "the type is correct");
     saveCount++;
@@ -762,6 +766,7 @@ test("if an updated record is marked as invalid by the server, you can attempt t
 test("if a updated record is marked as erred by the server, it enters an error state", function() {
   var error = new DS.AdapterError();
 
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.updateRecord = function(store, type, snapshot) {
     return Ember.RSVP.reject(error);
   };
@@ -803,6 +808,7 @@ test("can be created after the DS.Store", function() {
 });
 
 test("the filter method can optionally take a server query as well", function() {
+  adapter.shouldBackgroundReloadRecord = () => false;
   adapter.query = function(store, type, query, array) {
     return Ember.RSVP.resolve([
       { id: 1, name: "Yehuda Katz" },
@@ -894,6 +900,7 @@ test("relationships returned via `commit` do not trigger additional findManys", 
 });
 
 test("relationships don't get reset if the links is the same", function() {
+  adapter.shouldBackgroundReloadRecord = () => false;
   Person.reopen({
     dogs: DS.hasMany({ async: true })
   });

--- a/packages/ember-data/tests/integration/debug-adapter-test.js
+++ b/packages/ember-data/tests/integration/debug-adapter-test.js
@@ -8,8 +8,10 @@ module("DS.DebugAdapter", {
       App = Ember.Application.create();
       App.toString = function() { return 'App'; };
 
-      App.StoreService = DS.Store.extend({
-        adapter: DS.Adapter.extend()
+      App.StoreService = DS.Store.extend({});
+
+      App.ApplicationAdapter = DS.Adapter.extend({
+        shouldBackgroundReloadRecord: () => false
       });
 
       App.Post = DS.Model.extend({

--- a/packages/ember-data/tests/integration/filter-test.js
+++ b/packages/ember-data/tests/integration/filter-test.js
@@ -213,7 +213,8 @@ test("a Record Array can update its filter", function() {
   customAdapter(env, DS.Adapter.extend({
     deleteRecord: function(store, type, snapshot) {
       return Ember.RSVP.resolve();
-    }
+    },
+    shouldBackgroundReloadRecord: () => false
   }));
 
   run(function() {
@@ -286,7 +287,8 @@ test("a Record Array can update its filter and notify array observers", function
   customAdapter(env, DS.Adapter.extend({
     deleteRecord: function(store, type, snapshot) {
       return Ember.RSVP.resolve();
-    }
+    },
+    shouldBackgroundReloadRecord: () => false
   }));
 
   run(function() {
@@ -382,6 +384,9 @@ test("a Record Array can update its filter and notify array observers", function
 });
 
 test("it is possible to filter by computed properties", function() {
+  customAdapter(env, DS.Adapter.extend({
+    shouldBackgroundReloadRecord: () => false
+  }));
   Person.reopen({
     name: DS.attr('string'),
     upperName: Ember.computed(function() {
@@ -422,6 +427,9 @@ test("it is possible to filter by computed properties", function() {
 });
 
 test("a filter created after a record is already loaded works", function() {
+  customAdapter(env, DS.Adapter.extend({
+    shouldBackgroundReloadRecord: () => false
+  }));
   Person.reopen({
     name: DS.attr('string'),
     upperName: Ember.computed(function() {
@@ -514,7 +522,8 @@ test("it is possible to filter loaded records by dirtiness", function() {
   customAdapter(env, DS.Adapter.extend({
     updateRecord: function() {
       return Ember.RSVP.resolve();
-    }
+    },
+    shouldBackgroundReloadRecord: () => false
   }));
 
   var filter = store.filter('person', function(person) {
@@ -555,7 +564,8 @@ test("it is possible to filter created records by dirtiness", function() {
     customAdapter(env, DS.Adapter.extend({
       createRecord: function() {
         return Ember.RSVP.resolve();
-      }
+      },
+      shouldBackgroundReloadRecord: () => false
     }));
   });
 
@@ -662,7 +672,8 @@ test("a Record Array can update its filter after server-side updates one record"
   setup({
     updateRecord: function(store, type, snapshot) {
       return Ember.RSVP.resolve({ id: 1, name: "Scumbag Server-side Dale" });
-    }
+    },
+    shouldBackgroundReloadRecord: () => false
   });
 
   clientEdits([1]);
@@ -681,7 +692,8 @@ test("a Record Array can update its filter after server-side updates multiple re
         case "2":
           return Ember.RSVP.resolve({ id: 2, name: "Scumbag Server-side Katz" });
       }
-    }
+    },
+    shouldBackgroundReloadRecord: () => false
   });
 
   clientEdits([1,2]);
@@ -745,6 +757,9 @@ test("a Record Array can update its filter after server-side creates multiple re
 
 test("destroying filteredRecordArray unregisters models from being filtered", function() {
   var filterFn = tapFn(function() { return true; });
+  customAdapter(env, DS.Adapter.extend({
+    shouldBackgroundReloadRecord: () => false
+  }));
   run(function () {
     store.push({
       data: [{

--- a/packages/ember-data/tests/integration/multiple_stores_test.js
+++ b/packages/ember-data/tests/integration/multiple_stores_test.js
@@ -41,6 +41,10 @@ module("integration/multiple_stores - Multiple Stores Tests", {
 });
 
 test("should be able to push into multiple stores", function() {
+  env.registry.register('adapter:home-planet', DS.RESTAdapter.extend({
+    shouldBackgroundReloadRecord: () => false
+  }));
+
   var home_planet_main = { id: '1', name: 'Earth' };
   var home_planet_a = { id: '1', name: 'Mars' };
   var home_planet_b = { id: '1', name: 'Saturn' };
@@ -51,15 +55,15 @@ test("should be able to push into multiple stores", function() {
     env.store_b.push(env.store_b.normalize('home-planet', home_planet_b));
   });
 
-  run(env.store, 'find', 'home-planet', 1).then(async(function(homePlanet) {
+  run(env.store, 'findRecord', 'home-planet', 1).then(async(function(homePlanet) {
     equal(homePlanet.get('name'), "Earth");
   }));
 
-  run(env.store_a, 'find', 'home-planet', 1).then(async(function(homePlanet) {
+  run(env.store_a, 'findRecord', 'home-planet', 1).then(async(function(homePlanet) {
     equal(homePlanet.get('name'), "Mars");
   }));
 
-  run(env.store_b, 'find', 'home-planet', 1).then(async(function(homePlanet) {
+  run(env.store_b, 'findRecord', 'home-planet', 1).then(async(function(homePlanet) {
     equal(homePlanet.get('name'), "Saturn");
   }));
 

--- a/packages/ember-data/tests/integration/records/reload-test.js
+++ b/packages/ember-data/tests/integration/records/reload-test.js
@@ -91,6 +91,9 @@ test("When a record is reloaded and fails, it can try again", function() {
 });
 
 test("When a record is loaded a second time, isLoaded stays true", function() {
+  env.adapter.findRecord = function(store, type, id, snapshot) {
+    return { id: 1, name: "Tom Dale" };
+  };
   run(function() {
     env.store.push({
       data: {

--- a/packages/ember-data/tests/integration/records/unload-test.js
+++ b/packages/ember-data/tests/integration/records/unload-test.js
@@ -226,6 +226,10 @@ test("unloading all records also updates record array from peekAll()", function(
 
 test("unloading a record also clears its relationship", function() {
   var adam, bob;
+
+  // disable background reloading so we do not re-create the relationship.
+  env.adapter.shouldBackgroundReloadRecord = () => false;
+
   run(function() {
     env.store.push({
       data: {
@@ -266,7 +270,7 @@ test("unloading a record also clears its relationship", function() {
   });
 
   run(function() {
-    env.store.find('person', 1).then(function(person) {
+    env.store.findRecord('person', 1).then(function(person) {
       equal(person.get('cars.length'), 1, 'The inital length of cars is correct');
 
       run(function() {
@@ -280,6 +284,9 @@ test("unloading a record also clears its relationship", function() {
 
 test("unloading a record also clears the implicit inverse relationships", function() {
   var adam, bob;
+  // disable background reloading so we do not re-create the relationship.
+  env.adapter.shouldBackgroundReloadRecord = () => false;
+
   run(function() {
     env.store.push({
       data: {
@@ -311,7 +318,7 @@ test("unloading a record also clears the implicit inverse relationships", functi
   });
 
   run(function() {
-    env.store.find('group', 1).then(function(group) {
+    env.store.findRecord('group', 1).then(function(group) {
       equal(group.get('people.length'), 1, 'The inital length of people is correct');
       var person = env.store.peekRecord('person', 1);
       run(function() {

--- a/packages/ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/integration/relationships/belongs-to-test.js
@@ -105,7 +105,7 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
       inverse: 'messages'
     })
   });
-
+  env.adapter.shouldBackgroundReloadRecord = () => false;
   env.adapter.findRecord = function(store, type, id, snapshot) {
     ok(true, "The adapter's find method should be called");
     return Ember.RSVP.resolve({
@@ -139,7 +139,7 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
 
 test("Only a record of the same type can be used with a monomorphic belongsTo relationship", function() {
   expect(1);
-
+  env.adapter.shouldBackgroundReloadRecord = () => false;
   run(function() {
     store.push({
       data: {
@@ -169,6 +169,7 @@ test("Only a record of the same type can be used with a monomorphic belongsTo re
 });
 
 test("Only a record of the same base type can be used with a polymorphic belongsTo relationship", function() {
+  env.adapter.shouldBackgroundReloadRecord = () => false;
   expect(1);
   run(function() {
     store.push({
@@ -219,6 +220,7 @@ test("Only a record of the same base type can be used with a polymorphic belongs
 });
 
 test("The store can load a polymorphic belongsTo association", function() {
+  env.adapter.shouldBackgroundReloadRecord = () => false;
   run(function() {
     env.store.push({
       data: {
@@ -254,6 +256,7 @@ test("The store can load a polymorphic belongsTo association", function() {
 });
 
 test("The store can serialize a polymorphic belongsTo association", function() {
+  env.adapter.shouldBackgroundReloadRecord = () => false;
   var serializerInstance = store.serializerFor('comment');
 
   serializerInstance.serializePolymorphicType = function(record, json, relationship) {
@@ -291,6 +294,7 @@ test("The store can serialize a polymorphic belongsTo association", function() {
 });
 
 test("A serializer can materialize a belongsTo as a link that gets sent back to findBelongsTo", function() {
+  env.adapter.shouldBackgroundReloadRecord = () => false;
   var Group = DS.Model.extend({
     people: DS.hasMany('person', { async: false })
   });
@@ -341,6 +345,7 @@ test("A serializer can materialize a belongsTo as a link that gets sent back to 
 });
 
 test('A record with an async belongsTo relationship always returns a promise for that relationship', function () {
+  env.adapter.shouldBackgroundReloadRecord = () => false;
   var Seat = DS.Model.extend({
     person: DS.belongsTo('person', { async: false })
   });
@@ -391,6 +396,7 @@ test('A record with an async belongsTo relationship always returns a promise for
 test("A record with an async belongsTo relationship returning null should resolve null", function() {
   expect(1);
 
+  env.adapter.shouldBackgroundReloadRecord = () => false;
   var Group = DS.Model.extend({
     people: DS.hasMany('person', { async: false })
   });
@@ -436,6 +442,7 @@ test("A record with an async belongsTo relationship returning null should resolv
 test("A record can be created with a resolved belongsTo promise", function() {
   expect(1);
 
+  env.adapter.shouldBackgroundReloadRecord = () => false;
   var Group = DS.Model.extend({
     people: DS.hasMany('person', { async: false })
   });

--- a/packages/ember-data/tests/integration/store/query-record-test.js
+++ b/packages/ember-data/tests/integration/store/query-record-test.js
@@ -56,9 +56,9 @@ test("When a record is requested, and the promise is rejected, .queryRecord() is
   }));
 
   run(function() {
-    store.queryRecord('person', {}).then(null, async(function(reason) {
+    store.queryRecord('person', {}).catch(function(reason) {
       ok(true, "The rejection handler was called");
-    }));
+    });
   });
 });
 

--- a/packages/ember-data/tests/unit/model-test.js
+++ b/packages/ember-data/tests/unit/model-test.js
@@ -38,7 +38,7 @@ test("can have a property set on it", function() {
 
 test("setting a property on a record that has not changed does not cause it to become dirty", function() {
   expect(2);
-
+  env.adapter.shouldBackgroundReloadRecord = () => false;
   run(function() {
     store.push({
       data: {
@@ -64,6 +64,7 @@ test("setting a property on a record that has not changed does not cause it to b
 
 test("resetting a property on a record cause it to become clean again", function() {
   expect(3);
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({
@@ -88,6 +89,7 @@ test("resetting a property on a record cause it to become clean again", function
 
 test("a record becomes clean again only if all changed properties are reset", function() {
   expect(5);
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({
@@ -116,6 +118,7 @@ test("a record becomes clean again only if all changed properties are reset", fu
 
 test("a record reports its unique id via the `id` property", function() {
   expect(1);
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({
@@ -132,6 +135,7 @@ test("a record reports its unique id via the `id` property", function() {
 
 test("a record's id is included in its toString representation", function() {
   expect(1);
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({
@@ -174,6 +178,7 @@ test("trying to set an `id` attribute should raise", function() {
 
 test("a collision of a record's id with object function's name", function() {
   expect(1);
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   var hasWatchMethod = Object.prototype.watch;
   try {
@@ -431,6 +436,7 @@ module("unit/model - DS.Model updating", {
 
 test("a DS.Model can update its attributes", function() {
   expect(1);
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.findRecord('person', 2).then(function(person) {
@@ -562,6 +568,7 @@ test("setting a property to undefined on a newly created record should not impac
 // thrown out if/when the current `_attributes` hash logic is removed.
 test("setting a property back to its original value removes the property from the `_attributes` hash", function() {
   expect(3);
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.findRecord('person', 1).then(function(person) {
@@ -706,9 +713,8 @@ var converts = function(type, provided, expected) {
   run(function() {
     testStore.push(testStore.normalize('model', { id: 1, name: provided }));
     testStore.push(testStore.normalize('model', { id: 2 }));
-    testStore.findRecord('model', 1).then(function(record) {
-      deepEqual(get(record, 'name'), expected, type + " coerces " + provided + " to " + expected);
-    });
+    var record = testStore.peekRecord('model', 1);
+    deepEqual(get(record, 'name'), expected, type + " coerces " + provided + " to " + expected);
   });
 
   // See: Github issue #421
@@ -730,7 +736,12 @@ var convertsFromServer = function(type, provided, expected) {
     container = new Ember.Container();
     registry = container;
   }
-  var testStore = createStore({ model: Model });
+  var testStore = createStore({
+    model: Model,
+    adapter: DS.Adapter.extend({
+      shouldBackgroundReloadRecord: () => false
+    })
+  });
 
   run(function() {
     testStore.push(testStore.normalize('model', { id: "1", name: provided }));
@@ -745,7 +756,12 @@ var convertsWhenSet = function(type, provided, expected) {
     name: DS.attr(type)
   });
 
-  var testStore = createStore({ model: Model });
+  var testStore = createStore({
+    model: Model,
+    adapter: DS.Adapter.extend({
+      shouldBackgroundReloadRecord: () => false
+    })
+  });
 
   run(function() {
     testStore.push({
@@ -813,7 +829,10 @@ test("a DS.Model can describe Date attributes", function() {
   });
 
   var store = createStore({
-    person: Person
+    person: Person,
+    adapter: DS.Adapter.extend({
+      shouldBackgroundReloadRecord: () => false
+    })
   });
 
   run(function() {

--- a/packages/ember-data/tests/unit/model/relationships/belongs-to-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/belongs-to-test.js
@@ -20,6 +20,7 @@ test("belongsTo lazily loads relationships as needed", function() {
 
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({
@@ -149,12 +150,11 @@ test("async belongsTo relationships work when the data hash has already been loa
   });
 
   run(function() {
-    store.findRecord('person', 1).then(async(function(person) {
-      equal(get(person, 'name'), "Tom Dale", "The person is now populated");
-      return run(function() {
-        return get(person, 'tag');
-      });
-    })).then(async(function(tag) {
+    var person = store.peekRecord('person', 1);
+    equal(get(person, 'name'), "Tom Dale", "The person is now populated");
+    return run(function() {
+      return get(person, 'tag');
+    }).then(async(function(tag) {
       equal(get(tag, 'name'), "friendly", "Tom Dale is now friendly");
       equal(get(tag, 'isLoaded'), true, "Tom Dale is now loaded");
     }));
@@ -176,6 +176,7 @@ test("calling createRecord and passing in an undefined value for a relationship 
 
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.createRecord('person', { id: 1, tag: undefined });
@@ -205,6 +206,7 @@ test("When finding a hasMany relationship the inverse belongsTo relationship is 
 
   var env = setupStore({ occupation: Occupation, person: Person });
   var store = env.store;
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   env.adapter.findMany = function(store, type, ids, snapshots) {
     equal(snapshots[0].belongsTo('person').id, '1');
@@ -312,6 +314,7 @@ test("belongsTo supports relationships to models with id 0", function() {
 
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({
@@ -375,6 +378,7 @@ test("belongsTo gives a warning when provided with a serialize option", function
 
   var env = setupStore({ hobby: Hobby, person: Person });
   var store = env.store;
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({
@@ -428,6 +432,7 @@ test("belongsTo gives a warning when provided with an embedded option", function
 
   var env = setupStore({ hobby: Hobby, person: Person });
   var store = env.store;
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({

--- a/packages/ember-data/tests/unit/model/relationships/has-many-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/has-many-test.js
@@ -38,6 +38,7 @@ test("hasMany handles pre-loaded relationships", function() {
       ok(false, "findRecord() should not be called with these values");
     }
   };
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   var store = env.store;
 
@@ -235,6 +236,7 @@ test("hasMany lazily loads async relationships", function() {
       ok(false, "findRecord() should not be called with these values");
     }
   };
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   var store = env.store;
 
@@ -411,6 +413,7 @@ test("relationships work when declared with a string path", function() {
     person: Person,
     tag: Tag
   });
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     env.store.push({
@@ -525,6 +528,7 @@ test("it is possible to add a new item to a relationship", function() {
     tag: Tag,
     person: Person
   });
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   var store = env.store;
 
@@ -656,6 +660,7 @@ test("it is possible to remove an item from a relationship", function() {
 
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({

--- a/packages/ember-data/tests/unit/model/relationships/record-array-test.js
+++ b/packages/ember-data/tests/unit/model/relationships/record-array-test.js
@@ -66,6 +66,7 @@ test("can create child record from a hasMany relationship", function() {
 
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({

--- a/packages/ember-data/tests/unit/record-array-test.js
+++ b/packages/ember-data/tests/unit/record-array-test.js
@@ -17,7 +17,10 @@ test("a record array is backed by records", function() {
   expect(3);
 
   var store = createStore({
-    person: Person
+    person: Person,
+    adapter: DS.Adapter.extend({
+      shouldBackgroundReloadRecord: () => false
+    })
   });
   run(function() {
     store.push({
@@ -146,7 +149,8 @@ test("a loaded record is removed from a record array when it is deleted", functi
     tag: Tag,
     person: Person,
     adapter: DS.Adapter.extend({
-      deleteRecord: () => Ember.RSVP.resolve()
+      deleteRecord: () => Ember.RSVP.resolve(),
+      shouldBackgroundReloadRecord: () => false
     })
   });
   var store = env.store;

--- a/packages/ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/ember-data/tests/unit/store/adapter-interop-test.js
@@ -4,7 +4,7 @@ var resolve = Ember.RSVP.resolve;
 var TestAdapter, store, person;
 var run = Ember.run;
 
-module("unit/store/adapter_interop - DS.Store working with a DS.Adapter", {
+module("unit/store/adapter-interop - DS.Store working with a DS.Adapter", {
   setup: function() {
     TestAdapter = DS.Adapter.extend();
   },
@@ -108,7 +108,7 @@ test("Returning a promise from `findRecord` asynchronously loads data", function
 });
 
 test("IDs provided as numbers are coerced to strings", function() {
-  expect(4);
+  expect(5);
 
   var adapter = TestAdapter.extend({
     findRecord: function(store, type, id, snapshot) {
@@ -152,7 +152,10 @@ test("can load data for the same record if it is not dirty", function() {
   });
 
   var store = createStore({
-    person: Person
+    person: Person,
+    adapter: DS.Adapter.extend({
+      shouldBackgroundReloadRecord: () => false
+    })
   });
 
   run(function() {
@@ -379,7 +382,10 @@ test("if an id is supplied in the initial data hash, it can be looked up using `
     name: DS.attr('string')
   });
   var store = createStore({
-    person: Person
+    person: Person,
+    adapter: DS.Adapter.extend({
+      shouldBackgroundReloadRecord: () => false
+    })
   });
   var person;
 
@@ -893,6 +899,7 @@ test("store should not reload record when shouldReloadRecord returns false", fun
       ok(true, 'shouldReloadRecord should be called when the record is in the store');
       return false;
     },
+    shouldBackgroundReloadRecord: () => false,
     findRecord: function() {
       ok(false, 'find should not be called when shouldReloadRecord returns false');
     }

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -50,6 +50,7 @@ module("unit/store/push - DS.Store#push", {
 
 test("Calling push with a normalized hash returns a record", function() {
   expect(2);
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     var person = store.push({
@@ -75,6 +76,7 @@ test("Calling push with a normalized hash returns a record", function() {
 
 test("Supplying a model class for `push` is the same as supplying a string", function () {
   expect(1);
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   var Programmer = Person.extend();
   env.registry.register('model:programmer', Programmer);
@@ -126,6 +128,7 @@ test("Calling push triggers `didLoad` even if the record hasn't been requested f
 
 test("Calling push with partial records updates just those attributes", function() {
   expect(2);
+  env.adapter.shouldBackgroundReloadRecord = () => false;
 
   run(function() {
     store.push({


### PR DESCRIPTION
This pr updates the `shouldReload*` flags to their default state for Ember Data 2.0. 

This pr is built on top of pr #3468 and assumes that will be merged first.