### PR TITLE
[BUGFIX beta] rollbackAttributes() works after multiple failed saves

### DIFF
--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -1,7 +1,6 @@
 /**
   @module ember-data
 */
-import EmptyObject from "ember-data/system/empty-object";
 var get = Ember.get;
 /*
   This file encapsulates the various states that a record can transition
@@ -347,10 +346,6 @@ var DirtyState = {
 
     invokeLifecycleCallbacks: function(internalModel) {
       internalModel.triggerLater('becameInvalid', internalModel);
-    },
-
-    exit: function(internalModel) {
-      internalModel._inFlightAttributes = new EmptyObject();
     }
   }
 };


### PR DESCRIPTION
A rollback of dirty attributes didn't work correctly when a model is
saved more than 1 time and the save fails. The issue is that the `exit`
handler on the invalid state - which is called when the model is saved
again and it is transitioned into the inFlight state - clears the
`_inFlightAttributes` which unfortunately wipes all the data needed to
rollback attributes.

The exit handler has been implemented in the course of #1755, but the
reported issue in that PR seems to be fixed ever since elsewhere in the
code base, since the added test back test still is green.

---

This depends on ~~#3856~~ #3859 and closes #3677.