### PR TITLE
Prevent exception in generatedDetailedMessage when requestData is missing

### DIFF
--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -1143,10 +1143,13 @@ var RESTAdapter = Adapter.extend(BuildURLMixin, {
       shortenedPayload = payload;
     }
 
-    var requestDescription = requestData.method + ' ' + requestData.url;
+    var requestDescription = ' '
+    if (requestData && typeof requestData === 'object') {
+        requestDescription = ' ' + requestData.method + ' ' + requestData.url + ' ';
+    }
     var payloadDescription = 'Payload (' + payloadContentType + ')';
 
-    return ['Ember Data Request ' + requestDescription + ' returned a ' + status,
+    return ['Ember Data Request' + requestDescription + 'returned a ' + status,
             payloadDescription,
             shortenedPayload].join('\n');
   },

--- a/tests/unit/adapters/rest-adapter/detailed-message-test.js
+++ b/tests/unit/adapters/rest-adapter/detailed-message-test.js
@@ -33,6 +33,20 @@ test("generating a wonderfully friendly error message should work", (assert) => 
                                  "I'm a little teapot, short and stout"].join("\n"));
 });
 
+test("generating a wonderfully friendly error message with missing requestData should work", (assert) => {
+  assert.expect(1);
+
+  let friendlyMessage = adapter.generatedDetailedMessage(
+    418,
+    { "Content-Type": "text/plain" },
+    "I'm a little teapot, short and stout"
+  );
+
+  assert.equal(friendlyMessage, ["Ember Data Request returned a 418",
+                                 "Payload (text/plain)",
+                                 "I'm a little teapot, short and stout"].join("\n"));
+});
+
 test("generating a friendly error message with a missing content-type header should work", (assert) => {
 
   let friendlyMessage = adapter.generatedDetailedMessage(


### PR DESCRIPTION
I kept getting exceptions here on unauthorized requests. For some reason the requestData is missing. With a little extra care this function can be robust against the omission. Added a test case.