### PR TITLE
Double background reload causes two requests

### DIFF
--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -13,6 +13,7 @@ var Person = DS.Model.extend({
   name: DS.attr('string'),
   cars: DS.hasMany('car', { async: false })
 });
+Person.reopenClass({ toString: () => 'Person' });
 
 var run = Ember.run;
 
@@ -21,6 +22,7 @@ var Car = DS.Model.extend({
   model: DS.attr('string'),
   person: DS.belongsTo('person', { async: false })
 });
+Car.reopenClass({ toString: () => 'Car' });
 
 function initializeStore(adapter) {
   env = setupStore({


### PR DESCRIPTION
```
    store.findRecord('car', 1, { backgroundReload: true });
    store.findRecord('car', 1, { backgroundReload: true });
```

Causes two requests to be sent.  This PR adds a failing test.  It will also add a fix, once we determine what the appropriate behaviour ought to be for all the various permutations between initial requests, reloads and background reloads.

When a request is made after another there are a couple of possible actions:

  - piggyback on prior request
  - cancel previous request; previous promise will fulfill with the new request's response


| First Request | Second Request | Action |
|---|---|---|
|Initial request (completed) | simple find | piggyback |
|Initial request (completed) | background reload | new request |
|Initial request (completed) | reload | new request |
|Initial request (in flight) | simple find | ? |
|Initial request (in flight) | background reload | ? |
|Initial request (in flight) | reload |? |
|background reload | simple find | ? |
|background reload| background reload | ? |
|background reload| reload |? |
|reload | simple find | ? |
|reload| background reload | ? |
|reload| reload |? |

Another possibility is to be completely indifferent about the source of the prior request and have a rule like: join the previous request if it's in the same runloop and cancel if in a subsequent runloop.

### Tasks

- [ ] decide what to do for combinations in matrix
- [ ] add fix to the test