### PR TITLE
[BUGFIX release-1-13] Ensure that `service:store` is cleared before regsitering.

### DIFF
--- a/packages/ember-data/lib/initializers/store.js
+++ b/packages/ember-data/lib/initializers/store.js
@@ -64,8 +64,10 @@ export default function initializeStore(registry, application) {
   }
 
   if (store) {
+    registry.unregister('service:store');
     registry.register('service:store', store, { instantiate: false });
   } else if (!registry.has('service:store')) {
+    registry.unregister('service:store');
     registry.register('service:store', application && application.Store || Store);
   }
 }


### PR DESCRIPTION
In globals apps, calling `App.reset()` will cause these initializers to be ran multiple times for each `container` / `registry` instance.  This means that when `App.reset()` is called, `service:store` is already registered **AND** resolved, throwing the following error:

```
Cannot re-register: `service:store`, as it has already been resolved.
```

The fix is to `unregister` before `register`ing again.

Fixes https://github.com/emberjs/ember.js/issues/10310.

---

Please note, this is already a non-issue in 2.0.0 (aka release branch).  This PR is targeting the `release-1-13` branch (which was branched from the `v1.13.11` tag).