### PR TITLE
[FEATURE ds-payload-hooks] Add hooks to map type in payload to modelName

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -82,3 +82,52 @@ entry in `config/features.json`.
   * [404] `DS.NotFoundError`
   * [409] `DS.ConflictError`
   * [500] `DS.ServerError`
+
+- `ds-payload-type-hooks`
+
+  Adds two new hooks `modelNameFromPayloadType` and `payloadTypeFromModelName`
+  hooks to the serializers. They are used to map a custom type in the payload
+  to the Ember-Data model name and vice versa.
+
+  It also deprecates `modelNameFromPayloadKey` and `payloadKeyFromModelName`
+  for the JSONSerializer and JSONAPISerializer: those payloads don't have
+  _keys_ which represent a model name. Only the keys in the payload for a
+  RESTSerializer represent model names, so the `payloadKeyFromModelName` and
+  `modelNameFromPayloadKey` are available in that serializer.
+
+  ```js
+  // rest reponse
+  {
+    "blog/post": {
+      "id": 1,
+      "user": 1,
+      "userType": "api::v1::administrator"
+    }
+  }
+
+  // RESTSerializer invokes the following hooks
+  restSerializer.modelNameFromPayloadKey("blog/post");
+  restSerializer.modelNameFromPayloadType("api::v1::administrator");
+  ```
+
+  ```js
+  // json-api reponse
+  {
+    "data": {
+      "id": 1,
+      "type": "api::v1::administrator",
+      "relationships": {
+        "supervisor": {
+          "data": {
+            "id": 1,
+            "type": "api::v1::super-user"
+          }
+        }
+      }
+    }
+  }
+
+  // JSONAPISerializer invokes the following hooks
+  jsonApiSerializer.modelNameFromPayloadType("api::v1::administrator");
+  jsonApiSerializer.modelNameFromPayloadType("api::v1::super-user");
+  ```

--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -3,7 +3,7 @@
 */
 
 import Ember from 'ember';
-import { assert, runInDebug, warn } from 'ember-data/-private/debug';
+import { assert, deprecate, runInDebug, warn } from 'ember-data/-private/debug';
 import JSONSerializer from 'ember-data/serializers/json';
 import normalizeModelName from 'ember-data/-private/system/normalize-model-name';
 import { pluralize, singularize } from 'ember-inflector';
