### PR TITLE
[BUGFIX beta] Support JSON API links object

### DIFF
--- a/packages/ember-data/lib/system/normalize-link.js
+++ b/packages/ember-data/lib/system/normalize-link.js
@@ -1,0 +1,19 @@
+/**
+  This method normalizes a link to an "links object". If the passed link is
+  already an object it's returned without any modifications.
+
+  See http://jsonapi.org/format/#document-links for more information.
+
+  @method _normalizeLink
+  @private
+  @param {String} link
+  @return {Object|null}
+  @for DS
+*/
+export default function _normalizeLink(link) {
+  switch (typeof link) {
+    case 'object': return link;
+    case 'string': return { href: link };
+  }
+  return null;
+}

--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -5,6 +5,7 @@
   @module ember-data
 */
 
+import _normalizeLink from "ember-data/system/normalize-link";
 import normalizeModelName from "ember-data/system/normalize-model-name";
 import {
   InvalidError
@@ -2057,8 +2058,11 @@ function setupRelationships(store, record, data) {
     var relationship;
 
     if (data.relationships[key].links && data.relationships[key].links.related) {
-      relationship = record._relationships.get(key);
-      relationship.updateLink(data.relationships[key].links.related);
+      let relatedLink = _normalizeLink(data.relationships[key].links.related);
+      if (relatedLink && relatedLink.href) {
+        relationship = record._relationships.get(key);
+        relationship.updateLink(relatedLink.href);
+      }
     }
 
     if (data.relationships[key].meta) {

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -469,23 +469,26 @@ test('Calling push with an unknown model name throws an assertion error', functi
   }, /You tried to push data with a type 'unknown' but no model could be found with that name/);
 });
 
-test('Calling push with a link containing an object throws an assertion error', function() {
+test('Calling push with a link containing an object', function() {
   Person.reopen({
     phoneNumbers: hasMany('phone-number', { async: true })
   });
 
-  expectAssertion(function() {
-    run(function() {
-      store.push(store.normalize('person', {
-        id: '1',
-        links: {
-          phoneNumbers: {
-            href: '/api/people/1/phone-numbers'
-          }
+  run(function() {
+    store.push(store.normalize('person', {
+      id: '1',
+      firstName: 'Tan',
+      links: {
+        phoneNumbers: {
+          href: '/api/people/1/phone-numbers'
         }
-      }));
-    });
-  }, "You have pushed a record of type 'person' with 'phoneNumbers' as a link, but the value of that link is not a string.");
+      }
+    }));
+  });
+
+  var person = store.peekRecord('person', 1);
+
+  equal(person.get('firstName'), "Tan", "you can use links containing an object");
 });
 
 test('Calling push with a link containing the value null', function() {


### PR DESCRIPTION
This PR introduces a private helper called `_normalizeLinks` that accepts a string or an object and returns an normalized "links object", see http://jsonapi.org/format/#document-links

Currently this helper is only used in the store's `setupRelationships` but we should probably have links objects reach further down in ED in the future (store => relationship => adapter) to allow access to meta and additional information on the links object.

Fixes #3588