### PR TITLE
Free up `internalModel`s

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -807,14 +807,6 @@ const Model = Ember.Object.extend(Ember.Evented, {
     this._super(...arguments);
   },
 
-  willDestroy() {
-    //TODO Move!
-    this._super(...arguments);
-    this._internalModel.clearRelationships();
-    this._internalModel.recordObjectWillDestroy();
-    //TODO should we set internalModel to null here?
-  },
-
   // This is a temporary solution until we refactor DS.Model to not
   // rely on the data property.
   willMergeMixin(props) {

--- a/addon/-private/system/model/states.js
+++ b/addon/-private/system/model/states.js
@@ -459,10 +459,6 @@ const RootState = {
   // you out of the in-flight state.
   rolledBack() { },
   unloadRecord(internalModel) {
-    // clear relationships before moving to deleted state
-    // otherwise it fails
-    internalModel.clearRelationships();
-    internalModel.transitionTo('deleted.saved');
   },
 
   propertyWasReset() { },
@@ -573,10 +569,6 @@ const RootState = {
       },
 
       unloadRecord(internalModel) {
-        // clear relationships before moving to deleted state
-        // otherwise it fails
-        internalModel.clearRelationships();
-        internalModel.transitionTo('deleted.saved');
       },
 
       didCommit() {},
@@ -680,8 +672,6 @@ const RootState = {
 
       setup(internalModel) {
         internalModel.clearRelationships();
-        var store = internalModel.store;
-        store._dematerializeRecord(internalModel);
       },
 
       invokeLifecycleCallbacks(internalModel) {

--- a/addon/-private/system/record-array-manager.js
+++ b/addon/-private/system/record-array-manager.js
@@ -117,8 +117,15 @@ export default class RecordArrayManager {
     for (let i = 0, l = updated.length; i < l; i++) {
       let internalModel = updated[i];
 
-      if (internalModel.isDestroyed ||
-        internalModel.currentState.stateName === 'root.deleted.saved') {
+      // During dematerialization we don't want to rematerialize the record.
+      // recordWasDeleted can cause other records to rematerialize because it
+      // removes the internal model from the array and Ember arrays will always
+      // `objectAt(0)` and `objectAt(len -1)` to check whether `firstObject` or
+      // `lastObject` have changed.  When this happens we don't want those
+      // models to rematerialize their records.
+      if (internalModel._isDematerializing ||
+          internalModel.isDestroyed ||
+          internalModel.currentState.stateName === 'root.deleted.saved') {
         this._recordWasDeleted(internalModel);
       } else {
         this._recordWasChanged(internalModel);

--- a/addon/-private/system/record-map.js
+++ b/addon/-private/system/record-map.js
@@ -120,7 +120,6 @@ export default class RecordMap {
       for (let i = 0; i < records.length; i++) {
         record = records[i];
         record.unloadRecord();
-        record.destroy(); // maybe within unloadRecord
       }
     }
 

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -46,6 +46,10 @@ export default class BelongsToRelationship extends Relationship {
     super.addCanonicalRecord(newRecord);
   }
 
+  inverseDidDematerialize() {
+    this.notifyBelongsToChanged();
+  }
+
   flushCanonical() {
     //temporary fix to not remove newly created records if server returned null.
     //TODO remove once we have proper diffing
@@ -54,7 +58,7 @@ export default class BelongsToRelationship extends Relationship {
     }
     if (this.inverseRecord !== this.canonicalState) {
       this.inverseRecord = this.canonicalState;
-      this.internalModel.notifyBelongsToChanged(this.key);
+      this.notifyBelongsToChanged();
     }
 
     super.flushCanonical();
@@ -71,7 +75,7 @@ export default class BelongsToRelationship extends Relationship {
 
     this.inverseRecord = newRecord;
     super.addRecord(newRecord);
-    this.internalModel.notifyBelongsToChanged(this.key);
+    this.notifyBelongsToChanged();
   }
 
   setRecordPromise(newPromise) {
@@ -84,6 +88,10 @@ export default class BelongsToRelationship extends Relationship {
     if (!this.members.has(record)) { return;}
     this.inverseRecord = null;
     super.removeRecordFromOwn(record);
+    this.notifyBelongsToChanged();
+  }
+
+  notifyBelongsToChanged() {
     this.internalModel.notifyBelongsToChanged(this.key);
   }
 

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -30,8 +30,10 @@ export default class ManyRelationship extends Relationship {
   }
 
   destroy() {
+    super.destroy();
     if (this._manyArray) {
       this._manyArray.destroy();
+      this._manyArray = null;
     }
   }
 
@@ -52,6 +54,14 @@ export default class ManyRelationship extends Relationship {
       this.canonicalState.push(record);
     }
     super.addCanonicalRecord(record, idx);
+  }
+
+  inverseDidDematerialize() {
+    if (this._manyArray) {
+      this._manyArray.destroy();
+      this._manyArray = null;
+    }
+    this.notifyHasManyChanged();
   }
 
   addRecord(record, idx) {

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2541,15 +2541,13 @@ Store = Service.extend({
     When a record is destroyed, this un-indexes it and
     removes it from any record arrays so it can be GCed.
 
-    @method _dematerializeRecord
+    @method _removeFromIdMap
     @private
     @param {InternalModel} internalModel
   */
-  _dematerializeRecord(internalModel) {
+  _removeFromIdMap(internalModel) {
     let recordMap = this._recordMapFor(internalModel.modelName);
     let id = internalModel.id;
-
-    internalModel.updateRecordArrays();
 
     recordMap.remove(internalModel, id);
   },

--- a/tests/integration/adapter/find-all-test.js
+++ b/tests/integration/adapter/find-all-test.js
@@ -19,6 +19,7 @@ module("integration/adapter/find_all - Finding All Records of a Type", {
       firstName: attr('string'),
       lastName: attr('string')
     });
+    Person.reopenClass({ toString() { return 'Person'; } });
 
     allRecords = null;
 

--- a/tests/integration/records/delete-record-test.js
+++ b/tests/integration/records/delete-record-test.js
@@ -17,6 +17,7 @@ module("integration/deletedRecord - Deleting Records", {
     Person = DS.Model.extend({
       name: attr('string')
     });
+    Person.toString = () => { return 'Person'; };
 
     env = setupStore({
       person: Person
@@ -78,6 +79,7 @@ test('deleting a record that is part of a hasMany removes it from the hasMany re
   const Group = DS.Model.extend({
     people: DS.hasMany('person', { inverse: null, async: false })
   });
+  Group.toString = () => { return 'Group'; }
 
   env.adapter.deleteRecord = function() {
     return Ember.RSVP.Promise.resolve();

--- a/tests/integration/records/load-test.js
+++ b/tests/integration/records/load-test.js
@@ -25,19 +25,14 @@ module("integration/load - Loading Records", {
   }
 });
 
-test("When loading a record fails, the isLoading is set to false", function(assert) {
+test("When loading a record fails, the record is not left behind", function(assert) {
   env.adapter.findRecord = function(store, type, id, snapshot) {
     return Ember.RSVP.reject();
   };
 
   run(function() {
     env.store.findRecord('post', 1).then(null, assert.wait(function() {
-      // store.recordForId is private, but there is currently no other way to
-      // get the specific record instance, since it is not passed to this
-      // rejection handler
-      var post = env.store.recordForId('post', 1);
-
-      assert.equal(post.get("isLoading"), false, "post is not loading anymore");
+      assert.equal(env.store.hasRecordForId('post', 1), false);
     }));
   });
 });

--- a/tests/integration/records/rematerialize-test.js
+++ b/tests/integration/records/rematerialize-test.js
@@ -1,0 +1,245 @@
+/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "(adam|bob|dudu)" }]*/
+
+import setupStore from 'dummy/tests/helpers/store';
+import Ember from 'ember';
+
+import {module, test} from 'qunit';
+
+import DS from 'ember-data';
+
+let attr = DS.attr;
+let belongsTo = DS.belongsTo;
+let hasMany = DS.hasMany;
+let run = Ember.run;
+let env;
+
+let Person = DS.Model.extend({
+  name: attr('string'),
+  cars: hasMany('car', { async: false }),
+  boats: hasMany('boat', { async: true })
+});
+Person.reopenClass({ toString() { return 'Person'; } });
+
+let Group = DS.Model.extend({
+  people: hasMany('person', { async: false })
+});
+Group.reopenClass({ toString() { return 'Group'; } });
+
+let Car = DS.Model.extend({
+  make: attr('string'),
+  model: attr('string'),
+  person: belongsTo('person', { async: false })
+});
+Car.reopenClass({ toString() { return 'Car'; } });
+
+let Boat = DS.Model.extend({
+  name: attr('string'),
+  person: belongsTo('person', { async: false })
+});
+Boat.toString = function() { return 'Boat'; };
+
+module("integration/unload - Unloading Records", {
+  beforeEach() {
+    env = setupStore({
+      adapter: DS.JSONAPIAdapter,
+      person: Person,
+      car: Car,
+      group: Group,
+      boat: Boat
+    });
+  },
+
+  afterEach() {
+    Ember.run(function() {
+      env.container.destroy();
+    });
+  }
+});
+
+test("a sync belongs to relationship to an unloaded record can restore that record", function(assert) {
+  let adam, bob;
+
+  // disable background reloading so we do not re-create the relationship.
+  env.adapter.shouldBackgroundReloadRecord = () => false;
+
+  run(function() {
+    env.store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Adam Sunderland'
+        },
+        relationships: {
+          cars: {
+            data: [
+              { type: 'car', id: '1' }
+            ]
+          }
+        }
+      }
+    });
+    adam = env.store.peekRecord('person', 1);
+  });
+
+  run(function() {
+    env.store.push({
+      data: {
+        type: 'car',
+        id: '1',
+        attributes: {
+          make: "Lotus",
+          model: "Exige"
+        },
+        relationships: {
+          person: {
+            data: { type: 'person', id: '1' }
+          }
+        }
+      }
+    });
+    bob = env.store.peekRecord('car', 1);
+  });
+
+  let person = env.store.peekRecord('person', 1);
+  assert.equal(person.get('cars.length'), 1, 'The inital length of cars is correct');
+
+  assert.equal(env.store.hasRecordForId('person', 1), true, 'The person is in the store');
+  assert.equal(env.store._recordMapFor('person').has(1), true, 'The person internalModel is loaded');
+
+  run(function() {
+    person.unloadRecord();
+  });
+
+  assert.equal(env.store.hasRecordForId('person', 1), false, 'The person is unloaded');
+  assert.equal(env.store._recordMapFor('person').has(1), true, 'The person internalModel is retained');
+
+  run(() => {
+    env.store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Adam Sunderland'
+        },
+        relationships: {
+          cars: {
+            data: [
+              { type: 'car', id: '1' }
+            ]
+          }
+        }
+      }
+    });
+  });
+
+  let rematerializedPerson = bob.get('person');
+  assert.equal(rematerializedPerson.get('id'), '1');
+  // the person is rematerialized; the previous person is *not* re-used
+  assert.notEqual(rematerializedPerson, adam, 'the person is rematerialized, not recycled');
+});
+
+test("an async has many relationship to an unloaded record can restore that record", function(assert) {
+  assert.expect(13);
+
+  // disable background reloading so we do not re-create the relationship.
+  env.adapter.shouldBackgroundReloadRecord = () => false;
+
+  env.adapter.findRecord = function() {
+    assert.ok('adapter called');
+    return Ember.RSVP.Promise.resolve({
+      data: {
+        type: 'boat',
+        id: '1',
+        attributes: {
+          name: "Boaty McBoatface"
+        },
+        relationships: {
+          person: {
+            data: { type: 'person', id: '1' }
+          }
+        }
+      }
+    });
+  }
+
+  run(function() {
+    env.store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Adam Sunderland'
+        },
+        relationships: {
+          boats: {
+            data: [
+              { type: 'boat', id: '2' },
+              { type: 'boat', id: '1' }
+            ]
+          }
+        }
+      }
+    });
+  });
+
+  run(function() {
+    env.store.push({
+      data: [{
+        type: 'boat',
+        id: '2',
+        attributes: {
+          name: 'Some other boat'
+        },
+        relationships: {
+          person: {
+            data: { type: 'person', id: '1' }
+          }
+        }
+      }, {
+        type: 'boat',
+        id: '1',
+        attributes: {
+          name: 'Boaty McBoatface'
+        },
+        relationships: {
+          person: {
+            data: { type: 'person', id: '1' }
+          }
+        }
+      }]
+    });
+  });
+
+  let adam = env.store.peekRecord('person', 1);
+  let boaty = env.store.peekRecord('boat', 1);
+
+  assert.equal(env.store.hasRecordForId('person', 1), true, 'The person is in the store');
+  assert.equal(env.store._recordMapFor('person').has(1), true, 'The person internalModel is loaded');
+  assert.equal(env.store.hasRecordForId('boat', 1), true, 'The boat is in the store');
+  assert.equal(env.store._recordMapFor('boat').has(1), true, 'The boat internalModel is loaded');
+
+  let boats = run(() => {
+    return adam.get('boats');
+  });
+
+  assert.equal(boats.get('length'), 2, 'Before unloading boats.length is correct');
+
+  run(function() {
+    boaty.unloadRecord();
+  });
+
+  assert.equal(env.store.hasRecordForId('boat', 1), false, 'The boat is unloaded');
+  assert.equal(env.store._recordMapFor('boat').has(1), true, 'The boat internalModel is retained');
+
+  let rematerializedBoaty = run(() => {
+    return rematerializedBoaty = adam.get('boats').objectAt(1);
+  });
+
+  assert.equal(adam.get('boats.length'), 2, 'boats.length correct after rematerialization');
+  assert.equal(rematerializedBoaty.get('id'), '1');
+  assert.notEqual(rematerializedBoaty, boaty, 'the boat is rematerialized, not recycled');
+
+  assert.equal(env.store.hasRecordForId('boat', 1), true, 'The boat is loaded');
+  assert.equal(env.store._recordMapFor('boat').has(1), true, 'The boat internalModel is retained');
+});

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -29,44 +29,53 @@ module("integration/relationships/has_many - Has-Many Relationships", {
     Contact = DS.Model.extend({
       user: belongsTo('user', { async: false })
     });
+    Contact.reopenClass({ toString: () => 'Contact' });
 
     Email = Contact.extend({
       email: attr('string')
     });
+    Email.reopenClass({ toString: () => 'Email' });
 
     Phone = Contact.extend({
       number: attr('string')
     });
+    Phone.reopenClass({ toString: () => 'Phone' });
 
     Message = DS.Model.extend({
       user: belongsTo('user', { async: false }),
       created_at: attr('date')
     });
+    Message.reopenClass({ toString: () => 'Message' });
 
     Post = Message.extend({
       title: attr('string'),
       comments: hasMany('comment', { async: false })
     });
+    Post.reopenClass({ toString: () => 'Post' });
 
     Comment = Message.extend({
       body: DS.attr('string'),
       message: DS.belongsTo('post', { polymorphic: true, async: true })
     });
+    Comment.reopenClass({ toString: () => 'Comment' });
 
     Book = DS.Model.extend({
       title: attr(),
       chapters: hasMany('chapter', { async: true })
     });
+    Book.reopenClass({ toString: () => 'Book' });
 
     Chapter = DS.Model.extend({
       title: attr(),
       pages: hasMany('page', { async: false })
     });
+    Chapter.reopenClass({ toString: () => 'Chapter' });
 
     Page = DS.Model.extend({
       number: attr('number'),
       chapter: belongsTo('chapter', { async: false })
     });
+    Page.reopenClass({ toString: () => 'Page' });
 
     env = setupStore({
       user: User,
@@ -2197,10 +2206,12 @@ test("adding and removing records from hasMany relationship #2666", function(ass
   var Post = DS.Model.extend({
     comments: DS.hasMany('comment', { async: true })
   });
+  Post.reopenClass({ toString: () => 'Post' });
 
   var Comment = DS.Model.extend({
     post: DS.belongsTo('post', { async: false })
   });
+  Comment.reopenClass({ toString: () => 'Comment' });
 
   env = setupStore({
     post: Post,
@@ -2776,7 +2787,7 @@ test("unloading and reloading a record with hasMany relationship - #3084", funct
 
     user = env.store.peekRecord('user', 'user-1');
 
-    assert.equal(get(user, 'messages.firstObject.id'), 'message-1');
-    assert.equal(get(message, 'user.id'), 'user-1');
+    assert.equal(get(user, 'messages.firstObject.id'), 'message-1', 'user points to message');
+    assert.equal(get(message, 'user.id'), 'user-1', 'message points to user');
   });
 });

--- a/tests/integration/relationships/many-to-many-test.js
+++ b/tests/integration/relationships/many-to-many-test.js
@@ -525,7 +525,7 @@ test("Deleting a record that has a hasMany relationship removes it from the othe
     user.rollbackAttributes();
   });
   assert.equal(account.get('users.length'), 0, 'Users got removed');
-  assert.equal(user.get('accounts.length'), undefined, 'Accounts got rolledback correctly');
+  assert.equal(user.get('accounts.length'), 0, 'Accounts got rolledback correctly');
 });
 
 

--- a/tests/integration/relationships/one-to-many-test.js
+++ b/tests/integration/relationships/one-to-many-test.js
@@ -1449,6 +1449,6 @@ test("Rollbacking attributes of a created record works correctly when the belong
     user.get('accounts').pushObject(account);
   });
   run(user, 'rollbackAttributes');
-  assert.equal(user.get('accounts.length'), undefined, "User does not have the account anymore");
+  assert.equal(user.get('accounts.length'), 0, "User does not have the account anymore");
   assert.equal(account.get('user'), null, 'Account does not have the user anymore');
 });

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -13,6 +13,7 @@ var Person = DS.Model.extend({
   name: DS.attr('string'),
   cars: DS.hasMany('car', { async: false })
 });
+Person.reopenClass({ toString: () => 'Person' });
 
 var run = Ember.run;
 
@@ -21,6 +22,7 @@ var Car = DS.Model.extend({
   model: DS.attr('string'),
   person: DS.belongsTo('person', { async: false })
 });
+Car.reopenClass({ toString: () => 'Car' });
 
 function initializeStore(adapter) {
   env = setupStore({
@@ -195,10 +197,7 @@ test("destroying the store correctly cleans everything up", function(assert) {
   assert.equal(car.get('person'), person, "expected car's person to be the correct person");
   assert.equal(person.get('cars.firstObject'), car, " expected persons cars's firstRecord to be the correct car");
 
-  Ember.run(person, person.destroy);
   Ember.run(store, 'destroy');
-
-  assert.equal(car.get('person'), null, "expected car.person to no longer be present");
 
   assert.equal(personWillDestroy.called.length, 1, 'expected person to have recieved willDestroy once');
   assert.equal(carWillDestroy.called.length, 1, 'expected car to recieve willDestroy once');

--- a/tests/unit/many-array-test.js
+++ b/tests/unit/many-array-test.js
@@ -19,11 +19,13 @@ module("unit/many_array - DS.ManyArray", {
       title: attr('string'),
       tags: hasMany('tag', { async: false })
     });
+    Post.reopenClass({ toString: () => 'Post'});
 
     Tag = DS.Model.extend({
       name: attr('string'),
       post: belongsTo('post', { async: false })
     });
+    Tag.reopenClass({ toString: () => 'Tag'});
 
     env = setupStore({
       post: Post,
@@ -88,7 +90,7 @@ test("manyArray.save() calls save() on all records", function(assert) {
 });
 
 test("manyArray trigger arrayContentChange functions with the correct values", function(assert) {
-  assert.expect(12);
+  assert.expect(6);
   var willChangeStartIdx;
   var willChangeRemoveAmt;
   var willChangeAddAmt;

--- a/tests/unit/model/rollback-attributes-test.js
+++ b/tests/unit/model/rollback-attributes-test.js
@@ -15,6 +15,7 @@ module("unit/model/rollbackAttributes - model.rollbackAttributes()", {
       firstName: DS.attr(),
       lastName: DS.attr()
     });
+    Person.reopenClass({ toString() { return 'Person'; } });
 
     env = setupStore({ person: Person });
     store = env.store;


### PR DESCRIPTION
`internalModel`s need to stay around as long as they're connected to a live record via relationships.  Once an entire subgraph is removed however, we can free all of it.

Also add a couple of "late private" fields to `internalModel`'s constructor for shape preservation.

Includes work from @igort and @sly7-7

[Fix #3296]
[Supercede #3301]
