### PR TITLE
[PERF] HasMany doesn't need to inform RecordArrayManager

### DIFF
--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -174,7 +174,6 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
       //TODO(Igor) probably needed only for unloaded records
       this.relationship.notifyHasManyChanged();
     }
-    this.record.updateRecordArrays();
   },
 
   //TODO(Igor) optimize


### PR DESCRIPTION
At one point, relationships were managed by the recordArrayManager, this is no longer true. But we still spuriously inform the manager when we flush a relationship