### PR TITLE
[BUGFIX] EmbeddedRecordMixin should include the type serializing hasMany as ids

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -30,3 +30,27 @@ entry in `config/features.json`.
 
   Enables `pushPayload` to return the model(s) that are created or
   updated via the internal `store.push`. [PR 4110](https://github.com/emberjs/data/pull/4110)
+
+- `ds-serialize-ids-and-types`
+
+  Enables a new `ids-and-type` strategy (in addition to the already existing `ids` and `records`) for
+  serializing has many relationships using the `DS.EmbeddedRecordsMixin` that  will include both
+  `id` and `type` of each model as an object.
+
+  For instance, if a use has many pets, which is a polymorphic relationship, the generated payload would be:
+
+  ```js
+  {
+    "user": {
+      "id": "1"
+      "name": "Bertin Osborne",
+      "pets": [
+        { "id": "1", "type": "Cat" },
+        { "id": "2", "type": "Parrot"}
+      ]
+    }
+  }
+  ```
+
+  This is particularly useful for polymorphic relationships not backed by STI when just including the id
+  of the records is not enough.

--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { warn } from "ember-data/-private/debug";
+import isEnabled from 'ember-data/-private/features';
 
 var get = Ember.get;
 var set = Ember.set;
@@ -235,7 +236,7 @@ export default Ember.Mixin.create({
   },
 
   /**
-    Serialize `hasMany` relationship when it is configured as embedded objects.
+    Serializes `hasMany` relationships when it is configured as embedded objects.
 
     This example of a post model has many comments:
 
@@ -285,7 +286,7 @@ export default Ember.Mixin.create({
     ```
 
     The attrs options object can use more specific instruction for extracting and
-    serializing. When serializing, an option to embed `ids` or `records` can be set.
+    serializing. When serializing, an option to embed `ids`, `ids-and-types` or `records` can be set.
     When extracting the only option is `records`.
 
     So `{ embedded: 'always' }` is shorthand for:
@@ -314,6 +315,58 @@ export default Ember.Mixin.create({
     }
     ```
 
+    To embed the relationship as a collection of objects with `id` and `type` keys, set
+    `ids-and-types` for the related object.
+
+    This is particularly useful for polymorphic relationships where records don't share
+    the same table and the `id` is not enough information.
+
+    By example having a user that has many pets:
+
+    ```js
+    User = DS.Model.extend({
+      name:    DS.attr('string'),
+      pets: DS.hasMany('pet', { polymorphic: true })
+    });
+
+    Pet = DS.Model.extend({
+      name: DS.attr('string'),
+    });
+
+    Cat = Pet.extend({
+      // ...
+    });
+
+    Parrot = Pet.extend({
+      // ...
+    });
+    ```
+
+    ```app/serializers/user.js
+    import DS from 'ember-data;
+
+    export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+      attrs: {
+        pets: { serialize: 'ids-and-types', deserialize: 'records' }
+      }
+    });
+    ```
+
+    ```js
+    {
+      "user": {
+        "id": "1"
+        "name": "Bertin Osborne",
+        "pets": [
+          { "id": "1", "type": "Cat" },
+          { "id": "1", "type": "Parrot"}
+        ]
+      }
+    }
+    ```
+
+    Note that the `ids-and-types` strategy is still behind the `ds-serialize-ids-and-types` feature flag.
+
     @method serializeHasMany
     @param {DS.Snapshot} snapshot
     @param {Object} json
@@ -325,14 +378,40 @@ export default Ember.Mixin.create({
       this._super(snapshot, json, relationship);
       return;
     }
-    var includeIds = this.hasSerializeIdsOption(attr);
-    var includeRecords = this.hasSerializeRecordsOption(attr);
-    if (includeIds) {
+
+    if (this.hasSerializeIdsOption(attr)) {
       let serializedKey = this.keyForRelationship(attr, relationship.kind, 'serialize');
       json[serializedKey] = snapshot.hasMany(attr, { ids: true });
-    } else if (includeRecords) {
+    } else if (this.hasSerializeRecordsOption(attr)) {
       this._serializeEmbeddedHasMany(snapshot, json, relationship);
+    } else {
+      if (isEnabled("ds-serialize-ids-and-types")) {
+        if (this.hasSerializeIdsAndTypesOption(attr)) {
+          this._serializeHasManyAsIdsAndTypes(snapshot, json, relationship);
+        }
+      }
     }
+  },
+
+  /**
+    Serializes a hasMany relationship as an array of objects containing only `id` and `type`
+    keys.
+    This has its use case on polymorphic hasMany relationships where the server is not storing
+    all records in the same table using STI, and therefore the `id` is not enough information
+
+    TODO: Make the default in Ember-data 3.0??
+  */
+  _serializeHasManyAsIdsAndTypes(snapshot, json, relationship) {
+    var serializedKey = this.keyForAttribute(relationship.key, 'serialize');
+    var hasMany = snapshot.hasMany(relationship.key);
+
+    json[serializedKey] = Ember.A(hasMany).map(function (recordSnapshot) {
+      //
+      // I'm sure I'm being utterly naive here. Propably id is a configurate property and
+      // type too, and the modelName has to be normalized somehow.
+      //
+      return { id: recordSnapshot.id, type: recordSnapshot.modelName };
+    });
   },
 
   _serializeEmbeddedHasMany(snapshot, json, relationship) {
@@ -418,6 +497,12 @@ export default Ember.Mixin.create({
   hasSerializeIdsOption(attr) {
     var option = this.attrsOption(attr);
     return option && (option.serialize === 'ids' || option.serialize === 'id');
+  },
+
+  // checks config for attrs option to serialize records as objects containing id and types
+  hasSerializeIdsAndTypesOption(attr) {
+    var option = this.attrsOption(attr);
+    return option && (option.serialize === 'ids-and-types' || option.serialize === 'id-and-type');
   },
 
   // checks config for attrs option to serialize records

--- a/config/features.json
+++ b/config/features.json
@@ -2,5 +2,6 @@
   "ds-finder-include": null,
   "ds-references": null,
   "ds-transform-pass-options": null,
-  "ds-pushpayload-return": null
+  "ds-pushpayload-return": null,
+  "ds-serialize-ids-and-types": null
 }


### PR DESCRIPTION
It is better explained with an example.

Lets say that that you have an error that contains many attachable items 
(`attachables: DS.hasMany(‘attachable’, { polymorphic: true })`) and the serializer looks like this:

```
export default ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
  attrs: {
    attachables: {
      serialize: 'ids',
      deserialize: 'ids'
    }
  }
});
```

At the moment the serialized json contains `attachables: [1,2,3, ...]` but that is useless for polymorphic relationships, the serialized array should contain `{id, type}` tuples (`attachables: [{type: 'pdf', id: 1}, {type: 'xls', id: 1}]`)