### PR TITLE
[BUGFIX beta] References load() enhancements

### DIFF
--- a/addon/-private/system/references/belongs-to.js
+++ b/addon/-private/system/references/belongs-to.js
@@ -5,6 +5,9 @@ import Reference from './reference';
 import isEnabled from '../../features';
 import { assertPolymorphicType, deprecate } from "ember-data/-private/debug";
 
+const {
+  RSVP: { resolve }
+} = Ember;
 
 /**
    A BelongsToReference is a low level API that allows users and
@@ -240,7 +243,7 @@ BelongsToReference.prototype.meta = function() {
    @return {Promise<record>} A promise that resolves with the new value in this belongs-to relationship.
 */
 BelongsToReference.prototype.push = function(objectOrPromise) {
-  return Ember.RSVP.resolve(objectOrPromise).then((data) => {
+  return resolve(objectOrPromise).then((data) => {
     let record;
 
     if (data instanceof Model) {
@@ -358,13 +361,11 @@ BelongsToReference.prototype.value = function() {
 */
 BelongsToReference.prototype.load = function() {
   if (this.remoteType() === "id") {
-    return this.belongsToRelationship.getRecord();
+    return resolve(this.belongsToRelationship.getRecord());
   }
 
   if (this.remoteType() === "link") {
-    return this.belongsToRelationship.findLink().then((internalModel) => {
-      return this.value();
-    });
+    return this.belongsToRelationship.findLink().then(() => this.value());
   }
 };
 
@@ -403,9 +404,7 @@ BelongsToReference.prototype.load = function() {
    @return {Promise} a promise that resolves with the record in this belongs-to relationship after the reload has completed.
 */
 BelongsToReference.prototype.reload = function() {
-  return this.belongsToRelationship.reload().then((internalModel) => {
-    return this.value();
-  });
+  return this.belongsToRelationship.reload().then(() => this.value());
 };
 
 export default BelongsToReference;

--- a/addon/-private/system/references/has-many.js
+++ b/addon/-private/system/references/has-many.js
@@ -152,11 +152,9 @@ HasManyReference.prototype.link = function() {
    @return {Array} The ids in this has-many relationship
 */
 HasManyReference.prototype.ids = function() {
-  let members = this.hasManyRelationship.members.toArray();
-
-  return members.map(function(internalModel) {
-    return internalModel.id;
-  });
+  return this.hasManyRelationship.members
+    .toArray()
+    .map(internalModel => internalModel.id);
 };
 
 /**
@@ -286,8 +284,7 @@ HasManyReference.prototype.push = function(objectOrPromise) {
         return record._internalModel;
       });
     } else {
-      let records = this.store.push(payload);
-      internalModels = Ember.A(records).mapBy('_internalModel');
+      internalModels = this.store.push(payload).map(record => record._internalModel);
 
       runInDebug(() => {
         internalModels.forEach((internalModel) => {
@@ -401,7 +398,7 @@ HasManyReference.prototype.value = function() {
 */
 HasManyReference.prototype.load = function() {
   if (!this._isLoaded()) {
-    return this.hasManyRelationship.getRecords();
+    return resolve(this.hasManyRelationship.getRecords());
   }
 
   return resolve(this.hasManyRelationship.manyArray);
@@ -442,7 +439,7 @@ HasManyReference.prototype.load = function() {
    @return {Promise} a promise that resolves with the ManyArray in this has-many relationship.
 */
 HasManyReference.prototype.reload = function() {
-  return this.hasManyRelationship.reload();
+  return this.hasManyRelationship.reload().then(() => this.value());
 };
 
 export default HasManyReference;

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -314,7 +314,10 @@ export default class Relationship {
     } else {
       let promise = this.fetchLink();
       this.linkPromise = promise;
-      return promise.then((result) => result);
+      return promise.then((result) => result, (error) => {
+        this.linkPromise = null;
+        throw error;
+      });
     }
   }
 

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -46,8 +46,8 @@ export function _find(adapter, store, modelClass, id, internalModel, options) {
     return store._push(payload);
   }, error => {
     internalModel.notFound();
-    if (internalModel.isEmpty()) {
-      internalModel.unloadRecord();
+    if (internalModel.isEmpty()) {    
+      internalModel.unloadRecord();   
     }
 
     throw error;
@@ -72,7 +72,13 @@ export function _findMany(adapter, store, modelName, ids, internalModels) {
     let serializer = serializerForAdapter(store, adapter, modelName);
     let payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, null, 'findMany');
     return store._push(payload);
-  }, null, `DS: Extract payload of ${modelName}`);
+  }, error => {
+    for (let i = 0; i < internalModels.length; i++) {
+      internalModels[i].notFound();
+    }
+
+    throw error;
+  }, `DS: Extract payload of ${modelName}`);
 }
 
 export function _findHasMany(adapter, store, internalModel, link, relationship) {


### PR DESCRIPTION
- ensure reference.load() is always returning a simple RSVP.Promise not an ObjectProxy

I don't expect any breaking changes here.
