### PR TITLE
Solves #4186 and fixes `this._super` call within `normalize` method.

### DIFF
--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -15,8 +15,7 @@ var camelize = Ember.String.camelize;
 
 /**
   Normally, applications will use the `RESTSerializer` by implementing
-  the `normalize` method and individual normalizations under
-  `normalizeHash`.
+  the `normalize` method.
 
   This allows you to do whatever kind of munging you need, and is
   especially useful if your server is inconsistent and you need to
@@ -29,7 +28,7 @@ var camelize = Ember.String.camelize;
   There are also a number of hooks that you might find useful to define
   across-the-board rules for your payload. These rules will be useful
   if your server is consistent, or if you're building an adapter for
-  an infrastructure service, like Parse, and want to encode service
+  an infrastructure service, like Firebase, and want to encode service
   conventions.
 
   For example, if all of your keys are underscored and all-caps, but
@@ -124,10 +123,8 @@ var RESTSerializer = JSONSerializer.extend({
     * With `App.Comment`, `"comments"` and `{ id: 2, body: "Rails is unagi" }`
 
     You can use this method, for example, to normalize underscored keys to camelized
-    or other general-purpose normalizations.
-
-    If you want to do normalizations specific to some part of the payload, you
-    can specify those under `normalizeHash`.
+    or other general-purpose normalizations. You will only need to implement 
+    `normalize` and manipulate the payload as desired.
 
     For example, if the `IDs` under `"comments"` are provided as `_id` instead of
     `id`, you can specify how to normalize just the comments:
@@ -136,18 +133,20 @@ var RESTSerializer = JSONSerializer.extend({
     import DS from 'ember-data';
 
     export default DS.RESTSerializer.extend({
-      normalizeHash: {
-        comments: function(hash) {
+      normalize(model, hash, prop) {
+        if (prop === 'comments') {
           hash.id = hash._id;
-          delete hash._id;
-          return hash;
+          delete hash._id;   
         }
+
+        return this._super(...arguments);
       }
     });
     ```
 
-    The key under `normalizeHash` is just the original key that was in the original
-    payload.
+    On each call to the `normalize` method, the third parameter (`prop`) is always 
+    one of the keys that were in the original payload or in the result of another 
+    normalization as `normalizeResponse`.
 
     @method normalize
     @param {DS.Model} modelClass
@@ -159,7 +158,7 @@ var RESTSerializer = JSONSerializer.extend({
     if (this.normalizeHash && this.normalizeHash[prop]) {
       this.normalizeHash[prop](resourceHash);
     }
-    return this._super(modelClass, resourceHash, prop);
+    return this._super(modelClass, resourceHash);
   },
 
   /**


### PR DESCRIPTION
See #4186.

Also, the `normalize` method was calling super with three parameters while it only receives two: http://emberjs.com/api/data/classes/DS.JSONSerializer.html#method_normalize
