### PR TITLE
Add ember-publisher to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-inflector": "^1.9.4",
+    "ember-publisher": "0.0.7",
     "ember-try": "0.0.6",
     "ember-watson": "^0.7.0",
     "git-repo-version": "^0.3.0",


### PR DESCRIPTION
This package is needed within [`bin/publish-to-s3.js`](https://github.com/emberjs/data/blob/7a23274db30325549e3c13967f431ddffd8f0771/bin/publish-to-s3.js#L17).

---

This is a followup to #4000. Sorry @bmac, I missed that dependency...