### PR TITLE
[BUGFIX beta] Correctly handle object level errors in json api

### DIFF
--- a/packages/ember-data/lib/adapters/errors.js
+++ b/packages/ember-data/lib/adapters/errors.js
@@ -1,6 +1,8 @@
 const EmberError = Ember.Error;
 
 const SOURCE_POINTER_REGEXP = /^\/?data\/(attributes|relationships)\/(.*)/;
+const SOURCE_POINTER_PRIMARY_REGEXP = /^\/?data/;
+const PRIMARY_ATTRIBUTE_KEY = 'base';
 
 /**
   @class AdapterError
@@ -115,11 +117,17 @@ export function errorsHashToArray(errors) {
     Object.keys(errors).forEach((key) => {
       let messages = Ember.makeArray(errors[key]);
       for (let i = 0; i < messages.length; i++) {
+        let title = 'Invalid Attribute';
+        let pointer = `/data/attributes/${key}`;
+        if (key === PRIMARY_ATTRIBUTE_KEY) {
+          title = 'Invalid Document';
+          pointer = `/data`;
+        }
         out.push({
-          title: 'Invalid Attribute',
+          title: title,
           detail: messages[i],
           source: {
-            pointer: `/data/attributes/${key}`
+            pointer: pointer
           }
         });
       }
@@ -143,6 +151,11 @@ export function errorsArrayToHash(errors) {
 
         if (key) {
           key = key[2];
+        } else if (error.source.pointer.search(SOURCE_POINTER_PRIMARY_REGEXP) !== -1) {
+          key = PRIMARY_ATTRIBUTE_KEY;
+        }
+
+        if (key) {
           out[key] = out[key] || [];
           out[key].push(error.detail || error.title);
         }

--- a/packages/ember-data/tests/unit/adapter-errors-test.js
+++ b/packages/ember-data/tests/unit/adapter-errors-test.js
@@ -47,9 +47,31 @@ var errorsArray = [
   }
 ];
 
+var errorsPrimaryHash = {
+  base: ['is invalid', 'error message']
+};
+
+var errorsPrimaryArray = [
+  {
+    title: 'Invalid Document',
+    detail: 'is invalid',
+    source: { pointer: '/data' }
+  },
+  {
+    title: 'Invalid Document',
+    detail: 'error message',
+    source: { pointer: '/data' }
+  }
+];
+
 test("errorsHashToArray", function() {
   var result = DS.errorsHashToArray(errorsHash);
   deepEqual(result, errorsArray);
+});
+
+test("errorsHashToArray for primary data object", function() {
+  var result = DS.errorsHashToArray(errorsPrimaryHash);
+  deepEqual(result, errorsPrimaryArray);
 });
 
 test("errorsArrayToHash", function() {
@@ -65,6 +87,11 @@ test("errorsArrayToHash without trailing slash", function() {
     }
   ]);
   deepEqual(result, { name: ['error message'] });
+});
+
+test("errorsArrayToHash for primary data object", function() {
+  var result = DS.errorsArrayToHash(errorsPrimaryArray);
+  deepEqual(result, errorsPrimaryHash);
 });
 
 test("DS.InvalidError will normalize errors hash will assert", function() {


### PR DESCRIPTION
Should fix https://github.com/emberjs/data/issues/3602. As per the JSON API spec object level errors should be placed in an object with pointer `/data`.

I have chosen to put object level data into errors.base, but this could be anything. If anyone is already using base in the form `pointer: '/data/attributes/base` then the object level ones are combined with this.

This is my first ever open source pull request so I fully expect to have missed other things I need to do or improve the code's style.