### PR TITLE
[DOC] Fix store.findAll return type

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -978,7 +978,7 @@ Store = Service.extend({
     @method findAll
     @param {String} modelName
     @param {Object} options
-    @return {DS.AdapterPopulatedRecordArray}
+    @return {Promise} promise
   */
   findAll(modelName, options) {
     assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');


### PR DESCRIPTION
`store.findAll` directly returns the result of `store._fetchAll`, which appears to return a promise. However, `store.findAll` is currently documented as returning an `AdapterPopulatedRecordArray`.