### PR TITLE
[BUGFIX beta] Prefer the new injection methods.

### DIFF
--- a/packages/ember-data/lib/initializers/store-injections.js
+++ b/packages/ember-data/lib/initializers/store-injections.js
@@ -8,7 +8,7 @@
 export default function initializeStoreInjections(registry) {
   // registry.injection for Ember < 2.1.0
   // application.inject for Ember 2.1.0+
-  var inject = registry.injection || registry.inject;
+  var inject = registry.inject || registry.injection;
   inject.call(registry, 'controller', 'store', 'service:store');
   inject.call(registry, 'route', 'store', 'service:store');
   inject.call(registry, 'data-adapter', 'store', 'service:store');

--- a/packages/ember-data/lib/initializers/store.js
+++ b/packages/ember-data/lib/initializers/store.js
@@ -22,7 +22,7 @@ function has(applicationOrRegistry, fullName) {
 export default function initializeStore(registry) {
   // registry.optionsForType for Ember < 2.1.0
   // application.registerOptionsForType for Ember 2.1.0+
-  var registerOptionsForType = registry.optionsForType || registry.registerOptionsForType;
+  var registerOptionsForType = registry.registerOptionsForType || registry.optionsForType;
   registerOptionsForType.call(registry, 'serializer', { singleton: false });
   registerOptionsForType.call(registry, 'adapter', { singleton: false });
 


### PR DESCRIPTION
This way Ember Data won't log deprecation warnings when https://github.com/emberjs/ember.js/pull/12157 lands in Ember.