### PR TITLE
[BUGFIX beta] JSONAPI serializer not respecting 'attrs' hash

### DIFF
--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -276,7 +276,13 @@ const JSONAPISerializer = JSONSerializer.extend({
     @return {Object} the normalized resource hash
   */
   normalize: function(modelClass, resourceHash) {
-    this.normalizeUsingDeclaredMapping(modelClass, resourceHash);
+    if (resourceHash.attributes) {
+      this.normalizeUsingDeclaredMapping(modelClass, resourceHash.attributes);
+    }
+
+    if (resourceHash.relationships) {
+      this.normalizeUsingDeclaredMapping(modelClass, resourceHash.relationships);
+    }
 
     let data = {
       id:            this.extractId(modelClass, resourceHash),

--- a/packages/ember-data/tests/integration/serializers/json-api-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-api-serializer-test.js
@@ -10,6 +10,7 @@ module('integration/serializers/json-api-serializer - JSONAPISerializer', {
     User = DS.Model.extend({
       firstName: DS.attr('string'),
       lastName: DS.attr('string'),
+      title: DS.attr('string'),
       handles: DS.hasMany('handle', { async: true, polymorphic: true }),
       company: DS.belongsTo('company', { async: true })
     });
@@ -119,4 +120,69 @@ test('Warns when normalizing an unknown type', function() {
       env.store.serializerFor('user').normalizeResponse(env.store, User, documentHash, '1', 'findRecord');
     });
   }, /Encountered a resource object with type "UnknownType", but no model was found for model name "unknown-type"/);
+});
+
+test('Serializer should respect the attrs hash when extracting attributes and relationships', function() {
+  env.registry.register("serializer:user", DS.JSONAPISerializer.extend({
+    attrs: {
+      title: "title_attribute_key",
+      company: { key: 'company_relationship_key' }
+    }
+  }));
+
+  var jsonHash = {
+    data: {
+      type: 'users',
+      id: '1',
+      attributes: {
+        'title_attribute_key': 'director'
+      },
+      relationships: {
+        'company_relationship_key': {
+          data: { type: 'companies', id: '2' }
+        }
+      }
+    },
+    included: [{
+      type: 'companies',
+      id: '2',
+      attributes: {
+        name: 'Tilde Inc.'
+      }
+    }]
+  };
+
+  var user = env.store.serializerFor("user").normalizeResponse(env.store, User, jsonHash, '1', 'findRecord');
+
+  equal(user.data.attributes.title, "director");
+  deepEqual(user.data.relationships.company.data, { id: "2", type: "company" });
+});
+
+test('Serializer should respect the attrs hash when serializing attributes and relationships', function() {
+  env.registry.register("serializer:user", DS.JSONAPISerializer.extend({
+    attrs: {
+      title: "title_attribute_key",
+      company: { key: 'company_relationship_key' }
+    }
+  }));
+  var company, user;
+
+  run(function() {
+    env.store.push({
+      data: {
+        type: 'company',
+        id: '1',
+        attributes: {
+          name: "Tilde Inc."
+        }
+      }
+    });
+    company = env.store.peekRecord('company', 1);
+    user = env.store.createRecord('user', { firstName: "Yehuda", title: "director", company: company });
+  });
+
+  var payload = env.store.serializerFor("user").serialize(user._createSnapshot());
+
+  equal(payload.data.relationships['company_relationship_key'].data.id, "1");
+  equal(payload.data.attributes['title_attribute_key'], "director");
 });


### PR DESCRIPTION
Fix for [3810](https://github.com/emberjs/data/issues/3810).

This applies `normalizeUsingDeclaredMapping` to both the `attributes` and `relationships` of the resource hash in `normalize`.