### PR TITLE
Upgraded IdentityMap and RecordMap

### DIFF
--- a/addon/-private/system/identity-map.js
+++ b/addon/-private/system/identity-map.js
@@ -1,0 +1,49 @@
+import RecordMap from './record-map';
+
+/**
+ `IdentityMap` is a custom storage map for records by modelName
+ used by `DS.Store`.
+
+ @class IdentityMap
+ @private
+ */
+export default class IdentityMap {
+  constructor() {
+    this._map = Object.create(null);
+  }
+
+  /**
+   Retrieves the `RecordMap` for a given modelName,
+   creating one if one did not already exist. This is
+   similar to `getWithDefault` or `get` on a `MapWithDefault`
+
+   @method retrieve
+   @param modelName a previously normalized modelName
+   @returns {RecordMap} the RecordMap for the given modelName
+   */
+  retrieve(modelName) {
+    let recordMap = this._map[modelName];
+
+    if (!recordMap) {
+      recordMap = this._map[modelName] = new RecordMap(modelName);
+    }
+
+    return recordMap;
+  }
+
+  /**
+   Clears the contents of all known `RecordMaps`, but does
+   not remove the RecordMap instances.
+
+   @method clear
+   */
+  clear() {
+    let recordMaps = this._map;
+    let keys = Object.keys(recordMaps);
+
+    for (let i = 0; i < keys.length; i++) {
+      let key = keys[i];
+      recordMaps[key].clear();
+    }
+  }
+}

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -87,6 +87,8 @@ const {
   'updateChangedAttributes'
 );
 
