### PR TITLE
unloadRecord does not remove observers

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -122,8 +122,8 @@ var Model = Ember.Object.extend(Ember.Evented, {
     @type {Boolean}
     @readOnly
   */
-  hasDirtyAttributes: Ember.computed('currentState.isDirty', function() {
-    return this.get('currentState.isDirty');
+  hasDirtyAttributes: Ember.computed('currentState', function() {
+    return this.get('_internalModel.currentState.isDirty');
   }),
   /**
     If this property is `true` the record is in the `saving` state. A

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -376,6 +376,7 @@ Store = Service.extend({
   */
   unloadRecord(record) {
     record.unloadRecord();
+    record.destroy();
   },
 
   // ................
@@ -1476,8 +1477,7 @@ Store = Service.extend({
 
       for (let i = 0; i < records.length; i++) {
         record = records[i];
-        record.unloadRecord();
-        record.destroy(); // maybe within unloadRecord
+        this.unloadRecord(record);
       }
 
       typeMap.metadata = new EmptyObject();


### PR DESCRIPTION
**Issue:** https://github.com/emberjs/data/issues/4126

This is a work in progress to get conversation going on what the expectation should be. The test shows the issue where when you unload a record from the store, the observers on that object are not torn down. 

* Should `unloadRecord` set the object as destroyed?
* Should `unloadRecord` clear observers?