### PR TITLE
[DOC] Update descriptions of findRecord() and findAll()

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -619,8 +619,7 @@ Store = Service.extend({
     model, when we retrieve a specific post we can have the server also return that post's
     comments in the same request:
 
-    ```
-    // app/routes/post.js
+    ```app/routes/post.js
     import Ember from 'ember';
 
     export default Ember.Route.extend({
@@ -638,8 +637,7 @@ Store = Service.extend({
     using a dot-separated sequence of relationship names. So to request both the post's
     comments and the authors of those comments the request would look like this:
 
-    ```
-    // app/routes/post.js
+    ```app/routes/post.js
     import Ember from 'ember';
 
     export default Ember.Route.extend({
@@ -1451,8 +1449,7 @@ Store = Service.extend({
     model, when we retrieve all of the post records we can have the server also return
     all of the posts' comments in the same request:
 
-    ```
-    // app/routes/posts.js
+    ```app/routes/posts.js
     import Ember from 'ember';
 
     export default Ember.Route.extend({
@@ -1467,8 +1464,7 @@ Store = Service.extend({
     using a dot-separated sequence of relationship names. So to request both the posts'
     comments and the authors of those comments the request would look like this:
 
-    ```
-    // app/routes/posts.js
+    ```app/routes/posts.js
     import Ember from 'ember';
 
     export default Ember.Route.extend({

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -605,6 +605,51 @@ Store = Service.extend({
 
     See [peekRecord](#method_peekRecord) to get the cached version of a record.
 
+    ### Retrieving Related Model Records
+
+    If you use an adapter such as Ember's default
+    [`JSONAPIAdapter`](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html)
+    that supports the [JSON API specification](http://jsonapi.org/) and if your server
+    endpoint supports the use of an
+    ['include' query parameter](http://jsonapi.org/format/#fetching-includes),
+    you can use `findRecord()` to automatically retrieve additional records related to
+    the one you request by supplying an `include` parameter in the `options` object.
+
+    For example, given a `post` model that has a `hasMany` relationship with a `comment`
+    model, when we retrieve a specific post we can have the server also return that post's
+    comments in the same request:
+
+    ```
+    // app/routes/post.js
+    import Ember from 'ember';
+
+    export default Ember.Route.extend({
+      model: function(params) {
+       return this.store.findRecord('post', params.post_id, {include: 'comments'});
+      }
+    });
+
+    ```
+    In this case, the post's comments would then be available in your template as
+    `model.comments`.
+
+    Multiple relationships can be requested using an `include` parameter consisting of a
+    comma-separated list (without white-space) while nested relationships can be specified
+    using a dot-separated sequence of relationship names. So to request both the post's
+    comments and the authors of those comments the request would look like this:
+
+    ```
+    // app/routes/post.js
+    import Ember from 'ember';
+
+    export default Ember.Route.extend({
+      model: function(params) {
+       return this.store.findRecord('post', params.post_id, {include: 'comments,comments.author'});
+      }
+    });
+
+    ```
+
     @since 1.13.0
     @method findRecord
     @param {String} modelName
@@ -1391,6 +1436,48 @@ Store = Service.extend({
 
     See [peekAll](#method_peekAll) to get an array of current records in the
     store, without waiting until a reload is finished.
+
+    ### Retrieving Related Model Records
+
+    If you use an adapter such as Ember's default
+    [`JSONAPIAdapter`](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html)
+    that supports the [JSON API specification](http://jsonapi.org/) and if your server
+    endpoint supports the use of an
+    ['include' query parameter](http://jsonapi.org/format/#fetching-includes),
+    you can use `findAll()` to automatically retrieve additional records related to
+    those requested by supplying an `include` parameter in the `options` object.
+
+    For example, given a `post` model that has a `hasMany` relationship with a `comment`
+    model, when we retrieve all of the post records we can have the server also return
+    all of the posts' comments in the same request:
+
+    ```
+    // app/routes/posts.js
+    import Ember from 'ember';
+
+    export default Ember.Route.extend({
+      model: function() {
+       return this.store.findAll('post', {include: 'comments'});
+      }
+    });
+
+    ```
+    Multiple relationships can be requested using an `include` parameter consisting of a
+    comma-separated list (without white-space) while nested relationships can be specified
+    using a dot-separated sequence of relationship names. So to request both the posts'
+    comments and the authors of those comments the request would look like this:
+
+    ```
+    // app/routes/posts.js
+    import Ember from 'ember';
+
+    export default Ember.Route.extend({
+      model: function() {
+       return this.store.findAll('post', {include: 'comments,comments.author'});
+      }
+    });
+
+    ```
 
     See [query](#method_query) to only get a subset of records from the server.
 


### PR DESCRIPTION
This commit adds documentation on the use of the `include` query parameter in `DS.Store` methods `findRecord()` and `findAll()`. This feature allows records of models related to those requested to be retrieved from JSON API compliant server in a single request. This capability was added in https://github.com/emberjs/data/pull/3976 but is not currently documented.