### PR TITLE
Use keyForReliationship for belongsTo and hasMany

### DIFF
--- a/addon/-private/serializers/embedded-records-mixin.js
+++ b/addon/-private/serializers/embedded-records-mixin.js
@@ -217,7 +217,7 @@ export default Ember.Mixin.create({
 
   _serializeEmbeddedBelongsTo(snapshot, json, relationship) {
     let embeddedSnapshot = snapshot.belongsTo(relationship.key);
-    let serializedKey = this.keyForAttribute(relationship.key, 'serialize');
+    let serializedKey = this.keyForRelationship(relationship.key, 'serialize');
     if (!embeddedSnapshot) {
       json[serializedKey] = null;
     } else {
@@ -332,7 +332,7 @@ export default Ember.Mixin.create({
   },
 
   _serializeEmbeddedHasMany(snapshot, json, relationship) {
-    let serializedKey = this.keyForAttribute(relationship.key, 'serialize');
+    let serializedKey = this.keyForRelationship(relationship.key, 'serialize');
 
     warn(
       `The embedded relationship '${serializedKey}' is undefined for '${snapshot.modelName}' with id '${snapshot.id}'. Please include it in your original payload.`,

--- a/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/tests/integration/serializers/embedded-records-mixin-test.js
@@ -910,7 +910,7 @@ test("serialize with embedded objects and a custom keyForAttribute (hasMany rela
   });
 
   env.registry.register('serializer:home-planet', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
-    keyForAttribute(key) {
+    keyForRelationship(key) {
       return key + '-custom';
     },
     attrs: {
@@ -926,7 +926,7 @@ test("serialize with embedded objects and a custom keyForAttribute (hasMany rela
   });
 
   assert.deepEqual(json, {
-    "name-custom": "Villain League",
+    "name": "Villain League",
     "villains-custom": [{
       id: get(tom, "id"),
       firstName: "Tom",


### PR DESCRIPTION
This PR is related to https://github.com/ember-data/active-model-adapter/issues/74 .

It makes more sense to use `keyForReliationship` for relationships insteed of `keyForAttribute`.