### PR TITLE
fix(benchmarks): benchmarks for store.query no longer included record…

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -263,6 +263,7 @@ export default class InternalModel {
   getRecord() {
     if (!this._record) {
       heimdall.increment(materializeRecord);
+      let token = heimdall.start('InternalModel.getRecord');
 
       // lookupFactory should really return an object that creates
       // instances with the injections applied
@@ -285,6 +286,7 @@ export default class InternalModel {
       this._record = this.modelClass._create(createOptions);
 
       this._triggerDeferredTriggers();
+      heimdall.stop(token);
     }
 
     return this._record;

--- a/tests/dummy/app/routes/query/route.js
+++ b/tests/dummy/app/routes/query/route.js
@@ -27,6 +27,7 @@ export default Route.extend({
     let token = heimdall.start('ember-data');
     return this.get('store').query(modelName, params)
       .then((records) => {
+        records.toArray();
         heimdall.stop(token);
         window.result = heimdall.toString();
 

--- a/tests/dummy/app/routes/query/route.js
+++ b/tests/dummy/app/routes/query/route.js
@@ -27,6 +27,10 @@ export default Route.extend({
     let token = heimdall.start('ember-data');
     return this.get('store').query(modelName, params)
       .then((records) => {
+        // RecordArray lazily materializes the records
+        // We call toArray() to force materialization for benchmarking
+        // otherwise we would need to consume the RecordArray in our UI
+        // and clutter our benchmarks and make it harder to time.
         records.toArray();
         heimdall.stop(token);
         window.result = heimdall.toString();


### PR DESCRIPTION
… materialization as this is now so lazy that it must be forced, this makes the benchmark force it so that we can continue to measure improvement within materialization