### PR TITLE
Assert serializers are using the same API

### DIFF
--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -350,6 +350,9 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
       if (parentRecord) {
         var name = parentRecord.name;
         var embeddedSerializer = this.store.serializerFor(embeddedSnapshot.modelName);
+
+        Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${embeddedSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(embeddedSerializer, 'isNewSerializerAPI'));
+
         var parentKey = embeddedSerializer.keyForRelationship(name, parentRecord.kind, 'deserialize');
         if (parentKey) {
           delete json[parentKey];
@@ -445,6 +448,9 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     var ids = [];
 
     var embeddedSerializer = store.serializerFor(embeddedTypeClass.modelName);
+
+    Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${embeddedSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(embeddedSerializer, 'isNewSerializerAPI'));
+
     forEach.call(hash[key], function(data) {
       var embeddedRecord = embeddedSerializer.normalize(embeddedTypeClass, data, null);
       store.push(embeddedTypeClass.modelName, embeddedRecord);
@@ -466,9 +472,12 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
 
     var ids = [];
 
-    forEach.call(hash[key], function(data) {
+    forEach.call(hash[key], (data) => {
       var modelName = data.type;
       var embeddedSerializer = store.serializerFor(modelName);
+
+      Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${embeddedSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(embeddedSerializer, 'isNewSerializerAPI'));
+
       var embeddedTypeClass = store.modelFor(modelName);
       // var primaryKey = embeddedSerializer.get('primaryKey');
 
@@ -495,6 +504,9 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     }
 
     var embeddedSerializer = store.serializerFor(embeddedTypeClass.modelName);
+
+    Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${embeddedSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(embeddedSerializer, 'isNewSerializerAPI'));
+
     var embeddedRecord = embeddedSerializer.normalize(embeddedTypeClass, hash[key], null);
     store.push(embeddedTypeClass.modelName, embeddedRecord);
 
@@ -514,6 +526,9 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     var data = hash[key];
     var modelName = data.type;
     var embeddedSerializer = store.serializerFor(modelName);
+
+    Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${embeddedSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(embeddedSerializer, 'isNewSerializerAPI'));
+
     var embeddedTypeClass = store.modelFor(modelName);
     // var primaryKey = embeddedSerializer.get('primaryKey');
 
@@ -536,6 +551,8 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     }
     let modelClass = store.modelFor(modelName);
     let serializer = store.serializerFor(modelName);
+
+    Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${serializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(serializer, 'isNewSerializerAPI'));
 
     return serializer.normalize(modelClass, relationshipHash, null);
   }

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -7,6 +7,7 @@ import normalizeModelName from 'ember-data/system/normalize-model-name';
 import { pluralize, singularize } from 'ember-inflector/lib/system/string';
 
 var dasherize = Ember.String.dasherize;
+var get = Ember.get;
 var map = Ember.ArrayPolyfills.map;
 
 /**
@@ -69,6 +70,9 @@ export default JSONSerializer.extend({
     let modelName = this.modelNameFromPayloadKey(resourceHash.type);
     let modelClass = this.store.modelFor(modelName);
     let serializer = this.store.serializerFor(modelName);
+
+    Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${serializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(serializer, 'isNewSerializerAPI'));
+
     let { data } = serializer.normalize(modelClass, resourceHash);
     return data;
   },

--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -475,6 +475,8 @@ var RESTSerializer = JSONSerializer.extend({
         var type = store.modelFor(typeName);
         var typeSerializer = store.serializerFor(type.modelName);
 
+        Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${typeSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(typeSerializer, 'isNewSerializerAPI'));
+
         hash = typeSerializer.normalize(type, hash, prop);
 
         var isFirstCreatedRecord = isPrimary && !recordId && !primaryRecord;
@@ -620,6 +622,9 @@ var RESTSerializer = JSONSerializer.extend({
       }
       var type = store.modelFor(typeName);
       var typeSerializer = store.serializerFor(type.modelName);
+
+      Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${typeSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(typeSerializer, 'isNewSerializerAPI'));
+
       var isPrimary = (!forcedSecondary && this.isPrimaryType(store, typeName, primaryTypeClass));
 
       /*jshint loopfunc:true*/
@@ -690,6 +695,8 @@ var RESTSerializer = JSONSerializer.extend({
       }
       var typeClass = store.modelFor(modelName);
       var typeSerializer = store.serializerFor(modelName);
+
+      Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${typeSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(typeSerializer, 'isNewSerializerAPI'));
 
       /*jshint loopfunc:true*/
       var normalizedArray = map.call(Ember.makeArray(payload[prop]), function(hash) {
@@ -1079,6 +1086,8 @@ function _newPushPayload(store, rawPayload) {
     }
     var type = store.modelFor(modelName);
     var typeSerializer = store.serializerFor(type.modelName);
+
+    Ember.assert(`${this.toString()} is using the ${get(this, 'isNewSerializerAPI') ? 'new' : 'old'} serializer API and expects ${typeSerializer.toString()} it collaborates with to do the same. Make sure to set \`isNewSerializerAPI: true\` in your custom serializers if you want to use the new Serializer API.`, get(this, 'isNewSerializerAPI') === get(typeSerializer, 'isNewSerializerAPI'));
 
     /*jshint loopfunc:true*/
     forEach.call(Ember.makeArray(payload[prop]), (hash) => {


### PR DESCRIPTION
This makes it a little bit easier to track down issues where serializers collaborates and are using different versions (old/new) of the Serializer API.

Closes #3424