### PR TITLE
[BUGFIX beta] Add ducktyping of `AdapterError`

### DIFF
--- a/addon/-private/adapters/errors.js
+++ b/addon/-private/adapters/errors.js
@@ -12,6 +12,7 @@ const PRIMARY_ATTRIBUTE_KEY = 'base';
   @namespace DS
 */
 export function AdapterError(errors, message = 'Adapter operation failed') {
+  this.isAdapterError = true;
   EmberError.call(this, message);
 
   this.errors = errors || [

--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -853,7 +853,7 @@ export default Adapter.extend(BuildURLMixin, {
           requestData
         );
 
-        if (response instanceof AdapterError) {
+        if (response && response.isAdapterError) {
           Ember.run.join(null, reject, response);
         } else {
           Ember.run.join(null, resolve, response);

--- a/tests/unit/adapter-errors-test.js
+++ b/tests/unit/adapter-errors-test.js
@@ -10,24 +10,28 @@ test("DS.AdapterError", function(assert) {
   var error = new DS.AdapterError();
   assert.ok(error instanceof Error);
   assert.ok(error instanceof Ember.Error);
+  assert.ok(error.isAdapterError);
 });
 
 test("DS.InvalidError", function(assert) {
   var error = new DS.InvalidError();
   assert.ok(error instanceof Error);
   assert.ok(error instanceof DS.AdapterError);
+  assert.ok(error.isAdapterError);
 });
 
 test("DS.TimeoutError", function(assert) {
   var error = new DS.TimeoutError();
   assert.ok(error instanceof Error);
   assert.ok(error instanceof DS.AdapterError);
+  assert.ok(error.isAdapterError);
 });
 
 test("DS.AbortError", function(assert) {
   var error = new DS.AbortError();
   assert.ok(error instanceof Error);
   assert.ok(error instanceof DS.AdapterError);
+  assert.ok(error.isAdapterError);
 });
 
 var errorsHash = {


### PR DESCRIPTION
There are `instanceof` checks for `AdapterError`; this removes it in favor of checking for a property on the error. `isAdapterError` appears on all errors that use `AdapterError` as the base.


This PR is looking to avoid the need to import private errors in fastboot to keep the same code flow in the ajax method used in node land, related PR: https://github.com/tildeio/ember-cli-fastboot/pull/95