### PR TITLE
Fixed modelFor documentation. Look up model's class name

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -996,7 +996,7 @@ Model.reopenClass({
 
   /**
    Represents the model's class name as a string. This can be used to look up the model's class name through
-   DS.Store's modelFor method.
+   `DS.Store`'s modelFor method.
 
    `modelName` is generated for you by Ember Data. It will be a lowercased, dasherized string.
    For example:

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -995,7 +995,7 @@ Model.reopenClass({
   },
 
   /**
-   Represents the model's class name as a string. This can be used to look up the model through
+   Represents the model's class name as a string. This can be used to look up the model's class name through
    DS.Store's modelFor method.
 
    `modelName` is generated for you by Ember Data. It will be a lowercased, dasherized string.


### PR DESCRIPTION
```Represents the model's class name as a string. This can be used to look up the model's class name through DS.Store's modelFor method.```

This is wrong and should be `model's class name` since you don't look up the actual model but the name.