### PR TITLE
[PERF] fix sub-optimal compiler output

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -466,7 +466,7 @@ export default class InternalModel {
       let attribute = changedAttributeNames[i];
       let data = changedAttributes[attribute];
       let oldData = data[0];
-      let newData = data[0];
+      let newData = data[1];
 
       if (oldData === newData) {
         delete attrs[attribute];

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -464,7 +464,9 @@ export default class InternalModel {
 
     for (let i = 0, length = changedAttributeNames.length; i < length; i++) {
       let attribute = changedAttributeNames[i];
-      let [oldData, newData] = changedAttributes[attribute];
+      let data = changedAttributes[attribute];
+      let oldData = data[0];
+      let newData = data[0];
 
       if (oldData === newData) {
         delete attrs[attribute];


### PR DESCRIPTION
given:

```js
let [a, b] = thing;
```

If it is not statically known to babel, it will assume an iterator may be present. At which the following code is omitted.

```js
var _changedAttributes$attribute = _slicedToArray(changedAttributes[attribute], 2);

var oldData = _changedAttributes$attribute[0];
var newData = _changedAttributes$attribute[1];
```

```js
  var _slicedToArray = (function () {
    function sliceIterator(arr, i) {
      var _arr = [];var _n = true;var _d = false;var _e = undefined;try {
        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
          _arr.push(_s.value);if (i && _arr.length === i) break;
        }
      } catch (err) {
        _d = true;_e = err;
      } finally {
        try {
          if (!_n && _i["return"]) _i["return"]();
        } finally {
          if (_d) throw _e;
        }
      }return _arr;
    }return function (arr, i) {
      if (Array.isArray(arr)) {
        return arr;
      } else if (Symbol.iterator in Object(arr)) {
        return sliceIterator(arr, i);
      } else {
        throw new TypeError("Invalid attempt to destructure non-iterable instance");
      }
    };
  })();
```

instead of the expected:

```js
let a = thing[0];
let b = thing[1];
```