### PR TITLE
[BUGFIX beta] Don't invoke findRecord for a new record with client side id

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -658,6 +658,12 @@ Store = Service.extend({
   },
 
   _findRecord(internalModel, options) {
+    // we can reach this code path when a new record is created with a client
+    // side id and this record is requested via `#findRecord(modelName, newRecord.get('id'))
+    if (internalModel.isNew()) {
+      return Promise.resolve(internalModel);
+    }
+
     // Refetch if the reload option is passed
     if (options.reload) {
       return this.scheduleFetch(internalModel, options);

--- a/tests/integration/adapter/find-test.js
+++ b/tests/integration/adapter/find-test.js
@@ -168,3 +168,33 @@ testInDebug("warns when returned record has different id", function(assert) {
     env.store.findRecord('person', 'me');
   });
 });
+
+test('findRecord() does not fetch a new record with client side id - GH#3678', function(assert) {
+  const done = assert.async();
+
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    shouldBackgroundReloadRecord() {
+      assert.ok(false, 'shouldBackgroundReloadRecord should not be called');
+    },
+
+    shouldReloadRecord() {
+      assert.ok(false, 'shouldReloadRecord should not be called');
+    },
+
+    findRecord() {
+      assert.ok(false, 'findRecord should not be called');
+    }
+  }));
+
+  run(function() {
+    let person = env.store.createRecord('person', {
+      id: 'client-side-id'
+    });
+
+    env.store.findRecord('person', person.get('id')).then(function(foundPerson) {
+      assert.deepEqual(foundPerson, person);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Addresses #3678

---

Do we want to warn when a `store.findRecord(modelName, newRecord.get("id"))` is called? Something like `You called store.findRecord to find a new record with a client side id. Use the record directly as store.findRecord should not be used for new records`?
