### PR TITLE
Cleanup `.codeclimate.yml`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,6 +2,5 @@
 languages:
   JavaScript: true
  exclude_paths:
-  - "packages/activemodel-adapter/tests/*"
   - "packages/ember/tests/*"
   - "packages/ember-data/tests/*"


### PR DESCRIPTION
Now activemodel-adapter is removed from core package.