### PR TITLE
[BUGFIX release] Guard against isDestroyed in ManyArray.flushCanonical

### DIFF
--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -4,6 +4,7 @@
 import Ember from 'ember';
 import { assert } from "ember-data/-private/debug";
 import { PromiseArray } from "ember-data/-private/system/promise-proxies";
+import { _objectIsAlive } from "ember-data/-private/system/store/common";
 
 var get = Ember.get;
 var set = Ember.set;
@@ -84,7 +85,10 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
     toSet = toSet.concat(newRecords);
     var oldLength = this.length;
     this.arrayContentWillChange(0, this.length, toSet.length);
-    this.set('length', toSet.length);
+    // It’s possible the parent side of the relationship may have been unloaded by this point
+    if (_objectIsAlive(this)) {
+      this.set('length', toSet.length);
+    }
     this.currentState = toSet;
     this.arrayContentDidChange(0, oldLength, this.length);
     //TODO Figure out to notify only on additions and maybe only if unloaded


### PR DESCRIPTION
Addresses #3084

This is the simplest-possible-patch I could find to get around a real pain point for unloading records. It looks like you guys are doing more fundamental work to address this but I wonder if we could put a fix like this in place as a stopgap.

If it’s needless and the real fix is about to land, I totally understand. If you think it is worthwhile I’ll flesh it out and add tests.
