### PR TITLE
Don't preload the belongsTo to be available synchronously

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs-to.js
@@ -130,8 +130,7 @@ BelongsToRelationship.prototype.getRecord = function() {
     }
 
     return PromiseObject.create({
-      promise: promise,
-      content: this.inverseRecord ? this.inverseRecord.getRecord() : null
+      promise: promise
     });
   } else {
     if (this.inverseRecord === null) {


### PR DESCRIPTION
Having this preload is inconsistent with the way that the `hasMany` relationship proxy works. In particular, it has different semantics when rendering a property on proxied relationship.

For example, let's say there is a template containing `{{post.author.someComputedProperty}}` where author `belongsTo` post. If `someComputedProperty` relies on a dependent key being present in order to compute correctly, `{{post.author.someComputedProperty}}` will throw.

Without the preload, the lookup chain stops at the null `content` property of the `PromiseObject` and `someComputedProperty` is only evaluated once the promise resolves and a fully materialized author is set as the `content`. This is how things used to work up until 1.0.0.beta.10

The preload was added in 12301b9405c4ffde31d9dd027c8b266c1231d0f8 and released in 1.0.0.beta.11. I don't fully understand why it was needed at that time, but without it the tests did not pass.

This is no longer the case. After removing the preload the suite is green and the above rendering issue is resolved.

/cc @ghedamat who tracked this down with me and @mmun who pointed us in the right direction.