### PR TITLE
Only show ember-cli-shims errors if actually installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,17 +52,17 @@ module.exports = {
 
       var emberDataBower = checker.for('ember-data', 'bower');
 
-      if (shims && !shims.satisfies('< 0.1.0') && emberDataBower.satisfies('< 2.3.0-beta.3')) {
+      if (shims && shims.version && !shims.satisfies('< 0.1.0') && emberDataBower.satisfies('< 2.3.0-beta.3')) {
         throw new SilentError('Using a version of ember-cli-shims greater than or equal to 0.1.0 will cause errors while loading Ember Data < 2.3.0-beta.3 Please update ember-cli-shims from ' + shims.version + ' to 0.0.6');
       }
 
-      if (shims && !shims.satisfies('>= 0.1.0') && emberDataBower.satisfies('>= 2.3.0-beta.3')) {
+      if (shims && shims.version && !shims.satisfies('>= 0.1.0') && emberDataBower.satisfies('>= 2.3.0-beta.3')) {
         throw new SilentError('Using a version of ember-cli-shims prior to 0.1.0 will cause errors while loading Ember Data 2.3.0-beta.3+. Please update ember-cli-shims from ' + shims.version + ' to 0.1.0.');
       }
 
     } else {
       // NPM only, but ember-cli-shims does not match
-      if (shims && !shims.satisfies('>= 0.1.0') && semver.satisfies(version, '^2.3.0-beta.3')) {
+      if (shims && shims.version && !shims.satisfies('>= 0.1.0') && semver.satisfies(version, '^2.3.0-beta.3')) {
         throw new SilentError('Using a version of ember-cli-shims prior to 0.1.0 will cause errors while loading Ember Data 2.3.0-beta.3+. Please update ember-cli-shims from ' + shims.version + ' to 0.1.0.');
       }
     }


### PR DESCRIPTION
This is useful for blueprint testing scenarios of other Ember.js addons, where ember-cli-shims might be mentioned in bower.json but is not actually installed just for the blueprint testing. Example: https://github.com/ember-cli/ember-cli-legacy-blueprints/pull/4

This PR resolves part of https://github.com/ember-cli/ember-cli-blueprint-test-helpers/issues/33 and continues #4200 

/cc @rwjblue @trabus @marcoow