### PR TITLE
Strip stuff from addon before it is added to app

### DIFF
--- a/lib/babel-build.js
+++ b/lib/babel-build.js
@@ -1,0 +1,48 @@
+var babel = require('broccoli-babel-transpiler');
+var path  = require('path');
+
+function babelOptions(libraryName, _options) {
+  _options = _options || {};
+
+  var options = {
+    whitelist: [
+      'es6.templateLiterals',
+      'es6.parameters',
+      'es6.arrowFunctions',
+      'es6.destructuring',
+      'es6.spread',
+      'es6.properties.computed',
+      'es6.properties.shorthand',
+      'es6.blockScoping',
+      'es6.constants',
+      'es6.modules'
+    ],
+    sourceMaps: false,
+    modules: 'amdStrict',
+    moduleRoot: libraryName,
+    moduleId: true,
+    // Transforms /index.js files to use their containing directory name
+    getModuleId: function (name) {
+      return name.replace(/\/index$/g, '');
+    },
+    resolveModuleSource: function(name, filename) {
+      if (name.indexOf('.') === 0) {
+        return libraryName + '/' + path.join(path.dirname(filename), name);
+      } else {
+        return name;
+      }
+    }
+  };
+
+  Object.keys(_options).forEach(function(opt) {
+    options[opt] = _options[opt];
+  });
+
+  return options;
+}
+
+module.exports = function(packageName, tree, _options) {
+  var options = babelOptions(packageName, _options);
+
+  return babel(tree, options);
+}

--- a/lib/javascripts.js
+++ b/lib/javascripts.js
@@ -1,8 +1,5 @@
 /* jshint node:true */
 
-var filterImports = require('babel-plugin-filter-imports');
-var featureFlags  = require('babel-plugin-feature-flags');
-var babel         = require('broccoli-babel-transpiler');
 var merge         = require('broccoli-merge-trees');
 var concat        = require('broccoli-concat');
 var uglify        = require('broccoli-uglify-sourcemap');
@@ -13,84 +10,23 @@ var path          = require('path');
 var Funnel        = require('broccoli-funnel');
 var versionReplace = require('./version-replace');
 var fileCreator   = require('broccoli-file-creator');
-
-function babelOptions(libraryName, _options) {
-  _options = _options || {};
-
-  var options = {
-    whitelist: [
-      'es6.templateLiterals',
-      'es6.parameters',
-      'es6.arrowFunctions',
-      'es6.destructuring',
-      'es6.spread',
-      'es6.properties.computed',
-      'es6.properties.shorthand',
-      'es6.blockScoping',
-      'es6.constants',
-      'es6.modules'
-    ],
-    sourceMaps: false,
-    modules: 'amdStrict',
-    moduleRoot: libraryName,
-    moduleId: true,
-    // Transforms /index.js files to use their containing directory name
-    getModuleId: function (name) {
-      return name.replace(/\/index$/g, '');
-    },
-    resolveModuleSource: function(name, filename) {
-      if (name.indexOf('.') === 0) {
-        return libraryName + '/' + path.join(path.dirname(filename), name);
-      } else {
-        return name;
-      }
-    }
-  };
-
-  Object.keys(_options).forEach(function(opt) {
-    options[opt] = _options[opt];
-  });
-
-  return options;
-}
+var babelBuild    = require('./babel-build');
+var strippedBuild = require('./stripped-build');
 
 function debugBuild(packageName, tree) {
-  var compiled = babel(tree, babelOptions(packageName));
+  var compiled = babelBuild(packageName, tree);
+
   return stew.mv(compiled, packageName);
 }
 
-function strippedBuild(packageName, tree) {
-  var featuresJson = fs.readFileSync('config/features.json', { encoding: 'utf8' });
-  var features = JSON.parse(featuresJson);
-
-  var plugins = [
-    featureFlags({
-      import: { module: 'ember-data/-private/features' },
-      features: features
-    }),
-
-    filterImports({
-      'ember-data/-private/debug': [
-        'assert',
-        'debug',
-        'deprecate',
-        'info',
-        'runInDebug',
-        'warn',
-        'debugSeal'
-      ]
-    })
-  ];
-
+function makeStrippedBuild(packageName, tree) {
   var withoutDebug = new Funnel(tree, {
     exclude: ['ember-data/-private/debug.js']
   });
 
-  var compiled = babel(withoutDebug , babelOptions(packageName, {
-    plugins: plugins
-  }));
+  var stripped = strippedBuild(packageName, withoutDebug);
 
-  return stew.mv(compiled, packageName);
+  return stew.mv(stripped, packageName);
 }
 
 function collapse(tree, outputFileName) {
@@ -130,21 +66,26 @@ function minify(tree) {
   });
 }
 
