### PR TITLE
[CLEANUP] use debug helpers from ember-data/debug

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,5 @@
 import Ember from "ember";
+import { warn } from "ember-data/debug";
 /**
   Ember Data
   @module ember-data
@@ -12,7 +13,7 @@ if (Ember.VERSION.match(/^1\.([0-9]|1[0-2])\./)) {
 }
 
 if (Ember.VERSION.match(/^1\.13\./)) {
-  Ember.warn(`Use of Ember Data 2+ with Ember 1.13 is unsupported. Please upgrade your version of Ember to 2.0 or higher.`, false, {
+  warn(`Use of Ember Data 2+ with Ember 1.13 is unsupported. Please upgrade your version of Ember to 2.0 or higher.`, false, {
     id: 'ds.version.ember-1-13'
   });
 }

--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -1,3 +1,5 @@
+import { warn } from "ember-data/debug";
+
 var get = Ember.get;
 var set = Ember.set;
 var camelize = Ember.String.camelize;
@@ -331,7 +333,7 @@ export default Ember.Mixin.create({
   _serializeEmbeddedHasMany(snapshot, json, relationship) {
     let serializedKey = this.keyForAttribute(relationship.key, 'serialize');
 
-    Ember.warn(
+    warn(
       `The embedded relationship '${serializedKey}' is undefined for '${snapshot.modelName}' with id '${snapshot.id}'. Please include it in your original payload.`,
       Ember.typeOf(snapshot.hasMany(relationship.key)) !== 'undefined',
       { id: 'ds.serializer.embedded-relationship-undefined' }

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -2,6 +2,7 @@
   @module ember-data
 */
 
+import { assert, runInDebug, warn } from 'ember-data/debug';
 import JSONSerializer from 'ember-data/serializers/json-serializer';
 import normalizeModelName from 'ember-data/system/normalize-model-name';
 import { pluralize, singularize } from 'ember-inflector';
