### PR TITLE
Merge `normalizeRelationships` and `setupRelationships` methods in store

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1346,7 +1346,7 @@ Store = Service.extend({
     }
     if (data) {
       // normalize relationship IDs into records
-      this._backburner.schedule('normalizeRelationships', this, '_setupRelationships', internalModel, internalModel.type, data);
+      this._backburner.schedule('normalizeRelationships', this, '_setupRelationships', internalModel, data);
       this.updateId(internalModel, data);
     }
 
@@ -1717,23 +1717,15 @@ Store = Service.extend({
     var internalModel = this._load(data);
 
     this._backburner.join(() => {
-      this._backburner.schedule('normalizeRelationships', this, '_setupRelationships', internalModel, type, data);
+      this._backburner.schedule('normalizeRelationships', this, '_setupRelationships', internalModel, data);
     });
 
     return internalModel;
   },
 
-  _setupRelationships: function(record, type, data) {
-    // If the payload contains relationships that are specified as
-    // IDs, normalizeRelationships will convert them into DS.Model instances
-    // (possibly unloaded) before we push the payload into the
-    // store.
-
-    data = normalizeRelationships(this, type, data);
-
-
-    // Now that the pushed record as well as any related records
-    // are in the store, create the data structures used to track
+  _setupRelationships: function(record, data) {
+    // This will convert relationships specified as IDs into DS.Model instances
+    // (possibly unloaded) and also create the data structures used to track
     // relationships.
     setupRelationships(this, record, data);
   },
@@ -2022,25 +2014,6 @@ Store = Service.extend({
 
 });
 
-
-function normalizeRelationships(store, type, data, record) {
-  data.relationships = data.relationships || {};
-  type.eachRelationship(function(key, relationship) {
-    var kind = relationship.kind;
-    var value;
-    if (data.relationships[key] && data.relationships[key].data) {
-      value = data.relationships[key].data;
-      if (kind === 'belongsTo') {
-        data.relationships[key].data = deserializeRecordId(store,  key, relationship, value);
-      } else if (kind === 'hasMany') {
-        data.relationships[key].data = deserializeRecordIds(store, key, relationship, value);
-      }
-    }
-  });
-
-  return data;
-}
-
 function deserializeRecordId(store, key, relationship, id) {
   if (isNone(id)) {
     return;
@@ -2110,13 +2083,13 @@ function _commit(adapter, store, operation, snapshot) {
 }
 
 function setupRelationships(store, record, data) {
-  var typeClass = record.type;
   if (!data.relationships) {
     return;
   }
 
-  typeClass.eachRelationship((key, descriptor) => {
+  record.type.eachRelationship((key, descriptor) => {
     var kind = descriptor.kind;
+
     if (!data.relationships[key]) {
       return;
     }
@@ -2135,7 +2108,11 @@ function setupRelationships(store, record, data) {
       relationship = record._relationships.get(key);
       relationship.updateMeta(data.relationships[key].meta);
     }
-    var value = data.relationships[key].data;
+
+    // If the data contains a relationship that is specified as an ID (or IDs),
+    // normalizeRelationship will convert them into DS.Model instances
+    // (possibly unloaded) before we push the payload into the store.
+    var value = normalizeRelationship(store, key, descriptor, data.relationships[key]);
 
     if (value !== undefined) {
       if (kind === 'belongsTo') {
@@ -2147,6 +2124,19 @@ function setupRelationships(store, record, data) {
       }
     }
   });
+}
+
+function normalizeRelationship(store, key, relationship, value) {
+  var data = value.data;
+  if (data) {
+    var kind = relationship.kind;
+    if (kind === 'belongsTo') {
+      return value.data = deserializeRecordId(store, key, relationship, data);
+    } else if (kind === 'hasMany') {
+      return value.data = deserializeRecordIds(store, key, relationship, data);
+    }
+  }
+  return data;
 }
 
 export { Store };


### PR DESCRIPTION
While working on some performance related tasks, I noticed that `normalizeRelationships` and `setupRelationships` both loop over the relationships for a record. The only time these functions are used is in sequence, so it looks like these could be merged to cut down on some time complexity.

Will be trying this out in our application tomorrow to see if it has any side effects, but it doesn't appear to so far.