### PR TITLE
[BUGFIX] Pass options to transform for serialization in json-api

### DIFF
--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -499,7 +499,7 @@ const JSONAPISerializer = JSONSerializer.extend({
       let value = snapshot.attr(key);
       if (type) {
         const transform = this.transformFor(type);
-        value = transform.serialize(value);
+        value = transform.serialize(value, attribute.options);
       }
 
       let payloadKey = this._getMappedKey(key, snapshot.type);

--- a/tests/integration/serializers/json-api-serializer-test.js
+++ b/tests/integration/serializers/json-api-serializer-test.js
@@ -263,6 +263,28 @@ test('Serializer should respect the attrs hash when serializing attributes with 
   assert.equal(payload.data.attributes['company_name'], 'Tilde Inc.');
 });
 
+test('options are passed to transform for serialization', function(assert) {
+  assert.expect(1);
+
+  env.registry.register('transform:custom', DS.Transform.extend({
+    serialize: function(deserialized, options) {
+      assert.deepEqual(options, { custom: 'config' });
+    }
+  }));
+
+  User.reopen({
+    myCustomField: DS.attr('custom', {
+      custom: 'config'
+    })
+  });
+
+  var user;
+  run(function() {
+    user = env.store.createRecord('user', { myCustomField: 'value' });
+  });
+
+  env.store.serializerFor('user').serialize(user._createSnapshot());
+});
 
 testInDebug('JSON warns when combined with EmbeddedRecordsMixin', function(assert) {
   assert.expectWarning(function() {


### PR DESCRIPTION
Since json serializer's serializeAttribute function is been overwritten in json api serializer, the feature to pass the options to the transform is not working when using the json api adapter. This fixes the problem.