### PR TITLE
Don't warn for 'async: false' relationships with link + data

### DIFF
--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -37,8 +37,6 @@ BelongsToRelationship.prototype.setCanonicalRecord = function(newRecord) {
     this.removeCanonicalRecord(this.canonicalState);
   }
   this.flushCanonicalLater();
-  this.setHasData(true);
-  this.setHasLoaded(true);
 };
 
 BelongsToRelationship.prototype._super$addCanonicalRecord = Relationship.prototype.addCanonicalRecord;
@@ -161,4 +159,9 @@ BelongsToRelationship.prototype.reload = function() {
   }
 
   return this.findRecord();
+};
+
+BelongsToRelationship.prototype.updateData = function(data) {
+  let internalModel = this.store._pushResourceIdentity(this, data);
+  this.setCanonicalRecord(internalModel);
 };

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -162,6 +162,6 @@ BelongsToRelationship.prototype.reload = function() {
 };
 
 BelongsToRelationship.prototype.updateData = function(data) {
-  let internalModel = this.store._pushResourceIdentity(this, data);
+  let internalModel = this.store._pushResourceIdentifier(this, data);
   this.setCanonicalRecord(internalModel);
 };

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -230,6 +230,11 @@ ManyRelationship.prototype.getRecords = function() {
   }
 };
 
