### PR TITLE
Rollback Relationships

### DIFF
--- a/addon/-debug/index.js
+++ b/addon/-debug/index.js
@@ -25,7 +25,7 @@ export function instrument(method) {
   @param {InternalModel} addedRecord record which
          should be added/set for the relationship
 */
-let assertPolymorphicType;
+let assertPolymorphicType = () => {};
 
 if (DEBUG) {
   let checkPolymorphic = function checkPolymorphic(modelClass, addedModelClass) {

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -161,10 +161,20 @@ export default class ManyRelationship extends Relationship {
     super.flushCanonical();
   }
 
-  removeInternalModelFromOwn(internalModel, idx) {
-    if (!this.members.has(internalModel)) {
-      return;
+  addInternalModelToOwn(internalModel, idx) {
+    if (this.members.has(internalModel)) { return; }
+    super.addInternalModelToOwn(internalModel, idx);
+    let manyArray = this.manyArray;
+    if (idx !== undefined) {
+      //TODO(Igor) not used currently, fix
+      manyArray.currentState.insertAt(idx);
+    } else {
+      manyArray._addInternalModels([internalModel]);
     }
+  }
+
+  removeInternalModelFromOwn(internalModel, idx) {
+    if (!this.members.has(internalModel)) { return; }
     super.removeInternalModelFromOwn(internalModel, idx);
     // note that ensuring the many array is created, via `this.manyArray`
     // (instead of `this._manyArray`) is intentional.
@@ -203,6 +213,10 @@ export default class ManyRelationship extends Relationship {
 
   notifyRecordRelationshipAdded(internalModel, idx) {
     this.internalModel.notifyHasManyAdded(this.key, internalModel, idx);
+  }
+
+  notifyRecordRelationshipRemoved(internalModel) {
+    this.internalModel.notifyHasManyRemoved(this.key, internalModel);
   }
 
   reload() {
@@ -297,7 +311,9 @@ export default class ManyRelationship extends Relationship {
   }
 
   notifyHasManyChanged() {
-    this.internalModel.notifyHasManyAdded(this.key);
+    //TODO MMP Why?
+    //this.internalModel.notifyHasManyAdded(this.key);
+    this.internalModel.notifyPropertyChange(this.key);
   }
 
   getRecords() {
@@ -336,6 +352,52 @@ export default class ManyRelationship extends Relationship {
     }
   }
 
+  canonicalizeOrder() {
+    let canonicalMembers = this.canonicalMembers;
+    let canonicalState = this.canonicalState;
+    let currentState = this.manyArray.currentState;
+    const length = canonicalState.length;
+
+    for (let i = 0, j= 0; i < length; i++) {
+      let canonicalModel = canonicalState[i];
+      let currentModel = currentState[i];
+
+      if (canonicalModel === currentModel) { j++; continue; }
+      if (!canonicalMembers.has(currentModel)) { continue; }
+
+      this.removeInternalModel(canonicalModel);
+      this.addInternalModel(canonicalModel, j++);
+    }
+
+    this.internalModel.notifyPropertyChange(this.key);
+    this.internalModel.send('propertyWasReset', this.key);
+  }
+
+  rollback() {
+    let canonicalMembers = this.canonicalMembers;
+    let canonicalState = this.canonicalState;
+    let currentState = this.manyArray.currentState;
+    const length = canonicalState.length;
+
+    for (let i = 0; i < length; i++) {
+      let canonicalModel = canonicalState[i];
+      let currentModel = currentState[i];
+
+      if (canonicalModel === currentModel) { continue; }
+
+      if (!canonicalMembers.has(currentModel)) {
+        this.removeInternalModel(currentModel);
+      }
+
+      this.removeInternalModel(canonicalModel);
+      this.addInternalModel(canonicalModel, i);
+    }
+
+    this.removeInternalModels(currentState.slice(canonicalState.length));
+    this.internalModel.notifyPropertyChange(this.key);
+    this.internalModel.send('propertyWasReset', this.key);
+  }
+
   destroy() {
     super.destroy();
     let manyArray = this._manyArray;
@@ -354,10 +416,12 @@ export default class ManyRelationship extends Relationship {
 }
 
 function setForArray(array) {
-  var set = new OrderedSet();
+  const set = new OrderedSet();
 
   if (array) {
-    for (var i=0, l=array.length; i<l; i++) {
+    let i = 0;
+    const l = array.length;
+    for (; i<l; i++) {
       set.add(array[i]);
     }
   }

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -10,6 +10,8 @@ const {
   addCanonicalInternalModel,
   addCanonicalInternalModels,
   addInternalModel,
+  addInternalModelToInverse,
+  addInternalModelToOwn,
   addInternalModels,
   clear,
   findLink,
@@ -34,6 +36,8 @@ const {
   'addCanonicalInternalModel',
   'addCanonicalInternalModels',
   'addInternalModel',
+  'addInternalModelToInverse',
+  'addInternalModelToOwn',
   'addInternalModels',
   'clear',
   'findLink',
@@ -78,6 +82,7 @@ export default class Relationship {
     this.hasData = false;
     this.hasLoaded = false;
     this.__inverseMeta = undefined;
+    this.isDirty = false;
   }
 
   _inverseIsAsync() {
@@ -279,6 +284,27 @@ export default class Relationship {
     this.setHasData(true);
   }
 
+  addInternalModelToInverse(internalModel) {
+    heimdall.increment(addInternalModelToInverse);
+    let inverseRelationship = internalModel._relationships.get(this.inverseKey);
+    //Need to check for existence, as the record might unloading at the moment
+    if (inverseRelationship) {
+      inverseRelationship.addInternalModelToOwn(this.internalModel);
+    }
+  }
+
+  addInternalModelsToInverse() {
+    this.members.forEach((internalModel) => {
+      this.addInternalModelToInverse(internalModel);
+    });
+  }
+
+  addInternalModelToOwn(internalModel) {
+    heimdall.increment(addInternalModelToOwn);
+    this.members.add(internalModel);
+    this.internalModel.updateRecordArrays();
+  }
+
   removeInternalModel(internalModel) {
     heimdall.increment(removeInternalModel);
     if (this.members.has(internalModel)) {
@@ -300,6 +326,12 @@ export default class Relationship {
     if (inverseRelationship) {
       inverseRelationship.removeInternalModelFromOwn(this.internalModel);
     }
+  }
+
+  removeInternalModelsFromInverse() {
+    this.members.forEach((internalModel) => {
+      this.removeInternalModelFromInverse(internalModel);
+    });
   }
 
   removeInternalModelFromOwn(internalModel) {
@@ -539,6 +571,7 @@ export default class Relationship {
 
   updateData() {}
 
-  destroy() {
-  }
+  rollback() {}
+
+  destroy() {}
 }

--- a/addon/attr.js
+++ b/addon/attr.js
@@ -127,7 +127,9 @@ export default function attr(type, options) {
 
   let meta = {
     type: type,
+    kind: 'attr',
     isAttribute: true,
+    key: null,
     options: options
   };
 
@@ -156,8 +158,10 @@ export default function attr(type, options) {
           originalValue = internalModel._data[key];
         }
 
-        this._internalModel.send('didSetProperty', {
-          name: key,
+        internalModel.send('didSetProperty', {
+          key: key,
+          kind: 'attr',
+          isAttribute: true,
           oldValue: oldValue,
           originalValue: originalValue,
           value: value

--- a/app/instance-initializers/ember-data.js
+++ b/app/instance-initializers/ember-data.js
@@ -1,5 +1,7 @@
 import initializeStoreService from 'ember-data/initialize-store-service';
 
+initializeStoreService.initialize = () => {};
+
 export default {
   name: "ember-data",
   initialize: initializeStoreService

--- a/tests/integration/relationships/one-to-one-test.js
+++ b/tests/integration/relationships/one-to-one-test.js
@@ -955,3 +955,43 @@ test("Rollbacking attributes of created record removes the relationship on both 
   assert.equal(user.get('job'), null, 'Job got rollbacked correctly');
   assert.equal(job.get('user'), null, 'Job does not have user anymore');
 });
+
+/*
+Rollback relationships tests
+*/
+
+test("Rollback one-to-one relationships restores both sides of the relationship - async", function (assert) {
+  let stanley, bob, jim;
+  run(() => {
+    stanley = store.push({ data: { type: 'user', id: 1, attributes: { name: 'Stanley' }, relationships: { bestFriend: { data: { type: 'user', id: 2 } } } } });
+    bob = store.push({ data: { type: 'user', id: 2, name: "Stanley's friend" } });
+    jim = store.push({ data: { type: 'user', id: 3, name: "Stanley's other friend" } });
+    stanley.set('bestFriend', jim);
+  });
+  run(() => {
+    stanley.rollback();
+    stanley.get('bestFriend').then(function (fetchedUser) {
+      assert.equal(fetchedUser, bob, "Stanley's bestFriend is still Bob");
+    });
+    bob.get('bestFriend').then(function (fetchedUser) {
+      assert.equal(fetchedUser, stanley, "Bob's  bestFriend is still Stanley");
+    });
+    jim.get('bestFriend').then(function (fetchedUser) {
+      assert.equal(fetchedUser, null, "Jim still has no bestFriend");
+    });
+  });
+});
+
+test("Rollback one-to-one relationships restores both sides of the relationship - sync", function (assert) {
+  let job, stanley, bob;
+  run(function () {
+    job = store.push({ data: { type: 'job', id: 2, attributes: { isGood: true } } });
+    stanley = store.push({ data: { type: 'user', id: 1, attributes: { name: 'Stanley' }, relationships: { job: { data: { type: 'job', id: 2 } } } } });
+    bob = store.push({ data: { type: 'user', id: 2, attributes: { name: 'Bob' } } });
+    job.set('user', bob);
+  });
+  run(job,'rollback');
+  assert.equal(stanley.get('job'), job, 'Stanley still has a job');
+  assert.equal(bob.get('job'), null, 'Bob still has no job');
+  assert.equal(job.get('user'), stanley, 'The job still belongs to Stanley');
+});

--- a/tests/unit/model/relationships/rollback-test.js
+++ b/tests/unit/model/relationships/rollback-test.js
@@ -1,0 +1,253 @@
+import setupStore from 'dummy/tests/helpers/store';
+import Ember from 'ember';
+
+import {module, test} from 'qunit';
+
+import DS from 'ember-data';
+
+let env, store, Person, Dog;
+const run = Ember.run;
+
+module("unit/model/relationships/rollback - model.rollback()", {
+  beforeEach() {
+    Person = DS.Model.extend({
+      firstName: DS.attr(),
+      lastName: DS.attr(),
+      dogs: DS.hasMany({ async: true })
+    });
+
+    Dog = DS.Model.extend({
+      name: DS.attr(),
+      owner: DS.belongsTo('person', { async: true })
+    });
+
+    env = setupStore({ person: Person, dog: Dog });
+    store = env.store;
+  }
+});
+
+test("saved changes to relationships should not roll back to a pre-saved state (from child)", function(assert) {
+  let person1, person2, dog1, dog2, dog3;
+
+  env.adapter.updateRecord = function(store, type, snapshot) {
+    return Ember.RSVP.resolve({ data: { type: 'dog', id: 2, relationships: { owner: { data: { type: 'person', id: 1 } } } } });
+  };
+
+  run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          firstName: "Tom",
+          lastName: "Dale"
+        }
+      }
+    });
+    store.push({
+      data: {
+        type: 'person',
+        id: 2,
+        attributes: {
+          firstName: "John",
+          lastName: "Doe"
+        }
+      }
+    });
+    store.push({
+      data: {
+        type: 'dog',
+        id: 1,
+        attributes: {
+          name: "Fido"
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'person',
+              id: 1
+            }
+          }
+        }
+      }
+    });
+    store.push({
+      data: {
+        type: 'dog',
+        id: 2,
+        attributes: {
+          name: "Bear"
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'person',
+              id: 2
+            }
+          }
+        }
+      }
+    });
+    store.push({
+      data: {
+        type: 'dog',
+        id: 3,
+        attributes: {
+          name: "Spot"
+        }
+      }
+    });
+    person1 = store.peekRecord('person', 1);
+    person2 = store.peekRecord('person', 2);
+    dog1 = store.peekRecord('dog', 1);
+    dog2 = store.peekRecord('dog', 2);
+    dog3 = store.peekRecord('dog', 3);
+    person1.get('dogs').addObject(dog2);
+  });
+
+  run(() => {
+    dog2.save().then(() => {
+      person1.get('dogs').addObject(dog3);
+      dog2.rollback();
+      dog3.rollback();
+      person1.get('dogs').then(function (dogs) {
+        assert.deepEqual(dogs.toArray(), [dog1,dog2]);
+      });
+      person2.get('dogs').then(function (dogs) {
+        assert.deepEqual(dogs.toArray(), []);
+      });
+      dog1.get('owner').then(function (owner) {
+        assert.equal(owner, person1);
+      });
+      dog2.get('owner').then(function (owner) {
+        assert.equal(owner, person1);
+      });
+    });
+  });
+});
+
+// skip("saved changes to relationships should not roll back to a pre-saved state (from parent)", function(assert) {
+//   var person1, person2, dog1, dog2, dog3;
+//
+//   env.adapter.updateRecord = function(store, type, snapshot) {
+//     return Ember.RSVP.resolve({ id: 1, dogs: [1] });
+//   };
+//
+//   run(function() {
+//     store.push({
+//       data: {
+//         type: 'person',
+//         id: 1,
+//         attributes: {
+//           firstName: "Tom",
+//           lastName: "Dale"
+//         },
+//         relationships: {
+//           dogs: {
+//             data: [{
+//               type: 'dog',
+//               id: 1
+//             }]
+//           }
+//         }
+//       }
+//     });
+//     store.push({
+//       data: {
+//         type: 'person',
+//         id: 2,
+//         attributes: {
+//           firstName: "John",
+//           lastName: "Doe"
+//         },
+//         relationships: {
+//           dogs: {
+//             data: [{
+//               type: 'dog',
+//               id: 2
+//             }]
+//           }
+//         }
+//       }
+//     });
+//     store.push({
+//       data: {
+//         type: 'dog',
+//         id: 1,
+//         attributes: {
+//           name: "Fido"
+//         },
+//         relationships: {
+//           owner: {
+//             data: {
+//               type: 'person',
+//               id: 1
+//             }
+//           }
+//         }
+//       }
+//     });
+//     store.push({
+//       data: {
+//         type: 'dog',
+//         id: 2,
+//         attributes: {
+//           name: "Bear"
+//         },
+//         relationships: {
+//           owner: {
+//             data: {
+//               type: 'person',
+//               id: 2
+//             }
+//           }
+//         }
+//       }
+//     });
+//     store.push({
+//       data: {
+//         type: 'dog',
+//         id: 3,
+//         attributes: {
+//           name: "Spot"
+//         },
+//         relationships: {
+//           owner: {
+//             data: null
+//           }
+//         }
+//       }
+//     });
+//     person1 = store.peekRecord('person', 1);
+//     person2 = store.peekRecord('person', 2);
+//     dog1 = store.peekRecord('dog', 1);
+//     dog2 = store.peekRecord('dog', 2);
+//     dog3 = store.peekRecord('dog', 3);
+//
+//     person1.get('dogs').addObject(dog2);
+//   });
+//
+//   run(function() {
+//     person1.save().then(function () {
+//       person1.get('dogs').addObject(dog3);
+//       return Ember.RSVP.all([person1.rollback()]);
+//     }).then(function () {
+//       person1.get('dogs').then(function (dogs) {
+//         assert.deepEqual(dogs.toArray(), [dog1,dog2]);
+//       });
+//       person2.get('dogs').then(function (dogs) {
+//         assert.deepEqual(dogs.toArray(), []);
+//       });
+//       dog1.get('owner').then(function (owner) {
+//         assert.equal(owner, person1);
+//       }).then(function () {
+//         console.log(person1._internalModel._relationships.get('dogs').manyArray.currentState.map(function (i) { return i.id; }));
+//         console.log(dog2._internalModel._relationships.get('owner').get('id'));
+//         console.log(dog3._internalModel._relationships.get('owner').get('id'));
+//       });
+//       dog2.get('owner').then(function (owner) {
+//         assert.equal(owner, person1);
+//       });
+//     });
+//   });
+// });


### PR DESCRIPTION
This commit:
1. Allows one to rollback `belongsTo` and `hasMany` relationships.
2. Reintroduces `dirtyRecordFor*Change` hooks on the adapter that allow one to customize when a record becomes dirty.
3. Added `removeDeletedFromRelationshipsPriorToSave` flag to Adapter that allows one to opt back into the old deleted record from many array behavior (pre #3539).

Known issues:
- Rolling back a `hasMany` relationship from the `parent` side of the relationship does not work (doing the same from the child side works fine). See test that is commented out below as well as the discussion at the end of [#2881#issuecomment-204634262](https://github.com/emberjs/data/pull/2881#issuecomment-204634262)

This was previously #2881 and is related to #3698 
