### PR TITLE
[BUGFIX beta] Don't unnecessarily materialize records

### DIFF
--- a/addon/-private/system/record-arrays/adapter-populated-record-array.js
+++ b/addon/-private/system/record-arrays/adapter-populated-record-array.js
@@ -67,14 +67,12 @@ export default RecordArray.extend({
 
   /**
     @method loadRecords
-    @param {Array} records
+    @param {Array} internalModels
     @param {Object} payload normalized payload
     @private
   */
-  loadRecords(records, payload) {
+  loadRecords(internalModels, payload) {
     let token = heimdall.start('AdapterPopulatedRecordArray.loadRecords');
-    //TODO Optimize
-    let internalModels = records.map(record => get(record, '_internalModel'));
     this.setProperties({
       content: Ember.A(internalModels),
       isLoaded: true,

--- a/addon/-private/system/references/belongs-to.js
+++ b/addon/-private/system/references/belongs-to.js
@@ -66,8 +66,8 @@ BelongsToReference.prototype.push = function(objectOrPromise) {
 BelongsToReference.prototype.value = function() {
   var inverseRecord = this.belongsToRelationship.inverseRecord;
 
-  if (inverseRecord && inverseRecord.record) {
-    return inverseRecord.record;
+  if (inverseRecord && inverseRecord.isLoaded()) {
+    return inverseRecord.getRecord();
   }
 
   return null;

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1295,7 +1295,15 @@ Store = Service.extend({
     assert("You tried to make a query but you have no adapter (for " + typeClass + ")", adapter);
     assert("You tried to make a query but your adapter does not implement `queryRecord`", typeof adapter.queryRecord === 'function');
 
-    return promiseObject(_queryRecord(adapter, this, typeClass, query));
+    return promiseObject(_queryRecord(adapter, this, typeClass, query).then((internalModel) => {
+      // the promise returned by store.queryRecord is expected to resolve with
+      // an instance of DS.Model
+      if (internalModel) {
+        return internalModel.getRecord();
+      }
+
+      return null;
+    }));
   },
 
   /**
@@ -2194,6 +2202,37 @@ Store = Service.extend({
   */
   push(data) {
     let token = heimdall.start('store.push');
+    let pushed = this._push(data);
+
+    if (Array.isArray(pushed)) {
+      let records = pushed.map(function(internalModel) {
+        return internalModel.getRecord();
+      });
+      heimdall.stop(token);
+      return records;
+    }
+
+    if (pushed === null) {
+      heimdall.stop(token);
+      return null;
+    }
+
+    var record = pushed.getRecord();
+    heimdall.stop(token);
+    return record;
+  },
+
+  /*
+    Push some data into the store, without creating materialized records.
+
+    @method _push
+    @private
+    @param {Object} data
+    @return {DS.InternalModel|Array<DS.InternalModel>} pushed InternalModel(s)
+  */
+  _push(data) {
+    let token = heimdall.start('store._push');
+
     var included = data.included;
     var i, length;
     if (included) {
@@ -2206,7 +2245,7 @@ Store = Service.extend({
       length = data.data.length;
       var internalModels = new Array(length);
       for (i = 0; i < length; i++) {
-        internalModels[i] = this._pushInternalModel(data.data[i]).getRecord();
+        internalModels[i] = this._pushInternalModel(data.data[i]);
       }
       heimdall.stop(token);
       return internalModels;
@@ -2220,10 +2259,8 @@ Store = Service.extend({
     assert(`Expected an object in the 'data' property in a call to 'push' for ${data.type}, but was ${Ember.typeOf(data.data)}`, Ember.typeOf(data.data) === 'object');
 
     var internalModel = this._pushInternalModel(data.data);
-
-    var record = internalModel.getRecord();
     heimdall.stop(token);
-    return record;
+    return internalModel;
   },
 
   _hasModelFor(type) {

--- a/tests/unit/adapter-populated-record-array-test.js
+++ b/tests/unit/adapter-populated-record-array-test.js
@@ -53,7 +53,7 @@ test("when a record is deleted in an adapter populated record array, it should b
   };
 
   run(function() {
-    var records = store.push(payload);
+    var records = store._push(payload);
     recordArray.loadRecords(records, payload);
   });
 
@@ -95,7 +95,7 @@ test("stores the metadata off the payload", function(assert) {
   };
 
   run(function() {
-    var records = store.push(payload);
+    var records = store._push(payload);
     recordArray.loadRecords(records, payload);
   });
 
@@ -131,8 +131,8 @@ test('stores the links off the payload', function(assert) {
   };
 
   run(function() {
-    var records = store.push(payload);
-    recordArray.loadRecords(records, payload);
+    var internalModels = store._push(payload);
+    recordArray.loadRecords(internalModels, payload);
   });
 
   assert.equal(recordArray.get('links.first'), '/foo?page=1', 'expected links.first to be "/foo?page=1" from payload');

--- a/tests/unit/record-arrays/adapter-populated-record-array-test.js
+++ b/tests/unit/record-arrays/adapter-populated-record-array-test.js
@@ -127,7 +127,7 @@ test('#loadRecords', function(assert) {
   let meta = { bar:2 };
 
   run(() => {
-    assert.equal(recordArray.loadRecords([model1, model2], {
+    assert.equal(recordArray.loadRecords([model1._internalModel, model2._internalModel], {
       links,
       meta
     }), undefined, 'loadRecords should have no return value');

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -715,6 +715,50 @@ if (isEnabled('ds-pushpayload-return')) {
   });
 }
 
+test("_push returns an instance of InternalModel if an object is pushed", function(assert) {
+  let pushResult;
+
+  run(function() {
+    pushResult = store._push({
+      data: {
+        id: 1,
+        type: 'person'
+      }
+    });
+  });
+
+  assert.ok(pushResult instanceof DS.InternalModel);
+});
+
+test("_push returns an array of InternalModels if an array is pushed", function(assert) {
+  let pushResult;
+
+  run(function() {
+    pushResult = store._push({
+      data: [{
+        id: 1,
+        type: 'person'
+      }]
+    });
+  });
+
+  assert.ok(pushResult instanceof Array);
+  assert.ok(pushResult[0] instanceof DS.InternalModel);
+});
+
+
+test("_push returns null if no data is pushed", function(assert) {
+  let pushResult;
+
+  run(function() {
+    pushResult = store._push({
+      data: null
+    });
+  });
+
+  assert.strictEqual(pushResult, null);
+});
+
 module("unit/store/push - DS.Store#push with JSON-API", {
   beforeEach() {
     var Person = DS.Model.extend({


### PR DESCRIPTION
This adds a `store#_push` method which returns DS.InternalModel's
instead of materialized DS.Model instances. This allows us to defer the
materialization process of an InternalModel until the corresponding
record is actually needed.