### PR TITLE
isUpdating should be true only if a reload happens

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1375,15 +1375,15 @@ Store = Service.extend({
     assert("You tried to load all records but you have no adapter (for " + typeClass + ")", adapter);
     assert("You tried to load all records but your adapter does not implement `findAll`", typeof adapter.findAll === 'function');
 
-    set(array, 'isUpdating', true);
-
     if (options.reload) {
+      set(array, 'isUpdating', true);
       return promiseArray(_findAll(adapter, this, typeClass, sinceToken, options));
     }
 
     var snapshotArray = array.createSnapshot(options);
 
     if (adapter.shouldReloadAll(this, snapshotArray)) {
+      set(array, 'isUpdating', true);
       return promiseArray(_findAll(adapter, this, typeClass, sinceToken, options));
     }
 
@@ -1392,6 +1392,7 @@ Store = Service.extend({
     }
 
     if (options.backgroundReload || adapter.shouldBackgroundReloadAll(this, snapshotArray)) {
+      set(array, 'isUpdating', true);
       _findAll(adapter, this, typeClass, sinceToken, options);
     }
 

--- a/tests/integration/adapter/find-all-test.js
+++ b/tests/integration/adapter/find-all-test.js
@@ -238,3 +238,34 @@ test("isUpdating is true while records are fetched in the background", function(
     });
   });
 });
+
+test("isUpdating is false if records are not fetched in the background", function(assert) {
+  let findAllDeferred = Ember.RSVP.defer();
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    findAll() {
+      return findAllDeferred.promise;
+    },
+    shouldReloadAll: () => false,
+    shouldBackgroundReloadAll: () => false
+  }));
+
+  run(function() {
+    store.push({
+      data: [{
+        type: 'person',
+        id: 1
+      }]
+    });
+  });
+
+  let persons = store.peekAll('person');
+  assert.equal(persons.get("length"), 1);
+
+  run(function() {
+    store.findAll('person').then(function(persons) {
+      assert.equal(persons.get("isUpdating"), false);
+    });
+  });
+
+  assert.equal(persons.get("isUpdating"), false);
+});


### PR DESCRIPTION
See https://github.com/emberjs/data/issues/4527 for jsbin

I think this was fixed incorrectly in https://github.com/emberjs/data/pull/4386 – `isUpdating` would be true on the returned cached array even if `backgroundReload` or `shouldBackgroundReloadAll` is false

