### PR TITLE
[BUGFIX] extract polymorphic belongsTo in RESTSerializer

### DIFF
--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -56,6 +56,37 @@ var camelize = Ember.String.camelize;
 var RESTSerializer = JSONSerializer.extend({
 
   /**
+   `keyForPolymorphicType` can be used to define a custom key when
+   serializing and deserializing a polymorphic type. By default, the
+   returned key is `${key}Type`.
+
+   Example
+
+    ```app/serializers/post.js
+    import DS from 'ember-data';
+
+    export default DS.RESTSerializer.extend({
+      keyForPolymorphicType: function(key, relationship) {
+        var relationshipKey = this.keyForRelationship(key);
+
+        return 'type-' + relationshipKey;
+      }
+    });
+    ```
+
+   @method keyForPolymorphicType
+   @param {String} key
+   @param {String} typeClass
+   @param {String} method
+   @return {String} normalized key
+  */
+  keyForPolymorphicType: function(key, typeClass, method) {
+    var relationshipKey = this.keyForRelationship(key);
+
+    return `${relationshipKey}Type`;
+  },
+
+  /**
     Normalizes a part of the JSON payload returned by
     the server. You should override this method, munge the hash
     and call super if you have generic normalization to do.
@@ -689,6 +720,50 @@ var RESTSerializer = JSONSerializer.extend({
     } else {
       json[key + "Type"] = Ember.String.camelize(belongsTo.modelName);
     }
+  },
+
+  /**
+    You can use this method to customize how a polymorphic relationship should
+    be extracted.
+
+    @method extractPolymorphicRelationship
+    @param {Object} relationshipType
+    @param {Object} relationshipHash
+    @param {Object} relationshipOptions
+    @return {Object}
+   */
+  extractPolymorphicRelationship: function(relationshipType, relationshipHash, relationshipOptions) {
+    var { key, resourceHash, relationshipMeta } = relationshipOptions;
+
+    // A polymorphic belongsTo relationship can be present in the payload
+    // either in the form where the `id` and the `type` are given:
+    //
+    //   {
+    //     message: { id: 1, type: 'post' }
+    //   }
+    //
+    // or by the `id` and a `<relationship>Type` attribute:
+    //
+    //   {
+    //     message: 1,
+    //     messageType: 'post'
+    //   }
+    //
+    // The next code checks if the latter case is present and returns the
+    // corresponding JSON-API representation. The former case is handled within
+    // the base class JSONSerializer.
+    var isPolymorphic = relationshipMeta.options.polymorphic;
+    var typeProperty = this.keyForPolymorphicType(key, relationshipType, 'deserialize');
+
+    if (isPolymorphic && resourceHash.hasOwnProperty(typeProperty) && typeof relationshipHash !== 'object') {
+      let type = this.modelNameFromPayloadKey(resourceHash[typeProperty]);
+      return {
+        id: relationshipHash,
+        type: type
+      };
+    }
+
+    return this._super(...arguments);
   }
 });
 

--- a/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
@@ -455,6 +455,41 @@ test('serializeBelongsTo with async polymorphic', function() {
   deepEqual(json, expected, 'returned JSON is correct');
 });
 
