### PR TITLE
setCanonicalRecord should check for this.canonicalState, not this.inverseRecord

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs-to.js
@@ -35,8 +35,8 @@ BelongsToRelationship.prototype.setRecord = function(newRecord) {
 BelongsToRelationship.prototype.setCanonicalRecord = function(newRecord) {
   if (newRecord) {
     this.addCanonicalRecord(newRecord);
-  } else if (this.inverseRecord) {
-    this.removeCanonicalRecord(this.inverseRecord);
+  } else if (this.canonicalState) {
+    this.removeCanonicalRecord(this.canonicalState);
   }
   this.setHasData(true);
   this.setHasLoaded(true);


### PR DESCRIPTION
when calling setCanonicalRecord(null) it should check for presence
of canonicalState instead of inverseRecord.

Otherwise setCanonicalRecord(null) does nothing when inverseRecord is also null.