### PR TITLE
Use the record as "this" inside fun defaultValue

### DIFF
--- a/addon/attr.js
+++ b/addon/attr.js
@@ -226,7 +226,7 @@ Model.reopen({
 
 function getDefaultValue(record, options, key) {
   if (typeof options.defaultValue === "function") {
-    return options.defaultValue.apply(null, arguments);
+    return options.defaultValue.apply(record, key);
   } else {
     let defaultValue = options.defaultValue;
     deprecate(`Non primitive defaultValues are deprecated because they are shared between all instances. If you would like to use a complex object as a default value please provide a function that returns the complex object.`,


### PR DESCRIPTION
Maybe there is a reason for not using the very record as the value for `this` inside the function `defaultValue`, but I just can't figure it out.

Consider a `session` model which belongs to a `user`. I think it woud be more "ember" to write code as such:

``` javascript
export default DS.Model.extend({
  user: DS.belongsTo('user'),
  email: DS.attr({
    defaultValue() { return this.get('user.email'); }
  })
});
```

Currently, to achive the same result, one would have to write:

``` javascript
export default DS.Model.extend({
  user: DS.belongsTo('user'),
  email: DS.attr({
    defaultValue(record /*, options, key */) { return record.get('user.email'); }
  })
});
```

The second argument, `options`, seems to be pretty useless, since it contains the very same function `defaultValue`, along with other options whose values were assigned by the time of defining the model.

If you guys don't see the point in merging this pull request, I will try to submit another one regarding the documentation for `DS.attr()`, since it fails to mention that the first argument to the function `defaultValue` is the record itself.