@@ -136,14 +137,14 @@ const JSONAPISerializer = JSONSerializer.extend({
     @private
   */
   _normalizeResourceHelper(resourceHash) {
-    Ember.assert(this.warnMessageForUndefinedType(), !Ember.isNone(resourceHash.type), {
+    assert(this.warnMessageForUndefinedType(), !Ember.isNone(resourceHash.type), {
       id: 'ds.serializer.type-is-undefined'
     });
 
     let modelName = this.modelNameFromPayloadKey(resourceHash.type);
 
     if (!this.store._hasModelFor(modelName)) {
-      Ember.warn(this.warnMessageNoModelForType(modelName, resourceHash.type), false, {
+      warn(this.warnMessageNoModelForType(modelName, resourceHash.type), false, {
         id: 'ds.serializer.model-for-type-missing'
       });
       return null;
@@ -467,7 +468,7 @@ const JSONAPISerializer = JSONSerializer.extend({
   }
 });
 
-Ember.runInDebug(function() {
+runInDebug(function() {
   JSONAPISerializer.reopen({
     warnMessageForUndefinedType() {
       return 'Encountered a resource object with an undefined type (resolved resource using ' + this.constructor.toString() + ')';

--- a/addon/serializers/json-serializer.js
+++ b/addon/serializers/json-serializer.js
@@ -1,3 +1,4 @@
+import { assert, warn } from 'ember-data/debug';
 import Serializer from "ember-data/system/serializer";
 import coerceId from "ember-data/system/coerce-id";
 import normalizeModelName from "ember-data/system/normalize-model-name";
@@ -440,7 +441,7 @@ export default Serializer.extend({
 
     let meta = this.extractMeta(store, primaryModelClass, payload);
     if (meta) {
-      Ember.assert('The `meta` returned from `extractMeta` has to be an object, not "' + Ember.typeOf(meta) + '".', Ember.typeOf(meta) === 'object');
+      assert('The `meta` returned from `extractMeta` has to be an object, not "' + Ember.typeOf(meta) + '".', Ember.typeOf(meta) === 'object');
       documentHash.meta = meta;
     }
 
@@ -750,7 +751,7 @@ export default Serializer.extend({
     @return {String} key
   */
   _getMappedKey(key, modelClass) {
-    Ember.warn('There is no attribute or relationship with the name `' + key + '` on `' + modelClass.modelName + '`. Check your serializers attrs hash.', get(modelClass, 'attributes').has(key) || get(modelClass, 'relationshipsByName').has(key), {
+    warn('There is no attribute or relationship with the name `' + key + '` on `' + modelClass.modelName + '`. Check your serializers attrs hash.', get(modelClass, 'attributes').has(key) || get(modelClass, 'relationshipsByName').has(key), {
       id: 'ds.serializer.no-mapped-attrs-key'
     });
 
@@ -1373,7 +1374,7 @@ export default Serializer.extend({
   transformFor(attributeType, skipAssertion) {
     var transform = getOwner(this).lookup('transform:' + attributeType);
 
-    Ember.assert("Unable to find transform for '" + attributeType + "'", skipAssertion || !!transform);
+    assert("Unable to find transform for '" + attributeType + "'", skipAssertion || !!transform);
 
     return transform;
   }

--- a/addon/serializers/rest-serializer.js
+++ b/addon/serializers/rest-serializer.js
@@ -2,6 +2,7 @@
   @module ember-data
 */
 
+import { assert, deprecate, runInDebug, warn } from "ember-data/debug";
 import JSONSerializer from "ember-data/serializers/json-serializer";
 import normalizeModelName from "ember-data/system/normalize-model-name";
 import {singularize} from "ember-inflector";
@@ -225,7 +226,7 @@ var RESTSerializer = JSONSerializer.extend({
 
     let meta = this.extractMeta(store, primaryModelClass, payload);
     if (meta) {
-      Ember.assert('The `meta` returned from `extractMeta` has to be an object, not "' + Ember.typeOf(meta) + '".', Ember.typeOf(meta) === 'object');
+      assert('The `meta` returned from `extractMeta` has to be an object, not "' + Ember.typeOf(meta) + '".', Ember.typeOf(meta) === 'object');
       documentHash.meta = meta;
     }
 
@@ -263,7 +264,7 @@ var RESTSerializer = JSONSerializer.extend({
 
       var typeName = this.modelNameFromPayloadKey(modelName);
       if (!store.modelFactoryFor(typeName)) {
-        Ember.warn(this.warnMessageNoModelForKey(modelName, typeName), false, {
+        warn(this.warnMessageNoModelForKey(modelName, typeName), false, {
           id: 'ds.serializer.model-for-key-missing'
         });
         continue;
@@ -383,7 +384,7 @@ var RESTSerializer = JSONSerializer.extend({
     for (var prop in payload) {
       var modelName = this.modelNameFromPayloadKey(prop);
       if (!store.modelFactoryFor(modelName)) {
-        Ember.warn(this.warnMessageNoModelForKey(prop, modelName), false, {
+        warn(this.warnMessageNoModelForKey(prop, modelName), false, {
           id: 'ds.serializer.model-for-key-missing'
         });
         continue;
@@ -727,7 +728,7 @@ var RESTSerializer = JSONSerializer.extend({
     // `keyForPolymorphicType`. If this is the case, a deprecation warning is
     // logged and the old way is restored (so nothing breaks).
     if (key !== typeKey && this.keyForPolymorphicType === RESTSerializer.prototype.keyForPolymorphicType) {
-      Ember.deprecate("The key to serialize the type of a polymorphic record is created via keyForAttribute which has been deprecated. Use the keyForPolymorphicType hook instead.", false, {
+      deprecate("The key to serialize the type of a polymorphic record is created via keyForAttribute which has been deprecated. Use the keyForPolymorphicType hook instead.", false, {
         id: 'ds.rest-serializer.deprecated-key-for-polymorphic-type',
         until: '3.0.0'
       });
@@ -787,7 +788,7 @@ var RESTSerializer = JSONSerializer.extend({
   }
 });
 
-Ember.runInDebug(function() {
+runInDebug(function() {
   RESTSerializer.reopen({
     warnMessageNoModelForKey(prop, typeKey) {
       return 'Encountered "' + prop + '" in payload, but no model was found for model name "' + typeKey + '" (resolved model name using ' + this.constructor.toString() + '.modelNameFromPayloadKey("' + prop + '"))';

--- a/addon/system/container-proxy.js
+++ b/addon/system/container-proxy.js
@@ -1,3 +1,5 @@
+import { deprecate } from "ember-data/debug";
+
 /**
   This is used internally to enable deprecation of container paths and provide
   a decent message to the user indicating how to fix the issue.
@@ -28,7 +30,7 @@ ContainerProxy.prototype.registerAlias = function(source, dest, preLookup) {
 
 ContainerProxy.prototype.registerDeprecation = function(deprecated, valid) {
   var preLookupCallback = function() {
-    Ember.deprecate(`You tried to look up '${deprecated}', but this has been deprecated in favor of '${valid}'.`, false, {
+    deprecate(`You tried to look up '${deprecated}', but this has been deprecated in favor of '${valid}'.`, false, {
       id: 'ds.store.deprecated-lookup',
       until: '2.0.0'
     });

--- a/addon/system/many-array.js
+++ b/addon/system/many-array.js
@@ -1,6 +1,7 @@
 /**
   @module ember-data
 */
+import { assert } from "ember-data/debug";
 import { PromiseArray } from "ember-data/system/promise-proxies";
 
 var get = Ember.get;
@@ -272,7 +273,7 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
     var type = get(this, 'type');
     var record;
 
-    Ember.assert("You cannot add '" + type.modelName + "' records to this polymorphic relationship.", !get(this, 'isPolymorphic'));
+    assert("You cannot add '" + type.modelName + "' records to this polymorphic relationship.", !get(this, 'isPolymorphic'));
     record = store.createRecord(type.modelName, hash);
     this.pushObject(record);
 

--- a/addon/system/model/attributes.js
+++ b/addon/system/model/attributes.js
@@ -1,4 +1,5 @@
 import Model from "ember-data/system/model/model";
+import { assert, deprecate } from "ember-data/debug";
 
 /**
   @module ember-data
@@ -55,7 +56,7 @@ Model.reopenClass({
 
     this.eachComputedProperty((name, meta) => {
       if (meta.isAttribute) {
-        Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.toString(), name !== 'id');
+        assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.toString(), name !== 'id');
 
         meta.name = name;
         map.set(name, meta);
@@ -227,7 +228,7 @@ function getDefaultValue(record, options, key) {
     return options.defaultValue.apply(null, arguments);
   } else {
     let defaultValue = options.defaultValue;
-    Ember.deprecate(`Non primitive defaultValues are deprecated because they are shared between all instances. If you would like to use a complex object as a default value please provide a function that returns the complex object.`,
+    deprecate(`Non primitive defaultValues are deprecated because they are shared between all instances. If you would like to use a complex object as a default value please provide a function that returns the complex object.`,
       typeof defaultValue !== 'object' || defaultValue === null, {
         id: 'ds.defaultValue.complex-object',
         until: '3.0.0'

--- a/addon/system/model/errors.js
+++ b/addon/system/model/errors.js
@@ -1,3 +1,5 @@
+import { deprecate, warn } from "ember-data/debug";
+
 var get = Ember.get;
 var set = Ember.set;
 var isEmpty = Ember.isEmpty;
@@ -110,7 +112,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     @deprecated
   */
   registerHandlers(target, becameInvalid, becameValid) {
-    Ember.deprecate(
+    deprecate(
       `Record errors will no longer be evented.`, false, {
         id: 'ds.errors.registerHandlers',
         until: '3.0.0'
@@ -236,7 +238,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     @deprecated
   */
   add(attribute, messages) {
-    Ember.warn(`Interacting with a record errors object will no longer change the record state.`, false, {
+    warn(`Interacting with a record errors object will no longer change the record state.`, false, {
       id: 'ds.errors.add'
     });
 
@@ -315,7 +317,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     @deprecated
   */
   remove(attribute) {
-    Ember.warn(`Interacting with a record errors object will no longer change the record state.`, false, {
+    warn(`Interacting with a record errors object will no longer change the record state.`, false, {
       id: 'ds.errors.remove'
     });
 
@@ -367,7 +369,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     @deprecated
   */
   clear() {
-    Ember.warn(`Interacting with a record errors object will no longer change the record state.`, false, {
+    warn(`Interacting with a record errors object will no longer change the record state.`, false, {
       id: 'ds.errors.clear'
     });
 

--- a/addon/system/model/internal-model.js
+++ b/addon/system/model/internal-model.js
@@ -1,3 +1,4 @@
+import { assert } from "ember-data/debug";
 import merge from "ember-data/system/merge";
 import RootState from "ember-data/system/model/states";
 import Relationships from "ember-data/system/relationships/state/create";
@@ -113,7 +114,7 @@ InternalModel.prototype = {
 
   constructor: InternalModel,
   materializeRecord() {
-    Ember.assert("Materialized " + this.modelName + " record with id:" + this.id + "more than once", this.record === null || this.record === undefined);
+    assert("Materialized " + this.modelName + " record with id:" + this.id + "more than once", this.record === null || this.record === undefined);
 
     // lookupFactory should really return an object that creates
     // instances with the injections applied
@@ -563,7 +564,7 @@ InternalModel.prototype = {
   },
 
   _preloadHasMany(key, preloadValue, type) {
-    Ember.assert("You need to pass in an array to set a hasMany property on a record", Ember.isArray(preloadValue));
+    assert("You need to pass in an array to set a hasMany property on a record", Ember.isArray(preloadValue));
     var internalModel = this;
 
     var recordsToSet = preloadValue.map((recordToPush) => {
@@ -603,7 +604,7 @@ InternalModel.prototype = {
   },
 
   setId(id) {
-    Ember.assert('A record\'s id cannot be changed once it is in the loaded state', this.id === null || this.id === id || this.isNew());
+    assert('A record\'s id cannot be changed once it is in the loaded state', this.id === null || this.id === id || this.isNew());
     this.id = id;
     if (this.record.get('id') !== id) {
       this.record.set('id', id);

--- a/addon/system/model/model.js
+++ b/addon/system/model/model.js
@@ -1,3 +1,4 @@
+import { assert, deprecate } from "ember-data/debug";
 import { PromiseObject } from "ember-data/system/promise-proxies";
 import Errors from "ember-data/system/model/errors";
 
@@ -749,20 +750,20 @@ var Model = Ember.Object.extend(Ember.Evented, {
   // rely on the data property.
   willMergeMixin(props) {
     var constructor = this.constructor;
-    Ember.assert('`' + intersection(Object.keys(props), RESERVED_MODEL_PROPS)[0] + '` is a reserved property name on DS.Model objects. Please choose a different property name for ' + constructor.toString(), !intersection(Object.keys(props), RESERVED_MODEL_PROPS)[0]);
-    Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + constructor.toString(), Object.keys(props).indexOf('id') === -1);
+    assert('`' + intersection(Object.keys(props), RESERVED_MODEL_PROPS)[0] + '` is a reserved property name on DS.Model objects. Please choose a different property name for ' + constructor.toString(), !intersection(Object.keys(props), RESERVED_MODEL_PROPS)[0]);
+    assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + constructor.toString(), Object.keys(props).indexOf('id') === -1);
   },
 
   attr() {
-    Ember.assert("The `attr` method is not available on DS.Model, a DS.Snapshot was probably expected. Are you passing a DS.Model instead of a DS.Snapshot to your serializer?", false);
+    assert("The `attr` method is not available on DS.Model, a DS.Snapshot was probably expected. Are you passing a DS.Model instead of a DS.Snapshot to your serializer?", false);
   },
 
   belongsTo() {
-    Ember.assert("The `belongsTo` method is not available on DS.Model, a DS.Snapshot was probably expected. Are you passing a DS.Model instead of a DS.Snapshot to your serializer?", false);
+    assert("The `belongsTo` method is not available on DS.Model, a DS.Snapshot was probably expected. Are you passing a DS.Model instead of a DS.Snapshot to your serializer?", false);
   },
 
   hasMany() {
-    Ember.assert("The `hasMany` method is not available on DS.Model, a DS.Snapshot was probably expected. Are you passing a DS.Model instead of a DS.Snapshot to your serializer?", false);
+    assert("The `hasMany` method is not available on DS.Model, a DS.Snapshot was probably expected. Are you passing a DS.Model instead of a DS.Snapshot to your serializer?", false);
   },
 
   setId: Ember.observer('id', function () {
@@ -836,7 +837,7 @@ if (Ember.setOwner) {
     configurable: true,
     enumerable: false,
     get() {
-      Ember.deprecate('Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.',
+      deprecate('Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.',
                       false,
                       { id: 'ember-application.injected-container', until: '3.0.0' });
 

--- a/addon/system/model/states.js
+++ b/addon/system/model/states.js
@@ -1,6 +1,8 @@
 /**
   @module ember-data
 */
+import { assert } from "ember-data/debug";
+
 var get = Ember.get;
 /*
   This file encapsulates the various states that a record can transition
@@ -425,7 +427,7 @@ createdState.uncommitted.pushedData = function(internalModel) {
 createdState.uncommitted.propertyWasReset = Ember.K;
 
 function assertAgainstUnloadRecord(internalModel) {
-  Ember.assert("You can only unload a record which is not inFlight. `" + internalModel + "`", false);
+  assert("You can only unload a record which is not inFlight. `" + internalModel + "`", false);
 }
 
 updatedState.inFlight.unloadRecord = assertAgainstUnloadRecord;

--- a/addon/system/promise-proxies.js
+++ b/addon/system/promise-proxies.js
@@ -1,3 +1,5 @@
+import { assert } from "ember-data/debug";
+
 var Promise = Ember.RSVP.Promise;
 var get = Ember.get;
 
@@ -103,7 +105,7 @@ function proxyToContent(method) {
 var PromiseManyArray = PromiseArray.extend({
   reload() {
     //I don't think this should ever happen right now, but worth guarding if we refactor the async relationships
-    Ember.assert('You are trying to reload an async manyArray before it has been created', get(this, 'content'));
+    assert('You are trying to reload an async manyArray before it has been created', get(this, 'content'));
     return PromiseManyArray.create({
       promise: get(this, 'content').reload()
     });

--- a/addon/system/relationships/belongs-to.js
+++ b/addon/system/relationships/belongs-to.js
@@ -1,3 +1,4 @@
+import { assert, warn } from "ember-data/debug";
 import Model from 'ember-data/system/model';
 import normalizeModelName from "ember-data/system/normalize-model-name";
 
@@ -87,7 +88,7 @@ export default function belongsTo(modelName, options) {
     userEnteredModelName = normalizeModelName(userEnteredModelName);
   }
 
-  Ember.assert("The first argument to DS.belongsTo must be a string representing a model type key, not an instance of " + Ember.inspect(userEnteredModelName) + ". E.g., to define a relation to the Person model, use DS.belongsTo('person')", typeof userEnteredModelName === 'string' || typeof userEnteredModelName === 'undefined');
+  assert("The first argument to DS.belongsTo must be a string representing a model type key, not an instance of " + Ember.inspect(userEnteredModelName) + ". E.g., to define a relation to the Person model, use DS.belongsTo('person')", typeof userEnteredModelName === 'string' || typeof userEnteredModelName === 'undefined');
 
   opts = opts || {};
 
@@ -102,13 +103,13 @@ export default function belongsTo(modelName, options) {
   return Ember.computed({
     get(key) {
       if (opts.hasOwnProperty('serialize')) {
-        Ember.warn(`You provided a serialize option on the "${key}" property in the "${this._internalModel.modelName}" class, this belongs in the serializer. See DS.Serializer and it's implementations http://emberjs.com/api/data/classes/DS.Serializer.html`, false, {
+        warn(`You provided a serialize option on the "${key}" property in the "${this._internalModel.modelName}" class, this belongs in the serializer. See DS.Serializer and it's implementations http://emberjs.com/api/data/classes/DS.Serializer.html`, false, {
           id: 'ds.model.serialize-option-in-belongs-to'
         });
       }
 
       if (opts.hasOwnProperty('embedded')) {
-        Ember.warn(`You provided an embedded option on the "${key}" property in the "${this._internalModel.modelName}" class, this belongs in the serializer. See DS.EmbeddedRecordsMixin http://emberjs.com/api/data/classes/DS.EmbeddedRecordsMixin.html`, false, {
+        warn(`You provided an embedded option on the "${key}" property in the "${this._internalModel.modelName}" class, this belongs in the serializer. See DS.EmbeddedRecordsMixin http://emberjs.com/api/data/classes/DS.EmbeddedRecordsMixin.html`, false, {
           id: 'ds.model.embedded-option-in-belongs-to'
         });
       }

--- a/addon/system/relationships/ext.js
+++ b/addon/system/relationships/ext.js
@@ -1,3 +1,4 @@
+import { assert, warn } from "ember-data/debug";
 import {
   typeForRelationshipMeta,
   relationshipFromMeta
@@ -52,10 +53,10 @@ var relatedTypesDescriptor = Ember.computed(function() {
       meta.key = name;
       modelName = typeForRelationshipMeta(meta);
 
-      Ember.assert("You specified a hasMany (" + meta.type + ") on " + meta.parentType + " but " + meta.type + " was not found.", modelName);
+      assert("You specified a hasMany (" + meta.type + ") on " + meta.parentType + " but " + meta.type + " was not found.", modelName);
 
       if (!types.contains(modelName)) {
-        Ember.assert("Trying to sideload " + name + " on " + this.toString() + " but the type doesn't exist.", !!modelName);
+        assert("Trying to sideload " + name + " on " + this.toString() + " but the type doesn't exist.", !!modelName);
         types.push(modelName);
       }
     }
@@ -247,14 +248,14 @@ Model.reopenClass({
       inverseName = options.inverse;
       inverse = Ember.get(inverseType, 'relationshipsByName').get(inverseName);
 
-      Ember.assert("We found no inverse relationships by the name of '" + inverseName + "' on the '" + inverseType.modelName +
+      assert("We found no inverse relationships by the name of '" + inverseName + "' on the '" + inverseType.modelName +
         "' model. This is most likely due to a missing attribute on your model definition.", !Ember.isNone(inverse));
 
       inverseKind = inverse.kind;
     } else {
       //No inverse was specified manually, we need to use a heuristic to guess one
       if (propertyMeta.type === propertyMeta.parentType.modelName) {
-        Ember.warn(`Detected a reflexive relationship by the name of '${name}' without an inverse option. Look at http://emberjs.com/guides/models/defining-models/#toc_reflexive-relation for how to explicitly specify inverses.`, false, {
+        warn(`Detected a reflexive relationship by the name of '${name}' without an inverse option. Look at http://emberjs.com/guides/models/defining-models/#toc_reflexive-relation for how to explicitly specify inverses.`, false, {
           id: 'ds.model.reflexive-relationship-without-inverse'
         });
       }
@@ -268,7 +269,7 @@ Model.reopenClass({
         return name === optionsForRelationship.inverse;
       });
 
-      Ember.assert("You defined the '" + name + "' relationship on " + this + ", but you defined the inverse relationships of type " +
+      assert("You defined the '" + name + "' relationship on " + this + ", but you defined the inverse relationships of type " +
         inverseType.toString() + " multiple times. Look at http://emberjs.com/guides/models/defining-models/#toc_explicit-inverses for how to explicitly specify inverses",
         filteredRelationships.length < 2);
 
@@ -276,7 +277,7 @@ Model.reopenClass({
         possibleRelationships = filteredRelationships;
       }
 
-      Ember.assert("You defined the '" + name + "' relationship on " + this + ", but multiple possible inverse relationships of type " +
+      assert("You defined the '" + name + "' relationship on " + this + ", but multiple possible inverse relationships of type " +
         this + " were found on " + inverseType + ". Look at http://emberjs.com/guides/models/defining-models/#toc_explicit-inverses for how to explicitly specify inverses",
         possibleRelationships.length === 1);
 

--- a/addon/system/relationships/has-many.js
+++ b/addon/system/relationships/has-many.js
@@ -2,6 +2,7 @@
   @module ember-data
 */
 
+import { assert } from "ember-data/debug";
 import Model from "ember-data/system/model";
 import normalizeModelName from "ember-data/system/normalize-model-name";
 import isArrayLike from "ember-data/system/is-array-like";
@@ -118,7 +119,7 @@ export default function hasMany(type, options) {
     type = undefined;
   }
 
-  Ember.assert("The first argument to DS.hasMany must be a string representing a model type key, not an instance of " + Ember.inspect(type) + ". E.g., to define a relation to the Comment model, use DS.hasMany('comment')", typeof type === 'string' || typeof type === 'undefined');
+  assert("The first argument to DS.hasMany must be a string representing a model type key, not an instance of " + Ember.inspect(type) + ". E.g., to define a relation to the Comment model, use DS.hasMany('comment')", typeof type === 'string' || typeof type === 'undefined');
 
   options = options || {};
 
@@ -144,8 +145,8 @@ export default function hasMany(type, options) {
       return relationship.getRecords();
     },
     set(key, records) {
-      Ember.assert("You must pass an array of records to set a hasMany relationship", isArrayLike(records));
-      Ember.assert(`All elements of a hasMany relationship must be instances of DS.Model, you passed ${Ember.inspect(records)}`, (function() {
+      assert("You must pass an array of records to set a hasMany relationship", isArrayLike(records));
+      assert(`All elements of a hasMany relationship must be instances of DS.Model, you passed ${Ember.inspect(records)}`, (function() {
         return Ember.A(records).every((record) => Model.detectInstance(record) );
       })());
 

--- a/addon/system/relationships/state/belongs-to.js
+++ b/addon/system/relationships/state/belongs-to.js
@@ -1,3 +1,4 @@
+import { assert } from "ember-data/debug";
 import {
   PromiseObject
 } from "ember-data/system/promise-proxies";
@@ -79,7 +80,7 @@ BelongsToRelationship.prototype.addRecord = function(newRecord) {
 
 BelongsToRelationship.prototype.setRecordPromise = function(newPromise) {
   var content = newPromise.get && newPromise.get('content');
-  Ember.assert("You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo or hasMany relationship to the get call.", content !== undefined);
+  assert("You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo or hasMany relationship to the get call.", content !== undefined);
   this.setRecord(content ? content._internalModel : content);
 };
 
@@ -138,7 +139,7 @@ BelongsToRelationship.prototype.getRecord = function() {
       return null;
     }
     var toReturn = this.inverseRecord.getRecord();
-    Ember.assert("You looked up the '" + this.key + "' relationship on a '" + this.record.type.modelName + "' with id " + this.record.id +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.belongsTo({ async: true })`)", toReturn === null || !toReturn.get('isEmpty'));
+    assert("You looked up the '" + this.key + "' relationship on a '" + this.record.type.modelName + "' with id " + this.record.id +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.belongsTo({ async: true })`)", toReturn === null || !toReturn.get('isEmpty'));
     return toReturn;
   }
 };

--- a/addon/system/relationships/state/has-many.js
+++ b/addon/system/relationships/state/has-many.js
@@ -1,3 +1,4 @@
+import { assert } from "ember-data/debug";
 import { PromiseManyArray } from "ember-data/system/promise-proxies";
 import Relationship from "ember-data/system/relationships/state/relationship";
 import OrderedSet from "ember-data/system/ordered-set";
@@ -198,7 +199,7 @@ ManyRelationship.prototype.getRecords = function() {
     });
     return this._loadingPromise;
   } else {
-    Ember.assert("You looked up the '" + this.key + "' relationship on a '" + this.record.type.modelName + "' with id " + this.record.id +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", this.manyArray.isEvery('isEmpty', false));
+    assert("You looked up the '" + this.key + "' relationship on a '" + this.record.type.modelName + "' with id " + this.record.id +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", this.manyArray.isEvery('isEmpty', false));
 
     //TODO(Igor) WTF DO I DO HERE?
     if (!this.manyArray.get('isDestroyed')) {

--- a/addon/system/relationships/state/relationship.js
+++ b/addon/system/relationships/state/relationship.js
@@ -1,3 +1,4 @@
+import { assert, warn } from "ember-data/debug";
 import OrderedSet from "ember-data/system/ordered-set";
 
 export default function Relationship(store, record, inverseKey, relationshipMeta) {
@@ -184,10 +185,10 @@ Relationship.prototype = {
   },
 
   updateLink(link) {
-    Ember.warn(`You have pushed a record of type '${this.record.type.modelName}' with '${this.key}' as a link, but the association is not an async relationship.`, this.isAsync, {
+    warn(`You have pushed a record of type '${this.record.type.modelName}' with '${this.key}' as a link, but the association is not an async relationship.`, this.isAsync, {
       id: 'ds.store.push-link-for-sync-relationship'
     });
-    Ember.assert("You have pushed a record of type '" + this.record.type.modelName + "' with '" + this.key + "' as a link, but the value of that link is not a string.", typeof link === 'string' || link === null);
+    assert("You have pushed a record of type '" + this.record.type.modelName + "' with '" + this.key + "' as a link, but the value of that link is not a string.", typeof link === 'string' || link === null);
     if (link !== this.link) {
       this.link = link;
       this.linkPromise = null;

--- a/addon/system/store.js
+++ b/addon/system/store.js
@@ -5,6 +5,7 @@
   @module ember-data
 */
 
+import { assert, warn } from "ember-data/debug";
 import _normalizeLink from "ember-data/system/normalize-link";
 import normalizeModelName from "ember-data/system/normalize-model-name";
 import {
@@ -283,7 +284,7 @@ Store = Service.extend({
   defaultAdapter: Ember.computed('adapter', function() {
     var adapter = get(this, 'adapter');
 
-    Ember.assert('You tried to set `adapter` property to an instance of `DS.Adapter`, where it should be a name', typeof adapter === 'string');
+    assert('You tried to set `adapter` property to an instance of `DS.Adapter`, where it should be a name', typeof adapter === 'string');
 
     adapter = this.retrieveManagedInstance('adapter', adapter);
 
@@ -323,7 +324,7 @@ Store = Service.extend({
     @return {DS.Model} record
   */
   createRecord(modelName, inputProperties) {
-    Ember.assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
+    assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     var properties = copy(inputProperties) || new EmptyObject();
 
@@ -437,20 +438,20 @@ Store = Service.extend({
     // the public way to get a record by modelName and id.
 
     if (arguments.length === 1) {
-      Ember.assert('Using store.find(type) has been removed. Use store.findAll(type) to retrieve all records for a given type.');
+      assert('Using store.find(type) has been removed. Use store.findAll(type) to retrieve all records for a given type.');
     }
 
     if (Ember.typeOf(id) === 'object') {
-      Ember.assert('Calling store.find() with a query object is no longer supported. Use store.query() instead.');
+      assert('Calling store.find() with a query object is no longer supported. Use store.query() instead.');
     }
 
     if (options) {
-      Ember.assert('Calling store.find(type, id, { preload: preload }) is no longer supported. Use store.findRecord(type, id, { preload: preload }) instead.');
+      assert('Calling store.find(type, id, { preload: preload }) is no longer supported. Use store.findRecord(type, id, { preload: preload }) instead.');
     }
 
-    Ember.assert("You need to pass the model name and id to the store's find method", arguments.length === 2);
-    Ember.assert("You cannot pass `" + Ember.inspect(id) + "` as id to the store's find method", Ember.typeOf(id) === 'string' || Ember.typeOf(id) === 'number');
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert("You need to pass the model name and id to the store's find method", arguments.length === 2);
+    assert("You cannot pass `" + Ember.inspect(id) + "` as id to the store's find method", Ember.typeOf(id) === 'string' || Ember.typeOf(id) === 'number');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
 
     return this.findRecord(modelName, id);
   },
@@ -499,8 +500,8 @@ Store = Service.extend({
     @return {Promise} promise
   */
   findRecord(modelName, id, options) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
-    Ember.assert(badIdFormatAssertion, (typeof id === 'string' && id.length > 0) || (typeof id === 'number' && !isNaN(id)));
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert(badIdFormatAssertion, (typeof id === 'string' && id.length > 0) || (typeof id === 'number' && !isNaN(id)));
 
     var internalModel = this._internalModelForId(modelName, id);
     options = options || {};
@@ -574,7 +575,7 @@ Store = Service.extend({
     @return {Promise} promise
   */
   findByIds(modelName, ids) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var store = this;
 
     return promiseArray(Ember.RSVP.all(ids.map((id) => {
@@ -598,8 +599,8 @@ Store = Service.extend({
     var id = internalModel.id;
     var adapter = this.adapterFor(typeClass.modelName);
 
-    Ember.assert("You tried to find a record but you have no adapter (for " + typeClass + ")", adapter);
-    Ember.assert("You tried to find a record but your adapter (for " + typeClass + ") does not implement 'findRecord'", typeof adapter.findRecord === 'function' || typeof adapter.find === 'function');
+    assert("You tried to find a record but you have no adapter (for " + typeClass + ")", adapter);
+    assert("You tried to find a record but your adapter (for " + typeClass + ") does not implement 'findRecord'", typeof adapter.findRecord === 'function' || typeof adapter.find === 'function');
 
     var promise = _find(adapter, this, typeClass, id, internalModel, options);
     return promise;
@@ -670,7 +671,7 @@ Store = Service.extend({
         resolvedRecords = Ember.A(resolvedRecords);
         var missingRecords = requestedRecords.reject((record) => resolvedRecords.contains(record));
         if (missingRecords.length) {
-          Ember.warn('Ember Data expected to find records with the following ids in the adapter response but they were missing: ' + Ember.inspect(Ember.A(missingRecords).mapBy('id')), false, {
+          warn('Ember Data expected to find records with the following ids in the adapter response but they were missing: ' + Ember.inspect(Ember.A(missingRecords).mapBy('id')), false, {
             id: 'ds.store.missing-records-from-adapter'
           });
         }
@@ -724,7 +725,7 @@ Store = Service.extend({
           var pair = Ember.A(pendingFetchItems).findBy('record', groupOfRecords[0]);
           _fetchRecord(pair);
         } else {
-          Ember.assert("You cannot return an empty array from adapter's method groupRecordsForFindMany", false);
+          assert("You cannot return an empty array from adapter's method groupRecordsForFindMany", false);
         }
       });
     } else {
@@ -753,7 +754,7 @@ Store = Service.extend({
     @return {DS.Model|null} record
   */
   peekRecord(modelName, id) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     if (this.hasRecordForId(modelName, id)) {
       return this._internalModelForId(modelName, id).getRecord();
     } else {
@@ -778,9 +779,9 @@ Store = Service.extend({
     var adapter = this.adapterFor(modelName);
     var id = internalModel.id;
 
-    Ember.assert("You cannot reload a record without an ID", id);
-    Ember.assert("You tried to reload a record but you have no adapter (for " + modelName + ")", adapter);
-    Ember.assert("You tried to reload a record but your adapter does not implement `findRecord`", typeof adapter.findRecord === 'function' || typeof adapter.find === 'function');
+    assert("You cannot reload a record without an ID", id);
+    assert("You tried to reload a record but you have no adapter (for " + modelName + ")", adapter);
+    assert("You tried to reload a record but your adapter does not implement `findRecord`", typeof adapter.findRecord === 'function' || typeof adapter.find === 'function');
 
     return this.scheduleFetch(internalModel);
   },
@@ -794,7 +795,7 @@ Store = Service.extend({
     @return {Boolean}
   */
   hasRecordForId(modelName, inputId) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     var id = coerceId(inputId);
     var internalModel = this.typeMapFor(typeClass).idToRecord[id];
@@ -812,7 +813,7 @@ Store = Service.extend({
     @return {DS.Model} record
   */
   recordForId(modelName, id) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     return this._internalModelForId(modelName, id).getRecord();
   },
 
@@ -863,8 +864,8 @@ Store = Service.extend({
   findHasMany(owner, link, relationship) {
     var adapter = this.adapterFor(owner.type.modelName);
 
-    Ember.assert("You tried to load a hasMany relationship but you have no adapter (for " + owner.type + ")", adapter);
-    Ember.assert("You tried to load a hasMany relationship from a specified `link` in the original payload but your adapter does not implement `findHasMany`", typeof adapter.findHasMany === 'function');
+    assert("You tried to load a hasMany relationship but you have no adapter (for " + owner.type + ")", adapter);
+    assert("You tried to load a hasMany relationship from a specified `link` in the original payload but your adapter does not implement `findHasMany`", typeof adapter.findHasMany === 'function');
 
     return _findHasMany(adapter, this, owner, link, relationship);
   },
@@ -880,8 +881,8 @@ Store = Service.extend({
   findBelongsTo(owner, link, relationship) {
     var adapter = this.adapterFor(owner.type.modelName);
 
-    Ember.assert("You tried to load a belongsTo relationship but you have no adapter (for " + owner.type + ")", adapter);
-    Ember.assert("You tried to load a belongsTo relationship from a specified `link` in the original payload but your adapter does not implement `findBelongsTo`", typeof adapter.findBelongsTo === 'function');
+    assert("You tried to load a belongsTo relationship but you have no adapter (for " + owner.type + ")", adapter);
+    assert("You tried to load a belongsTo relationship from a specified `link` in the original payload but your adapter does not implement `findBelongsTo`", typeof adapter.findBelongsTo === 'function');
 
     return _findBelongsTo(adapter, this, owner, link, relationship);
   },
@@ -935,15 +936,15 @@ Store = Service.extend({
     @return {Promise} promise
   */
   query(modelName, query) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     var array = this.recordArrayManager
       .createAdapterPopulatedRecordArray(typeClass, query);
 
     var adapter = this.adapterFor(modelName);
 
-    Ember.assert("You tried to load a query but you have no adapter (for " + typeClass + ")", adapter);
-    Ember.assert("You tried to load a query but your adapter does not implement `query`", typeof adapter.query === 'function');
+    assert("You tried to load a query but you have no adapter (for " + typeClass + ")", adapter);
+    assert("You tried to load a query but your adapter does not implement `query`", typeof adapter.query === 'function');
 
     return promiseArray(_query(adapter, this, typeClass, query, array));
   },
@@ -965,15 +966,15 @@ Store = Service.extend({
     @return {Promise} promise
   */
   queryRecord(modelName, query) {
-    Ember.assert("You need to pass a type to the store's queryRecord method", modelName);
-    Ember.assert("You need to pass a query hash to the store's queryRecord method", query);
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert("You need to pass a type to the store's queryRecord method", modelName);
+    assert("You need to pass a query hash to the store's queryRecord method", query);
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
 
     var typeClass = this.modelFor(modelName);
     var adapter = this.adapterFor(modelName);
 
-    Ember.assert("You tried to make a query but you have no adapter (for " + typeClass + ")", adapter);
-    Ember.assert("You tried to make a query but your adapter does not implement `queryRecord`", typeof adapter.queryRecord === 'function');
+    assert("You tried to make a query but you have no adapter (for " + typeClass + ")", adapter);
+    assert("You tried to make a query but your adapter does not implement `queryRecord`", typeof adapter.queryRecord === 'function');
 
     return promiseObject(_queryRecord(adapter, this, typeClass, query));
   },
@@ -1001,7 +1002,7 @@ Store = Service.extend({
     @return {DS.AdapterPopulatedRecordArray}
   */
   findAll(modelName, options) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
 
     return this._fetchAll(typeClass, this.peekAll(modelName), options);
@@ -1021,8 +1022,8 @@ Store = Service.extend({
 
     set(array, 'isUpdating', true);
 
-    Ember.assert("You tried to load all records but you have no adapter (for " + typeClass + ")", adapter);
-    Ember.assert("You tried to load all records but your adapter does not implement `findAll`", typeof adapter.findAll === 'function');
+    assert("You tried to load all records but you have no adapter (for " + typeClass + ")", adapter);
+    assert("You tried to load all records but your adapter does not implement `findAll`", typeof adapter.findAll === 'function');
     if (options.reload) {
       return promiseArray(_findAll(adapter, this, typeClass, sinceToken, options));
     }
@@ -1070,7 +1071,7 @@ Store = Service.extend({
     @return {DS.RecordArray}
   */
   peekAll(modelName) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
 
     var liveRecordArray = this.recordArrayManager.liveRecordArrayFor(typeClass);
@@ -1093,7 +1094,7 @@ Store = Service.extend({
    @param {String=} modelName
   */
   unloadAll(modelName) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), !modelName || typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), !modelName || typeof modelName === 'string');
     if (arguments.length === 0) {
       var typeMaps = this.typeMaps;
       var keys = Object.keys(typeMaps);
@@ -1174,10 +1175,10 @@ Store = Service.extend({
     @return {DS.PromiseArray}
   */
   filter(modelName, query, filter) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
 
     if (!Ember.ENV.ENABLE_DS_FILTER) {
-      Ember.assert('The filter API has been moved to a plugin. To enable store.filter using an environment flag, or to use an alternative, you can visit the ember-data-filter addon page. https://github.com/ember-data/ember-data-filter', false);
+      assert('The filter API has been moved to a plugin. To enable store.filter using an environment flag, or to use an alternative, you can visit the ember-data-filter addon page. https://github.com/ember-data/ember-data-filter', false);
     }
 
     var promise;
@@ -1225,7 +1226,7 @@ Store = Service.extend({
     @return {boolean}
   */
   recordIsLoaded(modelName, id) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     return this.hasRecordForId(modelName, id);
   },
 
@@ -1236,7 +1237,7 @@ Store = Service.extend({
     @private
   */
   _metadataFor(modelName) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     return this.typeMapFor(typeClass).metadata;
   },
@@ -1248,7 +1249,7 @@ Store = Service.extend({
     @private
   */
   _setMetadataFor(modelName, metadata) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     Ember.merge(this.typeMapFor(typeClass).metadata, metadata);
   },
@@ -1402,7 +1403,7 @@ Store = Service.extend({
     var oldId = internalModel.id;
     var id = coerceId(data.id);
 
-    Ember.assert("An adapter cannot assign a new id to a record that already has an id. " + internalModel + " had id: " + oldId + " and you tried to update it with " + id + ". This likely happened because your server returned data in response to a find or update that had a different id than the one you sent.", oldId === null || id === oldId);
+    assert("An adapter cannot assign a new id to a record that already has an id. " + internalModel + " had id: " + oldId + " and you tried to update it with " + id + ". This likely happened because your server returned data in response to a find or update that had a different id than the one you sent.", oldId === null || id === oldId);
 
     this.typeMapFor(internalModel.type).idToRecord[id] = internalModel;
 
@@ -1505,7 +1506,7 @@ Store = Service.extend({
     @return {DS.Model}
   */
   modelFor(modelName) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
 
     var factory = this.modelFactoryFor(modelName);
     if (!factory) {
@@ -1521,7 +1522,7 @@ Store = Service.extend({
   },
 
   modelFactoryFor(modelName) {
-    Ember.assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
+    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var normalizedKey = normalizeModelName(modelName);
 
     var owner = getOwner(this);
@@ -1701,7 +1702,7 @@ Store = Service.extend({
       return null;
     }
 
-    Ember.assert(`Expected an object in the 'data' property in a call to 'push' for ${data.type}, but was ${Ember.typeOf(data.data)}`, Ember.typeOf(data.data) === 'object');
+    assert(`Expected an object in the 'data' property in a call to 'push' for ${data.type}, but was ${Ember.typeOf(data.data)}`, Ember.typeOf(data.data) === 'object');
 
     var internalModel = this._pushInternalModel(data.data);
 
@@ -1714,8 +1715,8 @@ Store = Service.extend({
 
   _pushInternalModel(data) {
     var modelName = data.type;
-    Ember.assert(`You must include an 'id' for ${modelName} in an object passed to 'push'`, data.id != null && data.id !== '');
-    Ember.assert(`You tried to push data with a type '${modelName}' but no model could be found with that name.`, this._hasModelFor(modelName));
+    assert(`You must include an 'id' for ${modelName} in an object passed to 'push'`, data.id != null && data.id !== '');
+    assert(`You tried to push data with a type '${modelName}' but no model could be found with that name.`, this._hasModelFor(modelName));
 
     var type = this.modelFor(modelName);
 
@@ -1723,7 +1724,7 @@ Store = Service.extend({
     // contains unknown keys, log a warning.
 
     if (Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS) {
-      Ember.warn("The payload for '" + type.modelName + "' contains these unknown keys: " +
+      warn("The payload for '" + type.modelName + "' contains these unknown keys: " +
         Ember.inspect(Object.keys(data).forEach((key) => {
           return !(key === 'id' || key === 'links' || get(type, 'fields').has(key) || key.match(/Type$/));
         })) + ". Make sure they've been defined in your model.",
@@ -1812,10 +1813,10 @@ Store = Service.extend({
     if (!inputPayload) {
       payload = modelName;
       serializer = defaultSerializer(this);
-      Ember.assert("You cannot use `store#pushPayload` without a modelName unless your default serializer defines `pushPayload`", typeof serializer.pushPayload === 'function');
+      assert("You cannot use `store#pushPayload` without a modelName unless your default serializer defines `pushPayload`", typeof serializer.pushPayload === 'function');
     } else {
       payload = inputPayload;
-      Ember.assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
+      assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
       serializer = this.serializerFor(modelName);
     }
     this._adapterRun(() => serializer.pushPayload(this, payload));
@@ -1841,7 +1842,7 @@ Store = Service.extend({
     @return {Object} The normalized payload
   */
   normalize(modelName, payload) {
-    Ember.assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
+    assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
     var serializer = this.serializerFor(modelName);
     var model = this.modelFor(modelName);
     return serializer.normalize(model, payload);
@@ -1862,8 +1863,8 @@ Store = Service.extend({
     var typeMap = this.typeMapFor(type);
     var idToRecord = typeMap.idToRecord;
 
-    Ember.assert(`The id ${id} has already been used with another record of type ${type.toString()}.`, !id || !idToRecord[id]);
-    Ember.assert(`'${Ember.inspect(type)}' does not appear to be an ember-data model`, (typeof type._create === 'function') );
+    assert(`The id ${id} has already been used with another record of type ${type.toString()}.`, !id || !idToRecord[id]);
+    assert(`'${Ember.inspect(type)}' does not appear to be an ember-data model`, (typeof type._create === 'function') );
 
     // lookupFactory should really return an object that creates
     // instances with the injections applied
@@ -1935,7 +1936,7 @@ Store = Service.extend({
   */
   adapterFor(modelName) {
 
-    Ember.assert(`Passing classes to store.adapterFor has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
+    assert(`Passing classes to store.adapterFor has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
 
     return this.lookupAdapter(modelName);
   },
@@ -1971,7 +1972,7 @@ Store = Service.extend({
   */
   serializerFor(modelName) {
 
-    Ember.assert(`Passing classes to store.serializerFor has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
+    assert(`Passing classes to store.serializerFor has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
 
     var fallbacks = [
       'application',
@@ -2040,7 +2041,7 @@ function deserializeRecordId(store, key, relationship, id) {
     return;
   }
 
-  Ember.assert(`A ${relationship.parentType} record was pushed into the store with the value of ${key} being ${Ember.inspect(id)}, but ${key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !isArray(id));
+  assert(`A ${relationship.parentType} record was pushed into the store with the value of ${key} being ${Ember.inspect(id)}, but ${key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !isArray(id));
 
   //TODO:Better asserts
   return store._internalModelForId(id.type, id.id);
@@ -2051,7 +2052,7 @@ function deserializeRecordIds(store, key, relationship, ids) {
     return;
   }
 
-  Ember.assert(`A ${relationship.parentType} record was pushed into the store with the value of ${key} being '${Ember.inspect(ids)}', but ${key} is a hasMany relationship so the value must be an array. You should probably check your data payload or serializer.`, isArray(ids));
+  assert(`A ${relationship.parentType} record was pushed into the store with the value of ${key} being '${Ember.inspect(ids)}', but ${key} is a hasMany relationship so the value must be an array. You should probably check your data payload or serializer.`, isArray(ids));
   return ids.map((id) => deserializeRecordId(store, key, relationship, id));
 }
 
@@ -2071,7 +2072,7 @@ function _commit(adapter, store, operation, snapshot) {
   var serializer = serializerForAdapter(store, adapter, modelName);
   var label = `DS: Extract and notify about ${operation} completion of ${internalModel}`;
 
-  Ember.assert(`Your adapter's '${operation}' method must return a value, but it returned 'undefined'`, promise !==undefined);
+  assert(`Your adapter's '${operation}' method must return a value, but it returned 'undefined'`, promise !==undefined);
 
   promise = Promise.resolve(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));

--- a/addon/system/store/finders.js
+++ b/addon/system/store/finders.js
@@ -1,3 +1,4 @@
+import { assert } from "ember-data/debug";
 import {
   _bind,
   _guard,
@@ -32,10 +33,10 @@ export function _find(adapter, store, typeClass, id, internalModel, options) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    Ember.assert("You made a `find` request for a " + typeClass.typeClassKey + " with id " + id + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    assert("You made a `find` request for a " + typeClass.typeClassKey + " with id " + id + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, id, 'findRecord');
-      Ember.assert('Ember Data expected the primary data returned from a `findRecord` response to be an object but instead it found an array.', !Array.isArray(payload.data));
+      assert('Ember Data expected the primary data returned from a `findRecord` response to be an object but instead it found an array.', !Array.isArray(payload.data));
       //TODO Optimize
       var record = store.push(payload);
       return record._internalModel;
@@ -65,7 +66,7 @@ export function _findMany(adapter, store, typeClass, ids, internalModels) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    Ember.assert("You made a `findMany` request for a " + typeClass.typeClassKey + " with ids " + ids + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    assert("You made a `findMany` request for a " + typeClass.typeClassKey + " with ids " + ids + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findMany');
       //TODO Optimize, no need to materialize here
@@ -87,7 +88,7 @@ export function _findHasMany(adapter, store, internalModel, link, relationship) 
   promise = _guard(promise, _bind(_objectIsAlive, internalModel));
 
   return promise.then(function(adapterPayload) {
-    Ember.assert("You made a `findHasMany` request for a " + internalModel.modelName + "'s `" + relationship.key + "` relationship, using link " + link + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    assert("You made a `findHasMany` request for a " + internalModel.modelName + "'s `" + relationship.key + "` relationship, using link " + link + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findHasMany');
       //TODO Use a non record creating push
@@ -137,7 +138,7 @@ export function _findAll(adapter, store, typeClass, sinceToken, options) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    Ember.assert("You made a `findAll` request for " + typeClass.typeClassKey + "records, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    assert("You made a `findAll` request for " + typeClass.typeClassKey + "records, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findAll');
       //TODO Optimize
@@ -167,7 +168,7 @@ export function _query(adapter, store, typeClass, query, recordArray) {
       records = store.push(payload);
     });
 
-    Ember.assert('The response to store.query is expected to be an array but it was a single record. Please wrap your response in an array or use `store.queryRecord` to query for a single record.', Ember.isArray(records));
+    assert('The response to store.query is expected to be an array but it was a single record. Please wrap your response in an array or use `store.queryRecord` to query for a single record.', Ember.isArray(records));
     recordArray.loadRecords(records);
     return recordArray;
 
@@ -184,7 +185,7 @@ export function _queryRecord(adapter, store, typeClass, query) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    Ember.assert("You made a `queryRecord` request for " + typeClass.typeClassKey + "records, with query `" + query + "`, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    assert("You made a `queryRecord` request for " + typeClass.typeClassKey + "records, with query `" + query + "`, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     var record;
     store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'queryRecord');

--- a/addon/system/store/serializer-response.js
+++ b/addon/system/store/serializer-response.js
@@ -1,3 +1,5 @@
+import { assert, runInDebug } from "ember-data/debug";
+
 /*
   This is a helper method that validates a JSON API top-level document
 
@@ -72,10 +74,10 @@ export function validateDocumentStructure(doc) {
 export function normalizeResponseHelper(serializer, store, modelClass, payload, id, requestType) {
   let normalizedResponse = serializer.normalizeResponse(store, modelClass, payload, id, requestType);
   let validationErrors = [];
-  Ember.runInDebug(() => {
+  runInDebug(() => {
     validationErrors = validateDocumentStructure(normalizedResponse);
   });
-  Ember.assert(`normalizeResponse must return a valid JSON API document:\n\t* ${validationErrors.join('\n\t* ')}`, Ember.isEmpty(validationErrors));
+  assert(`normalizeResponse must return a valid JSON API document:\n\t* ${validationErrors.join('\n\t* ')}`, Ember.isEmpty(validationErrors));
   // TODO: Remove after metadata refactor
   if (normalizedResponse.meta) {
     store._setMetadataFor(modelClass.modelName, normalizedResponse.meta);

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { assert } from "ember-data/debug";
 
 const get = Ember.get;
 
@@ -29,7 +30,7 @@ var assertPolymorphicType = function(record, relationshipMeta, addedRecord) {
 
   var assertionMessage = `You cannot add a record of type '${addedType}' to the '${recordType}.${key}' relationship (only '${typeClass.modelName}' allowed)`;
 
-  Ember.assert(assertionMessage, checkPolymorphic(typeClass, addedRecord));
+  assert(assertionMessage, checkPolymorphic(typeClass, addedRecord));
 };
 
 function checkPolymorphic(typeClass, addedRecord) {


### PR DESCRIPTION
By this, the calls to `assert`, `warn` etcetera are corectly stripped
when a new production build is created.

cc @fivetanley 