### PR TITLE
[BUGFIX beta] serialize type for embedded, polymorphic belongsTo

### DIFF
--- a/packages/ember-data/lib/serializers/embedded-records-mixin.js
+++ b/packages/ember-data/lib/serializers/embedded-records-mixin.js
@@ -202,6 +202,10 @@ export default Ember.Mixin.create({
         json[key] = null;
       } else {
         json[key] = embeddedSnapshot.id;
+
+        if (relationship.options.polymorphic) {
+          this.serializePolymorphicType(snapshot, json, relationship);
+        }
       }
     } else if (includeRecords) {
       this._serializeEmbeddedBelongsTo(snapshot, json, relationship);
@@ -216,6 +220,10 @@ export default Ember.Mixin.create({
     } else {
       json[serializedKey] = embeddedSnapshot.record.serialize({ includeId: true });
       this.removeEmbeddedForeignKey(snapshot, embeddedSnapshot, relationship, json[serializedKey]);
+
+      if (relationship.options.polymorphic) {
+        this.serializePolymorphicType(snapshot, json, relationship);
+      }
     }
   },
 

--- a/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/packages/ember-data/tests/integration/serializers/embedded-records-mixin-test.js
@@ -1157,6 +1157,57 @@ test("serialize with embedded object (belongsTo relationship)", function() {
   });
 });
 
+test("serialize with embedded object (polymorphic belongsTo relationship)", function() {
+  env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: { embedded: 'always' }
+    }
+  }));
+
+  SuperVillain.reopen({
+    secretLab: DS.belongsTo('secret-lab', { polymorphic: true })
+  });
+
+  var json, tom;
+  run(function() {
+    tom = env.store.createRecord(
+      'super-villain',
+      {
+        id: "1",
+        firstName: "Tom",
+        lastName: "Dale",
+        secretLab: env.store.createRecord('bat-cave', {
+          id: "101",
+          minionCapacity: 5000,
+          vicinity: "California, USA",
+          infiltrated: true
+        }),
+        homePlanet: env.store.createRecord('home-planet', {
+          id: "123",
+          name: "Villain League"
+        })
+      }
+    );
+  });
+
+  run(function() {
+    json = tom.serialize();
+  });
+
+  deepEqual(json, {
+    firstName: get(tom, "firstName"),
+    lastName: get(tom, "lastName"),
+    homePlanet: get(tom, "homePlanet").get("id"),
+    secretLabType: 'batCave',
+    secretLab: {
+      id: get(tom, "secretLab").get("id"),
+      minionCapacity: get(tom, "secretLab").get("minionCapacity"),
+      vicinity: get(tom, "secretLab").get("vicinity"),
+      infiltrated: true
+    }
+  });
+});
+
 test("serialize with embedded object (belongsTo relationship) works with different primaryKeys", function() {
   env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     primaryKey: '_id',
@@ -1233,6 +1284,111 @@ test("serialize with embedded object (belongsTo relationship, new no id)", funct
       minionCapacity: get(tom, "secretLab").get("minionCapacity"),
       vicinity: get(tom, "secretLab").get("vicinity")
     }
+  });
+});
+
+test("serialize with embedded object (polymorphic belongsTo relationship) supports serialize:ids", function() {
+  SuperVillain.reopen({
+    secretLab: DS.belongsTo('secret-lab', { polymorphic: true })
+  });
+
+  env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: { serialize: 'ids' }
+    }
+  }));
+
+  var tom, json;
+  run(function() {
+    tom = env.store.createRecord(
+      'super-villain',
+      { firstName: "Tom", lastName: "Dale", id: "1",
+        secretLab: env.store.createRecord('bat-cave', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+      }
+    );
+  });
+
+  run(function() {
+    json = tom.serialize();
+  });
+
+  deepEqual(json, {
+    firstName: get(tom, "firstName"),
+    lastName: get(tom, "lastName"),
+    homePlanet: get(tom, "homePlanet").get("id"),
+    secretLab: get(tom, "secretLab").get("id"),
+    secretLabType: 'batCave'
+  });
+});
+
+test("serialize with embedded object (belongsTo relationship) supports serialize:id", function() {
+  SuperVillain.reopen({
+    secretLab: DS.belongsTo('secret-lab', { polymorphic: true })
+  });
+
+  env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: { serialize: 'id' }
+    }
+  }));
+
+  var tom, json;
+  run(function() {
+    tom = env.store.createRecord(
+      'super-villain',
+      { firstName: "Tom", lastName: "Dale", id: "1",
+        secretLab: env.store.createRecord('bat-cave', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+      }
+    );
+  });
+
+  run(function() {
+    json = tom.serialize();
+  });
+
+  deepEqual(json, {
+    firstName: get(tom, "firstName"),
+    lastName: get(tom, "lastName"),
+    homePlanet: get(tom, "homePlanet").get("id"),
+    secretLab: get(tom, "secretLab").get("id"),
+    secretLabType: 'batCave'
+  });
+});
+
+test("serialize with embedded object (belongsTo relationship) supports serialize:id in conjunction with deserialize:records", function() {
+  SuperVillain.reopen({
+    secretLab: DS.belongsTo('secret-lab', { polymorphic: true })
+  });
+
+  env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      secretLab: { serialize: 'id', deserialize: 'records' }
+    }
+  }));
+
+  var tom, json;
+  run(function() {
+    tom = env.store.createRecord(
+      'super-villain',
+      { firstName: "Tom", lastName: "Dale", id: "1",
+        secretLab: env.store.createRecord('bat-cave', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+      }
+    );
+  });
+
+  run(function() {
+    json = tom.serialize();
+  });
+
+  deepEqual(json, {
+    firstName: get(tom, "firstName"),
+    lastName: get(tom, "lastName"),
+    homePlanet: get(tom, "homePlanet").get("id"),
+    secretLab: get(tom, "secretLab").get("id"),
+    secretLabType: 'batCave'
   });
 });
 


### PR DESCRIPTION
This fixes the issue where the `serializePolymorphicType` hook on the
serializer hasn't been invoked when an embedded, polymorphic belongsTo
relationship is serialized.

---

This issue has been reported in #3871 (though for ember-data `v1.13.8`).