### PR TITLE
[BUGFIX release] Revert pr #3864

### DIFF
--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -196,7 +196,6 @@ export function _queryRecord(adapter, store, typeClass, query) {
     var record;
     store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'queryRecord');
-      assert('`store.queryRecord` expected the adapter to return one record but the response from the adapter was empty.', payload.data);
       //TODO Optimize
       record = store.push(payload);
     });

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -1337,18 +1337,6 @@ test("queryRecord - returning an array picks the first one but saves all records
   }));
 });
 
-testInDebug("queryRecord - returning an empty array errors", function(assert) {
-  ajaxResponse({
-    post: []
-  });
-
-  assert.expectAssertion(function() {
-    Ember.run(function() {
-      store.queryRecord('post', { slug: 'rails-is-omakaze' });
-    });
-  }, /`store.queryRecord` expected the adapter to return one record/);
-});
-
 test("queryRecord - data is normalized through custom serializers", function(assert) {
   env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primaryKey: '_ID_',


### PR DESCRIPTION
The origial intent was for a queryRecord with no response to reject the promise so it would act like a `findRecord` with a 404. This change introduced a regression that broke existing apps so it is going to be reverted.

Closes #4219