### PR TITLE
[FEATURE ds-rollback-attribute] rename ds-reset-attribute

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -110,9 +110,9 @@ entry in `config/features.json`.
   Adds public method for `shouldSerializeHasMany`, used to determine if a
   `hasMany` relationship can be serialized.
 
-- `ds-reset-attribute` [#4246](https://github.com/emberjs/data/pull/4246)
+- `ds-rollback-attribute` [#4246](https://github.com/emberjs/data/pull/4246)
 
-  Adds a `resetAttribute` method to models. Similar to `rollbackAttributes`,
+  Adds a `rollbackAttribute` method to models. Similar to `rollbackAttributes`,
   but for only a single attribute.
 
   ```js
@@ -124,10 +124,10 @@ entry in `config/features.json`.
       lastName: 'Katz'
     });
 
-    tom.resetAttribute('firstName') // { firstName: 'Tom', lastName: 'Katz' }
+    tom.rollbackAttribute('firstName') // { firstName: 'Tom', lastName: 'Katz' }
     tom.get('hasDirtyAttributes')   // true
 
-    tom.resetAttribute('lastName')  // { firstName: 'Tom', lastName: 'Dale' }
+    tom.rollbackAttribute('lastName')  // { firstName: 'Tom', lastName: 'Dale' }
     tom.get('hasDirtyAttributes')   // false
   ```
 

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -1016,7 +1016,7 @@ export default class InternalModel {
   }
 }
 
-if (isEnabled('ds-reset-attribute')) {
+if (isEnabled('ds-rollback-attribute')) {
   /*
      Returns the latest truth for an attribute - the canonical value, or the
      in-flight value.

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1038,7 +1038,7 @@ if (Ember.setOwner) {
   });
 }
 
-if (isEnabled('ds-reset-attribute')) {
+if (isEnabled('ds-rollback-attribute')) {
   Model.reopen({
     /**
       Discards any unsaved changes to the given attribute.
@@ -1049,13 +1049,13 @@ if (isEnabled('ds-reset-attribute')) {
       record.get('name'); // 'Untitled Document'
       record.set('name', 'Doc 1');
       record.get('name'); // 'Doc 1'
-      record.resetAttribute('name');
+      record.rollbackAttribute('name');
       record.get('name'); // 'Untitled Document'
       ```
 
-      @method resetAttribute
+      @method rollbackAttribute
     */
-    resetAttribute(attributeName) {
+    rollbackAttribute(attributeName) {
       if (attributeName in this._internalModel._attributes) {
         this.set(attributeName, this._internalModel.lastAcknowledgedValue(attributeName));
       }

--- a/config/features.json
+++ b/config/features.json
@@ -5,7 +5,7 @@
   "ds-overhaul-references": null,
   "ds-payload-type-hooks": null,
   "ds-check-should-serialize-relationships": null,
-  "ds-reset-attribute": null,
+  "ds-rollback-attribute": null,
   "ds-serialize-id": null,
   "ds-deprecate-store-serialize": true
 }

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -428,8 +428,8 @@ test("changedAttributes() works while the record is being updated", function(ass
   });
 });
 
-if (isEnabled('ds-reset-attribute')) {
-  test("resetAttribute() reverts a single attribute to its canonical value", function(assert) {
+if (isEnabled('ds-rollback-attribute')) {
+  test("rollbackAttribute() reverts a single attribute to its canonical value", function(assert) {
     assert.expect(5);
 
     run(function() {
@@ -452,14 +452,14 @@ if (isEnabled('ds-reset-attribute')) {
         isDrugAddict: false
       });
       assert.equal(person.get('hasDirtyAttributes'), true, "record becomes dirty after setting property to a new value");
-      person.resetAttribute('isDrugAddict');
+      person.rollbackAttribute('isDrugAddict');
       assert.equal(person.get('isDrugAddict'), true, "The specified attribute is rolled back");
       assert.equal(person.get('name'), 'Piper', "Unspecified attributes are not rolled back");
       assert.equal(person.get('hasDirtyAttributes'), true, "record with changed attributes is still dirty");
     });
   });
 
-  test("calling resetAttribute() on an unmodified property has no effect", function(assert) {
+  test("calling rollbackAttribute() on an unmodified property has no effect", function(assert) {
     assert.expect(5);
 
     run(function() {
@@ -479,14 +479,14 @@ if (isEnabled('ds-reset-attribute')) {
       assert.equal(person.get('hasDirtyAttributes'), false, "precond - person record should not be dirty");
       person.set('name', 'Piper');
       assert.equal(person.get('hasDirtyAttributes'), true, "record becomes dirty after setting property to a new value");
-      person.resetAttribute('isDrugAddict');
+      person.rollbackAttribute('isDrugAddict');
       assert.equal(person.get('isDrugAddict'), true, "The specified attribute does not change value");
       assert.equal(person.get('name'), 'Piper', "Unspecified attributes are not rolled back");
       assert.equal(person.get('hasDirtyAttributes'), true, "record with changed attributes is still dirty");
     });
   });
 
-  test("Rolling back the final value with resetAttribute() causes the record to become clean again", function(assert) {
+  test("Rolling back the final value with rollbackAttribute() causes the record to become clean again", function(assert) {
     assert.expect(3);
 
     run(function() {
@@ -506,12 +506,12 @@ if (isEnabled('ds-reset-attribute')) {
       assert.equal(person.get('hasDirtyAttributes'), false, "precond - person record should not be dirty");
       person.set('isDrugAddict', false);
       assert.equal(person.get('hasDirtyAttributes'), true, "record becomes dirty after setting property to a new value");
-      person.resetAttribute('isDrugAddict');
+      person.rollbackAttribute('isDrugAddict');
       assert.equal(person.get('hasDirtyAttributes'), false, "record becomes clean after resetting property to the old value");
     });
   });
 
-  test("Using resetAttribute on an in-flight record reverts to the latest in-flight value", function(assert) {
+  test("Using rollbackAttribute on an in-flight record reverts to the latest in-flight value", function(assert) {
     assert.expect(4);
 
     var person, finishSaving;
@@ -546,14 +546,14 @@ if (isEnabled('ds-reset-attribute')) {
       person.set('name', "Tomathy");
       assert.equal(person.get('name'), "Tomathy");
 
-      person.resetAttribute('name');
+      person.rollbackAttribute('name');
       assert.equal(person.get('name'), "Thomas");
 
       finishSaving();
     });
   });
 
-  test("Saving an in-flight record updates the in-flight value resetAttribute will use", function(assert) {
+  test("Saving an in-flight record updates the in-flight value rollbackAttribute will use", function(assert) {
     assert.expect(7);
 
     var person, finishSaving;
@@ -598,7 +598,7 @@ if (isEnabled('ds-reset-attribute')) {
       person.set('name', "Tomny");
       assert.equal(person.get('name'), "Tomny");
 
-      person.resetAttribute('name');
+      person.rollbackAttribute('name');
       assert.equal(person.get('name'), 'Tomathy');
 
       finishSaving();


### PR DESCRIPTION
As discussed in the ember data weekly meeting, the initial thought of
naming the method `resetAttribute` introduces a new verb "reset" into
the ember data terminology, which is not ideal.

This renames the method to `rollbackAttribute` to be more consistent with
the current terminology.

---

This addresses https://github.com/emberjs/data/issues/3705#issuecomment-261467358