### PR TITLE
Re-enable feature flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 script:
   - ./bin/lint-features
   - npm run-script test
+  - npm run-script test:optional-features
 after_success:
   - npm run-script production
   - "./bin/bower-ember-data-build"

--- a/addon/features.js
+++ b/addon/features.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default function isEnabled() {
+  return Ember.FEATURES.isEnabled(...arguments);
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,13 +1,23 @@
 'use strict';
 
+var fs = require('fs');
+var featuresJson = fs.readFileSync('config/features.json', { encoding: 'utf8' });
+var featureFlags = JSON.parse(featuresJson);
+
 module.exports = function(environment, appConfig) {
   var ENV = { };
 
-  if (environment === 'testing') {
-    ENV.EmberENV = {
-      RAISE_ON_DEPRECATION: true,
-      ENABLE_DS_FILTER: true
-    };
+  ENV.EmberENV = {
+    FEATURES: featureFlags,
+    ENABLE_DS_FILTER: true,
+
+    // don't raise on deprecation yet, since there are too many thrown errors;
+    // this should be addressed in another PR
+    // RAISE_ON_DEPRECATION: true
+  };
+
+  if (environment === 'test-optional-features') {
+    ENV.EmberENV.ENABLE_OPTIONAL_FEATURES = true;
   }
 
   return ENV;

--- a/lib/enable-optional-features-via-url/index.js
+++ b/lib/enable-optional-features-via-url/index.js
@@ -1,0 +1,27 @@
+/*jshint node:true*/
+module.exports = {
+  name: 'enable-optional-features-via-url',
+
+  /**
+    So the ENABLE_OPTIONAL_FEATURES flag is considered correctly within the
+    index.html, it needs to be set before Ember.js is loaded. Since there is
+    currently no way to access the `window` object within config/environment.js
+    (and hereby check if there is a query parameter present for the checkbox),
+    a script is injected, before Ember.js is loaded. The script checks if there
+    is no value yet for the ENABLE_OPTIONAL_FEATURES flag, and if so, it sets
+    the flag to true when there is a `enableoptionalfeatures` query parameter.
+   */
+  contentFor: function(name) {
+    if (name === "vendor-prefix") {
+      var array = [
+        "<!-- injected by lib/enable-optional-features-via-url -->",
+        "window.EmberENV = window.EmberENV || {};",
+        "if (typeof window.EmberENV.ENABLE_OPTIONAL_FEATURES === 'undefined') {",
+        "  window.EmberENV.ENABLE_OPTIONAL_FEATURES = window.location.search.indexOf('enableoptionalfeatures') !== -1;",
+        "}"
+      ];
+
+      return array.join('\n');
+    }
+  }
+};

--- a/lib/enable-optional-features-via-url/package.json
+++ b/lib/enable-optional-features-via-url/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "enable-optional-features-via-url",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/lib/javascripts.js
+++ b/lib/javascripts.js
@@ -1,10 +1,12 @@
 var filterImports = require('babel-plugin-filter-imports');
+var featureFlags  = require('babel-plugin-feature-flags');
 var babel         = require('broccoli-babel-transpiler');
 var merge         = require('broccoli-merge-trees');
 var concat        = require('broccoli-concat');
 var uglify        = require('broccoli-uglify-sourcemap');
 var stew          = require('broccoli-stew');
 var version       = require('./version');
+var fs            = require('fs');
 var path          = require('path');
 var Funnel        = require('broccoli-funnel');
 var versionReplace = require('./version-replace');
@@ -56,7 +58,15 @@ function debugBuild(packageName, tree) {
 }
 
 function strippedBuild(packageName, tree) {
+  var featuresJson = fs.readFileSync('config/features.json', { encoding: 'utf8' });
+  var features = JSON.parse(featuresJson);
+
   var plugins = [
+    featureFlags({
+      import: { module: 'ember-data/features' },
+      features: features
+    }),
+
     filterImports({
       'ember-data/debug': [
         'assert',

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "paths": [
+      "lib/enable-optional-features-via-url"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "ember build",
     "start": "ember server",
     "test": "ember try:testall",
+    "test:optional-features": "ember test --environment=test-optional-features",
     "bower": "bower install",
     "production": "ember build --environment=production"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ember-cli-babel": "^5.1.3"
   },
   "devDependencies": {
+    "babel-plugin-feature-flags": "^0.2.0",
     "babel-plugin-filter-imports": "^0.2.0",
     "bower": "^1.6.5",
     "broccoli-asset-rev": "^2.1.2",

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -19,13 +19,7 @@ import Ember from 'ember';
 
 setResolver(resolver);
 
-const ENV = Ember.ENV;
-const QUNIT_PARAMS = QUnit.urlParams;
 const { assert } = QUnit;
-
-ENV.EXTEND_PROTOTYPES = QUNIT_PARAMS.extendprototypes;
-ENV.ENABLE_OPTIONAL_FEATURES = QUNIT_PARAMS.enableoptionalfeatures;
-ENV.ENABLE_DS_FILTER = true;
 
 QUnit.begin(function() {
   Ember.RSVP.configure('onerror', function(reason) {
@@ -76,6 +70,5 @@ assert.without = function(array, item)  {
 
 addEmberAssertions(assert);
 
-QUnit.config.testTimeout= 2000;
+QUnit.config.testTimeout = 2000;
 QUnit.config.urlConfig.push({ id: 'enableoptionalfeatures', label: "Enable Opt Features" });
-


### PR DESCRIPTION
This re-enables testing feature flags and stripping disabled feature flags from production build (using [ember-cli/babel-plugin-feature-flags](https://github.com/ember-cli/babel-plugin-feature-flags)).

Feature flags are now possible within ember-data by using the following setup:

```js
import isEnabled from 'ember-data/features';

if (isEnabled("ds-my-feature")) {
  // ...
}
```

The features need to be defined within `config/features.json`. Disabled feature flags are also stripped from production builds.

---

Running the tests with all optional feature flags enabled is possible via `ember test --environment=test-optional-features`. When the tests are run via `ember serve`, the optional feature flags can be enabled via a checkbox.

---

This addresses #3922.