### PR TITLE
Add support for HATEOAS link parsing in JSONSerializer

### DIFF
--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -605,10 +605,21 @@ var JSONSerializer = Serializer.extend({
       }
 
       let linkKey = this.keyForLink(key, relationshipMeta.kind);
-      if (resourceHash.links && resourceHash.links.hasOwnProperty(linkKey)) {
-        let related = resourceHash.links[linkKey];
-        relationship = relationship || {};
-        relationship.links = { related };
+      if (resourceHash.links) {
+        var related;
+        if (Ember.isArray(resourceHash.links)) {
+          let links = resourceHash.links.filter(link => link.rel === linkKey);
+          if (links && links[0]) {
+            related = links[0].href;
+          }
+        } else if (resourceHash.links.hasOwnProperty(linkKey)) {
+          related = resourceHash.links[linkKey];
+        }
+
+        if (related) {
+          relationship = relationship || {};
+          relationship.links = { related };
+        }
       }
 
       if (relationship) {

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -776,3 +776,19 @@ test('normalizeResponse respects `included` items (array response)', function() 
     { id: "3", type: "comment", attributes: { body: "comment 3" }, relationships: {} }
   ]);
 });
+
+test('extractRelationships parses HATEOAS links', function() {
+  var payload = { links: [ { rel: 'post', href: '/foo/bar' } ] };
+
+  var relationships = env.serializer.extractRelationships(Favorite, payload);
+
+  deepEqual(relationships, { post: { links: { related: '/foo/bar' } } });
+});
+
+test('extractRelationships parses links object', function() {
+  var payload = { links: { post: '/foo/bar' } };
+
+  var relationships = env.serializer.extractRelationships(Favorite, payload);
+
+  deepEqual(relationships, { post: { links: { related: '/foo/bar' } } });
+});

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -778,7 +778,7 @@ test('normalizeResponse respects `included` items (array response)', function() 
 });
 
 test('extractRelationships parses HATEOAS links', function() {
-  var payload = { links: [ { rel: 'post', href: '/foo/bar' } ] };
+  var payload = { links: [{ rel: 'post', href: '/foo/bar' }] };
 
   var relationships = env.serializer.extractRelationships(Favorite, payload);
 


### PR DESCRIPTION
When using a HATEOAS approach (e.g. with spring HATEOAS) JSONSerializer cannot parse the links of a resource.

This is due to the fact that extractRelationships expects links to be an object where the keys are the model's attributes. This is not the case though when using HATEOAS.

Suppose we have a spring HATEOAS application where users have posts. The response that comes back from the server has the following format:

```javascript
{
  "firstName": "John",
  "lastName": "Doe",
  "username": "john.doe",
  "links": [
    {
      "rel": "posts",
      "href": "user/john.doe/posts"
    }
  ]
}
````

The above links format is not supported from JSONSerializer since it expects an object as:

```javascript
{
  "firstName": "John",
  "lastName": "Doe",
  "username": "john.doe",
  "links": {
    "posts": "user/john.doe/posts"
  }
}
````

This pull request resolves that issue and adds support for HATEOAS links without breaking the existing behavior. Two tests cases have also been added. One for the existing link parsing and one for HATEOAS.