### PR TITLE
Remove initializer methods from the API docs

### DIFF
--- a/addon/-private/core.js
+++ b/addon/-private/core.js
@@ -6,7 +6,7 @@ import VERSION from 'ember-data/version';
 */
 
 /**
-  All Ember Data methods and functions are defined inside of this namespace.
+  All Ember Data classes, methods and functions are defined inside of this namespace.
 
   @class DS
   @static

--- a/addon/-private/ext/date.js
+++ b/addon/-private/ext/date.js
@@ -5,6 +5,19 @@
 import Ember from 'ember';
 import { deprecate } from 'ember-data/-private/debug';
 
+
+/**
+   Date.parse with progressive enhancement for ISO 8601 <https://github.com/csnover/js-iso8601>
+
+   © 2011 Colin Snover <http://zetafleet.com>
+
+   Released under MIT license.
+
+   @class Date
+   @namespace Ember
+   @static
+   @deprecated
+*/
 Ember.Date = Ember.Date || {};
 
 var origParse = Date.parse;

--- a/addon/-private/initializers/data-adapter.js
+++ b/addon/-private/initializers/data-adapter.js
@@ -1,10 +1,10 @@
 import DebugAdapter from "ember-data/-private/system/debug/debug-adapter";
 
-/**
+/*
   Configures a registry with injections on Ember applications
   for the Ember-Data store. Accepts an optional namespace argument.
 
-  @method initializeStoreInjections
+  @method initializeDebugAdapter
   @param {Ember.Registry} registry
 */
 export default function initializeDebugAdapter(registry) {

--- a/addon/-private/initializers/store-injections.js
+++ b/addon/-private/initializers/store-injections.js
@@ -1,4 +1,4 @@
-/**
+/*
   Configures a registry with injections on Ember applications
   for the Ember-Data store. Accepts an optional namespace argument.
 

--- a/addon/-private/initializers/store.js
+++ b/addon/-private/initializers/store.js
@@ -12,7 +12,7 @@ function has(applicationOrRegistry, fullName) {
   }
 }
 
-/**
+/*
   Configures a registry for use with an Ember-Data
   store. Accepts an optional namespace argument.
 

--- a/addon/-private/initializers/transforms.js
+++ b/addon/-private/initializers/transforms.js
@@ -5,7 +5,7 @@ import {
   NumberTransform
 } from "ember-data/-private/transforms";
 
-/**
+/*
   Configures a registry for use with Ember-Data
   transforms.
 

--- a/addon/-private/instance-initializers/initialize-store-service.js
+++ b/addon/-private/instance-initializers/initialize-store-service.js
@@ -1,8 +1,8 @@
-/**
+/*
  Configures a registry for use with an Ember-Data
  store.
 
- @method initializeStore
+ @method initializeStoreService
  @param {Ember.ApplicationInstance} applicationOrRegistry
  */
 export default function initializeStoreService(application) {


### PR DESCRIPTION
(they are showing up on the DS.Model class)

Add missing API docs for Ember.Date

Add minor doc update to the DS namespace API docs.