### PR TITLE
[BUGFIX canary] Improve finders assertion messages

### DIFF
--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -34,7 +34,7 @@ export function _find(adapter, store, typeClass, id, internalModel, options) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    assert("You made a `findRecord` request for a " + typeClass.typeClassKey + " with id " + id + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    assert("You made a `findRecord` request for a " + typeClass.modelName + " with id " + id + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, id, 'findRecord');
       assert('Ember Data expected the primary data returned from a `findRecord` response to be an object but instead it found an array.', !Array.isArray(payload.data));
@@ -67,7 +67,7 @@ export function _findMany(adapter, store, typeClass, ids, internalModels) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    assert("You made a `findMany` request for a " + typeClass.typeClassKey + " with ids " + ids + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    assert("You made a `findMany` request for " + typeClass.modelName + " records with ids " + ids + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       let payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findMany');
       //TODO Optimize, no need to materialize here
@@ -145,7 +145,7 @@ export function _findAll(adapter, store, typeClass, sinceToken, options) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    assert("You made a `findAll` request for " + typeClass.typeClassKey + "records, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    assert("You made a `findAll` request for " + typeClass.modelName + " records, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findAll');
       //TODO Optimize
@@ -192,7 +192,7 @@ export function _queryRecord(adapter, store, typeClass, query) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    assert("You made a `queryRecord` request for " + typeClass.typeClassKey + "records, with query `" + query + "`, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    assert("You made a `queryRecord` request for a " + typeClass.modelName + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     var record;
     store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'queryRecord');

--- a/tests/integration/adapter/find-all-test.js
+++ b/tests/integration/adapter/find-all-test.js
@@ -153,5 +153,5 @@ testInDebug('When all records are requested, assert the payload is not blank', (
 
   assert.expectAssertion(() => {
     run(() => store.findAll('person'));
-  }, /the adapter's response did not have any data/);
+  }, /You made a `findAll` request for person records, but the adapter's response did not have any data/);
 });

--- a/tests/integration/adapter/find-test.js
+++ b/tests/integration/adapter/find-test.js
@@ -138,7 +138,17 @@ testInDebug('When a single record is requested, and the payload is blank', (asse
 
   assert.expectAssertion(() => {
     run(() => store.findRecord('person', 'the-id'));
-  }, /the adapter's response did not have any data/);
+  }, /You made a `findRecord` request for a person with id the-id, but the adapter's response did not have any data/);
+});
+
+testInDebug('When a single record is queried for, and the payload is blank', (assert) => {
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    queryRecord: () => Ember.RSVP.resolve({})
+  }));
+
+  assert.expectAssertion(() => {
+    run(() => store.queryRecord('person', { name: 'the-name' }));
+  }, /You made a `queryRecord` request for a person, but the adapter's response did not have any data/);
 });
 
 testInDebug('When multiple records are requested, and the payload is blank', (assert) => {
@@ -152,5 +162,5 @@ testInDebug('When multiple records are requested, and the payload is blank', (as
       store.findRecord('person', '1');
       store.findRecord('person', '2');
     });
-  }, /the adapter's response did not have any data/);
+  }, /You made a `findMany` request for person records with ids 1,2, but the adapter's response did not have any data/);
 });


### PR DESCRIPTION
As explained [here](https://github.com/emberjs/data/issues/4217) the current assertion messages for finders are outdated because they are still accessing `typeClass.typeClassKey` which has been removed. This PR updates those messages to use `typeClass.modelName` instead, and updates the tests to be more specific.