### PR TITLE
[BUGFIX beta] Make `Model#data` a plain getter.

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -476,13 +476,6 @@ var Model = Ember.Object.extend(Ember.Evented, {
   */
   rolledBack: Ember.K,
 
-  /**
-    @property data
-    @private
-    @type {Object}
-  */
-  data: Ember.computed.readOnly('_internalModel._data'),
-
   //TODO Do we want to deprecate these?
   /**
     @method send
@@ -949,6 +942,17 @@ var Model = Ember.Object.extend(Ember.Evented, {
   setId: Ember.observer('id', function () {
     this._internalModel.setId(this.get('id'));
   })
+});
+
+/**
+ @property data
+ @private
+ @type {Object}
+ */
+Object.defineProperty(Model.prototype, 'data', {
+  get() {
+    return this._internalModel._data;
+  }
 });
 
 Model.reopenClass({

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -905,5 +905,3 @@ testInDebug('store#queryRecord should assert when normalized payload of adapter 
     });
   }, /Expected the primary data returned by the serializer for a `queryRecord` response to be a single object or null but instead it was an array./);
 });
-
-


### PR DESCRIPTION
In Ember 2.9, using an `Ember.computed.alias` or `Ember.computed.readOnly` automatically adds mandatory setter's getter/setter to the properties being watched, and defers reading the current value to the objects own meta.

This avoids creating an watcher for `_internalModel` and therefore prevents an error that ocurrs when we attempt to read from `meta` after the object has been destroyed.