### PR TITLE
Don't Call `set()` on Destroyed ManyArray

### DIFF
--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -75,6 +75,7 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
 
   flushCanonical() {
     //TODO make this smarter, currently its plenty stupid
+    if (this.isDestroyed || this.isDestroying) { return; }
     var toSet = this.canonicalState.filter((internalModel) => !internalModel.isDeleted());
 
     //a hack for not removing new records


### PR DESCRIPTION
This is a simple "fix" for a problem I encountered in my app. Essentially, MannyArray was attempting to set a property on itself after it had been destroyed. A simple guard clause stopped the error from crashing my app.

I'd love some feedback on this issue which is why I'm submitting it before it has tests, etc... Any comments would be greatly appreciated.