### PR TITLE
[WIP] Add `normalizePayload(modelName, payload)` to DS.Store

### DIFF
--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -161,6 +161,10 @@ const JSONAPISerializer = JSONSerializer.extend({
     store.push(normalizedPayload);
   },
 
+  normalizePayload: function(primaryModelName, payload) {
+    return this._normalizeDocumentHelper(payload);
+  },
+
   /**
     @method _normalizeResponse
     @param {DS.Store} store

--- a/packages/ember-data/tests/integration/serializers/json-api-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-api-serializer-test.js
@@ -120,3 +120,51 @@ test('Warns when normalizing an unknown type', function() {
     });
   }, /Encountered a resource object with type "UnknownType", but no model was found for model name "unknown-type"/);
 });
+
+test('normalizePayload(modelName, payload)', function() {
+  var payload = {
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        company: {
+          data: { type: 'company', id: '2' }
+        }
+      }
+    },
+    included: [{
+      type: 'company',
+      id: '2',
+      attributes: {
+        name: 'Tilde Inc.'
+      }
+    }]
+  };
+
+  var normalizedPayload = env.store.normalizePayload('user', payload);
+  deepEqual(normalizedPayload, payload);
+});
+
+test('normalizePayload(payload)', function() {
+  var payload = {
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        company: {
+          data: { type: 'company', id: '2' }
+        }
+      }
+    },
+    included: [{
+      type: 'company',
+      id: '2',
+      attributes: {
+        name: 'Tilde Inc.'
+      }
+    }]
+  };
+
+  var normalizedPayload = env.store.normalizePayload('user', payload);
+  deepEqual(normalizedPayload, payload);
+});

--- a/packages/ember-data/tests/unit/store/normalize-payload-test.js
+++ b/packages/ember-data/tests/unit/store/normalize-payload-test.js
@@ -1,0 +1,136 @@
+var env, store, Person, PhoneNumber, Post;
+var attr = DS.attr;
+var hasMany = DS.hasMany;
+var belongsTo = DS.belongsTo;
+var run = Ember.run;
+
+module("unit/store/normalize-payload - DS.Store#normalizePayload", {
+  setup: function() {
+    Person = DS.Model.extend({
+      firstName: attr('string'),
+      lastName: attr('string'),
+      phoneNumbers: hasMany('phone-number', { async: false })
+    });
+    Person.toString = function() {
+      return 'Person';
+    };
+
+    PhoneNumber = DS.Model.extend({
+      number: attr('string'),
+      person: belongsTo('person', { async: false })
+    });
+    PhoneNumber.toString = function() {
+      return 'PhoneNumber';
+    };
+
+    Post = DS.Model.extend({
+      postTitle: attr('string')
+    });
+    Post.toString = function() {
+      return 'Post';
+    };
+
+    env = setupStore({
+      post: Post,
+      person: Person,
+      "phone-number": PhoneNumber
+    });
+
+    store = env.store;
+
+    env.registry.register('serializer:post', DS.RESTSerializer);
+  },
+
+  teardown: function() {
+    run(function() {
+      store.destroy();
+    });
+  }
+});
+
+test("normalizePayload(modelName, payload)", function() {
+  env.registry.register('serializer:application', DS.RESTSerializer.extend());
+
+  var payload = {
+    person: {
+      id: 1,
+      firstName: "first name",
+      phoneNumbers: [1]
+    },
+    phoneNumbers: [
+      { id: 1, number: "1234" }
+    ]
+  };
+  var normalized = store.normalizePayload('person', payload);
+
+  deepEqual(normalized, {
+    data: {
+      id: '1',
+      type: 'person',
+      attributes: {
+        firstName: 'first name'
+      },
+      relationships: {
+        phoneNumbers: {
+          data: [
+            { id: '1', type: 'phone-number' }
+          ]
+        }
+      }
+    },
+    included: [
+      {
+        id: '1',
+        type: 'phone-number',
+        attributes: {
+          number: '1234'
+        },
+        relationships: {}
+      }
+    ]
+  });
+});
+
+test("normalizePayload(payload)", function() {
+  env.registry.register('serializer:application', DS.RESTSerializer.extend());
+
+  var payload = {
+    person: {
+      id: 1,
+      firstName: "first name",
+      phoneNumbers: [1]
+    },
+    phoneNumbers: [
+      { id: 1, number: "1234" }
+    ]
+  };
+  var normalized = store.normalizePayload(payload);
+
+  deepEqual(normalized, {
+    data: [
+      {
+        id: '1',
+        type: 'person',
+        attributes: {
+          firstName: 'first name'
+        },
+        relationships: {
+          phoneNumbers: {
+            data: [
+              { id: '1', type: 'phone-number' }
+            ]
+          }
+        }
+      },
+      {
+        id: '1',
+        type: 'phone-number',
+        attributes: {
+          number: '1234'
+        },
+        relationships: {}
+      }
+    ],
+    included: []
+  });
+});


### PR DESCRIPTION
A payload can be normalized by `store.normalizePayload()` into the JSON
API format Ember Data expects for `store.push`. The method optionally
takes a primary model name as first argument. If a primary model is
specified, the normalized payloads' primary data contains data for this
model from the payload and all other data is included.

---

This addresses #3605.

Opened this PR to get some feedback if I understood #3605 correctly and if this is heading the right direction...
