### PR TITLE
dirty check to prevent liveRecordArrays being rebuilt too often

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1596,10 +1596,10 @@ Store = Service.extend({
     heimdall.increment(peekAll);
     assert("You need to pass a model name to the store's peekAll method", isPresent(modelName));
     assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ Ember.inspect(modelName), typeof modelName === 'string');
-    var typeClass = this.modelFor(modelName);
+    let modelClass = this.modelFor(modelName);
+    let liveRecordArray = this.recordArrayManager.liveRecordArrayFor(modelClass);
 
-    var liveRecordArray = this.recordArrayManager.liveRecordArrayFor(typeClass);
-    this.recordArrayManager.populateLiveRecordArray(liveRecordArray, typeClass);
+    this.recordArrayManager.syncLiveRecordArray(liveRecordArray, modelClass);
 
     return liveRecordArray;
   },


### PR DESCRIPTION
Every call to `peekAll` currently forces us to completely rebuild the live array. This is a stop gap until recordArrayManager can be improved ( @stefanpenner and I have been brainstorming our way through how to improve it.).

