### PR TITLE
[DOC release] Fix typo in JSONSerializer.extractAttributes docs

### DIFF
--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -536,7 +536,8 @@ var JSONSerializer = Serializer.extend({
 
     http://jsonapi.org/format/#document-resource-object-attributes
 
-    @method extractId
+    @method extractAttributes
+    @param {Object} modelClass
     @param {Object} resourceHash
     @return {Object}
   */


### PR DESCRIPTION
A fix for a small typo found when working on #3477 