### PR TITLE
Removes store._adapterRun

### DIFF
--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -24,27 +24,25 @@ function payloadIsNotBlank(adapterPayload) {
   }
 }
 
-export function _find(adapter, store, typeClass, id, internalModel, options) {
+export function _find(adapter, store, modelClass, id, internalModel, options) {
   var snapshot = internalModel.createSnapshot(options);
-  var promise = adapter.findRecord(store, typeClass, id, snapshot);
+  var promise = adapter.findRecord(store, modelClass, id, snapshot);
   var serializer = serializerForAdapter(store, adapter, internalModel.type.modelName);
-  var label = "DS: Handle Adapter#findRecord of " + typeClass + " with id: " + id;
+  var label = "DS: Handle Adapter#findRecord of " + modelClass + " with id: " + id;
 
   promise = Promise.resolve(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    assert("You made a `findRecord` request for a " + typeClass.modelName + " with id " + id + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
-    return store._adapterRun(function() {
-      var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, id, 'findRecord');
-      assert('Ember Data expected the primary data returned from a `findRecord` response to be an object but instead it found an array.', !Array.isArray(payload.data));
+    assert("You made a `findRecord` request for a " + modelClass.modelName + " with id " + id + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    let payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, id, 'findRecord');
+    assert('Ember Data expected the primary data returned from a `findRecord` response to be an object but instead it found an array.', !Array.isArray(payload.data));
 
-      warn(`You requested a record of type '${typeClass.modelName}' with id '${id}' but the adapter returned a payload with primary data having an id of '${payload.data.id}'. Use 'store.findRecord()' when the requested id is the same as the one returned by the adapter. In other cases use 'store.queryRecord()' instead http://emberjs.com/api/data/classes/DS.Store.html#method_queryRecord`, payload.data.id === id, {
-        id: 'ds.store.findRecord.id-mismatch'
-      });
-
-      return store._push(payload);
+    warn(`You requested a record of type '${modelClass.modelName}' with id '${id}' but the adapter returned a payload with primary data having an id of '${payload.data.id}'. Use 'store.findRecord()' when the requested id is the same as the one returned by the adapter. In other cases use 'store.queryRecord()' instead http://emberjs.com/api/data/classes/DS.Store.html#method_queryRecord`, payload.data.id === id, {
+      id: 'ds.store.findRecord.id-mismatch'
     });
+
+    return store._push(payload);
   }, function(error) {
     internalModel.notFound();
     if (internalModel.isEmpty()) {
@@ -52,15 +50,15 @@ export function _find(adapter, store, typeClass, id, internalModel, options) {
     }
 
     throw error;
-  }, "DS: Extract payload of '" + typeClass + "'");
+  }, "DS: Extract payload of '" + modelClass + "'");
 }
 
 
-export function _findMany(adapter, store, typeClass, ids, internalModels) {
+export function _findMany(adapter, store, modelClass, ids, internalModels) {
   let snapshots = Ember.A(internalModels).invoke('createSnapshot');
-  let promise = adapter.findMany(store, typeClass, ids, snapshots);
-  let serializer = serializerForAdapter(store, adapter, typeClass.modelName);
-  let label = "DS: Handle Adapter#findMany of " + typeClass;
+  let promise = adapter.findMany(store, modelClass, ids, snapshots);
+  let serializer = serializerForAdapter(store, adapter, modelClass.modelName);
+  let label = "DS: Handle Adapter#findMany of " + modelClass;
 
   if (promise === undefined) {
     throw new Error('adapter.findMany returned undefined, this was very likely a mistake');
@@ -70,17 +68,15 @@ export function _findMany(adapter, store, typeClass, ids, internalModels) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    assert("You made a `findMany` request for " + typeClass.modelName + " records with ids " + ids + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
-    return store._adapterRun(function() {
-      let payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findMany');
-      return store._push(payload);
-    });
-  }, null, "DS: Extract payload of " + typeClass);
+    assert("You made a `findMany` request for " + modelClass.modelName + " records with ids " + ids + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    let payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, null, 'findMany');
+    return store._push(payload);
+  }, null, "DS: Extract payload of " + modelClass);
 }
 
 export function _findHasMany(adapter, store, internalModel, link, relationship) {
   var snapshot = internalModel.createSnapshot();
-  var typeClass = store.modelFor(relationship.type);
+  var modelClass = store.modelFor(relationship.type);
   var promise = adapter.findHasMany(store, snapshot, link, relationship);
   var serializer = serializerForAdapter(store, adapter, relationship.type);
   var label = "DS: Handle Adapter#findHasMany of " + internalModel + " : " + relationship.type;
@@ -91,19 +87,17 @@ export function _findHasMany(adapter, store, internalModel, link, relationship) 
 
   return promise.then(function(adapterPayload) {
     assert("You made a `findHasMany` request for a " + internalModel.modelName + "'s `" + relationship.key + "` relationship, using link " + link + ", but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
-    return store._adapterRun(function() {
-      let payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findHasMany');
-      let internalModelArray = store._push(payload);
+    let payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, null, 'findHasMany');
+    let internalModelArray = store._push(payload);
 
-      internalModelArray.meta = payload.meta;
-      return internalModelArray;
-    });
+    internalModelArray.meta = payload.meta;
+    return internalModelArray;
   }, null, "DS: Extract payload of " + internalModel + " : hasMany " + relationship.type);
 }
 
 export function _findBelongsTo(adapter, store, internalModel, link, relationship) {
   var snapshot = internalModel.createSnapshot();
-  var typeClass = store.modelFor(relationship.type);
+  var modelClass = store.modelFor(relationship.type);
   var promise = adapter.findBelongsTo(store, snapshot, link, relationship);
   var serializer = serializerForAdapter(store, adapter, relationship.type);
   var label = "DS: Handle Adapter#findBelongsTo of " + internalModel + " : " + relationship.type;
@@ -113,67 +107,61 @@ export function _findBelongsTo(adapter, store, internalModel, link, relationship
   promise = _guard(promise, _bind(_objectIsAlive, internalModel));
 
   return promise.then(function(adapterPayload) {
-    return store._adapterRun(function() {
-      var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findBelongsTo');
+    let payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, null, 'findBelongsTo');
 
-      if (!payload.data) {
-        return null;
-      }
+    if (!payload.data) {
+      return null;
+    }
 
-      return store._push(payload);
-    });
+    return store._push(payload);
   }, null, "DS: Extract payload of " + internalModel + " : " + relationship.type);
 }
 
