### PR TITLE
[BUGFIX release] Remove 'v' prefix from `DS.VERSION`

### DIFF
--- a/lib/calculate-version.js
+++ b/lib/calculate-version.js
@@ -9,7 +9,7 @@ module.exports = function() {
   if (existsSync(gitPath)) {
     var info = gitRepoInfo(gitPath);
     if (info.tag) {
-      return info.tag;
+      return info.tag.replace(/^v/, '');
     }
 
     return packageVersion + '+' + info.sha.slice(0, 10);

--- a/lib/version-replace.js
+++ b/lib/version-replace.js
@@ -1,5 +1,5 @@
 var calculateVersion = require('./calculate-version');
-var version = calculateVersion().replace(/^v/, '');
+var version = calculateVersion();
 var replace = require('broccoli-string-replace');
 
 module.exports = function configFiles(tree) {


### PR DESCRIPTION
The change of version number format may break version checking from other libs.

Before:
``` js
DS.VERSION //=> "v2.3.2"
```

After:
``` js
DS.VERSION //=> "2.3.2"
```