### PR TITLE
[BUGFIX beta] Overhaul queryRecord

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1043,20 +1043,96 @@ Store = Service.extend({
   },
 
   /**
-    This method delegates a query to the adapter. This is the one place where
-    adapter-level semantics are exposed to the application.
+    This method makes a request for one record, where the `id` is not known
+    beforehand (if the `id` is known, use `findRecord` instead).
 
-    Exposing queries this way seems preferable to creating an abstract query
-    language for all server-side queries, and then require all adapters to
-    implement them.
+    This method can be used when it is certain that the server will return a
+    single object for the primary data.
 
-    This method returns a promise, which is resolved with a `RecordObject`
-    once the server returns.
+    Let's assume our API provides an endpoint for the currently logged in user
+    via:
+
+    ```
+    // GET /api/current_user
+    {
+      user: {
+        id: 1234,
+        username: 'admin'
+      }
+    }
+    ```
+
+    Since the specific `id` of the `user` is not known beforehand, we can use
+    `queryRecord` to get the user:
+
+    ```javascript
+    store.queryRecord('user', {}).then(function(user) {
+      let username = user.get('username');
+      console.log(`Currently logged in as ${username}`);
+    });
+    ```
+
+    The request is made through the adapters' `queryRecord`:
+
+    ```javascript
+    // app/adapters/user.js
+    import Adapter from "ember-data/adapter";
+
+    export default Adapter.extend({
+      queryRecord(modelName, query) {
+        return Ember.$.getJSON("/api/current_user");
+      }
+    });
+    ```
+
+    Note: the primary use case for `store.queryRecord` is when a single record
+    is queried and the `id` is not kown beforehand. In all other cases
+    `store.query` and using the first item of the array is likely the preferred
+    way:
+
+    ```
+    // GET /users?username=unique
+    {
+      data: [{
+        id: 1234,
+        type: 'user',
+        attributes: {
+          username: "unique"
+        }
+      }]
+    }
+    ```
+
+    ```javascript
+    store.query('user', { username: 'unique' }).then(function(users) {
+      return users.get('firstObject');
+    }).then(function(user) {
+      let id = user.get('id');
+    });
+    ```
+
+    This method returns a promise, which resolves with the found record.
+
+    If the adapter returns no data for the primary data of the payload, then
+    `queryRecord` resolves with `null`:
+
+    ```
+    // GET /users?username=unique
+    {
+      data: null
+    }
+    ```
+
+    ```javascript
+    store.queryRecord('user', { username: 'unique' }).then(function(user) {
+      console.log(user); // null
+    });
+    ```
 
     @method queryRecord
     @param {String} modelName
     @param {any} query an opaque query to be used by the adapter
-    @return {Promise} promise
+    @return {Promise} promise which resolves with the found record or `null`
   */
   queryRecord(modelName, query) {
     assert("You need to pass a model name to the store's queryRecord method", isPresent(modelName));

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -192,10 +192,14 @@ export function _queryRecord(adapter, store, typeClass, query) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    assert("You made a `queryRecord` request for a " + typeClass.modelName + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     var record;
     store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'queryRecord');
+
+      assert("Expected the primary data returned by the serializer for a `queryRecord` response to be a single object or null but instead it was an array.", !Array.isArray(payload.data), {
+        id: 'ds.store.queryRecord-array-response'
+      });
+
       //TODO Optimize
       record = store.push(payload);
     });