-export function _findAll(adapter, store, typeClass, sinceToken, options) {
-  var modelName = typeClass.modelName;
+export function _findAll(adapter, store, modelClass, sinceToken, options) {
+  var modelName = modelClass.modelName;
   var recordArray = store.peekAll(modelName);
   var snapshotArray = recordArray._createSnapshot(options);
-  var promise = adapter.findAll(store, typeClass, sinceToken, snapshotArray);
+  var promise = adapter.findAll(store, modelClass, sinceToken, snapshotArray);
   var serializer = serializerForAdapter(store, adapter, modelName);
-  var label = "DS: Handle Adapter#findAll of " + typeClass;
+  var label = "DS: Handle Adapter#findAll of " + modelClass;
 
   promise = Promise.resolve(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    assert("You made a `findAll` request for " + typeClass.modelName + " records, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
-    store._adapterRun(function() {
-      var payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'findAll');
-      store._push(payload);
-    });
+    assert("You made a `findAll` request for " + modelClass.modelName + " records, but the adapter's response did not have any data", payloadIsNotBlank(adapterPayload));
+    let payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, null, 'findAll');
 
+    store._push(payload);
     store.didUpdateAll(modelName);
+
     return store.peekAll(modelName);
-  }, null, "DS: Extract payload of findAll " + typeClass);
+  }, null, "DS: Extract payload of findAll " + modelClass);
 }
 
-export function _query(adapter, store, typeClass, query, recordArray) {
-  let modelName = typeClass.modelName;
-  let promise = adapter.query(store, typeClass, query, recordArray);
+export function _query(adapter, store, modelClass, query, recordArray) {
+  let modelName = modelClass.modelName;
+  let promise = adapter.query(store, modelClass, query, recordArray);
 
   let serializerToken = heimdall.start('initial-serializerFor-lookup');
   let serializer = serializerForAdapter(store, adapter, modelName);
   heimdall.stop(serializerToken);
-  let label = 'DS: Handle Adapter#query of ' + typeClass;
+  let label = 'DS: Handle Adapter#query of ' + modelClass;
 
   promise = Promise.resolve(promise, label);
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(adapterPayload => {
-    let internalModels, payload;
-    store._adapterRun(() => {
-      let normalizeToken = heimdall.start('finders#_query::normalizeResponseHelper');
-      payload = normalizeResponseHelper(serializer, store, typeClass, adapterPayload, null, 'query');
-      heimdall.stop(normalizeToken);
-      internalModels = store._push(payload);
-    });
+    let normalizeToken = heimdall.start('finders#_query::normalizeResponseHelper');
+    let payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, null, 'query');
+    heimdall.stop(normalizeToken);
+    let internalModels = store._push(payload);
 
     assert('The response to store.query is expected to be an array but it was a single record. Please wrap your response in an array or use `store.queryRecord` to query for a single record.', Array.isArray(internalModels));
     recordArray._setInternalModels(internalModels, payload);
 
     return recordArray;
-  }, null, 'DS: Extract payload of query ' + typeClass);
+  }, null, 'DS: Extract payload of query ' + modelName);
 }
 
 export function _queryRecord(adapter, store, modelClass, query) {
@@ -186,18 +174,12 @@ export function _queryRecord(adapter, store, modelClass, query) {
   promise = _guard(promise, _bind(_objectIsAlive, store));
 
   return promise.then(function(adapterPayload) {
-    let internalModel;
-    store._adapterRun(function() {
-      let payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, null, 'queryRecord');
+    let payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, null, 'queryRecord');
 
-      assert("Expected the primary data returned by the serializer for a `queryRecord` response to be a single object or null but instead it was an array.", !Array.isArray(payload.data), {
-        id: 'ds.store.queryRecord-array-response'
-      });
-
-      internalModel = store._push(payload);
+    assert("Expected the primary data returned by the serializer for a `queryRecord` response to be a single object or null but instead it was an array.", !Array.isArray(payload.data), {
+      id: 'ds.store.queryRecord-array-response'
     });
 
-    return internalModel;
-
-  }, null, "DS: Extract payload of queryRecord " + modelClass);
+    return store._push(payload);
+  }, null, "DS: Extract payload of queryRecord " + modelName);
 }


### PR DESCRIPTION
With #4698 having landed, it's potentially possible we can remove some if not all calls to `store._adapterRun`. This PR currently removes all calls, leading to a small handful of failed tests which I'm investigating.  I'll also run it against LI's test suite once those pass (if I can make them pass) to see if there are undocumented behaviors that this might break.

**Benefits**

- many fewer closures
- reduced overhead (one layer of abstraction fewer)
- easier to understand the data flow in `finders`
- simplifies the "async story" in ember-data, helping us find more avenues for improving our async data flow story in the future.
- gets us within a very very short step of removing backburner entirely. Only necessary thing would be for a true microtask based flush mechanism to be available.

cc @igor for recommending I investigate this.