### PR TITLE
Check if primary model has type attribute using _normalizePolymorphicRecord

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data",
-  "version": "1.13.12",
+  "version": "1.13.13",
   "namespace": "DS",
   "repository": "git://github.com/emberjs/data.git",
   "license": "MIT",


### PR DESCRIPTION
Add the primaryHasTypeAttribute to the _normalizePolymorphicRecord call in rest-serializer's _normalizeResponse. Fixes bug if the primary model has a type property.