### PR TITLE
Add ember-cli-dependency-checker.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "defeatureify": "~0.1.4",
     "ejs": "^1.0.0",
     "ember-cli": "^0.1.15",
+    "ember-cli-dependency-checker": "^1.0.1",
     "ember-inflector": "^1.9.0",
     "ember-publisher": "0.0.7",
     "es6-module-transpiler": "^0.9.5",


### PR DESCRIPTION
Since we are using ember-cli to build ember-data we can take advantage of the work done in ember-cli-dependency-checker to ensure that the deps in `node_modules` and `bower_components` actually match what is specified in the `package.json`/`bower.json`.

With this added, running `ember` commands will error if matching versions are not found.

This will help prevent issues like #3635 in the future.