### PR TITLE
[DOC beta] Remove `Ember.ArrayController` from initializer example

### DIFF
--- a/app/initializers/ember-data.js
+++ b/app/initializers/ember-data.js
@@ -19,7 +19,7 @@ import 'ember-data/-private/core';
     adapter: 'custom'
   });
 
-  App.PostsController = Ember.ArrayController.extend({
+  App.PostsController = Ember.Controller.extend({
     // ...
   });
 


### PR DESCRIPTION
`Ember.ArrayController` is deprecated since Ember 1.11.
ref: http://emberjs.com/deprecations/v1.x/#toc_arraycontroller