### PR TITLE
[BUGFIX release] Only setup babel options once.

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,12 +98,22 @@ module.exports = {
     ]));
   },
 
-  included: function(app) {
-    this._super.included.apply(this, arguments);
+  _setupBabelOptions() {
+    if (this._hasSetupBabelOptions) {
+      return;
+    }
 
     this.options.babel = this.options.babel || {};
     add(this.options.babel, 'blacklist', ['es6.modules', 'useStrict']);
     add(this.options.babel, 'plugins', require('./lib/stripped-build-plugins')(process.env.EMBER_ENV));
+
+    this._hasSetupBabelOptions = true;
+  },
+
+  included: function(app) {
+    this._super.included.apply(this, arguments);
+
+    this._setupBabelOptions();
 
     if (this._forceBowerUsage) {
       this.app.import({


### PR DESCRIPTION
`included` is called for each instance of `EmberApp` created within the consuming applicationm, which means that we would be adding the same plugins if the consuming application happened to be creating two `EmberApp` instances.

For example, ember-cli-fastboot currently uses this technique to build both for fastboot AND the normal build. I know of a few other applications that use similar techniques to build two versions of the same `EmberApp` (i.e. a mobile version and a desktop one).

This allows us to ensure that `this.options.babel` is only setup once (regardless of how many times `included` is being called).

Fixes #4322.