### PR TITLE
[CLEANUP] remove `toString` definitions for models in tests

### DIFF
--- a/tests/integration/adapter/build-url-mixin-test.js
+++ b/tests/integration/adapter/build-url-mixin-test.js
@@ -15,10 +15,6 @@ module("integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter", {
       name: DS.attr("string")
     });
 
-    Post.toString = function() {
-      return "Post";
-    };
-
     Comment = DS.Model.extend({
       name: DS.attr("string")
     });

--- a/tests/integration/adapter/record-persistence-test.js
+++ b/tests/integration/adapter/record-persistence-test.js
@@ -22,7 +22,6 @@ module("integration/adapter/record_persistence - Persisting Records", {
       firstName: attr('string'),
       lastName: attr('string')
     });
-    Person.toString = function() { return "Person"; };
 
     env = setupStore({
       adapter: DS.Adapter.extend({

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -17,10 +17,6 @@ module("integration/adapter/rest_adapter - REST Adapter", {
       name: DS.attr("string")
     });
 
-    Post.toString = function() {
-      return "Post";
-    };
-
     Comment = DS.Model.extend({
       name: DS.attr("string")
     });

--- a/tests/integration/debug-adapter-test.js
+++ b/tests/integration/debug-adapter-test.js
@@ -12,7 +12,6 @@ module("DS.DebugAdapter", {
   beforeEach() {
     Ember.run(function() {
       App = Ember.Application.create();
-      App.toString = function() { return 'App'; };
 
       App.StoreService = DS.Store.extend({});
 

--- a/tests/integration/record-array-manager-test.js
+++ b/tests/integration/record-array-manager-test.js
@@ -13,15 +13,11 @@ var Person = DS.Model.extend({
   cars: DS.hasMany('car', { async: false })
 });
 
-Person.toString = function() { return "Person"; };
-
 var Car = DS.Model.extend({
   make: DS.attr('string'),
   model: DS.attr('string'),
   person: DS.belongsTo('person', { async: false })
 });
-
-Car.toString = function() { return "Car"; };
 
 var manager;
 

--- a/tests/integration/records/collection-save-test.js
+++ b/tests/integration/records/collection-save-test.js
@@ -14,8 +14,6 @@ module("integration/records/collection_save - Save Collection of Records", {
       title: DS.attr('string')
     });
 
-    Post.toString = function() { return "Post"; };
-
     env = setupStore({ post: Post });
   },
 

--- a/tests/integration/records/delete-record-test.js
+++ b/tests/integration/records/delete-record-test.js
@@ -15,8 +15,6 @@ module("integration/deletedRecord - Deleting Records", {
       name: attr('string')
     });
 
-    Person.toString = function() { return "Person"; };
-
     env = setupStore({
       person: Person
     });

--- a/tests/integration/records/error-test.js
+++ b/tests/integration/records/error-test.js
@@ -13,7 +13,6 @@ module('integration/records/error', {
       firstName: attr('string'),
       lastName: attr('string')
     });
-    Person.toString = function() { return 'Person'; };
 
     env = setupStore({
       person: Person

--- a/tests/integration/records/load-test.js
+++ b/tests/integration/records/load-test.js
@@ -17,9 +17,6 @@ module("integration/load - Loading Records", {
 
     Comment = DS.Model.extend();
 
-    Post.toString = function() { return "Post"; };
-    Comment.toString = function() { return "Comment"; };
-
     env = setupStore({ post: Post, comment: Comment });
   },
 

--- a/tests/integration/records/property-changes-test.js
+++ b/tests/integration/records/property-changes-test.js
@@ -15,7 +15,6 @@ module('integration/records/property-changes - Property changes', {
       firstName: attr('string'),
       lastName: attr('string')
     });
-    Person.toString = function() { return 'Person'; };
 
     env = setupStore({
       person: Person

--- a/tests/integration/records/reload-test.js
+++ b/tests/integration/records/reload-test.js
@@ -19,8 +19,6 @@ module("integration/reload - Reloading Records", {
       lastName: attr('string')
     });
 
-    Person.toString = function() { return "Person"; };
-
     env = setupStore({ person: Person });
   },
 

--- a/tests/integration/records/save-test.js
+++ b/tests/integration/records/save-test.js
@@ -14,8 +14,6 @@ module("integration/records/save - Save Record", {
       title: DS.attr('string')
     });
 
-    Post.toString = function() { return "Post"; };
-
     env = setupStore({ post: Post });
   },
 

--- a/tests/integration/records/unload-test.js
+++ b/tests/integration/records/unload-test.js
@@ -16,21 +16,15 @@ var Person = DS.Model.extend({
   cars: hasMany('car', { async: false })
 });
 
-Person.toString = function() { return "Person"; };
-
 var Group = DS.Model.extend({
   people: hasMany('person', { async: false })
 });
-
-Group.toString = function() { return "Group"; };
 
 var Car = DS.Model.extend({
   make: attr('string'),
   model: attr('string'),
   person: belongsTo('person', { async: false })
 });
-
-Car.toString = function() { return "Car"; };
 
 module("integration/unload - Unloading Records", {
   beforeEach() {

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -15,10 +15,6 @@ var attr = DS.attr;
 var hasMany = DS.hasMany;
 var belongsTo = DS.belongsTo;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module("integration/relationships/has_many - Has-Many Relationships", {
   beforeEach() {
     User = DS.Model.extend({
@@ -43,37 +39,31 @@ module("integration/relationships/has_many - Has-Many Relationships", {
       user: belongsTo('user', { async: false }),
       created_at: attr('date')
     });
-    Message.toString = stringify('Message');
 
     Post = Message.extend({
       title: attr('string'),
       comments: hasMany('comment', { async: false })
     });
-    Post.toString = stringify('Post');
 
     Comment = Message.extend({
       body: DS.attr('string'),
       message: DS.belongsTo('post', { polymorphic: true, async: true })
     });
-    Comment.toString = stringify('Comment');
 
     Book = DS.Model.extend({
       title: attr(),
       chapters: hasMany('chapter', { async: true })
     });
-    Book.toString = stringify('Book');
 
     Chapter = DS.Model.extend({
       title: attr(),
       pages: hasMany('page', { async: false })
     });
-    Chapter.toString = stringify('Chapter');
 
     Page = DS.Model.extend({
       number: attr('number'),
       chapter: belongsTo('chapter', { async: false })
     });
-    Page.toString = stringify('Page');
 
     env = setupStore({
       user: User,

--- a/tests/integration/relationships/many-to-many-test.js
+++ b/tests/integration/relationships/many-to-many-test.js
@@ -11,10 +11,6 @@ var run = Ember.run;
 var attr = DS.attr;
 var hasMany = DS.hasMany;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module('integration/relationships/many_to_many_test - ManyToMany relationships', {
   beforeEach() {
     User = DS.Model.extend({
@@ -23,21 +19,15 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
       accounts: hasMany('account', { async: false })
     });
 
-    User.toString = stringify('User');
-
     Account = DS.Model.extend({
       state: attr(),
       users: hasMany('user', { async: false })
     });
 
-    Account.toString = stringify('Account');
-
     Topic = DS.Model.extend({
       title: attr('string'),
       users: hasMany('user', { async: true })
     });
-
-    Topic.toString = stringify('Topic');
 
     env = setupStore({
       user: User,

--- a/tests/integration/relationships/one-to-many-test.js
+++ b/tests/integration/relationships/one-to-many-test.js
@@ -13,10 +13,6 @@ var attr = DS.attr;
 var hasMany = DS.hasMany;
 var belongsTo = DS.belongsTo;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module('integration/relationships/one_to_many_test - OneToMany relationships', {
   beforeEach() {
     User = DS.Model.extend({
@@ -24,19 +20,16 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', {
       messages: hasMany('message', { async: true }),
       accounts: hasMany('account', { async: false })
     });
-    User.toString = stringify('User');
 
     Account = DS.Model.extend({
       state: attr(),
       user: belongsTo('user', { async: false })
     });
-    Account.toString = stringify('Account');
 
     Message = DS.Model.extend({
       title: attr('string'),
       user: belongsTo('user', { async: true })
     });
-    Message.toString = stringify('Message');
 
     env = setupStore({
       user: User,

--- a/tests/integration/relationships/one-to-one-test.js
+++ b/tests/integration/relationships/one-to-one-test.js
@@ -11,10 +11,6 @@ var run = Ember.run;
 var attr = DS.attr;
 var belongsTo = DS.belongsTo;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module('integration/relationships/one_to_one_test - OneToOne relationships', {
   beforeEach() {
     User = DS.Model.extend({
@@ -22,13 +18,11 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', {
       bestFriend: belongsTo('user', { async: true, inverse: 'bestFriend' }),
       job: belongsTo('job', { async: false })
     });
-    User.toString = stringify('User');
 
     Job = DS.Model.extend({
       isGood: attr(),
       user: belongsTo('user', { async: false })
     });
-    Job.toString = stringify('Job');
 
     env = setupStore({
       user: User,

--- a/tests/integration/relationships/polymorphic-mixins-belongs-to-test.js
+++ b/tests/integration/relationships/polymorphic-mixins-belongs-to-test.js
@@ -11,23 +11,17 @@ var run = Ember.run;
 var attr = DS.attr;
 var belongsTo = DS.belongsTo;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module('integration/relationships/polymorphic_mixins_belongs_to_test - Polymorphic belongsTo relationships with mixins', {
   beforeEach() {
     User = DS.Model.extend({
       name: attr('string'),
       bestMessage: belongsTo('message', { async: true, polymorphic: true })
     });
-    User.toString = stringify('User');
 
     Message = Ember.Mixin.create({
       title: attr('string'),
       user: belongsTo('user', { async: true })
     });
-    Message.toString = stringify('Message');
 
     NotMessage = DS.Model.extend({
       video: attr()

--- a/tests/integration/relationships/polymorphic-mixins-has-many-test.js
+++ b/tests/integration/relationships/polymorphic-mixins-has-many-test.js
@@ -12,23 +12,17 @@ var attr = DS.attr;
 var hasMany = DS.hasMany;
 var belongsTo = DS.belongsTo;
 
-function stringify(string) {
-  return function() { return string; };
-}
-
 module('integration/relationships/polymorphic_mixins_has_many_test - Polymorphic hasMany relationships with mixins', {
   beforeEach() {
     User = DS.Model.extend({
       name: attr('string'),
       messages: hasMany('message', { async: true, polymorphic: true })
     });
-    User.toString = stringify('User');
 
     Message = Ember.Mixin.create({
       title: attr('string'),
       user: belongsTo('user', { async: true })
     });
-    Message.toString = stringify('Message');
 
     Video = DS.Model.extend(Message, {
       video: attr()

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -14,15 +14,11 @@ var Person = DS.Model.extend({
 
 var run = Ember.run;
 
-Person.toString = function() { return "Person"; };
-
 var Car = DS.Model.extend({
   make: DS.attr('string'),
   model: DS.attr('string'),
   person: DS.belongsTo('person', { async: false })
 });
-
-Car.toString = function() { return "Car"; };
 
 function initializeStore(adapter) {
   env = setupStore({

--- a/tests/unit/many-array-test.js
+++ b/tests/unit/many-array-test.js
@@ -19,17 +19,11 @@ module("unit/many_array - DS.ManyArray", {
       title: attr('string'),
       tags: hasMany('tag', { async: false })
     });
-    Post.toString = function() {
-      return 'Post';
-    };
 
     Tag = DS.Model.extend({
       name: attr('string'),
       post: belongsTo('post', { async: false })
     });
-    Tag.toString = function() {
-      return 'Tag';
-    };
 
     env = setupStore({
       post: Post,

--- a/tests/unit/model/relationships/belongs-to-test.js
+++ b/tests/unit/model/relationships/belongs-to-test.js
@@ -17,13 +17,11 @@ test("belongsTo lazily loads relationships as needed", function(assert) {
     name: DS.attr('string'),
     people: DS.hasMany('person', { async: false })
   });
-  Tag.toString = function() { return "Tag"; };
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     tag: DS.belongsTo('tag', { async: false })
   });
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;
@@ -202,14 +200,10 @@ test("When finding a hasMany relationship the inverse belongsTo relationship is 
     person: DS.belongsTo('person', { async: false })
   });
 
-  Occupation.toString = function() { return "Occupation"; };
-
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     occupations: DS.hasMany('occupation', { async: true })
   });
-
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ occupation: Occupation, person: Person });
   var store = env.store;
@@ -265,14 +259,10 @@ test("When finding a belongsTo relationship the inverse belongsTo relationship i
     person: DS.belongsTo('person', { async: false })
   });
 
-  Occupation.toString = function() { return "Occupation"; };
-
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     occupation: DS.belongsTo('occupation', { async: true })
   });
-
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ occupation: Occupation, person: Person });
   var store = env.store;
@@ -317,7 +307,6 @@ test("belongsTo supports relationships to models with id 0", function(assert) {
     name: DS.attr('string'),
     tag: DS.belongsTo('tag', { async: false })
   });
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;
@@ -375,13 +364,11 @@ test("belongsTo gives a warning when provided with a serialize option", function
   var Hobby = DS.Model.extend({
     name: DS.attr('string')
   });
-  Hobby.toString = function() { return "Hobby"; };
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     hobby: DS.belongsTo('hobby', { serialize: true, async: true })
   });
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ hobby: Hobby, person: Person });
   var store = env.store;
@@ -429,13 +416,11 @@ test("belongsTo gives a warning when provided with an embedded option", function
   var Hobby = DS.Model.extend({
     name: DS.attr('string')
   });
-  Hobby.toString = function() { return "Hobby"; };
 
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     hobby: DS.belongsTo('hobby', { embedded: true, async: true })
   });
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ hobby: Hobby, person: Person });
   var store = env.store;

--- a/tests/unit/model/relationships/has-many-test.js
+++ b/tests/unit/model/relationships/has-many-test.js
@@ -478,14 +478,10 @@ test("hasMany relationships work when the data hash has not been loaded", functi
     person: DS.belongsTo('person', { async: false })
   });
 
-  Tag.toString = function() { return "Tag"; };
-
   var Person = DS.Model.extend({
     name: DS.attr('string'),
     tags: DS.hasMany('tag', { async: true })
   });
-
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;
@@ -721,9 +717,6 @@ test("it is possible to add an item to a relationship, remove it, then add it ag
     name: DS.attr('string'),
     tags: DS.hasMany('tag', { async: false })
   });
-
-  Tag.toString = function() { return "Tag"; };
-  Person.toString = function() { return "Person"; };
 
   var env = setupStore({ tag: Tag, person: Person });
   var store = env.store;

--- a/tests/unit/store/has-record-for-id-test.js
+++ b/tests/unit/store/has-record-for-id-test.js
@@ -19,17 +19,11 @@ module("unit/store/hasRecordForId - Store hasRecordForId", {
       lastName: attr('string'),
       phoneNumbers: hasMany('phone-number', { async: false })
     });
-    Person.toString = function() {
-      return 'Person';
-    };
 
     PhoneNumber = DS.Model.extend({
       number: attr('string'),
       person: belongsTo('person', { async: false })
     });
-    PhoneNumber.toString = function() {
-      return 'PhoneNumber';
-    };
 
     env = setupStore({
       person: Person,

--- a/tests/unit/store/peek-record-test.js
+++ b/tests/unit/store/peek-record-test.js
@@ -12,9 +12,6 @@ module("unit/store/peekRecord - Store peekRecord", {
   beforeEach() {
 
     Person = DS.Model.extend();
-    Person.toString = function() {
-      return 'Person';
-    };
 
     env = setupStore({
       person: Person

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -20,24 +20,15 @@ module("unit/store/push - DS.Store#push", {
       lastName: attr('string'),
       phoneNumbers: hasMany('phone-number', { async: false })
     });
-    Person.toString = function() {
-      return 'Person';
-    };
 
     PhoneNumber = DS.Model.extend({
       number: attr('string'),
       person: belongsTo('person', { async: false })
     });
-    PhoneNumber.toString = function() {
-      return 'PhoneNumber';
-    };
 
     Post = DS.Model.extend({
       postTitle: attr('string')
     });
-    Post.toString = function() {
-      return 'Post';
-    };
 
     env = setupStore({
       post: Post,
@@ -706,15 +697,11 @@ module("unit/store/push - DS.Store#push with JSON-API", {
       cars: DS.hasMany('car', { async: false })
     });
 
-    Person.toString = function() { return "Person"; };
-
     var Car = DS.Model.extend({
       make: DS.attr('string'),
       model: DS.attr('string'),
       person: DS.belongsTo('person', { async: false })
     });
-
-    Car.toString = function() { return "Car"; };
 
     env = setupStore({
       adapter: DS.Adapter,


### PR DESCRIPTION
My string theory: the definitions for `toString` are a relict from the
pre-container era where this might have been needed. :barber:

This makes the recently failing builds for `master` green again. :green_apple: 

---

Note: the tests were failing since `2.3.1` ember seals `Mixin` so adding stuff
after `create` will error out: emberjs/ember.js#12612.