### PR TITLE
Fixup feature flagging infrastructure.

### DIFF
--- a/config/features.json
+++ b/config/features.json
@@ -1,11 +1,11 @@
 {
   "ds-boolean-transform-allow-null": null,
-  "ds-finder-include": null,
+  "ds-finder-include": true,
   "ds-improved-ajax": null,
-  "ds-references": null,
-  "ds-transform-pass-options": null,
+  "ds-references": true,
+  "ds-transform-pass-options": true,
   "ds-pushpayload-return": null,
-  "ds-serialize-ids-and-types": null,
+  "ds-serialize-ids-and-types": true,
   "ds-extended-errors": null,
   "ds-links-in-record-array": null
 }

--- a/index.js
+++ b/index.js
@@ -101,11 +101,9 @@ module.exports = {
   included: function(app) {
     this._super.included.apply(this, arguments);
 
-    if (process.env.EMBER_ENV === 'production') {
-      this.options.babel = this.options.babel || {};
-      add(this.options.babel, 'blacklist', ['es6.modules', 'useStrict']);
-      add(this.options.babel, 'plugins', require('./lib/stripped-build-plugins')());
-    }
+    this.options.babel = this.options.babel || {};
+    add(this.options.babel, 'blacklist', ['es6.modules', 'useStrict']);
+    add(this.options.babel, 'plugins', require('./lib/stripped-build-plugins')(process.env.EMBER_ENV));
 
     if (this._forceBowerUsage) {
       this.app.import({

--- a/lib/javascripts.js
+++ b/lib/javascripts.js
@@ -10,11 +10,10 @@ var path          = require('path');
 var Funnel        = require('broccoli-funnel');
 var versionReplace = require('./version-replace');
 var fileCreator   = require('broccoli-file-creator');
-var babelBuild    = require('./babel-build');
 var strippedBuild = require('./stripped-build');
 
 function debugBuild(packageName, tree) {
-  var compiled = babelBuild(packageName, tree);
+  var compiled = strippedBuild(packageName, tree, 'development');
 
   return stew.mv(compiled, packageName);
 }
@@ -24,7 +23,7 @@ function makeStrippedBuild(packageName, tree) {
     exclude: ['ember-data/-private/debug.js']
   });
 
-  var stripped = strippedBuild(packageName, withoutDebug);
+  var stripped = strippedBuild(packageName, withoutDebug, 'production');
 
   return stew.mv(stripped, packageName);
 }

--- a/lib/stripped-build-plugins.js
+++ b/lib/stripped-build-plugins.js
@@ -3,7 +3,7 @@ var path          = require('path');
 var filterImports = require('babel-plugin-filter-imports');
 var featureFlags  = require('babel-plugin-feature-flags');
 
-module.exports = function() {
+module.exports = function(environment) {
   var featuresJsonPath = __dirname + '/../config/features.json';
   var featuresJson = fs.readFileSync(featuresJsonPath, { encoding: 'utf8' });
   var features = JSON.parse(featuresJson);
@@ -16,24 +16,29 @@ module.exports = function() {
   //     features[feature] = false;
   //   }
   // }
-
-  return [
+  var plugins = [
     featureFlags({
       import: { module: 'ember-data/-private/features' },
       features: features
-    }),
-
-    filterImports({
-      'ember-data/-private/debug': [
-        'assert',
-        'assertPolymorphicType',
-        'debug',
-        'deprecate',
-        'info',
-        'runInDebug',
-        'warn',
-        'debugSeal'
-      ]
     })
   ];
+
+  if (environment === 'production') {
+    plugins.push(
+      filterImports({
+        'ember-data/-private/debug': [
+          'assert',
+          'assertPolymorphicType',
+          'debug',
+          'deprecate',
+          'info',
+          'runInDebug',
+          'warn',
+          'debugSeal'
+        ]
+      })
+    );
+  }
+
+  return plugins;
 };

--- a/lib/stripped-build.js
+++ b/lib/stripped-build.js
@@ -5,9 +5,9 @@ var featureFlags  = require('babel-plugin-feature-flags');
 var babelBuild    = require('./babel-build');
 var strippedBuildPlugins = require('./stripped-build-plugins');
 
-module.exports = function(packageName, tree, _options) {
-  var options = _options || {};
-  options.plugins = strippedBuildPlugins();
+module.exports = function(packageName, tree, environmentBuildingFor) {
+  var options = {};
+  options.plugins = strippedBuildPlugins(environmentBuildingFor);
 
   return babelBuild(packageName, tree, options);
 };


### PR DESCRIPTION
Prior to this:

* When used as an ember-cli addon, the feature flags would only be processed for `production` builds.
* When built for globals builds, the features flags would only be processed for `ember-data.prod.js` builds.

This is incorrect, they should be processed for all builds (for every environment) so that any features explicitly enabled or disabled in the version of Ember data being used are stripped properly.