### PR TITLE
Simplify PhantomJS installation on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ sudo: false
 node_js:
   - "4.2"
 before_install:
-  - mkdir travis-phantomjs
-  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
+  - npm install -g phantomjs-prebuilt@2
+
 install:
   - npm install --no-optional
   - ./node_modules/.bin/bower install


### PR DESCRIPTION
This PR simplifies the PhantomJS installation on TravisCI by using the `phantomjs-prebuilt` NPM package.