### PR TITLE
remove DEPRECATION: Using the global version of DS is deprecated when running tests

### DIFF
--- a/tests/ember-data-initializers.js
+++ b/tests/ember-data-initializers.js
@@ -1,11 +1,11 @@
 /* eslint no-extra-semi: "off" */
 
-import DS from 'ember-data';
-
 ;(function() {
-  /* globals Ember */
+  /* globals Ember, require */
   var K = Ember.K;
   Ember.onLoad('Ember.Application', function(Application) {
+
+    var DS = require('ember-data').default;
 
     Application.initializer({
       name:       "ember-data",

--- a/tests/ember-data-initializers.js
+++ b/tests/ember-data-initializers.js
@@ -1,8 +1,9 @@
 /* eslint no-extra-semi: "off" */
 
+import DS from 'ember-data';
+
 ;(function() {
   /* globals Ember */
-  /* globals DS */
   var K = Ember.K;
   Ember.onLoad('Ember.Application', function(Application) {
 


### PR DESCRIPTION
remove DEPRECATION: Using the global version of DS is deprecated.
Imported DS explicitly in tests/ember-data-initializers.js.