### PR TITLE
[BUGFIX beta] Avoid using `Ember.lookup` to setup global.

### DIFF
--- a/addon/-private/core.js
+++ b/addon/-private/core.js
@@ -17,8 +17,9 @@ import VERSION from 'ember-data/version';
   @type String
   @static
 */
-var DS = Ember.Namespace.create({
-  VERSION: VERSION
+const DS = Ember.Namespace.create({
+  VERSION: VERSION,
+  name: "DS"
 });
 
 if (Ember.libraries) {

--- a/addon/-private/global.js
+++ b/addon/-private/global.js
@@ -1,0 +1,19 @@
+/* globals global, window, self */
+
+// originally from https://github.com/emberjs/ember.js/blob/c0bd26639f50efd6a03ee5b87035fd200e313b8e/packages/ember-environment/lib/global.js
+
+// from lodash to catch fake globals
+function checkGlobal(value) {
+  return (value && value.Object === Object) ? value : undefined;
+}
+
+// element ids can ruin global miss checks
+function checkElementIdShadowing(value) {
+  return (value && value.nodeType === undefined) ? value : undefined;
+}
+
+// export real global
+export default checkGlobal(checkElementIdShadowing(typeof global === 'object' && global)) ||
+  checkGlobal(typeof self === 'object' && self) ||
+  checkGlobal(typeof window === 'object' && window) ||
+  new Function('return this')(); // eval outside of strict mode

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,8 @@
 import Ember from "ember";
-import { warn } from "ember-data/-private/debug";
+import { warn, deprecate } from "ember-data/-private/debug";
 import isEnabled from "ember-data/-private/features";
+import global from "ember-data/-private/global";
+
 /**
   Ember Data
   @module ember-data
@@ -164,6 +166,17 @@ Object.defineProperty(DS, 'normalizeModelName', {
   value: normalizeModelName
 });
 
-Ember.lookup.DS = DS;
+Object.defineProperty(global, 'DS', {
+  get() {
+    deprecate(
+      'Using the global version of DS is deprecated. Please either import ' +
+        'the specific modules needed or `import DS from \'ember-data\';`.',
+      false,
+      { id: 'ember-data.global-ds', until: '3.0.0' }
+    );
+
+    return DS;
+  }
+});
 
 export default DS;


### PR DESCRIPTION
`Ember.lookup` is an internal mechanism used by older versions of Ember
to "lookup" things on the global scope. In Ember 2.7 usage of
`Ember.lookup` will be deprecated, so this removes our need for it.

This also adds a deprecation when using the global `DS` (suggesting
imports instead).

---

Currently, `import DS from 'ember-data';` when ran as an ember-cli addon, still adds a `window.DS` global. This PR maintains that status quo (but prevents issues on Ember 2.7), if we want to only set `window.DS` up for globals builds (which seems better to me) I can modify this PR.