### PR TITLE
[BUGFIX beta] Ensure record array length is reset during willDestroy.

### DIFF
--- a/addon/-private/system/record-arrays/record-array.js
+++ b/addon/-private/system/record-arrays/record-array.js
@@ -211,6 +211,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     this._unregisterFromManager();
     this._dissociateFromOwnRecords();
     set(this, 'content', undefined);
+    set(this, 'length', 0);
     this._super.apply(this, arguments);
   },
 


### PR DESCRIPTION
In Ember 2.10+ objects that are in the middle of being destroyed no longer notify property changes on itself (or other destroying objects) to avoid wasted work.  This means that `set(this, 'content', undefined)` isn't enough to ensure that `Enumerable` mixin will `notifyPropertyChange(this, 'length')` (since its observers are not fired).

This change also sets `length` during cleanup so it properly resets to `0`.

This fixes the build against latest ember#canary.