### PR TITLE
[DOC beta] Mark comments as private

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -303,6 +303,8 @@ InternalModel.prototype = {
 
     This method is needed when data for the internal model is pushed and the
     pushed data might acknowledge dirty attributes as confirmed.
+
+    @private
    */
   updateChangedAttributes() {
     var changedAttributes = this.changedAttributes();
@@ -321,6 +323,8 @@ InternalModel.prototype = {
   /**
     Returns an object, whose keys are changed properties, and value is an
     [oldProp, newProp] array.
+
+    @private
   */
   changedAttributes() {
     var oldData = this._data;


### PR DESCRIPTION
Otherwise YUIDoc complains that those methods don't have an item type:

```
> ember build --environment=production
version: 1.13.12
Could not find watchman, falling back to NodeWatcher for file system events.
Visit http://www.ember-cli.com/user-guide/#watchman for more info.
Building
info: YUIDoc Starting from: /home/travis/build/emberjs/data/addon,/home/travis/build/emberjs/data/node_modules/ember-inflector
warn: Missing item type:  /home/travis/build/emberjs/data/addon/-private/system/model/internal-model.js:300
warn: 		Checks if the attributes which are considered as changed are still
different to the state which is acknowledged by the server.
This method is needed when data for the internal model is pushed and the
pushed data might acknowledge dirty attributes as confirmed.
warn: Missing item type:  /home/travis/build/emberjs/data/addon/-private/system/model/internal-model.js:321
warn: 		Returns an object, whose keys are changed properties, and value is an
[oldProp, newProp] array.
info: Making out dir: /home/travis/build/emberjs/data/tmp/broccoli_yuidoc-output_path-7S7rqKph.tmp/docs
info: Parsed 105 files in 0.085 seconds
info: Building..
```