@@ -141,8 +141,25 @@ const JSONAPISerializer = JSONSerializer.extend({
     @private
   */
   _normalizeRelationshipDataHelper(relationshipDataHash) {
-    let type = this.modelNameFromPayloadKey(relationshipDataHash.type);
-    relationshipDataHash.type = type;
+    if (isEnabled("ds-payload-type-hooks")) {
+      let modelName = this.modelNameFromPayloadType(relationshipDataHash.type);
+      let deprecatedModelNameLookup = this.modelNameFromPayloadKey(relationshipDataHash.type);
+
+      if (modelName !== deprecatedModelNameLookup && this._hasCustomModelNameFromPayloadKey()) {
+        deprecate("You are using modelNameFromPayloadKey to normalize the type for a relationship. This has been deprecated in favor of modelNameFromPayloadType", false, {
+          id: 'ds.json-api-serializer.deprecated-model-name-for-relationship',
+          until: '3.0.0'
+        });
+
+        modelName = deprecatedModelNameLookup;
+      }
+
+      relationshipDataHash.type = modelName;
+    } else {
+      let type = this.modelNameFromPayloadKey(relationshipDataHash.type);
+      relationshipDataHash.type = type;
+    }
+
     return relationshipDataHash;
   },
 
@@ -157,10 +174,30 @@ const JSONAPISerializer = JSONSerializer.extend({
       id: 'ds.serializer.type-is-undefined'
     });
 
-    let modelName = this.modelNameFromPayloadKey(resourceHash.type);
+    let modelName, usedLookup;
+
+    if (isEnabled("ds-payload-type-hooks")) {
+      modelName = this.modelNameFromPayloadType(resourceHash.type);
+      let deprecatedModelNameLookup = this.modelNameFromPayloadKey(resourceHash.type);
+
+      usedLookup = 'modelNameFromPayloadType';
+
+      if (modelName !== deprecatedModelNameLookup && this._hasCustomModelNameFromPayloadKey()) {
+        deprecate("You are using modelNameFromPayloadKey to normalize the type for a resource. This has been deprecated in favor of modelNameFromPayloadType", false, {
+          id: 'ds.json-api-serializer.deprecated-model-name-for-resource',
+          until: '3.0.0'
+        });
+
+        modelName = deprecatedModelNameLookup;
+        usedLookup = 'modelNameFromPayloadKey';
+      }
+    } else {
+      modelName = this.modelNameFromPayloadKey(resourceHash.type);
+      usedLookup = 'modelNameFromPayloadKey';
+    }
 
     if (!this.store._hasModelFor(modelName)) {
-      warn(this.warnMessageNoModelForType(modelName, resourceHash.type), false, {
+      warn(this.warnMessageNoModelForType(modelName, resourceHash.type, usedLookup), false, {
         id: 'ds.serializer.model-for-type-missing'
       });
       return null;
@@ -280,7 +317,23 @@ const JSONAPISerializer = JSONSerializer.extend({
     @private
   */
   _extractType(modelClass, resourceHash) {
-    return this.modelNameFromPayloadKey(resourceHash.type);
+    if (isEnabled("ds-payload-type-hooks")) {
+      let modelName = this.modelNameFromPayloadType(resourceHash.type);
+      let deprecatedModelNameLookup = this.modelNameFromPayloadKey(resourceHash.type);
+
+      if (modelName !== deprecatedModelNameLookup && this._hasCustomModelNameFromPayloadKey()) {
+        deprecate("You are using modelNameFromPayloadKey to normalize the type for a polymorphic relationship. This has been deprecated in favor of modelNameFromPayloadType", false, {
+          id: 'ds.json-api-serializer.deprecated-model-name-for-polymorphic-type',
+          until: '3.0.0'
+        });
+
+        modelName = deprecatedModelNameLookup;
+      }
+
+      return modelName;
+    } else {
+      return this.modelNameFromPayloadKey(resourceHash.type);
+    }
   },
 
   /**
@@ -288,6 +341,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     @param {String} key
     @return {String} the model's modelName
   */
+  // TODO @deprecated Use modelNameFromPayloadType instead
   modelNameFromPayloadKey(key) {
     return singularize(normalizeModelName(key));
   },
@@ -297,6 +351,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     @param {String} modelName
     @return {String}
   */
+  // TODO @deprecated Use payloadTypeFromModelName instead
   payloadKeyFromModelName(modelName) {
     return pluralize(modelName);
   },
@@ -396,7 +451,25 @@ const JSONAPISerializer = JSONSerializer.extend({
   */
   serialize(snapshot, options) {
     let data = this._super(...arguments);
-    data.type = this.payloadKeyFromModelName(snapshot.modelName);
+
+    let payloadType;
+    if (isEnabled("ds-payload-type-hooks")) {
+      payloadType = this.payloadTypeFromModelName(snapshot.modelName);
+      let deprecatedPayloadTypeLookup = this.payloadKeyFromModelName(snapshot.modelName);
+
+      if (payloadType !== deprecatedPayloadTypeLookup && this._hasCustomPayloadKeyFromModelName()) {
+        deprecate("You used payloadKeyFromModelName to customize how a type is serialized. Use payloadTypeFromModelName instead.", false, {
+          id: 'ds.json-api-serializer.deprecated-payload-type-for-model',
+          until: '3.0.0'
+        });
+
+        payloadType = deprecatedPayloadTypeLookup;
+      }
+    } else {
+      payloadType = this.payloadKeyFromModelName(snapshot.modelName);
+    }
+
+    data.type = payloadType;
     return { data };
   },
 
@@ -451,8 +524,26 @@ const JSONAPISerializer = JSONSerializer.extend({
 
         let data = null;
         if (belongsTo) {
+          let payloadType;
+
+          if (isEnabled("ds-payload-type-hooks")) {
+            payloadType = this.payloadTypeFromModelName(belongsTo.modelName);
+            let deprecatedPayloadTypeLookup = this.payloadKeyFromModelName(belongsTo.modelName);
+
+            if (payloadType !== deprecatedPayloadTypeLookup && this._hasCustomPayloadKeyFromModelName()) {
+              deprecate("You used payloadKeyFromModelName to serialize type for belongs-to relationship. Use payloadTypeFromModelName instead.", false, {
+                id: 'ds.json-api-serializer.deprecated-payload-type-for-belongs-to',
+                until: '3.0.0'
+              });
+
+              payloadType = deprecatedPayloadTypeLookup;
+            }
+          } else {
+            payloadType = this.payloadKeyFromModelName(belongsTo.modelName);
+          }
+
           data = {
-            type: this.payloadKeyFromModelName(belongsTo.modelName),
+            type: payloadType,
             id: belongsTo.id
           };
         }
@@ -486,8 +577,27 @@ const JSONAPISerializer = JSONSerializer.extend({
 
         for (let i = 0; i < hasMany.length; i++) {
           let item = hasMany[i];
+
+          let payloadType;
+
+          if (isEnabled("ds-payload-type-hooks")) {
+            payloadType = this.payloadTypeFromModelName(item.modelName);
+            let deprecatedPayloadTypeLookup = this.payloadKeyFromModelName(item.modelName);
+
+            if (payloadType !== deprecatedPayloadTypeLookup && this._hasCustomPayloadKeyFromModelName()) {
+              deprecate("You used payloadKeyFromModelName to serialize type for belongs-to relationship. Use payloadTypeFromModelName instead.", false, {
+                id: 'ds.json-api-serializer.deprecated-payload-type-for-has-many',
+                until: '3.0.0'
+              });
+
+              payloadType = deprecatedPayloadTypeLookup;
+            }
+          } else {
+            payloadType = this.payloadKeyFromModelName(item.modelName);
+          }
+
           data[i] = {
-            type: this.payloadKeyFromModelName(item.modelName),
+            type: payloadType,
             id: item.id
           };
         }
@@ -497,6 +607,117 @@ const JSONAPISerializer = JSONSerializer.extend({
     }
   }
 });
+
+if (isEnabled("ds-payload-type-hooks")) {
+
+  JSONAPISerializer.reopen({
+
+    /**
+      `modelNameFromPayloadType` can be used to change the mapping for a DS model
+      name, taken from the value in the payload.
+
+      Say your API namespaces the type of a model and returns the following
+      payload for the `post` model:
+
+      ```javascript
+      // GET /api/posts/1
+      {
+        "data": {
+          "id": 1,
+          "type: "api::v1::post"
+        }
+      }
+      ```
+
+      By overwriting `modelNameFromPayloadType` you can specify that the
+      `posr` model should be used:
+
+      ```app/serializers/application.js
+      import JSONAPISerializer from "ember-data/serializers/json-api";
+
+      export default JSONAPISerializer.extend({
+        modelNameFromPayloadType(payloadType) {
+          return payloadType.replace('api::v1::', '');
+        }
+      });
+      ```
+
+      By default the modelName for a model is its singularized name in dasherized
+      form.  Usually, Ember Data can use the correct inflection to do this for
+      you. Most of the time, you won't need to override
+      `modelNameFromPayloadType` for this purpose.
+
+      Also take a look at
+      [payloadTypeFromModelName](#method_payloadTypeFromModelName) to customize
+      how the type of a record should be serialized.
+
+      @method modelNameFromPayloadType
+      @public
+      @param {String} payloadType type from payload
+      @return {String} modelName
+    */
+    modelNameFromPayloadType(type) {
+      return singularize(normalizeModelName(type));
+    },
+
+    /**
+      `payloadTypeFromModelName` can be used to change the mapping for the type in
+      the payload, taken from the model name.
+
+      Say your API namespaces the type of a model and expects the following
+      payload when you update the `post` model:
+
+      ```javascript
+      // POST /api/posts/1
+      {
+        "data": {
+          "id": 1,
+          "type": "api::v1::post"
+        }
+      }
+      ```
+
+      By overwriting `payloadTypeFromModelName` you can specify that the
+      namespaces model name for the `post` should be used:
+
+      ```app/serializers/application.js
+      import JSONAPISerializer from "ember-data/serializers/json-api";
+
+      export default JSONAPISerializer.extend({
+        payloadTypeFromModelName(modelName) {
+          return "api::v1::" + modelName;
+        }
+      });
+      ```
+
+      By default the payload type is the pluralized model name. Usually, Ember
+      Data can use the correct inflection to do this for you. Most of the time,
+      you won't need to override `payloadTypeFromModelName` for this purpose.
+
+      Also take a look at
+      [modelNameFromPayloadType](#method_modelNameFromPayloadType) to customize
+      how the model name from should be mapped from the payload.
+
+      @method payloadTypeFromModelName
+      @public
+      @param {String} modelname modelName from the record
+      @return {String} payloadType
+    */
+    payloadTypeFromModelName(modelName) {
+      return pluralize(modelName);
+    },
+
+    _hasCustomModelNameFromPayloadKey() {
+      return this.modelNameFromPayloadKey !== JSONAPISerializer.prototype.modelNameFromPayloadKey;
+    },
+
+    _hasCustomPayloadKeyFromModelName() {
+      return this.payloadKeyFromModelName !== JSONAPISerializer.prototype.payloadKeyFromModelName;
+    }
+
+  });
+
+}
 
 runInDebug(function() {
   JSONAPISerializer.reopen({
@@ -508,8 +729,8 @@ runInDebug(function() {
     warnMessageForUndefinedType() {
       return 'Encountered a resource object with an undefined type (resolved resource using ' + this.constructor.toString() + ')';
     },
-    warnMessageNoModelForType(modelName, originalType) {
-      return 'Encountered a resource object with type "' + originalType + '", but no model was found for model name "' + modelName + '" (resolved model name using ' + this.constructor.toString() + '.modelNameFromPayloadKey("' + originalType + '"))';
+    warnMessageNoModelForType(modelName, originalType, usedLookup) {
+      return `Encountered a resource object with type "${originalType}", but no model was found for model name "${modelName}" (resolved model name using '${this.constructor.toString()}.${usedLookup}("${originalType}")).`;
     }
   });
 });

--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -199,16 +199,36 @@ var RESTSerializer = JSONSerializer.extend({
   },
 
   _normalizePolymorphicRecord(store, hash, prop, primaryModelClass, primarySerializer) {
-    let serializer, modelClass;
+    let serializer = primarySerializer;
+    let modelClass = primaryModelClass;
+
     const primaryHasTypeAttribute = modelHasAttributeOrRelationshipNamedType(primaryModelClass);
-    // Support polymorphic records in async relationships
-    if (!primaryHasTypeAttribute && hash.type && store._hasModelFor(this.modelNameFromPayloadKey(hash.type))) {
-      serializer = store.serializerFor(this.modelNameFromPayloadKey(hash.type));
-      modelClass = store.modelFor(this.modelNameFromPayloadKey(hash.type));
-    } else {
-      serializer = primarySerializer;
-      modelClass = primaryModelClass;
+
+    if (!primaryHasTypeAttribute && hash.type) {
+      // Support polymorphic records in async relationships
+      let modelName;
+      if (isEnabled("ds-payload-type-hooks")) {
+        modelName = this.modelNameFromPayloadType(hash.type);
+        let deprecatedModelNameLookup = this.modelNameFromPayloadKey(hash.type);
+
+        if (modelName !== deprecatedModelNameLookup && !this._hasCustomModelNameFromPayloadType() && this._hasCustomModelNameFromPayloadKey()) {
+          deprecate("You are using modelNameFromPayloadKey to normalize the type for a polymorphic relationship. This is has been deprecated in favor of modelNameFromPayloadType", false, {
+            id: 'ds.rest-serializer.deprecated-model-name-for-polymorphic-type',
+            until: '3.0.0'
+          });
+
+          modelName = deprecatedModelNameLookup;
+        }
+      } else {
+        modelName = this.modelNameFromPayloadKey(hash.type);
+      }
+
+      if (store._hasModelFor(modelName)) {
+        serializer = store.serializerFor(modelName);
+        modelClass = store.modelFor(modelName);
+      }
     }
+
     return serializer.normalize(modelClass, hash, prop);
   },
 
@@ -748,7 +768,11 @@ var RESTSerializer = JSONSerializer.extend({
     if (Ember.isNone(belongsTo)) {
       json[typeKey] = null;
     } else {
-      json[typeKey] = camelize(belongsTo.modelName);
+      if (isEnabled("ds-payload-type-hooks")) {
+        json[typeKey] = this.payloadTypeFromModelName(belongsTo.modelName);
+      } else {
+        json[typeKey] = camelize(belongsTo.modelName);
+      }
     }
   },
 
@@ -786,16 +810,164 @@ var RESTSerializer = JSONSerializer.extend({
     var typeProperty = this.keyForPolymorphicType(key, relationshipType, 'deserialize');
 
     if (isPolymorphic && resourceHash.hasOwnProperty(typeProperty) && typeof relationshipHash !== 'object') {
-      let type = this.modelNameFromPayloadKey(resourceHash[typeProperty]);
-      return {
-        id: relationshipHash,
-        type: type
-      };
+
+      if (isEnabled("ds-payload-type-hooks")) {
+
+        let payloadType = resourceHash[typeProperty];
+        let type = this.modelNameFromPayloadType(payloadType);
+        let deprecatedTypeLookup = this.modelNameFromPayloadKey(payloadType);
+
+        if (payloadType !== deprecatedTypeLookup && !this._hasCustomModelNameFromPayloadType() && this._hasCustomModelNameFromPayloadKey()) {
+          deprecate("You are using modelNameFromPayloadKey to normalize the type for a polymorphic relationship. This has been deprecated in favor of modelNameFromPayloadType", false, {
+            id: 'ds.rest-serializer.deprecated-model-name-for-polymorphic-type',
+            until: '3.0.0'
+          });
+
+          type = deprecatedTypeLookup;
+        }
+
+        return {
+          id: relationshipHash,
+          type: type
+        };
+
+      } else {
+
+        let type = this.modelNameFromPayloadKey(resourceHash[typeProperty]);
+        return {
+          id: relationshipHash,
+          type: type
+        };
+
+      }
     }
 
     return this._super(...arguments);
   }
 });
+
+
+if (isEnabled("ds-payload-type-hooks")) {
+
+  RESTSerializer.reopen({
+
+    /**
+      `modelNameFromPayloadType` can be used to change the mapping for a DS model
+      name, taken from the value in the payload.
+
+      Say your API namespaces the type of a model and returns the following
+      payload for the `post` model, which has a polymorphic `user` relationship:
+
+      ```javascript
+      // GET /api/posts/1
+      {
+        "post": {
+          "id": 1,
+          "user": 1,
+          "userType: "api::v1::administrator"
+        }
+      }
+      ```
+
+      By overwriting `modelNameFromPayloadType` you can specify that the
+      `administrator` model should be used:
+
+      ```app/serializers/application.js
+      import RESTSerializer from "ember-data/serializers/rest";
+
+      export default RESTSerializer.extend({
+        modelNameFromPayloadType(payloadType) {
+          return payloadType.replace('api::v1::', '');
+        }
+      });
+      ```
+
+      By default the modelName for a model is its name in dasherized form.
+      Usually, Ember Data can use the correct inflection to do this for you. Most
+      of the time, you won't need to override `modelNameFromPayloadType` for this
+      purpose.
+
+      Also take a look at
+      [payloadTypeFromModelName](#method_payloadTypeFromModelName) to customize
+      how the type of a record should be serialized.
+
+      @method modelNameFromPayloadType
+      @public
+      @param {String} payloadType type from payload
+      @return {String} modelName
+    */
+    modelNameFromPayloadType(payloadType) {
+      return singularize(normalizeModelName(payloadType));
+    },
+
+    /**
+      `payloadTypeFromModelName` can be used to change the mapping for the type in
+      the payload, taken from the model name.
+
+      Say your API namespaces the type of a model and expects the following
+      payload when you update the `post` model, which has a polymorphic `user`
+      relationship:
+
+      ```javascript
+      // POST /api/posts/1
+      {
+        "post": {
+          "id": 1,
+          "user": 1,
+          "userType": "api::v1::administrator"
+        }
+      }
+      ```
+
+      By overwriting `payloadTypeFromModelName` you can specify that the
+      namespaces model name for the `administrator` should be used:
+
+      ```app/serializers/application.js
+      import RESTSerializer from "ember-data/serializers/rest";
+
+      export default RESTSerializer.extend({
+        payloadTypeFromModelName(modelName) {
+          return "api::v1::" + modelName;
+        }
+      });
+      ```
+
+      By default the payload type is the camelized model name. Usually, Ember
+      Data can use the correct inflection to do this for you. Most of the time,
+      you won't need to override `payloadTypeFromModelName` for this purpose.
+
+      Also take a look at
+      [modelNameFromPayloadType](#method_modelNameFromPayloadType) to customize
+      how the model name from should be mapped from the payload.
+
+      @method payloadTypeFromModelName
+      @public
+      @param {String} modelname modelName from the record
+      @return {String} payloadType
+    */
+    payloadTypeFromModelName(modelName) {
+      return camelize(modelName);
+    },
+
+    _hasCustomModelNameFromPayloadKey() {
+      return this.modelNameFromPayloadKey !== RESTSerializer.prototype.modelNameFromPayloadKey;
+    },
+
+    _hasCustomModelNameFromPayloadType() {
+      return this.modelNameFromPayloadType !== RESTSerializer.prototype.modelNameFromPayloadType;
+    },
+
+    _hasCustomPayloadTypeFromModelName() {
+      return this.payloadTypeFromModelName !== RESTSerializer.prototype.payloadTypeFromModelName;
+    },
+
+    _hasCustomPayloadKeyFromModelName() {
+      return this.payloadKeyFromModelName !== RESTSerializer.prototype.payloadKeyFromModelName;
+    },
+
+  });
+
+}
 
 runInDebug(function() {
   RESTSerializer.reopen({

--- a/config/features.json
+++ b/config/features.json
@@ -7,5 +7,6 @@
   "ds-pushpayload-return": null,
   "ds-serialize-ids-and-types": true,
   "ds-extended-errors": null,
-  "ds-links-in-record-array": null
+  "ds-links-in-record-array": null,
+  "ds-payload-type-hooks": null
 }

--- a/tests/integration/serializers/json-serializer-test.js
+++ b/tests/integration/serializers/json-serializer-test.js
@@ -1,6 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -974,3 +975,77 @@ test('Serializer should respect the attrs hash in links', function(assert) {
   assert.equal(post.data.attributes.title, "Rails is omakase");
   assert.equal(post.data.relationships.comments.links.related, 'posts/1/comments');
 });
+
+if (isEnabled("ds-payload-type-hooks")) {
+
+  test("mapping of model name can be customized via modelNameFromPayloadType", function(assert) {
+    env.serializer.modelNameFromPayloadType = function(payloadType) {
+      return payloadType.replace("api::v1::", "");
+    };
+
+    let jsonHash = {
+      id: '1',
+      post: {
+        id: '1',
+        type: "api::v1::post"
+      }
+    };
+
+    assert.expectNoDeprecation();
+
+    let normalized = env.serializer.normalizeSingleResponse(env.store, Favorite, jsonHash);
+
+    assert.deepEqual(normalized, {
+      data: {
+        id: '1',
+        type: 'favorite',
+        attributes: {},
+        relationships: {
+          post: {
+            data: {
+              id: '1',
+              type: 'post'
+            }
+          }
+        }
+      },
+      included: []
+    });
+  });
+
+  testInDebug("DEPRECATED - mapping of model name can be customized via modelNameFromPayloadKey", function(assert) {
+    env.serializer.modelNameFromPayloadKey = function(payloadType) {
+      return payloadType.replace("api::v1::", "");
+    };
+
+    let jsonHash = {
+      id: '1',
+      post: {
+        id: '1',
+        type: "api::v1::post"
+      }
+    };
+
+    assert.expectDeprecation("You used modelNameFromPayloadKey to customize how a type is normalized. Use modelNameFromPayloadType instead");
+
+    let normalized = env.serializer.normalizeSingleResponse(env.store, Favorite, jsonHash);
+
+    assert.deepEqual(normalized, {
+      data: {
+        id: '1',
+        type: 'favorite',
+        attributes: {},
+        relationships: {
+          post: {
+            data: {
+              id: '1',
+              type: 'post'
+            }
+          }
+        }
+      },
+      included: []
+    });
+  });
+
+}


### PR DESCRIPTION
The `modelNameFromPayloadKey` and `payloadKeyFromModelName` hooks on the
serializer allow to customize the mapping between the key of a JSON and
the corresponding name of the model. Consider the following payload:

```json
{
  "blog/post": {
    "id": 1
  }
}
```

To map the "blog/post" key to the `post` model, the
`modelNameFromPayloadKey` hook is used:

```js
serializer.modelNameFromPayloadKey("blog/post")
```

---

There are some issues with the current code base, as the
`modelNameFromPayloadKey` and `payloadKeyFromModelName` hooks are also
used to map the "value" of a type from / to the payload. Consider the
following payload of a JSON-API document:

```json
{
  "data": {
    "id": 1,
    "type": "API:V1::User"
  }
}
```

To map the namespaced type to the model name ember-data is using,
currently the `modelNameFromPayloadKey` is used:

```js
serializer.modelNameFromPayloadKey("API::V1::User")
```

Now this gets complicated if your API responds with the following
payload (using custom key and custom types for polymorphic records for
example):

```json
{
  "blog/post": {
    "id": 1,
    "user": 2,
    "userType": "API:V1::Administrator"
  }
}
```

Now the `modelNameFromPayloadKey` is invoked for both:

```js
serializer.modelNameFromPayloadKey("blog/post")
serializer.modelNameFromPayloadKey("API::V1::Administrator")
```

This means that the logic within the hook would get complicated.

---

As the name suggests, the method should only be used to map the key, not
the value. This commit adds `modelNameFromPayloadType` and
`payloadTypeFromModelName` hooks and uses them during normalization and
serialization.

This commit maintains the old behavior using, if it is used and logs a
deprecation warning to move to the new hooks.

---

This PR should help tackling the issues raised in #3801 and #4208.