### PR TITLE
[DOC] Mark `DS.Store.filter` as private

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1189,6 +1189,7 @@ Store = Service.extend({
     ```
 
     @method filter
+    @private
     @param {String} modelName
     @param {Object} query optional query
     @param {Function} filter


### PR DESCRIPTION
`DS.Store.filter` was deprecated and moved to an addon in https://github.com/emberjs/data/pull/3364. 

It has not been available without using the addon since https://github.com/emberjs/data/pull/3778/files.

The addon can be found at https://github.com/ember-data/ember-data-filter.