### PR TITLE
[CLEANUP] Remove shim for Ember.Service

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -118,10 +118,7 @@ var Promise = Ember.RSVP.Promise;
 var copy = Ember.copy;
 var Store;
 
-var Service = Ember.Service;
-if (!Service) {
-  Service = Ember.Object;
-}
+const { Service } = Ember;
 
 // Implementors Note:
 //


### PR DESCRIPTION
Removes a shim for `Ember.Service`.

This isn't needed anymore since Ember 2.x.x all have `Ember.Service` available.