### PR TITLE
restore globals publishing to canary build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - ./bin/lint-features
   - npm run-script test
 after_success:
-  - npm run-script publish-build:prebuilt
+  - npm run-script production
   - "./bin/bower-ember-data-build"
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "ember-data",
   "version": "2.3.0+canary",
-  "description": "The default blueprint for ember-cli addons.",
+  "description": "A data layer for your Ember applications.",
+  "repository": "git://github.com/emberjs/data.git",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -10,7 +11,8 @@
     "build": "ember build",
     "start": "ember server",
     "test": "ember try:testall",
-    "bower": "bower install"
+    "bower": "bower install",
+    "production": "ember build --environment=production"
   },
   "repository": "",
   "engines": {


### PR DESCRIPTION
The globals only build in production mode, so we change travis to build
that after success.

fixes components/ember-data#31