+ManyRelationship.prototype.updateData = function(data) {
+  let internalModels = this.store._pushResourceIdentities(this, data);
+  this.updateRecordsFromAdapter(internalModels);
+};
+
 function setForArray(array) {
   var set = new OrderedSet();
 

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -231,7 +231,7 @@ ManyRelationship.prototype.getRecords = function() {
 };
 
 ManyRelationship.prototype.updateData = function(data) {
-  let internalModels = this.store._pushResourceIdentities(this, data);
+  let internalModels = this.store._pushResourceIdentifiers(this, data);
   this.updateRecordsFromAdapter(internalModels);
 };
 

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -255,7 +255,7 @@ Relationship.prototype = {
 
   updateLink(link) {
     heimdall.increment(updateLink);
-    warn(`You have pushed a record of type '${this.record.type.modelName}' with '${this.key}' as a link, but the association is not an async relationship.`, this.isAsync, {
+    warn(`You pushed a record of type '${this.record.type.modelName}' with a relationship '${this.key}' configured as 'async: false'. You've included a link but no primary data, this may be an error in your payload.`, this.isAsync || this.hasData , {
       id: 'ds.store.push-link-for-sync-relationship'
     });
     assert("You have pushed a record of type '" + this.record.type.modelName + "' with '" + this.key + "' as a link, but the value of that link is not a string.", typeof link === 'string' || link === null);

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2612,27 +2612,27 @@ Store = Service.extend({
     this.unloadAll();
   },
 
-  _pushResourceIdentity(relationship, resourceIdentity) {
-    if (isNone(resourceIdentity)) {
+  _pushResourceIdentifier(relationship, resourceIdentifier) {
+    if (isNone(resourceIdentifier)) {
       return;
     }
 
-    assert(`A ${relationship.parentType} record was pushed into the store with the value of ${relationship.key} being ${inspect(resourceIdentity)}, but ${relationship.key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(resourceIdentity));
+    assert(`A ${relationship.parentType} record was pushed into the store with the value of ${relationship.key} being ${inspect(resourceIdentifier)}, but ${relationship.key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(resourceIdentifier));
 
     //TODO:Better asserts
-    return this._internalModelForId(resourceIdentity.type, resourceIdentity.id);
+    return this._internalModelForId(resourceIdentifier.type, resourceIdentifier.id);
   },
 
-  _pushResourceIdentities(relationship, resourceIdentities) {
-    if (isNone(resourceIdentities)) {
+  _pushResourceIdentifiers(relationship, resourceIdentifiers) {
+    if (isNone(resourceIdentifiers)) {
       return;
     }
 
-    assert(`A ${relationship.parentType} record was pushed into the store with the value of ${relationship.key} being '${inspect(resourceIdentities)}', but ${relationship.key} is a hasMany relationship so the value must be an array. You should probably check your data payload or serializer.`, Array.isArray(resourceIdentities));
+    assert(`A ${relationship.parentType} record was pushed into the store with the value of ${relationship.key} being '${inspect(resourceIdentifiers)}', but ${relationship.key} is a hasMany relationship so the value must be an array. You should probably check your data payload or serializer.`, Array.isArray(resourceIdentifiers));
 
-    let _internalModels = new Array(resourceIdentities.length);
-    for (let i = 0; i < resourceIdentities.length; i++) {
-      _internalModels[i] = this._pushResourceIdentity(relationship, resourceIdentities[i]);
+    let _internalModels = new Array(resourceIdentifiers.length);
+    for (let i = 0; i < resourceIdentifiers.length; i++) {
+      _internalModels[i] = this._pushResourceIdentifier(relationship, resourceIdentifiers[i]);
     }
     return _internalModels;
   }

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -5,7 +5,6 @@
 import Ember from 'ember';
 import Model from 'ember-data/model';
 import { instrument, assert, deprecate, warn, runInDebug } from "ember-data/-private/debug";
-import _normalizeLink from "ember-data/-private/system/normalize-link";
 import normalizeModelName from "ember-data/-private/system/normalize-model-name";
 import { InvalidError } from 'ember-data/adapters/errors';
 
@@ -2611,34 +2610,33 @@ Store = Service.extend({
     this._instanceCache.destroy();
 
     this.unloadAll();
+  },
+
+  _pushResourceIdentity(relationship, resourceIdentity) {
+    if (isNone(resourceIdentity)) {
+      return;
+    }
+
+    assert(`A ${relationship.parentType} record was pushed into the store with the value of ${relationship.key} being ${inspect(resourceIdentity)}, but ${relationship.key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(resourceIdentity));
+
+    //TODO:Better asserts
+    return this._internalModelForId(resourceIdentity.type, resourceIdentity.id);
+  },
+
+  _pushResourceIdentities(relationship, resourceIdentities) {
+    if (isNone(resourceIdentities)) {
+      return;
+    }
+
+    assert(`A ${relationship.parentType} record was pushed into the store with the value of ${relationship.key} being '${inspect(resourceIdentities)}', but ${relationship.key} is a hasMany relationship so the value must be an array. You should probably check your data payload or serializer.`, Array.isArray(resourceIdentities));
+
+    let _internalModels = new Array(resourceIdentities.length);
+    for (let i = 0; i < resourceIdentities.length; i++) {
+      _internalModels[i] = this._pushResourceIdentity(relationship, resourceIdentities[i]);
+    }
+    return _internalModels;
   }
 });
-
-function deserializeRecordId(store, key, relationship, id) {
-  if (isNone(id)) {
-    return;
-  }
-
-  assert(`A ${relationship.parentType} record was pushed into the store with the value of ${key} being ${inspect(id)}, but ${key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(id));
-
-  //TODO:Better asserts
-  return store._internalModelForId(id.type, id.id);
-}
-
-function deserializeRecordIds(store, key, relationship, ids) {
-  if (isNone(ids)) {
-    return;
-  }
-
-  assert(`A ${relationship.parentType} record was pushed into the store with the value of ${key} being '${inspect(ids)}', but ${key} is a hasMany relationship so the value must be an array. You should probably check your data payload or serializer.`, Array.isArray(ids));
-  let _ids = new Array(ids.length);
-
-  for (let i = 0; i < ids.length; i++) {
-    _ids[i] = deserializeRecordId(store, key, relationship, ids[i]);
-  }
-
-  return _ids;
-}
 
 // Delegation to the adapter and promise management
 
@@ -2697,56 +2695,13 @@ function setupRelationships(store, record, data) {
   }
 
   record.type.eachRelationship((key, descriptor) => {
-    let kind = descriptor.kind;
-
     if (!data.relationships[key]) {
       return;
     }
 
-    let relationship;
-
-    if (data.relationships[key].links && data.relationships[key].links.related) {
-      let relatedLink = _normalizeLink(data.relationships[key].links.related);
-      if (relatedLink && relatedLink.href) {
-        relationship = record._relationships.get(key);
-        relationship.updateLink(relatedLink.href);
-      }
-    }
-
-    if (data.relationships[key].meta) {
-      relationship = record._relationships.get(key);
-      relationship.updateMeta(data.relationships[key].meta);
-    }
-
-    // If the data contains a relationship that is specified as an ID (or IDs),
-    // normalizeRelationship will convert them into DS.Model instances
-    // (possibly unloaded) before we push the payload into the store.
-    normalizeRelationship(store, key, descriptor, data.relationships[key]);
-
-    let value = data.relationships[key].data;
-
-    if (value !== undefined) {
-      if (kind === 'belongsTo') {
-        relationship = record._relationships.get(key);
-        relationship.setCanonicalRecord(value);
-      } else if (kind === 'hasMany') {
-        relationship = record._relationships.get(key);
-        relationship.updateRecordsFromAdapter(value);
-      }
-    }
+    let relationship = record._relationships.get(key);
+    relationship.push(data.relationships[key]);
   });
-}
-
-function normalizeRelationship(store, key, relationship, jsonPayload) {
-  let data = jsonPayload.data;
-  if (data) {
-    let kind = relationship.kind;
-    if (kind === 'belongsTo') {
-      jsonPayload.data = deserializeRecordId(store, key, relationship, data);
-    } else if (kind === 'hasMany') {
-      jsonPayload.data = deserializeRecordIds(store, key, relationship, data);
-    }
-  }
 }
 
 export { Store };


### PR DESCRIPTION
This PR moves most of the code from `store.setupRelationships()` to `relationship.push()` to be able to set the `hasData` and `hasLoaded` flags correctly depending on both data and links in the payload.

`relationship.push()` will also allow us to push the contents from a relationship's self link in the future.

Fixes #3393
