### PR TITLE
include related record on the complex test

### DIFF
--- a/benchmarks/config.js
+++ b/benchmarks/config.js
@@ -8,7 +8,7 @@ module.exports = {
     // "query?modelName=simple&limit=2",  // 2 total
     // "query?modelName=simple&limit=34",  // 34 total
     // "query?modelName=simple&limit=119",  // 119 total
-    "query?modelName=simple&limit=238",  // 238 total
+    // "query?modelName=simple&limit=238",  // 238 total
 
 
     // complex returns 7 total records of 3 model types per count in limit
@@ -18,7 +18,7 @@ module.exports = {
     // "query?modelName=complex&limit=2", // 14 total
     // "query?modelName=complex&limit=5", // 35 total
     // "query?modelName=complex&limit=17", // 119 total
-    // "query?modelName=complex&limit=34", // 238 total
+    "query?modelName=complex&limit=34&included=foo,baz", // 238 total
 
 
     // heavy returns 17 total records of 5 model types per count in limit

--- a/tests/dummy/app/routes/query/route.js
+++ b/tests/dummy/app/routes/query/route.js
@@ -13,6 +13,9 @@ export default Route.extend({
     },
     modelName: {
       refreshModel: true
+    },
+    included: {
+      refreshModel: true
     }
   },
 


### PR DESCRIPTION
When benchmarking the micro queues for store._push I realized that I wasn't including related records in the payload anymore, this fixes that for the one scenario in the config but should be fixed for more of them long term.