### PR TITLE
[DOC] Fix hard-coded "Customizing Adapters" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ set of RESTful JSON conventions.
 
 To learn more about adapters, including what conventions the
 `RESTAdapter` follows and how to build your own, see the Ember.js
-Guides: [Customizing Adapters](https://guides.emberjs.com/v2.3.0/models/customizing-adapters/).
+Guides: [Customizing Adapters](http://emberjs.com/guides/models/customizing-adapters).
 
 ### Fetching a Collection of Models
 


### PR DESCRIPTION
The link to the Customizing Adapters guide was hard-coded to point to the v2.3.0 docs. I updated the link so that it will redirect to the latest version's guide page instead.