### PR TITLE
[BUGFIX release] Fix bundled source path for gem

### DIFF
--- a/lib/ember/data/source.rb
+++ b/lib/ember/data/source.rb
@@ -4,7 +4,7 @@ module Ember
   module Data
     module Source
       def self.bundled_path_for(distro)
-        File.expand_path("../../../../dist/#{distro}", __FILE__)
+        File.expand_path("../../../../dist/globals/#{distro}", __FILE__)
       end
     end
   end


### PR DESCRIPTION
Currently, global builds are placed into `./dist/globals`.

Related to https://github.com/emberjs/data/issues/4069