### PR TITLE
Make `RESTAdapter#ajax` public

### DIFF
--- a/packages/ember-data/lib/adapters/rest-adapter.js
+++ b/packages/ember-data/lib/adapters/rest-adapter.js
@@ -803,7 +803,7 @@ export default Adapter.extend(BuildURLMixin, {
     * Registers success and failure handlers.
 
     @method ajax
-    @private
+    @public
     @param {String} url
     @param {String} type The request type GET, POST, PUT, DELETE etc.
     @param {Object} options


### PR DESCRIPTION
It is beneficial to use `this.ajax` within functions defined on your
adapter, since it provides a promise wrapped ajax call. I commonly
define various ajax request within adapters, to keep ajax
requests all within the Adapter layer, serving as a way to define the
interactions with the backend in a common spot