### PR TITLE
Fixes broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ set of RESTful JSON conventions.
 
 To learn more about adapters, including what conventions the
 `RESTAdapter` follows and how to build your own, see the Ember.js
-Guides: [Connecting to an HTTP
-Server](http://emberjs.com/guides/models/connecting-to-an-http-server/).
+Guides: [Customizing Adapters](https://guides.emberjs.com/v2.3.0/models/customizing-adapters/).
 
 ### Fetching a Collection of Models
 


### PR DESCRIPTION
Previously the link to the emberjs guides on customizing adapters was broken, this fix points to the correct link for the current stable version of emberjs and ember data.

Looks like the previous link (https://guides.emberjs.com/v2.0.0/models/connecting-to-an-http-server/) was resolving to the version 2.0 guides on Models -> Connecting to an HTTP Server, but that does not exist anymore. It is now just Models -> Customizing Adapters.