### PR TITLE
[FEATURE ds-overhaul-references] Fix inconsistencies with Reference#push

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -114,3 +114,22 @@ entry in `config/features.json`.
   jsonApiSerializer.modelNameFromPayloadType("api::v1::administrator");
   jsonApiSerializer.modelNameFromPayloadType("api::v1::super-user");
   ```
+
+- `ds-overhaul-references` [#4398](https://github.com/emberjs/data/pull/4398)
+
+  This tackles some inconsistencies within `push()` on references. It should
+  only be used to push a JSON-API payload. The following use cases are
+  addressed and deprecated:
+
+  - `BelongsToReference#push()` accepts a `DS.Model`
+  - `HasManyReference#push()` accepts a plain array
+  - `HasManyReference#push()` accepts a pseudo-JSON-API format:
+
+      ```js
+      {
+        data: [
+          { data: { type: 'model', id: 1 } }
+        ]
+      }
+      ```
+

--- a/addon/-private/system/references/belongs-to.js
+++ b/addon/-private/system/references/belongs-to.js
@@ -2,7 +2,8 @@ import Model from 'ember-data/model';
 import Ember from 'ember';
 import Reference from './reference';
 
-import { assertPolymorphicType } from "ember-data/-private/debug";
+import isEnabled from 'ember-data/-private/features';
+import { assertPolymorphicType, deprecate } from "ember-data/-private/debug";
 
 var BelongsToReference = function(store, parentInternalModel, belongsToRelationship) {
   this._super$constructor(store, parentInternalModel);
@@ -43,6 +44,12 @@ BelongsToReference.prototype.push = function(objectOrPromise) {
     var record;
 
     if (data instanceof Model) {
+      if (isEnabled('ds-overhaul-references')) {
+        deprecate("BelongsToReference#push(DS.Model) is deprecated. Update relationship via `model.set('relationshipName', value)` instead.", false, {
+          id: 'ds.references.belongs-to.push-record',
+          until: '3.0'
+        });
+      }
       record = data;
     } else {
       record = this.store.push(data);

--- a/config/features.json
+++ b/config/features.json
@@ -5,5 +5,6 @@
   "ds-serialize-ids-and-types": true,
   "ds-extended-errors": null,
   "ds-links-in-record-array": null,
+  "ds-overhaul-references": null,
   "ds-payload-type-hooks": null
 }

--- a/tests/integration/references/belongs-to-test.js
+++ b/tests/integration/references/belongs-to-test.js
@@ -2,6 +2,7 @@ import DS from 'ember-data';
 import Ember from 'ember';
 import setupStore from 'dummy/tests/helpers/store';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
+import isEnabled from 'ember-data/-private/features';
 import { module, test } from 'qunit';
 
 var get = Ember.get;
@@ -163,7 +164,7 @@ test("push(object)", function(assert) {
   });
 });
 
-test("push(record)", function(assert) {
+testInDebug("push(record)", function(assert) {
   var done = assert.async();
 
   var person, family;
@@ -193,6 +194,10 @@ test("push(record)", function(assert) {
   var familyReference = person.belongsTo('family');
 
   run(function() {
+    if (isEnabled('ds-overhaul-references')) {
+      assert.expectDeprecation("BelongsToReference#push(DS.Model) is deprecated. Update relationship via `model.set('relationshipName', value)` instead.");
+    }
+
     familyReference.push(family).then(function(record) {
       assert.ok(Family.detectInstance(record), "push resolves with the referenced record");
       assert.equal(get(record, 'name'), "Coreleone", "name is set");


### PR DESCRIPTION
`push()` for a belongs-to and has-many reference accepts weird formats,
where it basically should only support a JSON-API document. If this
feature is enabled, it adds deprecation messages if something different
than a JSON-API document is pushed.