### PR TITLE
[FEATURE ds-transform-pass-options] pass options to DS.Transform

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -20,3 +20,8 @@ entry in `config/features.json`.
 - `ds-references`
 
   Adds references as described in [RFC 57](https://github.com/emberjs/rfcs/pull/57)
+
+- `ds-transform-pass-options`
+
+  Pass options specified for a `DS.attr` to the `DS.Tranform`'s `serialize` and
+  `deserialize` methods (described in [RFC 1](https://github.com/emberjs/rfcs/pull/1))

--- a/addon/attr.js
+++ b/addon/attr.js
@@ -349,3 +349,35 @@ export default function attr(type, options) {
     }
   }).meta(meta);
 }
+
+// TODO add to documentation of `attr` function above, once this feature is added
+// /**
+//  * The `options` hash is passed as second argument to a transforms'
+//  * `serialize` and `deserialize` method. This allows to configure a
+//  * transformation and adapt the corresponding value, based on the config:
+//  *
+//  * ```app/models/post.js
+//  * export default DS.Model.extend({
+//  *   text: DS.attr('text', {
+//  *     uppercase: true
+//  *   })
+//  * });
+//  * ```
+//  *
+//  * ```app/transforms/text.js
+//  * export default DS.Transform.extend({
+//  *   serialize: function(value, options) {
+//  *     if (options.uppercase) {
+//  *       return value.toUpperCase();
+//  *     }
+//  *
+//  *     return value;
+//  *   },
+//  *
+//  *   deserialize: function(value) {
+//  *     return value;
+//  *   }
+//  * })
+//  * ```
+//  *
+//  */

--- a/config/features.json
+++ b/config/features.json
@@ -1,4 +1,5 @@
 {
   "ds-finder-include": null,
-  "ds-references": null
+  "ds-references": null,
+  "ds-transform-pass-options": null
 }


### PR DESCRIPTION
This feature passes the options hash defined for an attribute to the
`serialize` and `deserialize` methods of `DS.Transform`:

```js
// app/models/post.js
export default Model.extend({
  text: DS.attr('text'),

  otherText: DS.attr('text', {
    lowercaseInput: true,
    uppercaseOutput: true
  })
});

// app/transforms/text.js
export default DS.Tranform.extend({
  serialize(value, options) {
    if (options.uppercaseOutput) {
      return value.toUpperCase();
    }

    return value;
  },

  deserialize(value, options) {
    if (options.lowercaseInput) {
      return value.toLowerCase();
    }

    return value;
  }
});
```

---

This implements emberjs/rfcs#1.