--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -202,6 +202,16 @@ const JSONAPISerializer = JSONSerializer.extend({
     return normalizedPayload;
   },
 
+  normalizeQueryRecordResponse() {
+    let normalized = this._super(...arguments);
+
+    assert('Expected the primary data returned by the serializer for a `queryRecord` response to be a single object but instead it was an array.', !Array.isArray(normalized.data), {
+      id: 'ds.serializer.json-api.queryRecord-array-response'
+    });
+
+    return normalized;
+  },
+
   /**
     @method extractAttributes
     @param {DS.Model} modelClass

--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -282,6 +282,16 @@ var RESTSerializer = JSONSerializer.extend({
         continue;
       }
 
+      runInDebug(function() {
+        let isQueryRecordAnArray = requestType === 'queryRecord' && isPrimary && Array.isArray(value);
+        let message = "The adapter returned an array for the primary data of a `queryRecord` response. This is deprecated as `queryRecord` should return a single record.";
+
+        deprecate(message, !isQueryRecordAnArray, {
+          id: 'ds.serializer.rest.queryRecord-array-response',
+          until: '3.0'
+        });
+      });
+
       /*
         Support primary data as an object instead of an array.
 

--- a/tests/integration/adapter/find-test.js
+++ b/tests/integration/adapter/find-test.js
@@ -141,16 +141,6 @@ testInDebug('When a single record is requested, and the payload is blank', (asse
   }, /You made a `findRecord` request for a person with id the-id, but the adapter's response did not have any data/);
 });
 
-testInDebug('When a single record is queried for, and the payload is blank', (assert) => {
-  env.registry.register('adapter:person', DS.Adapter.extend({
-    queryRecord: () => Ember.RSVP.resolve({})
-  }));
-
-  assert.expectAssertion(() => {
-    run(() => store.queryRecord('person', { name: 'the-name' }));
-  }, /You made a `queryRecord` request for a person, but the adapter's response did not have any data/);
-});
-
 testInDebug('When multiple records are requested, and the payload is blank', (assert) => {
   env.registry.register('adapter:person', DS.Adapter.extend({
     coalesceFindRequests: true,

--- a/tests/integration/adapter/json-api-adapter-test.js
+++ b/tests/integration/adapter/json-api-adapter-test.js
@@ -2,6 +2,7 @@ import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
 import {module, test} from 'qunit';
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 
 import DS from 'ember-data';
 import isEnabled from 'ember-data/-private/features';
@@ -232,6 +233,55 @@ test('find many records', function(assert) {
       assert.equal(posts.get('firstObject.title'), 'Ember.js rocks');
     });
   });
+});
+
+test('queryRecord - primary data being a single record', function(assert) {
+  ajaxResponse([{
+    data: {
+      type: 'posts',
+      id: '1',
+      attributes: {
+        title: 'Ember.js rocks'
+      }
+    }
+  }]);
+
+  run(function() {
+    store.queryRecord('post', {}).then(function(post) {
+      assert.equal(passedUrl[0], '/posts');
+
+      assert.equal(post.get('title'), 'Ember.js rocks');
+    });
+  });
+});
+
+test('queryRecord - primary data being null', function(assert) {
+  ajaxResponse([{
+    data: null
+  }]);
+
+  run(function() {
+    store.queryRecord('post', {}).then(function(post) {
+      assert.equal(passedUrl[0], '/posts');
+
+      assert.strictEqual(post, null);
+    });
+  });
+});
+
+testInDebug('queryRecord - primary data being an array throws an assertion', function(assert) {
+  ajaxResponse([{
+    data: [{
+      type: 'posts',
+      id: '1'
+    }]
+  }]);
+
+  assert.expectAssertion(function() {
+    run(function() {
+      store.queryRecord('post', {});
+    });
+  }, "Expected the primary data returned by the serializer for a `queryRecord` response to be a single object but instead it was an array.");
 });
 
 test('find a single record with belongsTo link as object { related }', function(assert) {

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -1299,7 +1299,25 @@ test("query - data is normalized through custom serializers", function(assert) {
   }));
 });
 
-test("queryRecord - returns a single record in an object", function(assert) {
+test("queryRecord - empty response", function(assert) {
+  ajaxResponse({});
+
+  store.queryRecord('post', { slug: 'ember-js-rocks' }).then(assert.wait(function(post) {
+    assert.strictEqual(post, null);
+  }));
+});
+
+test("queryRecord - primary data being null", function(assert) {
+  ajaxResponse({
+    post: null
+  });
+
+  store.queryRecord('post', { slug: 'ember-js-rocks' }).then(assert.wait(function(post) {
+    assert.strictEqual(post, null);
+  }));
+});
+
+test("queryRecord - primary data being a single object", function(assert) {
   ajaxResponse({
     post: {
       id: '1',
@@ -1336,6 +1354,38 @@ test("queryRecord - returning an array picks the first one but saves all records
     assert.deepEqual(post.getProperties('id', 'name'), { id: "1", name: "Rails is omakase" });
     assert.deepEqual(post2.getProperties('id', 'name'), { id: "2", name: "Ember is js" });
   }));
+});
+
+testInDebug("queryRecord - returning an array is deprecated", function(assert) {
+  let done = assert.async();
+
+  ajaxResponse({
+    post: [{ id: 1, name: "Rails is omakase" }, { id: 2, name: "Ember is js" }]
+  });
+
+  assert.expectDeprecation('The adapter returned an array for the primary data of a `queryRecord` response. This is deprecated as `queryRecord` should return a single record.');
+
+  run(function() {
+    store.queryRecord('post', { slug: 'rails-is-omakaze' }).then(function() {
+      done();
+    });
+  });
+});
+
+testInDebug("queryRecord - returning an single object doesn't throw a deprecation", function(assert) {
+  let done = assert.async();
+
+  ajaxResponse({
+    post: { id: 1, name: "Rails is omakase" }
+  });
+
+  assert.expectNoDeprecation();
+
+  run(function() {
+    store.queryRecord('post', { slug: 'rails-is-omakaze' }).then(function() {
+      done();
+    });
+  });
 });
 
 test("queryRecord - data is normalized through custom serializers", function(assert) {

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -590,3 +590,29 @@ testInDebug('store#findRecord that returns an array should assert', assert => {
     });
   }, /expected the primary data returned from a `findRecord` response to be an object but instead it found an array/);
 });
+
+module("integration/store - queryRecord", {
+  beforeEach() {
+    initializeStore(DS.Adapter.extend());
+  }
+});
+
+testInDebug('store#queryRecord should assert when normalized payload of adapter has an array an data', function(assert) {
+  env.adapter.queryRecord = function() {
+    return {
+      cars: [{ id: 1 }]
+    };
+  };
+
+  env.serializer.normalizeQueryRecordResponse = function() {
+    return {
+      data: [{ id: 1, type: 'car' }]
+    };
+  };
+
+  assert.expectAssertion(function() {
+    run(function() {
+      store.queryRecord('car', {});
+    });
+  }, /Expected the primary data returned by the serializer for a `queryRecord` response to be a single object or null but instead it was an array./);
+});


### PR DESCRIPTION
Currently the use case for `store.queryRecord` is not communicated very
well and there has been some confusion on what the expected server
response should look like (array, or an object).

There are several issues with the current code base:

- in general, if the serializer returns an array for the primary data
  returned by `normalizeQueryRecordResponse`, then `store.queryRecord`
  resolves with an array

- if rest serializer is used and an array is returned by the adapter,
  then the first entry of the array is used as primary data and
  `store.queryRecord` resolves with the first record

- if json-api serializer is used and the primary data is an array, then
  `store.queryRecord` resolves with an array of the primary records

- the API documentation for `queryRecord` is similar to `query` and
  doesn't indicate when this method should be used in contrast to
  `store.query` and getting the first record of the array

- an assertion for the payload returned by the adapter for `queryRecord`
  not being an empty object has been added in 2.4, which is a regression
  to the behavior of 2.3

-----------------------------------------------------------------------

This commit addresses the above issues and makes the following changes:

- add assertion that `store.queryRecord` never resolves with an array

- add deprecation warning for the rest-serializers' `queryRecord`, if an
  array is returned instead of a single record

- removes the assertion that the returned payload from the adapter for
  `queryRecord` is not an empty object

- add assertion within json-api serializer that the primary data of the
  normalized response is not an array

---

I am not so sure about the deprecation for the `rest-serializer`, since it looks like currently also `findRecord` works when an array is returned (see [this test](https://github.com/emberjs/data/blob/v2.4.3/tests/integration/adapter/rest-adapter-test.js#L94-L114)). But since `json-api-adapter` doesn't allow `data: [...]` responses for `queryRecord`, this seems like an inconsistency which is a little surprising IMHO `¯\_(ツ)_/¯` .

This addresses issues raised in #3977, #4227 and #4255.