### PR TITLE
es6 RecordArrayManager

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -5,6 +5,7 @@ import Relationships from "ember-data/-private/system/relationships/state/create
 import Snapshot from "ember-data/-private/system/snapshot";
 import EmptyObject from "ember-data/-private/system/empty-object";
 import isEnabled from 'ember-data/-private/features';
+import OrderedSet from "ember-data/-private/system/ordered-set";
 
 import {
   getOwner
@@ -114,7 +115,6 @@ export default class InternalModel {
     this.modelName = modelName;
     this.dataHasInitialized = false;
     this._loadingPromise = null;
-    this._recordArrays = undefined;
     this._record = null;
     this.currentState = RootState.empty;
     this.isReloading = false;
@@ -126,6 +126,7 @@ export default class InternalModel {
     // caches for lazy getters
     this._modelClass = null;
     this.__deferredTriggers = null;
+    this.__recordArrays = null;
     this._references = null;
     this._recordReference = null;
     this.__inFlightAttributes = null;
@@ -147,6 +148,13 @@ export default class InternalModel {
       this._recordReference = new RecordReference(this.store, this)
     }
     return this._recordReference;
+  }
+
+  get _recordArrays() {
+    if (this.__recordArrays === null) {
+      this.__recordArrays = OrderedSet.create();
+    }
+    return this.__recordArrays;
   }
 
   get references() {

--- a/addon/-private/system/record-arrays/adapter-populated-record-array.js
+++ b/addon/-private/system/record-arrays/adapter-populated-record-array.js
@@ -87,7 +87,10 @@ export default RecordArray.extend({
       links: cloneNull(payload.links)
     });
 
-    internalModels.forEach(internalModel => this.manager.recordArraysForRecord(internalModel).add(this));
+    for (let i = 0, l = internalModels.length; i < l; i++) {
+      let internalModel = internalModels[i];
+      this.manager.recordArraysForRecord(internalModel).add(this)
+    }
 
     // TODO: should triggering didLoad event be the last action of the runLoop?
     Ember.run.once(this, 'trigger', 'didLoad');

--- a/addon/-private/system/record-arrays/record-array.js
+++ b/addon/-private/system/record-arrays/record-array.js
@@ -202,7 +202,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
 
   _dissociateFromOwnRecords() {
     this.get('content').forEach(internalModel => {
-      let recordArrays = internalModel._recordArrays;
+      let recordArrays = internalModel.__recordArrays;
 
       if (recordArrays) {
         recordArrays.delete(this);
@@ -215,7 +215,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     @private
   */
   _unregisterFromManager() {
-    get(this, 'manager').unregisterRecordArray(this);
+    this.manager.unregisterRecordArray(this);
   },
 
   willDestroy() {

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -209,9 +209,7 @@ Store = Service.extend({
     this._super(...arguments);
     this._backburner = new Backburner(['normalizeRelationships', 'syncRelationships', 'finished']);
     // internal bookkeeping; not observable
-    this.recordArrayManager = RecordArrayManager.create({
-      store: this
-    });
+    this.recordArrayManager = new RecordArrayManager({ store: this });
     this._identityMap = new IdentityMap();
     this._pendingSave = [];
     this._instanceCache = new ContainerInstanceCache(getOwner(this), this);

--- a/tests/dummy/app/routes/query/route.js
+++ b/tests/dummy/app/routes/query/route.js
@@ -24,8 +24,6 @@ export default Route.extend({
     let modelName = params.modelName;
     delete params.modelName;
 
-    heimdall.enableTimelineFeatures();
-
     let token = heimdall.start('ember-data');
     return this.get('store').query(modelName, params)
       .then((records) => {

--- a/tests/unit/record-arrays/record-array-test.js
+++ b/tests/unit/record-arrays/record-array-test.js
@@ -192,14 +192,25 @@ test('#_removeInternalModels', function(assert) {
   assert.deepEqual(content, [], 'now contains no models');
 });
 
+class FakeInternalModel {
+  constructor(record) {
+    this._record = record;
+    this.__recordArrays = null;
+  }
+
+  get _recordArrays() {
+    return this.__recordArrays;
+  }
+
+  getRecord() { return this._record; }
+
+  createSnapshot() {
+    return this._record;
+  }
+}
+
 function internalModelFor(record) {
-  return {
-    _recordArrays: undefined,
-    getRecord() { return record; },
-    createSnapshot() {
-      return record;
-    }
-  };
+  return new FakeInternalModel(record);
 }
 
 test('#save', function(assert) {
@@ -237,7 +248,7 @@ test('#destroy', function(assert) {
   let internalModel1 = internalModelFor(model1);
 
   // TODO: this will be removed once we fix ownership related memory leaks.
-  internalModel1._recordArrays = {
+  internalModel1.__recordArrays = {
     delete(array) {
       didDissociatieFromOwnRecords++;
       assert.equal(array, recordArray);
@@ -308,7 +319,7 @@ test('#destroy', function(assert) {
   let internalModel1 = internalModelFor(model1);
 
   // TODO: this will be removed once we fix ownership related memory leaks.
-  internalModel1._recordArrays = {
+  internalModel1.__recordArrays = {
     delete(array) {
       didDissociatieFromOwnRecords++;
       assert.equal(array, recordArray);


### PR DESCRIPTION
There wasn't really a good reason for this singleton being an Ember.Object (it's not resolved / not in the container / no ember-y things in use), and converting it shaves 33% off it's instantiation time in addition to giving us nice es6 syntax (1.53ms => .97ms).

I additionally moved the instantiation of the `OrderedSet` used to track the `RecordArray`s for an `internalModel` into internal models directly instead of having the manager reach in.  I'm slightly conflicted on this because of the resulting double-underscore for the cached property, but I prefer to leave objects in control of their own properties.

**Before**
![es6-manager-before](https://cloud.githubusercontent.com/assets/650309/21060860/84a36c6c-bdfe-11e6-9dd4-2fd7320938d9.png)

**After**
![es6-manager-after](https://cloud.githubusercontent.com/assets/650309/21060869/8a7fb776-bdfe-11e6-8ecc-3fdab1a71715.png)
