### PR TITLE
[CLEANUP] Don't cache length in for loops

### DIFF
--- a/addon/-private/serializers/embedded-records-mixin.js
+++ b/addon/-private/serializers/embedded-records-mixin.js
@@ -463,7 +463,7 @@ export default Ember.Mixin.create({
 
     let hasMany = new Array(relationshipHash.length);
 
-    for (let i = 0, l = relationshipHash.length; i < l; i++) {
+    for (let i = 0; i < relationshipHash.length; i++) {
       let item = relationshipHash[i];
       let { data, included } = this._normalizeEmbeddedRelationship(store, relationshipMeta, item);
       hash.included = hash.included || [];

--- a/addon/-private/serializers/json-api-serializer.js
+++ b/addon/-private/serializers/json-api-serializer.js
@@ -111,7 +111,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     } else if (Array.isArray(documentHash.data)) {
       let ret = new Array(documentHash.data.length);
 
-      for (let i = 0, l = documentHash.data.length; i < l; i++) {
+      for (let i = 0; i < documentHash.data.length; i++) {
         let data = documentHash.data[i];
         ret[i] = this._normalizeResourceHelper(data);
       }
@@ -122,7 +122,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     if (Array.isArray(documentHash.included)) {
       let ret = new Array(documentHash.included.length);
 
-      for (let i = 0, l = documentHash.included.length; i < l; i++) {
+      for (let i = 0; i < documentHash.included.length; i++) {
         let included = documentHash.included[i];
         ret[i] = this._normalizeResourceHelper(included);
       }
@@ -232,7 +232,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     if (Array.isArray(relationshipHash.data)) {
       let ret = new Array(relationshipHash.data.length);
 
-      for (let i = 0, l = relationshipHash.data.length; i < l; i++) {
+      for (let i = 0; i < relationshipHash.data.length; i++) {
         let data = relationshipHash.data[i];
         ret[i] = this._normalizeRelationshipDataHelper(data);
       }
@@ -479,7 +479,7 @@ const JSONAPISerializer = JSONSerializer.extend({
 
         let data = new Array(hasMany.length);
 
-        for (let i = 0, l = hasMany.length; i < l; i++) {
+        for (let i = 0; i < hasMany.length; i++) {
           let item = hasMany[i];
           data[i] = {
             type: this.payloadKeyFromModelName(item.modelName),

--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -276,7 +276,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     let messagesArray = makeArray(messages);
     let _messages = new Array(messagesArray.length);
 
-    for (let i = 0, l = messagesArray.length; i < l; i++) {
+    for (let i = 0; i < messagesArray.length; i++) {
       let message = messagesArray[i];
       let err = errors.findBy('message', message);
       if (err) {

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -579,7 +579,7 @@ InternalModel.prototype = {
     assert("You need to pass in an array to set a hasMany property on a record", Ember.isArray(preloadValue));
     let recordsToSet = new Array(preloadValue.length);
 
-    for (let i = 0, l = preloadValue.length; i < l; i++) {
+    for (let i = 0; i < preloadValue.length; i++) {
       let recordToPush = preloadValue[i];
       recordsToSet[i] = this._convertStringOrNumberIntoInternalModel(recordToPush, type);
     }

--- a/addon/-private/system/record-array-manager.js
+++ b/addon/-private/system/record-array-manager.js
@@ -138,7 +138,7 @@ export default Ember.Object.extend({
     var records = typeMap.records;
     var record;
 
-    for (var i = 0, l = records.length; i < l; i++) {
+    for (var i = 0; i < records.length; i++) {
       record = records[i];
 
       if (!record.isDeleted() && !record.isEmpty()) {
@@ -164,7 +164,7 @@ export default Ember.Object.extend({
     var records = typeMap.records;
     var record;
 
-    for (var i = 0, l = records.length; i < l; i++) {
+    for (var i = 0; i < records.length; i++) {
       record = records[i];
 
       if (!record.isDeleted() && !record.isEmpty()) {

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -169,7 +169,7 @@ ManyRelationship.prototype.findRecords = function() {
   let manyArray = this.manyArray.toArray();
   let internalModels = new Array(manyArray.length);
 
-  for (let i = 0, l = manyArray.length; i < l; i++) {
+  for (let i = 0; i < manyArray.length; i++) {
     internalModels[i] = manyArray[i]._internalModel;
   }
 

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -93,7 +93,7 @@ if (!Backburner.prototype.join) {
         return method.call(target);
       } else {
         var args = new Array(length - 2);
-        for (var i =0, l = length - 2; i < l; i++) {
+        for (var i = 0; i < args.length; i++) {
           args[i] = arguments[i + 2];
         }
         return method.apply(target, args);
@@ -581,7 +581,7 @@ Store = Service.extend({
     assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     let promises = new Array(ids.length);
 
-    for (let i = 0, l = ids.length; i < l; i++) {
+    for (let i = 0; i < ids.length; i++) {
       promises[i] = this.findRecord(modelName, ids[i]);
     }
 
@@ -614,11 +614,11 @@ Store = Service.extend({
   scheduleFetchMany(records) {
     let internalModels = new Array(records.length);
     let fetches = new Array(records.length);
-    for (let i = 0, l = records.length; i < l; i++) {
+    for (let i = 0; i < records.length; i++) {
       internalModels[i] = records[i]._internalModel;
     }
 
-    for (let i = 0, l = internalModels.length; i < l; i++) {
+    for (let i = 0; i < internalModels.length; i++) {
       fetches[i] = this.scheduleFetch(internalModels[i]);
     }
 
@@ -855,7 +855,7 @@ Store = Service.extend({
   findMany(internalModels) {
     let finds = new Array(internalModels.length);
 
-    for (let i = 0, l = internalModels.length; i < l; i++) {
+    for (let i = 0; i < internalModels.length; i++) {
       finds[i] = this._findByInternalModel(internalModels[i]);
     }
 
@@ -1120,7 +1120,7 @@ Store = Service.extend({
       let keys = Object.keys(typeMaps);
       let types = new Array(keys.length);
 
-      for (let i = 0, l = keys.length; i < l; i++) {
+      for (let i = 0; i < keys.length; i++) {
         types[i] = typeMaps[keys[i]]['type'].modelName;
       }
 
@@ -2120,7 +2120,7 @@ function deserializeRecordIds(store, key, relationship, ids) {
   assert(`A ${relationship.parentType} record was pushed into the store with the value of ${key} being '${Ember.inspect(ids)}', but ${key} is a hasMany relationship so the value must be an array. You should probably check your data payload or serializer.`, isArray(ids));
   let _ids = new Array(ids.length);
 
-  for (let i = 0, l = ids.length; i < l; i++) {
+  for (let i = 0; i < ids.length; i++) {
     _ids[i] = deserializeRecordId(store, key, relationship, ids[i]);
   }
 

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -74,7 +74,7 @@ export function _findMany(adapter, store, typeClass, ids, internalModels) {
       let records = store.push(payload);
       let internalModels = new Array(records.length);
 
-      for (let i = 0, l = records.length; i < l; i++) {
+      for (let i = 0; i < records.length; i++) {
         internalModels[i] = records[i]._internalModel;
       }
 

--- a/lib/jscs-rules/disallow-space-before-semicolon.js
+++ b/lib/jscs-rules/disallow-space-before-semicolon.js
@@ -20,7 +20,7 @@ module.exports.prototype = {
 
   check: function(file, errors) {
     var lines = file.getLines();
-    for (var i = 0, l = lines.length; i < l; i++) {
+    for (var i = 0; i < lines.length; i++) {
       if (lines[i].match(/\s+;$/)) {
         errors.add('Spaces are disallowed before semicolons.', i + 1, lines[i].length - 2);
       }


### PR DESCRIPTION
Caching length of arrays in for loops isn't necessary and don't bring any (perf) benefits.

Also mentioned here by stef:
https://github.com/emberjs/data/pull/3988#issuecomment-165272429
https://github.com/emberjs/data/pull/3988/files#r47439430