### PR TITLE
Use new blueprint testing API

### DIFF
--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -1,133 +1,106 @@
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerate = blueprintHelpers.emberGenerate;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
+
+var SilentError = require('silent-error');
 
 describe('Acceptance: generate and destroy adapter blueprints', function() {
   setupTestHooks(this);
 
   it('adapter', function() {
-    return generateAndDestroy(['adapter', 'foo'], {
-      files: [
-        {
-          file: 'app/adapters/foo.js',
-          contains: [
-            'import JSONAPIAdapter from \'ember-data/adapters/json-api\';',
-            'export default JSONAPIAdapter.extend({'
-          ]
-        },
-        {
-          file: 'tests/unit/adapters/foo-test.js',
-          contains: [
-            'moduleFor(\'adapter:foo\''
-          ]
-        }
-      ]
-    });
+    var args = ['adapter', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/adapters/foo.js'))
+          .to.contain('import JSONAPIAdapter from \'ember-data/adapters/json-api\';')
+          .to.contain('export default JSONAPIAdapter.extend({');
+
+        expect(_file('tests/unit/adapters/foo-test.js'))
+          .to.contain('moduleFor(\'adapter:foo\'');
+      }));
   });
 
   it('adapter extends application adapter if it exists', function() {
-    return generateAndDestroy(['adapter', 'application'], {
-      afterGenerate: function() {
-        return generateAndDestroy(['adapter', 'foo'], {
-          skipInit: true,
-          files: [
-            {
-              file: 'app/adapters/foo.js',
-              contains: [
-                'import ApplicationAdapter from \'./application\';',
-                'export default ApplicationAdapter.extend({'
-              ]
-            },
-            {
-              file: 'tests/unit/adapters/foo-test.js',
-              contains: [
-                'moduleFor(\'adapter:foo\''
-              ]
-            }
-          ]
-        });
-      }
-    });
+    var args = ['adapter', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerate(['adapter', 'application']))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/adapters/foo.js'))
+          .to.contain('import ApplicationAdapter from \'./application\';')
+          .to.contain('export default ApplicationAdapter.extend({');
+
+        expect(_file('tests/unit/adapters/foo-test.js'))
+          .to.contain('moduleFor(\'adapter:foo\'');
+      }));
   });
 
   it('adapter with --base-class', function() {
-    return generateAndDestroy(['adapter', 'foo', '--base-class=bar'], {
-      files: [
-        {
-          file: 'app/adapters/foo.js',
-          contains: [
-            'import BarAdapter from \'./bar\';',
-            'export default BarAdapter.extend({'
-          ]
-        },
-        {
-          file: 'tests/unit/adapters/foo-test.js',
-          contains: [
-            'moduleFor(\'adapter:foo\''
-          ]
-        }
-      ]
-    });
+    var args = ['adapter', 'foo', '--base-class=bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/adapters/foo.js'))
+          .to.contain('import BarAdapter from \'./bar\';')
+          .to.contain('export default BarAdapter.extend({');
+
+        expect(_file('tests/unit/adapters/foo-test.js'))
+          .to.contain('moduleFor(\'adapter:foo\'');
+      }));
   });
 
   it('adapter throws when --base-class is same as name', function() {
-    return generateAndDestroy(['adapter', 'application', '--base-class=application'], {
-      throws: {
-        message: /Adapters cannot extend from themself/,
-        type: 'SilentError'
-      }
-    });
+    var args = ['adapter', 'foo', '--base-class=foo'];
+
+    return emberNew()
+      .then(() => expect(emberGenerate(args))
+        .to.be.rejectedWith(SilentError, /Adapters cannot extend from themself/));
   });
 
   it('adapter when is named "application"', function() {
-    return generateAndDestroy(['adapter', 'application'], {
-      files: [
-        {
-          file: 'app/adapters/application.js',
-          contains: [
-            'import JSONAPIAdapter from \'ember-data/adapters/json-api\';',
-            'export default JSONAPIAdapter.extend({'
-          ]
-        },
-        {
-          file: 'tests/unit/adapters/application-test.js',
-          contains: [
-            'moduleFor(\'adapter:application\''
-          ]
-        }
-      ]
-    });
+    var args = ['adapter', 'application'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/adapters/application.js'))
+          .to.contain('import JSONAPIAdapter from \'ember-data/adapters/json-api\';')
+          .to.contain('export default JSONAPIAdapter.extend({');
+
+        expect(_file('tests/unit/adapters/application-test.js'))
+          .to.contain('moduleFor(\'adapter:application\'');
+      }));
   });
 
   it('adapter-test', function() {
-    return generateAndDestroy(['adapter-test', 'foo'], {
-      files: [
-        {
-          file: 'tests/unit/adapters/foo-test.js',
-          contains: [
-            'moduleFor(\'adapter:foo\''
-          ]
-        }
-      ]
-    });
+    var args = ['adapter-test', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/adapters/foo-test.js'))
+          .to.contain('moduleFor(\'adapter:foo\'');
+      }));
   });
 
   it('adapter-test for mocha', function() {
-    return generateAndDestroy(['adapter-test', 'foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/adapters/foo-test.js',
-          contains: [
-            'import { describeModule, it } from \'ember-mocha\';',
-            'describeModule(\n  \'adapter:foo\',',
-            'expect(adapter).to.be.ok;'
-          ]
-        }
-      ]
-    });
+    var args = ['adapter-test', 'foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/adapters/foo-test.js'))
+          .to.contain('import { describeModule, it } from \'ember-mocha\';')
+          .to.contain('describeModule(\n  \'adapter:foo\',')
+          .to.contain('expect(adapter).to.be.ok;');
+      }));
   });
 });

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -1,38 +1,35 @@
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: generate and destroy model blueprints', function() {
   setupTestHooks(this);
 
   it('model', function() {
-    return generateAndDestroy(['model', 'foo'], {
-      files: [
-        {
-          file: 'app/models/foo.js',
-          contains: [
-            'import Model from \'ember-data/model\';',
-            'export default Model.extend('
-          ],
-          doesNotContain: [
-            'import attr from \'ember-data/attr\';',
-            'import { belongsTo } from \'ember-data/relationships\';',
-            'import { hasMany } from \'ember-data/relationships\';',
-            'import { belongsTo, hasMany } from \'ember-data/relationships\';'
-          ]
-        },
-        {
-          file: 'tests/unit/models/foo-test.js',
-          contains: [
-            'moduleForModel(\'foo\''
-          ]
-        }
-      ]
-    });
+    var args = ['model', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/models/foo.js'))
+          .to.contain('import Model from \'ember-data/model\';')
+          .to.contain('export default Model.extend(')
+          .to.not.contain('import attr from \'ember-data/attr\';')
+          .to.not.contain('import { belongsTo } from \'ember-data/relationships\';')
+          .to.not.contain('import { hasMany } from \'ember-data/relationships\';')
+          .to.not.contain('import { belongsTo, hasMany } from \'ember-data/relationships\';');
+
+        expect(_file('tests/unit/models/foo-test.js'))
+          .to.contain('moduleForModel(\'foo\'');
+      }));
   });
 
   it('model with attrs', function() {
-    return generateAndDestroy([
+    var args = [
       'model',
       'foo',
       'misc',
@@ -43,144 +40,109 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       'age:number',
       'name:string',
       'customAttr:custom-transform'
-    ], {
-      files: [
-        {
-          file: 'app/models/foo.js',
-          contains: [
-            'import Model from \'ember-data/model\';',
-            'import attr from \'ember-data/attr\';',
-            'export default Model.extend(',
-            'misc: attr()',
-            'skills: attr(\'array\')',
-            'isActive: attr(\'boolean\')',
-            'birthday: attr(\'date\')',
-            'someObject: attr(\'object\')',
-            'age: attr(\'number\')',
-            'name: attr(\'string\')',
-            'customAttr: attr(\'custom-transform\')'
-          ],
-          doesNotContain: [
-            'import { belongsTo } from \'ember-data/relationships\';',
-            'import { hasMany } from \'ember-data/relationships\';',
-            'import { belongsTo, hasMany } from \'ember-data/relationships\';'
-          ]
-        },
-        {
-          file: 'tests/unit/models/foo-test.js',
-          contains: [
-            'moduleForModel(\'foo\''
-          ]
-        }
-      ]
-    });
+    ];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/models/foo.js'))
+          .to.contain('import Model from \'ember-data/model\';')
+          .to.contain('import attr from \'ember-data/attr\';')
+          .to.contain('export default Model.extend(')
+          .to.contain('misc: attr()')
+          .to.contain('skills: attr(\'array\')')
+          .to.contain('isActive: attr(\'boolean\')')
+          .to.contain('birthday: attr(\'date\')')
+          .to.contain('someObject: attr(\'object\')')
+          .to.contain('age: attr(\'number\')')
+          .to.contain('name: attr(\'string\')')
+          .to.contain('customAttr: attr(\'custom-transform\')')
+          .to.not.contain('import { belongsTo } from \'ember-data/relationships\';')
+          .to.not.contain('import { hasMany } from \'ember-data/relationships\';')
+          .to.not.contain('import { belongsTo, hasMany } from \'ember-data/relationships\';');
+
+        expect(_file('tests/unit/models/foo-test.js'))
+          .to.contain('moduleForModel(\'foo\'');
+      }));
   });
 
   it('model with belongsTo', function() {
-    return generateAndDestroy(['model', 'comment', 'post:belongs-to', 'author:belongs-to:user'], {
-      files: [
-        {
-          file: 'app/models/comment.js',
-          contains: [
-            'import Model from \'ember-data/model\';',
-            'import { belongsTo } from \'ember-data/relationships\';',
-            'export default Model.extend(',
-            'post: belongsTo(\'post\')',
-            'author: belongsTo(\'user\')',
-          ],
-          doesNotContain: [
-            'import attr from \'ember-data/attr\';',
-            'import { hasMany } from \'ember-data/relationships\';',
-            'import { belongsTo, hasMany } from \'ember-data/relationships\';'
-          ]
-        },
-        {
-          file: 'tests/unit/models/comment-test.js',
-          contains: [
-            'moduleForModel(\'comment\'',
-            'needs: [\'model:post\', \'model:user\']'
-          ]
-        }
-      ]
-    });
+    var args = ['model', 'comment', 'post:belongs-to', 'author:belongs-to:user'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/models/comment.js'))
+          .to.contain('import Model from \'ember-data/model\';')
+          .to.contain('import { belongsTo } from \'ember-data/relationships\';')
+          .to.contain('export default Model.extend(')
+          .to.contain('post: belongsTo(\'post\')')
+          .to.contain('author: belongsTo(\'user\')')
+          .to.not.contain('import attr from \'ember-data/attr\';')
+          .to.not.contain('import { hasMany } from \'ember-data/relationships\';')
+          .to.not.contain('import { belongsTo, hasMany } from \'ember-data/relationships\';');
+
+        expect(_file('tests/unit/models/comment-test.js'))
+          .to.contain('moduleForModel(\'comment\'')
+          .to.contain('needs: [\'model:post\', \'model:user\']');
+      }));
   });
 
   it('model with hasMany', function() {
-    return generateAndDestroy(['model', 'post', 'comments:has-many', 'otherComments:has-many:comment'], {
-      files: [
-        {
-          file: 'app/models/post.js',
-          contains: [
-            'import Model from \'ember-data/model\';',
-            'import { hasMany } from \'ember-data/relationships\';',
-            'export default Model.extend(',
-            'comments: hasMany(\'comment\')',
-            'otherComments: hasMany(\'comment\')',
-          ],
-          doesNotContain: [
-            'import attr from \'ember-data/attr\';',
-            'import { belongsTo } from \'ember-data/relationships\';',
-            'import { belongsTo, hasMany } from \'ember-data/relationships\';'
-          ]
-        },
-        {
-          file: 'tests/unit/models/post-test.js',
-          contains: [
-            'moduleForModel(\'post\'',
-            'needs: [\'model:comment\']'
-          ]
-        }
-      ]
-    });
+    var args = ['model', 'post', 'comments:has-many', 'otherComments:has-many:comment'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/models/post.js'))
+          .to.contain('import Model from \'ember-data/model\';')
+          .to.contain('import { hasMany } from \'ember-data/relationships\';')
+          .to.contain('export default Model.extend(')
+          .to.contain('comments: hasMany(\'comment\')')
+          .to.contain('otherComments: hasMany(\'comment\')')
+          .to.not.contain('import attr from \'ember-data/attr\';')
+          .to.not.contain('import { belongsTo } from \'ember-data/relationships\';')
+          .to.not.contain('import { belongsTo, hasMany } from \'ember-data/relationships\';');
+
+        expect(_file('tests/unit/models/post-test.js'))
+          .to.contain('moduleForModel(\'post\'')
+          .to.contain('needs: [\'model:comment\']');
+      }));
   });
 
   it('model with belongsTo and hasMany has both imports', function() {
-    return generateAndDestroy(['model', 'post', 'comments:has-many', 'user:belongs-to'], {
-      files: [
-        {
-          file: 'app/models/post.js',
-          contains: [
-            'import { belongsTo, hasMany } from \'ember-data/relationships\';'
-          ],
-          doesNotContain: [
-            'import attr from \'ember-data/attr\';',
-            'import { belongsTo } from \'ember-data/relationships\';',
-            'import { hasMany } from \'ember-data/relationships\';'
-          ]
-        }
-      ]
-    });
+    var args = ['model', 'post', 'comments:has-many', 'user:belongs-to'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/models/post.js'))
+          .to.contain('import { belongsTo, hasMany } from \'ember-data/relationships\';')
+          .to.not.contain('import attr from \'ember-data/attr\';')
+          .to.not.contain('import { belongsTo } from \'ember-data/relationships\';')
+          .to.not.contain('import { hasMany } from \'ember-data/relationships\';');
+      }));
   });
 
   it('model-test', function() {
-    return generateAndDestroy(['model-test', 'foo'], {
-      files: [
-        {
-          file: 'tests/unit/models/foo-test.js',
-          contains: [
-            'moduleForModel(\'foo\''
-          ]
-        }
-      ]
-    });
+    var args = ['model-test', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/models/foo-test.js'))
+          .to.contain('moduleForModel(\'foo\'');
+      }));
   });
 
   it('model-test for mocha', function() {
-    return generateAndDestroy(['model-test', 'foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/models/foo-test.js',
-          contains: [
-            'import { describeModel, it } from \'ember-mocha\';',
-            'describeModel(\n  \'foo\',',
-            'expect(model).to.be.ok;'
-          ]
-        }
-      ]
-    });
+    var args = ['model-test', 'foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/models/foo-test.js'))
+          .to.contain('import { describeModel, it } from \'ember-mocha\';')
+          .to.contain('describeModel(\n  \'foo\',')
+          .to.contain('expect(model).to.be.ok;');
+      }));
   });
 });

