### PR TITLE
Don't use Ember.create by default

### DIFF
--- a/packages/ember-data/lib/system/empty-object.js
+++ b/packages/ember-data/lib/system/empty-object.js
@@ -3,7 +3,8 @@
 // when you're treating the object instances as arbitrary dictionaries
 // and don't want your keys colliding with build-in methods on the
 // default object prototype.
-var proto = Ember.create(null, {
+var create = Object.create || Ember.create;
+var proto = create(null, {
   // without this, we will always still end up with (new
   // EmptyObject()).constructor === Object
   constructor: {


### PR DESCRIPTION
Fall back to Ember.create if Object.create is missing.

Fixes the deprecation coming back..