### PR TITLE
Revert "[BUGFIX release] There is no `store` property on a serializer"

### DIFF
--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -94,7 +94,6 @@ var camelize = Ember.String.camelize;
 */
 var EmbeddedRecordsMixin = Ember.Mixin.create({
 
-  _store: Ember.inject.service('store'),
   /**
     Normalize the record and recursively normalize/extract all the embedded records
     while pushing them into the store as they are encountered
@@ -123,9 +122,8 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
    @return {Object} the normalized hash
   **/
   normalize: function(typeClass, hash, prop) {
-    var normalizedHash = this._super(typeClass, hash);
-    var store = this.get('_store');
-    return this._extractEmbeddedRecords(this, store, typeClass, normalizedHash);
+    var normalizedHash = this._super(typeClass, hash, prop);
+    return this._extractEmbeddedRecords(this, this.store, typeClass, normalizedHash);
   },
 
   keyForRelationship: function(key, typeClass, method) {
@@ -347,14 +345,13 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     @param {Object} json
   */
   removeEmbeddedForeignKey: function (snapshot, embeddedSnapshot, relationship, json) {
-    var store = this.get('_store');
     if (relationship.kind === 'hasMany') {
       return;
     } else if (relationship.kind === 'belongsTo') {
-      var parentRecord = snapshot.type.inverseFor(relationship.key, store);
+      var parentRecord = snapshot.type.inverseFor(relationship.key, this.store);
       if (parentRecord) {
         var name = parentRecord.name;
-        var embeddedSerializer = store.serializerFor(embeddedSnapshot.modelName);
+        var embeddedSerializer = this.store.serializerFor(embeddedSnapshot.modelName);
         var parentKey = embeddedSerializer.keyForRelationship(name, parentRecord.kind, 'deserialize');
         if (parentKey) {
           delete json[parentKey];
@@ -480,7 +477,7 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     let modelClass = store.modelFor(modelName);
     let serializer = store.serializerFor(modelName);
 
-    return serializer.normalize(modelClass, relationshipHash);
+    return serializer.normalize(modelClass, relationshipHash, null);
   }
 });
 

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -21,16 +21,16 @@ export default JSONSerializer.extend({
     @return {Object}
     @private
   */
-  _normalizeDocumentHelper: function(store, documentHash) {
+  _normalizeDocumentHelper: function(documentHash) {
 
     if (Ember.typeOf(documentHash.data) === 'object') {
-      documentHash.data = this._normalizeResourceHelper(store, documentHash.data);
+      documentHash.data = this._normalizeResourceHelper(documentHash.data);
     } else if (Ember.typeOf(documentHash.data) === 'array') {
-      documentHash.data = documentHash.data.map((resourceHash) => this._normalizeResourceHelper(store, resourceHash));
+      documentHash.data = documentHash.data.map(this._normalizeResourceHelper, this);
     }
 
     if (Ember.typeOf(documentHash.included) === 'array') {
-      documentHash.included = documentHash.included.map((resourceHash) => this._normalizeResourceHelper(store, resourceHash));
+      documentHash.included = documentHash.included.map(this._normalizeResourceHelper, this);
     }
 
     return documentHash;
@@ -54,10 +54,10 @@ export default JSONSerializer.extend({
     @return {Object}
     @private
   */
-  _normalizeResourceHelper: function(store, resourceHash) {
+  _normalizeResourceHelper: function(resourceHash) {
     let modelName = this.modelNameFromPayloadKey(resourceHash.type);
-    let modelClass = store.modelFor(modelName);
-    let serializer = store.serializerFor(modelName);
+    let modelClass = this.store.modelFor(modelName);
+    let serializer = this.store.serializerFor(modelName);
     let { data } = serializer.normalize(modelClass, resourceHash);
     return data;
   },
@@ -68,7 +68,7 @@ export default JSONSerializer.extend({
     @param {Object} payload
   */
   pushPayload: function(store, payload) {
-    let normalizedPayload = this._normalizeDocumentHelper(store, payload);
+    let normalizedPayload = this._normalizeDocumentHelper(payload);
     store.push(normalizedPayload);
   },
 
@@ -84,7 +84,7 @@ export default JSONSerializer.extend({
     @private
   */
   _normalizeResponse: function(store, primaryModelClass, payload, id, requestType, isSingle) {
-    let normalizedPayload = this._normalizeDocumentHelper(store, payload);
+    let normalizedPayload = this._normalizeDocumentHelper(payload);
     return normalizedPayload;
   },
 

--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -803,8 +803,7 @@ var JSONSerializer = Serializer.extend({
     @return {boolean} true if the hasMany relationship should be serialized
   */
   _shouldSerializeHasMany: function (snapshot, key, relationship) {
-    var store = snapshot.record.store;
-    var relationshipType = snapshot.type.determineRelationshipType(relationship, store);
+    var relationshipType = snapshot.type.determineRelationshipType(relationship, this.store);
     if (this._mustSerialize(key)) {
       return true;
     }

--- a/tests/ember-configuration.js
+++ b/tests/ember-configuration.js
@@ -99,7 +99,7 @@
     registry.register('adapter:-json-api', DS.JSONAPIAdapter);
     registry.register('serializer:-json-api', DS.JSONAPISerializer);
 
-    registry.register('service:store', DS.Store);
+    registry.injection('serializer', 'store', 'store:main');
 
     env.serializer = container.lookup('serializer:-default');
     env.restSerializer = container.lookup('serializer:-rest');


### PR DESCRIPTION
Reverts emberjs/data#3506

Looks like I was wrong and a `store` property gets set by `retrieveManagedInstance` https://github.com/bmac/data/blob/18a3c3a356995d1d8f95f02152185699cd99063b/packages/ember-data/lib/system/store.js#L2078