### PR TITLE
[BUGFIX beta] Move `jQuery.ajax` call to a method separate method

### DIFF
--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -881,8 +881,17 @@ export default Adapter.extend(BuildURLMixin, {
         Ember.run.join(null, reject, error);
       };
 
-      Ember.$.ajax(hash);
+      adapter._ajaxRequest(hash);
     }, 'DS: RESTAdapter#ajax ' + type + ' to ' + url);
+  },
+
+  /**
+    @method _ajaxRequest
+    @private
+    @param {Object} options jQuery ajax options to be used for the ajax request
+  */
+  _ajaxRequest(options) {
+    Ember.$.ajax(options);
   },
 
   /**


### PR DESCRIPTION
Allow for overriding of the `ajax` request by overriding
`RESTAdapter.ajaxRequest` instead of the `RESTAdapter.ajax`, which
perform promise wrapping and Ember Data specific errors