### PR TITLE
[BUGFIX beta] flag ds-serialize-ids-and-types should not be enabled by default

### DIFF
--- a/config/features.json
+++ b/config/features.json
@@ -2,7 +2,7 @@
   "ds-boolean-transform-allow-null": null,
   "ds-improved-ajax": null,
   "ds-pushpayload-return": null,
-  "ds-serialize-ids-and-types": true,
+  "ds-serialize-ids-and-types": null,
   "ds-extended-errors": null,
   "ds-links-in-record-array": null,
   "ds-overhaul-references": null,


### PR DESCRIPTION
The feature is enabled by default in the repo and therefore throwing deprecation warnings.