### PR TITLE
chore(build): strip debug statements from production builds

### DIFF
--- a/lib/javascripts.js
+++ b/lib/javascripts.js
@@ -1,3 +1,5 @@
+/* jshint node:true */
+
 var filterImports = require('babel-plugin-filter-imports');
 var featureFlags  = require('babel-plugin-feature-flags');
 var babel         = require('broccoli-babel-transpiler');
@@ -63,12 +65,12 @@ function strippedBuild(packageName, tree) {
 
   var plugins = [
     featureFlags({
-      import: { module: 'ember-data/features' },
+      import: { module: 'ember-data/-private/features' },
       features: features
     }),
 
     filterImports({
-      'ember-data/debug': [
+      'ember-data/-private/debug': [
         'assert',
         'debug',
         'deprecate',
@@ -81,10 +83,10 @@ function strippedBuild(packageName, tree) {
   ];
 
   var withoutDebug = new Funnel(tree, {
-    exclude: ['debug.js']
+    exclude: ['ember-data/-private/debug.js']
   });
 
-  var compiled = babel(tree , babelOptions(packageName, {
+  var compiled = babel(withoutDebug , babelOptions(packageName, {
     plugins: plugins
   }));
 


### PR DESCRIPTION
@fivetanley - from our discussion the other day - this does not fix the entire problem, which goes much deeper, but this does fix the bower production build (which has been broken for some time b/c debug statements(or callers of them) we're not stripped.)

To make this fully work, meaning for it to work without using the legacy bower build we'll need to address this error, which is the next error that pops up when using the non-bower build.

```
Could not find module `ember-data/-private/setup-container` imported from `my-app/initializers/ember-data`
```

Sorry I wish I had more context, perhaps you or someone else does. I've hacked around it by copying the output when running `ember build --prod`, e.g., dist/global/ember-data.js, ember-data.prod.js and ember-data.min.js, (with this commit merged) into my own bower repo(which i check in). There and in my package.json I've set the version number back to ^2.2.1 - like I said, super hacky - but after trying to get rid of error above, including updating ember-cli and some other deps, I found lots of odd things - even double module prefixes such as `ember-data/ember-data/blah/blah` in one case, and this error **always**. 

Anyway, let me know if you have any questions or drop me your thoughts/wisdom and I'll try to move forward with this PR or another which fixes the problem entirely.