### PR TITLE
[CLEANUP] Remove duplicate test for creating record

### DIFF
--- a/packages/ember-data/tests/unit/store/create-record-test.js
+++ b/packages/ember-data/tests/unit/store/create-record-test.js
@@ -66,39 +66,6 @@ module("unit/store/createRecord - Store with models by dash", {
     container = env.container;
   }
 });
-test("creating a record by camel-case string finds the model", function() {
-  var attributes = { foo: 'bar' };
-  var record;
-
-  run(function() {
-    record = store.createRecord('some-thing', attributes);
-  });
-
-  equal(record.get('foo'), attributes.foo, "The record is created");
-  equal(store.modelFor('someThing').modelName, 'some-thing');
-});
-
-test("creating a record by dasherize string finds the model", function() {
-  var attributes = { foo: 'bar' };
-  var record;
-
-  run(function() {
-    record = store.createRecord('some-thing', attributes);
-  });
-
-  equal(record.get('foo'), attributes.foo, "The record is created");
-  equal(store.modelFor('some-thing').modelName, 'some-thing');
-});
-
-module("unit/store/createRecord - Store with models by camelCase", {
-  setup: function() {
-    var env = setupStore({
-      someThing: DS.Model.extend({ foo: DS.attr('string') })
-    });
-    store = env.store;
-    container = env.container;
-  }
-});
 
 test("creating a record by camel-case string finds the model", function() {
   var attributes = { foo: 'bar' };


### PR DESCRIPTION
In the refactor in #3033 the test for passing a camelCased model name
has been renamed due to deprecations to a dash-erized model name. This
introduced the exact same test.

---

The source code [in lines 60-91](http://git.io/vc5cq) and [the lines 93-125](http://git.io/vc5cY) are equal: https://www.diffchecker.com/xcehwtlm