### PR TITLE
[skip ci] fix invalid indentation in codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,6 @@
 # Save as .codeclimate.yml (note leading .) in project root directory
 languages:
   JavaScript: true
- exclude_paths:
+
+exclude_paths:
   - "tests/*"


### PR DESCRIPTION
That's why the codeclimate score hasn't been updated in a while.

Error in CodeClimate: `Unparsable .codeclimate.yml Configuration File`