### PR TITLE
Modified the setup-ember-dev test helper to use `ember-metal/debug`s override hooks

### DIFF
--- a/tests/helpers/setup-ember-dev.js
+++ b/tests/helpers/setup-ember-dev.js
@@ -4,12 +4,26 @@ import EmberTestHelpers from "ember-dev/test-helper/index";
 
 const AVAILABLE_ASSERTIONS = ['expectAssertion', 'expectDeprecation', 'expectNoDeprecation', 'expectWarning', 'expectNoWarning'];
 
+// Maintain backwards compatiblity with older versions of ember.
+var emberDebugModule;
+if (Ember.__loader && Ember.__loader.registry && Ember.__loader.registry["ember-metal/debug"]) {
+  emberDebugModule = Ember.__loader.require('ember-metal/debug');
+}
+
 function getDebugFunction(name) {
-  return Ember[name];
+  if (emberDebugModule && emberDebugModule.getDebugFunction) {
+    return emberDebugModule.getDebugFunction(name);
+  } else {
+    return Ember[name];
+  }
 }
 
 function setDebugFunction(name, func) {
-  Ember[name] = func;
+  if (emberDebugModule && emberDebugModule.setDebugFunction) {
+    emberDebugModule.setDebugFunction(name, func);
+  } else {
+    Ember[name] = func;
+  }
 }
 
 var originalModule = QUnit.module;


### PR DESCRIPTION
I've been helping to "addonify"® [ember-data-model-fragments](https://github.com/lytics/ember-data-model-fragments) which also uses the `ember-dev` test suite. I noticed that `expectNoDeprecations` was no longer working as expected. After investigating I discovered that because Ember no longer uses `Ember.deprecate` internally, overriding that has little effect. I checked to see how ember-data's test suite handled this and discovered you have the same problem. See: [setup-ember-dev.js#L7-L13](https://github.com/emberjs/data/blob/master/tests/helpers/setup-ember-dev.js#L7-L13).

This PR fixes that issue by using `ember-metal/debug` proper hooks. This PR is meant to keep backwards compatibility and work with older versions of ember which did not offer these hooks. If the feeling is that ember and ember-data usage is truly lockstep, this PR could be simplified by removing the `getDebugFunction` and `setDebugFunction ` all together. Example: [ember-data-model-fragments/.../setup-ember-dev.js](https://github.com/lytics/ember-data-model-fragments/blob/addonify/tests/helpers/setup-ember-dev.js#L21-L25).

~~Lastly, I ran the tests locally and there were quite a few failures due to deprecations spewing out. This PR was intended to start a discussion about that.~~ Temporary insanity :stuck_out_tongue_winking_eye: .