### PR TITLE
Links formatting affects the resulting request URL

### DIFF
--- a/addon/-private/adapters/rest-adapter.js
+++ b/addon/-private/adapters/rest-adapter.js
@@ -518,13 +518,13 @@ export default Adapter.extend(BuildURLMixin, {
     This method will be called with the parent record and `/posts/1/comments`.
 
     The `findHasMany` method will make an Ajax (HTTP GET) request to the originally specified URL.
-    
+
     The format of your `links` value will influence the final request URL via the `urlPrefix` method:
-    
+
     * Links beginning with `//`, `http://`, `https://`, will be used as is, with no further manipulation.
-    
+
     * Links beginning with a single `/` will have the current adapter's `host` value prepended to it.
-    
+
     * Links with no beginning `/` will have a parentURL prepended to it, via the current adapter's `buildURL`.
 
     @method findHasMany
@@ -562,13 +562,13 @@ export default Adapter.extend(BuildURLMixin, {
     This method will be called with the parent record and `/people/1/group`.
 
     The `findBelongsTo` method will make an Ajax (HTTP GET) request to the originally specified URL.
-    
+
     The format of your `links` value will influence the final request URL via the `urlPrefix` method:
-    
+
     * Links beginning with `//`, `http://`, `https://`, will be used as is, with no further manipulation.
-    
+
     * Links beginning with a single `/` will have the current adapter's `host` value prepended to it.
-    
+
     * Links with no beginning `/` will have a parentURL prepended to it, via the current adapter's `buildURL`.
 
     @method findBelongsTo

--- a/addon/-private/adapters/rest-adapter.js
+++ b/addon/-private/adapters/rest-adapter.js
@@ -518,6 +518,14 @@ export default Adapter.extend(BuildURLMixin, {
     This method will be called with the parent record and `/posts/1/comments`.
 
     The `findHasMany` method will make an Ajax (HTTP GET) request to the originally specified URL.
+    
+    The format of your `links` value will influence the final request URL via the `urlPrefix` method:
+    
+    * Links beginning with `//`, `http://`, `https://`, will be used as is, with no further manipulation.
+    
+    * Links beginning with a single `/` will have the current adapter's `host` value prepended to it.
+    
+    * Links with no beginning `/` will have a parentURL prepended to it, via the current adapter's `buildURL`.
 
     @method findHasMany
     @param {DS.Store} store
@@ -554,6 +562,14 @@ export default Adapter.extend(BuildURLMixin, {
     This method will be called with the parent record and `/people/1/group`.
 
     The `findBelongsTo` method will make an Ajax (HTTP GET) request to the originally specified URL.
+    
+    The format of your `links` value will influence the final request URL via the `urlPrefix` method:
+    
+    * Links beginning with `//`, `http://`, `https://`, will be used as is, with no further manipulation.
+    
+    * Links beginning with a single `/` will have the current adapter's `host` value prepended to it.
+    
+    * Links with no beginning `/` will have a parentURL prepended to it, via the current adapter's `buildURL`.
 
     @method findBelongsTo
     @param {DS.Store} store


### PR DESCRIPTION
Just some description about how the formatting of the `links` value in a payload can affect the request URL that is produced