### PR TITLE
Fix `ds.store.missing-records-from-adapter` with mixed adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ### Master
 
+### Release 2.9.0-beta.1 (September 10, 2016)
+- [#4490](https://github.com/emberjs/data/pull/4490) [DOCS] No need to use Ember.run in succes and failure of wrapped getJSON
+- [#4493](https://github.com/emberjs/data/pull/4493) Addresses #4492
+- [#4503](https://github.com/emberjs/data/pull/4503) Update ember-try config to test against alpha.
+- [#4515](https://github.com/emberjs/data/pull/4515) Document the allowNull property on the boolean transform
+- [#4516](https://github.com/emberjs/data/pull/4516) Update the docs for normalizeModelName so they explain the intent of …
+- [#4521](https://github.com/emberjs/data/pull/4521) Remove ContainerProxy
+- [#4522](https://github.com/emberjs/data/pull/4522) add license to bower.json
+
+
 ### Release 2.8.0 (September 8, 2016)
 
 - [#4464](https://github.com/emberjs/data/pull/4464) Add benchmarks directory to npmignore

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -746,7 +746,7 @@ Store = Service.extend({
 
     function resolveFoundRecords(records) {
       records.forEach((record) => {
-        var pair = Ember.A(pendingFetchItems).findBy('record', record);
+        var pair = Ember.A(pendingFetchItems).findBy('record.id', record.id);
         if (pair) {
           var resolver = pair.resolver;
           resolver.resolve(record);
@@ -758,7 +758,7 @@ Store = Service.extend({
     function makeMissingRecordsRejector(requestedRecords) {
       return function rejectMissingRecords(resolvedRecords) {
         resolvedRecords = Ember.A(resolvedRecords);
-        var missingRecords = requestedRecords.reject((record) => resolvedRecords.includes(record));
+        var missingRecords = requestedRecords.reject((record) => resolvedRecords.findBy('id', record.id));
         if (missingRecords.length) {
           warn('Ember Data expected to find records with the following ids in the adapter response but they were missing: ' + Ember.inspect(Ember.A(missingRecords).mapBy('id')), false, {
             id: 'ds.store.missing-records-from-adapter'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data",
-  "version": "2.9.0-canary",
+  "version": "2.9.0-beta.1",
   "description": "A data layer for your Ember applications.",
   "repository": "git://github.com/emberjs/data.git",
   "directories": {


### PR DESCRIPTION
When using mixed adapters and referencing a model in one adapter from a model in a different adapter and coalescing finds, the adapter presents an error similar to:

```
Ember Data expected to find records with the following ids in the adapter response but they were missing: [...]
```

When loading the records directly, for any of the two models, there's no problem.

As an example one might have:
- A `project` model that is loaded from a JSON API backend, with coalescing finds by id
- A `token` model that is loaded from a `ember-local-storage` backend that references the project (with `inverse: null`)

Then trying to load all projects from the list of tokens like this:

``` javascript
Ember.RSVP.all(this.store.findAll(`token`).then((tokens) => tokens.mapBy('project')))
```

Executes a coalesced find many by id that gives the error above.

The root of this problem is that the records passed to `_flushPendingFetchForType` are not the same as found by the adapter, and they are rejected. This PR makes the comparison of those records by `id` instead of comparing directly.

There might be a more basic problem here but I don't seem to find the real culprit of it.

P.S. I need some guidance to write some tests for this.
