### PR TITLE
When using the `JSONAPISerializer` normalize the response of `queryRe…

### DIFF
--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -183,6 +183,22 @@ const JSONAPISerializer = JSONSerializer.extend({
     return normalizedPayload;
   },
 
+  normalizeQueryRecordResponse(store, primaryModelClass, payload, id, requestType) {
+    let normalizedPayload = this._normalizeResponse(store, primaryModelClass, payload, id, requestType, false);
+
+    if (Array.isArray(normalizedPayload.data)) {
+      // If the store is expecting a single response normalize the
+      // payload and move the extra records into the included array.
+      let arrayData = normalizedPayload.data;
+      let included = normalizedPayload.included || [];
+      normalizedPayload.data = arrayData[0];
+      normalizedPayload.included = included.concat(arrayData.slice(1));
+      return normalizedPayload;
+    }
+
+    return normalizedPayload;
+  },
+
   /**
     @method extractAttributes
     @param {DS.Model} modelClass

--- a/tests/integration/serializers/json-api-serializer-test.js
+++ b/tests/integration/serializers/json-api-serializer-test.js
@@ -259,3 +259,27 @@ test('Serializer should respect the attrs hash when serializing attributes with 
 
   assert.equal(payload.data.attributes['company_name'], 'Tilde Inc.');
 });
+
+test('Serializer should normalize array responses to a single data object', function(assert) {
+
+  var jsonHash = {
+    data: [{
+      type: 'company',
+      id: '1',
+      attributes: {
+        name: "Tilde Inc."
+      }
+    }, {
+      type: 'company',
+      id: '2',
+      attributes: {
+        name: "Weyland-Yutani Corporation"
+      }
+    }]
+  };
+
+  var project = env.store.serializerFor('company').normalizeQueryRecordResponse(env.store, Company, jsonHash, 1, 'findRecord');
+
+  assert.equal(project.data.attributes['name'], 'Tilde Inc.');
+  assert.equal(project.included[0].attributes['name'], 'Weyland-Yutani Corporation');
+});


### PR DESCRIPTION
…cord` if it is an array

Currently both the `JSONSerializer` and `RestSerializer` do this kind of normalization. The `JSONAPISerializer` is the odd one out with it's current behavior.