### PR TITLE
fix model relationship name generation

### DIFF
--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -19,25 +19,40 @@ module.exports = {
 
     for (var name in entityOptions) {
       var type = entityOptions[name] || '';
+      var foreignModel = name;
+      if (type.indexOf(':') > -1) {
+        foreignModel = type.split(':')[1];
+        type = type.split(':')[0];
+      }
       var dasherizedName = stringUtils.dasherize(name);
       var dasherizedNameSingular = inflection.singularize(dasherizedName);
       var camelizedName = stringUtils.camelize(name);
       var dasherizedType = stringUtils.dasherize(type);
+      var dasherizedForeignModel = stringUtils.dasherize(foreignModel);
+      var dasherizedForeignModelSingular = inflection.singularize(dasherizedForeignModel);
 
       if (/has-many/.test(dasherizedType)) {
         var camelizedNamePlural = inflection.pluralize(camelizedName);
-        attrs.push(camelizedNamePlural + ': ' + dsAttr(dasherizedName, dasherizedType));
+        var attr = dsAttr(dasherizedForeignModelSingular, dasherizedType);
+        attrs.push(camelizedNamePlural + ': ' + attr);
+      } else if (/belongs-to/.test(dasherizedType)) {
+        var attr = dsAttr(dasherizedForeignModel, dasherizedType)
+        attrs.push(camelizedName + ': ' + attr);
       } else {
-        attrs.push(camelizedName + ': ' + dsAttr(dasherizedName, dasherizedType));
+        var attr = dsAttr(dasherizedName, dasherizedType)
+        attrs.push(camelizedName + ': ' + attr);
       }
 
       if (/has-many|belongs-to/.test(dasherizedType)) {
-        needs.push("'model:" + dasherizedNameSingular + "'");
+        needs.push("'model:" + dasherizedForeignModelSingular + "'");
       }
     }
+    var needsDeduplicated = needs.filter(function(need, i) {
+      return needs.indexOf(need) === i;
+    })
 
     attrs = attrs.join(',' + EOL + '  ');
-    needs = '  needs: [' + needs.join(', ') + ']';
+    needs = '  needs: [' + needsDeduplicated.join(', ') + ']';
 
     return {
       attrs: attrs,
@@ -51,8 +66,7 @@ function dsAttr(name, type) {
   case 'belongs-to':
     return 'DS.belongsTo(\'' + name + '\')';
   case 'has-many':
-    var singularizedName = inflection.singularize(name);
-    return 'DS.hasMany(\'' + singularizedName + '\')';
+    return 'DS.hasMany(\'' + name + '\')';
   case '':
     //"If you don't specify the type of the attribute, it will be whatever was provided by the server"
     //http://emberjs.com/guides/models/defining-models/


### PR DESCRIPTION
It is not currently possible to generate a model with a relationship named differently from the model's name ([despite the help indicating it should be](https://github.com/emberjs/data/blob/addonified/blueprints/model/HELP.md))

This patch brings the code's behavior in line with the docs.

I've also filed ember-cli/ember-cli#4986 as a hold-over until ember-cli/ember-cli#4909 lands

(not sure how closely you monitor ED PRs, so cc: @stefanpenner )