### PR TITLE
Restructure and elaborate on test which fixes a tricky bug

### DIFF
--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -79,6 +79,9 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
     //a hack for not removing new records
     //TODO remove once we have proper diffing
     var newRecords = this.currentState.filter(
+      // only add new records which are not yet in the canonical state of this
+      // relationship (a new record can be in the canonical state if it has
+      // been 'acknowleged' to be in the relationship via a store.push)
       (internalModel) => internalModel.isNew() && toSet.indexOf(internalModel) === -1
     );
     toSet = toSet.concat(newRecords);


### PR DESCRIPTION
This slightly restructures and adds more comments to a test, which fixed
a tricky bug which occurred while updating the canonical state of a
hasMany relationship in combination with locally created records.