### PR TITLE
Fix embedded key serialization bug and refactor key serialization

### DIFF
--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -210,12 +210,12 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
 
   _serializeEmbeddedBelongsTo: function(snapshot, json, relationship) {
     let embeddedSnapshot = snapshot.belongsTo(relationship.key);
-    let key = this.keyForAttribute(relationship.key, 'serialize');
+    let serializedKey = this.keyForAttribute(relationship.key, 'serialize');
     if (!embeddedSnapshot) {
-      json[key] = null;
+      json[serializedKey] = null;
     } else {
-      json[key] = embeddedSnapshot.record.serialize({ includeId: true });
-      this.removeEmbeddedForeignKey(snapshot, embeddedSnapshot, relationship, json[key]);
+      json[serializedKey] = embeddedSnapshot.record.serialize({ includeId: true });
+      this.removeEmbeddedForeignKey(snapshot, embeddedSnapshot, relationship, json[serializedKey]);
     }
   },
 
@@ -312,32 +312,31 @@ var EmbeddedRecordsMixin = Ember.Mixin.create({
     }
     var includeIds = this.hasSerializeIdsOption(attr);
     var includeRecords = this.hasSerializeRecordsOption(attr);
-    var key;
     if (includeIds) {
-      key = this.keyForRelationship(attr, relationship.kind, 'serialize');
-      json[key] = snapshot.hasMany(attr, { ids: true });
+      let serializedKey = this.keyForRelationship(attr, relationship.kind, 'serialize');
+      json[serializedKey] = snapshot.hasMany(attr, { ids: true });
     } else if (includeRecords) {
       this._serializeEmbeddedHasMany(snapshot, json, relationship);
     }
   },
 
   _serializeEmbeddedHasMany: function(snapshot, json, relationship) {
-    let key = this.keyForAttribute(relationship.key, 'serialize');
+    let serializedKey = this.keyForAttribute(relationship.key, 'serialize');
 
     Ember.warn(
-      `The embedded relationship '${key}' is undefined for '${snapshot.modelName}' with id '${snapshot.id}'. Please include it in your original payload.`,
-      Ember.typeOf(snapshot.hasMany(key)) !== 'undefined',
+      `The embedded relationship '${serializedKey}' is undefined for '${snapshot.modelName}' with id '${snapshot.id}'. Please include it in your original payload.`,
+      Ember.typeOf(snapshot.hasMany(relationship.key)) !== 'undefined',
       { id: 'ds.serializer.embedded-relationship-undefined' }
     );
 
-    json[key] = this._generateSerializedHasMany(snapshot, key, relationship);
+    json[serializedKey] = this._generateSerializedHasMany(snapshot, relationship);
   },
 
   /*
     Returns an array of embedded records serialized to JSON
   */
-  _generateSerializedHasMany: function(snapshot, key, relationship) {
-    let hasMany = snapshot.hasMany(key);
+  _generateSerializedHasMany: function(snapshot, relationship) {
+    let hasMany = snapshot.hasMany(relationship.key);
     return Ember.A(hasMany).map((embeddedSnapshot) => {
       var embeddedJson = embeddedSnapshot.record.serialize({ includeId: true });
       this.removeEmbeddedForeignKey(snapshot, embeddedSnapshot, relationship, embeddedJson);

--- a/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
@@ -895,6 +895,41 @@ test("serialize with embedded objects (hasMany relationship)", function() {
   });
 });
 
+test("serialize with embedded objects and a custom keyForAttribute (hasMany relationship)", function() {
+  var tom, league;
+  run(function() {
+    league = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
+    tom = env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
+  });
+
+  env.registry.register('serializer:home-planet', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+    keyForAttribute: function(key) {
+      return key + '-custom';
+    },
+    attrs: {
+      villains: { embedded: 'always' }
+    }
+  }));
+
+  var serializer, json;
+  run(function() {
+    serializer = env.store.serializerFor("home-planet");
+
+    json = serializer.serialize(league._createSnapshot());
+  });
+
+  deepEqual(json, {
+    "name-custom": "Villain League",
+    "villains-custom": [{
+      id: get(tom, "id"),
+      firstName: "Tom",
+      lastName: "Dale",
+      homePlanet: get(league, "id"),
+      secretLab: null
+    }]
+  });
+});
+
 test("serialize with embedded objects (unknown hasMany relationship)", function() {
   var league;
   run(function() {


### PR DESCRIPTION
We now refer to the serialized key as `serializedKey` to reduce confusion which
led to this bug