### PR TITLE
Fix failing build with Ember beta and canary

### DIFF
--- a/addon/-private/system/relationships/belongs-to.js
+++ b/addon/-private/system/relationships/belongs-to.js
@@ -114,7 +114,7 @@ export default function belongsTo(modelName, options) {
         });
       }
 
-      return this._internalModel._relationships.get(key).getRecord();
+      return this._internalModel && this._internalModel._relationships.get(key).getRecord();
     },
     set(key, value) {
       if (value === undefined) {


### PR DESCRIPTION
It looks like something changed with the recent Ember beta that caused values that are provided to `Ember.Object.create()` to get stored on meta and cleared out when the object is destroyed.

Ember Data was injecting `_internalModel` into the model when its created [here](https://github.com/emberjs/data/blob/1f7e2a24a4f5758ce0ec288db29e814d8d637124/addon/-private/system/model/internal-model.js#L148). On Ember 2.8.0 the `_internalModel` property was still available after the model was destroyed. In the Ember 2.9.0-beta.3 `record._internalModel` is no longer accessible after a record has been destroyed.

cc @rwjblue @stefanpenner 