### PR TITLE
[DOC release] Update misleading example for Adapter.queryRecord()

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -199,13 +199,16 @@ var Adapter = Ember.Object.extend({
 
     Example
 
-    ```javascript
-    App.ApplicationAdapter = DS.Adapter.extend({
-      queryRecord: function(store, typeClass, query) {
-        var url = [type.typeKey, id].join('/');
+    ```app/adapters/application.js
+    import DS from 'ember-data';
+    import Ember from 'ember';
+
+    export default DS.Adapter.extend(DS.BuildURLMixin, {
+      queryRecord: function(store, type, query) {
+        var urlForQueryRecord = this.buildURL(type.modelName, null, null, 'queryRecord', query);
 
         return new Ember.RSVP.Promise(function(resolve, reject) {
-          Ember.$.getJSON(url, query).then(function(data) {
+          Ember.$.getJSON(urlForQueryRecord, query).then(function(data) {
             Ember.run(null, resolve, data);
           }, function(jqXHR) {
             jqXHR.then = null; // tame jQuery's ill mannered promises
@@ -220,7 +223,6 @@ var Adapter = Ember.Object.extend({
     @param {DS.Store} store
     @param {subclass of DS.Model} type
     @param {Object} query
-    @param {String} id
     @return {Promise} promise
   */
   queryRecord: null,


### PR DESCRIPTION
- Uses ember-cli style modules
- Removes `id` param