### PR TITLE
[BUGFIX beta] prevent record duplication due to EmbeddedRecordsMixin

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2437,7 +2437,7 @@ function _commit(adapter, store, operation, snapshot) {
           types.forEach(function (type) {
             var existingRecords = store.peekAll(type);
             var uncommitted = existingRecords.filter(function (record) {
-              return record.get('isNew') && !record.get('isSaving');
+              return record.get('id') === 'embedded';
             });
             // and remove them
             uncommitted.invoke('unloadRecord');

--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -438,6 +438,10 @@ export default Ember.Mixin.create({
       let embeddedJson = embeddedSnapshot.serialize({ includeId: true });
       this.removeEmbeddedForeignKey(snapshot, embeddedSnapshot, relationship, embeddedJson);
       ret[i] = embeddedJson;
+
+      if (!embeddedSnapshot.record.id) {
+        embeddedSnapshot.record.set('id', 'embedded');
+      }
     }
 
     return ret;


### PR DESCRIPTION
This is a proposed fix to #1829

When the EmbeddedRecordsMixin is used to persist embedded records to the backend, the parent record is handled as expected. However, nested children are neglected in the run loop and upon pushing a returned payload from the server into the store we end up with duplication. This commits adds a procedure for cleaning up these flagged 'uncommitted' records from the store before pushing the created ones.
