### PR TITLE
Rely on internalModel.createSnapshot to set adapterOptions

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -524,8 +524,7 @@ Store = Service.extend({
     }
 
     // Refetch the record if the adapter thinks the record is stale
-    var snapshot = internalModel.createSnapshot();
-    snapshot.adapterOptions = options && options.adapterOptions;
+    var snapshot = internalModel.createSnapshot(options);
     var typeClass = internalModel.type;
     var adapter = this.adapterFor(typeClass.modelName);
     if (adapter.shouldReloadRecord(this, snapshot)) {


### PR DESCRIPTION
[internalModel.createSnapshot](https://github.com/HeroicEric/data/blob/use-create-snapshot-options/addon/-private/system/model/internal-model.js#L241-L250) already sets the `adapterOptions` on
the new snapshot the same way when `options` are provided.

Found this while working on https://github.com/emberjs/data/pull/3976 and figured that it would make sense to try to keep the logic for creating the snapshot in one place.