### PR TITLE
fix transitioning into invalid state

### DIFF
--- a/addon/system/model/internal-model.js
+++ b/addon/system/model/internal-model.js
@@ -676,17 +676,24 @@ InternalModel.prototype = {
 
   addErrorMessageToAttribute: function(attribute, message) {
     var record = this.getRecord();
-    get(record, 'errors').add(attribute, message);
+    get(record, 'errors')._add(attribute, message);
   },
 
   removeErrorMessageFromAttribute: function(attribute) {
     var record = this.getRecord();
-    get(record, 'errors').remove(attribute);
+    get(record, 'errors')._remove(attribute);
   },
 
   clearErrorMessages: function() {
     var record = this.getRecord();
-    get(record, 'errors').clear();
+    get(record, 'errors')._clear();
+  },
+
+  hasErrors: function() {
+    var record = this.getRecord();
+    var errors = get(record, 'errors');
+
+    return !Ember.isEmpty(errors);
   },
 
   // FOR USE DURING COMMIT PROCESS

--- a/addon/system/model/model.js
+++ b/addon/system/model/model.js
@@ -351,14 +351,13 @@ var Model = Ember.Object.extend(Ember.Evented, {
   errors: Ember.computed(function() {
     let errors = Errors.create();
 
-    errors.registerHandlers(this._internalModel,
+    errors._registerHandlers(this._internalModel,
       function() {
         this.send('becameInvalid');
       },
       function() {
         this.send('becameValid');
       });
-
     return errors;
   }).readOnly(),
 

--- a/addon/system/model/states.js
+++ b/addon/system/model/states.js
@@ -326,6 +326,10 @@ var DirtyState = {
       internalModel.removeErrorMessageFromAttribute(context.name);
 
       didSetProperty(internalModel, context);
+
+      if (!internalModel.hasErrors()) {
+        this.becameValid(internalModel);
+      }
     },
 
     becameInvalid: Ember.K,
@@ -695,6 +699,10 @@ var RootState = {
         internalModel.removeErrorMessageFromAttribute(context.name);
 
         didSetProperty(internalModel, context);
+
+        if (!internalModel.hasErrors()) {
+          this.becameValid(internalModel);
+        }
       },
 
       becameInvalid: Ember.K,

--- a/tests/integration/records/save-test.js
+++ b/tests/integration/records/save-test.js
@@ -58,7 +58,9 @@ test("Will reject save on error", function(assert) {
   });
 
   env.adapter.createRecord = function(store, type, snapshot) {
-    return Ember.RSVP.reject();
+    var error = new DS.InvalidError([{ title: 'not valid' }]);
+
+    return Ember.RSVP.reject(error);
   };
 
   run(function() {
@@ -77,8 +79,10 @@ test("Retry is allowed in a failure handler", function(assert) {
   var count = 0;
 
   env.adapter.createRecord = function(store, type, snapshot) {
+    var error = new DS.InvalidError([{ title: 'not valid' }]);
+
     if (count++ === 0) {
-      return Ember.RSVP.reject();
+      return Ember.RSVP.reject(error);
     } else {
       return Ember.RSVP.resolve({ id: 123 });
     }
@@ -181,7 +185,9 @@ test("Will reject save on invalid", function(assert) {
   });
 
   env.adapter.createRecord = function(store, type, snapshot) {
-    return Ember.RSVP.reject({ title: 'invalid' });
+    var error = new DS.InvalidError([{ title: 'not valid' }]);
+
+    return Ember.RSVP.reject(error);
   };
 
   run(function() {


### PR DESCRIPTION
Fixes issue #3851.  

Removes events from error class that was causing side effects.   I don't think the error class should be responsible for updating the model state. 