### PR TITLE
[BUGFIX release-1-13] Disable polymorphic deserialization when a mode…

### DIFF
--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -228,9 +228,10 @@ var RESTSerializer = JSONSerializer.extend({
 
     Ember.assert(`${this.toString()} has opted into the new serializer API and expects the ${serializer.toString()} it collaborates with to also support the new serializer API by setting its \`isNewSerializerAPI\` property to true.`, get(serializer, 'isNewSerializerAPI'));
 
+    const primaryHasTypeAttribute = get(modelClass, 'attributes').get('type');
     /*jshint loopfunc:true*/
     forEach.call(arrayHash, (hash) => {
-      let { data, included } = this._normalizePolymorphicRecord(store, hash, prop, modelClass, serializer);
+      let { data, included } = this._normalizePolymorphicRecord(store, hash, prop, modelClass, serializer, primaryHasTypeAttribute);
       documentHash.data.push(data);
       if (included) {
         documentHash.included.push(...included);
@@ -240,10 +241,10 @@ var RESTSerializer = JSONSerializer.extend({
     return documentHash;
   },
 
-  _normalizePolymorphicRecord(store, hash, prop, primaryModelClass, primarySerializer) {
+  _normalizePolymorphicRecord(store, hash, prop, primaryModelClass, primarySerializer, primaryHasTypeAttribute) {
     let serializer, modelClass;
     // Support polymorphic records in async relationships
-    if (hash.type && store._hasModelFor(this.modelNameFromPayloadKey(hash.type))) {
+    if (!primaryHasTypeAttribute && hash.type && store._hasModelFor(this.modelNameFromPayloadKey(hash.type))) {
       serializer = store.serializerFor(hash.type);
       modelClass = store.modelFor(hash.type);
     } else {


### PR DESCRIPTION
…l expects a type attribute

b7f7b7a introduced a bug where if there is a type key in a payload that is part
of an array, it would be used for polymorphic deserialization even when the
model expects an attribute that is named "type".

Interestingly, for such payloads, `arrayHash` passed into `normalizeArray()` in
rest-serializer.js contains Ember.Object instances as opposed to plain objects.
This causes the code to throw, since `hash.type` would be a computed property
in that case instead of a string that `dasherize` expects. This is probably because
of extending from JSONAPISerializer.

Fixes #3702.

It probably also fixes #3724, but needs a port to 2.0