### PR TITLE
moves the ember dep in the package-manager package.json into optionalDependencies

### DIFF
--- a/config/package-manager-files/package.json
+++ b/config/package-manager-files/package.json
@@ -6,7 +6,7 @@
     "ember"
   ],
   "main": "./ember-data.js",
-  "dependencies": {
+  "optionalDependencies": {
     "ember": ">= 2.0.0 < 3.0.0"
   },
   "jspm": {


### PR DESCRIPTION
having ember in the dependencies forces a npm install of this repo to have a duplicate install of ember. If someone is installing ember/ember-data via the components shim library, their package.json will have to look something like this

```
    "components-ember": "https://github.com/components/ember/archive/2.4.2.tar.gz",
    "components-ember-data": "https://github.com/components/ember-data/archive/2.4.0.tar.gz",
    "ember": "https://github.com/emberjs/ember.js/archive/v2.4.2.tar.gz"
```