### PR TITLE
Fix dummy app serializer

### DIFF
--- a/tests/dummy/app/serializers/application.js
+++ b/tests/dummy/app/serializers/application.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  keyForRelationship(key) {
+    return key;
+  }
+});


### PR DESCRIPTION
We were not correctly deserializing relationships coming from the mock server,
because we try to dasherize by default.