### PR TITLE
Fix paths to files which should be uploaded to S3

### DIFF
--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -1,10 +1,10 @@
 function fileMap(revision,tag,date) {
   return {
-    'ember-data.js': fileObject('ember-data',             '.js',   'text/javascript',  revision, tag, date),
-    'ember-data.js.map': fileObject('ember-data.js',      '.map',  'application/json', revision, tag, date),
-    'ember-data.min.js': fileObject('ember-data.min',     '.js',   'text/javascript',  revision, tag, date),
-    'ember-data.prod.js': fileObject('ember-data.prod',   '.js',   'text/javascript',  revision, tag, date),
-    'docs/data.json':  fileObject('ember-data-docs',   '.json', 'application/json', revision, tag, date)
+    'globals/ember-data.js':      fileObject('ember-data',      '.js',   'text/javascript',  revision, tag, date),
+    'globals/ember-data.js.map':  fileObject('ember-data.js',   '.map',  'application/json', revision, tag, date),
+    'globals/ember-data.min.js':  fileObject('ember-data.min',  '.js',   'text/javascript',  revision, tag, date),
+    'globals/ember-data.prod.js': fileObject('ember-data.prod', '.js',   'text/javascript',  revision, tag, date),
+    'docs/data.json':             fileObject('ember-data-docs', '.json', 'application/json', revision, tag, date)
   };
 }
 


### PR DESCRIPTION
The generated files via `ember build --env=production` are located
inside the `dist/globals` directory.

---

This is yet another follow up for #4000, but when I am reading [the corresponding code in `ember-publisher`](https://github.com/rondale-sc/ember-publisher/blob/8bff5417cf94fced70fb50705f88a9563c7befff/index.js#L75-L81) correctly, this should finally work so the files - which are located inside `dist/globals/` and not just `dist/` - are uploaded to S3.