### PR TITLE
Warn when findRecord returns a different id than the one requested

### DIFF
--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assert } from "ember-data/-private/debug";
+import { assert, warn } from "ember-data/-private/debug";
 import {
   _bind,
   _guard,
@@ -38,6 +38,11 @@ export function _find(adapter, store, typeClass, id, internalModel, options) {
     return store._adapterRun(function() {
       var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, id, 'findRecord');
       assert('Ember Data expected the primary data returned from a `findRecord` response to be an object but instead it found an array.', !Array.isArray(payload.data));
+
+      warn(`You requested a record of type '${typeClass.modelName}' with id '${id}' but the adapter returned a payload with primary data having an id of '${payload.data.id}'. Looks like you want to use store.queryRecord instead http://emberjs.com/api/data/classes/DS.Store.html#method_queryRecord`, payload.data.id === id, {
+        id: 'ds.store.findRecord.id-mismatch'
+      });
+
       //TODO Optimize
       var record = store.push(payload);
       return record._internalModel;

--- a/tests/integration/adapter/find-test.js
+++ b/tests/integration/adapter/find-test.js
@@ -154,3 +154,17 @@ testInDebug('When multiple records are requested, and the payload is blank', (as
     });
   }, /You made a `findMany` request for person records with ids 1,2, but the adapter's response did not have any data/);
 });
+
+testInDebug("warns when returned record has different id", function(assert) {
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    findRecord() {
+      return { id: 1, name: "Braaaahm Dale" };
+    }
+  }));
+
+  assert.expectWarning(/You requested a record of type 'person' with id 'me' but the adapter returned a payload with primary data having an id of '1'/);
+
+  run(function() {
+    env.store.findRecord('person', 'me');
+  });
+});

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -102,7 +102,7 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
   env.adapter.findRecord = function(store, type, id, snapshot) {
     assert.ok(true, "The adapter's find method should be called");
     return Ember.RSVP.resolve({
-      id: 1
+      id
     });
   };
 

--- a/tests/unit/store/adapter-interop-test.js
+++ b/tests/unit/store/adapter-interop-test.js
@@ -128,7 +128,7 @@ test("IDs provided as numbers are coerced to strings", function(assert) {
   var adapter = TestAdapter.extend({
     findRecord(store, type, id, snapshot) {
       assert.equal(typeof id, 'string', "id has been normalized to a string");
-      return resolve({ id: 1, name: "Scumbag Sylvain" });
+      return resolve({ id, name: "Scumbag Sylvain" });
     }
   });
 


### PR DESCRIPTION
This addresses the problem stumbled over in #4414.

Basically we can't `assert` here as this would be a breaking change, since the bug mostly will not occur unless you try to reload the originally requested record again.

cc @igorT 