### PR TITLE
Properly cleanup store and env in store integration test

### DIFF
--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -35,6 +35,10 @@ function initializeStore(adapter) {
 module("integration/store - destroy", {
   beforeEach() {
     initializeStore(DS.Adapter.extend());
+  },
+  afterEach() {
+    store = null;
+    env = null;
   }
 });
 
@@ -243,6 +247,8 @@ test("store#findRecord fetches record from server when cached record is not pres
 
 test("store#findRecord returns cached record immediately and reloads record in the background", function(assert) {
   assert.expect(2);
+
+  initializeStore(DS.RESTAdapter.extend());
 
   run(function() {
     store.push({


### PR DESCRIPTION
The find test was failing when run by itself as it wasn't setting up the
store correctly. It just happens to have worked on Travis due to us not
cleaning up the store