### PR TITLE
[BUGFIX beta] Ensure `null` is returned for Reference#value()

### DIFF
--- a/addon/-private/system/references/belongs-to.js
+++ b/addon/-private/system/references/belongs-to.js
@@ -58,7 +58,12 @@ BelongsToReference.prototype.push = function(objectOrPromise) {
 
 BelongsToReference.prototype.value = function() {
   var inverseRecord = this.belongsToRelationship.inverseRecord;
-  return inverseRecord && inverseRecord.record;
+
+  if (inverseRecord && inverseRecord.record) {
+    return inverseRecord.record;
+  }
+
+  return null;
 };
 
 BelongsToReference.prototype.load = function() {

--- a/tests/integration/references/belongs-to-test.js
+++ b/tests/integration/references/belongs-to-test.js
@@ -332,7 +332,7 @@ if (isEnabled("ds-references")) {
     });
 
     var familyReference = person.belongsTo('family');
-    assert.equal(familyReference.value(), null);
+    assert.strictEqual(familyReference.value(), null);
   });
 
   test("value() returns the referenced record when loaded", function(assert) {

--- a/tests/integration/references/has-many-test.js
+++ b/tests/integration/references/has-many-test.js
@@ -338,7 +338,7 @@ if (isEnabled("ds-references")) {
     });
 
     var personsReference = family.hasMany('persons');
-    assert.equal(personsReference.value(), null);
+    assert.strictEqual(personsReference.value(), null);
   });
 
   test("value() returns the referenced records when all records are loaded", function(assert) {


### PR DESCRIPTION
The documentation states that `null` is returned for `Reference#value()`,
when it is not yet loaded. This commit fixes the bug where `undefined`
has been returned for `BelongsToReference#value()`.