### PR TITLE
convert undefined json values into null in rest adapter. fixes #3807

### DIFF
--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -875,7 +875,10 @@ var RESTAdapter =  Adapter.extend(BuildURLMixin, {
 
     if (hash.data && type !== 'GET') {
       hash.contentType = 'application/json; charset=utf-8';
-      hash.data = JSON.stringify(hash.data);
+      hash.data = JSON.stringify(hash.data, (key, val) => {
+        if (val === undefined) { return null; }
+        return val;
+      });
     }
 
     var headers = get(this, 'headers');

--- a/packages/ember-data/tests/unit/adapters/rest-adapter/ajax-test.js
+++ b/packages/ember-data/tests/unit/adapters/rest-adapter/ajax-test.js
@@ -102,3 +102,18 @@ test("ajaxOptions() empty data", function() {
     url: 'example.com'
   });
 });
+
+test("ajaxOptions() converts undefined data values to null", function() {
+  var url = 'example.com';
+  var type = 'POST';
+  var ajaxOptions = adapter.ajaxOptions(url, type, { data: { key: undefined } });
+
+  deepEqual(ajaxOptions, {
+    contentType: "application/json; charset=utf-8",
+    context: adapter,
+    data: '{"key":null}',
+    dataType: 'json',
+    type: 'POST',
+    url: 'example.com'
+  });
+});


### PR DESCRIPTION
When using Ember Data with the rest adapter it's not possible to unset a model attribute on the server because of: 
```javascript
JSON.stringify({key: undefined}) // => "{}"
JSON.stringify({key: null}) // => "{"key":null}"
```
This pull requests converts all undefined keys to null so you're able to unset values on the server.