### PR TITLE
`Store._find` asserts `adapterPayload` not empty

### DIFF
--- a/addon/system/store/finders.js
+++ b/addon/system/store/finders.js
@@ -14,6 +14,14 @@ import {
 
 var Promise = Ember.RSVP.Promise;
 
+function payloadIsNotBlank(adapterPayload) {
+  if (Ember.isArray(adapterPayload)) {
+    return true;
+  } else {
+    return Object.keys(adapterPayload || {}).length;
+  }
+}
+
 export function _find(adapter, store, typeClass, id, internalModel, options) {
   var snapshot = internalModel.createSnapshot(options);
   var promise = adapter.findRecord(store, typeClass, id, snapshot);
@@ -24,7 +32,7 @@ export function _find(adapter, store, typeClass, id, internalModel, options) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    Ember.assert("You made a request for a " + typeClass.typeClassKey + " with id " + id + ", but the adapter's response did not have any data", adapterPayload);
+    Ember.assert("You made a `find` request for a " + typeClass.typeClassKey + " with id " + id + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, id, 'findRecord');
       //TODO Optimize
@@ -56,6 +64,7 @@ export function _findMany(adapter, store, typeClass, ids, internalModels) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
+    Ember.assert("You made a `findMany` request for a " + typeClass.typeClassKey + " with ids " + ids + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findMany');
       //TODO Optimize, no need to materialize here
@@ -77,6 +86,7 @@ export function _findHasMany(adapter, store, internalModel, link, relationship) 
   promise = _guard(promise, _bind(_objectIsAlive, internalModel));
 
   return promise.then(function(adapterPayload) {
+    Ember.assert("You made a `findHasMany` request for a " + internalModel.modelName + "'s `" + relationship.key + "` relationship, using link " + link + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findHasMany');
       //TODO Use a non record creating push
@@ -126,6 +136,7 @@ export function _findAll(adapter, store, typeClass, sinceToken, options) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
+    Ember.assert("You made a `findAll` request for " + typeClass.typeClassKey + "records, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findAll');
       //TODO Optimize
@@ -172,6 +183,7 @@ export function _queryRecord(adapter, store, typeClass, query) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
+    Ember.assert("You made a `queryRecord` request for " + typeClass.typeClassKey + "records, with query `" + query + "`, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     var record;
     store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'queryRecord');

--- a/tests/integration/adapter/find-all-test.js
+++ b/tests/integration/adapter/find-all-test.js
@@ -145,3 +145,13 @@ test("When all records for a type are requested, records that are created on the
   assert.equal(get(allRecords, 'length'), 1, "the record array's length is 1");
   assert.equal(allRecords.objectAt(0).get('name'), "Carsten Nielsen", "the first item in the record array is Carsten Nielsen");
 });
+
+test('When all records are requested, assert the payload is not blank', (assert) => {
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    findAll: () => Ember.RSVP.resolve({})
+  }));
+
+  assert.expectAssertion(() => {
+    run(() => store.findAll('person'));
+  }, /the adapter's response did not have any data/);
+});

--- a/tests/integration/adapter/find-test.js
+++ b/tests/integration/adapter/find-test.js
@@ -137,3 +137,27 @@ test("When a single record is requested, and the promise is rejected, the record
   });
 
 });
+
+test('When a single record is requested, and the payload is blank', (assert) => {
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    findRecord: () => Ember.RSVP.resolve({})
+  }));
+
+  assert.expectAssertion(() => {
+    run(() => store.find('person', 'the-id'));
+  }, /the adapter's response did not have any data/);
+});
+
+test('When multiple records are requested, and the payload is blank', (assert) => {
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    coalesceFindRequests: true,
+    findMany: () => Ember.RSVP.resolve({})
+  }));
+
+  assert.expectAssertion(() => {
+    run(() => {
+      store.findRecord('person', '1');
+      store.findRecord('person', '2');
+    });
+  }, /the adapter's response did not have any data/);
+});

--- a/tests/integration/store/json-api-validation-test.js
+++ b/tests/integration/store/json-api-validation-test.js
@@ -34,7 +34,7 @@ test("when normalizeResponse returns undefined (or doesn't return), throws an er
 
   env.registry.register('adapter:person', DS.Adapter.extend({
     findRecord() {
-      return Ember.RSVP.resolve({});
+      return Ember.RSVP.resolve({ data: {} });
     }
   }));
 
@@ -53,7 +53,7 @@ test("when normalizeResponse returns null, throws an error", function(assert) {
 
   env.registry.register('adapter:person', DS.Adapter.extend({
     findRecord() {
-      return Ember.RSVP.resolve({});
+      return Ember.RSVP.resolve({ data: {} });
     }
   }));
 
@@ -73,7 +73,7 @@ test("when normalizeResponse returns an empty object, throws an error", function
 
   env.registry.register('adapter:person', DS.Adapter.extend({
     findRecord() {
-      return Ember.RSVP.resolve({});
+      return Ember.RSVP.resolve({ data: {} });
     }
   }));
 
@@ -97,7 +97,7 @@ test("when normalizeResponse returns a document with both data and errors, throw
 
   env.registry.register('adapter:person', DS.Adapter.extend({
     findRecord() {
-      return Ember.RSVP.resolve({});
+      return Ember.RSVP.resolve({ data: {} });
     }
   }));
 


### PR DESCRIPTION
Currently, [Store._find][find] only asserts that the `adapterPayload` is
non-null (i.e. `{}` is a valid payload).

This commit forces the `adapterPayload` to be non-empty.

When TDDing with Mirage, `adapterPayload` is often `{}`, which sneaks
through the asserts and ends up as a non-descriptive:

```
Assertion Failed: You must include an 'id' for undefined in an object
passed to 'push'
```

Which is triggered in [Store._pushInternalModel][_pushInternalModel],
which is a few method invocations away from the source of the issue.

[_pushInternalModel]: https://github.com/emberjs/data/blob/f1ccad8ab9356dd51f44d63585c27d8bb4ec9c3a/packages/ember-data/lib/system/store.js#L1709
[find]: https://github.com/emberjs/data/blob/f1ccad8ab9356dd51f44d63585c27d8bb4ec9c3a/packages/ember-data/lib/system/store/finders.js#L27