### PR TITLE
Fix #4366: EmbeddedRecordsMixin embeds the record, not the snapshot

### DIFF
--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -226,7 +226,7 @@ export default Ember.Mixin.create({
     if (!embeddedSnapshot) {
       json[serializedKey] = null;
     } else {
-      json[serializedKey] = embeddedSnapshot.record.serialize({ includeId: true });
+      json[serializedKey] = embeddedSnapshot.serialize({ includeId: true });
       this.removeEmbeddedForeignKey(snapshot, embeddedSnapshot, relationship, json[serializedKey]);
 
       if (relationship.options.polymorphic) {
@@ -440,7 +440,7 @@ export default Ember.Mixin.create({
 
     for (let i = 0; i < manyArray.length; i++) {
       let embeddedSnapshot = manyArray[i];
-      let embeddedJson = embeddedSnapshot.record.serialize({ includeId: true });
+      let embeddedJson = embeddedSnapshot.serialize({ includeId: true });
       this.removeEmbeddedForeignKey(snapshot, embeddedSnapshot, relationship, embeddedJson);
       ret[i] = embeddedJson;
     }


### PR DESCRIPTION
The change replaces references to `snapshot.record.serialize()` with `snapshot.serialize()` in the `EmbeddedRecordsMixin` to ensure that the snapshot state is serialized rather than the current state of the record.