### PR TITLE
[BUGFIX beta] add assertions for reference methods on DS.Model

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assert } from "ember-data/-private/debug";
+import { assert, runInDebug } from "ember-data/-private/debug";
 import RootState from "ember-data/-private/system/model/states";
 import Relationships from "ember-data/-private/system/relationships/state/create";
 import Snapshot from "ember-data/-private/system/snapshot";
@@ -839,6 +839,14 @@ InternalModel.prototype = {
 
     if (!reference) {
       var relationship = this._relationships.get(name);
+
+      runInDebug(() => {
+        let modelName = this.modelName;
+        assert(`There is no ${type} relationship named '${name}' on a model of type '${modelName}'`, relationship);
+
+        let actualRelationshipKind = relationship.relationshipMeta.kind;
+        assert(`You tried to get the '${name}' relationship on a '${modelName}' via record.${type}('${name}'), but the relationship is of type '${actualRelationshipKind}'. Use record.${actualRelationshipKind}('${name}') instead.`, actualRelationshipKind === type);
+      });
 
       if (type === "belongsTo") {
         reference = new BelongsToReference(this.store, this, relationship);

--- a/tests/integration/references/belongs-to-test.js
+++ b/tests/integration/references/belongs-to-test.js
@@ -30,6 +30,42 @@ module("integration/references/belongs-to", {
   }
 });
 
+testInDebug("record#belongsTo asserts when specified relationship doesn't exist", function(assert) {
+  var person;
+  run(function() {
+    person = env.store.push({
+      data: {
+        type: 'person',
+        id: 1
+      }
+    });
+  });
+
+  assert.expectAssertion(function() {
+    run(function() {
+      person.belongsTo("unknown-relationship");
+    });
+  }, "There is no belongsTo relationship named 'unknown-relationship' on a model of type 'person'");
+});
+
+testInDebug("record#belongsTo asserts when the type of the specified relationship isn't the requested one", function(assert) {
+  var family;
+  run(function() {
+    family = env.store.push({
+      data: {
+        type: 'family',
+        id: 1
+      }
+    });
+  });
+
+  assert.expectAssertion(function() {
+    run(function() {
+      family.belongsTo("persons");
+    });
+  }, "You tried to get the 'persons' relationship on a 'family' via record.belongsTo('persons'), but the relationship is of type 'hasMany'. Use record.hasMany('persons') instead.");
+});
+
 test("record#belongsTo", function(assert) {
   var person;
   run(function() {

--- a/tests/integration/references/has-many-test.js
+++ b/tests/integration/references/has-many-test.js
@@ -29,6 +29,42 @@ module("integration/references/has-many", {
   }
 });
 
+testInDebug("record#hasMany asserts when specified relationship doesn't exist", function(assert) {
+  var family;
+  run(function() {
+    family = env.store.push({
+      data: {
+        type: 'family',
+        id: 1
+      }
+    });
+  });
+
+  assert.expectAssertion(function() {
+    run(function() {
+      family.hasMany("unknown-relationship");
+    });
+  }, "There is no hasMany relationship named 'unknown-relationship' on a model of type 'family'");
+});
+
+testInDebug("record#hasMany asserts when the type of the specified relationship isn't the requested one", function(assert) {
+  var person;
+  run(function() {
+    person = env.store.push({
+      data: {
+        type: 'person',
+        id: 1
+      }
+    });
+  });
+
+  assert.expectAssertion(function() {
+    run(function() {
+      person.hasMany("family");
+    });
+  }, "You tried to get the 'family' relationship on a 'person' via record.hasMany('family'), but the relationship is of type 'belongsTo'. Use record.belongsTo('family') instead.");
+});
+
 test("record#hasMany", function(assert) {
   var family;
   run(function() {


### PR DESCRIPTION
Assertions are thrown when the specified relationship doesn't exist or
the passed type mismatches the one of the actual relationship.

---

This issue has been raised in the slack channel so adding assertions should help preventing this in the future.