### PR TITLE
[WIP] [Feat] implements Schema to separate store logic and model description from the model layer.

### DIFF
--- a/addon/-private/system/schema.js
+++ b/addon/-private/system/schema.js
@@ -1,0 +1,295 @@
+import EmptyObject from './empty-object';
+import { assert, warn } from 'ember-data/-private/debug'
+import Ember from 'ember';
+
+const {
+  get
+} = Ember;
+
+export default class Schema {
+  constructor(modelClass, store) {
+    this.primaryKey = 'id';
+    this._attributes = null;
+    this._relationships = null;
+    this._relationshipMap = null;
+    this._properties = null;
+    this._expandedModel = false;
+    this.modelClass = modelClass;
+    this.modelName = modelClass.modelName;
+    this._recordMap = null;
+    this._inverseMap = null;
+    this._adapter = null;
+    this._serializer = null;
+    this._superclass = null;
+    this.store = store;
+  }
+
+  get superclass() {
+    if (this._superclass === null) {
+      let superclass = this.modelClass.superclass;
+
+      this._superclass = superclass ? this.store.schemaFor(superclass.modelName) : undefined;
+    }
+
+    return this._superclass;
+  }
+
+  get adapter() {
+    if (this._adapter === null) {
+      this._adapter = this.store.adapterFor(this.modelName);
+    }
+    return this._adapter;
+  }
+
+  get serializer() {
+    if (this._serializer === null) {
+      this._serializer = this.store.serializerFor(this.modelName);
+    }
+    if (!this._serializer) {
+      throw new Error('Cant find serializer!');
+    }
+    return this._serializer;
+  }
+
+  get properties() {
+    if (this._expandedModel === false) {
+      this._parseModelClass();
+    }
+
+    return this._properties;
+  }
+
+  get relationships() {
+    if (this._expandedModel === false) {
+      this._parseModelClass();
+    }
+
+    return this._relationships;
+  }
+
+  get relationshipMap() {
+    if (this._expandedModel === false) {
+      this._parseModelClass();
+    }
+
+    return this._relationshipMap;
+  }
+
+  eachRelationship(callback, context) {
+    let relationships = this.relationships;
+
+    for (let name in relationships) {
+      let relationship = relationships[name];
+
+      callback.call(context, name, relationship);
+    }
+  }
+
+  get attributes() {
+    if (this._expandedModel === false) {
+      this._parseModelClass();
+    }
+
+    return this._attributes;
+  }
+
+  eachAttribute(callback, context) {
+    let attributes = this.attributes;
+
+    for (let name in attributes) {
+      let attribute = attributes[name];
+
+      callback.call(context, name, attribute);
+    }
+  }
+
+  inverseFor(name, store) {
+    const inverseMap = this.inverseMap;
+
+    if (inverseMap[name]) {
+      return inverseMap[name];
+    }
+
+    let inverse = this._findInverseFor(name, store);
+    inverseMap[name] = inverse;
+
+    return inverse;
+  }
+
+  get inverseMap() {
+    if (this._inverseMap === null) {
+      this._inverseMap = new EmptyObject();
+    }
+    return this._inverseMap;
+  }
+
+  schemaForRelationship(name, store) {
+    let relationship = this.relationships[name];
+
+    return relationship && store.schemaFor(relationship.type);
+  }
+
+  //Calculate the inverse, ignoring the cache
+  _findInverseFor(name, store) {
+    let inverseSchema = this.schemaForRelationship(name, store);
+
+    if (!inverseSchema) {
+      return null;
+    }
+
+    let propertyMeta = this.metaForProperty(name);
+
+    // If inverse is manually specified to be null, like  `comments: DS.hasMany('message', { inverse: null })`
+    let options = propertyMeta.options;
+    if (options.inverse === null) {
+      return null;
+    }
+
+    let inverseName;
+    let inverseKind;
+    let inverse;
+
+    // If inverse is specified manually, return the inverse
+    if (options.inverse) {
+      inverseName = options.inverse;
+      inverse = inverseSchema.relationships[inverseName];
+
+      assert("We found no inverse relationships by the name of '" + inverseName + "' on the '" + inverseSchema.modelName +
+        "' model. This is most likely due to a missing attribute on your model definition.", !Ember.isNone(inverse));
+
+      inverseKind = inverse.kind;
+    } else {
+      //No inverse was specified manually, we need to use a heuristic to guess one
+      if (propertyMeta.type === propertyMeta.parentType.modelName) {
+        warn(`Detected a reflexive relationship by the name of '${name}' without an inverse option. Look at http://emberjs.com/guides/models/defining-models/#toc_reflexive-relation for how to explicitly specify inverses.`, false, {
+          id: 'ds.model.reflexive-relationship-without-inverse'
+        });
+      }
+
+      let possibleRelationships = findPossibleInverses(this, inverseSchema);
+
+      if (possibleRelationships.length === 0) {
+        return null;
+      }
+
+      let filteredRelationships = possibleRelationships.filter((possibleRelationship) => {
+        let optionsForRelationship = inverseSchema.metaForProperty(possibleRelationship.name).options;
+
+        return name === optionsForRelationship.inverse;
+      });
+
+      assert("You defined the '" + name + "' relationship on model:" + this.modelName + ", but you defined the inverse relationships of model:" +
+        inverseSchema.modelName + " multiple times. Look at http://emberjs.com/guides/models/defining-models/#toc_explicit-inverses for how to explicitly specify inverses",
+        filteredRelationships.length < 2);
+
+      if (filteredRelationships.length === 1 ) {
+        possibleRelationships = filteredRelationships;
+      }
+
+      assert("You defined the '" + name + "' relationship on model:" + this.modelName + ", but multiple possible inverse relationships of model:" +
+        this.modelName + " were found on model:" + inverseSchema.modelName + ". Look at http://emberjs.com/guides/models/defining-models/#toc_explicit-inverses for how to explicitly specify inverses",
+        possibleRelationships.length === 1);
+
+      inverseName = possibleRelationships[0].name;
+      inverseKind = possibleRelationships[0].kind;
+    }
+
+    return {
+      type: inverseSchema,
+      name: inverseName,
+      kind: inverseKind
+    };
+  }
+
+  metaForProperty(propertyName) {
+    return this.properties[propertyName];
+  }
+
+  get recordMap() {
+    if (this._recordMap === null) {
+      this._recordMap = {
+        idToRecord: new EmptyObject(),
+        records: [],
+        metadata: new EmptyObject(),
+        type: this.model
+      };
+    }
+
+    return this._recordMap;
+  }
+
+  // TODO @runspired should we allow sets? or just clears?
+  set recordMap(v) {
+    this._recordMap = v;
+  }
+
+  _parseModelClass() {
+    let descriptors = get(this.modelClass, '_computedProperties');
+    let attributes;
+    let relationships;
+    let relationshipMap;
+    let properties = descriptors.length && new EmptyObject();
+
+    for (let i = 0; i < descriptors.length; i++) {
+      let value = descriptors[i];
+      let key = value.name;
+
+      if (value && value.meta) {
+        if (value.meta.isAttribute === true) {
+          properties[key] = value.meta;
+          if (!attributes) {
+            attributes = new EmptyObject();
+          }
+          attributes[key] = value.meta;
+        } else if (value.meta.isRelationship === true) {
+          properties[key] = value.meta;
+          if (!relationships) {
+            relationships = new EmptyObject();
+            relationshipMap = new EmptyObject();
+          }
+          relationships[key] = value.meta;
+          relationshipMap[value.meta.type] = relationshipMap[value.meta.type] || [];
+          relationshipMap[value.meta.type].push(value.meta);
+        }
+      }
+    }
+
+    this._expandedModel = true;
+    this._attributes = attributes;
+    this._relationships = relationships;
+    this._relationshipMap = relationshipMap;
+    this._properties = properties;
+  }
+}
+
+function findPossibleInverses(schema, inverseSchema, relationshipsSoFar) {
+  let possibleRelationships = relationshipsSoFar || [];
+  let relationshipMap = inverseSchema.relationshipMap;
+
+  if (!relationshipMap) {
+    return possibleRelationships;
+  }
+
+  var relationships = relationshipMap[schema.modelName];
+
+  relationships = relationships.filter((relationship) => {
+    var optionsForRelationship = inverseSchema.metaForProperty(relationship.name).options;
+
+    if (!optionsForRelationship.inverse) {
+      return true;
+    }
+
+    return name === optionsForRelationship.inverse;
+  });
+
+  if (relationships) {
+    possibleRelationships.push.apply(possibleRelationships, relationships);
+  }
+
+  //Recurse to support polymorphism
+  if (schema.superclass) {
+    findPossibleInverses(schema.superclass, inverseSchema, possibleRelationships);
+  }
+
+  return possibleRelationships;
+}

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1666,7 +1666,7 @@ Store = Service.extend({
       let keys = Object.keys(this._schemas);
       keys.forEach(this.unloadAll, this);
     } else {
-      let schema = this._schemas[modelName];
+      let schema = this._schemas[modelName] || this._schemas[guidFor(this.modelFor(modelName))];
 
       if (schema) {
         let recordMap = schema.recordMap;
@@ -1984,25 +1984,28 @@ Store = Service.extend({
     if (this._schemas === null) {
       this._schemas = new EmptyObject();
     }
-    if (!this._schemas[modelName]) {
-      let modelClass = this.modelFor(modelName);
-      this._schemas[modelName] = new Schema(modelClass, this);
+
+    let modelClass = this.modelFor(modelName);
+    let schemaKey = guidFor(modelClass);
+
+    if (!this._schemas[schemaKey]) {
+      this._schemas[schemaKey] = new Schema(modelClass, this);
     }
 
-    return this._schemas[modelName];
+    return this._schemas[schemaKey];
   },
 
   _schemaForModelClass(modelClass) {
-    let modelName = modelClass.modelName;
+    let schemaKey = guidFor(modelClass);
 
     if (this._schemas === null) {
       this._schemas = new EmptyObject();
     }
-    if (!this._schemas[modelName]) {
-      this._schemas[modelName] = new Schema(modelClass, this);
+    if (!this._schemas[schemaKey]) {
+      this._schemas[schemaKey] = new Schema(modelClass, this);
     }
 
-    return this._schemas[modelName];
+    return this._schemas[schemaKey];
   },
 
   // ................

--- a/tests/unit/store/adapter-interop-test.js
+++ b/tests/unit/store/adapter-interop-test.js
@@ -53,10 +53,10 @@ test("Calling Store#find invokes its adapter#find", function(assert) {
   let done = assert.async();
 
   var adapter = TestAdapter.extend({
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       assert.ok(true, "Adapter#find was called");
       assert.equal(store, currentStore, "Adapter#find was called with the right store");
-      assert.equal(type, store.modelFor('test'), "Adapter#find was called with the type passed into Store#find");
+      assert.equal(modelClass, store.modelFor('test'), "Adapter#find was called with the modelClass passed into Store#find");
       assert.equal(id, 1, "Adapter#find was called with the id passed into Store#find");
       assert.equal(snapshot.id, '1', "Adapter#find was called with the record created from Store#find");
 
@@ -78,10 +78,10 @@ test("Calling Store#findRecord multiple times coalesces the calls into a adapter
   let done = assert.async();
 
   var adapter = TestAdapter.extend({
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       assert.ok(false, "Adapter#findRecord was not called");
     },
-    findMany(store, type, ids, snapshots) {
+    findMany(store, modelClass, ids, snapshots) {
       assert.ok(true, "Adapter#findMany was called");
       assert.deepEqual(ids, ["1","2"], 'Correct ids were passed in to findMany');
       return Ember.RSVP.resolve([{ id: 1 }, { id: 2 }]);
@@ -105,7 +105,7 @@ test("Returning a promise from `findRecord` asynchronously loads data", function
   assert.expect(1);
 
   var adapter = TestAdapter.extend({
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       return resolve({ id: 1, name: "Scumbag Dale" });
     }
   });
@@ -126,7 +126,7 @@ test("IDs provided as numbers are coerced to strings", function(assert) {
   assert.expect(5);
 
   var adapter = TestAdapter.extend({
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       assert.equal(typeof id, 'string', "id has been normalized to a string");
       return resolve({ id, name: "Scumbag Sylvain" });
     }
@@ -224,8 +224,8 @@ test("loadMany takes an optional Object and passes it on to the Adapter", functi
   });
 
   var adapter = TestAdapter.extend({
-    query(store, type, query) {
-      assert.equal(type, store.modelFor('person'), 'The type was Person');
+    query(store, modelClass, query) {
+      assert.equal(modelClass, store.modelFor('person'), 'The modelClass was Person');
       assert.equal(query, passedQuery, "The query was passed in");
       return Ember.RSVP.resolve([]);
     }
@@ -249,7 +249,7 @@ test("Find with query calls the correct normalizeResponse", function(assert) {
   });
 
   var adapter = TestAdapter.extend({
-    query(store, type, query) {
+    query(store, modelClass, query) {
       return Ember.RSVP.resolve([]);
     }
   });
@@ -277,7 +277,7 @@ test("Find with query calls the correct normalizeResponse", function(assert) {
   assert.equal(callCount, 1, 'normalizeQueryResponse was called');
 });
 
-test("peekAll(type) returns a record array of all records of a specific type", function(assert) {
+test("peekAll(modelClass) returns a record array of all records of a specific modelClass", function(assert) {
   var Person = DS.Model.extend({
     name: DS.attr('string')
   });
@@ -319,7 +319,7 @@ test("peekAll(type) returns a record array of all records of a specific type", f
   assert.strictEqual(results, store.peekAll('person'), "subsequent calls to peekAll return the same recordArray)");
 });
 
-test("a new record of a particular type is created via store.createRecord(type)", function(assert) {
+test("a new record of a particular modelClass is created via store.createRecord(modelName)", function(assert) {
   var Person = DS.Model.extend({
     name: DS.attr('string')
   });
@@ -370,7 +370,7 @@ testInDebug("a new record with a specific id can't be created if this id is alre
   }, /The id 5 has already been used with another record for modelClass Person/);
 });
 
-test("an initial data hash can be provided via store.createRecord(type, hash)", function(assert) {
+test("an initial data hash can be provided via store.createRecord(modelName, hash)", function(assert) {
   var Person = DS.Model.extend({
     name: DS.attr('string')
   });
@@ -416,8 +416,8 @@ test("initial values of attributes can be passed in as the third argument to fin
   assert.expect(1);
 
   var adapter = TestAdapter.extend({
-    findRecord(store, type, id, snapshot) {
-      assert.equal(snapshot.attr('name'), 'Test', 'Preloaded attribtue set');
+    findRecord(store, modelClass, id, snapshot) {
+      assert.equal(snapshot.attr('name'), 'Test', 'Preloaded attribute set');
       return Ember.RSVP.resolve({ id: '1', name: 'Test' });
     }
   });
@@ -439,7 +439,7 @@ test("initial values of attributes can be passed in as the third argument to fin
 test("initial values of belongsTo can be passed in as the third argument to find as records", function(assert) {
   assert.expect(1);
   var adapter = TestAdapter.extend({
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       assert.equal(snapshot.belongsTo('friend').attr('name'), 'Tom', 'Preloaded belongsTo set');
       return new Ember.RSVP.Promise(function() {});
     }
@@ -477,7 +477,7 @@ test("initial values of belongsTo can be passed in as the third argument to find
   assert.expect(1);
 
   var adapter = TestAdapter.extend({
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       return Ember.RSVP.Promise.resolve({ id: id });
     }
   });
@@ -506,7 +506,7 @@ test("initial values of belongsTo can be passed in as the third argument to find
 test("initial values of hasMany can be passed in as the third argument to find as records", function(assert) {
   assert.expect(1);
   var adapter = TestAdapter.extend({
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       assert.equal(snapshot.hasMany('friends')[0].attr('name'), 'Tom', 'Preloaded hasMany set');
       return new Ember.RSVP.Promise(function() {});
     }
@@ -544,7 +544,7 @@ test("initial values of hasMany can be passed in as the third argument to find a
   assert.expect(1);
 
   var adapter = TestAdapter.extend({
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       assert.equal(snapshot.hasMany('friends')[0].id, '2', 'Preloaded hasMany set');
       return Ember.RSVP.resolve({ id: id });
     }
@@ -576,7 +576,7 @@ test("records should have their ids updated when the adapter returns the id data
 
   var idCounter = 1;
   var adapter = TestAdapter.extend({
-    createRecord(store, type, snapshot) {
+    createRecord(store, modelClass, snapshot) {
       return Ember.RSVP.resolve({ name: snapshot.attr('name'), id: idCounter++ });
     }
   });
@@ -635,7 +635,7 @@ test("store._scheduleFetchMany should not resolve until all the records are reso
   var Phone = DS.Model.extend();
 
   var adapter = TestAdapter.extend({
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       var wait = 5;
 
       var record = { id: id };
@@ -647,7 +647,7 @@ test("store._scheduleFetchMany should not resolve until all the records are reso
       });
     },
 
-    findMany(store, type, ids, snapshots) {
+    findMany(store, modelClass, ids, snapshots) {
       var wait = 15;
 
       var records = ids.map(function(id) {
@@ -700,12 +700,12 @@ test("the store calls adapter.findMany according to groupings returned by adapte
       ];
     },
 
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       assert.equal(id, "10", "The first group is passed to find");
       return Ember.RSVP.resolve({ id: id });
     },
 
-    findMany(store, type, ids, snapshots) {
+    findMany(store, modelClass, ids, snapshots) {
       var records = ids.map(function(id) {
         return { id: id };
       });
@@ -751,7 +751,7 @@ test("the promise returned by `_scheduleFetch`, when it resolves, does not depen
       ];
     },
 
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       var record = { id: id };
 
       return new Ember.RSVP.Promise(function(resolve, reject) {
@@ -800,7 +800,7 @@ test("the promise returned by `_scheduleFetch`, when it rejects, does not depend
       ];
     },
 
-    findRecord(store, type, id, snapshot) {
+    findRecord(store, modelClass, id, snapshot) {
       var record = { id: id };
 
       return new Ember.RSVP.Promise(function(resolve, reject) {
@@ -841,7 +841,7 @@ testInDebug("store._fetchRecord reject records that were not found, even when th
   var Person = DS.Model.extend();
 
   var adapter = TestAdapter.extend({
-    findMany(store, type, ids, snapshots) {
+    findMany(store, modelClass, ids, snapshots) {
       var records = ids.map(function(id) {
         return { id: id };
       });
@@ -879,7 +879,7 @@ testInDebug("store._fetchRecord warns when records are missing", function(assert
   var Person = DS.Model.extend();
 
   var adapter = TestAdapter.extend({
-    findMany(store, type, ids, snapshots) {
+    findMany(store, modelClass, ids, snapshots) {
       var records = ids.map(function(id) {
         return { id: id };
       });
@@ -913,7 +913,7 @@ test("store should not call shouldReloadRecord when the record is not in the sto
   });
 
   var TestAdapter = DS.Adapter.extend({
-    shouldReloadRecord(store, type, id, snapshot) {
+    shouldReloadRecord(store, modelClass, id, snapshot) {
       assert.ok(false, 'shouldReloadRecord should not be called when the record is not loaded');
       return false;
     },
@@ -941,7 +941,7 @@ test("store should not reload record when shouldReloadRecord returns false", fun
   });
 
   var TestAdapter = DS.Adapter.extend({
-    shouldReloadRecord(store, type, id, snapshot) {
+    shouldReloadRecord(store, modelClass, id, snapshot) {
       assert.ok(true, 'shouldReloadRecord should be called when the record is in the store');
       return false;
     },
@@ -975,7 +975,7 @@ test("store should reload record when shouldReloadRecord returns true", function
   });
 
   var TestAdapter = DS.Adapter.extend({
-    shouldReloadRecord(store, type, id, snapshot) {
+    shouldReloadRecord(store, modelClass, id, snapshot) {
       assert.ok(true, 'shouldReloadRecord should be called when the record is in the store');
       return true;
     },
@@ -1011,10 +1011,10 @@ test("store should not call shouldBackgroundReloadRecord when the store is alrea
   });
 
   var TestAdapter = DS.Adapter.extend({
-    shouldReloadRecord(store, type, id, snapshot) {
+    shouldReloadRecord(store, modelClass, id, snapshot) {
       return true;
     },
-    shouldBackgroundReloadRecord(store, type, id, snapshot) {
+    shouldBackgroundReloadRecord(store, modelClass, id, snapshot) {
       assert.ok(false, 'shouldBackgroundReloadRecord is not called when shouldReloadRecord returns true');
     },
     findRecord() {
@@ -1049,7 +1049,7 @@ test("store should not reload a record when `shouldBackgroundReloadRecord` is fa
   });
 
   var TestAdapter = DS.Adapter.extend({
-    shouldBackgroundReloadRecord(store, type, id, snapshot) {
+    shouldBackgroundReloadRecord(store, modelClass, id, snapshot) {
       assert.ok(true, 'shouldBackgroundReloadRecord is called when record is loaded form the cache');
       return false;
     },
@@ -1086,7 +1086,7 @@ test("store should reload the record in the background when `shouldBackgroundRel
   });
 
   var TestAdapter = DS.Adapter.extend({
-    shouldBackgroundReloadRecord(store, type, id, snapshot) {
+    shouldBackgroundReloadRecord(store, modelClass, id, snapshot) {
       assert.ok(true, 'shouldBackgroundReloadRecord is called when record is loaded form the cache');
       return true;
     },
@@ -1154,7 +1154,7 @@ test("store should reload all records when shouldReloadAll returns true", functi
   });
 
   var TestAdapter = DS.Adapter.extend({
-    shouldReloadAll(store, type, id, snapshot) {
+    shouldReloadAll(store, modelClass, id, snapshot) {
       assert.ok(true, 'shouldReloadAll should be called when the record is in the store');
       return true;
     },
@@ -1184,10 +1184,10 @@ test("store should not call shouldBackgroundReloadAll when the store is already 
   });
 
   var TestAdapter = DS.Adapter.extend({
-    shouldReloadAll(store, type, id, snapshot) {
+    shouldReloadAll(store, modelClass, id, snapshot) {
       return true;
     },
-    shouldBackgroundReloadAll(store, type, id, snapshot) {
+    shouldBackgroundReloadAll(store, modelClass, id, snapshot) {
       assert.ok(false, 'shouldBackgroundReloadRecord is not called when shouldReloadRecord returns true');
     },
     findAll() {
@@ -1216,11 +1216,11 @@ test("store should not reload all records when `shouldBackgroundReloadAll` is fa
   });
 
   var TestAdapter = DS.Adapter.extend({
-    shouldReloadAll(store, type, id, snapshot) {
+    shouldReloadAll(store, modelClass, id, snapshot) {
       assert.ok(true, 'shouldReloadAll is called when record is loaded form the cache');
       return false;
     },
-    shouldBackgroundReloadAll(store, type, id, snapshot) {
+    shouldBackgroundReloadAll(store, modelClass, id, snapshot) {
       assert.ok(true, 'shouldBackgroundReloadAll is called when record is loaded form the cache');
       return false;
     },


### PR DESCRIPTION
TODO
- [ ] Refactor areas where internal model is being used as schema
- [ ] Move as much logic off of DS.Model methods as we can, since it's public API we'll need to continue exposing it on that class, just not use it ourselves.
- [ ] Refactor InternalModel down to just a data/state container
- [ ] ? Refactor Model methods to use schema for descriptor iteration (tricky because Map => EmptyObject ) ?
- [ ] ? consider refactoring out relationshipMap, as it's almost certain to be greedy and allocates a bunch of arrays. While this may be better if we often iterate over relationships by related className, I suspect such iteration is rare ?
- [ ] ? InternalModel._loadingPromise ? 
- [ ] ? debugSeal on InternalModel so we can find anywhere we're being bad currently ?
