### PR TITLE
[FEATURE ds-references] More conistency for RecordReference

### DIFF
--- a/addon/-private/system/references/record.js
+++ b/addon/-private/system/references/record.js
@@ -4,13 +4,20 @@ import Reference from './reference';
 var RecordReference = function(store, internalModel) {
   this._super$constructor(store, internalModel);
   this.type = internalModel.modelName;
-  this.id = internalModel.id;
-  this.remoteType = 'identity';
+  this._id = internalModel.id;
 };
 
 RecordReference.prototype = Object.create(Reference.prototype);
 RecordReference.prototype.constructor = RecordReference;
 RecordReference.prototype._super$constructor = Reference;
+
+RecordReference.prototype.id = function() {
+  return this._id;
+};
+
+RecordReference.prototype.remoteType = function() {
+  return 'identity';
+};
 
 RecordReference.prototype.push = function(objectOrPromise) {
   return Ember.RSVP.resolve(objectOrPromise).then((data) => {
@@ -24,7 +31,7 @@ RecordReference.prototype.value = function() {
 };
 
 RecordReference.prototype.load = function() {
-  return this.store.findRecord(this.type, this.id);
+  return this.store.findRecord(this.type, this._id);
 };
 
 RecordReference.prototype.reload = function() {

--- a/tests/integration/references/record-test.js
+++ b/tests/integration/references/record-test.js
@@ -30,9 +30,9 @@ if (isEnabled("ds-references")) {
   test("a RecordReference can be retrieved via store.getReference(type, id)", function(assert) {
     var recordReference = env.store.getReference('person', 1);
 
-    assert.equal(recordReference.remoteType, 'identity');
+    assert.equal(recordReference.remoteType(), 'identity');
     assert.equal(recordReference.type, 'person');
-    assert.equal(recordReference.id, 1);
+    assert.equal(recordReference.id(), 1);
   });
 
   test("push(object)", function(assert) {


### PR DESCRIPTION
Since those properties are functions on a BelongsToReference and a
HasManyReference, they are changed for the RecordReference as well.
This makes it consistent.