### PR TITLE
update coalesceFindRequests doc for JSONAPIAdapter

### DIFF
--- a/packages/ember-data/lib/adapters/json-api-adapter.js
+++ b/packages/ember-data/lib/adapters/json-api-adapter.js
@@ -62,6 +62,55 @@ export default RESTAdapter.extend({
     return Ember.String.pluralize(dasherized);
   },
 
+/**
+    By default the RESTAdapter will send each find request coming from a `store.find`
+    or from accessing a relationship separately to the server. If your server supports passing
+    ids as a query string, you can set coalesceFindRequests to true to coalesce all find requests
+    within a single runloop.
+
+    For example, if you have an initial payload of:
+
+    ```javascript
+    {
+      post: {
+        id: 1,
+        comments: [1, 2]
+      }
+    }
+    ```
+
+    By default calling `post.get('comments')` will trigger the following requests(assuming the
+    comments haven't been loaded before):
+
+    ```
+    GET /comments/1
+    GET /comments/2
+    ```
+
+    If you set coalesceFindRequests to `true` it will instead trigger the following request:
+
+    ```
+    GET /comments?ids[]=1&ids[]=2
+    ```
+
+    Setting coalesceFindRequests to `true` also works for `store.find` requests and `belongsTo`
+    relationships accessed within the same runloop. If you set `coalesceFindRequests: true`
+
+    ```javascript
+    store.findRecord('comment', 1);
+    store.findRecord('comment', 2);
+    ```
+
+    will also send a request to: `GET /comments?ids[]=1&ids[]=2`
+
+    Note: Requests coalescing rely on URL building strategy. So if you override `buildURL` in your app
+    `groupRecordsForFindMany` more likely should be overridden as well in order for coalescing to work.
+
+    @property coalesceFindRequests
+    @type {boolean}
+  */
+  coalesceFindRequests: false,
+
   // TODO: Remove this once we have a better way to override HTTP verbs.
   /**
     @method updateRecord


### PR DESCRIPTION
I noticed that the JSONAPIAdapter sends different query params then the RESTAPIAdapter, so took a stab at updating the documentation.  I felt it was better to put the info in the json-api-adapter.js rather than putting a "if you're using JSONAPIAdapter" statement into the rest-adapter.js.  I did override the coalesceFindRequests bool in json-api-adapter.js, but let me know if this is not the desired way to do things at this point.