### PR TITLE
Modernizes relationship containers

### DIFF
--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -5,163 +5,156 @@ import {
 } from "ember-data/-private/system/promise-proxies";
 
 import { assertPolymorphicType } from "ember-data/-private/debug";
-
 import Relationship from "ember-data/-private/system/relationships/state/relationship";
 
-export default function BelongsToRelationship(store, record, inverseKey, relationshipMeta) {
-  this._super$constructor(store, record, inverseKey, relationshipMeta);
-  this.record = record;
-  this.key = relationshipMeta.key;
-  this.inverseRecord = null;
-  this.canonicalState = null;
-}
-
-BelongsToRelationship.prototype = Object.create(Relationship.prototype);
-BelongsToRelationship.prototype.constructor = BelongsToRelationship;
-BelongsToRelationship.prototype._super$constructor = Relationship;
-
-BelongsToRelationship.prototype.setRecord = function(newRecord) {
-  if (newRecord) {
-    this.addRecord(newRecord);
-  } else if (this.inverseRecord) {
-    this.removeRecord(this.inverseRecord);
-  }
-  this.setHasData(true);
-  this.setHasLoaded(true);
-};
-
-BelongsToRelationship.prototype.setCanonicalRecord = function(newRecord) {
-  if (newRecord) {
-    this.addCanonicalRecord(newRecord);
-  } else if (this.canonicalState) {
-    this.removeCanonicalRecord(this.canonicalState);
-  }
-  this.flushCanonicalLater();
-};
-
-BelongsToRelationship.prototype._super$addCanonicalRecord = Relationship.prototype.addCanonicalRecord;
-BelongsToRelationship.prototype.addCanonicalRecord = function(newRecord) {
-  if (this.canonicalMembers.has(newRecord)) { return;}
-
-  if (this.canonicalState) {
-    this.removeCanonicalRecord(this.canonicalState);
+export default class BelongsToRelationship extends Relationship {
+  constructor(store, internalModel, inverseKey, relationshipMeta) {
+    super(store, internalModel, inverseKey, relationshipMeta);
+    this.internalModel = internalModel;
+    this.key = relationshipMeta.key;
+    this.inverseRecord = null;
+    this.canonicalState = null;
   }
 
-  this.canonicalState = newRecord;
-  this._super$addCanonicalRecord(newRecord);
-};
-
-BelongsToRelationship.prototype._super$flushCanonical = Relationship.prototype.flushCanonical;
-BelongsToRelationship.prototype.flushCanonical = function() {
-  //temporary fix to not remove newly created records if server returned null.
-  //TODO remove once we have proper diffing
-  if (this.inverseRecord && this.inverseRecord.isNew() && !this.canonicalState) {
-    return;
-  }
-  if (this.inverseRecord !== this.canonicalState) {
-    this.inverseRecord = this.canonicalState;
-    this.record.notifyBelongsToChanged(this.key);
-  }
-  this._super$flushCanonical();
-};
-
-BelongsToRelationship.prototype._super$addRecord = Relationship.prototype.addRecord;
-BelongsToRelationship.prototype.addRecord = function(newRecord) {
-  if (this.members.has(newRecord)) { return;}
-
-  assertPolymorphicType(this.record, this.relationshipMeta, newRecord);
-
-  if (this.inverseRecord) {
-    this.removeRecord(this.inverseRecord);
-  }
-
-  this.inverseRecord = newRecord;
-  this._super$addRecord(newRecord);
-  this.record.notifyBelongsToChanged(this.key);
-};
-
-BelongsToRelationship.prototype.setRecordPromise = function(newPromise) {
-  var content = newPromise.get && newPromise.get('content');
-  assert("You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo or hasMany relationship to the get call.", content !== undefined);
-  this.setRecord(content ? content._internalModel : content);
-};
-
-BelongsToRelationship.prototype._super$removeRecordFromOwn = Relationship.prototype.removeRecordFromOwn;
-BelongsToRelationship.prototype.removeRecordFromOwn = function(record) {
-  if (!this.members.has(record)) { return;}
-  this.inverseRecord = null;
-  this._super$removeRecordFromOwn(record);
-  this.record.notifyBelongsToChanged(this.key);
-};
-
-BelongsToRelationship.prototype._super$removeCanonicalRecordFromOwn = Relationship.prototype.removeCanonicalRecordFromOwn;
-BelongsToRelationship.prototype.removeCanonicalRecordFromOwn = function(record) {
-  if (!this.canonicalMembers.has(record)) { return;}
-  this.canonicalState = null;
-  this._super$removeCanonicalRecordFromOwn(record);
-};
-
-BelongsToRelationship.prototype.findRecord = function() {
-  if (this.inverseRecord) {
-    return this.store._findByInternalModel(this.inverseRecord);
-  } else {
-    return Ember.RSVP.Promise.resolve(null);
-  }
-};
-
-BelongsToRelationship.prototype.fetchLink = function() {
-  return this.store.findBelongsTo(this.record, this.link, this.relationshipMeta).then((record) => {
-    if (record) {
-      this.addRecord(record);
+  setRecord(newRecord) {
+    if (newRecord) {
+      this.addRecord(newRecord);
+    } else if (this.inverseRecord) {
+      this.removeRecord(this.inverseRecord);
     }
-    return record;
-  });
-};
+    this.setHasData(true);
+    this.setHasLoaded(true);
+  }
 
-BelongsToRelationship.prototype.getRecord = function() {
-  //TODO(Igor) flushCanonical here once our syncing is not stupid
-  if (this.isAsync) {
-    var promise;
-    if (this.link) {
-      if (this.hasLoaded) {
-        promise = this.findRecord();
-      } else {
-        promise = this.findLink().then(() => this.findRecord());
-      }
+  setCanonicalRecord(newRecord) {
+    if (newRecord) {
+      this.addCanonicalRecord(newRecord);
+    } else if (this.canonicalState) {
+      this.removeCanonicalRecord(this.canonicalState);
+    }
+    this.flushCanonicalLater();
+  }
+
+  addCanonicalRecord(newRecord) {
+    if (this.canonicalMembers.has(newRecord)) { return;}
+
+    if (this.canonicalState) {
+      this.removeCanonicalRecord(this.canonicalState);
+    }
+
+    this.canonicalState = newRecord;
+    super.addCanonicalRecord(newRecord);
+  }
+
+  flushCanonical() {
+    //temporary fix to not remove newly created records if server returned null.
+    //TODO remove once we have proper diffing
+    if (this.inverseRecord && this.inverseRecord.isNew() && !this.canonicalState) {
+      return;
+    }
+    if (this.inverseRecord !== this.canonicalState) {
+      this.inverseRecord = this.canonicalState;
+      this.internalModel.notifyBelongsToChanged(this.key);
+    }
+
+    super.flushCanonical();
+  }
+
+  addRecord(newRecord) {
+    if (this.members.has(newRecord)) { return; }
+
+    assertPolymorphicType(this.internalModel, this.relationshipMeta, newRecord);
+
+    if (this.inverseRecord) {
+      this.removeRecord(this.inverseRecord);
+    }
+
+    this.inverseRecord = newRecord;
+    super.addRecord(newRecord);
+    this.internalModel.notifyBelongsToChanged(this.key);
+  }
+
+  setRecordPromise(newPromise) {
+    var content = newPromise.get && newPromise.get('content');
+    assert("You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo or hasMany relationship to the get call.", content !== undefined);
+    this.setRecord(content ? content._internalModel : content);
+  }
+
+  removeRecordFromOwn(record) {
+    if (!this.members.has(record)) { return;}
+    this.inverseRecord = null;
+    super.removeRecordFromOwn(record);
+    this.internalModel.notifyBelongsToChanged(this.key);
+  }
+
+  removeCanonicalRecordFromOwn(record) {
+    if (!this.canonicalMembers.has(record)) { return;}
+    this.canonicalState = null;
+    super.removeCanonicalRecordFromOwn(record);
+  }
+
+  findRecord() {
+    if (this.inverseRecord) {
+      return this.store._findByInternalModel(this.inverseRecord);
     } else {
-      promise = this.findRecord();
+      return Ember.RSVP.Promise.resolve(null);
     }
+  }
 
-    return PromiseObject.create({
-      promise: promise,
-      content: this.inverseRecord ? this.inverseRecord.getRecord() : null
+  fetchLink() {
+    return this.store.findBelongsTo(this.internalModel, this.link, this.relationshipMeta).then((record) => {
+      if (record) {
+        this.addRecord(record);
+      }
+      return record;
     });
-  } else {
-    if (this.inverseRecord === null) {
-      return null;
+  }
+
+  getRecord() {
+    //TODO(Igor) flushCanonical here once our syncing is not stupid
+    if (this.isAsync) {
+      var promise;
+      if (this.link) {
+        if (this.hasLoaded) {
+          promise = this.findRecord();
+        } else {
+          promise = this.findLink().then(() => this.findRecord());
+        }
+      } else {
+        promise = this.findRecord();
+      }
+
+      return PromiseObject.create({
+        promise: promise,
+        content: this.inverseRecord ? this.inverseRecord.getRecord() : null
+      });
+    } else {
+      if (this.inverseRecord === null) {
+        return null;
+      }
+      var toReturn = this.inverseRecord.getRecord();
+      assert("You looked up the '" + this.key + "' relationship on a '" + this.internalModel.modelName + "' with id " + this.internalModel.id +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.belongsTo({ async: true })`)", toReturn === null || !toReturn.get('isEmpty'));
+      return toReturn;
     }
-    var toReturn = this.inverseRecord.getRecord();
-    assert("You looked up the '" + this.key + "' relationship on a '" + this.record.modelName + "' with id " + this.record.id +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.belongsTo({ async: true })`)", toReturn === null || !toReturn.get('isEmpty'));
-    return toReturn;
-  }
-};
-
-BelongsToRelationship.prototype.reload = function() {
-  // TODO handle case when reload() is triggered multiple times
-
-  if (this.link) {
-    return this.fetchLink();
   }
 
-  // reload record, if it is already loaded
-  if (this.inverseRecord && this.inverseRecord.hasRecord) {
-    return this.inverseRecord.record.reload();
+  reload() {
+    // TODO handle case when reload() is triggered multiple times
+
+    if (this.link) {
+      return this.fetchLink();
+    }
+
+    // reload record, if it is already loaded
+    if (this.inverseRecord && this.inverseRecord.hasRecord) {
+      return this.inverseRecord.record.reload();
+    }
+
+    return this.findRecord();
   }
 
-  return this.findRecord();
-};
-
-BelongsToRelationship.prototype.updateData = function(data) {
-  let internalModel = this.store._pushResourceIdentifier(this, data);
-  this.setCanonicalRecord(internalModel);
-};
+  updateData(data) {
+    let internalModel = this.store._pushResourceIdentifier(this, data);
+    this.setCanonicalRecord(internalModel);
+  }
+}

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -6,234 +6,228 @@ import ManyArray from "ember-data/-private/system/many-array";
 
 import { assertPolymorphicType } from "ember-data/-private/debug";
 
-export default function ManyRelationship(store, record, inverseKey, relationshipMeta) {
-  this._super$constructor(store, record, inverseKey, relationshipMeta);
-  this.belongsToType = relationshipMeta.type;
-  this.canonicalState = [];
-  this.isPolymorphic = relationshipMeta.options.polymorphic;
-}
-
-ManyRelationship.prototype = Object.create(Relationship.prototype);
-ManyRelationship.prototype.getManyArray = function() {
-  if (!this._manyArray) {
-    this._manyArray = ManyArray.create({
-      canonicalState: this.canonicalState,
-      store: this.store,
-      relationship: this,
-      type: this.store.modelFor(this.belongsToType),
-      record: this.record,
-      meta: this.meta,
-      isPolymorphic: this.isPolymorphic
-    });
+export default class ManyRelationship extends Relationship {
+  constructor(store, record, inverseKey, relationshipMeta) {
+    super(store, record, inverseKey, relationshipMeta);
+    this.belongsToType = relationshipMeta.type;
+    this.canonicalState = [];
+    this.isPolymorphic = relationshipMeta.options.polymorphic;
   }
-  return this._manyArray;
-};
 
-ManyRelationship.prototype.constructor = ManyRelationship;
-ManyRelationship.prototype._super$constructor = Relationship;
-
-ManyRelationship.prototype.destroy = function() {
-  if (this._manyArray) {
-    this._manyArray.destroy();
+  getManyArray() {
+    if (!this._manyArray) {
+      this._manyArray = ManyArray.create({
+        canonicalState: this.canonicalState,
+        store: this.store,
+        relationship: this,
+        type: this.store.modelFor(this.belongsToType),
+        record: this.record,
+        meta: this.meta,
+        isPolymorphic: this.isPolymorphic
+      });
+    }
+    return this._manyArray;
   }
-};
 
-ManyRelationship.prototype._super$updateMeta = Relationship.prototype.updateMeta;
-ManyRelationship.prototype.updateMeta = function(meta) {
-  this._super$updateMeta(meta);
-  if (this._manyArray) {
-    this._manyArray.set('meta', meta);
+  destroy() {
+    if (this._manyArray) {
+      this._manyArray.destroy();
+    }
   }
-};
 
-ManyRelationship.prototype._super$addCanonicalRecord = Relationship.prototype.addCanonicalRecord;
-ManyRelationship.prototype.addCanonicalRecord = function(record, idx) {
-  if (this.canonicalMembers.has(record)) {
-    return;
+  updateMeta(meta) {
+    super.updateMeta(meta);
+    if (this._manyArray) {
+      this._manyArray.set('meta', meta);
+    }
   }
-  if (idx !== undefined) {
-    this.canonicalState.splice(idx, 0, record);
-  } else {
-    this.canonicalState.push(record);
-  }
-  this._super$addCanonicalRecord(record, idx);
-};
 
-ManyRelationship.prototype._super$addRecord = Relationship.prototype.addRecord;
-ManyRelationship.prototype.addRecord = function(record, idx) {
-  if (this.members.has(record)) {
-    return;
+  addCanonicalRecord(record, idx) {
+    if (this.canonicalMembers.has(record)) {
+      return;
+    }
+    if (idx !== undefined) {
+      this.canonicalState.splice(idx, 0, record);
+    } else {
+      this.canonicalState.push(record);
+    }
+    super.addCanonicalRecord(record, idx);
   }
-  this._super$addRecord(record, idx);
-  // make lazy later
-  this.getManyArray().internalAddRecords([record], idx);
-};
 
-ManyRelationship.prototype._super$removeCanonicalRecordFromOwn = Relationship.prototype.removeCanonicalRecordFromOwn;
-ManyRelationship.prototype.removeCanonicalRecordFromOwn = function(record, idx) {
-  var i = idx;
-  if (!this.canonicalMembers.has(record)) {
-    return;
+  addRecord(record, idx) {
+    if (this.members.has(record)) {
+      return;
+    }
+    super.addRecord(record, idx);
+    // make lazy later
+    this.getManyArray().internalAddRecords([record], idx);
   }
-  if (i === undefined) {
-    i = this.canonicalState.indexOf(record);
+
+  removeCanonicalRecordFromOwn(record, idx) {
+    var i = idx;
+    if (!this.canonicalMembers.has(record)) {
+      return;
+    }
+    if (i === undefined) {
+      i = this.canonicalState.indexOf(record);
+    }
+    if (i > -1) {
+      this.canonicalState.splice(i, 1);
+    }
+    super.removeCanonicalRecordFromOwn(record, idx);
   }
-  if (i > -1) {
-    this.canonicalState.splice(i, 1);
+
+  flushCanonical() {
+    if (this._manyArray) {
+      this._manyArray.flushCanonical();
+    }
+    super.flushCanonical();
   }
-  this._super$removeCanonicalRecordFromOwn(record, idx);
-};
 
-ManyRelationship.prototype._super$flushCanonical = Relationship.prototype.flushCanonical;
-ManyRelationship.prototype.flushCanonical = function() {
-  if (this._manyArray) {
-    this._manyArray.flushCanonical();
+  removeRecordFromOwn(record, idx) {
+    if (!this.members.has(record)) {
+      return;
+    }
+    super.removeRecordFromOwn(record, idx);
+    let manyArray = this.getManyArray();
+    if (idx !== undefined) {
+      //TODO(Igor) not used currently, fix
+      manyArray.currentState.removeAt(idx);
+    } else {
+      manyArray.internalRemoveRecords([record]);
+    }
   }
-  this._super$flushCanonical();
-};
 
-ManyRelationship.prototype._super$removeRecordFromOwn = Relationship.prototype.removeRecordFromOwn;
-ManyRelationship.prototype.removeRecordFromOwn = function(record, idx) {
-  if (!this.members.has(record)) {
-    return;
+  notifyRecordRelationshipAdded(record, idx) {
+    assertPolymorphicType(this.record, this.relationshipMeta, record);
+
+    this.record.notifyHasManyAdded(this.key, record, idx);
   }
-  this._super$removeRecordFromOwn(record, idx);
-  let manyArray = this.getManyArray();
-  if (idx !== undefined) {
-    //TODO(Igor) not used currently, fix
-    manyArray.currentState.removeAt(idx);
-  } else {
-    manyArray.internalRemoveRecords([record]);
-  }
-};
 
-ManyRelationship.prototype.notifyRecordRelationshipAdded = function(record, idx) {
-  assertPolymorphicType(this.record, this.relationshipMeta, record);
+  reload() {
+    let manyArray = this.getManyArray();
+    let manyArrayLoadedState = manyArray.get('isLoaded');
 
-  this.record.notifyHasManyAdded(this.key, record, idx);
-};
+    if (this._loadingPromise) {
+      if (this._loadingPromise.get('isPending')) {
+        return this._loadingPromise;
+      }
+      if (this._loadingPromise.get('isRejected')) {
+        manyArray.set('isLoaded', manyArrayLoadedState);
+      }
+    }
 
-ManyRelationship.prototype.reload = function() {
-  let manyArray = this.getManyArray();
-  let manyArrayLoadedState = manyArray.get('isLoaded');
-
-  if (this._loadingPromise) {
-    if (this._loadingPromise.get('isPending')) {
+    if (this.link) {
+      this._loadingPromise = promiseManyArray(this.fetchLink(), 'Reload with link');
+      return this._loadingPromise;
+    } else {
+      this._loadingPromise = promiseManyArray(this.store._scheduleFetchMany(manyArray.currentState).then(() => manyArray), 'Reload with ids');
       return this._loadingPromise;
     }
-    if (this._loadingPromise.get('isRejected')) {
-      manyArray.set('isLoaded', manyArrayLoadedState);
-    }
   }
 
-  if (this.link) {
-    this._loadingPromise = promiseManyArray(this.fetchLink(), 'Reload with link');
-    return this._loadingPromise;
-  } else {
-    this._loadingPromise = promiseManyArray(this.store._scheduleFetchMany(manyArray.currentState).then(() => manyArray), 'Reload with ids');
-    return this._loadingPromise;
-  }
-};
+  computeChanges(records) {
+    var members = this.canonicalMembers;
+    var recordsToRemove = [];
+    var length;
+    var record;
+    var i;
 
-ManyRelationship.prototype.computeChanges = function(records) {
-  var members = this.canonicalMembers;
-  var recordsToRemove = [];
-  var length;
-  var record;
-  var i;
+    records = setForArray(records);
 
-  records = setForArray(records);
+    members.forEach(function(member) {
+      if (records.has(member)) { return; }
 
-  members.forEach(function(member) {
-    if (records.has(member)) { return; }
-
-    recordsToRemove.push(member);
-  });
-
-  this.removeCanonicalRecords(recordsToRemove);
-
-  // Using records.toArray() since currently using
-  // removeRecord can modify length, messing stuff up
-  // forEach since it directly looks at "length" each
-  // iteration
-  records = records.toArray();
-  length = records.length;
-  for (i = 0; i < length; i++) {
-    record = records[i];
-    this.removeCanonicalRecord(record);
-    this.addCanonicalRecord(record, i);
-  }
-};
-
-ManyRelationship.prototype.fetchLink = function() {
-  return this.store.findHasMany(this.record, this.link, this.relationshipMeta).then((records) => {
-    if (records.hasOwnProperty('meta')) {
-      this.updateMeta(records.meta);
-    }
-    this.store._backburner.join(() => {
-      this.updateRecordsFromAdapter(records);
-      this.getManyArray().set('isLoaded', true);
+      recordsToRemove.push(member);
     });
-    return this.getManyArray();
-  });
-};
 
-ManyRelationship.prototype.findRecords = function() {
-  let manyArray = this.getManyArray()
-  let array = manyArray.toArray();
-  let internalModels = new Array(array.length);
+    this.removeCanonicalRecords(recordsToRemove);
 
-  for (let i = 0; i < array.length; i++) {
-    internalModels[i] = array[i]._internalModel;
+    // Using records.toArray() since currently using
+    // removeRecord can modify length, messing stuff up
+    // forEach since it directly looks at "length" each
+    // iteration
+    records = records.toArray();
+    length = records.length;
+    for (i = 0; i < length; i++) {
+      record = records[i];
+      this.removeCanonicalRecord(record);
+      this.addCanonicalRecord(record, i);
+    }
   }
 
-  //TODO CLEANUP
-  return this.store.findMany(internalModels).then(() => {
-    if (!manyArray.get('isDestroyed')) {
-      //Goes away after the manyArray refactor
-      manyArray.set('isLoaded', true);
-    }
-    return manyArray;
-  });
-};
-ManyRelationship.prototype.notifyHasManyChanged = function() {
-  this.record.notifyHasManyAdded(this.key);
-};
-
-ManyRelationship.prototype.getRecords = function() {
-  //TODO(Igor) sync server here, once our syncing is not stupid
-  let manyArray = this.getManyArray();
-  if (this.isAsync) {
-    var promise;
-    if (this.link) {
-      if (this.hasLoaded) {
-        promise = this.findRecords();
-      } else {
-        promise = this.findLink().then(() => this.findRecords());
+  fetchLink() {
+    return this.store.findHasMany(this.record, this.link, this.relationshipMeta).then((records) => {
+      if (records.hasOwnProperty('meta')) {
+        this.updateMeta(records.meta);
       }
-    } else {
-      promise = this.findRecords();
-    }
-    this._loadingPromise = PromiseManyArray.create({
-      content: manyArray,
-      promise: promise
+      this.store._backburner.join(() => {
+        this.updateRecordsFromAdapter(records);
+        this.getManyArray().set('isLoaded', true);
+      });
+      return this.getManyArray();
     });
-    return this._loadingPromise;
-  } else {
-    assert("You looked up the '" + this.key + "' relationship on a '" + this.record.type.modelName + "' with id " + this.record.id +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", manyArray.isEvery('isEmpty', false));
-
-    //TODO(Igor) WTF DO I DO HERE?
-    if (!manyArray.get('isDestroyed')) {
-      manyArray.set('isLoaded', true);
-    }
-    return manyArray;
   }
-};
 
-ManyRelationship.prototype.updateData = function(data) {
-  let internalModels = this.store._pushResourceIdentifiers(this, data);
-  this.updateRecordsFromAdapter(internalModels);
-};
+  findRecords() {
+    let manyArray = this.getManyArray();
+    let array = manyArray.toArray();
+    let internalModels = new Array(array.length);
+
+    for (let i = 0; i < array.length; i++) {
+      internalModels[i] = array[i]._internalModel;
+    }
+
+    //TODO CLEANUP
+    return this.store.findMany(internalModels).then(() => {
+      if (!manyArray.get('isDestroyed')) {
+        //Goes away after the manyArray refactor
+        manyArray.set('isLoaded', true);
+      }
+      return manyArray;
+    });
+  }
+
+  notifyHasManyChanged() {
+    this.record.notifyHasManyAdded(this.key);
+  }
+
+  getRecords() {
+    //TODO(Igor) sync server here, once our syncing is not stupid
+    let manyArray = this.getManyArray();
+    if (this.isAsync) {
+      var promise;
+      if (this.link) {
+        if (this.hasLoaded) {
+          promise = this.findRecords();
+        } else {
+          promise = this.findLink().then(() => this.findRecords());
+        }
+      } else {
+        promise = this.findRecords();
+      }
+      this._loadingPromise = PromiseManyArray.create({
+        content: manyArray,
+        promise: promise
+      });
+      return this._loadingPromise;
+    } else {
+      assert("You looked up the '" + this.key + "' relationship on a '" + this.record.type.modelName + "' with id " + this.record.id +  " but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`DS.hasMany({ async: true })`)", manyArray.isEvery('isEmpty', false));
+
+      //TODO(Igor) WTF DO I DO HERE?
+      // TODO @runspired equal WTFs to Igor
+      if (!manyArray.get('isDestroyed')) {
+        manyArray.set('isLoaded', true);
+      }
+      return manyArray;
+    }
+  }
+
+  updateData(data) {
+    let internalModels = this.store._pushResourceIdentifiers(this, data);
+    this.updateRecordsFromAdapter(internalModels);
+  }
+}
 
 function setForArray(array) {
   var set = new OrderedSet();


### PR DESCRIPTION
Was spelunking about cleaning up our async story and fell into cleaning up this bit once I realized that `record` was meant to be `internalModel`.  Decided to go all the way and give us a fresh ES6 look.