### PR TITLE
[DOC] Fix typo in urlForFindBelongsTo adapter method

### DIFF
--- a/addon/-private/adapters/build-url-mixin.js
+++ b/addon/-private/adapters/build-url-mixin.js
@@ -169,7 +169,7 @@ export default Ember.Mixin.create({
   },
 
   /**
-   * @method urlForFindBelongTo
+   * @method urlForFindBelongsTo
    * @param {String} id
    * @param {String} modelName
    * @return {String} url


### PR DESCRIPTION
I generated the docs from the source code to preview the API documentation and thus verify the typo is fixed.