### PR TITLE
Remove unused helper function `normalizeAttributes`

### DIFF
--- a/addon/serializers/json.js
+++ b/addon/serializers/json.js
@@ -723,26 +723,6 @@ var JSONSerializer = Serializer.extend({
     return normalizeModelName(key);
   },
 
-
-  /**
-    @method normalizeAttributes
-    @private
-  */
-  normalizeAttributes(typeClass, hash) {
-    var payloadKey;
-
-    if (this.keyForAttribute) {
-      typeClass.eachAttribute((key) => {
-        payloadKey = this.keyForAttribute(key, 'deserialize');
-        if (key === payloadKey) { return; }
-        if (hash[payloadKey] === undefined) { return; }
-
-        hash[key] = hash[payloadKey];
-        delete hash[payloadKey];
-      });
-    }
-  },
-
   /**
     @method normalizeRelationships
     @private


### PR DESCRIPTION
I was not able to find any references to `normalizeAttribute`:
```
➜  frontend git:(master) ✗ grep 'normalizeAttributes' -R --exclude-dir tmp . | grep -v \.map
./dist/assets/vendor.js:      @method normalizeAttributes
./dist/assets/vendor.js:    normalizeAttributes: function normalizeAttributes(typeClass, hash) {
./node_modules/ember-data/addon/serializers/json.js:    @method normalizeAttributes
./node_modules/ember-data/addon/serializers/json.js:  normalizeAttributes(typeClass, hash) {
./node_modules/ember-data/CHANGELOG.md:* Moved several normalize helper methods to the JSONSerializer - Move `normalizeAttributes` to the `JSONSerializer` (mirrors `serializeAttributes`) - Move `normalizeRelationships` to the `JSONSerializer` - Move `normalizePayload` to the `JSONSerializer`
```
