### PR TITLE
If using {{input value=date}},  should got the right date instead of null.

### DIFF
--- a/packages/ember-data/lib/transforms/date.js
+++ b/packages/ember-data/lib/transforms/date.js
@@ -38,8 +38,12 @@ export default Transform.extend({
   },
 
   serialize: function(date) {
+    var type = typeof date;
+
     if (date instanceof Date) {
       return date.toISOString();
+    } else if (type === "string") {
+      return new Date(Ember.Date.parse(date)).toISOString();
     } else {
       return null;
     }

--- a/packages/ember-data/tests/unit/transform/date-test.js
+++ b/packages/ember-data/tests/unit/transform/date-test.js
@@ -11,6 +11,7 @@ test("#serialize", function() {
   equal(transform.serialize(undefined), null);
 
   equal(transform.serialize(date), dateString);
+  equal(transform.serialize(dateString), dateString);
 });
 
 test("#deserialize", function() {


### PR DESCRIPTION
To avoid writing below code in Ember app.

```javascript
export default Ember.Component.extend({
  actions: {
    save: function(item) {
      let self = this;
      item.set('start', new Date(item.get('start'))); # not necessary
      item.set('end', new Date(item.get('end')));   # after apply this commit.
      item.save().then(function() {
        self.set('isEditing', false);
      });
    }
  }
});
```
