### PR TITLE
converts Snapshot to an es6 class instead of using prototype assign

### DIFF
--- a/addon/-private/system/snapshot.js
+++ b/addon/-private/system/snapshot.js
@@ -5,7 +5,9 @@
 import Ember from 'ember';
 import EmptyObject from "ember-data/-private/system/empty-object";
 
-var get = Ember.get;
+const {
+  get
+} = Ember;
 
 /**
   @class Snapshot
@@ -14,137 +16,133 @@ var get = Ember.get;
   @constructor
   @param {DS.Model} internalModel The model to create a snapshot from
 */
-export default function Snapshot(internalModel, options = {}) {
-  this._attributes = new EmptyObject();
-  this._belongsToRelationships = new EmptyObject();
-  this._belongsToIds = new EmptyObject();
-  this._hasManyRelationships = new EmptyObject();
-  this._hasManyIds = new EmptyObject();
+export default class Snapshot {
+  constructor(internalModel, options = {}) {
+    this._attributes = new EmptyObject();
+    this._belongsToRelationships = new EmptyObject();
+    this._belongsToIds = new EmptyObject();
+    this._hasManyRelationships = new EmptyObject();
+    this._hasManyIds = new EmptyObject();
+    this._internalModel = internalModel;
 
-  let record = internalModel.getRecord();
-  this.record = record;
-  record.eachAttribute((keyName) => this._attributes[keyName] = get(record, keyName));
+    let record = internalModel.getRecord();
 
-  this.id = internalModel.id;
-  this._internalModel = internalModel;
-  this.type = internalModel.type;
-  this.modelName = internalModel.type.modelName;
+    /**
+     The underlying record for this snapshot. Can be used to access methods and
+     properties defined on the record.
 
-  /**
-    A hash of adapter options
-    @property adapterOptions
-    @type {Object}
-  */
-  this.adapterOptions = options.adapterOptions;
-  this.include = options.include;
+     Example
 
-  this._changedAttributes = record.changedAttributes();
-}
+     ```javascript
+     let json = snapshot.record.toJSON();
+     ```
 
-Snapshot.prototype = {
-  constructor: Snapshot,
+     @property record
+     @type {DS.Model}
+     */
+    this.record = record;
+    record.eachAttribute((keyName) => this._attributes[keyName] = get(record, keyName));
 
-  /**
-    The id of the snapshot's underlying record
+    /**
+     The id of the snapshot's underlying record
 
-    Example
+     Example
 
-    ```javascript
-    // store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
-    postSnapshot.id; // => '1'
-    ```
+     ```javascript
+     // store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
+     postSnapshot.id; // => '1'
+     ```
 
-    @property id
-    @type {String}
-  */
-  id: null,
+     @property id
+     @type {String}
+     */
+    this.id = internalModel.id;
 
-  /**
-    The underlying record for this snapshot. Can be used to access methods and
-    properties defined on the record.
+    /**
+     A hash of adapter options
+     @property adapterOptions
+     @type {Object}
+     */
+    this.adapterOptions = options.adapterOptions;
+    this.include = options.include;
 
-    Example
+    /**
+     The type of the underlying record for this snapshot, as a DS.Model.
 
-    ```javascript
-    var json = snapshot.record.toJSON();
-    ```
+     @property type
+     @type {DS.Model}
+     */
+    // TODO @runspired we should deprecate this in favor of modelClass but only once
+    // we've cleaned up the internals enough that a public change to follow suite is
+    // uncontroversial.
+    this.type = internalModel.modelClass;
 
-    @property record
-    @type {DS.Model}
-  */
-  record: null,
+    /**
+     The name of the type of the underlying record for this snapshot, as a string.
 
-  /**
-    The type of the underlying record for this snapshot, as a DS.Model.
+     @property modelName
+     @type {String}
+     */
+    this.modelName = internalModel.modelName;
 
-    @property type
-    @type {DS.Model}
-  */
-  type: null,
-
-  /**
-    The name of the type of the underlying record for this snapshot, as a string.
-
-    @property modelName
-    @type {String}
-  */
-  modelName: null,
+    this._changedAttributes = record.changedAttributes();
+  }
 
   /**
-    Returns the value of an attribute.
+   Returns the value of an attribute.
 
-    Example
+   Example
 
-    ```javascript
-    // store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
-    postSnapshot.attr('author'); // => 'Tomster'
-    postSnapshot.attr('title'); // => 'Ember.js rocks'
-    ```
+   ```javascript
+   // store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
+   postSnapshot.attr('author'); // => 'Tomster'
+   postSnapshot.attr('title'); // => 'Ember.js rocks'
+   ```
 
-    Note: Values are loaded eagerly and cached when the snapshot is created.
+   Note: Values are loaded eagerly and cached when the snapshot is created.
 
-    @method attr
-    @param {String} keyName
-    @return {Object} The attribute value or undefined
-  */
+   @method attr
+   @param {String} keyName
+   @return {Object} The attribute value or undefined
+   */
   attr(keyName) {
     if (keyName in this._attributes) {
       return this._attributes[keyName];
     }
     throw new Ember.Error("Model '" + Ember.inspect(this.record) + "' has no attribute named '" + keyName + "' defined.");
-  },
+  }
 
   /**
-    Returns all attributes and their corresponding values.
+   Returns all attributes and their corresponding values.
 
-    Example
+   Example
 
-    ```javascript
-    // store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
-    postSnapshot.attributes(); // => { author: 'Tomster', title: 'Ember.js rocks' }
-    ```
+   ```javascript
+   // store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
+   postSnapshot.attributes(); // => { author: 'Tomster', title: 'Ember.js rocks' }
+   ```
 
-    @method attributes
-    @return {Object} All attributes of the current snapshot
-  */
+   @method attributes
+   @return {Object} All attributes of the current snapshot
+   */
   attributes() {
     return Ember.copy(this._attributes);
-  },
+  }
 
   /**
-    Returns all changed attributes and their old and new values.
+   Returns all changed attributes and their old and new values.
 
-    Example
+   Example
 
-    ```javascript
-    // store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
-    postModel.set('title', 'Ember.js rocks!');
-    postSnapshot.changedAttributes(); // => { title: ['Ember.js rocks', 'Ember.js rocks!'] }
-    ```
+   ```javascript
+   // store.push('post', { id: 1, author: 'Tomster', title: 'Ember.js rocks' });
+   postModel.set('title', 'Ember.js rocks!');
+   postSnapshot.changedAttributes(); // => { title: ['Ember.js rocks', 'Ember.js rocks!'] }
+   ```
 
-    @method changedAttributes
-    @return {Object} All changed attributes of the current snapshot
-  */
+   @method changedAttributes
+   @return {Object} All changed attributes of the current snapshot
+   */
   changedAttributes() {
     let changedAttributes = new EmptyObject();
     let changedAttributeKeys = Object.keys(this._changedAttributes);
@@ -155,47 +153,47 @@ Snapshot.prototype = {
     }
 
     return changedAttributes;
-  },
+  }
 
   /**
-    Returns the current value of a belongsTo relationship.
+   Returns the current value of a belongsTo relationship.
 
-    `belongsTo` takes an optional hash of options as a second parameter,
-    currently supported options are:
+   `belongsTo` takes an optional hash of options as a second parameter,
+   currently supported options are:
 
    - `id`: set to `true` if you only want the ID of the related record to be
-      returned.
+   returned.
 
-    Example
+   Example
 
-    ```javascript
-    // store.push('post', { id: 1, title: 'Hello World' });
-    // store.createRecord('comment', { body: 'Lorem ipsum', post: post });
-    commentSnapshot.belongsTo('post'); // => DS.Snapshot
-    commentSnapshot.belongsTo('post', { id: true }); // => '1'
+   ```javascript
+   // store.push('post', { id: 1, title: 'Hello World' });
+   // store.createRecord('comment', { body: 'Lorem ipsum', post: post });
+   commentSnapshot.belongsTo('post'); // => DS.Snapshot
+   commentSnapshot.belongsTo('post', { id: true }); // => '1'
 
-    // store.push('comment', { id: 1, body: 'Lorem ipsum' });
-    commentSnapshot.belongsTo('post'); // => undefined
-    ```
+   // store.push('comment', { id: 1, body: 'Lorem ipsum' });
+   commentSnapshot.belongsTo('post'); // => undefined
+   ```
 
-    Calling `belongsTo` will return a new Snapshot as long as there's any known
-    data for the relationship available, such as an ID. If the relationship is
-    known but unset, `belongsTo` will return `null`. If the contents of the
-    relationship is unknown `belongsTo` will return `undefined`.
+   Calling `belongsTo` will return a new Snapshot as long as there's any known
+   data for the relationship available, such as an ID. If the relationship is
+   known but unset, `belongsTo` will return `null`. If the contents of the
+   relationship is unknown `belongsTo` will return `undefined`.
 
-    Note: Relationships are loaded lazily and cached upon first access.
+   Note: Relationships are loaded lazily and cached upon first access.
 
-    @method belongsTo
-    @param {String} keyName
-    @param {Object} [options]
-    @return {(DS.Snapshot|String|null|undefined)} A snapshot or ID of a known
-      relationship or null if the relationship is known but unset. undefined
-      will be returned if the contents of the relationship is unknown.
-  */
+   @method belongsTo
+   @param {String} keyName
+   @param {Object} [options]
+   @return {(DS.Snapshot|String|null|undefined)} A snapshot or ID of a known
+   relationship or null if the relationship is known but unset. undefined
+   will be returned if the contents of the relationship is unknown.
+   */
   belongsTo(keyName, options) {
-    var id = options && options.id;
-    var relationship, inverseRecord, hasData;
-    var result;
+    let id = options && options.id;
+    let relationship, inverseRecord, hasData;
+    let result;
 
     if (id && keyName in this._belongsToIds) {
       return this._belongsToIds[keyName];
@@ -232,41 +230,41 @@ Snapshot.prototype = {
     }
 
     return result;
-  },
+  }
 
   /**
-    Returns the current value of a hasMany relationship.
+   Returns the current value of a hasMany relationship.
 
-    `hasMany` takes an optional hash of options as a second parameter,
-    currently supported options are:
+   `hasMany` takes an optional hash of options as a second parameter,
+   currently supported options are:
 
    - `ids`: set to `true` if you only want the IDs of the related records to be
-      returned.
+   returned.
 
-    Example
+   Example
 
-    ```javascript
-    // store.push('post', { id: 1, title: 'Hello World', comments: [2, 3] });
-    postSnapshot.hasMany('comments'); // => [DS.Snapshot, DS.Snapshot]
-    postSnapshot.hasMany('comments', { ids: true }); // => ['2', '3']
+   ```javascript
+   // store.push('post', { id: 1, title: 'Hello World', comments: [2, 3] });
+   postSnapshot.hasMany('comments'); // => [DS.Snapshot, DS.Snapshot]
+   postSnapshot.hasMany('comments', { ids: true }); // => ['2', '3']
 
-    // store.push('post', { id: 1, title: 'Hello World' });
-    postSnapshot.hasMany('comments'); // => undefined
-    ```
+   // store.push('post', { id: 1, title: 'Hello World' });
+   postSnapshot.hasMany('comments'); // => undefined
+   ```
 
-    Note: Relationships are loaded lazily and cached upon first access.
+   Note: Relationships are loaded lazily and cached upon first access.
 
-    @method hasMany
-    @param {String} keyName
-    @param {Object} [options]
-    @return {(Array|undefined)} An array of snapshots or IDs of a known
-      relationship or an empty array if the relationship is known but unset.
-      undefined will be returned if the contents of the relationship is unknown.
-  */
+   @method hasMany
+   @param {String} keyName
+   @param {Object} [options]
+   @return {(Array|undefined)} An array of snapshots or IDs of a known
+   relationship or an empty array if the relationship is known but unset.
+   undefined will be returned if the contents of the relationship is unknown.
+   */
   hasMany(keyName, options) {
-    var ids = options && options.ids;
-    var relationship, members, hasData;
-    var results;
+    let ids = options && options.ids;
+    let relationship, members, hasData;
+    let results;
 
     if (ids && keyName in this._hasManyIds) {
       return this._hasManyIds[keyName];
@@ -304,7 +302,7 @@ Snapshot.prototype = {
     }
 
     return results;
-  },
+  }
 
   /**
     Iterates through all the attributes of the model, calling the passed
@@ -324,7 +322,7 @@ Snapshot.prototype = {
   */
   eachAttribute(callback, binding) {
     this.record.eachAttribute(callback, binding);
-  },
+  }
 
   /**
     Iterates through all the relationships of the model, calling the passed
@@ -344,7 +342,7 @@ Snapshot.prototype = {
   */
   eachRelationship(callback, binding) {
     this.record.eachRelationship(callback, binding);
-  },
+  }
 
   /**
     @method serialize
@@ -354,4 +352,4 @@ Snapshot.prototype = {
   serialize(options) {
     return this.record.store.serializerFor(this.modelName).serialize(this, options);
   }
-};
+}


### PR DESCRIPTION
Was working on cleaning up some things and just felt this could use a facelift. This isn't for perf, but I'm going to try to isolate it in a profile anyway because I'm personally curious the overall effects of:

- not setting things on the prototype that we're just going to override in the constructor anyway
- (obvs babelified) es6 class definitions vs. prototype definition using the `Object.assign` pattern