### PR TITLE
[BUGFIX beta] add custom warning when invalid JSON is returned

### DIFF
--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -17,6 +17,7 @@ import {
 } from 'ember-data/adapters/errors';
 import BuildURLMixin from "ember-data/-private/adapters/build-url-mixin";
 import isEnabled from 'ember-data/-private/features';
+import { runInDebug, warn } from 'ember-data/-private/debug';
 import parseResponseHeaders from 'ember-data/-private/utils/parse-response-headers';
 
 const {
@@ -1011,6 +1012,14 @@ var RESTAdapter = Adapter.extend(BuildURLMixin, {
       };
 
       hash.error = function(jqXHR, textStatus, errorThrown) {
+        runInDebug(function() {
+          let message = `The server returned an empty string for ${type} ${url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
+          let validJSONString = !(textStatus === "parsererror" && jqXHR.responseText === "");
+          warn(message, validJSONString, {
+            id: 'ds.adapter.returned-empty-string-as-JSON'
+          });
+        });
+
         let error;
 
         if (errorThrown instanceof Error) {
@@ -1378,6 +1387,14 @@ if (isEnabled('ds-improved-ajax')) {
         };
 
         hash.error = function(jqXHR, textStatus, errorThrown) {
+          runInDebug(function() {
+            let message = `The server returned an empty string for ${method} ${url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
+            let validJSONString = !(textStatus === "parsererror" && jqXHR.responseText === "");
+            warn(message, validJSONString, {
+              id: 'ds.adapter.returned-empty-string-as-JSON'
+            });
+          });
+
           let error;
 
           if (errorThrown instanceof Error) {

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
     "ember": "components/ember#release",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0"
+    "ember-qunit-notifications": "0.1.0",
+    "pretender": "^0.12.0"
   },
   "resolutions": {
     "ember": "release"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-internal-test-helpers": "^0.8.1",
+    "ember-cli-pretender": "0.6.0",
     "ember-cli-qunit": "^1.2.1",
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^2.1.0",
@@ -80,6 +81,7 @@
     "loader.js": "^4.0.0",
     "mocha": "2.4.5",
     "mocha-only-detector": "0.0.2",
+    "pretender": "1.0.0",
     "rimraf": "2.5.2",
     "rsvp": "3.2.1"
   },


### PR DESCRIPTION
When the server returns an empty string for a response which doesn't
indicate that the content is empty, jQuery tries to parse the JSON which
results in an error, which is not very helpful at first:

    JSON.parse("") === "SyntaxError: Unexpected end of input"

This change adds a custom warning when such a response is returned, so
the feedback is more valuable.

---

This addresses #4207