### PR TITLE
[FEATURE ds-pushpayload-return] Change `pushPayload` to return a value.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -25,3 +25,8 @@ entry in `config/features.json`.
 
   Pass options specified for a `DS.attr` to the `DS.Tranform`'s `serialize` and
   `deserialize` methods (described in [RFC 1](https://github.com/emberjs/rfcs/pull/1))
+
+- `ds-pushpayload-return`
+
+  Enables `pushPayload` to return the model(s) that are created or
+  updated via the internal `store.push`. [PR 4110](https://github.com/emberjs/data/pull/4110)

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1818,7 +1818,11 @@ Store = Service.extend({
       assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${Ember.inspect(modelName)}`, typeof modelName === 'string');
       serializer = this.serializerFor(modelName);
     }
-    this._adapterRun(() => serializer.pushPayload(this, payload));
+    if (isEnabled('ds-pushpayload-return')) {
+      return this._adapterRun(() => { return serializer.pushPayload(this, payload); });
+    } else {
+      this._adapterRun(() => serializer.pushPayload(this, payload));
+    }
   },
 
   /**

--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -7,6 +7,7 @@ import { assert, runInDebug, warn } from 'ember-data/-private/debug';
 import JSONSerializer from 'ember-data/serializers/json';
 import normalizeModelName from 'ember-data/-private/system/normalize-model-name';
 import { pluralize, singularize } from 'ember-inflector';
+import isEnabled from 'ember-data/-private/features';
 
 var dasherize = Ember.String.dasherize;
 
@@ -178,7 +179,11 @@ const JSONAPISerializer = JSONSerializer.extend({
   */
   pushPayload(store, payload) {
     let normalizedPayload = this._normalizeDocumentHelper(payload);
-    store.push(normalizedPayload);
+    if (isEnabled('ds-pushpayload-return')) {
+      return store.push(normalizedPayload);
+    } else {
+      store.push(normalizedPayload);
+    }
   },
 
   /**

--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -9,6 +9,7 @@ import normalizeModelName from "ember-data/-private/system/normalize-model-name"
 import {singularize} from "ember-inflector";
 import coerceId from "ember-data/-private/system/coerce-id";
 import { modelHasAttributeOrRelationshipNamedType } from "ember-data/-private/utils";
+import isEnabled from 'ember-data/-private/features';
 
 var camelize = Ember.String.camelize;
 
@@ -403,7 +404,11 @@ var RESTSerializer = JSONSerializer.extend({
       });
     }
 
-    store.push(documentHash);
+    if (isEnabled('ds-pushpayload-return')) {
+      return store.push(documentHash);
+    } else {
+      store.push(documentHash);
+    }
   },
 
   /**

--- a/config/features.json
+++ b/config/features.json
@@ -1,5 +1,6 @@
 {
   "ds-finder-include": null,
   "ds-references": null,
-  "ds-transform-pass-options": null
+  "ds-transform-pass-options": null,
+  "ds-pushpayload-return": null
 }

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -5,6 +5,8 @@ import {module, test} from 'qunit';
 
 import DS from 'ember-data';
 
+import isEnabled from 'ember-data/-private/features';
+
 var env, store, Person, PhoneNumber, Post;
 var attr = DS.attr;
 var hasMany = DS.hasMany;
@@ -667,6 +669,35 @@ test("Calling push with unknown keys should not warn by default", function(asser
     });
   }, /The payload for 'person' contains these unknown keys: \[emailAddress,isMascot\]. Make sure they've been defined in your model./);
 });
+
+if (isEnabled('ds-pushpayload-return')) {
+  test("Calling pushPayload returns records", function(assert) {
+    env.registry.register('serializer:person', DS.RESTSerializer);
+
+    var people;
+
+    run(function() {
+      people = store.pushPayload('person', {
+        people: [{
+          id: '1',
+          firstName: "Robert",
+          lastName: "Jackson"
+        }, {
+          id: '2',
+          firstName: "Matthew",
+          lastName: "Beale"
+        }]
+      });
+    });
+
+    assert.equal(people.length, 2, "both records were returned by `store.pushPayload`");
+
+    assert.equal(people[0].get('firstName'), "Robert", "pushPayload returns pushed records");
+    assert.equal(people[0].get('lastName'), "Jackson", "pushPayload returns pushed records");
+    assert.equal(people[1].get('firstName'), "Matthew", "pushPayload returns pushed records");
+    assert.equal(people[1].get('lastName'), "Beale", "pushPayload returns pushed records");
+  });
+}
 
 module("unit/store/push - DS.Store#push with JSON-API", {
   beforeEach() {


### PR DESCRIPTION
Changing `store.pushPayload` and `serializer.pushPayload` to return the "pushed value". Either a record or array of records.

You can see by the diff, this is actually a pretty trivial change and it would greatly benefit those of us using `pushPayload`. The only risk of breakage is if someone has overridden `pushPayload` in their serializer, the value may not be returned.

Addresses: #3576