--- a/node-tests/blueprints/serializer-test.js
+++ b/node-tests/blueprints/serializer-test.js
@@ -1,135 +1,108 @@
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerate = blueprintHelpers.emberGenerate;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
+
+var SilentError = require('silent-error');
 
 describe('Acceptance: generate and destroy serializer blueprints', function() {
   setupTestHooks(this);
 
   it('serializer', function() {
-    return generateAndDestroy(['serializer', 'foo'], {
-      files: [
-        {
-          file: 'app/serializers/foo.js',
-          contains: [
-            'import JSONAPISerializer from \'ember-data/serializers/json-api\';',
-            'export default JSONAPISerializer.extend('
-          ]
-        },
-        {
-          file: 'tests/unit/serializers/foo-test.js',
-          contains: [
-            'moduleForModel(\'foo\''
-          ]
-        }
-      ]
-    });
+    var args = ['serializer', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/serializers/foo.js'))
+          .to.contain('import JSONAPISerializer from \'ember-data/serializers/json-api\';')
+          .to.contain('export default JSONAPISerializer.extend(');
+
+        expect(_file('tests/unit/serializers/foo-test.js'))
+          .to.contain('moduleForModel(\'foo\'');
+      }));
   });
 
   it('serializer extends application serializer if it exists', function() {
-    return generateAndDestroy(['serializer', 'application'], {
-      afterGenerate: function() {
-        return generateAndDestroy(['serializer', 'foo'], {
-          skipInit: true,
-          files: [
-            {
-              file: 'app/serializers/foo.js',
-              contains: [
-                'import ApplicationSerializer from \'./application\';',
-                'export default ApplicationSerializer.extend({'
-              ]
-            },
-            {
-              file: 'tests/unit/serializers/foo-test.js',
-              contains: [
-                'moduleForModel(\'foo\''
-              ]
-            }
-          ]
-        });
-      }
-    });
+    var args = ['serializer', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerate(['serializer', 'application']))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/serializers/foo.js'))
+          .to.contain('import ApplicationSerializer from \'./application\';')
+          .to.contain('export default ApplicationSerializer.extend({');
+
+        expect(_file('tests/unit/serializers/foo-test.js'))
+          .to.contain('moduleForModel(\'foo\'');
+      }));
   });
 
   it('serializer with --base-class', function() {
-    return generateAndDestroy(['serializer', 'foo', '--base-class=bar'], {
-      files: [
-        {
-          file: 'app/serializers/foo.js',
-          contains: [
-            'import BarSerializer from \'./bar\';',
-            'export default BarSerializer.extend({'
-          ]
-        },
-        {
-          file: 'tests/unit/serializers/foo-test.js',
-          contains: [
-            'moduleForModel(\'foo\''
-          ]
-        }
-      ]
-    });
+    var args = ['serializer', 'foo', '--base-class=bar'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/serializers/foo.js'))
+          .to.contain('import BarSerializer from \'./bar\';')
+          .to.contain('export default BarSerializer.extend({');
+
+        expect(_file('tests/unit/serializers/foo-test.js'))
+          .to.contain('moduleForModel(\'foo\'');
+      }));
   });
 
   it('serializer throws when --base-class is same as name', function() {
-    return generateAndDestroy(['serializer', 'application', '--base-class=application'], {
-      throws: {
-        message: /Serializers cannot extend from themself/,
-        type: 'SilentError'
-      }
-    });
+    var args = ['serializer', 'foo', '--base-class=foo'];
+
+    return emberNew()
+      .then(() => expect(emberGenerate(args))
+        .to.be.rejectedWith(SilentError, /Serializers cannot extend from themself/));
   });
 
   it('serializer when is named "application"', function() {
-    return generateAndDestroy(['serializer', 'application'], {
-      files: [
-        {
-          file: 'app/serializers/application.js',
-          contains: [
-            'import JSONAPISerializer from \'ember-data/serializers/json-api\';',
-            'export default JSONAPISerializer.extend({'
-          ]
-        },
-        {
-          file: 'tests/unit/serializers/application-test.js',
-          contains: [
-            'moduleForModel(\'application\''
-          ]
-        }
-      ]
-    });
+    var args = ['serializer', 'application'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/serializers/application.js'))
+          .to.contain('import JSONAPISerializer from \'ember-data/serializers/json-api\';')
+          .to.contain('export default JSONAPISerializer.extend({');
+
+        expect(_file('tests/unit/serializers/application-test.js'))
+          .to.contain('moduleForModel(\'application\'');
+      }));
   });
 
   it('serializer-test', function() {
-    return generateAndDestroy(['serializer-test', 'foo'], {
-      files: [
-        {
-          file: 'tests/unit/serializers/foo-test.js',
-          contains: [
-            'moduleForModel(\'foo\''
-          ]
-        }
-      ]
-    });
+    var args = ['serializer-test', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/serializers/foo-test.js'))
+          .to.contain('moduleForModel(\'foo\'');
+      }));
   });
 
   it('serializer-test for mocha', function() {
-    return generateAndDestroy(['serializer-test', 'foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/serializers/foo-test.js',
-          contains: [
-            'import { describeModel, it } from \'ember-mocha\';',
-            'describeModel(\n  \'foo\',',
-            'Unit | Serializer | foo',
-            'needs: [\'serializer:foo\']',
-            'expect(serializedRecord).to.be.ok;'
-          ]
-        }
-      ]
-    });
+    var args = ['serializer-test', 'foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/serializers/foo-test.js'))
+          .to.contain('import { describeModel, it } from \'ember-mocha\';')
+          .to.contain('describeModel(\n  \'foo\',')
+          .to.contain('Unit | Serializer | foo')
+          .to.contain('needs: [\'serializer:foo\']')
+          .to.contain('expect(serializedRecord).to.be.ok;');
+      }));
   });
 });

