### PR TITLE
[CLEANUP beta] Change the way metadata in response is stored on record array

### DIFF
--- a/addon/-private/system/record-arrays/adapter-populated-record-array.js
+++ b/addon/-private/system/record-arrays/adapter-populated-record-array.js
@@ -29,20 +29,16 @@ export default RecordArray.extend({
   /**
     @method loadRecords
     @param {Array} records
+    @param {Object} payload normalized payload
     @private
   */
-  loadRecords(records) {
-    var store = get(this, 'store');
-    var type = get(this, 'type');
-    var modelName = type.modelName;
-    var meta = store._metadataFor(modelName);
-
+  loadRecords(records, payload) {
     //TODO Optimize
     var internalModels = Ember.A(records).mapBy('_internalModel');
     this.setProperties({
       content: Ember.A(internalModels),
       isLoaded: true,
-      meta: cloneNull(meta)
+      meta: cloneNull(payload.meta)
     });
 
     internalModels.forEach((record) => {

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1253,30 +1253,6 @@ Store = Service.extend({
     return this.hasRecordForId(modelName, id);
   },
 
-  /**
-    @method _metadataFor
-    @param {String} modelName
-    @return {object}
-    @private
-  */
-  _metadataFor(modelName) {
-    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
-    var typeClass = this.modelFor(modelName);
-    return this.typeMapFor(typeClass).metadata;
-  },
-
-  /**
-    @method _setMetadataFor
-    @param {String} modelName
-    @param {Object} metadata metadata to set
-    @private
-  */
-  _setMetadataFor(modelName, metadata) {
-    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
-    var typeClass = this.modelFor(modelName);
-    Ember.merge(this.typeMapFor(typeClass).metadata, metadata);
-  },
-
   // ............
   // . UPDATING .
   // ............

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -168,15 +168,15 @@ export function _query(adapter, store, typeClass, query, recordArray) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    var records;
+    var records, payload;
     store._adapterRun(function() {
-      var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'query');
+      payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'query');
       //TODO Optimize
       records = store.push(payload);
     });
 
     assert('The response to store.query is expected to be an array but it was a single record. Please wrap your response in an array or use `store.queryRecord` to query for a single record.', Ember.isArray(records));
-    recordArray.loadRecords(records);
+    recordArray.loadRecords(records, payload);
     return recordArray;
 
   }, null, "DS: Extract payload of query " + typeClass);

--- a/addon/-private/system/store/serializer-response.js
+++ b/addon/-private/system/store/serializer-response.js
@@ -79,10 +79,6 @@ export function normalizeResponseHelper(serializer, store, modelClass, payload, 
     validationErrors = validateDocumentStructure(normalizedResponse);
   });
   assert(`normalizeResponse must return a valid JSON API document:\n\t* ${validationErrors.join('\n\t* ')}`, Ember.isEmpty(validationErrors));
-  // TODO: Remove after metadata refactor
-  if (normalizedResponse.meta) {
-    store._setMetadataFor(modelClass.modelName, normalizedResponse.meta);
-  }
 
   return normalizedResponse;
 }

--- a/tests/unit/adapter-populated-record-array-test.js
+++ b/tests/unit/adapter-populated-record-array-test.js
@@ -30,30 +30,31 @@ module("unit/adapter_populated_record_array - DS.AdapterPopulatedRecordArray", {
 test("when a record is deleted in an adapter populated record array, it should be removed", function(assert) {
   var recordArray = store.recordArrayManager
     .createAdapterPopulatedRecordArray(store.modelFor('person'), null);
+  var payload = {
+    data: [{
+      type: 'person',
+      id: '1',
+      attributes: {
+        name: 'Scumbag Dale'
+      }
+    }, {
+      type: 'person',
+      id: '2',
+      attributes: {
+        name: 'Scumbag Katz'
+      }
+    }, {
+      type: 'person',
+      id: '3',
+      attributes: {
+        name: 'Scumbag Bryn'
+      }
+    }]
+  };
 
   run(function() {
-    var records = store.push({
-      data: [{
-        type: 'person',
-        id: '1',
-        attributes: {
-          name: 'Scumbag Dale'
-        }
-      }, {
-        type: 'person',
-        id: '2',
-        attributes: {
-          name: 'Scumbag Katz'
-        }
-      }, {
-        type: 'person',
-        id: '3',
-        attributes: {
-          name: 'Scumbag Bryn'
-        }
-      }]
-    });
-    recordArray.loadRecords(records);
+    var records = store.push(payload);
+    recordArray.loadRecords(records, payload);
   });
 
   assert.equal(recordArray.get('length'), 3, "expected recordArray to contain exactly 3 records");
@@ -63,6 +64,42 @@ test("when a record is deleted in an adapter populated record array, it should b
   });
 
   assert.equal(recordArray.get('length'), 2, "expected recordArray to contain exactly 2 records");
+});
+
+test("stores the metadata off the payload", function(assert) {
+  var recordArray = store.recordArrayManager
+    .createAdapterPopulatedRecordArray(store.modelFor('person'), null);
+  var payload = {
+    data: [{
+      type: 'person',
+      id: '1',
+      attributes: {
+        name: 'Scumbag Dale'
+      }
+    }, {
+      type: 'person',
+      id: '2',
+      attributes: {
+        name: 'Scumbag Katz'
+      }
+    }, {
+      type: 'person',
+      id: '3',
+      attributes: {
+        name: 'Scumbag Bryn'
+      }
+    }],
+    meta: {
+      foo: 'bar'
+    }
+  };
+
+  run(function() {
+    var records = store.push(payload);
+    recordArray.loadRecords(records, payload);
+  });
+
+  assert.equal(recordArray.get('meta.foo'), 'bar', 'expected meta.foo to be bar from payload');
 });
 
 test('recordArray.replace() throws error', function(assert) {


### PR DESCRIPTION
The previous implementation of inserting metadata from an ajax response
onto a record array used the store as temporary storage for the metadata
via `store._metadataFor` and `store._setMetadataFor`. Although rare, this could
store the wrong value on the record array due to a race condition, as
the metadata was stored based on the query's model's name. This moves
the storing of metadata to `AdapterPopulatedRecordArray.loadRecords`
since, at the time that that method is called, the payload is present,
so we don't have to use `store.{_setMetadataFor,_metadataFor}`.
`store._metadataFor` was only used in
`AdapterPopulatedRecordArray.loadRecords`, so it is no longer needed
with this new implementation.