### PR TITLE
[DOC] Document snapshotRecordArray param passed to adapter.findAll

### DIFF
--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -385,9 +385,10 @@ export default Adapter.extend(BuildURLMixin, {
     @param {DS.Store} store
     @param {DS.Model} type
     @param {String} sinceToken
+    @param {DS.SnapshotRecordArray} snapshotRecordArray
     @return {Promise} promise
   */
-  findAll: function(store, type, sinceToken) {
+  findAll: function(store, type, sinceToken, snapshotRecordArray) {
     var query, url;
 
     if (sinceToken) {


### PR DESCRIPTION
The [docs for DS.Adapter#findAll](https://github.com/emberjs/data/blob/4e79b27d48b71f8ad737471db706149164c4a27a/packages/ember-data/lib/system/adapter.js#L152) already include this and it is already being passed
[when DS.Store#findAll](https://github.com/emberjs/data/blob/8f83fbf27acdd642cb824e3286832acebdac0da1/packages/ember-data/lib/system/store/finders.js#L121) is used.