### PR TITLE
[Doc] Specify the status code expected to populate the error object

### DIFF
--- a/addon/system/model/errors.js
+++ b/addon/system/model/errors.js
@@ -36,8 +36,8 @@ var MapWithDefault = Ember.MapWithDefault;
   user.save();
   ```
 
-  Your backend data store might return a response that looks like
-  this. This response will be used to populate the error object.
+  Your backend data store might return a response with status code 422 (Unprocessable Entity)
+  and that looks like this. This response will be used to populate the error object.
 
   ```javascript
   {


### PR DESCRIPTION
For what I see, the `error` object is populated just when the status code is specifically `422`, and not for every code in the 400 family. I think it's worth having this information in the docs (as I spent some time trying to figure out why this was not working the way I was expecting).