### PR TITLE
[BUGFIX beta] strip assertPolymorphicType in production builds

### DIFF
--- a/addon/-private/debug.js
+++ b/addon/-private/debug.js
@@ -27,3 +27,45 @@ export function warn() {
 export function debugSeal() {
   return Ember.debugSeal(...arguments);
 }
+
+function checkPolymorphic(typeClass, addedRecord) {
+  if (typeClass.__isMixin) {
+    //TODO Need to do this in order to support mixins, should convert to public api
+    //once it exists in Ember
+    return typeClass.__mixin.detect(addedRecord.type.PrototypeMixin);
+  }
+  if (Ember.MODEL_FACTORY_INJECTIONS) {
+    typeClass = typeClass.superclass;
+  }
+  return typeClass.detect(addedRecord.type);
+}
+
+/**
+  Assert that `addedRecord` has a valid type so it can be added to the
+  relationship of the `record`.
+
+  The assert basically checks if the `addedRecord` can be added to the
+  relationship (specified via `relationshipMeta`) of the `record`.
+
+  This utility should only be used internally, as both record parameters must
+  be an InternalModel and the `relationshipMeta` needs to be the meta
+  information about the relationship, retrieved via
+  `record.relationshipFor(key)`.
+
+  @method assertPolymorphicType
+  @param {InternalModel} record
+  @param {RelationshipMeta} relationshipMeta retrieved via
+         `record.relationshipFor(key)`
+  @param {InternalModel} addedRecord record which
+         should be added/set for the relationship
+*/
+export function assertPolymorphicType(record, relationshipMeta, addedRecord) {
+  var addedType = addedRecord.type.modelName;
+  var recordType = record.type.modelName;
+  var key = relationshipMeta.key;
+  var typeClass = record.store.modelFor(relationshipMeta.type);
+
+  var assertionMessage = `You cannot add a record of type '${addedType}' to the '${recordType}.${key}' relationship (only '${typeClass.modelName}' allowed)`;
+
+  assert(assertionMessage, checkPolymorphic(typeClass, addedRecord));
+}

--- a/addon/-private/system/references/belongs-to.js
+++ b/addon/-private/system/references/belongs-to.js
@@ -2,7 +2,7 @@ import Model from 'ember-data/model';
 import Ember from 'ember';
 import Reference from './reference';
 
-import { assertPolymorphicType } from "ember-data/-private/utils";
+import { assertPolymorphicType } from "ember-data/-private/debug";
 
 var BelongsToReference = function(store, parentInternalModel, belongsToRelationship) {
   this._super$constructor(store, parentInternalModel);

--- a/addon/-private/system/references/has-many.js
+++ b/addon/-private/system/references/has-many.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import Reference from './reference';
-import { assertPolymorphicType } from 'ember-data/-private/utils';
-import { runInDebug } from 'ember-data/-private/debug';
+import {
+  assertPolymorphicType,
+  runInDebug
+} from 'ember-data/-private/debug';
 
 const get = Ember.get;
 

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -4,7 +4,7 @@ import {
   PromiseObject
 } from "ember-data/-private/system/promise-proxies";
 
-import { assertPolymorphicType } from "ember-data/-private/utils";
+import { assertPolymorphicType } from "ember-data/-private/debug";
 
 import Relationship from "ember-data/-private/system/relationships/state/relationship";
 

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -4,7 +4,7 @@ import Relationship from "ember-data/-private/system/relationships/state/relatio
 import OrderedSet from "ember-data/-private/system/ordered-set";
 import ManyArray from "ember-data/-private/system/many-array";
 
-import { assertPolymorphicType } from "ember-data/-private/utils";
+import { assertPolymorphicType } from "ember-data/-private/debug";
 
 export default function ManyRelationship(store, record, inverseKey, relationshipMeta) {
   this._super$constructor(store, record, inverseKey, relationshipMeta);

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -1,49 +1,6 @@
 import Ember from 'ember';
-import { assert } from "ember-data/-private/debug";
 
 const get = Ember.get;
-
-/**
-  Assert that `addedRecord` has a valid type so it can be added to the
-  relationship of the `record`.
-
-  The assert basically checks if the `addedRecord` can be added to the
-  relationship (specified via `relationshipMeta`) of the `record`.
-
-  This utility should only be used internally, as both record parameters must
-  be an InternalModel and the `relationshipMeta` needs to be the meta
-  information about the relationship, retrieved via
-  `record.relationshipFor(key)`.
-
-  @method assertPolymorphicType
-  @param {InternalModel} record
-  @param {RelationshipMeta} relationshipMeta retrieved via
-         `record.relationshipFor(key)`
-  @param {InternalModel} addedRecord record which
-         should be added/set for the relationship
-*/
-var assertPolymorphicType = function(record, relationshipMeta, addedRecord) {
-  var addedType = addedRecord.type.modelName;
-  var recordType = record.type.modelName;
-  var key = relationshipMeta.key;
-  var typeClass = record.store.modelFor(relationshipMeta.type);
-
-  var assertionMessage = `You cannot add a record of type '${addedType}' to the '${recordType}.${key}' relationship (only '${typeClass.modelName}' allowed)`;
-
-  assert(assertionMessage, checkPolymorphic(typeClass, addedRecord));
-};
-
-function checkPolymorphic(typeClass, addedRecord) {
-  if (typeClass.__isMixin) {
-    //TODO Need to do this in order to support mixins, should convert to public api
-    //once it exists in Ember
-    return typeClass.__mixin.detect(addedRecord.type.PrototypeMixin);
-  }
-  if (Ember.MODEL_FACTORY_INJECTIONS) {
-    typeClass = typeClass.superclass;
-  }
-  return typeClass.detect(addedRecord.type);
-}
 
 /**
   Check if the passed model has a `type` attribute or a relationship named `type`.
@@ -85,7 +42,6 @@ function getOwner(context) {
 }
 
 export {
-  assertPolymorphicType,
   modelHasAttributeOrRelationshipNamedType,
   getOwner
 };

--- a/lib/stripped-build.js
+++ b/lib/stripped-build.js
@@ -27,6 +27,7 @@ module.exports = function(packageName, tree, _options) {
     filterImports({
       'ember-data/-private/debug': [
         'assert',
+        'assertPolymorphicType',
         'debug',
         'deprecate',
         'info',

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -6,7 +6,7 @@ import {module, test} from 'qunit';
 import DS from 'ember-data';
 import Model from 'ember-data/model';
 
-import { assertPolymorphicType } from "ember-data/-private/utils";
+import { assertPolymorphicType } from "ember-data/-private/debug";
 import { modelHasAttributeOrRelationshipNamedType } from "ember-data/-private/utils";
 
 var env, User, Message, Post, Person, Video, Medium;


### PR DESCRIPTION
This assert statement checks if a record is of the expected polymporhic
type. Currently, this function is located in -private/utils and it is
not stripped from production builds. Since this function only contains
an `assert` (which gets stripped correctly), having this function in a
production build is not a severe issue.

Stripping it in production makes sense though since hereby we can get
rid of superfluous calls and it minifies the build size :hammer: