### PR TITLE
Revert "[DOC fix] Adds missing space before list"

### DIFF
--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -85,7 +85,6 @@ var camelize = Ember.String.camelize;
   to modify it to fit your specific needs.**
 
   For example review the docs for each method of this mixin:
-  
   * [normalize](/api/data/classes/DS.EmbeddedRecordsMixin.html#method_normalize)
   * [serializeBelongsTo](/api/data/classes/DS.EmbeddedRecordsMixin.html#method_serializeBelongsTo)
   * [serializeHasMany](/api/data/classes/DS.EmbeddedRecordsMixin.html#method_serializeHasMany)


### PR DESCRIPTION
Reverts emberjs/data#3923

Seems to have broken the build. cc @locks 