### PR TITLE
[CLEANUP] re-use test setup to assert correct call to adapter.ajax

### DIFF
--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -178,17 +178,12 @@ test("findRecord - payload with a serializer-specified attribute mapping", funct
 
 if (isEnabled('ds-finder-include')) {
   test("findRecord - passes `include` as a query parameter to ajax", function(assert) {
-    adapter.ajax = function(url, verb, hash) {
-      assert.deepEqual(hash.data, { include: 'comments' },
-        '`include` parameter sent to adapter.ajax');
-
-      return run(Ember.RSVP, 'resolve', {
-        post: { id: 1, name: 'Rails is very expensive sushi' }
-      });
-    };
+    ajaxResponse({
+      post: { id: 1, name: 'Rails is very expensive sushi' }
+    });
 
     run(store, 'findRecord', 'post', 1, { include: 'comments' }).then(assert.wait(function() {
-      // Noop
+      assert.deepEqual(passedHash.data, { include: 'comments' }, '`include` parameter sent to adapter.ajax');
     }));
   });
 }
@@ -1048,17 +1043,12 @@ test("findAll - passes buildURL the requestType", function(assert) {
 
 if (isEnabled('ds-finder-include')) {
   test("findAll - passed `include` as a query parameter to ajax", function(assert) {
-    adapter.ajax = function(url, verb, hash) {
-      assert.deepEqual(hash.data, { include: 'comments' },
-        '`include` params sent to adapter.ajax');
-
-      return run(Ember.RSVP, 'resolve', {
-        posts: [{ id: 1, name: 'Rails is very expensive sushi' }]
-      });
-    };
+    ajaxResponse({
+      posts: [{ id: 1, name: 'Rails is very expensive sushi' }]
+    });
 
     run(store, 'findAll', 'post', { include: 'comments' }).then(assert.wait(function() {
-      // Noop
+      assert.deepEqual(passedHash.data, { include: 'comments' }, '`include` params sent to adapter.ajax');
     }));
   });
 }
@@ -1117,18 +1107,12 @@ test("findAll - data is normalized through custom serializers", function(assert)
 });
 
 test("query - if `sortQueryParams` option is not provided, query params are sorted alphabetically", function(assert) {
-  adapter.ajax = function(url, verb, hash) {
-    passedUrl = url;
-    passedVerb = verb;
-    passedHash = hash;
-
-    assert.deepEqual(Object.keys(hash.data), ["in", "order", "params", "wrong"], 'query params are received in alphabetical order');
-
-    return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
-  };
+  ajaxResponse({
+    posts: [{ id: 1, name: "Rails is very expensive sushi" }]
+  });
 
   store.query('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(assert.wait(function() {
-    // Noop
+    assert.deepEqual(Object.keys(passedHash.data), ["in", "order", "params", "wrong"], 'query params are received in alphabetical order');
   }));
 });
 
@@ -1137,45 +1121,31 @@ test("query - passes buildURL the requestType", function(assert) {
     return "/" + requestType + "/posts";
   };
 
-  adapter.ajax = function(url, verb, hash) {
-    assert.equal(url, '/query/posts');
-
-    return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
-  };
+  ajaxResponse({
+    posts: [{ id: 1, name: "Rails is very expensive sushi" }]
+  });
 
   store.query('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(assert.wait(function() {
-    // NOOP
+    assert.equal(passedUrl, '/query/posts');
   }));
 });
 
 test("query - if `sortQueryParams` is falsey, query params are not sorted at all", function(assert) {
-  adapter.ajax = function(url, verb, hash) {
-    passedUrl = url;
-    passedVerb = verb;
-    passedHash = hash;
-
-    assert.deepEqual(Object.keys(hash.data), ["params", "in", "wrong", "order"], 'query params are received in their original order');
-
-    return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
-  };
+  ajaxResponse({
+    posts: [{ id: 1, name: "Rails is very expensive sushi" }]
+  });
 
   adapter.sortQueryParams = null;
 
   store.query('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(assert.wait(function() {
-    // Noop
+    assert.deepEqual(Object.keys(passedHash.data), ["params", "in", "wrong", "order"], 'query params are received in their original order');
   }));
 });
 
 test("query - if `sortQueryParams` is a custom function, query params passed through that function", function(assert) {
-  adapter.ajax = function(url, verb, hash) {
-    passedUrl = url;
-    passedVerb = verb;
-    passedHash = hash;
-
-    assert.deepEqual(Object.keys(hash.data), ["wrong", "params", "order", "in"], 'query params are received in reverse alphabetical order');
-
-    return run(Ember.RSVP, 'resolve', { posts: [{ id: 1, name: "Rails is very expensive sushi" }] });
-  };
+  ajaxResponse({
+    posts: [{ id: 1, name: "Rails is very expensive sushi" }]
+  });
 
   adapter.sortQueryParams = function(obj) {
     var sortedKeys = Object.keys(obj).sort().reverse();
@@ -1189,7 +1159,7 @@ test("query - if `sortQueryParams` is a custom function, query params passed thr
   };
 
   store.query('post', { "params": 1, "in": 2, "wrong": 3, "order": 4 }).then(assert.wait(function() {
-    // Noop
+    assert.deepEqual(Object.keys(passedHash.data), ["wrong", "params", "order", "in"], 'query params are received in reverse alphabetical order');
   }));
 });
 


### PR DESCRIPTION
`adapter.ajax` is setup before the tests, so a made AJAX call can be
asserted by checking `passedUrl`, `passedVerb` and `passedHash`. This
commit cleans up the tests so the existig setup is re-used.