### PR TITLE
[BUGFIX beta] Fix JSONSerializer.serializeHasMany() issue #3760

### DIFF
--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -1116,16 +1116,18 @@ var JSONSerializer = Serializer.extend({
     var key = relationship.key;
 
     if (this._shouldSerializeHasMany(snapshot, key, relationship)) {
-      var payloadKey;
+      var hasMany = snapshot.hasMany(key, { ids: true });
+      if (hasMany !== undefined) {
+        // if provided, use the mapping provided by `attrs` in
+        // the serializer
+        var payloadKey = this._getMappedKey(key);
+        if (payloadKey === key && this.keyForRelationship) {
+          payloadKey = this.keyForRelationship(key, "hasMany", "serialize");
+        }
 
-      // if provided, use the mapping provided by `attrs` in
-      // the serializer
-      payloadKey = this._getMappedKey(key);
-      if (payloadKey === key && this.keyForRelationship) {
-        payloadKey = this.keyForRelationship(key, "hasMany", "serialize");
+        json[payloadKey] = hasMany;
+        // TODO support for polymorphic manyToNone and manyToMany relationships
       }
-      json[payloadKey] = snapshot.hasMany(key, { ids: true });
-      // TODO support for polymorphic manyToNone and manyToMany relationships
     }
   },
 

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -171,6 +171,25 @@ test("serializeHasMany respects keyForRelationship", function() {
   });
 });
 
+test("serializeHasMany omits unknown relationships on pushed record", function() {
+
+  run(function() {
+    post = env.store.push({
+      id: "1",
+      type: "post",
+      attributes: {
+        title: "Rails is omakase"
+      }
+    });
+  });
+
+  var json = {};
+
+  env.store.serializerFor("post").serializeHasMany(post._createSnapshot(), json, { key: "comments", options: {} });
+
+  ok(!json.hasOwnProperty("comments"), "Does not add the relationship key to json");
+});
+
 test("serializeIntoHash", function() {
   run(function() {
     post = env.store.createRecord('post', { title: "Rails is omakase" });


### PR DESCRIPTION
`serializeHasMany()` omits unknown relationships of pushed record rather than
setting them to `undefined`.