### PR TITLE
Belongs to not updating when response contains a change with the previous value

### DIFF
--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -36,6 +36,7 @@ BelongsToRelationship.prototype.setCanonicalRecord = function(newRecord) {
   } else if (this.canonicalState) {
     this.removeCanonicalRecord(this.canonicalState);
   }
+  this.flushCanonicalLater();
   this.setHasData(true);
   this.setHasLoaded(true);
 };


### PR DESCRIPTION
If the response to a save of a model that includes a belongs to relationship is successful but that response contains data that sets the belongs to back to it's original value the change is not applied to the store. #4469 