### PR TITLE
Use property lookup in applyTransforms

### DIFF
--- a/addon/serializers/json.js
+++ b/addon/serializers/json.js
@@ -193,7 +193,7 @@ export default Serializer.extend({
     }
 
     typeClass.eachTransformedAttribute((key, typeClass) => {
-      if (!(key in data)) { return; }
+      if (data[key] === undefined) { return; }
 
       var transform = this.transformFor(typeClass);
       if (isEnabled('ds-transform-pass-options')) {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -906,18 +906,16 @@ AssertionPrototype.convertsWhenSet = function(type, provided, expected) {
 };
 
 test("a DS.Model can describe String attributes", function(assert) {
-  assert.expect(6);
+  assert.expect(4);
 
   assert.converts('string', "Scumbag Tom", "Scumbag Tom");
   assert.converts('string', 1, "1");
   assert.converts('string', "", "");
   assert.converts('string', null, null);
-  assert.converts('string', undefined, null);
-  assert.convertsFromServer('string', undefined, null);
 });
 
 test("a DS.Model can describe Number attributes", function(assert) {
-  assert.expect(9);
+  assert.expect(8);
 
   assert.converts('number', "1", 1);
   assert.converts('number', "0", 0);
@@ -925,7 +923,6 @@ test("a DS.Model can describe Number attributes", function(assert) {
   assert.converts('number', 0, 0);
   assert.converts('number', "", null);
   assert.converts('number', null, null);
-  assert.converts('number', undefined, null);
   assert.converts('number', true, 1);
   assert.converts('number', false, 0);
 });
@@ -938,18 +935,14 @@ test("a DS.Model can describe Boolean attributes", function(assert) {
 
   if (isEnabled('ds-transform-pass-options') && isEnabled('ds-boolean-transform-allow-null')) {
     assert.converts('boolean', null, null, { allowNull: true });
-    assert.converts('boolean', undefined, null, { allowNull: true });
 
     assert.converts('boolean', null, false, { allowNull: false });
-    assert.converts('boolean', undefined, false, { allowNull: false });
 
     // duplicating the tests from the else branch here, so once the feature is
     // enabled and the else branch is deleted, those assertions are kept
     assert.converts('boolean', null, false);
-    assert.converts('boolean', undefined, false);
   } else {
     assert.converts('boolean', null, false);
-    assert.converts('boolean', undefined, false);
   }
 
   assert.converts('boolean', true, true);


### PR DESCRIPTION
A property lookup is used to speed up the hot path of applying transforms when normalizing data received from the server.

See discussion on #2289 