### PR TITLE
[feature ds-better-adapter-populated-record-array-error-messages]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -150,3 +150,10 @@ entry in `config/features.json`.
 
   Adds a deprecation warning when using Store#serialize(record) method.
   You can use record.serialize() instead.
+
+- `ds-better-adapter-populated-record-array-error-messages` [#4045](https://github.com/emberjs/data/pull/4045)
+
+  The result returned from `store.query` is an
+  AdapterPopulatedRecordArray. This adds better error messages when you
+  try to mutate the array, as it is considered immutable and the
+  mutation methods should not be used.

--- a/addon/-private/system/record-arrays/adapter-populated-record-array.js
+++ b/addon/-private/system/record-arrays/adapter-populated-record-array.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import RecordArray from "ember-data/-private/system/record-arrays/record-array";
+import ImmutableArrayMixin from "ember-data/-private/system/record-arrays/immutable-array-mixin";
 import cloneNull from "ember-data/-private/system/clone-null";
 
 /**
@@ -45,7 +46,7 @@ const { get } = Ember;
   @namespace DS
   @extends DS.RecordArray
 */
-export default RecordArray.extend({
+export default RecordArray.extend(ImmutableArrayMixin, {
   init() {
     // yes we are touching `this` before super, but ArrayProxy has a bug that requires this.
     this.set('content', this.get('content') || Ember.A());

--- a/addon/-private/system/record-arrays/immutable-array-mixin.js
+++ b/addon/-private/system/record-arrays/immutable-array-mixin.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import isEnabled from 'ember-data/-private/features';
+
+const { get } = Ember;
+
+const MUTATION_METHODS = [
+  'addObject',
+  'addObjects',
+  'removeObject',
+  'removeObjects',
+  'unshiftObject',
+  'unshiftObjects',
+  'pushObject',
+  'pushObjects',
+  'reverseObjects',
+  'setObjects',
+  'shiftObject'
+];
+
+function useToArray() {
+  if (isEnabled('ds-better-adapter-populated-record-array-error-messages')) {
+    let type = get(this, 'type').toString();
+    throw new Error(`The result of a server query (on ${type}) is immutable. Use .toArray() to copy the array instead.`);
+  } else {
+    return this._super(...arguments);
+  }
+}
+
+const ImmutableArrayMixin = MUTATION_METHODS.reduce((mixin, method) => {
+  mixin[method] = useToArray;
+  return mixin;
+}, {});
+
+export default Ember.Mixin.create(ImmutableArrayMixin);

--- a/addon/-private/system/record-arrays/immutable-array-mixin.js
+++ b/addon/-private/system/record-arrays/immutable-array-mixin.js
@@ -25,17 +25,16 @@ const MUTATION_METHODS = [
 ];
 
 function useToArray() {
-  if (isEnabled('ds-better-adapter-populated-record-array-error-messages')) {
-    let type = get(this, 'type').toString();
-    throw new EmberError(`The result of a server query (on ${type}) is immutable. Use .toArray() to copy the array instead.`);
-  } else {
-    return this._super(...arguments);
-  }
+  let type = get(this, 'type').toString();
+  throw new EmberError(`The result of a server query (on ${type}) is immutable. Use .toArray() to copy the array instead.`);
 }
 
-const ImmutableArrayMixin = MUTATION_METHODS.reduce((mixin, method) => {
-  mixin[method] = useToArray;
-  return mixin;
-}, {});
+let ImmutableArrayMixin = {};
+
+if (isEnabled('ds-better-adapter-populated-record-array-error-messages')) {
+  MUTATION_METHODS.forEach((method) => {
+    ImmutableArrayMixin[method] = useToArray;
+  });
+}
 
 export default Ember.Mixin.create(ImmutableArrayMixin);

--- a/addon/-private/system/record-arrays/immutable-array-mixin.js
+++ b/addon/-private/system/record-arrays/immutable-array-mixin.js
@@ -7,6 +7,10 @@ const {
 } = Ember;
 
 const MUTATION_METHODS = [
+  'clear',
+  'popObject',
+  'removeAt',
+  'insertAt',
   'addObject',
   'addObjects',
   'removeObject',

--- a/addon/-private/system/record-arrays/immutable-array-mixin.js
+++ b/addon/-private/system/record-arrays/immutable-array-mixin.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
 import isEnabled from 'ember-data/-private/features';
 
-const { get } = Ember;
+const {
+   get,
+   Error: EmberError
+} = Ember;
 
 const MUTATION_METHODS = [
   'addObject',
@@ -20,7 +23,7 @@ const MUTATION_METHODS = [
 function useToArray() {
   if (isEnabled('ds-better-adapter-populated-record-array-error-messages')) {
     let type = get(this, 'type').toString();
-    throw new Error(`The result of a server query (on ${type}) is immutable. Use .toArray() to copy the array instead.`);
+    throw new EmberError(`The result of a server query (on ${type}) is immutable. Use .toArray() to copy the array instead.`);
   } else {
     return this._super(...arguments);
   }

--- a/addon/-private/system/record-arrays/immutable-array-mixin.js
+++ b/addon/-private/system/record-arrays/immutable-array-mixin.js
@@ -7,21 +7,21 @@ const {
 } = Ember;
 
 const MUTATION_METHODS = [
-  'clear',
-  'popObject',
-  'removeAt',
-  'insertAt',
   'addObject',
   'addObjects',
-  'removeObject',
-  'removeObjects',
-  'unshiftObject',
-  'unshiftObjects',
+  'clear',
+  'insertAt',
+  'popObject',
   'pushObject',
   'pushObjects',
+  'removeAt',
+  'removeObject',
+  'removeObjects',
   'reverseObjects',
   'setObjects',
-  'shiftObject'
+  'shiftObject',
+  'unshiftObject',
+  'unshiftObjects'
 ];
 
 function useToArray() {

--- a/config/features.json
+++ b/config/features.json
@@ -7,5 +7,6 @@
   "ds-check-should-serialize-relationships": null,
   "ds-reset-attribute": null,
   "ds-serialize-id": null,
-  "ds-deprecate-store-serialize": true
+  "ds-deprecate-store-serialize": true,
+  "ds-better-adapter-populated-record-array-error-messages": null
 }

--- a/tests/unit/record-arrays/adapter-populated-record-array-test.js
+++ b/tests/unit/record-arrays/adapter-populated-record-array-test.js
@@ -3,6 +3,9 @@ import DS from 'ember-data';
 import {module, test} from 'qunit';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
+import isEnabled from 'ember-data/-private/features';
+
 const { RSVP, run } = Ember;
 const { AdapterPopulatedRecordArray } = DS;
 
@@ -270,3 +273,30 @@ test('change events when receiving a new query payload', function(assert) {
 
   assert.deepEqual(recordArray.map(x => x.name), ['Scumbag Penner']);
 });
+
+if (isEnabled('ds-better-adapter-populated-record-array-error-messages')) {
+  testInDebug('array mutation methods throw an error and instead suggest to use toArray', function(assert) {
+    let recordArray = AdapterPopulatedRecordArray.create({ type: 'recordType' });
+
+    const MUTATION_METHODS = [
+      'addObject',
+      'addObjects',
+      'removeObject',
+      'removeObjects',
+      'unshiftObject',
+      'unshiftObjects',
+      'pushObject',
+      'pushObjects',
+      'reverseObjects',
+      'setObjects',
+      'shiftObject'
+    ];
+
+    MUTATION_METHODS.forEach((method) => {
+      assert.throws(() => {
+        recordArray[method]();
+      }, Error("The result of a server query (on recordType) is immutable. Use .toArray() to copy the array instead."), 'throws error');
+    });
+
+  });
+}

--- a/tests/unit/record-arrays/adapter-populated-record-array-test.js
+++ b/tests/unit/record-arrays/adapter-populated-record-array-test.js
@@ -279,6 +279,10 @@ if (isEnabled('ds-better-adapter-populated-record-array-error-messages')) {
     let recordArray = AdapterPopulatedRecordArray.create({ type: 'recordType' });
 
     const MUTATION_METHODS = [
+      'clear',
+      'popObject',
+      'removeAt',
+      'insertAt',
       'addObject',
       'addObjects',
       'removeObject',


### PR DESCRIPTION
The result returned from `store.query` is an
AdapterPopulatedRecordArray. This adds better error messages when you
try to mutate the array, as it is considered immutable and the mutation
methods should not be used.

Currently, there are some issues like #3886 where this does not fail in
a helpful way. This feature improves the developer ergonomics to prevent
the mutation from happening and explaining why.
