### PR TITLE
Fix: IE11 compatibility of JSONAPI adapter

### DIFF
--- a/packages/ember-data/lib/adapters/json-api-adapter.js
+++ b/packages/ember-data/lib/adapters/json-api-adapter.js
@@ -14,6 +14,16 @@ export default RESTAdapter.extend({
   defaultSerializer: '-json-api',
 
   /**
+    Regarding to the JSON API (and HTTP) spec, changes should be sent to the
+    server using the `PATCH` method. Since IE11 is still not supporting `PATCH`
+    it is necessary to use `PUT` to make an app work with the IE.
+
+    This property enables the user to change this incorrect behavior if an
+    IE compatibility is not necessary.
+  */
+  patchMethod: 'PUT',
+
+  /**
     @method ajaxOptions
     @private
     @param {String} url
@@ -79,6 +89,6 @@ export default RESTAdapter.extend({
     var id = snapshot.id;
     var url = this.buildURL(type.modelName, id, snapshot, 'updateRecord');
 
-    return this.ajax(url, 'PATCH', { data: data });
+    return this.ajax(url, this.get('patchMethod'), { data: data });
   }
 });

--- a/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -775,7 +775,7 @@ test('update record', function() {
 
       user.save().then(function() {
         equal(passedUrl[0], '/users/1');
-        equal(passedVerb[0], 'PATCH');
+        equal(passedVerb[0], 'PUT');
         deepEqual(passedHash[0], {
           data: {
             data : {
@@ -849,7 +849,7 @@ test('update record - serialize hasMany', function() {
 
       user.save().then(function() {
         equal(passedUrl[0], '/users/1');
-        equal(passedVerb[0], 'PATCH');
+        equal(passedVerb[0], 'PUT');
         deepEqual(passedHash[0], {
           data: {
             data : {


### PR DESCRIPTION
I know that the [JSON API](http://jsonapi.org/format/#crud-updating) spec uses the `PATCH` method for updating a record. Since the IE is still not supporting the `PATCH` method, I suggest to use the `PUT` method instead of `PATCH` but giving the user the ability to change this behaviour by setting a property on the `ApplicationAdapter`.

In this pull request I have introduced the property `patchMethod` which is set to `PUT` by default.

What do you think, is this a suitable way to deal with this problem?