### PR TITLE
Re-enable pushing builds to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - npm run-script test:optional-features
 after_success:
   - npm run-script production
-  - "./bin/bower-ember-data-build"
+  - "./bin/publish-builds"
 env:
   global:
   - BROCCOLI_ENV="production"

--- a/bin/publish-builds
+++ b/bin/publish-builds
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo -e "CURRENT_BRANCH: ${TRAVIS_BRANCH}\n"
+echo -e "PULL_REQUEST: ${TRAVIS_PULL_REQUEST}\n"
+
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  ./bin/publish-to-s3.js
+  ./bin/bower-ember-data-build
+fi


### PR DESCRIPTION
If I am not mistaken, it looks like the builds are not published on S3...

The `bin/publish-builds` script is inspired by [the one in the Ember.js repo](https://github.com/emberjs/ember.js/blob/fbab176eb41727dc6a4718ee3dfdc6490706b3b2/bin/publish_builds).