### PR TITLE
[BUGFIX release] import from ember-inflector to use the default instance

### DIFF
--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -4,7 +4,7 @@
 
 import JSONSerializer from 'ember-data/serializers/json-serializer';
 import normalizeModelName from 'ember-data/system/normalize-model-name';
-import { pluralize, singularize } from 'ember-inflector/lib/system/string';
+import { pluralize, singularize } from 'ember-inflector';
 
 var dasherize = Ember.String.dasherize;
 

--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -4,7 +4,7 @@
 
 import JSONSerializer from "ember-data/serializers/json-serializer";
 import normalizeModelName from "ember-data/system/normalize-model-name";
-import {singularize} from "ember-inflector/lib/system/string";
+import {singularize} from "ember-inflector";
 import coerceId from "ember-data/system/coerce-id";
 import { modelHasAttributeOrRelationshipNamedType } from "ember-data/utils";
 

--- a/packages/ember-data/lib/system/relationship-meta.js
+++ b/packages/ember-data/lib/system/relationship-meta.js
@@ -1,4 +1,4 @@
-import {singularize} from 'ember-inflector/lib/system/string';
+import {singularize} from 'ember-inflector';
 import normalizeModelName from 'ember-data/system/normalize-model-name';
 
 export function typeForRelationshipMeta(meta) {


### PR DESCRIPTION
Instead of importing from the path ember data should import from `ember-inflector` to use the default instance.

related issues: #3887, #3881