### PR TITLE
Adapter.query should be part of the public overrideable interface.

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -177,7 +177,6 @@ var Adapter = Ember.Object.extend({
     });
     ```
 
-    @private
     @method query
     @param {DS.Store} store
     @param {DS.Model} type


### PR DESCRIPTION
[The docs tell us to override `query`][override-docs] so it should be public.

This was made private in a commit in 2013 (ec2e040a) by @rwjblue. Many of the other private methods in that commit are now public.

[override-docs]: https://github.com/emberjs/data/blob/v1.13.8/packages/ember-data/lib/system/adapter.js#L47