### PR TITLE
[DOC canary] Update extractMeta documentation

### DIFF
--- a/addon/serializers/json.js
+++ b/addon/serializers/json.js
@@ -1248,9 +1248,10 @@ export default Serializer.extend({
 
     export default DS.JSONSerializer.extend({
       extractMeta: function(store, typeClass, payload) {
-        if (payload && payload._pagination) {
-          store.setMetadataFor(typeClass, payload._pagination);
+        if (payload && payload.hasOwnProperty('_pagination')) {
+          let meta = payload._pagination;
           delete payload._pagination;
+          return meta;
         }
       }
     });


### PR DESCRIPTION
As brought up [here](https://github.com/emberjs/data/issues/3882) the documentation for `extractMeta` was referring to a method which does not exist anymore. 