### PR TITLE
[BUGFIX release] ensure import paths are resolved \w posix separators

### DIFF
--- a/lib/babel-build.js
+++ b/lib/babel-build.js
@@ -25,13 +25,7 @@ function babelOptions(libraryName, _options) {
     getModuleId: function (name) {
       return name.replace(/\/index$/g, '');
     },
-    resolveModuleSource: function(name, filename) {
-      if (name.indexOf('.') === 0) {
-        return libraryName + '/' + path.join(path.dirname(filename), name);
-      } else {
-        return name;
-      }
-    }
+    resolveModuleSource: require('amd-name-resolver').moduleResolve
   };
 
   Object.keys(_options).forEach(function(opt) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "amd-name-resolver": "0.0.5",
     "babel-plugin-feature-flags": "^0.2.0",
     "babel-plugin-filter-imports": "^0.2.0",
     "broccoli-babel-transpiler": "^5.5.0",


### PR DESCRIPTION
* share the same algorithm ember.js uses
* path.join defaults to path[platform].join which results in path.win32.join on windows and path.posix.join on everything else.