### PR TITLE
[CLEANUP beta] Remove feature flag for ds-serialize-ids-and-types (shipped in 2.6) #4416

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -26,30 +26,6 @@ entry in `config/features.json`.
   Enables `pushPayload` to return the model(s) that are created or
   updated via the internal `store.push`.
 
-- `ds-serialize-ids-and-types` [#3848](https://github.com/emberjs/data/pull/3848)
-
-  Enables a new `ids-and-type` strategy (in addition to the already existing `ids` and `records`) for
-  serializing has many relationships using the `DS.EmbeddedRecordsMixin` that  will include both
-  `id` and `type` of each model as an object.
-
-  For instance, if a use has many pets, which is a polymorphic relationship, the generated payload would be:
-
-  ```js
-  {
-    "user": {
-      "id": "1"
-      "name": "Bertin Osborne",
-      "pets": [
-        { "id": "1", "type": "Cat" },
-        { "id": "2", "type": "Parrot"}
-      ]
-    }
-  }
-  ```
-
-  This is particularly useful for polymorphic relationships not backed by STI when just including the id
-  of the records is not enough.
-
 - `ds-extended-errors` [#3586](https://github.com/emberjs/data/pull/3586) [#4287](https://github.com/emberjs/data/pull/4287)
 
   Enables `extend` method on errors. It means you can extend from `DS.AdapterError`.

--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import { warn } from "ember-data/-private/debug";
-import isEnabled from 'ember-data/-private/features';
 
 var get = Ember.get;
 var set = Ember.set;
@@ -365,8 +364,6 @@ export default Ember.Mixin.create({
     }
     ```
 
-    Note that the `ids-and-types` strategy is still behind the `ds-serialize-ids-and-types` feature flag.
-
     @method serializeHasMany
     @param {DS.Snapshot} snapshot
     @param {Object} json
@@ -385,10 +382,8 @@ export default Ember.Mixin.create({
     } else if (this.hasSerializeRecordsOption(attr)) {
       this._serializeEmbeddedHasMany(snapshot, json, relationship);
     } else {
-      if (isEnabled("ds-serialize-ids-and-types")) {
-        if (this.hasSerializeIdsAndTypesOption(attr)) {
-          this._serializeHasManyAsIdsAndTypes(snapshot, json, relationship);
-        }
+      if (this.hasSerializeIdsAndTypesOption(attr)) {
+        this._serializeHasManyAsIdsAndTypes(snapshot, json, relationship);
       }
     }
   },

--- a/config/features.json
+++ b/config/features.json
@@ -2,7 +2,6 @@
   "ds-boolean-transform-allow-null": null,
   "ds-improved-ajax": null,
   "ds-pushpayload-return": null,
-  "ds-serialize-ids-and-types": true,
   "ds-extended-errors": null,
   "ds-links-in-record-array": null,
   "ds-overhaul-references": null,

--- a/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/tests/integration/serializers/embedded-records-mixin-test.js
@@ -5,7 +5,6 @@ import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
-import isEnabled from 'ember-data/-private/features';
 
 var get = Ember.get;
 var HomePlanet, SuperVillain, CommanderVillain, NormalMinion, EvilMinion, YellowMinion, RedMinion, SecretLab, SecretWeapon, BatCave, Comment,
@@ -1074,38 +1073,36 @@ test("serialize with embedded objects (hasMany relationships, including related 
   });
 });
 
-if (isEnabled("ds-serialize-ids-and-types")) {
-  test("serialize has many relationship using the `ids-and-types` strategy", function(assert) {
-    run(function() {
-      yellowMinion = env.store.createRecord('yellow-minion', { id: 1, name: "Yellowy" });
-      redMinion = env.store.createRecord('red-minion', { id: 1, name: "Reddy" });
-      commanderVillain = env.store.createRecord('commander-villain', { id: 1, name: "Jeff", minions: [yellowMinion, redMinion] });
-    });
-
-    env.registry.register('serializer:commander-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
-      attrs: {
-        minions: { serialize: 'ids-and-types' }
-      }
-    }));
-    var serializer, json;
-    run(function() {
-      serializer = env.container.lookup("serializer:commander-villain");
-      var snapshot = commanderVillain._createSnapshot();
-      json = serializer.serialize(snapshot);
-    });
-
-    assert.deepEqual(json, {
-      name: 'Jeff',
-      minions: [{
-        id: '1',
-        type: 'yellow-minion'
-      }, {
-        id: '1',
-        type: 'red-minion'
-      }]
-    });
+test("serialize has many relationship using the `ids-and-types` strategy", function(assert) {
+  run(function() {
+    yellowMinion = env.store.createRecord('yellow-minion', { id: 1, name: "Yellowy" });
+    redMinion = env.store.createRecord('red-minion', { id: 1, name: "Reddy" });
+    commanderVillain = env.store.createRecord('commander-villain', { id: 1, name: "Jeff", minions: [yellowMinion, redMinion] });
   });
-}
+
+  env.registry.register('serializer:commander-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
+    attrs: {
+      minions: { serialize: 'ids-and-types' }
+    }
+  }));
+  var serializer, json;
+  run(function() {
+    serializer = env.container.lookup("serializer:commander-villain");
+    var snapshot = commanderVillain._createSnapshot();
+    json = serializer.serialize(snapshot);
+  });
+
+  assert.deepEqual(json, {
+    name: 'Jeff',
+    minions: [{
+      id: '1',
+      type: 'yellow-minion'
+    }, {
+      id: '1',
+      type: 'red-minion'
+    }]
+  });
+});
 
 test("normalizeResponse with embedded object (belongsTo relationship)", function(assert) {
   env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {


### PR DESCRIPTION
This was originally found by looking into ember-data test deprecation warnings.  Then it was pointed out by @bmac that the feature actually shipped in 2.6, so now submitting a PR to remove the feature flag.