### PR TITLE
[FEATURE ds-customizable-error-key] Allow custom error keys in RESTAdapter

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -65,3 +65,7 @@ entry in `config/features.json`.
   * [404] `DS.NotFoundError`
   * [409] `DS.ConflictError`
   * [500] `DS.ServerError`
+
+- `ds-customizable-error-key`
+
+  Allows to specify a custom key by which the errors will be extracted by the `DS.RESTAdapter`.

--- a/config/features.json
+++ b/config/features.json
@@ -4,5 +4,6 @@
   "ds-pushpayload-return": null,
   "ds-serialize-ids-and-types": true,
   "ds-extended-errors": null,
-  "ds-links-in-record-array": null
+  "ds-links-in-record-array": null,
+  "ds-customizable-error-key": null
 }


### PR DESCRIPTION
Hey,
AFAIK, there is currently no way to customize the RESTAdapter's behavior on errors.
It will always look for `errors` top-level key, as described in [documentation](http://emberjs.com/api/data/classes/DS.RESTAdapter.html#toc_errors).
I think it would be nice to have a way to at least specify the key, which will be used to access the error data.
This PR adds an `errorKey` property to RESTAdapter, which allows to specify an expected key for failed request's payload to have.