### PR TITLE
[BUGFIX beta] Use lower-case header fields

### DIFF
--- a/addon/-private/utils/parse-response-headers.js
+++ b/addon/-private/utils/parse-response-headers.js
@@ -18,6 +18,16 @@ export default function parseResponseHeaders(headersString) {
     value = value.join(':').trim();
 
     if (value) {
+      // according to the spec header fields are case insensitive, that's why
+      // we are using the lowercase version here
+      //
+      // https://tools.ietf.org/html/rfc7230#section-3.2
+      let lowerCaseField = field.toLowerCase();
+      headers[lowerCaseField] = value;
+
+      // deprecated way since headers are case insensitive; this is kept here
+      // for backwards compatibility and should be remove in the next major
+      // release of ember-data
       headers[field] = value;
     }
   });

--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -1137,7 +1137,7 @@ var RESTAdapter = Adapter.extend(BuildURLMixin, {
   */
   generatedDetailedMessage: function(status, headers, payload, requestData) {
     var shortenedPayload;
-    var payloadContentType = headers["Content-Type"] || "Empty Content-Type";
+    var payloadContentType = headers["content-type"] || "Empty Content-Type";
 
     if (payloadContentType === "text/html" && payload.length > 250) {
       shortenedPayload = "[Omitted Lengthy HTML]";

--- a/tests/unit/adapters/rest-adapter/detailed-message-test.js
+++ b/tests/unit/adapters/rest-adapter/detailed-message-test.js
@@ -20,7 +20,7 @@ test("generating a wonderfully friendly error message should work", (assert) => 
 
   let friendlyMessage = adapter.generatedDetailedMessage(
     418,
-    { "Content-Type": "text/plain" },
+    { "content-type": "text/plain" },
     "I'm a little teapot, short and stout",
     {
       url: "/teapots/testing",

--- a/tests/unit/utils/parse-response-headers-test.js
+++ b/tests/unit/utils/parse-response-headers-test.js
@@ -12,16 +12,31 @@ test('returns an EmptyObject when headersString is undefined', function(assert) 
   assert.deepEqual(headers, new EmptyObject(), 'EmptyObject is returned');
 });
 
+test('field is lowercased', function(assert) {
+  let headersString = [
+    'Content-Type: application/json',
+    'CONTENT-ENCODING: gzip'
+  ].join(CRLF);
+
+  let headers = parseResponseHeaders(headersString);
+
+  assert.ok(headers['content-type']);
+  assert.ok(headers['Content-Type'], 'original cased field is present for backwards compatibility');
+
+  assert.ok(headers['content-encoding']);
+  assert.ok(headers['CONTENT-ENCODING'], 'original cased field is present for backwards compatibility');
+});
+
 test('header parsing', function(assert) {
   let headersString = [
-    'Content-Encoding: gzip',
+    'content-encoding: gzip',
     'content-type: application/json; charset=utf-8',
     'date: Fri, 05 Feb 2016 21:47:56 GMT'
   ].join(CRLF);
 
   let headers = parseResponseHeaders(headersString);
 
-  assert.equal(headers['Content-Encoding'], 'gzip', 'parses basic header pair');
+  assert.equal(headers['content-encoding'], 'gzip', 'parses basic header pair');
   assert.equal(headers['content-type'], 'application/json; charset=utf-8', 'parses header with complex value');
   assert.equal(headers['date'], 'Fri, 05 Feb 2016 21:47:56 GMT', 'parses header with date value');
 });
@@ -56,12 +71,12 @@ test('field-value parsing', function(assert) {
 
 test('ignores headers that do not contain a colon', function(assert) {
   let headersString = [
-    'Content-Encoding: gzip',
+    'content-encoding: gzip',
     'I am ignored because I do not contain a colon'
   ].join(CRLF);
 
   let headers = parseResponseHeaders(headersString);
 
-  assert.deepEqual(headers['Content-Encoding'], 'gzip', 'parses basic header pair');
+  assert.deepEqual(headers['content-encoding'], 'gzip', 'parses basic header pair');
   assert.equal(Object.keys(headers).length, 1, 'only has the one valid header');
 });


### PR DESCRIPTION
According to the spec header fields are case-insensitive.

https://tools.ietf.org/html/rfc7230#section-3.2
https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

The value is also available via the original case of the header field;
this is kept for backwards compatibility.

---

This closes #4342 