### PR TITLE
Add support to custom getters and setters at DS.attr

### DIFF
--- a/packages/ember-data/tests/unit/model-test.js
+++ b/packages/ember-data/tests/unit/model-test.js
@@ -176,6 +176,44 @@ test("trying to set an `id` attribute should raise", function() {
   }, /You may not set `id`/);
 });
 
+test("trying to set a custom `get` method to attribute", function() {
+  var Mascot = DS.Model.extend({
+    age: DS.attr('number', {
+      get: function(value) {
+        return value + 1;
+      }
+    })
+  });
+
+  var store = createStore({
+    mascot: Mascot
+  });
+
+  run(function() {
+    var mascot = store.createRecord('mascot', { age: 10 });
+    equal(mascot.get('age'), 11);
+  });
+});
+
+test("trying to set a custom `set` method to attribute", function() {
+  var Mascot = DS.Model.extend({
+    age: DS.attr('number', {
+      set: function(value) {
+        return value + 1;
+      }
+    })
+  });
+
+  var store = createStore({
+    mascot: Mascot
+  });
+
+  run(function() {
+    var mascot = store.createRecord('mascot', { age: 10 });
+    equal(mascot.get('age'), 11);
+  });
+});
+
 test("a collision of a record's id with object function's name", function() {
   expect(1);
   env.adapter.shouldBackgroundReloadRecord = () => false;


### PR DESCRIPTION
Add support to custom getters and setters to Model attributes as suggested by @rmachielse in issue https://github.com/emberjs/data/issues/3708

The user now should be able to customize them following the example
```javascript
export default DS.Model.extend({
  age: DS.attr('number', {
    // value: the stored value of the property age
    get: function(value) {
      var ret;
      // do whatever you want and
      // return the value the user will get
      return ret;
    },
    // value: the new value for property age
    set: function(value) {
      var ret;
      // do whatever you want and
      // return the value that will be stored
      return ret;
    }
  })
});
```