### PR TITLE
[BUGFIX beta] prevent calls to store.query leaking

### DIFF
--- a/addon/-private/system/record-array-manager.js
+++ b/addon/-private/system/record-array-manager.js
@@ -279,17 +279,22 @@ export default Ember.Object.extend({
     var typeClass = array.type;
 
     // unregister filtered record array
-    var recordArrays = this.filteredRecordArrays.get(typeClass);
-    var index = recordArrays.indexOf(array);
-    if (index !== -1) {
-      recordArrays.splice(index, 1);
+    const recordArrays = this.filteredRecordArrays.get(typeClass);
+    const removedFromFiltered = remove(recordArrays, array);
 
-    // unregister live record array
-    } else if (this.liveRecordArrays.has(typeClass)) {
-      var liveRecordArrayForType = this.liveRecordArrayFor(typeClass);
-      if (array === liveRecordArrayForType) {
-        this.liveRecordArrays.delete(typeClass);
+    // remove from adapter populated record array
+    const removedFromAdapterPopulated = remove(this._adapterPopulatedRecordArrays, array);
+
+    if (!removedFromFiltered && !removedFromAdapterPopulated) {
+
+      // unregister live record array
+      if (this.liveRecordArrays.has(typeClass)) {
+        var liveRecordArrayForType = this.liveRecordArrayFor(typeClass);
+        if (array === liveRecordArrayForType) {
+          this.liveRecordArrays.delete(typeClass);
+        }
       }
+
     }
   },
 
@@ -315,4 +320,15 @@ function flatten(list) {
   }
 
   return result;
+}
+
+function remove(array, item) {
+  const index = array.indexOf(item);
+
+  if (index !== -1) {
+    array.splice(index, 1);
+    return true;
+  }
+
+  return false;
 }

--- a/tests/integration/record-array-manager-test.js
+++ b/tests/integration/record-array-manager-test.js
@@ -171,3 +171,27 @@ test("Should not filter a store.peekAll() array when a record property is change
   assert.equal(updateFilterRecordArray.called.length, 0);
 
 });
+
+test('#GH-4041 store#query AdapterPopulatedRecordArrays are removed from their managers instead of retained when #destroy is called', function(assert) {
+  run(() => {
+    store.push({
+      data: {
+        type: 'car',
+        id: '1',
+        attributes: {
+          make: 'Honda',
+          model: 'fit'
+        }
+      }
+    });
+  });
+  const query = {};
+
+  var adapterPopulated = manager.createAdapterPopulatedRecordArray(Car, query);
+
+  run(() => {
+    adapterPopulated.destroy();
+  });
+
+  assert.equal(manager._adapterPopulatedRecordArrays.length, 0);
+});


### PR DESCRIPTION
Although the result from `store.query` is intended to never be re-used
as we delegate to the server for the truth of a query, the user still
needs an escape hatch to destroy these AdapterPopulatedRecordArrays
created by query in order to prevent excessive memory.

Before, calling `destroy` on an AdapterPopulatedRecordArray (the type
returned from store.query), the logic in
RecordArrayManager#unregisterRecordArray did not account for adapter
populated record arrays resulting in a leak.

This commit changes the logic to search for the array in the
RecordArrayManager's AdapterPopulatedRecordArray collection when
unregistering a record array.

Fixes #4041