### PR TITLE
[BUGFIX beta] pin jquery to 1.11.3 to fix broken build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "3.3.0",
     "qunit": "~1.18.0"
   },


### PR DESCRIPTION
See: http://benlimmer.com/2016/01/08/ember-jquery-dependancies/