### PR TITLE
[BUGFIX beta] Add sha suffix to `DS.VERSION` for unreleased version

### DIFF
--- a/lib/calculate-version.js
+++ b/lib/calculate-version.js
@@ -1,10 +1,13 @@
 var path = require('path');
 var existsSync = require('exists-sync');
 var gitRepoInfo = require('git-repo-info');
+var npmGitInfo = require('npm-git-info');
 
 module.exports = function() {
   var gitPath = path.join(__dirname, '..', '.git');
-  var packageVersion = require('../package.json').version;
+  var package = require('../package.json');
+  var packageVersion = package.version;
+  var suffix = '';
 
   if (existsSync(gitPath)) {
     var info = gitRepoInfo(gitPath);
@@ -12,8 +15,13 @@ module.exports = function() {
       return info.tag.replace(/^v/, '');
     }
 
-    return packageVersion + '+' + info.sha.slice(0, 10);
+    suffix = '+' + info.sha.slice(0, 10);
   } else {
-    return packageVersion;
+    var info = npmGitInfo(package);
+    if (info.isInstalledAsNpmPackage() && !info.hasVersionInRef()) {
+      suffix = '+' + info.abbreviatedSha;
+    }
   }
+
+  return packageVersion + suffix;
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "exists-sync": "0.0.3",
     "git-repo-info": "^1.1.2",
     "inflection": "^1.8.0",
+    "npm-git-info": "^1.0.0",
     "semver": "^5.1.0",
     "silent-error": "^1.0.0"
   },


### PR DESCRIPTION
When repository URL is specified for ember-data in `package.json`, `DS.VERSION` should have git sha as suffix.
```
# package.json
"ember-data": "git@github.com:emberjs/data.git"
```

Before:
![2016-02-02 20 11 46](https://cloud.githubusercontent.com/assets/290782/12748275/96d7fcd8-c9ec-11e5-85a9-ba22fe9683bd.png)

After:
![2016-02-02 20 16 47](https://cloud.githubusercontent.com/assets/290782/12748276/96dc6c64-c9ec-11e5-872c-d5d8e9f9f2b2.png)