### PR TITLE
Update blueprints to import modules directly

### DIFF
--- a/blueprints/adapter/index.js
+++ b/blueprints/adapter/index.js
@@ -13,8 +13,8 @@ module.exports = {
 
   locals: function(options) {
     var adapterName     = options.entity.name;
-    var baseClass       = 'DS.JSONAPIAdapter';
-    var importStatement = 'import DS from \'ember-data\';';
+    var baseClass       = 'JSONAPIAdapter';
+    var importStatement = 'import JSONAPIAdapter from \'ember-data/adapters/json-api\';';
     var isAddon         = options.inRepoAddon || options.project.isEmberCLIAddon();
     var relativePath    = pathUtil.getRelativePath(options.entity.name);
 

--- a/blueprints/model/files/__root__/__path__/__name__.js
+++ b/blueprints/model/files/__root__/__path__/__name__.js
@@ -1,5 +1,5 @@
-import DS from 'ember-data';
+<%= importStatements %>
 
-export default DS.Model.extend({
+export default Model.extend({
   <%= attrs %>
 });

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -16,6 +16,10 @@ module.exports = {
     var attrs = [];
     var needs = [];
     var entityOptions = options.entity.options;
+    var importStatements = ['import Model from \'ember-data/model\';'];
+    var shouldImportAttr = false;
+    var shouldImportBelongsTo = false;
+    var shouldImportHasMany = false;
 
     for (var name in entityOptions) {
       var type = entityOptions[name] || '';
@@ -35,26 +39,44 @@ module.exports = {
         var camelizedNamePlural = inflection.pluralize(camelizedName);
         attr = dsAttr(dasherizedForeignModelSingular, dasherizedType);
         attrs.push(camelizedNamePlural + ': ' + attr);
+        shouldImportHasMany = true;
       } else if (/belongs-to/.test(dasherizedType)) {
         attr = dsAttr(dasherizedForeignModel, dasherizedType);
         attrs.push(camelizedName + ': ' + attr);
+        shouldImportBelongsTo = true;
       } else {
         attr = dsAttr(dasherizedName, dasherizedType);
         attrs.push(camelizedName + ': ' + attr);
+        shouldImportAttr = true;
       }
 
       if (/has-many|belongs-to/.test(dasherizedType)) {
         needs.push("'model:" + dasherizedForeignModelSingular + "'");
       }
     }
+
     var needsDeduplicated = needs.filter(function(need, i) {
       return needs.indexOf(need) === i;
     });
 
+    if (shouldImportAttr) {
+      importStatements.push('import attr from \'ember-data/attr\';');
+    }
+
+    if (shouldImportBelongsTo && shouldImportHasMany) {
+      importStatements.push('import { belongsTo, hasMany } from \'ember-data/relationships\';');
+    } else if (shouldImportBelongsTo) {
+      importStatements.push('import { belongsTo } from \'ember-data/relationships\';');
+    } else if (shouldImportHasMany) {
+      importStatements.push('import { hasMany } from \'ember-data/relationships\';');
+    }
+
+    importStatements = importStatements.join(EOL);
     attrs = attrs.join(',' + EOL + '  ');
     needs = '  needs: [' + needsDeduplicated.join(', ') + ']';
 
     return {
+      importStatements: importStatements,
       attrs: attrs,
       needs: needs
     };
@@ -64,14 +86,14 @@ module.exports = {
 function dsAttr(name, type) {
   switch (type) {
   case 'belongs-to':
-    return 'DS.belongsTo(\'' + name + '\')';
+    return 'belongsTo(\'' + name + '\')';
   case 'has-many':
-    return 'DS.hasMany(\'' + name + '\')';
+    return 'hasMany(\'' + name + '\')';
   case '':
     //"If you don't specify the type of the attribute, it will be whatever was provided by the server"
     //http://emberjs.com/guides/models/defining-models/
-    return 'DS.attr()';
+    return 'attr()';
   default:
-    return 'DS.attr(\'' + type + '\')';
+    return 'attr(\'' + type + '\')';
   }
 }

--- a/blueprints/serializer/files/__root__/__path__/__name__.js
+++ b/blueprints/serializer/files/__root__/__path__/__name__.js
@@ -1,4 +1,4 @@
-import DS from 'ember-data';
+import JSONAPISerializer from 'ember-data/serializers/json-api';
 
-export default DS.JSONAPISerializer.extend({
+export default JSONAPISerializer.extend({
 });

--- a/blueprints/transform/files/__root__/__path__/__name__.js
+++ b/blueprints/transform/files/__root__/__path__/__name__.js
@@ -1,6 +1,6 @@
-import DS from 'ember-data';
+import Transform from 'ember-data/transform';
 
-export default DS.Transform.extend({
+export default Transform.extend({
   deserialize(serialized) {
     return serialized;
   },

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -60,8 +60,8 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
         {
           file: 'app/adapters/application.js',
           contains: [
-            'import DS from \'ember-data\';',
-            'export default DS.JSONAPIAdapter.extend({'
+            'import JSONAPIAdapter from \'ember-data/adapters/json-api\';',
+            'export default JSONAPIAdapter.extend({'
           ]
         },
         {

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -25,6 +25,55 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
     });
   });
 
+  it('adapter with --base-class', function() {
+    return generateAndDestroy(['adapter', 'foo', '--base-class=bar'], {
+      files: [
+        {
+          file: 'app/adapters/foo.js',
+          contains: [
+            'import BarAdapter from \'./bar\';',
+            'export default BarAdapter.extend({'
+          ]
+        },
+        {
+          file: 'tests/unit/adapters/foo-test.js',
+          contains: [
+            'moduleFor(\'adapter:foo\''
+          ]
+        }
+      ]
+    });
+  });
+
+  it('adapter throws when --base-class is same as name', function() {
+    return generateAndDestroy(['adapter', 'application', '--base-class=application'], {
+      throws: {
+        message: /Adapters cannot extend from themself/,
+        type: 'SilentError'
+      }
+    });
+  });
+
+  it('adapter when is named "application"', function() {
+    return generateAndDestroy(['adapter', 'application'], {
+      files: [
+        {
+          file: 'app/adapters/application.js',
+          contains: [
+            'import DS from \'ember-data\';',
+            'export default DS.JSONAPIAdapter.extend({'
+          ]
+        },
+        {
+          file: 'tests/unit/adapters/application-test.js',
+          contains: [
+            'moduleFor(\'adapter:application\''
+          ]
+        }
+      ]
+    });
+  });
+
   it('adapter-test', function() {
     return generateAndDestroy(['adapter-test', 'foo'], {
       files: [

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -25,6 +25,91 @@ describe('Acceptance: generate and destroy model blueprints', function() {
     });
   });
 
+  it('model with attrs', function() {
+    return generateAndDestroy([
+      'model',
+      'foo',
+      'misc',
+      'skills:array',
+      'isActive:boolean',
+      'birthday:date',
+      'someObject:object',
+      'age:number',
+      'name:string',
+      'customAttr:custom-transform'
+    ], {
+      files: [
+        {
+          file: 'app/models/foo.js',
+          contains: [
+            'import DS from \'ember-data\';',
+            'export default DS.Model.extend(',
+            'misc: DS.attr()',
+            'skills: DS.attr(\'array\')',
+            'isActive: DS.attr(\'boolean\')',
+            'birthday: DS.attr(\'date\')',
+            'someObject: DS.attr(\'object\')',
+            'age: DS.attr(\'number\')',
+            'name: DS.attr(\'string\')',
+            'customAttr: DS.attr(\'custom-transform\')'
+          ]
+        },
+        {
+          file: 'tests/unit/models/foo-test.js',
+          contains: [
+            'moduleForModel(\'foo\''
+          ]
+        }
+      ]
+    });
+  });
+
+  it('model with belongsTo', function() {
+    return generateAndDestroy(['model', 'comment', 'post:belongs-to', 'author:belongs-to:user'], {
+      files: [
+        {
+          file: 'app/models/comment.js',
+          contains: [
+            'import DS from \'ember-data\';',
+            'export default DS.Model.extend(',
+            'post: DS.belongsTo(\'post\')',
+            'author: DS.belongsTo(\'user\')',
+          ]
+        },
+        {
+          file: 'tests/unit/models/comment-test.js',
+          contains: [
+            'moduleForModel(\'comment\'',
+            'needs: [\'model:post\', \'model:user\']'
+          ]
+        }
+      ]
+    });
+  });
+
+  it('model with hasMany', function() {
+    return generateAndDestroy(['model', 'post', 'comments:has-many', 'otherComments:has-many:comment'], {
+      files: [
+        {
+          file: 'app/models/post.js',
+          contains: [
+            'import DS from \'ember-data\';',
+            'export default DS.Model.extend(',
+            'comments: DS.hasMany(\'comment\')',
+            'otherComments: DS.hasMany(\'comment\')',
+          ]
+        },
+        {
+          file: 'tests/unit/models/post-test.js',
+          contains: [
+            'moduleForModel(\'post\'',
+            'needs: [\'model:comment\']'
+          ]
+        }
+      ]
+    });
+  });
+
   it('model-test', function() {
     return generateAndDestroy(['model-test', 'foo'], {
       files: [

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -11,8 +11,14 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         {
           file: 'app/models/foo.js',
           contains: [
-            'import DS from \'ember-data\';',
-            'export default DS.Model.extend('
+            'import Model from \'ember-data/model\';',
+            'export default Model.extend('
+          ],
+          doesNotContain: [
+            'import attr from \'ember-data/attr\';',
+            'import { belongsTo } from \'ember-data/relationships\';',
+            'import { hasMany } from \'ember-data/relationships\';',
+            'import { belongsTo, hasMany } from \'ember-data/relationships\';'
           ]
         },
         {
@@ -42,16 +48,22 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         {
           file: 'app/models/foo.js',
           contains: [
-            'import DS from \'ember-data\';',
-            'export default DS.Model.extend(',
-            'misc: DS.attr()',
-            'skills: DS.attr(\'array\')',
-            'isActive: DS.attr(\'boolean\')',
-            'birthday: DS.attr(\'date\')',
-            'someObject: DS.attr(\'object\')',
-            'age: DS.attr(\'number\')',
-            'name: DS.attr(\'string\')',
-            'customAttr: DS.attr(\'custom-transform\')'
+            'import Model from \'ember-data/model\';',
+            'import attr from \'ember-data/attr\';',
+            'export default Model.extend(',
+            'misc: attr()',
+            'skills: attr(\'array\')',
+            'isActive: attr(\'boolean\')',
+            'birthday: attr(\'date\')',
+            'someObject: attr(\'object\')',
+            'age: attr(\'number\')',
+            'name: attr(\'string\')',
+            'customAttr: attr(\'custom-transform\')'
+          ],
+          doesNotContain: [
+            'import { belongsTo } from \'ember-data/relationships\';',
+            'import { hasMany } from \'ember-data/relationships\';',
+            'import { belongsTo, hasMany } from \'ember-data/relationships\';'
           ]
         },
         {
@@ -70,10 +82,16 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         {
           file: 'app/models/comment.js',
           contains: [
-            'import DS from \'ember-data\';',
-            'export default DS.Model.extend(',
-            'post: DS.belongsTo(\'post\')',
-            'author: DS.belongsTo(\'user\')',
+            'import Model from \'ember-data/model\';',
+            'import { belongsTo } from \'ember-data/relationships\';',
+            'export default Model.extend(',
+            'post: belongsTo(\'post\')',
+            'author: belongsTo(\'user\')',
+          ],
+          doesNotContain: [
+            'import attr from \'ember-data/attr\';',
+            'import { hasMany } from \'ember-data/relationships\';',
+            'import { belongsTo, hasMany } from \'ember-data/relationships\';'
           ]
         },
         {
@@ -93,10 +111,16 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         {
           file: 'app/models/post.js',
           contains: [
-            'import DS from \'ember-data\';',
-            'export default DS.Model.extend(',
-            'comments: DS.hasMany(\'comment\')',
-            'otherComments: DS.hasMany(\'comment\')',
+            'import Model from \'ember-data/model\';',
+            'import { hasMany } from \'ember-data/relationships\';',
+            'export default Model.extend(',
+            'comments: hasMany(\'comment\')',
+            'otherComments: hasMany(\'comment\')',
+          ],
+          doesNotContain: [
+            'import attr from \'ember-data/attr\';',
+            'import { belongsTo } from \'ember-data/relationships\';',
+            'import { belongsTo, hasMany } from \'ember-data/relationships\';'
           ]
         },
         {
@@ -104,6 +128,24 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           contains: [
             'moduleForModel(\'post\'',
             'needs: [\'model:comment\']'
+          ]
+        }
+      ]
+    });
+  });
+
+  it('model with belongsTo and hasMany has both imports', function() {
+    return generateAndDestroy(['model', 'post', 'comments:has-many', 'user:belongs-to'], {
+      files: [
+        {
+          file: 'app/models/post.js',
+          contains: [
+            'import { belongsTo, hasMany } from \'ember-data/relationships\';'
+          ],
+          doesNotContain: [
+            'import attr from \'ember-data/attr\';',
+            'import { belongsTo } from \'ember-data/relationships\';',
+            'import { hasMany } from \'ember-data/relationships\';'
           ]
         }
       ]

--- a/node-tests/blueprints/serializer-test.js
+++ b/node-tests/blueprints/serializer-test.js
@@ -11,8 +11,8 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
         {
           file: 'app/serializers/foo.js',
           contains: [
-            'import DS from \'ember-data\';',
-            'export default DS.JSONAPISerializer.extend('
+            'import JSONAPISerializer from \'ember-data/serializers/json-api\';',
+            'export default JSONAPISerializer.extend('
           ]
         },
         {

--- a/node-tests/blueprints/transform-test.js
+++ b/node-tests/blueprints/transform-test.js
@@ -11,8 +11,8 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
         {
           file: 'app/transforms/foo.js',
           contains: [
-            'import DS from \'ember-data\';',
-            'export default DS.Transform.extend(',
+            'import Transform from \'ember-data/transform\';',
+            'export default Transform.extend(',
             'deserialize(serialized) {',
             'serialize(deserialized) {'
           ]


### PR DESCRIPTION
## TL;DR;

This does two things:

- Adds more tests to the adapter & model blueprints
- Updates blueprints to import modules directly rather than access them through `DS`

I originally added the extra tests to cover the existing behavior before I changed it. If you'd rather have those split out into a separate PR LMK.

### Details

- Imports `JSONAPIAdapter` module directly in blueprint
- Imports `JSONAPISerializer` module directly in blueprint
- Imports `Transform` module directly in blueprint
- Imports `attr` module directly in model blueprints when needed
- Imports `belongsTo` and `hasMany` modules directly in blueprints when needed