### PR TITLE
Update the location of the custom store in the API doc example

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -140,7 +140,7 @@ if (!Service) {
 
   Define your application's store like this:
 
-  ```app/stores/application.js
+  ```app/services/store.js
   import DS from 'ember-data';
 
   export default DS.Store.extend({


### PR DESCRIPTION
`app/stores/application.js` is deprecated in 1.13 and no longer supported in 2.0.