### PR TITLE
Use modelNameFromPayloadKey when type is given

### DIFF
--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -200,8 +200,8 @@ var RESTSerializer = JSONSerializer.extend({
     const primaryHasTypeAttribute = modelHasAttributeOrRelationshipNamedType(primaryModelClass);
     // Support polymorphic records in async relationships
     if (!primaryHasTypeAttribute && hash.type && store._hasModelFor(this.modelNameFromPayloadKey(hash.type))) {
-      serializer = store.serializerFor(hash.type);
-      modelClass = store.modelFor(hash.type);
+      serializer = store.serializerFor(this.modelNameFromPayloadKey(hash.type));
+      modelClass = store.modelFor(this.modelNameFromPayloadKey(hash.type));
     } else {
       serializer = primarySerializer;
       modelClass = primaryModelClass;


### PR DESCRIPTION
The code checked for a model using the possibly-overridden `modelNameFromPayloadKey` but didn’t use the override when getting the serialiser and model.

The test is really only verifying the `store.modelFor(this.modelNameFromPayloadKey(hash.type));` change, not the serialiser one, since I didn’t see any tests for custom serialisers in this file. Let me know if I should make a test for that regardless.