### PR TITLE
Fix RESTAdapter.findRecord without a snapshot

### DIFF
--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -993,13 +993,15 @@ export default Adapter.extend(BuildURLMixin, {
   },
 
   buildQuery(snapshot) {
-    const { include } = snapshot;
-
     let query = {};
 
     if (isEnabled('ds-finder-include')) {
-      if (include) {
-        query.include = include;
+      if(snapshot) {
+        const { include } = snapshot;
+
+        if (include) {
+          query.include = include;
+        }
       }
     }
 

--- a/tests/unit/adapters/rest-adapter/build-query-test.js
+++ b/tests/unit/adapters/rest-adapter/build-query-test.js
@@ -13,6 +13,13 @@ test("buildQuery() returns an empty query when snapshot has no query params", fu
   assert.deepEqual(query, {}, 'query is empty');
 });
 
+test("buildQuery - doesn't fail without a snapshot", function(assert) {
+  const adapter = DS.RESTAdapter.create();
+  const query = adapter.buildQuery();
+
+  assert.deepEqual(query, {}, 'returns an empty query');
+});
+
 if (isEnabled('ds-finder-include')) {
   test("buildQuery() returns query with `include` from snapshot", function(assert) {
     const adapter = DS.RESTAdapter.create();


### PR DESCRIPTION
From the commit message:

```
Before introducing a feature ds-finder-include it was possible to run
findRecord on an adapter without passing a snapshot. After introducing
the feature it's no longer possible even if the feature is disabled,
because some of the code was outsief of the flag check.

This commit fixes the code to work like before introducing the
ds-finer-include change.
```

I'm not 100% sure if this is public behaviour of `findRecord`, but it will cause regressions for people that use it. In case it's not an issue, I can also submit a PR to have a more meaningful error (like "You need to pass a snapshot to `findRecord`").