### PR TITLE
[ci skip] Sort CHANGELOG by version and not date of release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,16 +134,6 @@
 - [#3816](https://github.com/emberjs/data/pull/3816) run optional feature tests on AppVeyor
 - [#3817](https://github.com/emberjs/data/pull/3817) Update the changelog for Ember Data 2.1.0
 
-### Release 1.13.14 (October 18, 2015)
-- [#3665](https://github.com/emberjs/data/pull/3665) [BUGFIX beta] Fix usage of registry for 2.1.0+.
-- [#3825](https://github.com/emberjs/data/pull/3825) [BUGFIX] Restore IE8 compatibility by using Ember.create
-- [#3837](https://github.com/emberjs/data/pull/3837) [BUGFIX] Attribute/relationship named "type" of embedded record is considered before normalization
-- [#3840](https://github.com/emberjs/data/pull/3840) Backport Fix usage of registry for 2.1.0+ from pr #3665
-- [#3846](https://github.com/emberjs/data/pull/3846) [BUGFIX beta] Attribute/relationship named "type" of primary record i…
-- [#3847](https://github.com/emberjs/data/pull/3847) [BUGFIX beta] JSONAPI serializer not respecting 'attrs' hash
-- [#3857](https://github.com/emberjs/data/pull/3857) [BUGFIX beta] rollbackAttributes() works after multiple failed saves
-- [#3859](https://github.com/emberjs/data/pull/3859) [BUGFIX beta] Correctly handle invalid errors without payload or pointer
-
 ### Release 2.1.0 (October 5, 2015)
 - [#3811](https://github.com/emberjs/data/pull/3811) Format lists in JSONSerializer docs for rendering
 - [#3814](https://github.com/emberjs/data/pull/3814) [BUGFIX] Do not deserialize when a relationship named `type` exists
@@ -177,10 +167,6 @@
 - [#3649](https://github.com/emberjs/data/pull/3649) Empty object
 - [#3647](https://github.com/emberjs/data/pull/3647) Adapter.query should be part of the public overrideable interface.
 
-### Release 1.13.13 (September 17, 2015)
-- [#3762](https://github.com/emberjs/data/pull/3762) [BUGFIX release]
-  Improve links vs. local data for relationships
-
 ### Release 2.0.1 (September 17, 2015)
 
 - [#3751](https://github.com/emberjs/data/pull/3751) Remove normalizePayload, associated docs, and mention of functionality.
@@ -191,41 +177,6 @@
 - [#3778](https://github.com/emberjs/data/pull/3778) [BUGFIX release] Remove deprecation on store.filter
 - [#3779](https://github.com/emberjs/data/pull/3779) [BUGFIX release] Remove store method deprecations
 - [#3782](https://github.com/emberjs/data/pull/3782) [DOC release] Remove private label for findAll, query, queryRecord
-
-### Release 1.13.12 (September 10, 2015)
-- [#3689](https://github.com/emberjs/data/pull/3689) Backport
-  empty-object performance improvements from 2.1.0-beta1
-- [#3690](https://github.com/emberjs/data/pull/3690)
-  [BUGFIX release-1-13] Ensure that `service:store` is cleared before
-  regsitering.
-- [#3725](https://github.com/emberjs/data/pull/3725)
-  [BUGFIX release-1-13] Disable polymorphic deserialization when a
-  mode…
-- [#3753](https://github.com/emberjs/data/pull/3753) Bumped the
-  ember-inflector version to 1.9.2.
-- [#3754](https://github.com/emberjs/data/pull/3754) Do not run tests
-  with Ember 2.0 in the Ember Data 1.13 appveyor builds
-
-
-### Release 1.13.11 (August 21, 2015)
-
-- [#3685](https://github.com/emberjs/data/pull/3685) Fixing typo that
-  causes Ember-Data v1.13.10 to crash with Ember v2.0.
-- [#3686](https://github.com/emberjs/data/pull/3686) Fix broken
-  rest-serializer test.
-
-### Release 1.13.10 (August 20, 2015)
-
-- [#3577](https://github.com/emberjs/data/pull/3577) Use the correct
-  modelClass and serializer to extract a polymorphic
-- [#3667](https://github.com/emberjs/data/pull/3667) Don’t crash \w
-  Ember 2.0
-
-
-### Release 2.1.0-beta.1 (August 20, 2015)
-- [#3641](https://github.com/emberjs/data/pull/3641) Improve InternalModel (2x - 3x faster)
-- [#3649](https://github.com/emberjs/data/pull/3649) Empty object
-- [#3647](https://github.com/emberjs/data/pull/3647) Adapter.query should be part of the public overrideable interface.
 
 ### Release 2.0.0 (August 20, 2015)
 
@@ -303,6 +254,50 @@ In Ember Data 2.0 a record will no longer be removed from hasMany relationships 
 - [#3533](https://github.com/emberjs/data/pull/3533) [CLEANUP beta] Remove console.log() call
 - [#3567](https://github.com/emberjs/data/pull/3567) Use Ember.$ instead of jQuery for AJAX requests
 - [#3570](https://github.com/emberjs/data/pull/3570) Update `Ember.deprecate` and `Ember.warn` calls to include required information
+
+### Release 1.13.14 (October 18, 2015)
+- [#3665](https://github.com/emberjs/data/pull/3665) [BUGFIX beta] Fix usage of registry for 2.1.0+.
+- [#3825](https://github.com/emberjs/data/pull/3825) [BUGFIX] Restore IE8 compatibility by using Ember.create
+- [#3837](https://github.com/emberjs/data/pull/3837) [BUGFIX] Attribute/relationship named "type" of embedded record is considered before normalization
+- [#3840](https://github.com/emberjs/data/pull/3840) Backport Fix usage of registry for 2.1.0+ from pr #3665
+- [#3846](https://github.com/emberjs/data/pull/3846) [BUGFIX beta] Attribute/relationship named "type" of primary record i…
+- [#3847](https://github.com/emberjs/data/pull/3847) [BUGFIX beta] JSONAPI serializer not respecting 'attrs' hash
+- [#3857](https://github.com/emberjs/data/pull/3857) [BUGFIX beta] rollbackAttributes() works after multiple failed saves
+- [#3859](https://github.com/emberjs/data/pull/3859) [BUGFIX beta] Correctly handle invalid errors without payload or pointer
+
+### Release 1.13.13 (September 17, 2015)
+- [#3762](https://github.com/emberjs/data/pull/3762) [BUGFIX release]
+  Improve links vs. local data for relationships
+
+### Release 1.13.12 (September 10, 2015)
+- [#3689](https://github.com/emberjs/data/pull/3689) Backport
+  empty-object performance improvements from 2.1.0-beta1
+- [#3690](https://github.com/emberjs/data/pull/3690)
+  [BUGFIX release-1-13] Ensure that `service:store` is cleared before
+  regsitering.
+- [#3725](https://github.com/emberjs/data/pull/3725)
+  [BUGFIX release-1-13] Disable polymorphic deserialization when a
+  mode…
+- [#3753](https://github.com/emberjs/data/pull/3753) Bumped the
+  ember-inflector version to 1.9.2.
+- [#3754](https://github.com/emberjs/data/pull/3754) Do not run tests
+  with Ember 2.0 in the Ember Data 1.13 appveyor builds
+
+
+### Release 1.13.11 (August 21, 2015)
+
+- [#3685](https://github.com/emberjs/data/pull/3685) Fixing typo that
+  causes Ember-Data v1.13.10 to crash with Ember v2.0.
+- [#3686](https://github.com/emberjs/data/pull/3686) Fix broken
+  rest-serializer test.
+
+### Release 1.13.10 (August 20, 2015)
+
+- [#3577](https://github.com/emberjs/data/pull/3577) Use the correct
+  modelClass and serializer to extract a polymorphic
+- [#3667](https://github.com/emberjs/data/pull/3667) Don’t crash \w
+  Ember 2.0
+
 
 ### Release 1.13.9 (August 13, 2015)
 


### PR DESCRIPTION
This also removes the entries for *Release 2.1.0-beta.1 (August 20,
2015)*, as those are already tracked in *Release 2.1.0*.