### PR TITLE
Add null implementation of findMany in DS.Adapter

### DIFF
--- a/packages/ember-data/lib/system/adapter.js
+++ b/packages/ember-data/lib/system/adapter.js
@@ -437,6 +437,7 @@ export default Ember.Object.extend({
     @param {Array} snapshots
     @return {Promise} promise
   */
+  findMany: null,
 
   /**
     Organize records into groups, each of which is to be passed to separate


### PR DESCRIPTION
Since the other primary methods for override (findRecord, createRecord,
findAll, etc) in the abstract class have null implementations, it makes
sense to me to have this for findMany as well.