### PR TITLE
Add error message in _pushInternalMessage when unknown type

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1702,10 +1702,15 @@ Store = Service.extend({
     return internalModel.getRecord();
   },
 
+  _hasModelFor: function(type) {
+    return this.container.lookupFactory(`model:${type}`);
+  },
+
   _pushInternalModel: function(data) {
     var modelName = data.type;
     Ember.assert(`Expected an object as 'data' in a call to 'push' for ${modelName}, but was ${Ember.typeOf(data)}`, Ember.typeOf(data) === 'object');
     Ember.assert(`You must include an 'id' for ${modelName} in an object passed to 'push'`, data.id != null && data.id !== '');
+    Ember.assert(`You tried to push data with a type '${modelName}' but no model could be found with that name.`, this._hasModelFor(modelName));
 
     var type = this.modelFor(modelName);
 

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -476,6 +476,20 @@ test('Calling push with a link for a non async relationship should warn', functi
   }, /You have pushed a record of type 'person' with 'phoneNumbers' as a link, but the association is not an async relationship./);
 });
 
+test('Calling push with an unknown model name throws an assertion error', function() {
+
+  expectAssertion(function() {
+    run(function() {
+      store.push({
+        data: {
+          id: '1',
+          type: 'unknown'
+        }
+      });
+    });
+  }, /You tried to push data with a type 'unknown' but no model could be found with that name/);
+});
+
 test('Calling push with a link containing an object throws an assertion error', function() {
   Person.reopen({
     phoneNumbers: hasMany('phone-number', { async: true })


### PR DESCRIPTION
When pushing data with an unknown type, an error is raised.
Fix #3542