### PR TITLE
Enhance blueprints

### DIFF
--- a/blueprints/adapter/index.js
+++ b/blueprints/adapter/index.js
@@ -1,8 +1,6 @@
 /*jshint node:true*/
 
-var stringUtil  = require('ember-cli-string-utils');
-var SilentError = require('silent-error');
-var pathUtil    = require('ember-cli-path-utils');
+var extendFromApplicationEntity = require('../../lib/utilities/extend-from-application-entity');
 
 module.exports = {
   description: 'Generates an ember-data adapter.',
@@ -12,33 +10,6 @@ module.exports = {
   ],
 
   locals: function(options) {
-    var adapterName     = options.entity.name;
-    var baseClass       = 'JSONAPIAdapter';
-    var importStatement = 'import JSONAPIAdapter from \'ember-data/adapters/json-api\';';
-    var isAddon         = options.inRepoAddon || options.project.isEmberCLIAddon();
-    var relativePath    = pathUtil.getRelativePath(options.entity.name);
-
-    if (options.pod && options.podPath) {
-        relativePath = pathUtil.getRelativePath(options.podPath + options.entity.name);
-    }
-
-    if (!isAddon && !options.baseClass && adapterName !== 'application') {
-      options.baseClass = 'application';
-    }
-
-    if (options.baseClass === adapterName) {
-      throw new SilentError('Adapters cannot extend from themself. To resolve this, remove the `--base-class` option or change to a different base-class.');
-    }
-
-    if (options.baseClass) {
-      baseClass = stringUtil.classify(options.baseClass.replace('\/', '-'));
-      baseClass = baseClass + 'Adapter';
-      importStatement = 'import ' + baseClass + ' from \'' + relativePath + options.baseClass + '\';';
-    }
-
-    return {
-      importStatement: importStatement,
-      baseClass: baseClass
-    };
+    return extendFromApplicationEntity('adapter', 'JSONAPIAdapter', 'ember-data/adapters/json-api', options);
   }
 };

--- a/blueprints/serializer/files/__root__/__path__/__name__.js
+++ b/blueprints/serializer/files/__root__/__path__/__name__.js
@@ -1,4 +1,4 @@
-import JSONAPISerializer from 'ember-data/serializers/json-api';
+<%= importStatement %>
 
-export default JSONAPISerializer.extend({
+export default <%= baseClass %>.extend({
 });

--- a/blueprints/serializer/index.js
+++ b/blueprints/serializer/index.js
@@ -1,5 +1,15 @@
 /*jshint node:true*/
 
+var extendFromApplicationEntity = require('../../lib/utilities/extend-from-application-entity');
+
 module.exports = {
-  description: 'Generates an ember-data serializer.'
+  description: 'Generates an ember-data serializer.',
+
+  availableOptions: [
+    { name: 'base-class', type: String }
+  ],
+
+  locals: function(options) {
+    return extendFromApplicationEntity('serializer', 'JSONAPISerializer', 'ember-data/serializers/json-api', options);
+  }
 };

--- a/lib/utilities/extend-from-application-entity.js
+++ b/lib/utilities/extend-from-application-entity.js
@@ -1,0 +1,40 @@
+var stringUtil  = require('ember-cli-string-utils');
+var SilentError = require('silent-error');
+var pathUtil    = require('ember-cli-path-utils');
+var existsSync  = require('exists-sync');
+var path        = require('path');
+
+module.exports = function(type, baseClass, packagePath, options) {
+  var entityName      = options.entity.name;
+  var isAddon         = options.inRepoAddon || options.project.isEmberCLIAddon();
+  var relativePath    = pathUtil.getRelativePath(options.entity.name);
+
+  if (options.pod && options.podPath) {
+    relativePath = pathUtil.getRelativePath(options.podPath + options.entity.name);
+  }
+
+  var entityDirectory = type + 's';
+  var applicationEntityPath = path.join(options.project.root, 'app', entityDirectory, 'application.js');
+  var hasApplicationEntity = existsSync(applicationEntityPath);
+  if (!isAddon && !options.baseClass && entityName !== 'application' && hasApplicationEntity) {
+    options.baseClass = 'application';
+    packagePath = './application';
+  }
+
+  if (options.baseClass === entityName) {
+    throw new SilentError(stringUtil.classify(type) + 's cannot extend from themself. To resolve this, remove the `--base-class` option or change to a different base-class.');
+  }
+
+  var importStatement = 'import ' + baseClass + ' from \'' + packagePath + '\';';
+
+  if (options.baseClass) {
+    baseClass = stringUtil.classify(options.baseClass.replace('\/', '-'));
+    baseClass = baseClass + stringUtil.classify(type);
+    importStatement = 'import ' + baseClass + ' from \'' + relativePath + options.baseClass + '\';';
+  }
+
+  return {
+    importStatement: importStatement,
+    baseClass: baseClass
+  };
+};

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -11,8 +11,8 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
         {
           file: 'app/adapters/foo.js',
           contains: [
-            'import ApplicationAdapter from \'./application\';',
-            'export default ApplicationAdapter.extend({'
+            'import JSONAPIAdapter from \'ember-data/adapters/json-api\';',
+            'export default JSONAPIAdapter.extend({'
           ]
         },
         {
@@ -22,6 +22,31 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
           ]
         }
       ]
