### PR TITLE
[cleanup] Remove unnecessary inline JSHint config

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1,6 +1,3 @@
-/*globals Ember*/
-/*jshint eqnull:true*/
-
 /**
   @module ember-data
 */


### PR DESCRIPTION
- `Ember` is imported below so we don’t need the global :smile:
- The `eqnull:true` rule was originally added for
https://github.com/emberjs/data/commit/beb2f26 but was later added to the `.jshintrc` in
https://github.com/emberjs/data/commit/caa2753