### PR TITLE
Reset changed attributes when matching data is pushed

### DIFF
--- a/packages/ember-data/lib/system/model/internal-model.js
+++ b/packages/ember-data/lib/system/model/internal-model.js
@@ -7,6 +7,7 @@ import EmptyObject from "ember-data/system/empty-object";
 var Promise = Ember.RSVP.Promise;
 var get = Ember.get;
 var set = Ember.set;
+var copy = Ember.copy;
 
 var _extractPivotNameCache = new EmptyObject();
 var _splitOnDotCache = new EmptyObject();
@@ -270,6 +271,52 @@ InternalModel.prototype = {
   flushChangedAttributes: function() {
     this._inFlightAttributes = this._attributes;
     this._attributes = new EmptyObject();
+  },
+
+  hasChangedAttributes: function() {
+    return Object.keys(this._attributes).length > 0;
+  },
+
+  /**
+    Checks if the attributes which are considered as changed are still
+    different to the state which is acknowledged by the server.
+
+    This method is needed when data for the internal model is pushed and the
+    pushed data might acknowledge dirty attributes as confirmed.
+   */
+  updateChangedAttributes: function() {
+    var changedAttributes = this.changedAttributes();
+    var changedAttributeNames = Object.keys(changedAttributes);
+
+    for (let i = 0, length = changedAttributeNames.length; i < length; i++) {
+      let attribute = changedAttributeNames[i];
+      let [oldData, newData] = changedAttributes[attribute];
+
+      if (oldData === newData) {
+        delete this._attributes[attribute];
+      }
+    }
+  },
+
+  /**
+    Returns an object, whose keys are changed properties, and value is an
+    [oldProp, newProp] array.
+  */
+  changedAttributes: function() {
+    var oldData = this._data;
+    var currentData = this._attributes;
+    var inFlightData = this._inFlightAttributes;
+    var newData = merge(copy(inFlightData), currentData);
+    var diffData = new EmptyObject();
+
+    var newDataKeys = Object.keys(newData);
+
+    for (let i = 0, length = newDataKeys.length; i < length; i++) {
+      let key = newDataKeys[i];
+      diffData[key] = [oldData[key], newData[key]];
+    }
+
+    return diffData;
   },
 
   /**

--- a/packages/ember-data/lib/system/model/model.js
+++ b/packages/ember-data/lib/system/model/model.js
@@ -1,14 +1,11 @@
 import { PromiseObject } from "ember-data/system/promise-proxies";
 import Errors from "ember-data/system/model/errors";
-import EmptyObject from "ember-data/system/empty-object";
 
 /**
   @module ember-data
 */
 
 var get = Ember.get;
-var merge = Ember.merge;
-var copy = Ember.copy;
 
 function intersection (array1, array2) {
   var result = [];
@@ -610,20 +607,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
       and value is an [oldProp, newProp] array.
   */
   changedAttributes: function() {
-    var oldData = get(this._internalModel, '_data');
-    var currentData = get(this._internalModel, '_attributes');
-    var inFlightData = get(this._internalModel, '_inFlightAttributes');
-    var newData = merge(copy(inFlightData), currentData);
-    var diffData = new EmptyObject();
-
-    var newDataKeys = Object.keys(newData);
-
-    for (let i = 0, length = newDataKeys.length; i < length; i++) {
-      let key = newDataKeys[i];
-      diffData[key] = [oldData[key], newData[key]];
-    }
-
-    return diffData;
+    return this._internalModel.changedAttributes();
   },
 
   //TODO discuss with tomhuda about events/hooks

--- a/packages/ember-data/lib/system/model/states.js
+++ b/packages/ember-data/lib/system/model/states.js
@@ -241,13 +241,16 @@ var DirtyState = {
     loadingData: Ember.K,
 
     propertyWasReset: function(internalModel, name) {
-      var length = Object.keys(internalModel._attributes).length;
-      var stillDirty = length > 0;
-
-      if (!stillDirty) { internalModel.send('rolledBack'); }
+      if (!internalModel.hasChangedAttributes()) { internalModel.send('rolledBack'); }
     },
 
-    pushedData: Ember.K,
+    pushedData: function(internalModel) {
+      internalModel.updateChangedAttributes();
+
+      if (!internalModel.hasChangedAttributes()) {
+        internalModel.transitionTo('loaded.saved');
+      }
+    },
 
     becomeDirty: Ember.K,
 
@@ -534,10 +537,7 @@ var RootState = {
     // in the `saved` state.
     saved: {
       setup: function(internalModel) {
-        var attrs = internalModel._attributes;
-        var isDirty = Object.keys(attrs).length > 0;
-
-        if (isDirty) {
+        if (internalModel.hasChangedAttributes()) {
           internalModel.adapterDidDirty();
         }
       },

--- a/packages/ember-data/tests/unit/store/push-test.js
+++ b/packages/ember-data/tests/unit/store/push-test.js
@@ -48,6 +48,50 @@ module("unit/store/push - DS.Store#push", {
   }
 });
 
+test('Changed attributes are reset when matching data is pushed', function(assert) {
+  var person;
+
+  run(function() {
+    person = store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          firstName: 'original first name'
+        }
+      }
+    });
+  });
+
+  assert.equal(person.get('firstName'), 'original first name');
+  assert.equal(person.get('currentState.stateName'), 'root.loaded.saved');
+
+  run(function() {
+    person.set('firstName', 'updated first name');
+  });
+
+  assert.equal(person.get('firstName'), 'updated first name');
+  assert.equal(person.get('lastName'), undefined);
+  assert.equal(person.get('currentState.stateName'), 'root.loaded.updated.uncommitted');
+  deepEqual(person.changedAttributes().firstName, ['original first name', 'updated first name']);
+
+  run(function() {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          firstName: 'updated first name'
+        }
+      }
+    });
+  });
+
+  assert.equal(person.get('firstName'), 'updated first name');
+  assert.equal(person.get('currentState.stateName'), 'root.loaded.saved');
+  assert.ok(!person.changedAttributes().firstName);
+});
+
 test("Calling push with a normalized hash returns a record", function() {
   expect(2);
   env.adapter.shouldBackgroundReloadRecord = () => false;


### PR DESCRIPTION
If an attribute is changed locally and data is pushed to the store which
matches the changed attribute, then this changed attribute is considered
as confirmed and is no more considered as dirty.

---

This addresses #3265