### PR TITLE
Replace calls to store.find with store.findRecord

### DIFF
--- a/addon/-private/system/coerce-id.js
+++ b/addon/-private/system/coerce-id.js
@@ -1,5 +1,5 @@
 // Used by the store to normalize IDs entering the store.  Despite the fact
-// that developers may provide IDs as numbers (e.g., `store.find(Person, 1)`),
+// that developers may provide IDs as numbers (e.g., `store.findRecord('person', 1)`),
 // it is important that internally we use strings, since IDs may be serialized
 // and lose type information.  For example, Ember's router may put a record's
 // ID into the URL, and if we later try to deserialize that URL and find the

--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -238,7 +238,7 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
     Example
 
     ```javascript
-    store.find('inbox', 1).then(function(inbox) {
+    store.findRecord('inbox', 1).then(function(inbox) {
       inbox.get('messages').then(function(messages) {
         messages.forEach(function(message) {
           message.set('isRead', true);

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -543,7 +543,7 @@ InternalModel.prototype = {
     came back from the server, except the user obtained them out of band and is informing
     the store of their existence. The most common use case is for supporting client side
     nested URLs, such as `/posts/1/comments/2` so the user can do
-    `store.find('comment', 2, {post:1})` without having to fetch the post.
+    `store.findRecord('comment', 2, { preload: { post: 1 } })` without having to fetch the post.
 
     Preloaded data can be attributes and relationships passed in either as IDs or as actual
     models.

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -83,7 +83,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     var record = store.createRecord('model');
     record.get('isLoaded'); // true
 
-    store.find('model', 1).then(function(model) {
+    store.findRecord('model', 1).then(function(model) {
       model.get('isLoaded'); // true
     });
     ```
@@ -105,7 +105,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     var record = store.createRecord('model');
     record.get('hasDirtyAttributes'); // true
 
