### PR TITLE
`modelHasAttributeOrRelationshipNamedType` should not show up in the …

### DIFF
--- a/addon/-private/debug.js
+++ b/addon/-private/debug.js
@@ -40,7 +40,7 @@ function checkPolymorphic(typeClass, addedRecord) {
   return typeClass.detect(addedRecord.type);
 }
 
-/**
+/*
   Assert that `addedRecord` has a valid type so it can be added to the
   relationship of the `record`.
 

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 const get = Ember.get;
 
-/**
+/*
   Check if the passed model has a `type` attribute or a relationship named `type`.
 
   @method modelHasAttributeOrRelationshipNamedType


### PR DESCRIPTION
…API docs