### PR TITLE
Run tests in production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - ./bin/lint-features
   - npm run-script test
   - npm run-script test:optional-features
+  - npm run-script test:production
   - npm run-script node-tests
 after_success:
   - npm run-script production

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ test_script:
   - npm version
   - cmd: npm run test
   - cmd: npm run test:optional-features
+  - cmd: npm run test:production
   - cmd: npm run node-tests
 
 # Don't actually build.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "ember try:testall",
     "node-tests": "node node-tests/nodetest-runner.js",
     "test:optional-features": "ember test --environment=test-optional-features",
+    "test:production": "ember test --environment=production",
     "bower": "bower install",
     "production": "ember build --environment=production"
   },

--- a/tests/helpers/test-in-debug.js
+++ b/tests/helpers/test-in-debug.js
@@ -1,0 +1,16 @@
+import { runInDebug } from 'ember-data/-private/debug';
+import { test, skip } from 'qunit';
+
+export default function testInDebug() {
+  let isDebug = false;
+
+  runInDebug(function() {
+    isDebug = true;
+  });
+
+  if (isDebug) {
+    test(...arguments);
+  } else {
+    skip(...arguments);
+  }
+}

--- a/tests/integration/adapter/find-all-test.js
+++ b/tests/integration/adapter/find-all-test.js
@@ -1,6 +1,7 @@
 import {createStore} from 'dummy/tests/helpers/store';
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 import DS from 'ember-data';
 
@@ -145,7 +146,7 @@ test("When all records for a type are requested, records that are created on the
   assert.equal(allRecords.objectAt(0).get('name'), "Carsten Nielsen", "the first item in the record array is Carsten Nielsen");
 });
 
