### PR TITLE
TravisCI: Use PhantomJS v2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: node_js
-sudo: required
-dist: trusty
+sudo: false
 node_js:
   - "4.2"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ sudo: false
 node_js:
   - "4.2"
 before_install:
+  - mkdir travis-phantomjs
+  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 install:


### PR DESCRIPTION
This PR changes the TravisCI builds back to their containerized infrastructure and installs PhantomJS v2.1.1 manually. This should significantly reduce the TravisCI startup times since their containerized infrastructure boots much faster and more instances are available.

see 8011a0484f483cad26d7c2a1c5ba2774a24d0488 for the commit that originally changed this