### PR TITLE
`DS.Store#findQuery` overrides `DS.Store#query` docs

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1156,7 +1156,7 @@ Store = Service.extend({
     This method returns a promise, which is resolved with a `RecordArray`
     once the server returns.
 
-    @method query
+    @method findQuery
     @param {String} modelName
     @param {any} query an opaque query to be used by the adapter
     @return {Promise} promise


### PR DESCRIPTION
`DS.Store#findQuery` [is mistakenly marked `@method query`](https://github.com/emberjs/data/blob/3d40f37767cc84e355033e3e89bf26dd1803d996/packages/ember-data/lib/system/store.js#L1136), so `DS.Store#query` is [improperly documented and marked as deprecated](http://emberjs.com/api/data/classes/DS.Store.html#method_query) in the API documentation.