### PR TITLE
[BUGFIX release] `isUpdating` flag is set correctly for `store.findAll`

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1313,6 +1313,8 @@ Store = Service.extend({
     assert("You tried to load all records but you have no adapter (for " + typeClass + ")", adapter);
     assert("You tried to load all records but your adapter does not implement `findAll`", typeof adapter.findAll === 'function');
 
+    set(array, 'isUpdating', true);
+
     if (options.reload) {
       return promiseArray(_findAll(adapter, this, typeClass, sinceToken, options));
     }

--- a/tests/integration/adapter/find-all-test.js
+++ b/tests/integration/adapter/find-all-test.js
@@ -155,3 +155,89 @@ testInDebug('When all records are requested, assert the payload is not blank', (
     run(() => store.findAll('person'));
   }, /You made a `findAll` request for person records, but the adapter's response did not have any data/);
 });
+
+test("isUpdating is true while records are fetched", function(assert) {
+  let done = assert.async();
+
+  let findAllDeferred = Ember.RSVP.defer();
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    findAll() {
+      return findAllDeferred.promise;
+    },
+
+    shouldReloadAll: () => true
+  }));
+
+  run(function() {
+    store.push({
+      data: [{
+        type: 'person',
+        id: 1
+      }]
+    });
+  });
+
+  let persons = store.peekAll('person');
+  assert.equal(persons.get("length"), 1);
+
+  run(function() {
+    store.findAll('person').then(function(persons) {
+      assert.equal(persons.get("isUpdating"), false);
+      assert.equal(persons.get("length"), 2);
+
+      done();
+    });
+  });
+
+  assert.equal(persons.get("isUpdating"), true);
+
+  findAllDeferred.resolve([{ id: 2 }]);
+});
+
+test("isUpdating is true while records are fetched in the background", function(assert) {
+  let done = assert.async();
+
+  let findAllDeferred = Ember.RSVP.defer();
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    findAll() {
+      return findAllDeferred.promise;
+    },
+
+    shouldReloadAll: () => false,
+    shouldBackgroundReloadAll: () => true
+  }));
+
+  run(function() {
+    store.push({
+      data: [{
+        type: 'person',
+        id: 1
+      }]
+    });
+  });
+
+  let persons = store.peekAll('person');
+  assert.equal(persons.get("length"), 1);
+
+  run(function() {
+    store.findAll('person').then(function(persons) {
+      assert.equal(persons.get("isUpdating"), true);
+      assert.equal(persons.get("length"), 1, "persons are updated in the background");
+    });
+  });
+
+  assert.equal(persons.get("isUpdating"), true);
+
+  run(function() {
+    findAllDeferred.resolve([{ id: 2 }]);
+  });
+
+  run(function() {
+    findAllDeferred.promise.then(function() {
+      assert.equal(persons.get("isUpdating"), false);
+      assert.equal(persons.get("length"), 2);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
A regression for the `isUpdating` flag on the RecordArray returned for
`store.peekAll` has been introduced in #4316: the flag isn't set to true
anymore when records are reloaded or a background reloaded.

---

This closes #4339.