### PR TITLE
[BUGFIX beta] JSONSerializer.extractRelationships() issue #3736

### DIFF
--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -599,7 +599,7 @@ var JSONSerializer = Serializer.extend({
         if (relationshipMeta.kind === 'belongsTo') {
           data = this.extractRelationship(relationshipMeta.type, relationshipHash);
         } else if (relationshipMeta.kind === 'hasMany') {
-          data = relationshipHash.map((item) => this.extractRelationship(relationshipMeta.type, item));
+          data = Ember.isNone(relationshipHash) ? null : relationshipHash.map((item) => this.extractRelationship(relationshipMeta.type, item));
         }
         relationship = { data };
       }

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -688,6 +688,20 @@ test('normalizeResponse returns empty `included` payload by default', function()
   deepEqual(post.included, []);
 });
 
+test('normalizeResponse returns empty `included` payload when relationship is undefined', function() {
+  env.registry.register("serializer:post", DS.JSONSerializer.extend());
+
+  var jsonHash = {
+    id: "1",
+    title: "Rails is omakase",
+    comments: null
+  };
+
+  var post = env.store.serializerFor("post").normalizeResponse(env.store, Post, jsonHash, '1', 'findRecord');
+
+  deepEqual(post.included, []);
+});
+
 test('normalizeResponse respects `included` items (single response)', function() {
   env.registry.register("serializer:post", DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {


### PR DESCRIPTION
`JSONSerializer.extractRelationships()` sets the undefined hasMany relationships in the
same way it was for the belongsTo relationships, i.e. to `null`.

I also enriched the corresponding test accordingly in order to cover the case.