### PR TITLE
[PERF backport to beta] fix sub-optimal compiler output (#4655)

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -349,7 +349,9 @@ InternalModel.prototype = {
 
     for (let i = 0, length = changedAttributeNames.length; i < length; i++) {
       let attribute = changedAttributeNames[i];
-      let [oldData, newData] = changedAttributes[attribute];
+      let data = changedAttributes[attribute];
+      let oldData = data[0];
+      let newData = data[1];
 
       if (oldData === newData) {
         delete this._attributes[attribute];


### PR DESCRIPTION
* [PERF] fix sub-optimal compiler output

given:

```js
let [a, b] = thing;
```

If it is not statically known to babel, it will assume an iterator may be present. At which the following code is omitted.

```js
  var _slicedToArray = (function () {
    function sliceIterator(arr, i) {
      var _arr = [];var _n = true;var _d = false;var _e = undefined;try {
        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
          _arr.push(_s.value);if (i && _arr.length === i) break;
        }
      } catch (err) {
        _d = true;_e = err;
      } finally {
        try {
          if (!_n && _i["return"]) _i["return"]();
        } finally {
          if (_d) throw _e;
        }
      }return _arr;
    }return function (arr, i) {
      if (Array.isArray(arr)) {
        return arr;
      } else if (Symbol.iterator in Object(arr)) {
        return sliceIterator(arr, i);
      } else {
        throw new TypeError("Invalid attempt to destructure non-iterable instance");
      }
    };
  })();
```

* Update internal-model.js