### PR TITLE
[BUGFIX beta] Use Ember.guidFor to set InternalModel's guid.

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -43,7 +43,6 @@ function retrieveFromCurrentState(key) {
   };
 }
 
-var guid = 0;
 /*
   `InternalModel` is the Model class that we use internally inside Ember Data to represent models.
   Internal ED methods should only deal with `InternalModel` objects. It is a fast, plain Javascript class.
@@ -81,7 +80,7 @@ export default function InternalModel(type, id, store, _, data) {
   this.isError = false;
   this.error = null;
   this.__ember_meta__ = null;
-  this[Ember.GUID_KEY] = guid++ + 'internal-model';
+  this[Ember.GUID_KEY] = Ember.guidFor(this);
   /*
     implicit relationships are relationship which have not been declared but the inverse side exists on
     another record somewhere


### PR DESCRIPTION
In future versions of Ember, the `Ember.GUID_KEY` property may not be the place that guids are stored per object (may be moving to a `WeakMap`).  This change keeps `this[GUID_KEY]` around for easier debugging (though it isn't _required_ per-se), and uses `Ember.guidFor` to get the guid and setup the object.

Related to conversation in https://github.com/emberjs/ember.js/pull/14383.