### PR TITLE
Explicitly set length after setting a new content property

### DIFF
--- a/packages/ember-data/lib/system/model/errors.js
+++ b/packages/ember-data/lib/system/model/errors.js
@@ -276,7 +276,13 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     if (get(this, 'isEmpty')) { return; }
 
     let content = this.rejectBy('attribute', attribute);
+    let length = get(content, 'length');
     set(this, 'content', content);
+    // Explicitly set length after setting a new content property as
+    // a work around for https://github.com/emberjs/ember.js/pull/12218
+    if (this.get('length') !== length) {
+      this.set('length', length);
+    }
     get(this, 'errorsByAttributeName').delete(attribute);
 
     this.notifyPropertyChange(attribute);


### PR DESCRIPTION
This is a workaround for https://github.com/emberjs/ember.js/pull/12218

This should fix the failing tests on canary.