### PR TITLE
[BUGFIX beta] Fix usage of registry for 2.1.0+.

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1475,8 +1475,11 @@ Store = Service.extend({
 
   _modelForMixin: function(modelName) {
     var normalizedModelName = normalizeModelName(modelName);
-    var registry = this.container._registry ? this.container._registry : this.container;
-    var mixin = registry.resolve('mixin:' + normalizedModelName);
+    // container.registry = 2.1
+    // container._registry = 1.11 - 2.0
+    // container = < 1.11
+    var registry = this.container.registry || this.container._registry || this.container;
+    var mixin = this.container.lookupFactory('mixin:' + normalizedModelName);
     if (mixin) {
       //Cache the class as a model
       registry.register('model:' + normalizedModelName, DS.Model.extend(mixin));

--- a/packages/ember-data/tests/unit/many-array-test.js
+++ b/packages/ember-data/tests/unit/many-array-test.js
@@ -98,13 +98,13 @@ test("manyArray trigger arrayContentChange functions with the correct values", f
       willChangeStartIdx = startIdx;
       willChangeRemoveAmt = removeAmt;
       willChangeAddAmt = addAmt;
-      return this._super.apply(arguments);
+      return this._super.apply(this, arguments);
     },
     arrayContentDidChange: function(startIdx, removeAmt, addAmt) {
       equal(startIdx, willChangeStartIdx, 'WillChange and DidChange startIdx should match');
       equal(removeAmt, willChangeRemoveAmt, 'WillChange and DidChange removeAmt should match');
       equal(addAmt, willChangeAddAmt, 'WillChange and DidChange addAmt should match');
-      return this._super.apply(arguments);
+      return this._super.apply(this, arguments);
     }
   });
   run(function() {


### PR DESCRIPTION
Using `registry.resolve` is generally private API, and `container.lookupFactory` provides roughly the same result.

We still need the registry to actually register the model we create, so I added a small matrix inline (this was the only usage of accessing the registry off of `this.container` that I found in the codebase).