### PR TITLE
[BUGFIX release] don't load "app" code when loading globals files

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,17 @@ module.exports = {
     return path.join(__dirname, 'blueprints');
   },
 
+  treeForApp: function(dir) {
+    if (this._forceBowerUsage) {
+      // Fake an empty broccoli tree
+      return { inputTree: dir, rebuild: function() { return []; } };
+    }
+
+    // this._super.treeForApp is undefined in ember-cli (1.13) for some reason.
+    // TODO: investigate why treeForApp isn't on _super
+    return dir;
+  },
+
   treeForAddon: function(dir) {
     if (this._forceBowerUsage) {
       // Fakes an empty broccoli tree


### PR DESCRIPTION
The code that gets compiled for the globals build is in a closure with
its own instance of `loader.js`, so the entries for ember-data don't end
up in ember-cli's instance of `loader.js`. The ember-data code does
include shims that end up in the app's instance of loader.js, so we
exclude the app code from running in this case.