+    });
+  });
+
+  it('adapter extends application adapter if it exists', function() {
+    return generateAndDestroy(['adapter', 'application'], {
+      afterGenerate: function() {
+        return generateAndDestroy(['adapter', 'foo'], {
+          skipInit: true,
+          files: [
+            {
+              file: 'app/adapters/foo.js',
+              contains: [
+                'import ApplicationAdapter from \'./application\';',
+                'export default ApplicationAdapter.extend({'
+              ]
+            },
+            {
+              file: 'tests/unit/adapters/foo-test.js',
+              contains: [
+                'moduleFor(\'adapter:foo\''
+              ]
+            }
+          ]
+        });
+      }
     });
   });
 

--- a/node-tests/blueprints/serializer-test.js
+++ b/node-tests/blueprints/serializer-test.js
@@ -25,6 +25,80 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
     });
   });
 
+  it('serializer extends application serializer if it exists', function() {
+    return generateAndDestroy(['serializer', 'application'], {
+      afterGenerate: function() {
+        return generateAndDestroy(['serializer', 'foo'], {
+          skipInit: true,
+          files: [
+            {
+              file: 'app/serializers/foo.js',
+              contains: [
+                'import ApplicationSerializer from \'./application\';',
+                'export default ApplicationSerializer.extend({'
+              ]
+            },
+            {
+              file: 'tests/unit/serializers/foo-test.js',
+              contains: [
+                'moduleForModel(\'foo\''
+              ]
+            }
+          ]
+        });
+      }
+    });
+  });
+
+  it('serializer with --base-class', function() {
+    return generateAndDestroy(['serializer', 'foo', '--base-class=bar'], {
+      files: [
+        {
+          file: 'app/serializers/foo.js',
+          contains: [
+            'import BarSerializer from \'./bar\';',
+            'export default BarSerializer.extend({'
+          ]
+        },
+        {
+          file: 'tests/unit/serializers/foo-test.js',
+          contains: [
+            'moduleForModel(\'foo\''
+          ]
+        }
+      ]
+    });
+  });
+
+  it('serializer throws when --base-class is same as name', function() {
+    return generateAndDestroy(['serializer', 'application', '--base-class=application'], {
+      throws: {
+        message: /Serializers cannot extend from themself/,
+        type: 'SilentError'
+      }
+    });
+  });
+
+  it('serializer when is named "application"', function() {
+    return generateAndDestroy(['serializer', 'application'], {
+      files: [
+        {
+          file: 'app/serializers/application.js',
+          contains: [
+            'import JSONAPISerializer from \'ember-data/serializers/json-api\';',
+            'export default JSONAPISerializer.extend({'
+          ]
+        },
+        {
+          file: 'tests/unit/serializers/application-test.js',
+          contains: [
+            'moduleForModel(\'application\''
+          ]
+        }
+      ]
+    });
+  });
+
   it('serializer-test', function() {
     return generateAndDestroy(['serializer-test', 'foo'], {
       files: [


### PR DESCRIPTION
This is a followup PR, made due to [a comment](https://github.com/emberjs/data/pull/4019#issuecomment-166396159) by @igorT: currently a serializer generate via `ember generate ember-data:serializer foo` extends `DS.JSONAPIAdapter`, where it should extend the `ApplicationAdapter`. This behavior is already the case when an adapter is generated, so this PR aligns the behavior of the serializer blueprint to the one of the adapter blueprint.

---

### TODO

- [x] Investigate timeout in test for `ember g adapter foo` when application adapter is present
- [x] Investigate how to check if a file exists within a blueprints' `index.js`
- [x] Check why test for serializer fail but for the adapter doesn't (though it's the same)