### PR TITLE
Add assertions for store#query()

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -957,6 +957,8 @@ Store = Service.extend({
   },
 
   _query(modelName, query, array) {
+    assert("You need to pass a type to the store's query method", modelName);
+    assert("You need to pass a query hash to the store's query method", query);
     assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
     var typeClass = this.modelFor(modelName);
     array = array || this.recordArrayManager

--- a/tests/integration/adapter/queries-test.js
+++ b/tests/integration/adapter/queries-test.js
@@ -28,6 +28,18 @@ module("integration/adapter/queries - Queries", {
   }
 });
 
+test("It raises an assertion when no type is passed", function(assert) {
+  assert.expectAssertion(function() {
+    store.query();
+  }, "You need to pass a type to the store's query method");
+});
+
+test("It raises an assertion when no query hash is passed", function(assert) {
+  assert.expectAssertion(function() {
+    store.query('person');
+  }, "You need to pass a query hash to the store's query method");
+});
+
 test("When a query is made, the adapter should receive a record array it can populate with the results of the query.", function(assert) {
   adapter.query = function(store, type, query, recordArray) {
     assert.equal(type, Person, "the query method is called with the correct type");


### PR DESCRIPTION
Currently invoking `store.query('person')` will fail with an error
within `RESTAdapter#sortQueryParams`, which is not helpful.

This adds the following assertions to store#query():

- a type is passed to the query method
- a query hash is passed to the query method

---

Those two assertions are available on `store#queryRecord` so this PR aligns `store#query` so it has the same assertions.