### PR TITLE
Deprecate date parse

### DIFF
--- a/addon/-private/ext/date.js
+++ b/addon/-private/ext/date.js
@@ -3,29 +3,14 @@
 */
 
 import Ember from 'ember';
+import { deprecate } from 'ember-data/-private/debug';
 
-/**
-  Date.parse with progressive enhancement for ISO 8601 <https://github.com/csnover/js-iso8601>
-
-  © 2011 Colin Snover <http://zetafleet.com>
-
-  Released under MIT license.
-
-  @class Date
-  @namespace Ember
-  @static
-*/
 Ember.Date = Ember.Date || {};
 
 var origParse = Date.parse;
 var numericKeys = [1, 4, 5, 6, 7, 10, 11];
 
-/**
-  @method parse
-  @param {Date} date
-  @return {Number} timestamp
-*/
-Ember.Date.parse = function (date) {
+export const parseDate = function (date) {
   var timestamp, struct;
   var minutesOffset = 0;
 
@@ -59,6 +44,34 @@ Ember.Date.parse = function (date) {
   return timestamp;
 };
 
+Ember.Date.parse = function (date) {
+  // throw deprecation
+  deprecate(`Ember.Date.parse is deprecated because Safari 5-, IE8-, and
+    Firefox 3.6- are no longer supported (see
+    https://github.com/csnover/js-iso8601 for the history of this issue).
+    Please use Date.parse instead`, false, {
+    id: 'ds.ember.date.parse-deprecate',
+    until: '3.0.0'
+  });
+
+  return parseDate(date);
+};
+
 if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Date) {
-  Date.parse = Ember.Date.parse;
+  deprecate(`Overriding Date.parse with Ember.Date.parse is deprecated. Please set ENV.EmberENV.EXTEND_PROTOTYPES.Date to false in config/environment.js
+
+
+// config/environment.js
+ENV = {
+  EmberENV: {
+    EXTEND_PROTOTYPES: {
+      Date: false,
+    }
+  }
+}
+`, false, {
+    id: 'ds.date.parse-deprecate',
+    until: '3.0.0'
+  });
+  Date.parse = parseDate;
 }

--- a/addon/-private/ext/date.js
+++ b/addon/-private/ext/date.js
@@ -33,7 +33,7 @@ Ember.Date.parse = function (date) {
   // before falling back to any implementation-specific date parsing, so that’s what we do, even if native
   // implementations could be faster
   //              1 YYYY                2 MM       3 DD           4 HH    5 mm       6 ss        7 msec        8 Z 9 ±    10 tzHH    11 tzmm
-  if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?::(\d{2}))?)?)?$/.exec(date))) {
+  if ((struct = /^(\d{4}|[+\-]\d{6})(?:-(\d{2})(?:-(\d{2}))?)?(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?(?:(Z)|([+\-])(\d{2})(?:(\d{2}))?)?)?$/.exec(date))) {
     // avoid NaN timestamps caused by “undefined” values being passed to Date.UTC
     for (var i = 0, k; (k = numericKeys[i]); ++i) {
       struct[k] = +struct[k] || 0;

--- a/addon/-private/ext/date.js
+++ b/addon/-private/ext/date.js
@@ -47,12 +47,12 @@ export const parseDate = function (date) {
 Ember.Date.parse = function (date) {
   // throw deprecation
   deprecate(`Ember.Date.parse is deprecated because Safari 5-, IE8-, and
-    Firefox 3.6- are no longer supported (see
-    https://github.com/csnover/js-iso8601 for the history of this issue).
-    Please use Date.parse instead`, false, {
-    id: 'ds.ember.date.parse-deprecate',
-    until: '3.0.0'
-  });
+      Firefox 3.6- are no longer supported (see
+      https://github.com/csnover/js-iso8601 for the history of this issue).
+      Please use Date.parse instead`, false, {
+        id: 'ds.ember.date.parse-deprecate',
+        until: '3.0.0'
+      });
 
   return parseDate(date);
 };
@@ -70,8 +70,8 @@ ENV = {
   }
 }
 `, false, {
-    id: 'ds.date.parse-deprecate',
-    until: '3.0.0'
-  });
+  id: 'ds.date.parse-deprecate',
+  until: '3.0.0'
+});
   Date.parse = parseDate;
 }

--- a/addon/-private/transforms/date.js
+++ b/addon/-private/transforms/date.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { parseDate } from "ember-data/-private/ext/date";
 
 /**

--- a/addon/-private/transforms/date.js
+++ b/addon/-private/transforms/date.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import "ember-data/-private/ext/date";
+import { parseDate } from "ember-data/-private/ext/date";
 
 /**
   The `DS.DateTransform` class is used to serialize and deserialize
@@ -28,7 +28,7 @@ export default Transform.extend({
     var type = typeof serialized;
 
     if (type === "string") {
-      return new Date(Ember.Date.parse(serialized));
+      return new Date(parseDate(serialized));
     } else if (type === "number") {
       return new Date(serialized);
     } else if (serialized === null || serialized === undefined) {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -5,6 +5,7 @@ import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import QUnit, {module, test} from 'qunit';
 import DS from 'ember-data';
 import isEnabled from 'ember-data/-private/features';
+import { parseDate } from "ember-data/-private/ext/date";
 
 const AssertionPrototype = QUnit.assert;
 
@@ -949,7 +950,7 @@ test("a DS.Model can describe Date attributes", function(assert) {
   assert.converts('date', undefined, undefined);
 
   var dateString = "2011-12-31T00:08:16.000Z";
-  var date = new Date(Ember.Date.parse(dateString));
+  var date = new Date(parseDate(dateString));
 
 
   var Person = DS.Model.extend({

--- a/tests/unit/transform/date-test.js
+++ b/tests/unit/transform/date-test.js
@@ -39,6 +39,17 @@ test("#deserialize", function(assert) {
   assert.equal(transform.deserialize(undefined), null);
 });
 
+test("#deserialize with different offset formats", function(assert) {
+  var transform = new DS.DateTransform();
+  var dateString = '2003-05-24T23:00:00.000+0000';
+  var dateStringColon = '2013-03-15T23:22:00.000+00:00';
+  var dateStringShortOffset = '2016-12-02T17:30:00.000+00';
+
+  assert.equal(transform.deserialize(dateString).getTime(), 1053817200000);
+  assert.equal(transform.deserialize(dateStringShortOffset).getTime(), 1480699800000);
+  assert.equal(transform.deserialize(dateStringColon).getTime(), 1363389720000);
+});
+
 testInDebug('Ember.Date.parse has been deprecated', function(assert) {
   run(function() {
     assert.expectDeprecation(function() {

--- a/tests/unit/transform/date-test.js
+++ b/tests/unit/transform/date-test.js
@@ -1,14 +1,17 @@
-import Ember from 'ember';
-
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
+import Ember from 'ember';
+
+import testInDebug from 'dummy/tests/helpers/test-in-debug';
+import { parseDate } from "ember-data/-private/ext/date";
 
 module("unit/transform - DS.DateTransform");
 
 var dateString = "2015-01-01T00:00:00.000Z";
-var dateInMillis = Ember.Date.parse(dateString);
+var dateInMillis = parseDate(dateString);
 var date = new Date(dateInMillis);
+var run = Ember.run;
 
 test("#serialize", function(assert) {
   var transform = new DS.DateTransform();
@@ -34,4 +37,12 @@ test("#deserialize", function(assert) {
   // from none
   assert.equal(transform.deserialize(null), null);
   assert.equal(transform.deserialize(undefined), null);
+});
+
+testInDebug('Ember.Date.parse has been deprecated', function(assert) {
+  run(function() {
+    assert.expectDeprecation(function() {
+      Ember.Date.parse(dateString);
+    }, /Ember.Date.parse is deprecated/);
+  });
 });


### PR DESCRIPTION
This pr deprecates overriding `Date.parse` however it keeps the current behavior (and where it differs from the native date.parse) for the date transform.

This pr supersedes https://github.com/emberjs/data/pull/4231 and https://github.com/emberjs/data/pull/4275 