### PR TITLE
[BUGFIX beta] Remove unused dev-dependency module

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "ember-watson": "^0.7.0",
     "github": "^0.2.4",
     "glob": "^5.0.13",
-    "lodash.assign": "^3.2.0",
     "mocha": "^2.3.4",
     "mocha-only-detector": "0.0.2",
     "rimraf": "^2.3.2",


### PR DESCRIPTION
`lodash.assign` might be unused.