### PR TITLE
[BUGFIX release] use es5 syntax for addon's index.js file

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = {
     ]));
   },
 
-  _setupBabelOptions() {
+  _setupBabelOptions: function() {
     if (this._hasSetupBabelOptions) {
       return;
     }


### PR DESCRIPTION
Older versions of node can't use the concise method syntax.