### PR TITLE
[BUGFIX release] Normalize attrs keys

### DIFF
--- a/packages/ember-data/lib/serializers/json-api-serializer.js
+++ b/packages/ember-data/lib/serializers/json-api-serializer.js
@@ -376,18 +376,19 @@ const JSONAPISerializer = JSONSerializer.extend({
    @param {Object} attribute
   */
   serializeAttribute: function(snapshot, json, key, attribute) {
-    var type = attribute.type;
+    const type = attribute.type;
 
     if (this._canSerialize(key)) {
       json.attributes = json.attributes || {};
 
-      var value = snapshot.attr(key);
+      let value = snapshot.attr(key);
       if (type) {
-        var transform = this.transformFor(type);
+        const transform = this.transformFor(type);
         value = transform.serialize(value);
       }
 
-      var payloadKey =  this._getMappedKey(key);
+      let payloadKey = this._getMappedKey(key, snapshot.type);
+
       if (payloadKey === key) {
         payloadKey = this.keyForAttribute(key, 'serialize');
       }
@@ -411,7 +412,7 @@ const JSONAPISerializer = JSONSerializer.extend({
 
         json.relationships = json.relationships || {};
 
-        var payloadKey = this._getMappedKey(key);
+        var payloadKey = this._getMappedKey(key, snapshot.type);
         if (payloadKey === key) {
           payloadKey = this.keyForRelationship(key, 'belongsTo', 'serialize');
         }
@@ -444,7 +445,7 @@ const JSONAPISerializer = JSONSerializer.extend({
 
         json.relationships = json.relationships || {};
 
-        var payloadKey = this._getMappedKey(key);
+        var payloadKey = this._getMappedKey(key, snapshot.type);
         if (payloadKey === key && this.keyForRelationship) {
           payloadKey = this.keyForRelationship(key, 'hasMany', 'serialize');
         }

--- a/packages/ember-data/lib/serializers/json-serializer.js
+++ b/packages/ember-data/lib/serializers/json-serializer.js
@@ -710,17 +710,26 @@ export default Serializer.extend({
     @method normalizeUsingDeclaredMapping
     @private
   */
-  normalizeUsingDeclaredMapping: function(typeClass, hash) {
+  normalizeUsingDeclaredMapping: function(modelClass, hash) {
     var attrs = get(this, 'attrs');
-    var payloadKey, key;
+    var payloadKey, normalizedKey, key;
 
     if (attrs) {
       for (key in attrs) {
-        payloadKey = this._getMappedKey(key);
+        payloadKey = this._getMappedKey(key, modelClass);
+
         if (!hash.hasOwnProperty(payloadKey)) { continue; }
 
-        if (payloadKey !== key) {
-          hash[key] = hash[payloadKey];
+        if (get(modelClass, 'attributes').has(key)) {
+          normalizedKey = this.keyForAttribute(key);
+        }
+
+        if (get(modelClass, 'relationshipsByName').has(key)) {
+          normalizedKey = this.keyForRelationship(key);
+        }
+
+        if (payloadKey !== normalizedKey) {
+          hash[normalizedKey] = hash[payloadKey];
           delete hash[payloadKey];
         }
       }
@@ -749,7 +758,9 @@ export default Serializer.extend({
     @param {String} key
     @return {String} key
   */
-  _getMappedKey: function(key) {
+  _getMappedKey: function(key, modelClass) {
+    Ember.assert('There is no attribute or relationship with the name `' + key + '` on `' + modelClass.modelName + '`. Check your serializers attrs hash.', get(modelClass, 'attributes').has(key) || get(modelClass, 'relationshipsByName').has(key));
+
     var attrs = get(this, 'attrs');
     var mappedKey;
     if (attrs && attrs[key]) {
@@ -1062,7 +1073,7 @@ export default Serializer.extend({
 
       // if provided, use the mapping provided by `attrs` in
       // the serializer
-      var payloadKey =  this._getMappedKey(key);
+      var payloadKey =  this._getMappedKey(key, snapshot.type);
 
       if (payloadKey === key && this.keyForAttribute) {
         payloadKey = this.keyForAttribute(key, 'serialize');
@@ -1107,7 +1118,7 @@ export default Serializer.extend({
 
       // if provided, use the mapping provided by `attrs` in
       // the serializer
-      var payloadKey = this._getMappedKey(key);
+      var payloadKey = this._getMappedKey(key, snapshot.type);
       if (payloadKey === key && this.keyForRelationship) {
         payloadKey = this.keyForRelationship(key, "belongsTo", "serialize");
       }
@@ -1159,7 +1170,7 @@ export default Serializer.extend({
       if (hasMany !== undefined) {
         // if provided, use the mapping provided by `attrs` in
         // the serializer
-        var payloadKey = this._getMappedKey(key);
+        var payloadKey = this._getMappedKey(key, snapshot.type);
         if (payloadKey === key && this.keyForRelationship) {
           payloadKey = this.keyForRelationship(key, "hasMany", "serialize");
         }

--- a/packages/ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/json-serializer-test.js
@@ -289,6 +289,30 @@ test('Serializer should respect the attrs hash when extracting records', functio
   deepEqual(post.data.relationships.comments.data, [{ id: "1", type: "comment" }, { id: "2", type: "comment" }]);
 });
 
+test('Serializer should map `attrs` attributes directly when keyForAttribute also has a transform', function() {
+  Post = DS.Model.extend({
+    authorName: DS.attr('string')
+  });
+  env = setupStore({
+    post: Post
+  });
+  env.registry.register("serializer:post", DS.JSONSerializer.extend({
+    keyForAttribute: Ember.String.underscore,
+    attrs: {
+      authorName: 'author_name_key'
+    }
+  }));
+
+  var jsonHash = {
+    id: "1",
+    author_name_key: "DHH"
+  };
+
+  var post = env.store.serializerFor("post").normalizeResponse(env.store, Post, jsonHash, '1', 'findRecord');
+
+  equal(post.data.attributes.authorName, "DHH");
+});
+
 test('Serializer should respect the attrs hash when serializing records', function() {
   Post.reopen({
     parentPost: DS.belongsTo('post', { inverse: null, async: true })

--- a/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
+++ b/packages/ember-data/tests/integration/serializers/rest-serializer-test.js
@@ -409,6 +409,28 @@ test('normalize should allow for different levels of normalization', function() 
   equal(array.data[0].relationships.superVillain.data.id, 1);
 });
 
+test('normalize should allow for different levels of normalization - attributes', function() {
+  env.registry.register('serializer:application', DS.RESTSerializer.extend({
+    attrs: {
+      name: 'full_name'
+    },
+    keyForAttribute: function(attr) {
+      return Ember.String.decamelize(attr);
+    }
+  }));
+
+  var jsonHash = {
+    evilMinions: [{ id: "1", full_name: "Tom Dale" }]
+  };
+  var array;
+
+  run(function() {
+    array = env.restSerializer.normalizeResponse(env.store, EvilMinion, jsonHash, null, 'findAll');
+  });
+
+  equal(array.data[0].attributes.name, 'Tom Dale');
+});
+
 test("serializeIntoHash", function() {
   run(function() {
     league = env.store.createRecord('home-planet', { name: "Umber", id: "123" });


### PR DESCRIPTION
The JSONAPISerializer expects
```
attrs: {
  'first-name': 'firstname'
}
```
The PR fixes that and now both (dasherized and camelized) work
```
attrs: {
  'first-name': 'firstname',
  lastName: 'lastname'
}
```
It also fixes #3879 but it breaks a [test](https://github.com/emberjs/data/blob/master/packages/ember-data/tests/integration/serializers/rest-serializer-test.js#L390). I wonder if the test is intentional because it declares a relationship mapping that uses `keyForAttribute` to normalize it. I added a test for an attribute but I'm worried to remove the (wrong) test.

I added two comments where I would add a deprecation if the `attrs` key includes a dash.

@wecc @bmac can you review?

