### PR TITLE
blueprints: Use project.dependencies() to determine test framework

### DIFF
--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -8,10 +8,11 @@ module.exports = function(blueprint) {
   blueprint.filesPath = function() {
     var type;
 
-    if ('ember-cli-mocha' in this.project.addonPackages) {
-      type = 'mocha';
-    } else if ('ember-cli-qunit' in this.project.addonPackages) {
+    var dependencies = this.project.dependencies();
+    if ('ember-cli-qunit' in dependencies) {
       type = 'qunit';
+    } else if ('ember-cli-mocha' in dependencies) {
+      type = 'mocha';
     } else {
       this.ui.writeLine('Couldn\'t determine test style - using QUnit');
       type = 'qunit';


### PR DESCRIPTION
This PR is changing the test framework detector of the blueprints to use `project.dependencies()` instead of `project.addonPackages`. This has the advantage of not requiring the test framework to actually be installed and will enable us to test the mocha blueprints properly.

see https://github.com/ember-cli/ember-cli-blueprint-test-helpers/pull/28 for further information on this

/cc @rwjblue @trabus 