### PR TITLE
[DOCS fix] fix incorrect argument description...

### DIFF
--- a/addon/system/store.js
+++ b/addon/system/store.js
@@ -960,7 +960,7 @@ Store = Service.extend({
     once the server returns.
 
     @method queryRecord
-    @param {String or subclass of DS.Model} type
+    @param {String} modelName
     @param {any} query an opaque query to be used by the adapter
     @return {Promise} promise
   */


### PR DESCRIPTION
...in `store.queryRecord`

Docs incorrectly say that passed in modelName can be a subclass of DS.Model. That behavior has been removed.