### PR TITLE
Don’t crash \w Ember 2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "qunit": "~1.17.0",
     "jquery": "~1.10.x",
-    "loader.js": "~1.0.0",
+    "loader.js": "~3.3.0",
     "es5-shim": "~4.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "broccoli-yuidoc": "^1.3.0",
     "defeatureify": "~0.1.4",
     "ejs": "^1.0.0",
-    "ember-cli": "^0.1.15",
+    "ember-cli": "^0.2.2",
     "ember-new-computed": "1.0.2",
     "ember-inflector": "^1.9.0",
     "ember-publisher": "0.0.7",

--- a/packages/activemodel-adapter/lib/system/active-model-serializer.js
+++ b/packages/activemodel-adapter/lib/system/active-model-serializer.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import RESTSerializer from 'ember-data/serializers/rest-serializer';
 import normalizeModelName from 'ember-data/system/normalize-model-name';
-
 /**
   @module ember-data
  */

--- a/packages/ember-data/lib/adapters/errors.js
+++ b/packages/ember-data/lib/adapters/errors.js
@@ -1,4 +1,5 @@
-import { forEach } from 'ember-data/ext/ember/array';
+import ArrayPolyfills  from 'ember-data/ext/ember/array';
+var forEach = ArrayPolyfills.forEach;
 
 const EmberError = Ember.Error;
 const SOURCE_POINTER_REGEXP = /^\/?data\/(attributes|relationships)\/(.*)/;

--- a/packages/ember-data/lib/adapters/errors.js
+++ b/packages/ember-data/lib/adapters/errors.js
@@ -1,5 +1,6 @@
+import { forEach } from 'ember-data/ext/ember/array';
+
 const EmberError = Ember.Error;