-
-module.exports = function(tree) {
+function buildEmberInflector() {
   var emberInflector = new Funnel(path.dirname(require.resolve('ember-inflector/addon')), {
     include: ['**/*.js']
   });
+
+  return debugBuild('ember-inflector', emberInflector);
+}
+
+module.exports = function(tree) {
+  var emberInflector = buildEmberInflector();
   var emberData = merge([tree, version()]);
 
   var javascripts = merge([
-    debugBuild('ember-inflector', emberInflector),
+    emberInflector,
     debugBuild('ember-data', emberData)
   ]);
 
   var strippedJavascripts = merge([
-    strippedBuild('ember-inflector', emberInflector),
-    strippedBuild('ember-data', emberData)
+    emberInflector,
+    makeStrippedBuild('ember-data', emberData)
   ]);
 
   var debug = collapse(javascripts, 'ember-data.js');

--- a/lib/stripped-build.js
+++ b/lib/stripped-build.js
@@ -1,0 +1,44 @@
+var fs            = require('fs');
+var path          = require('path');
+var filterImports = require('babel-plugin-filter-imports');
+var featureFlags  = require('babel-plugin-feature-flags');
+var babelBuild    = require('./babel-build');
+
+module.exports = function(packageName, tree, _options) {
+  var featuresJsonPath = path.join(__dirname, '../config/features.json');
+  var featuresJson = fs.readFileSync(featuresJsonPath, { encoding: 'utf8' });
+  var features = JSON.parse(featuresJson);
+
+  // TODO explicitly set all features which are not enabled to `false`, so
+  // they are stripped --> make this configurable or pass features
+  //
+  // for (var feature in features) {
+  //   if (features[feature] !== true) {
+  //     features[feature] = false;
+  //   }
+  // }
+
+  var plugins = [
+    featureFlags({
+      import: { module: 'ember-data/-private/features' },
+      features: features
+    }),
+
+    filterImports({
+      'ember-data/-private/debug': [
+        'assert',
+        'debug',
+        'deprecate',
+        'info',
+        'runInDebug',
+        'warn',
+        'debugSeal'
+      ]
+    })
+  ];
+
+  var options = _options || {};
+  options.plugins = plugins;
+
+  return babelBuild(packageName, tree, options);
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "babel-plugin-feature-flags": "^0.2.0",
+    "babel-plugin-filter-imports": "^0.2.0",
+    "broccoli-babel-transpiler": "^5.5.0",
     "broccoli-file-creator": "^1.0.0",
     "broccoli-merge-trees": "^1.0.0",
     "chalk": "^1.1.1",
@@ -35,11 +38,8 @@
     "silent-error": "^1.0.0"
   },
   "devDependencies": {
-    "babel-plugin-feature-flags": "^0.2.0",
-    "babel-plugin-filter-imports": "^0.2.0",
     "bower": "^1.6.5",
     "broccoli-asset-rev": "^2.1.2",
-    "broccoli-babel-transpiler": "^5.5.0",
     "broccoli-concat": "0.0.13",
     "broccoli-funnel": "^1.0.0",
     "broccoli-jscs": "^1.1.0",


### PR DESCRIPTION
Currently the code of the `ember-data` addon is added to the app. This is problematic since the code contains `assert`, `debug`, etcetera calls and also no feature flag code is stripped.

This PR is my stab at fixing this, so only the stripped code is added via the `treeForAddon` hook in `index.js`.

This addresses #4047 and takes inspiration from [@fivetanley's gist](https://gist.github.com/fivetanley/1708106ba3372b41dc94).

---

#### TODO

- [x] Check if this works as expected
- [x] Only strip debug statements imported from `ember-data/-private/debug` if `environment === "production"`? Currently the statements are always stripped.
- [x] ~~Correctly strip features which have a value other than `true` in `config/features.json`.~~ will be addressed in an upcoming PR