### PR TITLE
Fix key remapping for embedded belongsTo

### DIFF
--- a/addon/-private/serializers/embedded-records-mixin.js
+++ b/addon/-private/serializers/embedded-records-mixin.js
@@ -217,7 +217,11 @@ export default Ember.Mixin.create({
 
   _serializeEmbeddedBelongsTo(snapshot, json, relationship) {
     let embeddedSnapshot = snapshot.belongsTo(relationship.key);
-    let serializedKey = this.keyForRelationship(relationship.key, relationship.kind, 'serialize');
+    var serializedKey = this._getMappedKey(relationship.key, snapshot.type);
+    if (serializedKey === relationship.key && this.keyForRelationship) {
+      serializedKey = this.keyForRelationship(relationship.key, relationship.kind, "serialize");
+    }
+
     if (!embeddedSnapshot) {
       json[serializedKey] = null;
     } else {
@@ -332,7 +336,11 @@ export default Ember.Mixin.create({
   },
 
   _serializeEmbeddedHasMany(snapshot, json, relationship) {
-    let serializedKey = this.keyForRelationship(relationship.key, relationship.kind, 'serialize');
+    var serializedKey = this._getMappedKey(relationship.key, snapshot.type);
+    if (serializedKey === relationship.key && this.keyForRelationship) {
+      serializedKey = this.keyForRelationship(relationship.key, relationship.kind, "serialize");
+    }
+
 
     warn(
       `The embedded relationship '${serializedKey}' is undefined for '${snapshot.modelName}' with id '${snapshot.id}'. Please include it in your original payload.`,

--- a/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/tests/integration/serializers/embedded-records-mixin-test.js
@@ -2145,3 +2145,69 @@ test("serializing belongsTo correctly removes embedded foreign key", function(as
     }
   });
 });
+
+
+test("serializing embedded belongsTo respects remapped attrs key", function(assert) {
+  run(function() {
+    homePlanet = env.store.createRecord('home-planet', { name: "Hoth" });
+    superVillain = env.store.createRecord('super-villain', { firstName: "Ice", lastName: "Creature", homePlanet: homePlanet });
+  });
+
+  env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      homePlanet: { embedded: 'always', key: 'favorite_place' }
+    }
+  }));
+
+  var serializer = env.store.serializerFor("super-villain");
+  var json;
+
+  run(function() {
+    json = serializer.serialize(superVillain._createSnapshot());
+  });
+
+  assert.deepEqual(json, {
+    firstName: "Ice",
+    lastName: "Creature",
+    favorite_place: {
+      name: "Hoth"
+    },
+    secretLab: null
+  });
+});
+
+test("serializing embedded hasMany respects remapped attrs key", function(assert) {
+  run(function() {
+    homePlanet = env.store.createRecord('home-planet', { name: "Hoth" });
+    superVillain = env.store.createRecord('super-villain', { firstName: "Ice", lastName: "Creature", homePlanet: homePlanet });
+  });
+
+  env.registry.register('serializer:home-planet', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      villains: { embedded: 'always', key: 'notable_persons' }
+    }
+  }));
+
+  env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      homePlanet: { serialize: false },
+      secretLab: { serialize: false }
+    }
+  }));
+
+
+  var serializer = env.store.serializerFor("home-planet");
+  var json;
+
+  run(function() {
+    json = serializer.serialize(homePlanet._createSnapshot());
+  });
+
+  assert.deepEqual(json, {
+    name: "Hoth",
+    notable_persons: [{
+      firstName: 'Ice',
+      lastName: 'Creature'
+    }]
+  });
+});


### PR DESCRIPTION
Closes #4068. This implements the same semantics for `key` that are used in JSONSerializer.