-const forEach = Ember.ArrayPolyfills.forEach;
 const SOURCE_POINTER_REGEXP = /^\/?data\/(attributes|relationships)\/(.*)/;
 
 import {

--- a/packages/ember-data/lib/adapters/fixture-adapter.js
+++ b/packages/ember-data/lib/adapters/fixture-adapter.js
@@ -1,9 +1,11 @@
+import ArrayPolyfills  from 'ember-data/ext/ember/array';
 /**
   @module ember-data
 */
 var get = Ember.get;
 var fmt = Ember.String.fmt;
-var indexOf = Ember.ArrayPolyfills.indexOf;
+
+var indexOf = ArrayPolyfills.indexOf;
 
 var counter = 0;
 

--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -12,9 +12,11 @@ import {
 import {
   MapWithDefault
 } from "ember-data/system/map";
+import ArrayPolyfills  from 'ember-data/ext/ember/array';
+
 var get = Ember.get;
 var set = Ember.set;
-var forEach = Ember.ArrayPolyfills.forEach;
+var forEach = ArrayPolyfills.forEach;
 
 import {
   create,

--- a/packages/ember-data/lib/ext/ember/array.js
+++ b/packages/ember-data/lib/ext/ember/array.js
@@ -1,0 +1,2 @@
+import Ember from 'ember';
+export default (Array.prorotype || Ember.ArrayPolyfills);

--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -1,6 +1,8 @@
+import ArrayPolyfills from 'ember-data/ext/ember/array';
+
 var get = Ember.get;
 var set = Ember.set;
-var forEach = Ember.ArrayPolyfills.forEach;
+var forEach = ArrayPolyfills.forEach;
 var camelize = Ember.String.camelize;
 
 /**

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -5,10 +5,9 @@
 import JSONSerializer from 'ember-data/serializers/json-serializer';
 import normalizeModelName from 'ember-data/system/normalize-model-name';
 import { pluralize, singularize } from 'ember-inflector/lib/system/string';
+import { map } from "ember-data/ext/ember/enumerable-utils";
 
 var dasherize = Ember.String.dasherize;
-var get = Ember.get;
-var map = Ember.ArrayPolyfills.map;
 
 /**
   Ember Data 2.0 Serializer:

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -5,7 +5,8 @@
 import JSONSerializer from 'ember-data/serializers/json-serializer';
 import normalizeModelName from 'ember-data/system/normalize-model-name';
 import { pluralize, singularize } from 'ember-inflector/lib/system/string';
-import { map } from "ember-data/ext/ember/enumerable-utils";
+import ArrayPolyfills  from 'ember-data/ext/ember/array';
+var map = ArrayPolyfills.map;
 
 var dasherize = Ember.String.dasherize;
 
@@ -462,4 +463,3 @@ export default JSONSerializer.extend({
     }
   }
 });
-

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -180,7 +180,6 @@ export default JSONSerializer.extend({
     @private
   */
   _normalizeResponse: function(store, primaryModelClass, payload, id, requestType, isSingle) {
-
     let normalizedPayload = this._normalizeDocumentHelper(payload);
     return normalizedPayload;
   },

--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -6,9 +6,11 @@ import JSONSerializer from 'ember-data/serializers/json-serializer';
 import normalizeModelName from 'ember-data/system/normalize-model-name';
 import { pluralize, singularize } from 'ember-inflector/lib/system/string';
 import ArrayPolyfills  from 'ember-data/ext/ember/array';
-var map = ArrayPolyfills.map;
+import Ember from 'ember';
 
-var dasherize = Ember.String.dasherize;
+const map = ArrayPolyfills.map;
+const dasherize = Ember.String.dasherize;
+const get = Ember.get;
 
 /**
   Ember Data 2.0 Serializer:

--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -3,10 +3,11 @@ import coerceId from "ember-data/system/coerce-id";
 import normalizeModelName from "ember-data/system/normalize-model-name";
 
 import { errorsArrayToHash } from "ember-data/adapters/errors";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var get = Ember.get;
 var isNone = Ember.isNone;
-var map = Ember.ArrayPolyfills.map;
+var map = ArrayPolyfills.map;
 var merge = Ember.merge;
 
 /**

--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -7,13 +7,14 @@ import normalizeModelName from "ember-data/system/normalize-model-name";
 import {singularize} from "ember-inflector/lib/system/string";
 import coerceId from "ember-data/system/coerce-id";
 import { pushPayload } from "ember-data/system/store/serializer-response";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 import {
   keysFunc
 } from 'ember-data/system/object-polyfills';
 
-var forEach = Ember.ArrayPolyfills.forEach;
-var map = Ember.ArrayPolyfills.map;
+var forEach = ArrayPolyfills.forEach;
+var map = ArrayPolyfills.map;
 var camelize = Ember.String.camelize;
 var get = Ember.get;
 

--- a/packages/ember-data/lib/system/many-array.js
+++ b/packages/ember-data/lib/system/many-array.js
@@ -2,10 +2,11 @@
   @module ember-data
 */
 import { PromiseArray } from "ember-data/system/promise-proxies";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var get = Ember.get;
 var set = Ember.set;
-var filter = Ember.ArrayPolyfills.filter;
+var filter = ArrayPolyfills.filter;
 
 /**
   A `ManyArray` is a `MutableArray` that represents the contents of a has-many
@@ -192,7 +193,7 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
       records = this.currentState.slice(idx, idx+amt);
       this.get('relationship').removeRecords(records);
     }
-    var map = objects.map || Ember.ArrayPolyfills.map;
+    var map = objects.map || ArrayPolyfills.map;
     if (objects) {
       this.get('relationship').addRecords(map.call(objects, function(obj) { return obj._internalModel; }), idx);
     }

--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -1,8 +1,9 @@
 var get = Ember.get;
 var set = Ember.set;
 var isEmpty = Ember.isEmpty;
-var map = Ember.ArrayPolyfills.map;
 var makeArray = Ember.makeArray;
+import ArrayPolyfills from 'ember-data/ext/ember/array';
+var map = ArrayPolyfills.map;
 
 import {
   MapWithDefault

--- a/packages/ember-data/lib/system/model/internal-model.js
+++ b/packages/ember-data/lib/system/model/internal-model.js
@@ -2,6 +2,7 @@ import merge from "ember-data/system/merge";
 import RootState from "ember-data/system/model/states";
 import Relationships from "ember-data/system/relationships/state/create";
 import Snapshot from "ember-data/system/snapshot";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 import {
   create,
@@ -11,8 +12,9 @@ import {
 var Promise = Ember.RSVP.Promise;
 var get = Ember.get;
 var set = Ember.set;
-var forEach = Ember.ArrayPolyfills.forEach;
-var map = Ember.ArrayPolyfills.map;
+
+var forEach = ArrayPolyfills.forEach;
+var map = ArrayPolyfills.map;
 
 var _extractPivotNameCache = create(null);
 var _splitOnDotCache = create(null);

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -1,5 +1,6 @@
 import { PromiseObject } from "ember-data/system/promise-proxies";
 import Errors from "ember-data/system/model/errors";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 import {
   create,
@@ -14,10 +15,10 @@ var errorDeprecationShown = false;
 */
 
 var get = Ember.get;
-var forEach = Ember.ArrayPolyfills.forEach;
-var indexOf = Ember.ArrayPolyfills.indexOf;
 var merge = Ember.merge;
 var copy = Ember.copy;
+var forEach = ArrayPolyfills.forEach;
+var indexOf = ArrayPolyfills.indexOf;
 
 function intersection (array1, array2) {
   var result = [];

--- a/packages/ember-data/lib/system/record-array-manager.js
+++ b/packages/ember-data/lib/system/record-array-manager.js
@@ -11,9 +11,11 @@ import {
   MapWithDefault
 } from "ember-data/system/map";
 import OrderedSet from "ember-data/system/ordered-set";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
+
 var get = Ember.get;
-var forEach = Ember.ArrayPolyfills.forEach;
-var indexOf = Ember.ArrayPolyfills.indexOf;
+var forEach = ArrayPolyfills.forEach;
+var indexOf = ArrayPolyfills.indexOf;
 
 /**
   @class RecordArrayManager

--- a/packages/ember-data/lib/system/relationships/ext.js
+++ b/packages/ember-data/lib/system/relationships/ext.js
@@ -7,13 +7,14 @@ import {
   Map,
   MapWithDefault
 } from "ember-data/system/map";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 import {
   create
 } from 'ember-data/system/object-polyfills';
 
 var get = Ember.get;
-var filter = Ember.ArrayPolyfills.filter;
+var filter = ArrayPolyfills.filter;
 
 var relationshipsDescriptor = Ember.computed(function() {
   if (Ember.testing === true && relationshipsDescriptor._cacheable === true) {

--- a/packages/ember-data/lib/system/relationships/state/has-many.js
+++ b/packages/ember-data/lib/system/relationships/state/has-many.js
@@ -2,6 +2,7 @@ import { PromiseManyArray } from "ember-data/system/promise-proxies";
 import Relationship from "ember-data/system/relationships/state/relationship";
 import OrderedSet from "ember-data/system/ordered-set";
 import ManyArray from "ember-data/system/many-array";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 import { assertPolymorphicType } from "ember-data/utils";
 
@@ -9,8 +10,7 @@ import {
   create
 } from 'ember-data/system/object-polyfills';
 
-var map = Ember.ArrayPolyfills.map;
-
+var map = ArrayPolyfills.map;
 
 var ManyRelationship = function(store, record, inverseKey, relationshipMeta) {
   this._super$constructor(store, record, inverseKey, relationshipMeta);

--- a/packages/ember-data/lib/system/relationships/state/relationship.js
+++ b/packages/ember-data/lib/system/relationships/state/relationship.js
@@ -1,6 +1,7 @@
 import OrderedSet from "ember-data/system/ordered-set";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
-var forEach = Ember.ArrayPolyfills.forEach;
+var forEach = ArrayPolyfills.forEach;
 
 function Relationship(store, record, inverseKey, relationshipMeta) {
   this.members = new OrderedSet();

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -50,6 +50,7 @@ import RecordArrayManager from "ember-data/system/record-array-manager";
 import ContainerInstanceCache from 'ember-data/system/store/container-instance-cache';
 
 import InternalModel from "ember-data/system/model/internal-model";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 import {
   create,
@@ -112,9 +113,10 @@ var get = Ember.get;
 var set = Ember.set;
 var once = Ember.run.once;
 var isNone = Ember.isNone;
-var forEach = Ember.ArrayPolyfills.forEach;
-var indexOf = Ember.ArrayPolyfills.indexOf;
-var map = Ember.ArrayPolyfills.map;
+var forEach = ArrayPolyfills.forEach;
+var indexOf = ArrayPolyfills.indexOf;
+var map = ArrayPolyfills.map;
+var filter = ArrayPolyfills.filter;
 var Promise = Ember.RSVP.Promise;
 var copy = Ember.copy;
 var Store;
@@ -1922,7 +1924,6 @@ Store = Service.extend({
     Ember.assert(`You tried to push data with a type '${modelName}' but no model could be found with that name.`, this._hasModelFor(modelName));
 
     var type = this.modelFor(modelName);
-    var filter = Ember.ArrayPolyfills.filter;
 
     // If Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS is set to true and the payload
     // contains unknown keys, log a warning.

--- a/packages/ember-data/lib/system/store/finders.js
+++ b/packages/ember-data/lib/system/store/finders.js
@@ -12,9 +12,10 @@ import {
 import {
   serializerForAdapter
 } from "ember-data/system/store/serializers";
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var Promise = Ember.RSVP.Promise;
-var map = Ember.ArrayPolyfills.map;
+var map = ArrayPolyfills.map;
 var get = Ember.get;
 
 export function _find(adapter, store, typeClass, id, internalModel, options) {

--- a/packages/ember-data/lib/system/store/serializer-response.js
+++ b/packages/ember-data/lib/system/store/serializer-response.js
@@ -1,11 +1,12 @@
 import Model from 'ember-data/system/model/model';
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 import {
   keysFunc
 } from 'ember-data/system/object-polyfills';
 
-var forEach = Ember.ArrayPolyfills.forEach;
-var map = Ember.ArrayPolyfills.map;
+var forEach = ArrayPolyfills.forEach;
+var map = ArrayPolyfills.map;
 var get = Ember.get;
 
 /**

--- a/packages/ember-data/tests/integration/filter-test.js
+++ b/packages/ember-data/tests/integration/filter-test.js
@@ -1,6 +1,6 @@
 import customAdapter from 'ember-data/tests/helpers/custom-adapter';
-import ArrayPolyfills from 'ember-data/ext/ember/array';
 
+var ArrayPolyfills = Ember.ArrayPolyfills || Array.prototpe;
 var get = Ember.get;
 var set = Ember.set;
 var forEach = ArrayPolyfills.forEach;

--- a/packages/ember-data/tests/integration/filter-test.js
+++ b/packages/ember-data/tests/integration/filter-test.js
@@ -1,9 +1,10 @@
 import customAdapter from 'ember-data/tests/helpers/custom-adapter';
+import ArrayPolyfills from 'ember-data/ext/ember/array';
 
 var get = Ember.get;
 var set = Ember.set;
-var forEach = Ember.ArrayPolyfills.forEach;
-var indexOf = Ember.ArrayPolyfills.indexOf;
+var forEach = ArrayPolyfills.forEach;
+var indexOf = ArrayPolyfills.indexOf;
 var run = Ember.run;
 
 var Person, store, env, array, recordArray;

--- a/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
@@ -1,10 +1,8 @@
-import ArrayPolyfills from 'ember-data/ext/ember/array';
-
 var get = Ember.get;
 var HomePlanet, SuperVillain, EvilMinion, SecretLab, SecretWeapon, BatCave, Comment,
   league, superVillain, evilMinion, secretWeapon, homePlanet, secretLab, env;
 
-var indexOf = ArrayPolyfills.indexOf;
+var indexOf = (Ember.ArrayPolyfills || Array.prototype).indexOf;
 var run = Ember.run;
 var LightSaber;
 

--- a/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
@@ -1,7 +1,10 @@
+import ArrayPolyfills from 'ember-data/ext/ember/array';
+
 var get = Ember.get;
 var HomePlanet, SuperVillain, EvilMinion, SecretLab, SecretWeapon, BatCave, Comment,
   league, superVillain, evilMinion, secretWeapon, homePlanet, secretLab, env;
-var indexOf = Ember.ArrayPolyfills.indexOf;
+
+var indexOf = ArrayPolyfills.indexOf;
 var run = Ember.run;
 var LightSaber;
 

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -3,7 +3,8 @@ var attr = DS.attr;
 var hasMany = DS.hasMany;
 var belongsTo = DS.belongsTo;
 var run = Ember.run;
-var forEach = Ember.ArrayPolyfills.forEach;
+import ArrayPolyfills from 'ember-data/ext/ember/array';
+var forEach = ArrayPolyfills.forEach;
 
 module("unit/store/push - DS.Store#push", {
   setup: function() {

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -3,8 +3,7 @@ var attr = DS.attr;
 var hasMany = DS.hasMany;
 var belongsTo = DS.belongsTo;
 var run = Ember.run;
-import ArrayPolyfills from 'ember-data/ext/ember/array';
-var forEach = ArrayPolyfills.forEach;
+var forEach = (Ember.ArrayPolyfills || Array.prototype).forEach;
 
 module("unit/store/push - DS.Store#push", {
   setup: function() {

--- a/packages/ember/lib/main.js
+++ b/packages/ember/lib/main.js
@@ -1,2 +1,3 @@
 // Shim Ember module
+
 export default Ember;


### PR DESCRIPTION
There may be more, but this at-least makes my one app work correctly.

- [x] instead of poluting the Ember object, we should instead add a level of indirection by moving the polifills to a local module, and doing the funky work there.

Goal:
------

to ease upgrade pain for people
