### PR TITLE
Add license field to bower.json

### DIFF
--- a/config/package-manager-files/bower.json
+++ b/config/package-manager-files/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "ember-data",
   "version": "VERSION_STRING_PLACEHOLDER",
+  "license": "MIT",
   "main": "ember-data.js",
   "dependencies": {
     "ember": "^2.0.0"

--- a/config/package-manager-files/component.json
+++ b/config/package-manager-files/component.json
@@ -3,6 +3,7 @@
   "repo": "components/ember-data",
   "description": "A data persistence library for Ember.js.",
   "version": "VERSION_STRING_PLACEHOLDER",
+  "license": "MIT",
   "main": "ember-data.js",
   "scripts": [
     "ember-data.js",
@@ -11,6 +12,5 @@
   ],
   "dependencies": {
     "components/ember": ">= 2.0.0 < 3.0.0"
-  },
-  "license": "MIT"
+  }
 }


### PR DESCRIPTION
From components/ember-data#33.

bower.json is missing the license field. If I'm not mistaken, Data uses the same license as Ember (MIT). https://github.com/components/ember/blob/master/bower.json#L3

Our automated external library requests service is blocking the import of Ember Data canary for this reason.

I've also positioned the license field in component.json to mirror that of Ember.