+test('keyForPolymorphicType can be used to overwrite how the type of a polymorphic record is looked up for normalization', function() {
+  var json = {
+    doomsdayDevice: {
+      id: '1',
+      evilMinion: '2',
+      typeForEvilMinion: 'evilMinion'
+    }
+  };
+
+  var expected = {
+    data: {
+      type: 'doomsday-device',
+      id: '1',
+      attributes: {},
+      relationships: {
+        evilMinion: {
+          data: {
+            type: 'evil-minion',
+            id: '2'
+          }
+        }
+      }
+    },
+    included: []
+  };
+
+  env.restSerializer.keyForPolymorphicType = function() {
+    return 'typeForEvilMinion';
+  };
+
+  var normalized = env.restSerializer.normalizeResponse(env.store, DoomsdayDevice, json, null, 'findRecord');
+
+  deepEqual(normalized, expected, 'normalized JSON is correct');
+});
+
 test('serializeIntoHash uses payloadKeyFromModelName to normalize the payload root key', function() {
   run(function() {
     league = env.store.createRecord('home-planet', { name: "Umber", id: "123" });
@@ -472,6 +507,42 @@ test('serializeIntoHash uses payloadKeyFromModelName to normalize the payload ro
     'home-planet': {
       name: "Umber"
     }
+  });
+});
+
+test('normalizeResponse with async polymorphic belongsTo, using <relationshipName>Type', function() {
+  env.registry.register('serializer:application', DS.RESTSerializer.extend());
+  var store = env.store;
+  env.adapter.findRecord = (store, type) => {
+    if (type.modelName === 'doomsday-device') {
+      return {
+        doomsdayDevice: {
+          id: 1,
+          name: "DeathRay",
+          evilMinion: 1,
+          evilMinionType: 'yellowMinion'
+        }
+      };
+    }
+
+    equal(type.modelName, 'yellow-minion');
+
+    return {
+      yellowMinion: {
+        id: 1,
+        type: 'yellowMinion',
+        name: 'Alex',
+        eyes: 3
+      }
+    };
+  };
+
+  run(function() {
+    store.findRecord('doomsday-device', 1).then((deathRay) => {
+      return deathRay.get('evilMinion');
+    }).then((evilMinion) => {
+      equal(evilMinion.get('eyes'), 3);
+    });
   });
 });
 

--- a/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
@@ -455,6 +455,46 @@ test('serializeBelongsTo with async polymorphic', function() {
   deepEqual(json, expected, 'returned JSON is correct');
 });
 
+test('serializeBelongsTo logs deprecation when old behavior for getting polymorphic type key is used', function() {
+  var evilMinion, doomsdayDevice;
+  var json = {};
+  var expected = { evilMinion: '1', myCustomKeyType: 'evilMinion' };
+
+  env.restSerializer.keyForAttribute = function() {
+    return 'myCustomKey';
+  };
+
+  run(function() {
+    evilMinion = env.store.createRecord('evil-minion', { id: 1, name: 'Tomster' });
+    doomsdayDevice = env.store.createRecord('doomsday-device', { id: 2, name: 'Yehuda', evilMinion: evilMinion });
+  });
+
+  expectDeprecation(function() {
+    env.restSerializer.serializeBelongsTo(doomsdayDevice._createSnapshot(), json, { key: 'evilMinion', options: { polymorphic: true, async: true } });
+  }, "The key to serialize the type of a polymorphic record is created via keyForAttribute which has been deprecated. Use the keyForPolymorphicType hook instead.");
+
+  deepEqual(json, expected, 'returned JSON is correct');
+});
+
+test('keyForPolymorphicType can be used to overwrite how the type of a polymorphic record is serialized', function() {
+  var evilMinion, doomsdayDevice;
+  var json = {};
+  var expected = { evilMinion: '1', typeForEvilMinion: 'evilMinion' };
+
+  env.restSerializer.keyForPolymorphicType = function() {
+    return 'typeForEvilMinion';
+  };
+
+  run(function() {
+    evilMinion = env.store.createRecord('evil-minion', { id: 1, name: 'Tomster' });
+    doomsdayDevice = env.store.createRecord('doomsday-device', { id: 2, name: 'Yehuda', evilMinion: evilMinion });
+  });
+
+  env.restSerializer.serializeBelongsTo(doomsdayDevice._createSnapshot(), json, { key: 'evilMinion', options: { polymorphic: true, async: true } });
+
+  deepEqual(json, expected, 'returned JSON is correct');
+});
+
 test('keyForPolymorphicType can be used to overwrite how the type of a polymorphic record is looked up for normalization', function() {
   var json = {
     doomsdayDevice: {


### PR DESCRIPTION
This change adds the correct extraction of a polymorphic belongsTo
specified in the payload in the following form:

``` js
{
  id: 123,
  // ...
  message: 1,
  messageType: 'post'
}
```

where the model is specified as:

``` js
DS.Model.extend({
  message: DS.belongsTo('message', { polymorphic: true })
})
```

---

If this gets accepted, this should likely be ported back to `1.13` as well.

This closes #3806