### PR TITLE
[BUGFIX beta] Overhaul attr/relationships imports in model blueprint

### DIFF
--- a/blueprints/model/HELP.md
+++ b/blueprints/model/HELP.md
@@ -14,12 +14,16 @@ For instance: <green>\`ember generate model taco filling:belongs-to:protein topp
 would result in the following model:
 
 ```js
-import DS from 'ember-data';
-export default DS.Model.extend({
-  filling: DS.belongsTo('protein'),
-  toppings: DS.hasMany('topping'),
-  name: DS.attr('string'),
-  price: DS.attr('number'),
-  misc: DS.attr()
+import Model from 'ember-data/model';
+
+import attr from 'ember-data/attr';
+import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+  filling: belongsTo('protein'),
+  toppings: hasMany('topping'),
+  name: attr('string'),
+  price: attr('number'),
+  misc: attr()
 });
 ```

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -61,14 +61,20 @@ module.exports = {
 
     if (shouldImportAttr) {
       importStatements.push('import attr from \'ember-data/attr\';');
+    } else {
+      importStatements.push('// import attr from \'ember-data/attr\';');
     }
 
     if (shouldImportBelongsTo && shouldImportHasMany) {
       importStatements.push('import { belongsTo, hasMany } from \'ember-data/relationships\';');
     } else if (shouldImportBelongsTo) {
       importStatements.push('import { belongsTo } from \'ember-data/relationships\';');
+      importStatements.push('// import { hasMany } from \'ember-data/relationships\';');
     } else if (shouldImportHasMany) {
+      importStatements.push('// import { belongsTo } from \'ember-data/relationships\';');
       importStatements.push('import { hasMany } from \'ember-data/relationships\';');
+    } else {
+      importStatements.push('// import { belongsTo, hasMany } from \'ember-data/relationships\';');
     }
 
     importStatements = importStatements.join(EOL);

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -18,10 +18,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         expect(_file('app/models/foo.js'))
           .to.contain('import Model from \'ember-data/model\';')
           .to.contain('export default Model.extend(')
-          .to.not.contain('import attr from \'ember-data/attr\';')
+          .to.contain('// import attr from \'ember-data/attr\';')
+          .to.contain('// import { belongsTo, hasMany } from \'ember-data/relationships\';')
           .to.not.contain('import { belongsTo } from \'ember-data/relationships\';')
-          .to.not.contain('import { hasMany } from \'ember-data/relationships\';')
-          .to.not.contain('import { belongsTo, hasMany } from \'ember-data/relationships\';');
+          .to.not.contain('import { hasMany } from \'ember-data/relationships\';');
 
         expect(_file('tests/unit/models/foo-test.js'))
           .to.contain('moduleForModel(\'foo\'');
@@ -56,9 +56,9 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           .to.contain('age: attr(\'number\')')
           .to.contain('name: attr(\'string\')')
           .to.contain('customAttr: attr(\'custom-transform\')')
+          .to.contain('// import { belongsTo, hasMany } from \'ember-data/relationships\';')
           .to.not.contain('import { belongsTo } from \'ember-data/relationships\';')
-          .to.not.contain('import { hasMany } from \'ember-data/relationships\';')
-          .to.not.contain('import { belongsTo, hasMany } from \'ember-data/relationships\';');
+          .to.not.contain('import { hasMany } from \'ember-data/relationships\';');
 
         expect(_file('tests/unit/models/foo-test.js'))
           .to.contain('moduleForModel(\'foo\'');
@@ -76,8 +76,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           .to.contain('export default Model.extend(')
           .to.contain('post: belongsTo(\'post\')')
           .to.contain('author: belongsTo(\'user\')')
-          .to.not.contain('import attr from \'ember-data/attr\';')
-          .to.not.contain('import { hasMany } from \'ember-data/relationships\';')
+          .to.contain('// import attr from \'ember-data/attr\';')
+          .to.contain('// import { hasMany } from \'ember-data/relationships\';')
           .to.not.contain('import { belongsTo, hasMany } from \'ember-data/relationships\';');
 
         expect(_file('tests/unit/models/comment-test.js'))
@@ -97,8 +97,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           .to.contain('export default Model.extend(')
           .to.contain('comments: hasMany(\'comment\')')
           .to.contain('otherComments: hasMany(\'comment\')')
-          .to.not.contain('import attr from \'ember-data/attr\';')
-          .to.not.contain('import { belongsTo } from \'ember-data/relationships\';')
+          .to.contain('// import attr from \'ember-data/attr\';')
+          .to.contain('// import { belongsTo } from \'ember-data/relationships\';')
           .to.not.contain('import { belongsTo, hasMany } from \'ember-data/relationships\';');
 
         expect(_file('tests/unit/models/post-test.js'))
@@ -114,7 +114,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/models/post.js'))
           .to.contain('import { belongsTo, hasMany } from \'ember-data/relationships\';')
-          .to.not.contain('import attr from \'ember-data/attr\';')
+          .to.contain('// import attr from \'ember-data/attr\';')
           .to.not.contain('import { belongsTo } from \'ember-data/relationships\';')
           .to.not.contain('import { hasMany } from \'ember-data/relationships\';');
       }));


### PR DESCRIPTION
When a model is generated via `ember generate model` without attributes
and relationships, then it is not immediately clear from the generated
blueprint, on how to add attributes and relationships via importing
stuff from the modules.

This change adds the imports as comments, so uncommenting allows to
quickly add the imports without writing the import statement. So the
command `ember genrate model foo` now creates this file:

```js
import Model from "ember-data/model";
// import attr from "ember-data/attr";
// import { belongsTo, hasMany } from "ember-data/relationships";

export default Model.extend({
});
```

---

This has been raised in the `#-ember-data` slack channel, where it was confusing on how to add attributes and relationships, since there is no `import DS from "ember-data"` in the generated file anymore, and it is not immediately clear where `attr`, `belongsTo` and `hasMany` are imported from.