### PR TITLE
Fixed link

### DIFF
--- a/addon/-private/system/model/states.js
+++ b/addon/-private/system/model/states.js
@@ -162,7 +162,7 @@ import { assert } from "ember-data/-private/debug";
    * [isEmpty](DS.Model.html#property_isEmpty)
    * [isLoading](DS.Model.html#property_isLoading)
    * [isLoaded](DS.Model.html#property_isLoaded)
-   * [isDirty](DS.Model.html#property_isDirty)
+   * [hasDirtyAttributes](DS.Model.html#property_hasDirtyAttributes)
    * [isSaving](DS.Model.html#property_isSaving)
    * [isDeleted](DS.Model.html#property_isDeleted)
    * [isNew](DS.Model.html#property_isNew)

--- a/addon/-private/system/model/states.js
+++ b/addon/-private/system/model/states.js
@@ -162,7 +162,7 @@ import { assert } from "ember-data/-private/debug";
    * [isEmpty](DS.Model.html#property_isEmpty)
    * [isLoading](DS.Model.html#property_isLoading)
    * [isLoaded](DS.Model.html#property_isLoaded)
-   * [hasDirtyAttributes](DS.Model.html#property_hasDirtyAttributes)
+   * [isDirty](DS.Model.html#property_isDirty)
    * [isSaving](DS.Model.html#property_isSaving)
    * [isDeleted](DS.Model.html#property_isDeleted)
    * [isNew](DS.Model.html#property_isNew)


### PR DESCRIPTION
Replaced `isDirty` link for `hasDirtyAttributes` in the documentation of [DS.RootState](http://emberjs.com/api/data/classes/DS.RootState.html).