### PR TITLE
[DOC] Document behavior of object level errors with JSON API

### DIFF
--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -96,6 +96,33 @@ var MapWithDefault = Ember.MapWithDefault;
   {{/each}}
   ```
 
+  The JSON API spec also allows for object level errors to be placed
+  in an object with pointer `data`.
+
+  ```javascript
+  {
+    "errors": [
+      {
+        "detail": "Some generic non property error message",
+        "source": {
+          "pointer": "data"
+        }
+      }
+    ]
+  }
+  ```
+
+  You can access these errors by using the `base` property on the errors
+  object.
+
+  ```handlebars
+  {{#each model.errors.base as |error|}}
+    <div class="error">
+      {{error.message}}
+    </div>
+  {{/each}}
+  ```
+
   @class Errors
   @namespace DS
   @extends Ember.Object


### PR DESCRIPTION
This documents behavior added in https://github.com/emberjs/data/pull/3909.