### PR TITLE
Fix AMD dependencies

### DIFF
--- a/lib/babel-build.js
+++ b/lib/babel-build.js
@@ -1,5 +1,6 @@
 var babel = require('broccoli-babel-transpiler');
 var path  = require('path');
+var moduleResolve = require('amd-name-resolver').moduleResolve;
 
 function babelOptions(libraryName, _options) {
   _options = _options || {};
@@ -20,12 +21,12 @@ function babelOptions(libraryName, _options) {
     sourceMaps: false,
     modules: 'amdStrict',
     moduleRoot: libraryName,
-    moduleId: true,
+    moduleIds: true,
     // Transforms /index.js files to use their containing directory name
     getModuleId: function (name) {
       return name.replace(/\/index$/g, '');
     },
-    resolveModuleSource: require('amd-name-resolver').moduleResolve
+    resolveModuleSource: moduleResolve
   };
 
   Object.keys(_options).forEach(function(opt) {


### PR DESCRIPTION
This fixes the module name resolution. Currently production builds do
not resolve correctly as the dependencies of modules are being resolved
like the following.

```
define('ember-data/-private/system/references',
['exports',
'-private/system/references/record',
'-private/system/references/belongs-to',
'-private/system/references/has-many'],
function (exports, _privateSystemReferencesRecord, _privateSystemReferencesBelongsTo, _privateSystemReferencesHasMany) {...});
```

The module names should get resolved now. Such babel config.