### PR TITLE
Remove JSHint directives from Mocha test blueprints

### DIFF
--- a/blueprints/adapter-test/mocha-files/tests/unit/__path__/__test__.js
+++ b/blueprints/adapter-test/mocha-files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 

--- a/blueprints/model-test/mocha-files/tests/unit/__path__/__test__.js
+++ b/blueprints/model-test/mocha-files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describeModel, it } from 'ember-mocha';
 

--- a/blueprints/serializer-test/mocha-files/tests/unit/__path__/__test__.js
+++ b/blueprints/serializer-test/mocha-files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describeModel, it } from 'ember-mocha';
 

--- a/blueprints/transform-test/mocha-files/tests/unit/__path__/__test__.js
+++ b/blueprints/transform-test/mocha-files/tests/unit/__path__/__test__.js
@@ -1,4 +1,3 @@
-/* jshint expr:true */
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 


### PR DESCRIPTION
The `expr` rule should instead be deactivated in `tests/.jshintrc`.

see also https://github.com/ember-cli/ember-cli-legacy-blueprints/pull/33