### PR TITLE
Support other dataTypes in Adapter#AjaxOptions

### DIFF
--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -1065,7 +1065,7 @@ var RESTAdapter = Adapter.extend(BuildURLMixin, {
     var hash = options || {};
     hash.url = url;
     hash.type = type;
-    hash.dataType = 'json';
+    hash.dataType = options.dataType || 'json';
     hash.context = this;
 
     if (hash.data && type !== 'GET') {


### PR DESCRIPTION
I've been moving an older app off `ic-ajax` - and these days I often use `adapter#ajax` for non-restful API calls - it feels nice to take advantage of all of the adapter's niceties!

Often those calls need to be authenticated (I use Simple Auth).

Simple Auth have just moved the process of adding Auth headers to the Adapter via an adapter mixin, rather than adding a global jQuery beforeFilter.

I recently had a case where I had to fetch the body of an Email to show an admin.  Unfortunately, you can't use `adapter#ajax` to fetch anything other than `json` without this change.

If there's a reason this is so strict - let me know - otherwise I can add tests here 👍 
