### PR TITLE
Fix `isUpdating` for DS.AdapterPopulatedRecordArray#update()

### DIFF
--- a/addon/-private/system/record-arrays/adapter-populated-record-array.js
+++ b/addon/-private/system/record-arrays/adapter-populated-record-array.js
@@ -27,6 +27,14 @@ export default RecordArray.extend({
     throw new Error("The result of a server query (on " + type + ") is immutable.");
   },
 
+  _update() {
+    let store = get(this, 'store');
+    let modelName = get(this, 'type.modelName');
+    let query = get(this, 'query');
+
+    return store._query(modelName, query, this);
+  },
+
   /**
     @method loadRecords
     @param {Array} records
@@ -39,6 +47,7 @@ export default RecordArray.extend({
     this.setProperties({
       content: Ember.A(internalModels),
       isLoaded: true,
+      isUpdating: false,
       meta: cloneNull(payload.meta)
     });
 

--- a/addon/-private/system/record-arrays/adapter-populated-record-array.js
+++ b/addon/-private/system/record-arrays/adapter-populated-record-array.js
@@ -36,19 +36,14 @@ export default RecordArray.extend({
   loadRecords(records, payload) {
     //TODO Optimize
     var internalModels = Ember.A(records).mapBy('_internalModel');
+    this.setProperties({
+      content: Ember.A(internalModels),
+      isLoaded: true,
+      meta: cloneNull(payload.meta)
+    });
+
     if (isEnabled('ds-links-in-record-array')) {
-      this.setProperties({
-        content: Ember.A(internalModels),
-        isLoaded: true,
-        meta: cloneNull(payload.meta),
-        links: cloneNull(payload.links)
-      });
-    } else {
-      this.setProperties({
-        content: Ember.A(internalModels),
-        isLoaded: true,
-        meta: cloneNull(payload.meta)
-      });
+      this.set('links', cloneNull(payload.links));
     }
 
     internalModels.forEach((record) => {

--- a/addon/-private/system/record-arrays/record-array.js
+++ b/addon/-private/system/record-arrays/record-array.js
@@ -106,7 +106,11 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     ```javascript
     var people = store.peekAll('person');
     people.get('isUpdating'); // false
-    people.update();
+
+    people.update().then(function() {
+      people.get('isUpdating'); // false
+    });
+
     people.get('isUpdating'); // true
     ```
 
@@ -115,13 +119,17 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
   update() {
     if (get(this, 'isUpdating')) { return; }
 
+    this.set('isUpdating', true);
+    return this._update();
+  },
+
+  /*
+    Update this RecordArray and return a promise which resolves once the update
+    is finished.
+   */
+  _update() {
     let store = get(this, 'store');
     let modelName = get(this, 'type.modelName');
-    let query = get(this, 'query');
-
-    if (query) {
-      return store._query(modelName, query, this);
-    }
 
     return store.findAll(modelName, { reload: true });
   },

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1006,8 +1006,6 @@ Store = Service.extend({
     var adapter = this.adapterFor(typeClass.modelName);
     var sinceToken = this.typeMapFor(typeClass).metadata.since;
 
-    set(array, 'isUpdating', true);
-
     assert("You tried to load all records but you have no adapter (for " + typeClass + ")", adapter);
     assert("You tried to load all records but your adapter does not implement `findAll`", typeof adapter.findAll === 'function');
     if (options.reload) {

--- a/tests/integration/adapter/queries-test.js
+++ b/tests/integration/adapter/queries-test.js
@@ -57,6 +57,37 @@ test("When a query is made, the adapter should receive a record array it can pop
   }));
 });
 
+test("a query can be updated via `update()`", function(assert) {
+  adapter.query = function() {
+    return Ember.RSVP.resolve([{ id: 'first' }]);
+  };
+
+  run(function() {
+    store.query('person', {}).then(function(query) {
+      assert.equal(query.get('length'), 1);
+      assert.equal(query.get('firstObject.id'), 'first');
+      assert.equal(query.get('isUpdating'), false);
+
+      adapter.query = function() {
+        assert.ok('query is called a second time');
+        return Ember.RSVP.resolve([{ id: 'second' }]);
+      };
+
+      let updateQuery = query.update();
+
+      assert.equal(query.get('isUpdating'), true);
+
+      return updateQuery;
+
+    }).then(function(query) {
+      assert.equal(query.get('length'), 1);
+      assert.equal(query.get('firstObject.id'), 'second');
+
+      assert.equal(query.get('isUpdating'), false);
+    });
+  });
+});
+
 testInDebug("The store asserts when query is made and the adapter responses with a single record.", function(assert) {
   env = setupStore({ person: Person, adapter: DS.RESTAdapter });
   store = env.store;


### PR DESCRIPTION
The `isUpdating` flag is not set to `true` when the `update()` method on
a `DS.AdapterPopulatedRecordArray` is invoked. As with the flag on
`DS.RecordArray`, this should be `true` until the update is finished and
the array contains the most reset result for the query, fetched from the
adapter.

---

The `[FEATURE]` commit DRY's up some code in the `DS.AdapterPopulatedRecordArray` and by this makes it easier to cherry-pick this bugfix into `beta` (where this feature is not yet available).