### PR TITLE
[DOC] Fill @property of DS.Model.modelName

### DIFF
--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -872,7 +872,7 @@ Model.reopenClass({
      }
    });
    ```
-   @property
+   @property modelName
    @type String
    @readonly
   */


### PR DESCRIPTION
Before this commit, the property would should up as not having a name
in the docs.

![invisible property](http://i.imgur.com/jzF2QYU.png)