### PR TITLE
Don’t crash \w Ember 2.0

### DIFF
--- a/packages/activemodel-adapter/lib/system/active-model-serializer.js
+++ b/packages/activemodel-adapter/lib/system/active-model-serializer.js
@@ -1,11 +1,11 @@
 import { singularize } from "ember-inflector";
 import RESTSerializer from "ember-data/serializers/rest-serializer";
 import normalizeModelName from "ember-data/system/normalize-model-name";
+import { forEach } from "ember-data/ext/ember/enumerable-utils";
+
 /**
   @module ember-data
 */
-
-var forEach = Ember.EnumerableUtils.forEach;
 var camelize =   Ember.String.camelize;
 var classify = Ember.String.classify;
 var decamelize = Ember.String.decamelize;

--- a/packages/ember-data/lib/adapters/errors.js
+++ b/packages/ember-data/lib/adapters/errors.js
@@ -1,7 +1,9 @@
-const EmberError = Ember.Error;
-const create = Ember.create;
+import { forEach } from 'ember-data/ext/ember/array';
 
-const forEach = Ember.ArrayPolyfills.forEach;
+const EmberError = Ember.Error;
+const create = Object.create || Ember.create;
+
+
 const SOURCE_POINTER_REGEXP = /data\/(attributes|relationships)\/(.*)/;
 
 /**

--- a/packages/ember-data/lib/adapters/fixture-adapter.js
+++ b/packages/ember-data/lib/adapters/fixture-adapter.js
@@ -1,9 +1,11 @@
+import ArrayPolyfills  from 'ember-data/ext/ember/array';
 /**
   @module ember-data
 */
 var get = Ember.get;
 var fmt = Ember.String.fmt;
-var indexOf = Ember.ArrayPolyfills.indexOf;
+
+var indexOf = ArrayPolyfills.indexOf;
 
 var counter = 0;
 

