### PR TITLE
Remove JSONSerializer#normalizeId

### DIFF
--- a/addon/serializers/json-serializer.js
+++ b/addon/serializers/json-serializer.js
@@ -741,19 +741,6 @@ export default Serializer.extend({
   },
 
   /**
-    @method normalizeId
-    @private
-  */
-  normalizeId: function(hash) {
-    var primaryKey = get(this, 'primaryKey');
-
-    if (primaryKey === 'id') { return; }
-
-    hash.id = hash[primaryKey];
-    delete hash[primaryKey];
-  },
-
-  /**
     Looks up the property key that was set by the custom `attr` mapping
     passed to the serializer.
 


### PR DESCRIPTION
JSONSerializer#normalizeId seems to be unused, `extractId`/`coerceId` are used instead.

@wagenet is this something that can be just removed or needs a deprecation?

closes #3917 