### PR TITLE
Update name for feature in FEATURES.md

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,7 +11,7 @@ entry in `config/features.json`.
 
 ## Feature Flags
 
-- `ds-find-include`
+- `ds-finder-include`
 
   Allows an `include` query parameter to be specified with using
   `store.findRecord()` and `store.findAll()` as described in [RFC


### PR DESCRIPTION
The feature is implemented in 266d3b0 as `ds-finder-include`, see [`addon/adapters/rest.js#L990`](https://git.io/vzYmN).

@HeroicEric should the feature be named `ds-finder-include` or `ds-find-include`?