--- a/node-tests/blueprints/transform-test.js
+++ b/node-tests/blueprints/transform-test.js
@@ -1,61 +1,54 @@
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var modifyPackages = blueprintHelpers.modifyPackages;
+
+var chai = require('ember-cli-blueprint-test-helpers/chai');
+var expect = chai.expect;
 
 describe('Acceptance: generate and destroy transform blueprints', function() {
   setupTestHooks(this);
 
   it('transform', function() {
-    return generateAndDestroy(['transform', 'foo'], {
-      files: [
-        {
-          file: 'app/transforms/foo.js',
-          contains: [
-            'import Transform from \'ember-data/transform\';',
-            'export default Transform.extend(',
-            'deserialize(serialized) {',
-            'serialize(deserialized) {'
-          ]
-        },
-        {
-          file: 'tests/unit/transforms/foo-test.js',
-          contains: [
-            'moduleFor(\'transform:foo\''
-          ]
-        }
-      ]
-    });
+    var args = ['transform', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('app/transforms/foo.js'))
+          .to.contain('import Transform from \'ember-data/transform\';')
+          .to.contain('export default Transform.extend(')
+          .to.contain('deserialize(serialized) {')
+          .to.contain('serialize(deserialized) {');
+
+        expect(_file('tests/unit/transforms/foo-test.js'))
+          .to.contain('moduleFor(\'transform:foo\'');
+      }));
   });
 
   it('transforms-test', function() {
-    return generateAndDestroy(['transform-test', 'foo'], {
-      files: [
-        {
-          file: 'tests/unit/transforms/foo-test.js',
-          contains: [
-            'moduleFor(\'transform:foo\''
-          ]
-        }
-      ]
-    });
+    var args = ['transform-test', 'foo'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/transforms/foo-test.js'))
+          .to.contain('moduleFor(\'transform:foo\'');
+      }));
   });
 
   it('transform-test for mocha', function() {
-    return generateAndDestroy(['transform-test', 'foo'], {
-      packages: [
-        { name: 'ember-cli-qunit', delete: true },
-        { name: 'ember-cli-mocha', dev: true }
-      ],
-      files: [
-        {
-          file: 'tests/unit/transforms/foo-test.js',
-          contains: [
-            'import { describeModule, it } from \'ember-mocha\';',
-            'describeModule(\n  \'transform:foo\',',
-            'expect(transform).to.be.ok;'
-          ]
-        }
-      ]
-    });
+    var args = ['transform-test', 'foo'];
+
+    return emberNew()
+      .then(() => modifyPackages([
+        {name: 'ember-cli-qunit', delete: true},
+        {name: 'ember-cli-mocha', dev: true}
+      ]))
+      .then(() => emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/transforms/foo-test.js'))
+          .to.contain('import { describeModule, it } from \'ember-mocha\';')
+          .to.contain('describeModule(\n  \'transform:foo\',')
+          .to.contain('expect(transform).to.be.ok;');
+      }));
   });
 });

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-ajax": "0.7.1",
     "ember-cli": "2.4.1",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-blueprint-test-helpers": "0.10.2",
+    "ember-cli-blueprint-test-helpers": "0.11.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",


### PR DESCRIPTION
This PR modifies the blueprint tests to use the new blueprint testing API introduced in https://github.com/ember-cli/ember-cli-blueprint-test-helpers/pull/45.