### PR TITLE
Allow `include` query parameter with store.findRecord & store.findAll

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,6 +11,12 @@ entry in `config/features.json`.
 
 ## Feature Flags
 
+- `ds-find-include`
+
+  Allows an `include` query parameter to be specified with using
+  `store.findRecord()` and `store.findAll()` as described in [RFC
+  99](https://github.com/emberjs/rfcs/pull/99)
+
 - `ds-references`
 
   Adds references as described in [RFC 57](https://github.com/emberjs/rfcs/pull/57)

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -251,10 +251,7 @@ InternalModel.prototype = {
     @private
   */
   createSnapshot(options) {
-    var adapterOptions = options && options.adapterOptions;
-    var snapshot = new Snapshot(this);
-    snapshot.adapterOptions = adapterOptions;
-    return snapshot;
+    return new Snapshot(this, options);
   },
 
   /**

--- a/addon/-private/system/record-arrays/record-array.js
+++ b/addon/-private/system/record-arrays/record-array.js
@@ -202,8 +202,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
   },
 
   createSnapshot(options) {
-    var adapterOptions = options && options.adapterOptions;
-    var meta = this.get('meta');
-    return new SnapshotRecordArray(this, meta, adapterOptions);
+    const meta = this.get('meta');
+    return new SnapshotRecordArray(this, meta, options);
   }
 });

--- a/addon/-private/system/snapshot-record-array.js
+++ b/addon/-private/system/snapshot-record-array.js
@@ -2,6 +2,8 @@
   @module ember-data
 */
 
+import isEnabled from 'ember-data/-private/features';
+
 /**
   @class SnapshotRecordArray
   @namespace DS
@@ -10,7 +12,7 @@
   @param {Array} snapshots An array of snapshots
   @param {Object} meta
 */
-export default function SnapshotRecordArray(recordArray, meta, adapterOptions) {
+export default function SnapshotRecordArray(recordArray, meta, options = {}) {
   /**
     An array of snapshots
     @private
@@ -48,7 +50,11 @@ export default function SnapshotRecordArray(recordArray, meta, adapterOptions) {
     @property adapterOptions
     @type {Object}
   */
-  this.adapterOptions = adapterOptions;
+  this.adapterOptions = options.adapterOptions;
+
+  if (isEnabled('ds-finder-include')) {
+    this.include = options.include;
+  }
 }
 
 /**

--- a/addon/-private/system/snapshot.js
+++ b/addon/-private/system/snapshot.js
@@ -4,6 +4,8 @@
 
 import Ember from 'ember';
 import EmptyObject from "ember-data/-private/system/empty-object";
+import isEnabled from 'ember-data/-private/features';
+
 var get = Ember.get;
 
 /**
@@ -13,7 +15,7 @@ var get = Ember.get;
   @constructor
   @param {DS.Model} internalModel The model to create a snapshot from
 */
-export default function Snapshot(internalModel) {
+export default function Snapshot(internalModel, options = {}) {
   this._attributes = new EmptyObject();
   this._belongsToRelationships = new EmptyObject();
   this._belongsToIds = new EmptyObject();
@@ -28,6 +30,17 @@ export default function Snapshot(internalModel) {
   this._internalModel = internalModel;
   this.type = internalModel.type;
   this.modelName = internalModel.type.modelName;
+
+  /**
+    A hash of adapter options
+    @property adapterOptions
+    @type {Object}
+  */
+  this.adapterOptions = options.adapterOptions;
+
+  if (isEnabled('ds-finder-include')) {
+    this.include = options.include;
+  }
 
   this._changedAttributes = record.changedAttributes();
 }

--- a/config/features.json
+++ b/config/features.json
@@ -1,3 +1,4 @@
 {
+  "ds-finder-include": null,
   "ds-references": null
 }

--- a/tests/integration/adapter/store-adapter-test.js
+++ b/tests/integration/adapter/store-adapter-test.js
@@ -4,6 +4,7 @@ import Ember from 'ember';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
+import isEnabled from 'ember-data/-private/features';
 
 /*
  This is an integration test that tests the communication between a store
@@ -1303,7 +1304,7 @@ test("record.save should pass adapterOptions to the deleteRecord method", functi
 });
 
 
-test("findRecord should pass adapterOptions to the find method", function(assert) {
+test("store.findRecord should pass adapterOptions to adapter.findRecord", function(assert) {
   assert.expect(1);
 
   env.adapter.findRecord = assert.wait(function(store, type, id, snapshot) {
@@ -1316,8 +1317,20 @@ test("findRecord should pass adapterOptions to the find method", function(assert
   });
 });
 
+if (isEnabled('ds-finder-include')) {
+  test("store.findRecord should pass 'include' to adapter.findRecord", function(assert) {
+    assert.expect(1);
 
-test("findAll should pass adapterOptions to the findAll method", function(assert) {
+    env.adapter.findRecord = assert.wait((store, type, id, snapshot) => {
+      assert.equal(snapshot.include,  'books', 'include passed to adapter.findRecord');
+      return Ember.RSVP.resolve({ id: 1 });
+    });
+
+    run(() => store.findRecord('person', 1, { include: 'books' }));
+  });
+}
+
+test("store.findAll should pass adapterOptions to the adapter.findAll method", function(assert) {
   assert.expect(1);
 
   env.adapter.findAll = assert.wait(function(store, type, sinceToken, arraySnapshot) {
@@ -1331,6 +1344,18 @@ test("findAll should pass adapterOptions to the findAll method", function(assert
   });
 });
 
+if (isEnabled('ds-finder-include')) {
+  test("store.findAll should pass 'include' to adapter.findAll", function(assert) {
+    assert.expect(1);
+
+    env.adapter.findAll = assert.wait((store, type, sinceToken, arraySnapshot) => {
+      assert.equal(arraySnapshot.include, 'books', 'include passed to adapter.findAll');
+      return Ember.RSVP.resolve([{ id: 1 }]);
+    });
+
+    run(() => store.findAll('person', { include: 'books' }));
+  });
+}
 
 test("An async hasMany relationship with links should not trigger shouldBackgroundReloadRecord", function(assert) {
   var Post = DS.Model.extend({

--- a/tests/unit/adapters/rest-adapter/ajax-test.js
+++ b/tests/unit/adapters/rest-adapter/ajax-test.js
@@ -35,8 +35,8 @@ test("When an id is searched, the correct url should be generated", function(ass
     return Ember.RSVP.resolve();
   };
   run(function() {
-    adapter.findRecord(store, Person, 1);
-    adapter.findRecord(store, Place, 1);
+    adapter.findRecord(store, Person, 1, {});
+    adapter.findRecord(store, Place, 1, {});
   });
 });
 
@@ -47,7 +47,7 @@ test("id's should be sanatized", function(assert) {
     return Ember.RSVP.resolve();
   };
   run(function() {
-    adapter.findRecord(store, Person, '../place/1');
+    adapter.findRecord(store, Person, '../place/1', {});
   });
 });
 

--- a/tests/unit/adapters/rest-adapter/build-query-test.js
+++ b/tests/unit/adapters/rest-adapter/build-query-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import DS from 'ember-data';
+import isEnabled from 'ember-data/-private/features';
+
+module("unit/adapters/rest-adapter/build-query - building queries");
+
+test("buildQuery() returns an empty query when snapshot has no query params", function(assert) {
+  const adapter = DS.RESTAdapter.create();
+  const snapshotStub = {};
+
+  const query = adapter.buildQuery(snapshotStub);
+
+  assert.deepEqual(query, {}, 'query is empty');
+});
+
+if (isEnabled('ds-finder-include')) {
+  test("buildQuery() returns query with `include` from snapshot", function(assert) {
+    const adapter = DS.RESTAdapter.create();
+    const snapshotStub = { include: 'comments' };
+
+    const query = adapter.buildQuery(snapshotStub);
+
+    assert.deepEqual(query, { include: 'comments' }, 'query includes `include`');
+  });
+}


### PR DESCRIPTION
Related RFC: https://github.com/emberjs/rfcs/pull/99

### Description

These changes allow an `include` parameter to be specified when using
`store.findRecord` and `store.findAll`:

```javascript
store.findRecord('post', 123, { include: 'comments' });
store.findAll('post', { include: 'comments' });
```

The value for `include` is copied onto the `DS.Snapshot` or
`DS.SnapshotRecordArray` that is passed to the corresponding adapter
function. This value is then pulled from the snapshot and used as a
query parameter (`include`) when making an AJAX request via
`adapter.ajax`.

### Questions

1. ~~Is it OK that the `include` option is copied into `adapterOptions` or should it be copied into `adapterOptions.query`. I originally copied it into `adapterOptions.query` but the code was a little uglier so I went with just copying it into `adapterOptions`, but I'm still not sure.~~
1. If the value for `include` is an array, should we automatically join the values into a comma separated list? The [JSON API spec for "Inclusion of Related Resources"](http://jsonapi.org/format/#fetching-includes) requires that the value be a comma separated list but I didn't think that was necessarily what everyone would want. We could just do that in the JSON API adapter but I figured I'd ask for some feedback before proceeding with that.

### Work to be done in additional PRs

It was also [mentioned in the RFC](https://github.com/emberjs/rfcs/pull/99#issuecomment-153833942) that we could provide some additional functionality:

```javascript
post.save({ include: 'comments' });
post.destroyRecord({ include: 'comments' });
```

I'm not totally clear on what the behavior would be there yet so those were left unimplemented for now.