### PR TITLE
[BUGFIX beta] Fixes issue with GET requests appending ?{} to url

### DIFF
--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -1341,7 +1341,7 @@ if (isEnabled('ds-improved-ajax')) {
       hash.context = this;
 
       if (request.data) {
-        if (request.type !== 'GET') {
+        if (hash.type !== 'GET') {
           hash.contentType = 'application/json; charset=utf-8';
           hash.data = JSON.stringify(request.data);
         } else {

--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -1341,7 +1341,7 @@ if (isEnabled('ds-improved-ajax')) {
       hash.context = this;
 
       if (request.data) {
-        if (hash.type !== 'GET') {
+        if (request.method !== 'GET') {
           hash.contentType = 'application/json; charset=utf-8';
           hash.data = JSON.stringify(request.data);
         } else {

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -2593,3 +2593,26 @@ testInDebug("warns when an empty response is returned, though a valid stringifie
 
   assert.expectWarning("The server returned an empty string for POST /posts, which cannot be parsed into a valid JSON. Return either null or {}.");
 });
+
+if (isEnabled('ds-improved-ajax')) {
+
+  test("_requestToJQueryAjaxHash works correctly for GET requests - GH-4445", function(assert) {
+    let done = assert.async();
+    let server = new Pretender();
+
+    server.get('/posts/1', function(request) {
+      assert.equal(request.url, "/posts/1", "no query param is added to the GET request");
+
+      return [201, { "Content-Type": "application/json" }, JSON.stringify({ post: { id: 1 } })];
+    });
+
+    run(function() {
+      let post = store.findRecord('post', 1);
+
+      post.then(function() {
+        server.shutdown();
+        done();
+      });
+    });
+  });
+}

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -2614,5 +2614,6 @@ if (isEnabled('ds-improved-ajax')) {
         done();
       });
     });
+
   });
 }


### PR DESCRIPTION
This fixes a typo in the REST adapter comparing `request.type`, which doesn't exist. Either `request.method` or `hash.type` was meant. The symptom is that `?{}` is appended to the url of any GET requests by jQuery.