### PR TITLE
 [perf] minor adjustments to `store#push` flow

### DIFF
--- a/packages/ember-data/lib/system/store.js
+++ b/packages/ember-data/lib/system/store.js
@@ -1445,8 +1445,7 @@ Store = Service.extend({
     @param {Object} data
   */
   _load: function(data) {
-    var id = coerceId(data.id);
-    var internalModel = this._internalModelForId(data.type, id);
+    var internalModel = this._internalModelForId(data.type, data.id);
 
     internalModel.setupData(data);
 


### PR DESCRIPTION
Some simple suggestions of refactoring to squeeze out a little extra performance when calling `store#push`. In our application this shows ~50ms improvement for slower devices on medium-sized payloads. Changes are as follows:

- Don't call `coerceId` in `_load` since it gets called in `_internalModelForId`
- Use `Ember.isArray` instead of `Ember.typeOf`
- Use `for-loop`s instead of `Array.prototype` methods