### PR TITLE
[BUGFIX beta] Correctly serialize invalid dates

### DIFF
--- a/addon/-private/transforms/date.js
+++ b/addon/-private/transforms/date.js
@@ -41,7 +41,7 @@ export default Transform.extend({
   },
 
   serialize(date) {
-    if (date instanceof Date) {
+    if (date instanceof Date && !isNaN(date)) {
       return date.toISOString();
     } else {
       return null;

--- a/tests/unit/transform/date-test.js
+++ b/tests/unit/transform/date-test.js
@@ -18,6 +18,7 @@ test("#serialize", function(assert) {
 
   assert.equal(transform.serialize(null), null);
   assert.equal(transform.serialize(undefined), null);
+  assert.equal(transform.serialize(new Date("invalid")), null);
 
   assert.equal(transform.serialize(date), dateString);
 });


### PR DESCRIPTION
Invalid Date objects - such as `new Date("foo")` - are Date objects that
throw a `RangeError` when calling `date.toISOString()`. These are now
serialized like all other garbage-in inputs.