### PR TITLE
[BUGFIX release] extractMeta impossible to use with JSONSerializer

### DIFF
--- a/addon/-private/serializers/json-serializer.js
+++ b/addon/-private/serializers/json-serializer.js
@@ -230,6 +230,29 @@ export default Serializer.extend({
     @return {Object} JSON-API Document
   */
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+    let meta = this.extractMeta(store, primaryModelClass, payload);
+
+    let documentHash = this._normalizeResponseForType(...arguments);
+
+    if (meta) {
+      assert('The `meta` returned from `extractMeta` has to be an object, not "' + Ember.typeOf(meta) + '".', Ember.typeOf(meta) === 'object');
+      documentHash.meta = meta;
+    }
+    return documentHash;
+  },
+
+  /**
+    @method _normalizeResponseForType
+    @param {DS.Store} store
+    @param {DS.Model} primaryModelClass
+    @param {Object} payload
+    @param {String|Number} id
+    @param {String} requestType
+    @private
+    @return {Object} JSON-API Document
+  */
+
+  _normalizeResponseForType(store, primaryModelClass, payload, id, requestType) {
     switch (requestType) {
       case 'findRecord':
         return this.normalizeFindRecordResponse(...arguments);
@@ -439,12 +462,6 @@ export default Serializer.extend({
       data: null,
       included: []
     };
-
-    let meta = this.extractMeta(store, primaryModelClass, payload);
-    if (meta) {
-      assert('The `meta` returned from `extractMeta` has to be an object, not "' + Ember.typeOf(meta) + '".', Ember.typeOf(meta) === 'object');
-      documentHash.meta = meta;
-    }
 
     if (isSingle) {
       let { data, included } = this.normalize(primaryModelClass, payload);

--- a/addon/-private/serializers/rest-serializer.js
+++ b/addon/-private/serializers/rest-serializer.js
@@ -3,7 +3,7 @@
 */
 
 import Ember from 'ember';
-import { assert, deprecate, runInDebug, warn } from "ember-data/-private/debug";
+import { deprecate, runInDebug, warn } from "ember-data/-private/debug";
 import JSONSerializer from "ember-data/-private/serializers/json-serializer";
 import normalizeModelName from "ember-data/-private/system/normalize-model-name";
 import {singularize} from "ember-inflector";
@@ -224,12 +224,6 @@ var RESTSerializer = JSONSerializer.extend({
       data: null,
       included: []
     };
-
-    let meta = this.extractMeta(store, primaryModelClass, payload);
-    if (meta) {
-      assert('The `meta` returned from `extractMeta` has to be an object, not "' + Ember.typeOf(meta) + '".', Ember.typeOf(meta) === 'object');
-      documentHash.meta = meta;
-    }
 
     var keys = Object.keys(payload);
 


### PR DESCRIPTION
When using JSONSerializer it is impossible to extract metadata from query response because when payload is modified in normalizeQueryResponse (or any other hook) the metadata will go missing by the time extractMetadata is called.

I dug up earlier implementation before v1.13 and back then extractMeta was called before extractQueryResponse etc. methods - https://github.com/emberjs/data/blob/v1.0.0-beta.19.2/packages/ember-data/lib/serializers/json-serializer.js#L763

Which means that extractMeta always received unmodified payload. After 1.13 (making it a breaking change in a minor version) this changed, so extractMeta was called in _normalizeResponse method (https://github.com/emberjs/data/blob/v1.13.0/packages/ember-data/lib/serializers/json-serializer.js#L446, https://github.com/emberjs/data/blob/v2.2.1/packages/ember-data/lib/serializers/json-serializer.js#L437), which is the end path for all the normalize(Query/Find) etc. methods. This is the main issue here, because for example if one passes extracted array of records from the payload  to normalizeQueryResponse _super call, then there will no metadata left to extract. 

This restores previous "extract" method implementation logic, where first "extractMeta" is called and then "normalize*" methods.