### PR TITLE
[BUGFIX beta] Prefer includes over contains

### DIFF
--- a/addon/-private/system/record-arrays/record-array.js
+++ b/addon/-private/system/record-arrays/record-array.js
@@ -146,7 +146,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     var content = get(this, 'content');
     if (idx === undefined) {
       content.addObject(internalModel);
-    } else if (!content.contains(internalModel)) {
+    } else if (!content.includes(internalModel)) {
       content.insertAt(idx, internalModel);
     }
   },

--- a/addon/-private/system/relationships/ext.js
+++ b/addon/-private/system/relationships/ext.js
@@ -55,7 +55,7 @@ var relatedTypesDescriptor = Ember.computed(function() {
 
       assert("You specified a hasMany (" + meta.type + ") on " + meta.parentType + " but " + meta.type + " was not found.", modelName);
 
-      if (!types.contains(modelName)) {
+      if (!types.includes(modelName)) {
         assert("Trying to sideload " + name + " on " + this.toString() + " but the type doesn't exist.", !!modelName);
         types.push(modelName);
       }

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -758,7 +758,7 @@ Store = Service.extend({
     function makeMissingRecordsRejector(requestedRecords) {
       return function rejectMissingRecords(resolvedRecords) {
         resolvedRecords = Ember.A(resolvedRecords);
-        var missingRecords = requestedRecords.reject((record) => resolvedRecords.contains(record));
+        var missingRecords = requestedRecords.reject((record) => resolvedRecords.includes(record));
         if (missingRecords.length) {
           warn('Ember Data expected to find records with the following ids in the adapter response but they were missing: ' + Ember.inspect(Ember.A(missingRecords).mapBy('id')), false, {
             id: 'ds.store.missing-records-from-adapter'

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-version-checker": "^1.1.4",
     "ember-inflector": "^1.9.4",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.0",
     "exists-sync": "0.0.3",
     "git-repo-info": "^1.1.2",
     "inflection": "^1.8.0",


### PR DESCRIPTION
This pr adds the
[ember-runtime-enumerable-includes-polyfill](https://github.com/rwjblue/ember-runtime-enumerable-includes-polyfill)
to add includes if the user's version of Ember doesn't support it.

cc @rwjblue 