### PR TITLE
[FEATURE ds-boolean-transform-allow-null] allow null for boolean

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,6 +11,12 @@ entry in `config/features.json`.
 
 ## Feature Flags
 
+- `ds-boolean-transform-allow-null`
+
+  Allow `null`/`undefined` values for `boolean` attributes via `DS.attr('boolean', { allowNull: true })`
+
+  Note that this feature only works when `ds-transform-pass-options` is enabled too.
+
 - `ds-finder-include`
 
   Allows an `include` query parameter to be specified with using

--- a/addon/-private/transforms/boolean.js
+++ b/addon/-private/transforms/boolean.js
@@ -1,4 +1,8 @@
+import Ember from 'ember';
 import Transform from "ember-data/transform";
+import isEnabled from 'ember-data/-private/features';
+
+const { isNone } = Ember;
 
 /**
   The `DS.BooleanTransform` class is used to serialize and deserialize
@@ -23,8 +27,16 @@ import Transform from "ember-data/transform";
   @namespace DS
  */
 export default Transform.extend({
-  deserialize(serialized) {
+  deserialize(serialized, options) {
     var type = typeof serialized;
+
+    if (isEnabled('ds-transform-pass-options')) {
+      if (isEnabled('ds-boolean-transform-allow-null')) {
+        if (isNone(serialized) && options.allowNull === true) {
+          return null;
+        }
+      }
+    }
 
     if (type === "boolean") {
       return serialized;
@@ -37,7 +49,15 @@ export default Transform.extend({
     }
   },
 
-  serialize(deserialized) {
+  serialize(deserialized, options) {
+    if (isEnabled('ds-transform-pass-options')) {
+      if (isEnabled('ds-boolean-transform-allow-null')) {
+        if (isNone(deserialized) && options.allowNull === true) {
+          return null;
+        }
+      }
+    }
+
     return Boolean(deserialized);
   }
 });

--- a/config/features.json
+++ b/config/features.json
@@ -1,4 +1,5 @@
 {
+  "ds-boolean-transform-allow-null": null,
   "ds-finder-include": null,
   "ds-references": null,
   "ds-transform-pass-options": null,

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -822,9 +822,9 @@ test("when a method is invoked from an event with the same name the arguments ar
   assert.equal(eventMethodArgs[1], 2);
 });
 
-AssertionPrototype.converts = function converts(type, provided, expected) {
+AssertionPrototype.converts = function converts(type, provided, expected, options = {}) {
   var Model = DS.Model.extend({
-    name: DS.attr(type)
+    name: DS.attr(type, options)
   });
 
   var registry, container;
@@ -930,13 +930,27 @@ test("a DS.Model can describe Number attributes", function(assert) {
 });
 
 test("a DS.Model can describe Boolean attributes", function(assert) {
-  assert.expect(7);
-
   assert.converts('boolean', "1", true);
   assert.converts('boolean', "", false);
   assert.converts('boolean', 1, true);
   assert.converts('boolean', 0, false);
-  assert.converts('boolean', null, false);
+
+  if (isEnabled('ds-transform-pass-options') && isEnabled('ds-boolean-transform-allow-null')) {
+    assert.converts('boolean', null, null, { allowNull: true });
+    assert.converts('boolean', undefined, null, { allowNull: true });
+
+    assert.converts('boolean', null, false, { allowNull: false });
+    assert.converts('boolean', undefined, false, { allowNull: false });
+
+    // duplicating the tests from the else branch here, so once the feature is
+    // enabled and the else branch is deleted, those assertions are kept
+    assert.converts('boolean', null, false);
+    assert.converts('boolean', undefined, false);
+  } else {
+    assert.converts('boolean', null, false);
+    assert.converts('boolean', undefined, false);
+  }
+
   assert.converts('boolean', true, true);
   assert.converts('boolean', false, false);
 });

--- a/tests/unit/transform/boolean-test.js
+++ b/tests/unit/transform/boolean-test.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import isEnabled from 'ember-data/-private/features';
 
 import {module, test} from 'qunit';
 
@@ -7,8 +8,19 @@ module("unit/transform - DS.BooleanTransform");
 test("#serialize", function(assert) {
   var transform = new DS.BooleanTransform();
 
-  assert.equal(transform.serialize(null), false);
-  assert.equal(transform.serialize(undefined), false);
+  if (isEnabled('ds-transform-pass-options') && isEnabled('ds-boolean-transform-allow-null')) {
+    assert.equal(transform.serialize(null, { allowNull: true }), null);
+    assert.equal(transform.serialize(undefined, { allowNull: true }), null);
+
+    assert.equal(transform.serialize(null, { allowNull: false }), false);
+    assert.equal(transform.serialize(undefined, { allowNull: false }), false);
+
+    assert.equal(transform.serialize(null, {}), false);
+    assert.equal(transform.serialize(undefined, {}), false);
+  } else {
+    assert.equal(transform.serialize(null), false);
+    assert.equal(transform.serialize(undefined), false);
+  }
 
   assert.equal(transform.serialize(true), true);
   assert.equal(transform.serialize(false), false);
@@ -17,8 +29,19 @@ test("#serialize", function(assert) {
 test("#deserialize", function(assert) {
   var transform = new DS.BooleanTransform();
 
-  assert.equal(transform.deserialize(null), false);
-  assert.equal(transform.deserialize(undefined), false);
+  if (isEnabled('ds-transform-pass-options') && isEnabled('ds-boolean-transform-allow-null')) {
+    assert.equal(transform.deserialize(null, { allowNull: true }), null);
+    assert.equal(transform.deserialize(undefined, { allowNull: true }), null);
+
+    assert.equal(transform.deserialize(null, { allowNull: false }), false);
+    assert.equal(transform.deserialize(undefined, { allowNull: false }), false);
+
+    assert.equal(transform.deserialize(null, {}), false);
+    assert.equal(transform.deserialize(undefined, {}), false);
+  } else {
+    assert.equal(transform.deserialize(null), false);
+    assert.equal(transform.deserialize(undefined), false);
+  }
 
   assert.equal(transform.deserialize(true), true);
   assert.equal(transform.deserialize(false), false);


### PR DESCRIPTION
*NOTE:* this description is not completely accurate anymore, since the implementation changed so the `allowNull` flag needs to be passed to the options for the attribute. See discussion below for further context.

---

This feature allows `null` / `undefined` values for `DS.attr('boolean')`
attributes. Currently `DS.BooleanTransform` converts those values to
`false`; which means that a `DS.attr('boolean')` cannot be set to `null`
from the server. Other transforms (`string`, `number`) do allow `null`
values, so this is an inconsistency between the transforms.

The new feature `ds-boolean-transform-allow-null` changes this behavior
so `null` / `undefined` are converted to `null`. Since **this is a semver
breaking change**, a corresponding deprecation warning should be added
before this is accepted in ember data.

Current behavior of `DS.attr('boolean')`:

| incoming    | DS      | serialized |
|-------------|---------|------------|
| `null`      | `false` | `false`    |
| `undefined` | `false` | `false`    |

Behavior of `DS.attr('boolean')`, having
`ds-boolean-transform-allow-null` feature enabled:

| incoming    | DS      | serialized |
|-------------|---------|------------|
| `null`      | `null`  | `null`     |
| `undefined` | `null`  | `null`     |

---

Note that this feature only works if `ds-transform-pass-options` is
enabled as well, since passing the options from `DS.attr` to the
transform is added with that feature.

---

This addresses #3785.

---

### TODO

- [x] wait for implementation of https://github.com/emberjs/rfcs/pull/1 so this PR can be updated with `allowNull` flag