### PR TITLE
Update `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,10 +7,12 @@ dist/
 .editorconfig
 .ember-cli
 .travis.yml
+.appveyor.yml
 .npmignore
 **/.gitkeep
 bower.json
-Brocfile.js
 testem.json
 *.gem
+*.gemspec
+**/*.rb
 node-tests/


### PR DESCRIPTION
* Ruby files and testing yaml is unnecessary as a npm module.
* Now `Brocfile.js` is not exist anywhere.