### PR TITLE
Uses bin/start with friendly error message for npm start.

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [ ! -d "node_modules" ]; then
+  echo "Please make sure you run npm install before running npm start";
+  exit 0;
+fi
+
+if [ ! -d "bower_components" ]; then
+  echo "Please make sure you run bower install before running npm start";
+  exit 0;
+fi
+
+ember server;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "ember build",
-    "start": "ember server",
+    "start": "./bin/start",
     "test": "ember try:testall",
     "node-tests": "node node-tests/nodetest-runner.js",
     "test:optional-features": "ember test --environment=test-optional-features",


### PR DESCRIPTION
Running `npm start` (which originally ran `ember serve`) before running `npm install` and `bower install` was confusing. This introduces `bin/start` which checks if `node_modules` or `bower_components` exists before trying to run `ember serve`.