### PR TITLE
[CLEANUP] Clean up adapter/find-all-test.js

### DIFF
--- a/tests/integration/adapter/find-all-test.js
+++ b/tests/integration/adapter/find-all-test.js
@@ -1,23 +1,22 @@
 import {createStore} from 'dummy/tests/helpers/store';
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
-
 import {module, test} from 'qunit';
-
 import DS from 'ember-data';
 
-var get = Ember.get;
-var Person, store, allRecords;
-var run = Ember.run;
-var env;
+const { attr } = DS;
+const { get, run } = Ember;
+const { resolve, reject } = Ember.RSVP;
+
+let Person, store, allRecords, env;
 
 module("integration/adapter/find_all - Finding All Records of a Type", {
-  beforeEach: function() {
+  beforeEach() {
     Person = DS.Model.extend({
-      updatedAt: DS.attr('string'),
-      name: DS.attr('string'),
-      firstName: DS.attr('string'),
-      lastName: DS.attr('string')
+      updatedAt: attr('string'),
+      name: attr('string'),
+      firstName: attr('string'),
+      lastName: attr('string')
     });
 
     allRecords = null;
@@ -28,68 +27,68 @@ module("integration/adapter/find_all - Finding All Records of a Type", {
     store = env.store;
   },
 
-  afterEach: function() {
-    run(function() {
+  afterEach() {
+    run(() => {
       if (allRecords) { allRecords.destroy(); }
       store.destroy();
     });
   }
 });
 
-test("When all records for a type are requested, the store should call the adapter's `findAll` method.", function(assert) {
+test("When all records for a type are requested, the store should call the adapter's `findAll` method.", (assert) => {
   assert.expect(5);
 
   env.registry.register('adapter:person', DS.Adapter.extend({
-    findAll: function(store, type, since) {
+    findAll() {
       // this will get called twice
       assert.ok(true, "the adapter's findAll method should be invoked");
 
-      return Ember.RSVP.resolve([{ id: 1, name: "Braaaahm Dale" }]);
+      return resolve([{ id: 1, name: "Braaaahm Dale" }]);
     }
   }));
 
-  var allRecords;
+  let allRecords;
 
-  run(function() {
-    store.findAll('person').then(function(all) {
+  run(() => {
+    store.findAll('person').then((all) => {
       allRecords = all;
       assert.equal(get(all, 'length'), 1, "the record array's length is 1 after a record is loaded into it");
       assert.equal(all.objectAt(0).get('name'), "Braaaahm Dale", "the first item in the record array is Braaaahm Dale");
     });
   });
 
-  run(function() {
-    store.findAll('person').then(function(all) {
+  run(() => {
+    store.findAll('person').then((all) => {
       // Only one record array per type should ever be created (identity map)
       assert.strictEqual(allRecords, all, "the same record array is returned every time all records of a type are requested");
     });
   });
 });
 
-test("When all records for a type are requested, a rejection should reject the promise", function(assert) {
+test("When all records for a type are requested, a rejection should reject the promise", (assert) => {
   assert.expect(5);
 
-  var count = 0;
+  let count = 0;
   env.registry.register('adapter:person', DS.Adapter.extend({
-    findAll: function(store, type, since) {
+    findAll() {
       // this will get called twice
       assert.ok(true, "the adapter's findAll method should be invoked");
 
       if (count++ === 0) {
-        return Ember.RSVP.reject();
+        return reject();
       } else {
-        return Ember.RSVP.resolve([{ id: 1, name: "Braaaahm Dale" }]);
+        return resolve([{ id: 1, name: "Braaaahm Dale" }]);
       }
     }
   }));
 
-  var allRecords;
+  let allRecords;
 
-  run(function() {
-    store.findAll('person').then(null, function() {
+  run(() => {
+    store.findAll('person').then(null, () => {
       assert.ok(true, "The rejection should get here");
       return store.findAll('person');
-    }).then(function(all) {
+    }).then((all) => {
       allRecords = all;
       assert.equal(get(all, 'length'), 1, "the record array's length is 1 after a record is loaded into it");
       assert.equal(all.objectAt(0).get('name'), "Braaaahm Dale", "the first item in the record array is Braaaahm Dale");
@@ -97,14 +96,14 @@ test("When all records for a type are requested, a rejection should reject the p
   });
 });
 
-test("When all records for a type are requested, records that are already loaded should be returned immediately.", function(assert) {
+test("When all records for a type are requested, records that are already loaded should be returned immediately.", (assert) => {
   assert.expect(3);
   store = createStore({
     adapter: DS.Adapter.extend(),
     person: Person
   });
 
-  run(function() {
+  run(() => {
     // Load a record from the server
     store.push({
       data: {
@@ -126,7 +125,7 @@ test("When all records for a type are requested, records that are already loaded
   assert.equal(allRecords.objectAt(1).get('name'), "Alex MacCaw", "the second item in the record array is Alex MacCaw");
 });
 
-test("When all records for a type are requested, records that are created on the client should be added to the record array.", function(assert) {
+test("When all records for a type are requested, records that are created on the client should be added to the record array.", (assert) => {
   assert.expect(3);
 
   store = createStore({
@@ -138,7 +137,7 @@ test("When all records for a type are requested, records that are created on the
 
   assert.equal(get(allRecords, 'length'), 0, "precond - the record array's length is zero before any records are loaded");
 
-  run(function() {
+  run(() => {
     store.createRecord('person', { name: "Carsten Nielsen" });
   });
 


### PR DESCRIPTION
* Use ES6 `() =>` where applicable
* Remove unnecessary `Ember.` and `Ember.RSVP` prefixes
* Remove ignored closure parameters
* One-line adapater overrides when possible