### PR TITLE
Don't do inverse work if inverse is explicitly turned off

### DIFF
--- a/addon/-private/system/relationships/state/create.js
+++ b/addon/-private/system/relationships/state/create.js
@@ -5,9 +5,17 @@ import EmptyObject from "ember-data/-private/system/empty-object";
 
 var get = Ember.get;
 
+function shouldFindInverse(relationshipMeta) {
+  let options = relationshipMeta.options;
+  return !(options && options.inverse === null);
+}
+
 function createRelationshipFor(record, relationshipMeta, store) {
-  var inverseKey;
-  var inverse = record.type.inverseFor(relationshipMeta.key, store);
+  let inverseKey;
+  let inverse = null;
+  if (shouldFindInverse(relationshipMeta)) {
+    inverse = record.type.inverseFor(relationshipMeta.key, store);
+  }
 
   if (inverse) {
     inverseKey = inverse.name;


### PR DESCRIPTION
If the model explicitly [turns off inverse](https://guides.emberjs.com/v2.4.0/models/relationships/#toc_explicit-inverses), no work should be done to resolve this inverse.