### PR TITLE
Remove extraneous conditional in ajax()

### DIFF
--- a/addon/adapters/rest-adapter.js
+++ b/addon/adapters/rest-adapter.js
@@ -842,21 +842,19 @@ export default Adapter.extend(BuildURLMixin, {
       hash.error = function(jqXHR, textStatus, errorThrown) {
         let error;
 
-        if (!(error instanceof Error)) {
-          if (errorThrown instanceof Error) {
-            error = errorThrown;
-          } else if (textStatus === 'timeout') {
-            error = new TimeoutError();
-          } else if (textStatus === 'abort') {
-            error = new AbortError();
-          } else {
-            error = adapter.handleResponse(
-              jqXHR.status,
-              parseResponseHeaders(jqXHR.getAllResponseHeaders()),
-              adapter.parseErrorResponse(jqXHR.responseText) || errorThrown,
-              requestData
-            );
-          }
+        if (errorThrown instanceof Error) {
+          error = errorThrown;
+        } else if (textStatus === 'timeout') {
+          error = new TimeoutError();
+        } else if (textStatus === 'abort') {
+          error = new AbortError();
+        } else {
+          error = adapter.handleResponse(
+            jqXHR.status,
+            parseResponseHeaders(jqXHR.getAllResponseHeaders()),
+            adapter.parseErrorResponse(jqXHR.responseText) || errorThrown,
+            requestData
+          );
         }
 
         Ember.run.join(null, reject, error);


### PR DESCRIPTION
_I might be missing something obvious, so feel free to close if this code was intended and I just missed the effect._

The conditional was checking if `error` was not an instance of `Error`, but it was initialized on the previous line, ensuring the conditional would always pass.