### PR TITLE
Allow 'false' payload to get normalized

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2106,7 +2106,7 @@ function _commit(adapter, store, operation, snapshot) {
   return promise.then((adapterPayload) => {
     store._adapterRun(() => {
       var payload, data;
-      if (adapterPayload) {
+      if (typeof adapterPayload !== 'undefined') {
         payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, snapshot.id, operation);
         if (payload.included) {
           store.push({ data: payload.included });

--- a/tests/unit/store/adapter-interop-test.js
+++ b/tests/unit/store/adapter-interop-test.js
@@ -277,6 +277,43 @@ test("Find with query calls the correct normalizeResponse", function(assert) {
   assert.equal(callCount, 1, 'normalizeQueryResponse was called');
 });
 
+
+test("Find with query and a response of `false` calls the correct normalizeResponse", function(assert) {
+  var passedQuery = { page: 1 };
+
+  var Person = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  var adapter = TestAdapter.extend({
+    query(store, type, query) {
+      return Ember.RSVP.resolve(false);
+    }
+  });
+
+  var callCount = 0;
+
+  var ApplicationSerializer = DS.JSONSerializer.extend({
+    normalizeQueryResponse() {
+      callCount++;
+      return { data: [] };
+    }
+  });
+
+  var env = setupStore({
+    adapter: adapter,
+    person: Person
+  });
+  var store = env.store;
+
+  env.registry.register('serializer:application', ApplicationSerializer);
+
+  run(function() {
+    store.query('person', passedQuery);
+  });
+  assert.equal(callCount, 1, 'normalizeQueryResponse was called');
+});
+
 test("peekAll(type) returns a record array of all records of a specific type", function(assert) {
   var Person = DS.Model.extend({
     name: DS.attr('string')


### PR DESCRIPTION
I'm coding against an API that returns `true` for successful update and `false` for an unsuccessful one, both with a status code of 200.

When I was attempting to customize what happened in the uncessful path, I found that my normalization code wasn't being run at all. I tracked it down to this `_commit` method in system/store.js file. `false` is a valid JSON response, so I've updated the guard to use `typeof adapterPayload !== 'undefined'`.

I'm not sure the test I wrote is in the correct place or if it will even work (the directions on the homepage didn't work for me for running the tests), any pointers / comments about that would be appreciated.

Thanks!
