### PR TITLE
test demonstrating issue #3851 and #1764 possibly related to #3677

### DIFF
--- a/packages/ember-data/tests/integration/records/save-test.js
+++ b/packages/ember-data/tests/integration/records/save-test.js
@@ -95,7 +95,9 @@ test("Repeated failed saves keeps the record in uncommited state", function() {
   });
 
   env.adapter.createRecord = function(store, type, snapshot) {
-    return Ember.RSVP.reject();
+    var error = new DS.InvalidError([{ title: 'not valid' }]);
+
+    return Ember.RSVP.reject(error);
   };
 
   run(function() {


### PR DESCRIPTION
Records are remaining in `root.loaded.created.inFlight` after server returns validation error.