### PR TITLE
[DOC release] Mistaken back tick.

### DIFF
--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -692,7 +692,7 @@ var RESTSerializer = JSONSerializer.extend({
     });
     ```
 
-    Given a `TacoParty' model, calling `save` on a tacoModel would produce an outgoing
+    Given a `TacoParty` model, calling `save` on it would produce an outgoing
     request like:
 
     ```js


### PR DESCRIPTION
Hi! I was going through the docs and found an apostrophe(') mistaken for a back tick(`). Set that right.

You guys are doing some amazing work :clap:

 