### PR TITLE
[DOC beta] Update Object Root docs re: plurals

### DIFF
--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -66,6 +66,12 @@ import BuildURLMixin from "ember-data/adapters/build-url-mixin";
   }
   ```
 
+  Note that the object root can be pluralized for both a single-object response
+  and an array response: the REST adapter is not strict on this. Further, if the
+  HTTP server responds to a `GET` request to `/posts/1` (e.g. the response to a
+  `findRecord` query) with more than one object in the array, Ember Data will
+  only display the object with the matching ID.
+
   ### Conventional Names
 
   Attribute names in your JSON payload should be the camelCased versions of


### PR DESCRIPTION
This partially addresses some of the documentation requirements in emberjs/ember.js#12319

Specifically:

* Clarification that root keys can be pluralized regardless—Ember not being strict about this may help others understand whether they need to normalize a response.
* A further note that—if a HTTP server responds to a findRecord request for a specific ID (or other param) with more than one object in the array—Ember Data will only parse the object with the matching ID/param.

This is low hanging fruit but I wanted to test the appetite for small doc changes like this—I suspect I'll have a few as I work through some Go + Ember stuff!