--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -12,9 +12,11 @@ import {
 import {
   MapWithDefault
 } from "ember-data/system/map";
+import ArrayPolyfills  from 'ember-data/ext/ember/array';
+
 var get = Ember.get;
 var set = Ember.set;
-var forEach = Ember.ArrayPolyfills.forEach;
+var forEach = ArrayPolyfills.forEach;
 
 import BuildURLMixin from "ember-data/adapters/build-url-mixin";
 

--- a/packages/ember-data/lib/ext/ember/array.js
+++ b/packages/ember-data/lib/ext/ember/array.js
@@ -1,0 +1,2 @@
+import Ember from 'ember';
+export default (Array.prorotype || Ember.ArrayPolyfills);

--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -1,6 +1,8 @@
+import ArrayPolyfills from 'ember-data/ext/ember/array';
+
 var get = Ember.get;
 var set = Ember.set;
-var forEach = Ember.ArrayPolyfills.forEach;
+var forEach = ArrayPolyfills.forEach;
 var camelize = Ember.String.camelize;
 
 /**

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -5,9 +5,9 @@
 import JSONSerializer from 'ember-data/serializers/json-serializer';
 import normalizeModelName from 'ember-data/system/normalize-model-name';
 import { pluralize, singularize } from 'ember-inflector/lib/system/string';
+import { map } from "ember-data/ext/ember/enumerable-utils";
 
 var dasherize = Ember.String.dasherize;
-var map = Ember.EnumerableUtils.map;
 
 /**
   @class JSONAPISerializer

--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -3,10 +3,11 @@ import coerceId from "ember-data/system/coerce-id";
 import normalizeModelName from "ember-data/system/normalize-model-name";
 
 import { errorsArrayToHash } from "ember-data/adapters/errors";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var get = Ember.get;
 var isNone = Ember.isNone;
-var map = Ember.ArrayPolyfills.map;
+var map = ArrayPolyfills.map;
 var merge = Ember.merge;
 
 /*

--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -7,9 +7,10 @@ import normalizeModelName from "ember-data/system/normalize-model-name";
 import {singularize} from "ember-inflector/lib/system/string";
 import coerceId from "ember-data/system/coerce-id";
 import { pushPayload } from "ember-data/system/store/serializer-response";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
-var forEach = Ember.ArrayPolyfills.forEach;
-var map = Ember.ArrayPolyfills.map;
+var forEach = ArrayPolyfills.forEach;
+var map = ArrayPolyfills.map;
 var camelize = Ember.String.camelize;
 
 /**

--- a/packages/ember-data/lib/system/many-array.js
+++ b/packages/ember-data/lib/system/many-array.js
@@ -2,10 +2,11 @@
   @module ember-data
 */
 import { PromiseArray } from "ember-data/system/promise-proxies";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var get = Ember.get;
 var set = Ember.set;
-var filter = Ember.ArrayPolyfills.filter;
+var filter = ArrayPolyfills.filter;
 
 /**
   A `ManyArray` is a `MutableArray` that represents the contents of a has-many
@@ -192,7 +193,7 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
       records = this.currentState.slice(idx, idx+amt);
       this.get('relationship').removeRecords(records);
     }
-    var map = objects.map || Ember.ArrayPolyfills.map;
+    var map = objects.map || ArrayPolyfills.map;
     if (objects) {
       this.get('relationship').addRecords(map.call(objects, function(obj) { return obj._internalModel; }), idx);
     }

--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -1,6 +1,7 @@
 var get = Ember.get;
 var isEmpty = Ember.isEmpty;
-var map = Ember.ArrayPolyfills.map;
+import ArrayPolyfills from 'ember-data/ext/ember/array';
+var map = ArrayPolyfills.map;
 
 import {
   MapWithDefault

--- a/packages/ember-data/lib/system/model/internal-model.js
+++ b/packages/ember-data/lib/system/model/internal-model.js
@@ -2,12 +2,14 @@ import merge from "ember-data/system/merge";
 import RootState from "ember-data/system/model/states";
 import Relationships from "ember-data/system/relationships/state/create";
 import Snapshot from "ember-data/system/snapshot";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var Promise = Ember.RSVP.Promise;
 var get = Ember.get;
 var set = Ember.set;
-var forEach = Ember.ArrayPolyfills.forEach;
-var map = Ember.ArrayPolyfills.map;
+
+var forEach = ArrayPolyfills.forEach;
+var map = ArrayPolyfills.map;
 
 var _extractPivotNameCache = Ember.create(null);
 var _splitOnDotCache = Ember.create(null);

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -1,13 +1,14 @@
 import { PromiseObject } from "ember-data/system/promise-proxies";
 import Errors from "ember-data/system/model/errors";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 /**
   @module ember-data
 */
 
 var get = Ember.get;
-var forEach = Ember.ArrayPolyfills.forEach;
-var indexOf = Ember.ArrayPolyfills.indexOf;
+var forEach = ArrayPolyfills.forEach;
+var indexOf = ArrayPolyfills.indexOf;
 
 function intersection (array1, array2) {
   var result = [];

--- a/packages/ember-data/lib/system/record-array-manager.js
+++ b/packages/ember-data/lib/system/record-array-manager.js
@@ -11,9 +11,11 @@ import {
   MapWithDefault
 } from "ember-data/system/map";
 import OrderedSet from "ember-data/system/ordered-set";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
+
 var get = Ember.get;
-var forEach = Ember.ArrayPolyfills.forEach;
-var indexOf = Ember.ArrayPolyfills.indexOf;
+var forEach = ArrayPolyfills.forEach;
+var indexOf = ArrayPolyfills.indexOf;
 
 /**
   @class RecordArrayManager

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -7,9 +7,10 @@ import {
   Map,
   MapWithDefault
 } from "ember-data/system/map";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var get = Ember.get;
-var filter = Ember.ArrayPolyfills.filter;
+var filter = ArrayPolyfills.filter;
 
 var relationshipsDescriptor = Ember.computed(function() {
   if (Ember.testing === true && relationshipsDescriptor._cacheable === true) {

--- a/packages/ember-data/lib/system/relationships/state/has-many.js
+++ b/packages/ember-data/lib/system/relationships/state/has-many.js
@@ -2,10 +2,11 @@ import { PromiseManyArray } from "ember-data/system/promise-proxies";
 import Relationship from "ember-data/system/relationships/state/relationship";
 import OrderedSet from "ember-data/system/ordered-set";
 import ManyArray from "ember-data/system/many-array";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 import { assertPolymorphicType } from "ember-data/utils";
 
-var map = Ember.ArrayPolyfills.map;
+var map = ArrayPolyfills.map;
 
 
 var ManyRelationship = function(store, record, inverseKey, relationshipMeta) {

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -1,6 +1,7 @@
 import OrderedSet from "ember-data/system/ordered-set";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
-var forEach = Ember.ArrayPolyfills.forEach;
+var forEach = ArrayPolyfills.forEach;
 
 function Relationship(store, record, inverseKey, relationshipMeta) {
   this.members = new OrderedSet();

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -50,6 +50,7 @@ import RecordArrayManager from "ember-data/system/record-array-manager";
 import ContainerInstanceCache from 'ember-data/system/store/container-instance-cache';
 
 import InternalModel from "ember-data/system/model/internal-model";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var Backburner = Ember._Backburner || Ember.Backburner || Ember.__loader.require('backburner')['default'] || Ember.__loader.require('backburner')['Backburner'];
 
@@ -106,9 +107,10 @@ var get = Ember.get;
 var set = Ember.set;
 var once = Ember.run.once;
 var isNone = Ember.isNone;
-var forEach = Ember.ArrayPolyfills.forEach;
-var indexOf = Ember.ArrayPolyfills.indexOf;
-var map = Ember.ArrayPolyfills.map;
+var forEach = ArrayPolyfills.forEach;
+var indexOf = ArrayPolyfills.indexOf;
+var map = ArrayPolyfills.map;
+var filter = ArrayPolyfills.filter;
 var Promise = Ember.RSVP.Promise;
 var copy = Ember.copy;
 var Store;
@@ -1806,7 +1808,6 @@ Store = Service.extend({
     Ember.assert("You must include an `id` for " + modelName + " in an object passed to `push`", data.id != null && data.id !== '');
 
     var type = this.modelFor(modelName);
-    var filter = Ember.ArrayPolyfills.filter;
 
     // If Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS is set to true and the payload
     // contains unknown keys, log a warning.

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -12,9 +12,10 @@ import {
 import {
   serializerForAdapter
 } from "ember-data/system/store/serializers";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var Promise = Ember.RSVP.Promise;
-var map = Ember.ArrayPolyfills.map;
+var map = ArrayPolyfills.map;
 var get = Ember.get;
 
 export function _find(adapter, store, typeClass, id, internalModel, options) {

--- a/packages/ember-data/lib/system/store/serializer-response.js
+++ b/packages/ember-data/lib/system/store/serializer-response.js
@@ -1,7 +1,8 @@
 import Model from 'ember-data/system/model/model';
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
-var forEach = Ember.ArrayPolyfills.forEach;
-var map = Ember.ArrayPolyfills.map;
+var forEach = ArrayPolyfills.forEach;
+var map = ArrayPolyfills.map;
 var get = Ember.get;
 
 /**

--- a/packages/ember-data/tests/integration/filter-test.js
+++ b/packages/ember-data/tests/integration/filter-test.js
@@ -1,9 +1,10 @@
 import customAdapter from 'ember-data/tests/helpers/custom-adapter';
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var get = Ember.get;
 var set = Ember.set;
-var forEach = Ember.ArrayPolyfills.forEach;
-var indexOf = Ember.ArrayPolyfills.indexOf;
+var forEach = ArrayPolyfills.forEach;
+var indexOf = ArrayPolyfills.indexOf;
 var run = Ember.run;
 
 var Person, store, env, array, recordArray;

--- a/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
@@ -1,7 +1,10 @@
+import ArrayPolyfills from 'ember-data/ext/ember/array';
+
 var get = Ember.get;
 var HomePlanet, SuperVillain, EvilMinion, SecretLab, SecretWeapon, BatCave, Comment,
   league, superVillain, evilMinion, secretWeapon, homePlanet, secretLab, env;
-var indexOf = Ember.ArrayPolyfills.indexOf;
+
+var indexOf = ArrayPolyfills.indexOf;
 var run = Ember.run;
 var LightSaber;
 

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -3,7 +3,8 @@ var attr = DS.attr;
 var hasMany = DS.hasMany;
 var belongsTo = DS.belongsTo;
 var run = Ember.run;
-var forEach = Ember.ArrayPolyfills.forEach;
+import ArrayPolyfills from 'ember-data/ext/ember/array';
+var forEach = ArrayPolyfills.forEach;
 
 module("unit/store/push - DS.Store#push", {
   setup: function() {

--- a/packages/ember/lib/main.js
+++ b/packages/ember/lib/main.js
@@ -1,2 +1,3 @@
 // Shim Ember module
+
 export default Ember;


### PR DESCRIPTION
There may be more, but this at-least makes my one app work correctly.

- [ ] try getting tests working to get actual confidence.
- [ ] fix other things
- [ ] instead of poluting the Ember object, we should instead add a level of indirection by moving the polifills to a local module, and doing the funky work there.

Goal:
------

to ease upgrade pain for people
