### PR TITLE
[BUGFIX beta] Fix resetting of properties to in-flight values

### DIFF
--- a/addon/attr.js
+++ b/addon/attr.js
@@ -140,16 +140,23 @@ export default function attr(type, options) {
     set(key, value) {
       var internalModel = this._internalModel;
       var oldValue = getValue(internalModel, key);
+      var originalValue;
 
       if (value !== oldValue) {
         // Add the new value to the changed attributes hash; it will get deleted by
         // the 'didSetProperty' handler if it is no different from the original value
         internalModel._attributes[key] = value;
 
+        if (key in internalModel._inFlightAttributes) {
+          originalValue = internalModel._inFlightAttributes[key]
+        } else {
+          originalValue = internalModel._data[key]
+        }
+
         this._internalModel.send('didSetProperty', {
           name: key,
           oldValue: oldValue,
-          originalValue: internalModel._data[key],
+          originalValue: originalValue,
           value: value
         });
       }


### PR DESCRIPTION
Changing the value of an in-flight property, then changing back, had the
side effect that the record would be marked dirty once the save
completed.

`changedAttributes` would report that `name` had been changed from
'Thomas' to 'Thomas'

This is because the attr computed was only checking to see if the value
was being reset to the canonical value, not if it was being reset to the
in-flight value