### PR TITLE
Deprecate store.recordIsLoaded

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1025,20 +1025,31 @@ Store = Service.extend({
   },
 
   /**
-    Returns true if a record for a given type and ID is already loaded.
+   This method returns true if a record for a given modelName and id is already
+   loaded in the store. Use this function to know beforehand if a findRecord()
+   will result in a request or that it will be a cache hit.
+
+   Example
+
+   ```javascript
+   store.hasRecordForId('post', 1); // false
+   store.findRecord('post', 1).then(function() {
+      store.hasRecordForId('post', 1); // true
+    });
+   ```
 
     @method hasRecordForId
     @param {(String|DS.Model)} modelName
-    @param {(String|Integer)} inputId
+    @param {(String|Integer)} id
     @return {Boolean}
   */
-  hasRecordForId(modelName, inputId) {
+  hasRecordForId(modelName, id) {
     assert("You need to pass a model name to the store's hasRecordForId method", isPresent(modelName));
     assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ inspect(modelName), typeof modelName === 'string');
 
-    let id = coerceId(inputId);
+    let trueId = coerceId(id);
     let modelClass = this.modelFor(modelName);
-    let internalModel = this.typeMapFor(modelClass).idToRecord[id];
+    let internalModel = this.typeMapFor(modelClass).idToRecord[trueId];
 
     return !!internalModel && internalModel.isLoaded();
   },
@@ -1750,27 +1761,20 @@ Store = Service.extend({
   },
 
   /**
-    This method returns if a certain record is already loaded
-    in the store. Use this function to know beforehand if a findRecord()
-    will result in a request or that it will be a cache hit.
+    This method has been deprecated and is an alias for store.hasRecordForId, which should
+    be used instead.
 
-     Example
-
-    ```javascript
-    store.recordIsLoaded('post', 1); // false
-    store.findRecord('post', 1).then(function() {
-      store.recordIsLoaded('post', 1); // true
-    });
-    ```
-
+    @deprecated
     @method recordIsLoaded
     @param {String} modelName
     @param {string} id
     @return {boolean}
   */
   recordIsLoaded(modelName, id) {
-    assert("You need to pass a model name to the store's recordIsLoaded method", isPresent(modelName));
-    assert('Passing classes to store methods has been removed. Please pass a dasherized string instead of '+ inspect(modelName), typeof modelName === 'string');
+    deprecate(`Use of recordIsLoaded is deprecated, use hasRecordForId instead.`, {
+      id: 'ds.store.recordIsLoaded',
+      until: '3.0'
+    });
     return this.hasRecordForId(modelName, id);
   },
 

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -953,10 +953,10 @@ module("unit/model - with a simple Person model", {
 });
 
 test("can ask if record with a given id is loaded", function(assert) {
-  assert.equal(store.recordIsLoaded('person', 1), true, 'should have person with id 1');
-  assert.equal(store.recordIsLoaded('person', 1), true, 'should have person with id 1');
-  assert.equal(store.recordIsLoaded('person', 4), false, 'should not have person with id 4');
-  assert.equal(store.recordIsLoaded('person', 4), false, 'should not have person with id 4');
+  assert.equal(store.hasRecordForId('person', 1), true, 'should have person with id 1');
+  assert.equal(store.hasRecordForId('person', 1), true, 'should have person with id 1');
+  assert.equal(store.hasRecordForId('person', 4), false, 'should not have person with id 4');
+  assert.equal(store.hasRecordForId('person', 4), false, 'should not have person with id 4');
 });
 
 test("a listener can be added to a record", function(assert) {

--- a/tests/unit/store/asserts-test.js
+++ b/tests/unit/store/asserts-test.js
@@ -16,7 +16,6 @@ const MODEL_NAME_METHODS = [
   'findAll',
   'peekAll',
   'filter',
-  'recordIsLoaded',
   'modelFor',
   'modelFactoryFor',
   'normalize',
@@ -24,7 +23,7 @@ const MODEL_NAME_METHODS = [
   'serializerFor'
 ];
 
-testInDebug("Calling Store methods with no type asserts", function(assert) {
+testInDebug("Calling Store methods with no modelName asserts", function(assert) {
   assert.expect(MODEL_NAME_METHODS.length);
   let store = createStore();
 


### PR DESCRIPTION
It already just delegates to store.hasRecordForId