+let InternalModelReferenceId = 1;
+
 /*
   `InternalModel` is the Model class that we use internally inside Ember Data to represent models.
   Internal ED methods should only deal with `InternalModel` objects. It is a fast, plain Javascript class.
@@ -104,13 +106,13 @@ const {
   @class InternalModel
 */
 export default class InternalModel {
-  constructor(modelClass, id, store, data) {
+  constructor(modelName, id, store, data) {
     heimdall.increment(new_InternalModel);
-    this.modelClass = modelClass;
     this.id = id;
+    this._internalId = InternalModelReferenceId++;
     this.store = store;
     this._data = data || new EmptyObject();
-    this.modelName = modelClass.modelName;
+    this.modelName = modelName;
     this.dataHasInitialized = false;
     this._loadingPromise = null;
     this._recordArrays = undefined;
@@ -122,6 +124,7 @@ export default class InternalModel {
     this.error = null;
 
     // caches for lazy getters
+    this._modelClass = null;
     this.__deferredTriggers = null;
     this._references = null;
     this._recordReference = null;
@@ -129,6 +132,10 @@ export default class InternalModel {
     this.__relationships = null;
     this.__attributes = null;
     this.__implicitRelationships = null;
+  }
+
+  get modelClass() {
+    return this._modelClass || (this._modelClass = this.store.modelFor(this.modelName));
   }
 
   get type() {
@@ -778,7 +785,7 @@ export default class InternalModel {
   */
   updateRecordArrays() {
     this._updatingRecordArraysLater = false;
-    this.store.dataWasUpdated(this.modelClass, this);
+    this.store._dataWasUpdated(this);
   }
 
   setId(id) {

--- a/addon/-private/system/record-arrays/adapter-populated-record-array.js
+++ b/addon/-private/system/record-arrays/adapter-populated-record-array.js
@@ -56,16 +56,14 @@ export default RecordArray.extend({
   },
 
   replace() {
-    let type = get(this, 'type').toString();
-    throw new Error(`The result of a server query (on ${type}) is immutable.`);
+    throw new Error(`The result of a server query (on ${this.modelName}) is immutable.`);
   },
 
   _update() {
     let store = get(this, 'store');
-    let modelName = get(this, 'type.modelName');
     let query = get(this, 'query');
 
-    return store._query(modelName, query, this);
+    return store._query(this.modelName, query, this);
   },
 
   /**
@@ -89,7 +87,7 @@ export default RecordArray.extend({
       links: cloneNull(payload.links)
     });
 
-    internalModels.forEach(record => this.manager.recordArraysForRecord(record).add(this));
+    internalModels.forEach(internalModel => this.manager.recordArraysForRecord(internalModel).add(this));
 
     // TODO: should triggering didLoad event be the last action of the runLoop?
     Ember.run.once(this, 'trigger', 'didLoad');

--- a/addon/-private/system/record-arrays/filtered-record-array.js
+++ b/addon/-private/system/record-arrays/filtered-record-array.js
@@ -52,8 +52,7 @@ export default RecordArray.extend({
   */
 
   replace() {
-    let type = get(this, 'type').toString();
-    throw new Error(`The result of a client-side filter (on ${type}) is immutable.`);
+    throw new Error(`The result of a client-side filter (on ${this.modelName}) is immutable.`);
   },
 
   /**
@@ -64,7 +63,7 @@ export default RecordArray.extend({
     if (get(this, 'isDestroying') || get(this, 'isDestroyed')) {
       return;
     }
-    get(this, 'manager').updateFilter(this, get(this, 'type'), get(this, 'filterFunction'));
+    get(this, 'manager').updateFilter(this, this.modelName, get(this, 'filterFunction'));
   },
 
   updateFilter: Ember.observer('filterFunction', function() {

--- a/addon/-private/system/record-arrays/record-array.js
+++ b/addon/-private/system/record-arrays/record-array.js
@@ -5,11 +5,10 @@
 import Ember from 'ember';
 import { PromiseArray } from "ember-data/-private/system/promise-proxies";
 import SnapshotRecordArray from "ember-data/-private/system/snapshot-record-array";
-
-const { get, set, RSVP: { Promise } } = Ember;
+const { computed, get, set, RSVP: { Promise } } = Ember;
 
 /**
-  A record array is an array that contains records of a certain type. The record
+  A record array is an array that contains records of a certain modelName. The record
   array materializes records as needed when they are retrieved for the first
   time. You should not create record arrays yourself. Instead, an instance of
   `DS.RecordArray` or its subclasses will be returned by your application's store
@@ -24,14 +23,6 @@ const { get, set, RSVP: { Promise } } = Ember;
 export default Ember.ArrayProxy.extend(Ember.Evented, {
   init() {
     this._super(...arguments);
-
-    /**
-      The model type contained by this record array.
-
-      @property type
-      @type DS.Model
-      */
-    this.type = this.type || null;
 
     /**
       The array of client ids backing the record array. When a
@@ -88,9 +79,21 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
   },
 
   replace() {
-    let type = get(this, 'type').toString();
-    throw new Error(`The result of a server query (for all ${type} types) is immutable. To modify contents, use toArray()`);
+    throw new Error(`The result of a server query (for all ${this.modelName} types) is immutable. To modify contents, use toArray()`);
   },
+
+  /**
+   The modelClass represented by this record array.
+
+   @property type
+   @type DS.Model
+   */
+  type: computed.readOnly('modelName', function() {
+    if (!this.modelName) {
+      return null;
+    }
+    return this.store.modelFor(this.modelName);
+  }),
 
   /**
     Retrieves an object from the content by index.
@@ -145,10 +148,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     is finished.
    */
   _update() {
-    let store = get(this, 'store');
-    let modelName = get(this, 'type.modelName');
-
-    return store.findAll(modelName, { reload: true });
+    return this.store.findAll(this.modelName, { reload: true });
   },
 
   /**
@@ -193,9 +193,9 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     @return {DS.PromiseArray} promise
   */
   save() {
-    let promiseLabel = 'DS: RecordArray#save ' + get(this, 'type');
-    let promise = Promise.all(this.invoke('save'), promiseLabel).
-      then(() => this, null, 'DS: RecordArray#save return RecordArray');
+    let promiseLabel = `DS: RecordArray#save ${this.modelName}`;
+    let promise = Promise.all(this.invoke('save'), promiseLabel)
+      .then(() => this, null, 'DS: RecordArray#save return RecordArray');
 
     return PromiseArray.create({ promise });
   },

--- a/addon/-private/system/record-arrays/record-array.js
+++ b/addon/-private/system/record-arrays/record-array.js
@@ -88,12 +88,12 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
    @property type
    @type DS.Model
    */
-  type: computed.readOnly('modelName', function() {
+  type: computed('modelName', function() {
     if (!this.modelName) {
       return null;
     }
     return this.store.modelFor(this.modelName);
-  }),
+  }).readOnly(),
 
   /**
     Retrieves an object from the content by index.

--- a/addon/-private/system/record-map.js
+++ b/addon/-private/system/record-map.js
@@ -1,0 +1,134 @@
+import { assert, deprecate } from "ember-data/-private/debug";
+import InternalModel from './model/internal-model';
+
+/**
+ `RecordMap` is a custom storage map for records of a given modelName
+ used by `IdentityMap`.
+
+ It was extracted from an implicit pojo based "record map" and preserves
+ that interface while we work towards a more official API.
+
+ @class RecordMap
+ @private
+ */
+export default class RecordMap {
+  constructor(modelName) {
+    this.modelName = modelName;
+    this._idToRecord = Object.create(null);
+    this._records = [];
+    this._metadata = null;
+  }
+
+  /**
+    A "map" of records based on their ID for this modelName
+   */
+  get idToRecord() {
+    deprecate('Use of RecordMap.idToRecord is deprecated, use RecordMap.get(id) instead.', false, {
+      id: 'ds.record-map.idToRecord',
+      until: '2.13'
+    });
+    return this._idToRecord;
+  }
+
+  /**
+   *
+   * @param id
+   * @returns {InternalModel}
+   */
+  get(id) {
+    let r = this._idToRecord[id];
+    return r;
+  }
+
+  has(id) {
+    return !!this._idToRecord[id];
+  }
+
+  get length() {
+    return this._records.length;
+  }
+
+  set(id, internalModel) {
+    assert(`You cannot index an internalModel by an empty id'`, id);
+    assert(`You cannot set an index for an internalModel to something other than an internalModel`, internalModel instanceof InternalModel);
+    assert(`You cannot set an index for an internalModel that is not in the RecordMap`, this.contains(internalModel));
+    assert(`You cannot update the id index of an InternalModel once set. Attempted to update ${id}.`, !this.has(id) || this.get(id) === internalModel);
+
+    this._idToRecord[id] = internalModel;
+  }
+
+  add(internalModel, id) {
+    assert(`You cannot re-add an already present InternalModel to the RecordMap.`, !this.contains(internalModel));
+
+    if (id) {
+      this._idToRecord[id] = internalModel;
+    }
+
+    this._records.push(internalModel);
+  }
+
+  remove(internalModel, id) {
+    if (id) {
+      delete this._idToRecord[id];
+    }
+
+    let loc = this._records.indexOf(internalModel);
+
+    if (loc !== -1) {
+      this._records.splice(loc, 1);
+    }
+  }
+
+  contains(internalModel) {
+    return this._records.indexOf(internalModel) !== -1;
+  }
+
+  /**
+   An array of all records of this modelName
+   */
+  get records() {
+    return this._records;
+  }
+
+  /**
+   * meta information about records
+   */
+  get metadata() {
+    return this._metadata || (this._metadata = Object.create(null));
+  }
+
+  /**
+   deprecated (and unsupported) way of accessing modelClass
+
+   @deprecated
+   */
+  get type() {
+    throw new Error('RecordMap.type is no longer available');
+  }
+
+  /**
+   Destroy all records in the recordMap and wipe metadata.
+
+   @method clear
+   */
+  clear() {
+    if (this._records) {
+      let records = this._records;
+      this._records = [];
+      let record;
+
+      for (let i = 0; i < records.length; i++) {
+        record = records[i];
+        record.unloadRecord();
+        record.destroy(); // maybe within unloadRecord
+      }
+    }
+
+    this._metadata = null;
+  }
+
+  destroy() {
+    this._store = null;
+    this._modelClass = null;
+  }
+}

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -73,8 +73,7 @@ export function _findMany(adapter, store, typeClass, ids, internalModels) {
     assert("You made a `findMany` request for " + typeClass.modelName + " records with ids " + ids + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       let payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findMany');
-      let internalModels = store._push(payload);
-      return internalModels;
+      return store._push(payload);
     });
   }, null, "DS: Extract payload of " + typeClass);
 }
@@ -94,10 +93,10 @@ export function _findHasMany(adapter, store, internalModel, link, relationship) 
     assert("You made a `findHasMany` request for a " + internalModel.modelName + "'s `" + relationship.key + "` relationship, using link " + link + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
     return store._adapterRun(function() {
       let payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findHasMany');
-      let recordArray = store._push(payload);
+      let internalModelArray = store._push(payload);
 
-      recordArray.meta = payload.meta;
-      return recordArray;
+      internalModelArray.meta = payload.meta;
+      return internalModelArray;
     });
   }, null, "DS: Extract payload of " + internalModel + " : hasMany " + relationship.type);
 }
@@ -121,8 +120,7 @@ export function _findBelongsTo(adapter, store, internalModel, link, relationship
         return null;
       }
 
-      var internalModel = store._push(payload);
-      return internalModel;
+      return store._push(payload);
     });
   }, null, "DS: Extract payload of " + internalModel + " : " + relationship.type);
 }
