### PR TITLE
Assert serializers are using the same API

### DIFF
--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -355,6 +355,9 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
       if (parentRecord) {
         var name = parentRecord.name;
         var embeddedSerializer = store.serializerFor(embeddedSnapshot.modelName);
+
+        Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${embeddedSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(embeddedSerializer, 'isNewSerializerAPI'));
+
         var parentKey = embeddedSerializer.keyForRelationship(name, parentRecord.kind, 'deserialize');
         if (parentKey) {
           delete json[parentKey];
@@ -479,6 +482,8 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     }
     let modelClass = store.modelFor(modelName);
     let serializer = store.serializerFor(modelName);
+
+    Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${serializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(serializer, 'isNewSerializerAPI'));
 
     return serializer.normalize(modelClass, relationshipHash);
   }

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -7,6 +7,7 @@ import normalizeModelName from 'ember-data/system/normalize-model-name';
 import { pluralize, singularize } from 'ember-inflector/lib/system/string';
 
 var dasherize = Ember.String.dasherize;
+var get = Ember.get;
 
 /**
   @class JSONAPISerializer
@@ -58,6 +59,9 @@ export default JSONSerializer.extend({
     let modelName = this.modelNameFromPayloadKey(resourceHash.type);
     let modelClass = store.modelFor(modelName);
     let serializer = store.serializerFor(modelName);
+
+    Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${serializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(serializer, 'isNewSerializerAPI'));
+
     let { data } = serializer.normalize(modelClass, resourceHash);
     return data;
   },

--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -8,6 +8,7 @@ import {singularize} from "ember-inflector/lib/system/string";
 import coerceId from "ember-data/system/coerce-id";
 
 var camelize = Ember.String.camelize;
+var get = Ember.get;
 
 /**
   Normally, applications will use the `RESTSerializer` by implementing
@@ -147,6 +148,8 @@ var RESTSerializer = JSONSerializer.extend({
 
     let modelClass = store.modelFor(modelName);
     let serializer = store.serializerFor(modelName);
+
+    Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${serializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(serializer, 'isNewSerializerAPI'));
 
     arrayHash.forEach((hash) => {
       let { data, included } = serializer.normalize(modelClass, hash, prop);
@@ -339,6 +342,8 @@ var RESTSerializer = JSONSerializer.extend({
       }
       var type = store.modelFor(modelName);
       var typeSerializer = store.serializerFor(type.modelName);
+
+      Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${typeSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(typeSerializer, 'isNewSerializerAPI'));
 
       /*jshint loopfunc:true*/
       Ember.makeArray(payload[prop]).forEach((hash) => {


### PR DESCRIPTION
This makes it a little bit easier to track down issues where serializers collaborates and are using different versions (old/new) of the Serializer API.

Closes #3424