### PR TITLE
JSON API "included" should be an array of resource objects

### DIFF
--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -158,7 +158,7 @@ const JSONAPISerializer = JSONSerializer.extend({
       let ret = new Array(documentHash.included.length);
 
       for (let i = 0; i < documentHash.included.length; i++) {
-        let included = documentHash.included[i];
+        let included = documentHash.included[i].data;
         ret[i] = this._normalizeResourceHelper(included);
       }
 


### PR DESCRIPTION
According to the JSON API specs in http://jsonapi.org/format/#document-resource-objects

"In a compound document, all included resources MUST be represented as an array of resource objects in a top-level included member."

But it seems json-api.js expects having a type and id outside the data structure that wraps jsonapi resource objects.