-    store.find('model', 1).then(function(model) {
+    store.findRecord('model', 1).then(function(model) {
       model.get('hasDirtyAttributes'); // false
       model.set('foo', 'some value');
       model.get('hasDirtyAttributes'); // true
@@ -284,7 +284,7 @@ var Model = Ember.Object.extend(Ember.Evented, {
     var record = store.createRecord('model');
     record.get('id'); // null
 
-    store.find('model', 1).then(function(model) {
+    store.findRecord('model', 1).then(function(model) {
       model.get('id'); // '1'
     });
     ```
@@ -885,7 +885,7 @@ if (isEnabled("ds-references")) {
         var link = userRef.link();
       }
 
-      // load user (via store.find or store.findBelongsTo)
+      // load user (via store.findRecord or store.findBelongsTo)
       userRef.load().then(...)
 
       // or trigger a reload

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1227,14 +1227,14 @@ Store = Service.extend({
 
   /**
     This method returns if a certain record is already loaded
-    in the store. Use this function to know beforehand if a find()
+    in the store. Use this function to know beforehand if a findRecord()
     will result in a request or that it will be a cache hit.
 
      Example
 
     ```javascript
     store.recordIsLoaded('post', 1); // false
-    store.find('post', 1).then(function() {
+    store.findRecord('post', 1).then(function() {
       store.recordIsLoaded('post', 1); // true
     });
     ```

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -28,13 +28,13 @@ export function _find(adapter, store, typeClass, id, internalModel, options) {
   var snapshot = internalModel.createSnapshot(options);
   var promise = adapter.findRecord(store, typeClass, id, snapshot);
   var serializer = serializerForAdapter(store, adapter, internalModel.type.modelName);
-  var label = "DS: Handle Adapter#find of " + typeClass + " with id: " + id;
+  var label = "DS: Handle Adapter#findRecord of " + typeClass + " with id: " + id;
 
   promise = Promise.resolve(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    assert("You made a `find` request for a " + typeClass.typeClassKey + " with id " + id + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    assert("You made a `findRecord` request for a " + typeClass.typeClassKey + " with id " + id + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, id, 'findRecord');
       assert('Ember Data expected the primary data returned from a `findRecord` response to be an object but instead it found an array.', !Array.isArray(payload.data));

--- a/tests/integration/adapter/find-test.js
+++ b/tests/integration/adapter/find-test.js
@@ -60,7 +60,7 @@ test("When a single record is requested, the adapter's find method should be cal
   });
 });
 
-test("When a single record is requested multiple times, all .find() calls are resolved after the promise is resolved", (assert) => {
+test("When a single record is requested multiple times, all .findRecord() calls are resolved after the promise is resolved", (assert) => {
   var deferred = Ember.RSVP.defer();
 
   env.registry.register('adapter:person', DS.Adapter.extend({
@@ -103,7 +103,7 @@ test("When a single record is requested multiple times, all .find() calls are re
   run(() => deferred.resolve({ id: 1, name: "Braaaahm Dale" }));
 });
 
-test("When a single record is requested, and the promise is rejected, .find() is rejected.", (assert) => {
+test("When a single record is requested, and the promise is rejected, .findRecord() is rejected.", (assert) => {
   env.registry.register('adapter:person', DS.Adapter.extend({
     findRecord: () => reject()
   }));
@@ -136,7 +136,7 @@ test('When a single record is requested, and the payload is blank', (assert) => 
   }));
 
   assert.expectAssertion(() => {
-    run(() => store.find('person', 'the-id'));
+    run(() => store.findRecord('person', 'the-id'));
   }, /the adapter's response did not have any data/);
 });
 

--- a/tests/integration/adapter/json-api-adapter-test.js
+++ b/tests/integration/adapter/json-api-adapter-test.js
@@ -114,7 +114,7 @@ test('find a single record', function(assert) {
   }]);
 
   run(function() {
-    store.find('post', 1).then(function(post) {
+    store.findRecord('post', 1).then(function(post) {
       assert.equal(passedUrl[0], '/posts/1');
 
       assert.equal(post.get('id'), '1');
@@ -251,7 +251,7 @@ test('find a single record with belongsTo link as object { related }', function(
   }]);
 
   run(function() {
-    store.find('post', 1).then(function(post) {
+    store.findRecord('post', 1).then(function(post) {
       assert.equal(passedUrl[0], '/posts/1');
 
       assert.equal(post.get('id'), '1');
@@ -296,7 +296,7 @@ test('find a single record with belongsTo link as object { data }', function(ass
   }]);
 
   run(function() {
-    store.find('post', 1).then(function(post) {
+    store.findRecord('post', 1).then(function(post) {
       assert.equal(passedUrl[0], '/posts/1');
 
       assert.equal(post.get('id'), '1');
@@ -342,7 +342,7 @@ test('find a single record with belongsTo link as object { data } (polymorphic)'
   }]);
 
   run(function() {
-    store.find('user', 1).then(function(user) {
+    store.findRecord('user', 1).then(function(user) {
       assert.equal(passedUrl[0], '/users/1');
 
       assert.equal(user.get('id'), '1');
@@ -388,7 +388,7 @@ test('find a single record with sideloaded belongsTo link as object { data }', f
 
   run(function() {
 
-    store.find('post', 1).then(function(post) {
+    store.findRecord('post', 1).then(function(post) {
       assert.equal(passedUrl[0], '/posts/1');
 
       assert.equal(post.get('id'), '1');
@@ -440,7 +440,7 @@ test('find a single record with hasMany link as object { related }', function(as
   }]);
 
   run(function() {
-    store.find('post', 1).then(function(post) {
+    store.findRecord('post', 1).then(function(post) {
       assert.equal(passedUrl[0], '/posts/1');
 
       assert.equal(post.get('id'), '1');
@@ -495,7 +495,7 @@ test('find a single record with hasMany link as object { data }', function(asser
   }]);
 
   run(function() {
-    store.find('post', 1).then(function(post) {
+    store.findRecord('post', 1).then(function(post) {
       assert.equal(passedUrl[0], '/posts/1');
 
       assert.equal(post.get('id'), '1');
@@ -552,7 +552,7 @@ test('find a single record with hasMany link as object { data } (polymorphic)', 
   }]);
 
   run(function() {
-    store.find('user', 1).then(function(user) {
+    store.findRecord('user', 1).then(function(user) {
       assert.equal(passedUrl[0], '/users/1');
 
       assert.equal(user.get('id'), '1');
@@ -606,7 +606,7 @@ test('find a single record with sideloaded hasMany link as object { data }', fun
   }]);
 
   run(function() {
-    store.find('post', 1).then(function(post) {
+    store.findRecord('post', 1).then(function(post) {
       assert.equal(passedUrl[0], '/posts/1');
 
       assert.equal(post.get('id'), '1');
@@ -659,7 +659,7 @@ test('find a single record with sideloaded hasMany link as object { data } (poly
   }]);
 
   run(function() {
-    store.find('user', 1).then(function(user) {
+    store.findRecord('user', 1).then(function(user) {
       assert.equal(passedUrl[0], '/users/1');
 
       assert.equal(user.get('id'), '1');
@@ -906,7 +906,7 @@ test('fetching a belongsTo relationship link that returns null', function(assert
   }]);
 
   run(function() {
-    store.find('post', 1).then(function(post) {
+    store.findRecord('post', 1).then(function(post) {
       assert.equal(passedUrl[0], '/posts/1');
       return post.get('author');
 

--- a/tests/integration/adapter/record-persistence-test.js
+++ b/tests/integration/adapter/record-persistence-test.js
@@ -101,7 +101,7 @@ test("After a created record has been assigned an ID, finding a record by that I
     tom.save();
   });
 
-  assert.asyncEqual(tom, env.store.find('person', 1), "the retrieved record is the same as the created record");
+  assert.asyncEqual(tom, env.store.findRecord('person', 1), "the retrieved record is the same as the created record");
 });
 
 test("when a store is committed, the adapter's `commit` method should be called with records that have been deleted.", function(assert) {
@@ -125,7 +125,7 @@ test("when a store is committed, the adapter's `commit` method should be called 
       }
     });
   });
-  env.store.find('person', 1).then(assert.wait(function(person) {
+  env.store.findRecord('person', 1).then(assert.wait(function(person) {
     tom = person;
     tom.deleteRecord();
     return tom.save();
@@ -155,7 +155,7 @@ test("An adapter can notify the store that records were updated by calling `didS
     });
   });
 
-  all([env.store.find('person', 1), env.store.find('person', 2)])
+  all([env.store.findRecord('person', 1), env.store.findRecord('person', 2)])
     .then(assert.wait(function(array) {
       tom = array[0];
       yehuda = array[1];
@@ -203,7 +203,7 @@ test("An adapter can notify the store that records were updated and provide new 
     });
   });
 
-  hash({ tom: env.store.find('person', 1), yehuda: env.store.find('person', 2) }).then(assert.wait(function(people) {
+  hash({ tom: env.store.findRecord('person', 1), yehuda: env.store.findRecord('person', 2) }).then(assert.wait(function(people) {
     people.tom.set('name', "Draaaaaahm Dale");
     people.yehuda.set('name', "Goy Katz");
 
@@ -233,7 +233,7 @@ test("An adapter can notify the store that a record was updated by calling `didS
     });
   });
 
-  hash({ tom: store.find('person', 1), yehuda: store.find('person', 2) }).then(assert.wait(function(people) {
+  hash({ tom: store.findRecord('person', 1), yehuda: store.findRecord('person', 2) }).then(assert.wait(function(people) {
     people.tom.set('name', "Tom Dale");
     people.yehuda.set('name', "Yehuda Katz");
 
@@ -274,7 +274,7 @@ test("An adapter can notify the store that a record was updated and provide new 
     });
   });
 
-  hash({ tom: store.find('person', 1), yehuda: store.find('person', 2) }).then(assert.wait(function(people) {
+  hash({ tom: store.findRecord('person', 1), yehuda: store.findRecord('person', 2) }).then(assert.wait(function(people) {
     people.tom.set('name', "Draaaaaahm Dale");
     people.yehuda.set('name', "Goy Katz");
 
@@ -311,7 +311,7 @@ test("An adapter can notify the store that records were deleted by calling `didS
     });
   });
 
-  hash({ tom: store.find('person', 1), yehuda: store.find('person', 2) }).then(assert.wait(function(people) {
+  hash({ tom: store.findRecord('person', 1), yehuda: store.findRecord('person', 2) }).then(assert.wait(function(people) {
     people.tom.deleteRecord();
     people.yehuda.deleteRecord();
 

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -78,7 +78,7 @@ test("findRecord - passes buildURL a requestType", function(assert) {
   }));
 });
 
-test("find - basic payload (with legacy singular name)", function(assert) {
+test("findRecord - basic payload (with legacy singular name)", function(assert) {
   ajaxResponse({ post: { id: 1, name: "Rails is omakase" } });
 
   run(store, 'findRecord', 'post', 1).then(assert.wait(function(post) {
@@ -2069,7 +2069,7 @@ test('normalizeKey - to set up _ids and _id', function(assert) {
   });
 
   run(function() {
-    store.find('post', 1).then(assert.wait(function(post) {
+    store.findRecord('post', 1).then(assert.wait(function(post) {
       assert.equal(post.get('authorName'), "@d2h");
       assert.equal(post.get('author.name'), "D2H");
       assert.deepEqual(post.get('comments').mapBy('body'), ["Rails is unagi", "What is omakase?"]);
@@ -2163,7 +2163,7 @@ test('groupRecordsForFindMany groups calls for small ids', function(assert) {
   adapter.coalesceFindRequests = true;
 
   adapter.findRecord = function(store, type, id, snapshot) {
-    assert.ok(false, "find should not be called - we expect 1 call to findMany for a100 and b100");
+    assert.ok(false, "findRecord should not be called - we expect 1 call to findMany for a100 and b100");
     return Ember.RSVP.reject();
   };
 
@@ -2204,7 +2204,7 @@ test("calls adapter.handleResponse with the jqXHR and json", function(assert) {
 
   try {
     run(function() {
-      store.find('post', '1');
+      store.findRecord('post', '1');
     });
   } finally {
     Ember.$.ajax = originalAjax;
@@ -2238,7 +2238,7 @@ test('calls handleResponse with jqXHR, jqXHR.responseText, and requestData', fun
 
   try {
     run(function() {
-      store.find('post', '1').catch(function(err) {
+      store.findRecord('post', '1').catch(function(err) {
         assert.ok(err, 'promise rejected');
       });
     });
@@ -2267,7 +2267,7 @@ test("rejects promise if DS.AdapterError is returned from adapter.handleResponse
   };
 
   Ember.run(function() {
-    store.find('post', '1').then(null, function(reason) {
+    store.findRecord('post', '1').then(null, function(reason) {
       assert.ok(true, 'promise should be rejected');
       assert.ok(reason instanceof DS.AdapterError, 'reason should be an instance of DS.AdapterError');
     });
@@ -2297,7 +2297,7 @@ test('on error appends errorThrown for sanity', function(assert) {
 
   try {
     run(function() {
-      store.find('post', '1').catch(function(err) {
+      store.findRecord('post', '1').catch(function(err) {
         assert.equal(err, errorThrown);
         assert.ok(err, 'promise rejected');
       });
@@ -2325,7 +2325,7 @@ test('on error wraps the error string in an DS.AdapterError object', function(as
 
   try {
     run(function() {
-      store.find('post', '1').catch(function(err) {
+      store.findRecord('post', '1').catch(function(err) {
         assert.equal(err.errors[0].detail, errorThrown);
         assert.ok(err, 'promise rejected');
       });
@@ -2351,7 +2351,7 @@ test('error handling includes a detailed message from the server', (assert) => {
 
   try {
     run(function() {
-      store.find('post', '1').catch(function(err) {
+      store.findRecord('post', '1').catch(function(err) {
         assert.equal(err.message, "Ember Data Request GET /posts/1 returned a 500\nPayload (text/plain)\nAn error message, perhaps generated from a backend server!");
         assert.ok(err, 'promise rejected');
       });
@@ -2378,7 +2378,7 @@ test('error handling with a very long HTML-formatted payload truncates the frien
 
   try {
     run(function() {
-      store.find('post', '1').catch(function(err) {
+      store.findRecord('post', '1').catch(function(err) {
         assert.equal(err.message, "Ember Data Request GET /posts/1 returned a 500\nPayload (text/html)\n[Omitted Lengthy HTML]");
         assert.ok(err, 'promise rejected');
       });

--- a/tests/integration/adapter/store-adapter-test.js
+++ b/tests/integration/adapter/store-adapter-test.js
@@ -113,8 +113,8 @@ test("by default, createRecords calls createRecord once per record", function(as
     tom = records.tom;
     yehuda = records.yehuda;
 
-    assert.asyncEqual(tom, store.findRecord('person', 1), "Once an ID is in, find returns the same object");
-    assert.asyncEqual(yehuda, store.findRecord('person', 2), "Once an ID is in, find returns the same object");
+    assert.asyncEqual(tom, store.findRecord('person', 1), "Once an ID is in, findRecord returns the same object");
+    assert.asyncEqual(yehuda, store.findRecord('person', 2), "Once an ID is in, findRecord returns the same object");
     assert.equal(get(tom, 'updatedAt'), "now", "The new information is received");
     assert.equal(get(yehuda, 'updatedAt'), "now", "The new information is received");
   }));
@@ -1119,7 +1119,7 @@ test("deleteRecord receives a snapshot", function(assert) {
   });
 });
 
-test("find receives a snapshot", function(assert) {
+test("findRecord receives a snapshot", function(assert) {
   assert.expect(1);
 
   adapter.findRecord = function(store, type, id, snapshot) {
@@ -1397,7 +1397,7 @@ test("An async hasMany relationship with links should not trigger shouldBackgrou
 
   store = env.store;
 
-  run(store, 'find', 'post', '1').then(assert.wait(function(post) {
+  run(store, 'findRecord', 'post', '1').then(assert.wait(function(post) {
     return post.get('comments');
   })).then(assert.wait(function(comments) {
     assert.equal(comments.get('length'), 3);

--- a/tests/integration/debug-adapter-test.js
+++ b/tests/integration/debug-adapter-test.js
@@ -116,7 +116,7 @@ test("Watching Records", function(assert) {
   assert.deepEqual(record.color, 'black');
 
   Ember.run(function() {
-    post = store.find('post', 1);
+    post = store.findRecord('post', 1);
   });
 
   Ember.run(function() {

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -1145,7 +1145,7 @@ if (isEnabled('ds-references')) {
 
     run(function() {
       var chapter;
-      store.find('chapter', 1).then(function(_chapter) {
+      store.findRecord('chapter', 1).then(function(_chapter) {
         chapter = _chapter;
 
         return chapter.get('book');

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -576,7 +576,7 @@ test("A hasMany relationship can be reloaded even if it failed at the first time
     }
   };
   run(function() {
-    env.store.find('post', 1).then(function(post) {
+    env.store.findRecord('post', 1).then(function(post) {
       var comments = post.get('comments');
       return comments.catch(function() {
         return comments.reload();
@@ -617,7 +617,7 @@ test("A hasMany relationship can be directly reloaded if it was fetched via link
     ]);
   };
   run(function() {
-    env.store.find('post', 1).then(function(post) {
+    env.store.findRecord('post', 1).then(function(post) {
       return post.get('comments').reload().then(function(comments) {
         assert.equal(comments.get('isLoaded'), true, "comments are loaded");
         assert.equal(comments.get('length'), 2, "comments have 2 length");

--- a/tests/integration/store/json-api-validation-test.js
+++ b/tests/integration/store/json-api-validation-test.js
@@ -40,7 +40,7 @@ test("when normalizeResponse returns undefined (or doesn't return), throws an er
 
   assert.throws(function () {
     run(function() {
-      store.find('person', 1);
+      store.findRecord('person', 1);
     });
   }, /Top level of a JSON API document must be an object/);
 });
@@ -59,7 +59,7 @@ test("when normalizeResponse returns null, throws an error", function(assert) {
 
   assert.throws(function () {
     run(function() {
-      store.find('person', 1);
+      store.findRecord('person', 1);
     });
   }, /Top level of a JSON API document must be an object/);
 });
@@ -79,7 +79,7 @@ test("when normalizeResponse returns an empty object, throws an error", function
 
   assert.throws(function () {
     run(function() {
-      store.find('person', 1);
+      store.findRecord('person', 1);
     });
   }, /One or more of the following keys must be present/);
 });
@@ -103,7 +103,7 @@ test("when normalizeResponse returns a document with both data and errors, throw
 
   assert.throws(function () {
     run(function() {
-      store.find('person', 1);
+      store.findRecord('person', 1);
     });
   }, /cannot both be present/);
 });
@@ -121,7 +121,7 @@ QUnit.assert.payloadError = function payloadError(payload, expectedError) {
   }));
   this.throws(function () {
     run(function() {
-      store.find('person', 1);
+      store.findRecord('person', 1);
     });
   }, expectedError, `Payload ${JSON.stringify(payload)} should throw error ${expectedError}`);
   env.registry.unregister('serializer:person');

--- a/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
+++ b/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
@@ -48,7 +48,7 @@ test('groupRecordsForFindMany - findMany', function(assert) {
 
   Ember.run(function() {
     for (var i = 1; i <= 1024; i++) {
-      Store.find('testRecord', i);
+      Store.findRecord('testRecord', i);
     }
   });
 

--- a/tests/unit/model/relationships/belongs-to-test.js
+++ b/tests/unit/model/relationships/belongs-to-test.js
@@ -417,7 +417,7 @@ test("belongsTo gives a warning when provided with a serialize option", function
   });
 
   run(function() {
-      store.find('person', 1).then(assert.wait(function(person) {
+      store.findRecord('person', 1).then(assert.wait(function(person) {
         assert.warns(function() {
           get(person, 'hobby');
         }, /You provided a serialize option on the "hobby" property in the "person" class, this belongs in the serializer. See DS.Serializer and it's implementations/);
@@ -471,7 +471,7 @@ test("belongsTo gives a warning when provided with an embedded option", function
   });
 
   run(function() {
-      store.find('person', 1).then(assert.wait(function(person) {
+      store.findRecord('person', 1).then(assert.wait(function(person) {
         assert.warns(function() {
           get(person, 'hobby');
         }, /You provided an embedded option on the "hobby" property in the "person" class, this belongs in the serializer. See DS.EmbeddedRecordsMixin/);


### PR DESCRIPTION
`store.find` has been deprecated in `1.13` and been officially removed in the `2.x` series. This updates all references in the public documentation to use `store.findRecord`. Also some tests were still using `store.find` (which is still available since it is needed in the `model()` hook of Ember, but it is private now).