### PR TITLE
Added documentation to modify the hash by reference when working with `serializeIntoHash`

### DIFF
--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -988,6 +988,7 @@ var JSONSerializer = Serializer.extend({
     the payload and just sends the raw serialized JSON object.
     If your server expects namespaced keys, you should consider using the RESTSerializer.
     Otherwise you can override this method to customize how the record is added to the hash.
+    The hash property should be modified by reference (possibly using something like _.extend)
 
     For example, your server may expect underscored root objects.
 

--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -578,6 +578,7 @@ var RESTSerializer = JSONSerializer.extend({
 
   /**
     You can use this method to customize the root keys serialized into the JSON.
+    The hash property should be modified by reference (possibly using something like _.extend)
     By default the REST Serializer sends the modelName of a model, which is a camelized
     version of the name.
 


### PR DESCRIPTION
When working with `serializeIntoHash` if you want to modify the hash with a full set of other results, you are forced to either overwrite each individual key OR use something like `_.extend` to modify the `hash` argument in place using pass by reference.

This is a common use case when creating adapters for APIs that do not have a rootKey (though strongly discouraged).

I think this addition (or something to the effect should be added to make sure that this functionality is documented.