### PR TITLE
Trigger an assertion when calling `findRecord` with falsy (except 0) id

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -51,6 +51,8 @@ import InternalModel from "ember-data/system/model/internal-model";
 
 import EmptyObject from "ember-data/system/empty-object";
 
+export let badIdFormatAssertion = '`id` has to be non-empty string or number';
+
 var Backburner = Ember._Backburner || Ember.Backburner || Ember.__loader.require('backburner')['default'] || Ember.__loader.require('backburner')['Backburner'];
 var Map = Ember.Map;
 
@@ -495,6 +497,8 @@ Store = Service.extend({
   */
   findRecord: function(modelName, id, options) {
     Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    Ember.assert(badIdFormatAssertion, (typeof id === 'string' && id.length > 0) || (typeof id === 'number' && !isNaN(id)));
+
     var internalModel = this._internalModelForId(modelName, id);
     options = options || {};
 

--- a/packages/ember-data/tests/integration/store-test.js
+++ b/packages/ember-data/tests/integration/store-test.js
@@ -211,8 +211,7 @@ function ajaxResponse(value) {
 
 
 
-module("integration/store - findRecord", {
-});
+module("integration/store - findRecord");
 
 test("store#findRecord fetches record from server when cached record is not present", function() {
   expect(2);
@@ -312,6 +311,21 @@ test("store#findRecord { reload: true } ignores cached record and reloads record
   run(function() {
     store.findRecord('car', 1, { reload: true }).then(function(car) {
       equal(car.get('model'), 'Princess', 'cached record ignored, record reloaded via server');
+    });
+  });
+});
+
+test('store#findRecord call with `id` of type different than non-empty string or number should trigger an assertion', assert => {
+  const badValues = ['', undefined, null, NaN, false];
+  assert.expect(badValues.length);
+
+  initializeStore(DS.RESTAdapter.extend());
+
+  run(function() {
+    badValues.map(item => {
+      expectAssertion(function() {
+        store.findRecord('car', item);
+      }, '`id` has to be non-empty string or number');
     });
   });
 });

--- a/packages/ember-data/tests/unit/model-test.js
+++ b/packages/ember-data/tests/unit/model-test.js
@@ -467,7 +467,6 @@ test("currentState is accessible when the record is created", function() {
   });
 });
 
-
 module("unit/model - DS.Model updating", {
   setup: function() {
     Person = DS.Model.extend({ name: DS.attr('string') });


### PR DESCRIPTION
Attempt to close #2348. Do you think it is sufficient or should `Ember.Error` be thrown as @stefanpenner suggested [here](https://github.com/emberjs/data/pull/518#issuecomment-17819789)?