### PR TITLE
[BUGFIX beta] Use registry instead of container in tests

### DIFF
--- a/tests/integration/references/has-many-test.js
+++ b/tests/integration/references/has-many-test.js
@@ -171,7 +171,7 @@ if (isEnabled("ds-references")) {
   test("push(array) works with polymorphic type", function(assert) {
     var done = assert.async();
 
-    env.container.register('model:mafia-boss', Person.extend());
+    env.registry.register('model:mafia-boss', Person.extend());
 
     var family;
     run(function() {


### PR DESCRIPTION
This is the preferred method way to register additional stuff.