### PR TITLE
[BUGFIX release] Include initializers for global production build

### DIFF
--- a/lib/javascripts.js
+++ b/lib/javascripts.js
@@ -96,6 +96,9 @@ module.exports = function(tree) {
 
   var strippedJavascripts = merge([
     emberInflector,
+    loadInitializers,
+    makeStrippedBuild('ember-data/initializers', 'app/initializers'),
+    makeStrippedBuild('ember-data/instance-initializers', 'app/instance-initializers'),
     makeStrippedBuild('ember-data', emberData)
   ]);
 


### PR DESCRIPTION
In [`ember-data.prod.js`](http://builds.emberjs.com/tags/v2.8.0/ember-data.prod.js), the Ember Data's initializers are missing since 2.8.0.

Without these initializes, `DS.Store` isn't setup for Ember application :<