-test('When all records are requested, assert the payload is not blank', (assert) => {
+testInDebug('When all records are requested, assert the payload is not blank', (assert) => {
   env.registry.register('adapter:person', DS.Adapter.extend({
     findAll: () => Ember.RSVP.resolve({})
   }));

--- a/tests/integration/adapter/find-test.js
+++ b/tests/integration/adapter/find-test.js
@@ -1,5 +1,6 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 import DS from 'ember-data';
 
@@ -29,7 +30,7 @@ module("integration/adapter/find - Finding Records", {
   }
 });
 
-test("It raises an assertion when `undefined` is passed as id (#1705)", (assert) => {
+testInDebug("It raises an assertion when `undefined` is passed as id (#1705)", (assert) => {
   assert.expectAssertion(() => {
     store.find('person', undefined);
   }, "You cannot pass `undefined` as id to the store's find method");
@@ -130,7 +131,7 @@ test("When a single record is requested, and the promise is rejected, the record
   });
 });
 
-test('When a single record is requested, and the payload is blank', (assert) => {
+testInDebug('When a single record is requested, and the payload is blank', (assert) => {
   env.registry.register('adapter:person', DS.Adapter.extend({
     findRecord: () => Ember.RSVP.resolve({})
   }));
@@ -140,7 +141,7 @@ test('When a single record is requested, and the payload is blank', (assert) => 
   }, /the adapter's response did not have any data/);
 });
 
-test('When multiple records are requested, and the payload is blank', (assert) => {
+testInDebug('When multiple records are requested, and the payload is blank', (assert) => {
   env.registry.register('adapter:person', DS.Adapter.extend({
     coalesceFindRequests: true,
     findMany: () => Ember.RSVP.resolve({})

--- a/tests/integration/adapter/queries-test.js
+++ b/tests/integration/adapter/queries-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -28,13 +29,13 @@ module("integration/adapter/queries - Queries", {
   }
 });
 
-test("It raises an assertion when no type is passed", function(assert) {
+testInDebug("It raises an assertion when no type is passed", function(assert) {
   assert.expectAssertion(function() {
     store.query();
   }, "You need to pass a type to the store's query method");
 });
 
-test("It raises an assertion when no query hash is passed", function(assert) {
+testInDebug("It raises an assertion when no query hash is passed", function(assert) {
   assert.expectAssertion(function() {
     store.query('person');
   }, "You need to pass a query hash to the store's query method");
@@ -56,7 +57,7 @@ test("When a query is made, the adapter should receive a record array it can pop
   }));
 });
 
-test("The store asserts when query is made and the adapter responses with a single record.", function(assert) {
+testInDebug("The store asserts when query is made and the adapter responses with a single record.", function(assert) {
   env = setupStore({ person: Person, adapter: DS.RESTAdapter });
   store = env.store;
   adapter = env.adapter;

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -1326,7 +1327,7 @@ test("queryRecord - returning an array picks the first one but saves all records
   }));
 });
 
-test("queryRecord - returning an empty array errors", function(assert) {
+testInDebug("queryRecord - returning an empty array errors", function(assert) {
   ajaxResponse({
     post: []
   });
@@ -1876,7 +1877,7 @@ test('findBelongsTo - passes buildURL the requestType', function(assert) {
   }));
 });
 
-test('coalesceFindRequests assert.warns if the expected records are not returned in the coalesced request', function(assert) {
+testInDebug('coalesceFindRequests assert.warns if the expected records are not returned in the coalesced request', function(assert) {
   Comment.reopen({ post: DS.belongsTo('post', { async: false }) });
   Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
 

--- a/tests/integration/inverse-test.js
+++ b/tests/integration/inverse-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -98,7 +99,7 @@ test("Returns null if inverse relationship it is manually set with a different r
   assert.equal(User.inverseFor('job', store), null, 'There is no inverse');
 });
 
-test("Errors out if you define 2 inverses to the same model", function(assert) {
+testInDebug("Errors out if you define 2 inverses to the same model", function(assert) {
   Job.reopen({
     user: belongsTo('user', { inverse: 'job', async: false }),
     owner: belongsTo('user', { inverse: 'job', async: false })
@@ -125,7 +126,7 @@ test("Caches findInverseFor return value", function(assert) {
   assert.equal(inverseForUser, Job.inverseFor('user', store), 'Inverse cached succesfully');
 });
 
-test("Errors out if you do not define an inverse for a reflexive relationship", function(assert) {
+testInDebug("Errors out if you do not define an inverse for a reflexive relationship", function(assert) {
 
   //Maybe store is evaluated lazily, so we need this :(
   assert.expectWarning(function() {

--- a/tests/integration/references/belongs-to-test.js
+++ b/tests/integration/references/belongs-to-test.js
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 import setupStore from 'dummy/tests/helpers/store';
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { module, test } from 'qunit';
 import isEnabled from 'ember-data/-private/features';
 
@@ -251,7 +252,7 @@ if (isEnabled("ds-references")) {
     });
   });
 
-  test("push(record) asserts for invalid type", function(assert) {
+  testInDebug("push(record) asserts for invalid type", function(assert) {
     var person, anotherPerson;
     run(function() {
       person = env.store.push({

--- a/tests/integration/references/has-many-test.js
+++ b/tests/integration/references/has-many-test.js
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 import setupStore from 'dummy/tests/helpers/store';
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { module, test } from 'qunit';
 import isEnabled from 'ember-data/-private/features';
 
@@ -202,7 +203,7 @@ if (isEnabled("ds-references")) {
     });
   });
 
-  test("push(array) asserts polymorphic type", function(assert) {
+  testInDebug("push(array) asserts polymorphic type", function(assert) {
     var family;
     run(function() {
       family = env.store.push({

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -2,6 +2,7 @@ import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 import isEnabled from 'ember-data/-private/features';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -130,7 +131,7 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
   });
 });
 
-test("Only a record of the same type can be used with a monomorphic belongsTo relationship", function(assert) {
+testInDebug("Only a record of the same type can be used with a monomorphic belongsTo relationship", function(assert) {
   assert.expect(1);
   env.adapter.shouldBackgroundReloadRecord = () => false;
   run(function() {
@@ -161,7 +162,7 @@ test("Only a record of the same type can be used with a monomorphic belongsTo re
   });
 });
 
-test("Only a record of the same base type can be used with a polymorphic belongsTo relationship", function(assert) {
+testInDebug("Only a record of the same base type can be used with a polymorphic belongsTo relationship", function(assert) {
   env.adapter.shouldBackgroundReloadRecord = () => false;
   assert.expect(1);
   run(function() {
@@ -727,7 +728,7 @@ test("Destroying a record with an unloaded aync belongsTo association does not f
   run(post, 'destroyRecord');
 });
 
-test("A sync belongsTo errors out if the record is unlaoded", function(assert) {
+testInDebug("A sync belongsTo errors out if the record is unlaoded", function(assert) {
   var message;
   run(function() {
     message = env.store.push({
@@ -833,7 +834,7 @@ test("Rollbacking attributes for a deleted record restores implicit relationship
   assert.equal(book.get('author'), author, 'Book has an author after rollback attributes');
 });
 
-test("Passing a model as type to belongsTo should not work", function(assert) {
+testInDebug("Passing a model as type to belongsTo should not work", function(assert) {
   assert.expect(1);
 
   assert.expectAssertion(function() {

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -1201,7 +1202,7 @@ test("Polymorphic relationships with a hasMany is set up correctly on both sides
   assert.equal(get(email, 'posts.length'), 1, "The inverse has many is set up correctly on the email side.");
 });
 
-test("A record can't be created from a polymorphic hasMany relationship", function(assert) {
+testInDebug("A record can't be created from a polymorphic hasMany relationship", function(assert) {
   env.adapter.shouldBackgroundReloadRecord = () => false;
   run(function() {
     env.store.push({
@@ -1228,7 +1229,7 @@ test("A record can't be created from a polymorphic hasMany relationship", functi
   });
 });
 
-test("Only records of the same type can be added to a monomorphic hasMany relationship", function(assert) {
+testInDebug("Only records of the same type can be added to a monomorphic hasMany relationship", function(assert) {
   assert.expect(1);
   env.adapter.shouldBackgroundReloadRecord = () => false;
   run(function() {
@@ -1260,7 +1261,7 @@ test("Only records of the same type can be added to a monomorphic hasMany relati
   });
 });
 
-test("Only records of the same base type can be added to a polymorphic hasMany relationship", function(assert) {
+testInDebug("Only records of the same base type can be added to a polymorphic hasMany relationship", function(assert) {
   assert.expect(2);
   env.adapter.shouldBackgroundReloadRecord = () => false;
   run(function() {
@@ -1606,7 +1607,7 @@ test("When an unloaded record is added to the hasMany, it gets fetched once the 
   });
 });
 
-test("A sync hasMany errors out if there are unlaoded records in it", function(assert) {
+testInDebug("A sync hasMany errors out if there are unlaoded records in it", function(assert) {
   var post;
   run(function() {
     env.store.push({
@@ -2042,7 +2043,7 @@ test("ManyArray notifies the array observers and flushes bindings when adding", 
   });
 });
 
-test("Passing a model as type to hasMany should not work", function(assert) {
+testInDebug("Passing a model as type to hasMany should not work", function(assert) {
   assert.expect(1);
 
   assert.expectAssertion(function() {

--- a/tests/integration/relationships/inverse-relationships-test.js
+++ b/tests/integration/relationships/inverse-relationships-test.js
@@ -2,6 +2,7 @@ import {createStore} from 'dummy/tests/helpers/store';
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -424,7 +425,7 @@ test("When a record's polymorphic belongsTo relationship is set, it can specify 
   assert.equal(post.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
 });
 
-test("Inverse relationships that don't exist throw a nice error for a hasMany", function(assert) {
+testInDebug("Inverse relationships that don't exist throw a nice error for a hasMany", function(assert) {
   User = DS.Model.extend();
   Comment = DS.Model.extend();
 
@@ -446,7 +447,7 @@ test("Inverse relationships that don't exist throw a nice error for a hasMany", 
   }, /We found no inverse relationships by the name of 'testPost' on the 'comment' model/);
 });
 
-test("Inverse relationships that don't exist throw a nice error for a belongsTo", function(assert) {
+testInDebug("Inverse relationships that don't exist throw a nice error for a belongsTo", function(assert) {
   User = DS.Model.extend();
   Comment = DS.Model.extend();
 

--- a/tests/integration/relationships/one-to-one-test.js
+++ b/tests/integration/relationships/one-to-one-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -498,7 +499,7 @@ test("Setting a BelongsTo to a promise works when the promise returns null- asyn
 });
 
 
-test("Setting a BelongsTo to a promise that didn't come from a relationship errors out", function(assert) {
+testInDebug("Setting a BelongsTo to a promise that didn't come from a relationship errors out", function(assert) {
   var stanley, igor;
   run(function() {
     stanley = store.push({

--- a/tests/integration/relationships/polymorphic-mixins-belongs-to-test.js
+++ b/tests/integration/relationships/polymorphic-mixins-belongs-to-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -122,7 +123,7 @@ test("Setting the polymorphic belongsTo gets propagated to the inverse side - as
   });
 });
 
-test("Setting the polymorphic belongsTo with an object that does not implement the mixin errors out", function(assert) {
+testInDebug("Setting the polymorphic belongsTo with an object that does not implement the mixin errors out", function(assert) {
   var user, video;
   run(function() {
     store.push({
@@ -193,7 +194,7 @@ test("Setting the polymorphic belongsTo gets propagated to the inverse side - mo
   }
 });
 
-test("Setting the polymorphic belongsTo with an object that does not implement the mixin errors out - model injections true", function(assert) {
+testInDebug("Setting the polymorphic belongsTo with an object that does not implement the mixin errors out - model injections true", function(assert) {
   var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
   Ember.MODEL_FACTORY_INJECTIONS = true;
 

--- a/tests/integration/relationships/polymorphic-mixins-has-many-test.js
+++ b/tests/integration/relationships/polymorphic-mixins-has-many-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -132,7 +133,7 @@ test("Pushing to the hasMany reflects the change on the belongsTo side - async",
 /*
   Local edits
 */
-test("Pushing a an object that does not implement the mixin to the mixin accepting array errors out", function(assert) {
+testInDebug("Pushing a an object that does not implement the mixin to the mixin accepting array errors out", function(assert) {
   var user,notMessage;
   run(function() {
     store.push({
@@ -215,7 +216,7 @@ test("Pushing to the hasMany reflects the change on the belongsTo side - model i
 /*
   Local edits
 */
-test("Pushing a an object that does not implement the mixin to the mixin accepting array errors out - model injections true", function(assert) {
+testInDebug("Pushing a an object that does not implement the mixin to the mixin accepting array errors out - model injections true", function(assert) {
   var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
   Ember.MODEL_FACTORY_INJECTIONS = true;
 

--- a/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/tests/integration/serializers/embedded-records-mixin-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -952,7 +953,7 @@ test("serialize with embedded objects and a custom keyForAttribute (hasMany rela
   });
 });
 
-test("serialize with embedded objects (unknown hasMany relationship)", function(assert) {
+testInDebug("serialize with embedded objects (unknown hasMany relationship)", function(assert) {
   var league;
   run(function() {
     env.store.push({

--- a/tests/integration/serializers/json-api-serializer-test.js
+++ b/tests/integration/serializers/json-api-serializer-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -116,7 +117,7 @@ test('Calling pushPayload works', function(assert) {
   });
 });
 
-test('Warns when normalizing an unknown type', function(assert) {
+testInDebug('Warns when normalizing an unknown type', function(assert) {
   var documentHash = {
     data: {
       type: 'UnknownType',
@@ -134,7 +135,7 @@ test('Warns when normalizing an unknown type', function(assert) {
   }, /Encountered a resource object with type "UnknownType", but no model was found for model name "unknown-type"/);
 });
 
-test('Warns when normalizing with type missing', function(assert) {
+testInDebug('Warns when normalizing with type missing', function(assert) {
   var documentHash = {
     data: {
       id: '1',

--- a/tests/integration/serializers/rest-serializer-test.js
+++ b/tests/integration/serializers/rest-serializer-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -143,7 +144,7 @@ test("normalizeResponse with custom modelNameFromPayloadKey", function(assert) {
   });
 });
 
-test("normalizeResponse warning with custom modelNameFromPayloadKey", function(assert) {
+testInDebug("normalizeResponse warning with custom modelNameFromPayloadKey", function(assert) {
   var homePlanet;
   var oldModelNameFromPayloadKey = env.restSerializer.modelNameFromPayloadKey;
   env.restSerializer.modelNameFromPayloadKey = function(root) {
@@ -178,7 +179,7 @@ test("normalizeResponse warning with custom modelNameFromPayloadKey", function(a
   assert.deepEqual(homePlanet.data.relationships.superVillains.data, [{ id: '1', type: 'super-villain' }]);
 });
 
-test("normalizeResponse warning with custom modelNameFromPayloadKey", function(assert) {
+testInDebug("normalizeResponse warning with custom modelNameFromPayloadKey", function(assert) {
   var homePlanets;
   env.restSerializer.modelNameFromPayloadKey = function(root) {
     //return some garbage that won"t resolve in the container
@@ -484,7 +485,7 @@ test('serializeBelongsTo with async polymorphic', function(assert) {
   assert.deepEqual(json, expected, 'returned JSON is correct');
 });
 
-test('serializeBelongsTo logs deprecation when old behavior for getting polymorphic type key is used', function(assert) {
+testInDebug('serializeBelongsTo logs deprecation when old behavior for getting polymorphic type key is used', function(assert) {
   var evilMinion, doomsdayDevice;
   var json = {};
   var expected = { evilMinion: '1', myCustomKeyType: 'evilMinion' };

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -316,7 +317,7 @@ test("store#findRecord { reload: true } ignores cached record and reloads record
   });
 });
 
-test('store#findRecord call with `id` of type different than non-empty string or number should trigger an assertion', assert => {
+testInDebug('store#findRecord call with `id` of type different than non-empty string or number should trigger an assertion', assert => {
   const badValues = ['', undefined, null, NaN, false];
   assert.expect(badValues.length);
 
@@ -568,7 +569,7 @@ test("Store should accept a null value for `data`", function(assert) {
   });
 });
 
-test('store#findRecord that returns an array should assert', assert => {
+testInDebug('store#findRecord that returns an array should assert', assert => {
   initializeStore(DS.JSONAPIAdapter.extend({
     findRecord: function() {
       return { data: [] };

--- a/tests/integration/store/json-api-validation-test.js
+++ b/tests/integration/store/json-api-validation-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
-import QUnit, {module, test} from 'qunit';
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
+import QUnit, { module } from 'qunit';
 import DS from 'ember-data';
 
 var Person, store, env;
@@ -26,7 +27,7 @@ module("integration/store/json-validation", {
   }
 });
 
-test("when normalizeResponse returns undefined (or doesn't return), throws an error", function(assert) {
+testInDebug("when normalizeResponse returns undefined (or doesn't return), throws an error", function(assert) {
 
   env.registry.register('serializer:person', DS.Serializer.extend({
     normalizeResponse() {}
@@ -45,7 +46,7 @@ test("when normalizeResponse returns undefined (or doesn't return), throws an er
   }, /Top level of a JSON API document must be an object/);
 });
 
-test("when normalizeResponse returns null, throws an error", function(assert) {
+testInDebug("when normalizeResponse returns null, throws an error", function(assert) {
 
   env.registry.register('serializer:person', DS.Serializer.extend({
     normalizeResponse() {return null;}
@@ -65,7 +66,7 @@ test("when normalizeResponse returns null, throws an error", function(assert) {
 });
 
 
-test("when normalizeResponse returns an empty object, throws an error", function(assert) {
+testInDebug("when normalizeResponse returns an empty object, throws an error", function(assert) {
 
   env.registry.register('serializer:person', DS.Serializer.extend({
     normalizeResponse() {return {};}
@@ -84,7 +85,7 @@ test("when normalizeResponse returns an empty object, throws an error", function
   }, /One or more of the following keys must be present/);
 });
 
-test("when normalizeResponse returns a document with both data and errors, throws an error", function(assert) {
+testInDebug("when normalizeResponse returns a document with both data and errors, throws an error", function(assert) {
 
   env.registry.register('serializer:person', DS.Serializer.extend({
     normalizeResponse() {
@@ -128,7 +129,7 @@ QUnit.assert.payloadError = function payloadError(payload, expectedError) {
   env.registry.unregister('adapter:person');
 };
 
-test("normalizeResponse 'data' cannot be undefined, a number, a string or a boolean", function(assert) {
+testInDebug("normalizeResponse 'data' cannot be undefined, a number, a string or a boolean", function(assert) {
 
   assert.payloadError({ data: undefined }, /data must be/);
   assert.payloadError({ data: 1 }, /data must be/);
@@ -137,7 +138,7 @@ test("normalizeResponse 'data' cannot be undefined, a number, a string or a bool
 
 });
 
-test("normalizeResponse 'meta' cannot be an array, undefined, a number, a string or a boolean", function(assert) {
+testInDebug("normalizeResponse 'meta' cannot be an array, undefined, a number, a string or a boolean", function(assert) {
 
   assert.payloadError({ meta: undefined }, /meta must be an object/);
   assert.payloadError({ meta: [] }, /meta must be an object/);
@@ -147,7 +148,7 @@ test("normalizeResponse 'meta' cannot be an array, undefined, a number, a string
 
 });
 
-test("normalizeResponse 'links' cannot be an array, undefined, a number, a string or a boolean", function(assert) {
+testInDebug("normalizeResponse 'links' cannot be an array, undefined, a number, a string or a boolean", function(assert) {
 
   assert.payloadError({ data: [], links: undefined }, /links must be an object/);
   assert.payloadError({ data: [], links: [] }, /links must be an object/);
@@ -157,7 +158,7 @@ test("normalizeResponse 'links' cannot be an array, undefined, a number, a strin
 
 });
 
-test("normalizeResponse 'jsonapi' cannot be an array, undefined, a number, a string or a boolean", function(assert) {
+testInDebug("normalizeResponse 'jsonapi' cannot be an array, undefined, a number, a string or a boolean", function(assert) {
 
   assert.payloadError({ data: [], jsonapi: undefined }, /jsonapi must be an object/);
   assert.payloadError({ data: [], jsonapi: [] }, /jsonapi must be an object/);
@@ -167,7 +168,7 @@ test("normalizeResponse 'jsonapi' cannot be an array, undefined, a number, a str
 
 });
 
-test("normalizeResponse 'included' cannot be an object, undefined, a number, a string or a boolean", function(assert) {
+testInDebug("normalizeResponse 'included' cannot be an object, undefined, a number, a string or a boolean", function(assert) {
 
   assert.payloadError({ included: undefined }, /included must be an array/);
   assert.payloadError({ included: {} }, /included must be an array/);
@@ -177,7 +178,7 @@ test("normalizeResponse 'included' cannot be an object, undefined, a number, a s
 
 });
 
-test("normalizeResponse 'errors' cannot be an object, undefined, a number, a string or a boolean", function(assert) {
+testInDebug("normalizeResponse 'errors' cannot be an object, undefined, a number, a string or a boolean", function(assert) {
 
   assert.payloadError({ errors: undefined }, /errors must be an array/);
   assert.payloadError({ errors: {} }, /errors must be an array/);

--- a/tests/integration/store/query-record-test.js
+++ b/tests/integration/store/query-record-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -28,13 +29,13 @@ module("integration/store/query-record - Query one record with a query hash", {
   }
 });
 
-test("It raises an assertion when no type is passed", function(assert) {
+testInDebug("It raises an assertion when no type is passed", function(assert) {
   assert.expectAssertion(function() {
     store.queryRecord();
   }, "You need to pass a type to the store's queryRecord method");
 });
 
-test("It raises an assertion when no query hash is passed", function(assert) {
+testInDebug("It raises an assertion when no query hash is passed", function(assert) {
   assert.expectAssertion(function() {
     store.queryRecord('person');
   }, "You need to pass a query hash to the store's queryRecord method");

--- a/tests/unit/adapter-errors-test.js
+++ b/tests/unit/adapter-errors-test.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -104,7 +105,7 @@ test("errorsArrayToHash for primary data object", function(assert) {
   assert.deepEqual(result, errorsPrimaryHash);
 });
 
-test("DS.InvalidError will normalize errors hash will assert", function(assert) {
+testInDebug("DS.InvalidError will normalize errors hash will assert", function(assert) {
   var error;
 
   assert.expectAssertion(function() {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1,6 +1,7 @@
 import {createStore} from 'dummy/tests/helpers/store';
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import QUnit, {module, test} from 'qunit';
 import DS from 'ember-data';
 import isEnabled from 'ember-data/-private/features';
@@ -159,7 +160,7 @@ test("a record's id is included in its toString representation", function(assert
   });
 });
 
-test("trying to set an `id` attribute should raise", function(assert) {
+testInDebug("trying to set an `id` attribute should raise", function(assert) {
   Person = DS.Model.extend({
     id: DS.attr('number'),
     name: DS.attr('string')
@@ -416,7 +417,7 @@ test("a DS.Model can have a defaultValue without an attribute type", function(as
   assert.equal(get(tag, 'name'), "unknown", "the default value is found");
 });
 
-test("Calling attr() throws a warning", function(assert) {
+testInDebug("Calling attr() throws a warning", function(assert) {
   assert.expect(1);
 
   run(function() {
@@ -429,7 +430,7 @@ test("Calling attr() throws a warning", function(assert) {
 });
 
 if (!isEnabled('ds-references')) {
-  test("Calling belongsTo() throws a warning", function(assert) {
+  testInDebug("Calling belongsTo() throws a warning", function(assert) {
     assert.expect(1);
 
     run(function() {
@@ -441,7 +442,7 @@ if (!isEnabled('ds-references')) {
     });
   });
 
-  test("Calling hasMany() throws a warning", function(assert) {
+  testInDebug("Calling hasMany() throws a warning", function(assert) {
     assert.expect(1);
 
     run(function() {
@@ -630,7 +631,7 @@ test("a defaultValue function gets the record, options, and key", function(asser
   get(tag, 'createdAt');
 });
 
-test("a complex object defaultValue is deprecated ", function(assert) {
+testInDebug("a complex object defaultValue is deprecated ", function(assert) {
   var Tag = DS.Model.extend({
     tagInfo: DS.attr({ defaultValue: [] })
   });
@@ -648,7 +649,7 @@ test("a complex object defaultValue is deprecated ", function(assert) {
   }, /Non primitive defaultValues are deprecated/);
 });
 
-test("a null defaultValue is not deprecated", function(assert) {
+testInDebug("a null defaultValue is not deprecated", function(assert) {
   var Tag = DS.Model.extend({
     tagInfo: DS.attr({ defaultValue: null })
   });
@@ -980,7 +981,7 @@ test("a DS.Model can describe Date attributes", function(assert) {
   assert.convertsWhenSet('date', date, dateString);
 });
 
-test("don't allow setting", function(assert) {
+testInDebug("don't allow setting", function(assert) {
   var Person = DS.Model.extend();
   var record;
 
@@ -1033,7 +1034,7 @@ test("A DS.Model can be JSONified", function(assert) {
   assert.deepEqual(record.toJSON(), { name: "TomHuda" });
 });
 
-test("A subclass of DS.Model can not use the `data` property", function(assert) {
+testInDebug("A subclass of DS.Model can not use the `data` property", function(assert) {
   var Person = DS.Model.extend({
     data: DS.attr('string'),
     name: DS.attr('string')
@@ -1048,7 +1049,7 @@ test("A subclass of DS.Model can not use the `data` property", function(assert) 
   }, /`data` is a reserved property name on DS.Model objects/);
 });
 
-test("A subclass of DS.Model can not use the `store` property", function(assert) {
+testInDebug("A subclass of DS.Model can not use the `store` property", function(assert) {
   var Retailer = DS.Model.extend({
     store: DS.attr(),
     name: DS.attr()
@@ -1063,7 +1064,7 @@ test("A subclass of DS.Model can not use the `store` property", function(assert)
   }, /`store` is a reserved property name on DS.Model objects/);
 });
 
-test("A subclass of DS.Model can not use reserved properties", function(assert) {
+testInDebug("A subclass of DS.Model can not use reserved properties", function(assert) {
   assert.expect(3);
   [
     'currentState', 'data', 'store'
@@ -1105,7 +1106,7 @@ test("Pushing a record into the store should transition it to the loaded state",
   });
 });
 
-test("A subclass of DS.Model throws an error when calling create() directly", function(assert) {
+testInDebug("A subclass of DS.Model throws an error when calling create() directly", function(assert) {
   assert.throws(function() {
     Person.create();
   }, /You should not call `create` on a model/, "Throws an error when calling create() on model");

--- a/tests/unit/model/internal-model-test.js
+++ b/tests/unit/model/internal-model-test.js
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
 
-import {module, test} from 'qunit';
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
+import { module } from 'qunit';
 
 module("unit/model/internal-model - Internal Model");
 
@@ -12,7 +13,7 @@ MockModelFactory._create = function() {
 
 MockModelFactory.eachRelationship = function() { };
 
-test("Materializing a model twice errors out", function(assert) {
+testInDebug("Materializing a model twice errors out", function(assert) {
   assert.expect(1);
   var internalModel = new DS.InternalModel(MockModelFactory, null, { }, null);
 

--- a/tests/unit/model/relationships/belongs-to-test.js
+++ b/tests/unit/model/relationships/belongs-to-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -360,7 +361,7 @@ test("belongsTo supports relationships to models with id 0", function(assert) {
   });
 });
 
-test("belongsTo gives a warning when provided with a serialize option", function(assert) {
+testInDebug("belongsTo gives a warning when provided with a serialize option", function(assert) {
   var Hobby = DS.Model.extend({
     name: DS.attr('string')
   });
@@ -412,7 +413,7 @@ test("belongsTo gives a warning when provided with a serialize option", function
     });
 });
 
-test("belongsTo gives a warning when provided with an embedded option", function(assert) {
+testInDebug("belongsTo gives a warning when provided with an embedded option", function(assert) {
   var Hobby = DS.Model.extend({
     name: DS.attr('string')
   });

--- a/tests/unit/model/relationships/has-many-test.js
+++ b/tests/unit/model/relationships/has-many-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -770,7 +771,7 @@ test("DS.hasMany is async by default", function(assert) {
   });
 });
 
-test("throws assertion if of not set with an array", function(assert) {
+testInDebug("throws assertion if of not set with an array", function(assert) {
   var Person = DS.Model.extend();
   var Tag = DS.Model.extend({
     people: DS.hasMany('person')
@@ -791,7 +792,7 @@ test("throws assertion if of not set with an array", function(assert) {
   });
 });
 
-test("checks if passed array only contains instances of DS.Model", function(assert) {
+testInDebug("checks if passed array only contains instances of DS.Model", function(assert) {
   var Person = DS.Model.extend();
   var Tag = DS.Model.extend({
     people: DS.hasMany('person')

--- a/tests/unit/store/adapter-interop-test.js
+++ b/tests/unit/store/adapter-interop-test.js
@@ -2,6 +2,7 @@ import {createStore} from 'dummy/tests/helpers/store';
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -38,7 +39,7 @@ test('Adapter can be set as a name', function(assert) {
   assert.ok(store.get('defaultAdapter') instanceof DS.RESTAdapter);
 });
 
-test('Adapter can not be set as an instance', function(assert) {
+testInDebug('Adapter can not be set as an instance', function(assert) {
   assert.expect(1);
 
   store = DS.Store.create({
@@ -343,7 +344,7 @@ test("a new record of a particular type is created via store.createRecord(type)"
   assert.equal(get(person, 'name'), "Braaahm Dale", "Even if no hash is supplied, `set` still worked");
 });
 
-test("a new record with a specific id can't be created if this id is already used in the store", function(assert) {
+testInDebug("a new record with a specific id can't be created if this id is already used in the store", function(assert) {
   var Person = DS.Model.extend({
     name: DS.attr('string')
   });
@@ -871,7 +872,7 @@ test("store.fetchRecord reject records that were not found, even when those requ
   });
 });
 
-test("store.fetchRecord warns when records are missing", function(assert) {
+testInDebug("store.fetchRecord warns when records are missing", function(assert) {
   var Person = DS.Model.extend();
 
   var adapter = TestAdapter.extend({
@@ -1275,7 +1276,7 @@ test("store should reload all records in the background when `shouldBackgroundRe
   assert.equal(store.peekRecord('person', 1).get('name'), 'Tom');
 });
 
-test("store should assert of the user tries to call store.filter", function(assert) {
+testInDebug("store should assert of the user tries to call store.filter", function(assert) {
   assert.expect(1);
 
   var Person = DS.Model.extend({
@@ -1294,7 +1295,7 @@ test("store should assert of the user tries to call store.filter", function(asse
 });
 
 
-test("Calling adapterFor with a model class should assert", function(assert) {
+testInDebug("Calling adapterFor with a model class should assert", function(assert) {
   var Person = DS.Model.extend({
     name: DS.attr('string')
   });

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -482,7 +483,7 @@ test('calling push without data argument as an object raises an error', function
   });
 });
 
-test('Calling push with a link for a non async relationship should warn', function(assert) {
+testInDebug('Calling push with a link for a non async relationship should warn', function(assert) {
   Person.reopen({
     phoneNumbers: hasMany('phone-number', { async: false })
   });
@@ -499,7 +500,7 @@ test('Calling push with a link for a non async relationship should warn', functi
   }, /You have pushed a record of type 'person' with 'phoneNumbers' as a link, but the association is not an async relationship./);
 });
 
-test('Calling push with an unknown model name throws an assertion error', function(assert) {
+testInDebug('Calling push with an unknown model name throws an assertion error', function(assert) {
 
   assert.expectAssertion(function() {
     run(function() {
@@ -551,7 +552,7 @@ test('Calling push with a link containing the value null', function(assert) {
   assert.equal(person.get('firstName'), "Tan", "you can use links that contain null as a value");
 });
 
-test('calling push with hasMany relationship the value must be an array', function(assert) {
+testInDebug('calling push with hasMany relationship the value must be an array', function(assert) {
   var invalidValues = [
     1,
     'string',
@@ -581,7 +582,7 @@ test('calling push with hasMany relationship the value must be an array', functi
   });
 });
 
-test('calling push with missing or invalid `id` throws assertion error', function(assert) {
+testInDebug('calling push with missing or invalid `id` throws assertion error', function(assert) {
   var invalidValues = [
     {},
     { id: null },
@@ -601,7 +602,7 @@ test('calling push with missing or invalid `id` throws assertion error', functio
   });
 });
 
-test('calling push with belongsTo relationship the value must not be an array', function(assert) {
+testInDebug('calling push with belongsTo relationship the value must not be an array', function(assert) {
   assert.throws(function() {
     run(function() {
       store.push({
@@ -619,7 +620,7 @@ test('calling push with belongsTo relationship the value must not be an array', 
   }, /must not be an array/);
 });
 
-test("Enabling Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS should warn on unknown attributes", function(assert) {
+testInDebug("Enabling Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS should warn on unknown attributes", function(assert) {
   run(function() {
     var originalFlagValue = Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS;
     try {
@@ -643,7 +644,7 @@ test("Enabling Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS should warn on unknown attribut
   });
 });
 
-test("Enabling Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS should warn on unknown relationships", function(assert) {
+testInDebug("Enabling Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS should warn on unknown relationships", function(assert) {
   run(function() {
     var originalFlagValue = Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS;
     try {
@@ -667,7 +668,7 @@ test("Enabling Ember.ENV.DS_WARN_ON_UNKNOWN_KEYS should warn on unknown relation
   });
 });
 
-test("Calling push with unknown keys should not warn by default", function(assert) {
+testInDebug("Calling push with unknown keys should not warn by default", function(assert) {
   assert.expectNoWarning(function() {
     run(function() {
       store.push({

--- a/tests/unit/store/serializer-for-test.js
+++ b/tests/unit/store/serializer-for-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -45,7 +46,7 @@ test("Calling serializerFor with a type that has not been registered and in an a
   assert.ok(store.serializerFor('person') instanceof DS.JSONSerializer, "serializer returned from serializerFor is an instance of DS.JSONSerializer");
 });
 
-test("Calling serializerFor with a model class should assert", function(assert) {
+testInDebug("Calling serializerFor with a model class should assert", function(assert) {
   assert.expectAssertion(function() {
     store.serializerFor(Person);
   }, /Passing classes to store.serializerFor has been removed/);

--- a/tests/unit/store/unload-test.js
+++ b/tests/unit/store/unload-test.js
@@ -1,6 +1,7 @@
 import {createStore} from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -32,7 +33,7 @@ module("unit/store/unload - Store unloading records", {
   }
 });
 
-test("unload a dirty record", function(assert) {
+testInDebug("unload a dirty record asserts", function(assert) {
   assert.expect(2);
 
   run(function() {

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -42,7 +43,7 @@ module("unit/utils", {
   }
 });
 
-test("assertPolymorphicType works for subclasses", function(assert) {
+testInDebug("assertPolymorphicType works for subclasses", function(assert) {
   var user, post, person;
 
   Ember.run(function() {
@@ -103,7 +104,7 @@ test("modelHasAttributeOrRelationshipNamedType", function(assert) {
   assert.equal(modelHasAttributeOrRelationshipNamedType(ModelWithTypeHasMany), true);
 });
 
-test("assertPolymorphicType works for mixins", function(assert) {
+testInDebug("assertPolymorphicType works for mixins", function(assert) {
   var post, video, person;
 
   Ember.run(function() {


### PR DESCRIPTION
This adds a new test helper `testInDebug` which executes a test via `QUnit.test` if we are not in the `production` environment. If the tests are executed in `production` environment though, then the test is skipped via `QUnit.skip`.

The tests are now also run on TravisCI via `ember test --environment=production`.

This addresses #4203.

#### TODO

- [x] wait for relative paths to work, then remove relevant commit from this PR :arrow_right: looks like this has been resolved with #4215 