### PR TITLE
[BUGFIX beta] remove trailing whitespace from model blueprint

### DIFF
--- a/blueprints/model/files/__root__/__path__/__name__.js
+++ b/blueprints/model/files/__root__/__path__/__name__.js
@@ -1,5 +1,5 @@
 <%= importStatements %>
 
 export default Model.extend({
-  <%= attrs %>
+<%= attrs.length ? '  ' + attrs : '' %>
 });


### PR DESCRIPTION
Addresses: https://github.com/emberjs/data/issues/4306

This ensures that if attrs are present when generating a model, we indent them properly.  If no attrs are present, there should be no trailing whitespace.