@@ -145,7 +143,7 @@ export function _findAll(adapter, store, typeClass, sinceToken, options) {
       store._push(payload);
     });
 
-    store.didUpdateAll(typeClass);
+    store.didUpdateAll(modelName);
     return store.peekAll(modelName);
   }, null, "DS: Extract payload of findAll " + typeClass);
 }

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -557,9 +557,9 @@ test("createRecord - response can contain relationships the client doesn't yet k
   run(function() {
     post.save().then(assert.wait(function(post) {
       assert.equal(post.get('comments.firstObject.post'), post, "the comments are related to the correct post model");
-      assert.equal(store.typeMapFor(Post).records.length, 1, "There should only be one post record in the store");
+      assert.equal(store._recordMapFor('post').records.length, 1, "There should only be one post record in the store");
 
-      var postRecords = store.typeMapFor(Post).records;
+      var postRecords = store._recordMapFor('post').records;
       for (var i = 0; i < postRecords.length; i++) {
         assert.equal(post, postRecords[i].getRecord(), "The object in the identity map is the same");
       }

--- a/tests/integration/client-id-generation-test.js
+++ b/tests/integration/client-id-generation-test.js
@@ -77,6 +77,7 @@ test("empty string and undefined ids should coerce to null", function(assert) {
   assert.expect(6);
   var comment, post;
   var idCount = 0;
+  let id = 1;
   var ids = [undefined, ''];
   env.adapter.generateIdForRecord = function(passedStore, record) {
     assert.equal(env.store, passedStore, "store is the first parameter");
@@ -86,7 +87,7 @@ test("empty string and undefined ids should coerce to null", function(assert) {
 
   env.adapter.createRecord = function(store, type, record) {
     assert.equal(typeof get(record, 'id'), 'object', 'correct type');
-    return Ember.RSVP.resolve({ id: 1 });
+    return Ember.RSVP.resolve({ id: id++ });
   };
 
   run(function() {

--- a/tests/integration/record-array-manager-test.js
+++ b/tests/integration/record-array-manager-test.js
@@ -93,10 +93,10 @@ test('destroying the store correctly cleans everything up', function(assert) {
     person = store.peekRecord('person', 1);
   });
 
-  let filterd = manager.createFilteredRecordArray(Person, () => true);
-  let filterd2 = manager.createFilteredRecordArray(Person, () => true);
+  let filterd = manager.createFilteredRecordArray('person', () => true);
+  let filterd2 = manager.createFilteredRecordArray('person', () => true);
   let all = store.peekAll('person');
-  let adapterPopulated = manager.createAdapterPopulatedRecordArray(Person, query);
+  let adapterPopulated = manager.createAdapterPopulatedRecordArray('person', query);
 
   let filterdSummary = tap(filterd, 'willDestroy');
   let filterd2Summary = tap(filterd2, 'willDestroy');
@@ -117,13 +117,13 @@ test('destroying the store correctly cleans everything up', function(assert) {
   assert.equal(manager.recordArraysForRecord(internalPersonModel).size, 2, 'expected the person to be a member of 2 recordArrays');
   assert.equal(filterd2Summary.called.length, 1);
 
-  assert.equal(manager.liveRecordArrays.has(all.type), true);
+  assert.equal(manager.liveRecordArrays.has('person'), true);
 
   Ember.run(all, all.destroy);
 
   assert.equal(manager.recordArraysForRecord(internalPersonModel).size, 1, 'expected the person to be a member of 1 recordArrays');
   assert.equal(allSummary.called.length, 1);
-  assert.equal(manager.liveRecordArrays.has(all.type), false);
+  assert.equal(manager.liveRecordArrays.has('person'), false);
 
   Ember.run(manager, manager.destroy);
 
@@ -185,7 +185,7 @@ test('#GH-4041 store#query AdapterPopulatedRecordArrays are removed from their m
 
   const query = {};
 
-  let adapterPopulated = manager.createAdapterPopulatedRecordArray(Car, query);
+  let adapterPopulated = manager.createAdapterPopulatedRecordArray('car', query);
 
   run(() => adapterPopulated.destroy());
 

--- a/tests/integration/record-arrays/adapter-populated-record-array-test.js
+++ b/tests/integration/record-arrays/adapter-populated-record-array-test.js
@@ -33,7 +33,7 @@ module('integration/record-arrays/adapter_populated_record_array - DS.AdapterPop
 
 test('when a record is deleted in an adapter populated record array, it should be removed', function(assert) {
   let recordArray = store.recordArrayManager
-    .createAdapterPopulatedRecordArray(store.modelFor('person'), null);
+    .createAdapterPopulatedRecordArray('person', null);
 
   let payload = {
     data: [
@@ -74,7 +74,7 @@ test('when a record is deleted in an adapter populated record array, it should b
 
 test('stores the metadata off the payload', function(assert) {
   let recordArray = store.recordArrayManager
-    .createAdapterPopulatedRecordArray(Person, null);
+    .createAdapterPopulatedRecordArray('person', null);
 
   let payload = {
     data: [
@@ -114,7 +114,7 @@ test('stores the metadata off the payload', function(assert) {
 
 test('stores the links off the payload', function(assert) {
   let recordArray = store.recordArrayManager
-      .createAdapterPopulatedRecordArray(store.modelFor('person'), null);
+      .createAdapterPopulatedRecordArray('person', null);
 
   let payload = {
     data: [
@@ -154,11 +154,11 @@ test('stores the links off the payload', function(assert) {
 
 test('recordArray.replace() throws error', function(assert) {
   let recordArray = store.recordArrayManager
-    .createAdapterPopulatedRecordArray(Person, null);
+    .createAdapterPopulatedRecordArray('person', null);
 
   assert.throws(() => {
     recordArray.replace();
-  }, Error('The result of a server query (on (subclass of DS.Model)) is immutable.'), 'throws error');
+  }, Error('The result of a server query (on person) is immutable.'), 'throws error');
 });
 
 test('loadRecord re-syncs internalModels recordArrays', function(assert) {

--- a/tests/unit/model/relationships/record-array-test.js
+++ b/tests/unit/model/relationships/record-array-test.js
@@ -12,16 +12,17 @@ var run = Ember.run;
 module("unit/model/relationships - RecordArray");
 
 test("updating the content of a RecordArray updates its content", function(assert) {
-  var Tag = DS.Model.extend({
+  let Tag = DS.Model.extend({
     name: DS.attr('string')
   });
 
-  var env = setupStore({ tag: Tag });
-  var store = env.store;
-  var records, tags, internalModel;
+  let env = setupStore({ tag: Tag });
+  let store = env.store;
+  let tags;
+  let internalModels;
 
   run(function() {
-    store.push({
+    internalModels = store._push({
       data: [{
         type: 'tag',
         id: '5',
@@ -42,16 +43,18 @@ test("updating the content of a RecordArray updates its content", function(asser
         }
       }]
     });
-    records = store.peekAll('tag');
-    internalModel = Ember.A(records).mapBy('_internalModel');
-    tags = DS.RecordArray.create({ content: Ember.A(internalModel.slice(0, 2)), store: store, type: Tag });
+    tags = DS.RecordArray.create({
+      content: Ember.A(internalModels.slice(0, 2)),
+      store: store,
+      modelName: 'tag'
+    });
   });
 
-  var tag = tags.objectAt(0);
+  let tag = tags.objectAt(0);
   assert.equal(get(tag, 'name'), "friendly", "precond - we're working with the right tags");
 
   run(function() {
-    set(tags, 'content', Ember.A(internalModel.slice(1, 3)));
+    set(tags, 'content', Ember.A(internalModels.slice(1, 3)));
   });
 
   tag = tags.objectAt(0);

--- a/tests/unit/record-arrays/adapter-populated-record-array-test.js
+++ b/tests/unit/record-arrays/adapter-populated-record-array-test.js
@@ -23,10 +23,10 @@ function internalModelFor(record) {
 }
 
 test('default initial state', function(assert) {
-  let recordArray = AdapterPopulatedRecordArray.create({ type: 'recordType' });
+  let recordArray = AdapterPopulatedRecordArray.create({ modelName: 'recordType' });
 
   assert.equal(recordArray.get('isLoaded'), false, 'expected isLoaded to be false');
-  assert.equal(recordArray.get('type'), 'recordType');
+  assert.equal(recordArray.get('modelName'), 'recordType');
   assert.deepEqual(recordArray.get('content'), []);
   assert.equal(recordArray.get('query'), null);
   assert.equal(recordArray.get('store'), null);
@@ -37,17 +37,17 @@ test('custom initial state', function(assert) {
   let content = Ember.A([]);
   let store = {};
   let recordArray = AdapterPopulatedRecordArray.create({
-    type: 'apple',
+    modelName: 'apple',
     isLoaded: true,
     isUpdating: true,
     content,
     store,
     query: 'some-query',
     links: 'foo'
-  })
+  });
   assert.equal(recordArray.get('isLoaded'), true);
   assert.equal(recordArray.get('isUpdating'), false);
-  assert.equal(recordArray.get('type'), 'apple');
+  assert.equal(recordArray.get('modelName'), 'apple');
   assert.equal(recordArray.get('content'), content);
   assert.equal(recordArray.get('store'), store);
   assert.equal(recordArray.get('query'), 'some-query');
@@ -55,7 +55,7 @@ test('custom initial state', function(assert) {
 });
 
 test('#replace() throws error', function(assert) {
-  let recordArray = AdapterPopulatedRecordArray.create({ type: 'recordType' });
+  let recordArray = AdapterPopulatedRecordArray.create({ modelName: 'recordType' });
 
   assert.throws(() => {
     recordArray.replace();
@@ -78,7 +78,7 @@ test('#update uses _update enabling query specific behavior', function(assert) {
   };
 
   let recordArray = AdapterPopulatedRecordArray.create({
-    type: { modelName: 'recordType' },
+    modelName: 'recordType',
     store,
     query: 'some-query'
   });

--- a/tests/unit/record-arrays/filtered-record-array-test.js
+++ b/tests/unit/record-arrays/filtered-record-array-test.js
@@ -9,10 +9,10 @@ const { FilteredRecordArray } = DS;
 module('unit/record-arrays/filtered-record-array - DS.FilteredRecordArray');
 
 test('default initial state', function(assert) {
-  let recordArray = FilteredRecordArray.create({ type: 'recordType' });
+  let recordArray = FilteredRecordArray.create({ modelName: 'recordType' });
 
   assert.equal(get(recordArray, 'isLoaded'), true);
-  assert.equal(get(recordArray, 'type'), 'recordType');
+  assert.equal(get(recordArray, 'modelName'), 'recordType');
   assert.equal(get(recordArray, 'content'), null);
   assert.equal(get(recordArray, 'filterFunction'), null);
   assert.equal(get(recordArray, 'store'), null);
@@ -23,23 +23,23 @@ test('custom initial state', function(assert) {
   let store = {};
   let filterFunction = () => true;
   let recordArray = FilteredRecordArray.create({
-    type: 'apple',
+    modelName: 'apple',
     isLoaded: false, // ignored
     isUpdating: true,
     content,
     store,
     filterFunction
-  })
+  });
   assert.equal(get(recordArray, 'isLoaded'), true);
   assert.equal(get(recordArray, 'isUpdating'), false); // cannot set as default value:
-  assert.equal(get(recordArray, 'type'), 'apple');
+  assert.equal(get(recordArray, 'modelName'), 'apple');
   assert.equal(get(recordArray, 'content'), content);
   assert.equal(get(recordArray, 'store'), store);
   assert.equal(get(recordArray, 'filterFunction'), filterFunction);
 });
 
 test('#replace() throws error', function(assert) {
-  let recordArray = FilteredRecordArray.create({ type: 'recordType' });
+  let recordArray = FilteredRecordArray.create({ modelName: 'recordType' });
 
   assert.throws(function() {
     recordArray.replace();
@@ -51,17 +51,17 @@ test('updateFilter', function(assert) {
   const updatedFilterFunction = () => true;
 
   const manager = {
-    updateFilter(array, type, filterFunction) {
+    updateFilter(array, modelName, filterFunction) {
       didUpdateFilter++;
       assert.equal(recordArray, array);
-      assert.equal(type, 'recordType');
+      assert.equal(modelName, 'recordType');
       assert.equal(filterFunction, updatedFilterFunction);
     },
     unregisterRecordArray() {}
   };
 
   let recordArray = FilteredRecordArray.create({
-    type: 'recordType',
+    modelName: 'recordType',
     manager,
     content: Ember.A()
   });
@@ -86,4 +86,4 @@ test('updateFilter', function(assert) {
   });
 
   assert.equal(didUpdateFilter, 0, 'record array manager should not be informed of this change');
-})
+});

--- a/tests/unit/record-arrays/record-array-test.js
+++ b/tests/unit/record-arrays/record-array-test.js
@@ -8,11 +8,11 @@ const { RecordArray } = DS;
 module('unit/record-arrays/record-array - DS.RecordArray');
 
 test('default initial state', function(assert) {
-  let recordArray = RecordArray.create({ type: 'recordType' });
+  let recordArray = RecordArray.create({ modelName: 'recordType' });
 
   assert.equal(get(recordArray, 'isLoaded'), false);
   assert.equal(get(recordArray, 'isUpdating'), false);
-  assert.equal(get(recordArray, 'type'), 'recordType');
+  assert.equal(get(recordArray, 'modelName'), 'recordType');
   assert.equal(get(recordArray, 'content'), null);
   assert.equal(get(recordArray, 'store'), null);
 });
@@ -21,21 +21,21 @@ test('custom initial state', function(assert) {
   let content = Ember.A();
   let store = {};
   let recordArray = RecordArray.create({
-    type: 'apple',
+    modelName: 'apple',
     isLoaded: true,
     isUpdating: true,
     content,
     store
-  })
+  });
   assert.equal(get(recordArray, 'isLoaded'), true);
   assert.equal(get(recordArray, 'isUpdating'), false); // cannot set as default value:
-  assert.equal(get(recordArray, 'type'), 'apple');
+  assert.equal(get(recordArray, 'modelName'), 'apple');
   assert.equal(get(recordArray, 'content'), content);
   assert.equal(get(recordArray, 'store'), store);
 });
 
 test('#replace() throws error', function(assert) {
-  let recordArray = RecordArray.create({ type: 'recordType' });
+  let recordArray = RecordArray.create({ modelName: 'recordType' });
 
   assert.throws(function() {
     recordArray.replace();
@@ -50,7 +50,7 @@ test('#objectAtContent', function(assert) {
   ]);
 
   let recordArray = RecordArray.create({
-    type: 'recordType',
+    modelName: 'recordType',
     content
   });
 
@@ -76,7 +76,7 @@ test('#update', function(assert) {
   };
 
   let recordArray = RecordArray.create({
-    type: { modelName: 'recordType' },
+    modelName: 'recordType',
     store
   });
 
@@ -110,7 +110,7 @@ test('#update while updating', function(assert) {
   };
 
   let recordArray = RecordArray.create({
-    type: { modelName: 'recordType' },
+    modelName: { modelName: 'recordType' },
     store
   });
 

--- a/tests/unit/store/adapter-interop-test.js
+++ b/tests/unit/store/adapter-interop-test.js
@@ -367,7 +367,7 @@ testInDebug("a new record with a specific id can't be created if this id is alre
     run(function() {
       store.createRecord('person', { id: 5 });
     });
-  }, /The id 5 has already been used with another record for modelClass Person/);
+  }, /The id 5 has already been used with another record for modelClass 'person'/);
 });
 
 test("an initial data hash can be provided via store.createRecord(type, hash)", function(assert) {

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -766,6 +766,23 @@ test("_push returns an instance of InternalModel if an object is pushed", functi
   assert.notOk(pushResult.record, 'InternalModel is not materialized');
 });
 
+test("_push does not require a modelName to resolve to a modelClass", function(assert) {
+  let originalCall = store.modelFor;
+  store.modelFor = () => { assert.notOk('modelFor was triggered as a result of a call to store._push'); };
+
+  run(function() {
+    store._push({
+      data: {
+        id: 1,
+        type: 'person'
+      }
+    });
+  });
+
+  store.modelFor = originalCall;
+  assert.ok('We made it');
+});
+
 test("_push returns an array of InternalModels if an array is pushed", function(assert) {
   let pushResult;
 


### PR DESCRIPTION
When pushing records into the store (no materialization), we only needed to load the associated modelClass for "key" purposes. This PR shifts ember-data to consistently using a normalized `modelName` as the key, making it possible to push internal models, assemble record arrays, and (potentially in the future) even make requests without any access to the modelClass.

Step two of this effort (a separate PR) will be to enable the parsing of `modelClass` to avoid needing to load the classes for related models.  Combined, this gives us a happy story for initial render in apps with pre-loaded data and complicated relationship graphs.

In addition, this paved an easier path forward for #4584

- [x] refactor typeMap => recordMap
- [x] refactor to using modelName instead of guid as the class identifier for recordMap.
- [x] refactor InternalModel to not need `modelClass` at instantiation.
- [x] remove calls to `modelFor` where now possible
- [x] remove `typeMapFor`
- [x] consider deprecation notices for `InternalModel` and `buildInternalModel` in case private APIs were abusing them and now need to refactor from `modelClass` to `modelName`.

- (will be separate PR, but needed to complete this effort) refactor relationship setup to not need to lookup the related modelClass to prevent "pulling the string" on the entire graph.

**UPDATES**

I believe this is ready to ship but want to document a few things:

- `ClassMeta` is not unit tested (yet) but it is implicitly tested as it exposes an identical interface to the pojo that was our `TypeMap` before.
- @stefanpenner rightly points out areas we should be doing more to encapsulate things in this class, but this should be a follow up PR (that also moves to direct unit testing)
- A temporary compromise has been made to give `store` to `new ClassMeta(store)` instead of `owner` in order to support the ability for it to resolve the `modelClass` via `store.modelFor`.  Longer term this should be `owner` `store.modelFor` should instead use `classMeta.modelClass` to resolve the modelClass if necessary.
- with this PR, `_push` does not require `modelClass` at all. The relationship PR is related to this "lazy push" story but is not required for it.