### PR TITLE
Revert "[CLEANUP ds-serialize-ids-and-types]"

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -26,6 +26,30 @@ entry in `config/features.json`.
   Enables `pushPayload` to return the model(s) that are created or
   updated via the internal `store.push`. [PR 4110](https://github.com/emberjs/data/pull/4110)
 
+- `ds-serialize-ids-and-types`
+
+  Enables a new `ids-and-type` strategy (in addition to the already existing `ids` and `records`) for
+  serializing has many relationships using the `DS.EmbeddedRecordsMixin` that  will include both
+  `id` and `type` of each model as an object.
+
+  For instance, if a use has many pets, which is a polymorphic relationship, the generated payload would be:
+
+  ```js
+  {
+    "user": {
+      "id": "1"
+      "name": "Bertin Osborne",
+      "pets": [
+        { "id": "1", "type": "Cat" },
+        { "id": "2", "type": "Parrot"}
+      ]
+    }
+  }
+  ```
+
+  This is particularly useful for polymorphic relationships not backed by STI when just including the id
+  of the records is not enough.
+
 - `ds-extended-errors`
 
   Enables `extend` method on errors. It means you can extend from `DS.AdapterError`.

--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { warn } from "ember-data/-private/debug";
+import isEnabled from 'ember-data/-private/features';
 
 var get = Ember.get;
 var set = Ember.set;
@@ -364,6 +365,8 @@ export default Ember.Mixin.create({
     }
     ```
 
+    Note that the `ids-and-types` strategy is still behind the `ds-serialize-ids-and-types` feature flag.
+
     @method serializeHasMany
     @param {DS.Snapshot} snapshot
     @param {Object} json
@@ -381,12 +384,16 @@ export default Ember.Mixin.create({
       json[serializedKey] = snapshot.hasMany(attr, { ids: true });
     } else if (this.hasSerializeRecordsOption(attr)) {
       this._serializeEmbeddedHasMany(snapshot, json, relationship);
-    } else if (this.hasSerializeIdsAndTypesOption(attr)) {
-      this._serializeHasManyAsIdsAndTypes(snapshot, json, relationship);
+    } else {
+      if (isEnabled("ds-serialize-ids-and-types")) {
+        if (this.hasSerializeIdsAndTypesOption(attr)) {
+          this._serializeHasManyAsIdsAndTypes(snapshot, json, relationship);
+        }
+      }
     }
   },
 
-  /*
+  /**
     Serializes a hasMany relationship as an array of objects containing only `id` and `type`
     keys.
     This has its use case on polymorphic hasMany relationships where the server is not storing

--- a/config/features.json
+++ b/config/features.json
@@ -2,6 +2,7 @@
   "ds-boolean-transform-allow-null": null,
   "ds-improved-ajax": null,
   "ds-pushpayload-return": null,
+  "ds-serialize-ids-and-types": true,
   "ds-extended-errors": null,
   "ds-links-in-record-array": null
 }


### PR DESCRIPTION
This reverts commit 87e6e60e9b6266b27eceae17891839cf2b7a1787.

The cleanup for the ds-serialize-ids-and-types feature is made too
eagerly, since it hasn't been enabled in beta yet. This commit reverts
the cleanup so the functionality is still behind the (enabled) feature
flag. By this it can be tested via the beta channel.

Once the feature is go'ed in a release channel, this can be finally be
cleaned.

---

Cleanup happened to eagerly in #4349 