### PR TITLE
Add benchmarks directory to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@
 /node-tests
 /tests
 /tmp
+/benchmarks
 
 **/.gitkeep
 .appveyor.yml


### PR DESCRIPTION
This shaves 22MB off the size of the package installation