### PR TITLE
[FEATURE ds-normalize-invalid-errors] add normalizeInvalidErrorResponse hook to the adapter

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -134,3 +134,6 @@ entry in `config/features.json`.
     tom.resetAttribute('lastName')  // { firstName: 'Tom', lastName: 'Dale' }
     tom.get('hasDirtyAttributes')   // false
   ```
+
+- `ds-normalize-invalid-errors` [#4409](https://github.com/emberjs/data/pull/4409)
+  Adds normalizeInvalidErrorResponse hook to the adapter

--- a/config/features.json
+++ b/config/features.json
@@ -7,5 +7,6 @@
   "ds-overhaul-references": null,
   "ds-payload-type-hooks": null,
   "ds-check-should-serialize-relationships": null,
-  "ds-reset-attribute": null
+  "ds-reset-attribute": null,
+  "ds-normalize-invalid-errors": null
 }


### PR DESCRIPTION
This is another take on the problem reported in #4373. The hook solution IMHO aligns better with current adapter API.
