### PR TITLE
Run the Ember Data initializer when Ember Data is loaded as an Ember …

### DIFF
--- a/app/initializers/ember-data.js
+++ b/app/initializers/ember-data.js
@@ -1,0 +1,6 @@
+import setupContainer from 'ember-data/-private/setup-container';
+
+export default {
+  name: 'ember-data',
+  initialize: setupContainer
+};

--- a/app/instance-initializers/ember-data.js
+++ b/app/instance-initializers/ember-data.js
@@ -1,0 +1,6 @@
+import initializeStoreService from 'ember-data/-private/instance-initializers/initialize-store-service';
+
+export default {
+  name: "ember-data",
+  initialize: initializeStoreService
+};


### PR DESCRIPTION
…CLI addon.

I believe this fixes. http://discuss.emberjs.com/t/jsonapiadapter-not-recognized-findall-is-not-a-function/9307

In globals mode this code https://github.com/emberjs/data/blob/master/addon/-private/ember-initializer.js#L44-L80 registers the Ember initializers. However, it appears when Ember Data is loaded as an Ember CLI addon the `Ember.onLoad` callback is being called after Ember's initializers step has already completed. 

I suspect there is a better way of doing this. Possibly by ensuring https://github.com/emberjs/data/blob/master/addon/-private/ember-initializer.js#L44-L80 only gets added to the globals build.