### PR TITLE
AppVeyor: Use same line endings as original files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 # http://www.appveyor.com/docs/appveyor-yml
 
-# Fix line endings in Windows. (runs before repo cloning)
-init:
-  - git config --global core.autocrlf true
-
 # Test against these versions of Node.js.
 environment:
   matrix:


### PR DESCRIPTION
As a `npm install ember-data` on Windows will result in files with the original line endings (`\n`) we should also test in that configuration instead of using native line endings.