### PR TITLE
Small improvement for the badIdFormatAssertion

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -58,7 +58,7 @@ import EmptyObject from "ember-data/-private/system/empty-object";
 
 import isEnabled from 'ember-data/-private/features';
 
-export let badIdFormatAssertion = '`id` has to be non-empty string or number';
+export let badIdFormatAssertion = '`id` passed to `findRecord()` has to be non-empty string or number';
 
 var Backburner = Ember._Backburner || Ember.Backburner || Ember.__loader.require('backburner')['default'] || Ember.__loader.require('backburner')['Backburner'];
 var Map = Ember.Map;

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -330,7 +330,7 @@ test('store#findRecord call with `id` of type different than non-empty string or
     badValues.map(item => {
       assert.expectAssertion(function() {
         store.findRecord('car', item);
-      }, '`id` has to be non-empty string or number');
+      }, '`id` passed to `findRecord()` has to be non-empty string or number');
     });
   });
 });


### PR DESCRIPTION
Just a small helpful improvement.

Could potentially save users tens of minutes finding the cause. :tada:

My original assumption was that a payload was not including an `id`.. then i discovered it was my `findRecord()` call