### PR TITLE
Use `detail` instead of `details` for JSON API error objects

### DIFF
--- a/packages/ember-data/lib/adapters/errors.js
+++ b/packages/ember-data/lib/adapters/errors.js
@@ -12,7 +12,7 @@ export function AdapterError(errors, message = 'Adapter operation failed') {
   this.errors = errors || [
     {
       title: 'Adapter Error',
-      details: message
+      detail: message
     }
   ];
 }
@@ -56,11 +56,11 @@ AdapterError.prototype = Object.create(EmberError.prototype);
       // Fictional adapter that always rejects
       return Ember.RSVP.reject(new DS.InvalidError([
         {
-          details: 'Must be unique',
+          detail: 'Must be unique',
           source: { pointer: 'data/attributes/title' }
         },
         {
-          details: 'Must not be blank',
+          detail: 'Must not be blank',
           source: { pointer: 'data/attributes/content'}
         }
       ]));
@@ -119,7 +119,7 @@ export function errorsHashToArray(errors) {
       for (let i = 0; i < messages.length; i++) {
         out.push({
           title: 'Invalid Attribute',
-          details: messages[i],
+          detail: messages[i],
           source: {
             pointer: `data/attributes/${key}`
           }
@@ -142,7 +142,7 @@ export function errorsArrayToHash(errors) {
         if (key) {
           key = key[2];
           out[key] = out[key] || [];
-          out[key].push(error.details || error.title);
+          out[key].push(error.detail || error.title);
         }
       }
     });

--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -889,7 +889,7 @@ var RESTAdapter =  Adapter.extend(BuildURLMixin, {
         {
           status: `${status}`,
           title: "The backend responded with an error",
-          details: `${payload}`
+          detail: `${payload}`
         }
       ];
     }

--- a/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -1885,7 +1885,7 @@ test('on error wraps the error string in an DS.AdapterError object', function() 
   try {
     run(function() {
       store.find('post', '1').catch(function(err) {
-        equal(err.errors[0].details, errorThrown);
+        equal(err.errors[0].detail, errorThrown);
         ok(err, 'promise rejected');
       });
     });

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -566,11 +566,11 @@ test('extractErrors respects custom key mappings', function() {
     errors: [
       {
         source: { pointer: 'data/attributes/le_title' },
-        details: "title errors"
+        detail: "title errors"
       },
       {
         source: { pointer: 'data/attributes/my_comments' },
-        details: "comments errors"
+        detail: "comments errors"
       }
     ]
   };
@@ -591,7 +591,7 @@ test('extractErrors expects error information located on the errors property of 
     errors: [
       {
         source: { pointer: 'data/attributes/title' },
-        details: "title errors"
+        detail: "title errors"
       }
     ]
   };

--- a/packages/ember-data/tests/unit/adapter-errors-test.js
+++ b/packages/ember-data/tests/unit/adapter-errors-test.js
@@ -32,17 +32,17 @@ var errorsHash = {
 var errorsArray = [
   {
     title: 'Invalid Attribute',
-    details: 'is invalid',
+    detail: 'is invalid',
     source: { pointer: 'data/attributes/name' }
   },
   {
     title: 'Invalid Attribute',
-    details: 'must be a string',
+    detail: 'must be a string',
     source: { pointer: 'data/attributes/name' }
   },
   {
     title: 'Invalid Attribute',
-    details: 'must be a number',
+    detail: 'must be a number',
     source: { pointer: 'data/attributes/age' }
   }
 ];
@@ -67,7 +67,7 @@ test("DS.InvalidError will normalize errors hash with deprecation", function() {
   deepEqual(error.errors, [
     {
       title: 'Invalid Attribute',
-      details: 'is invalid',
+      detail: 'is invalid',
       source: { pointer: 'data/attributes/name' }
     }
   ]);


### PR DESCRIPTION
Fixes #3494.

The [current implementation](https://github.com/emberjs/data/blob/master/packages/ember-data/lib/adapters/errors.js#L145) reads the `details` property on JSON API errors.

[The JSON API spec](http://jsonapi.org/format/#error-objects) mentions a field named `detail`, which error objects "MAY" contain.

This PR changes all instances to be `detail`.