### PR TITLE
[BUGFIX beta] Inverse null relationships should throw if model doesn't exist 3

### DIFF
--- a/addon/-private/system/relationships/state/create.js
+++ b/addon/-private/system/relationships/state/create.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import ManyRelationship from "ember-data/-private/system/relationships/state/has-many";
 import BelongsToRelationship from "ember-data/-private/system/relationships/state/belongs-to";
 import EmptyObject from "ember-data/-private/system/empty-object";
+import { runInDebug } from 'ember-data/-private/debug';
 
 const { get } = Ember;
 
@@ -16,6 +17,10 @@ function createRelationshipFor(internalModel, relationshipMeta, store) {
 
   if (shouldFindInverse(relationshipMeta)) {
     inverse = internalModel.type.inverseFor(relationshipMeta.key, store);
+  } else {
+    runInDebug(() => {
+      internalModel.type.typeForRelationship(relationshipMeta.key, store);
+    });
   }
 
   if (inverse) {

--- a/tests/integration/relationships/inverse-relationships-test.js
+++ b/tests/integration/relationships/inverse-relationships-test.js
@@ -599,3 +599,17 @@ test("inverseFor is only called when inverse is not null", function(assert) {
     });
   });
 });
+
+testInDebug("Inverse null relationships with models that don't exist throw a nice error", function(assert) {
+  User = DS.Model.extend({
+    post: DS.belongsTo('post', { inverse: null })
+  });
+
+  var env = setupStore({ user: User });
+
+  assert.throws(function() {
+    run(function() {
+      env.store.createRecord('user');
+    });
+  }, /No model was found for 'post'/);
+});

--- a/tests/unit/debug-test.js
+++ b/tests/unit/debug-test.js
@@ -66,7 +66,8 @@ test("_debugInfo supports arbitray relationship types", function(assert) {
         options: { inverse: null },
         isRelationship: true,
         kind: 'customRelationship',
-        name: 'Custom Relationship'
+        name: 'Custom Relationship',
+        type: 'post'
       })
   });
 


### PR DESCRIPTION
this is continuation of #4675 which is closed in favour of this one.

`2.6.0` [Introduced](https://github.com/asakusuma/data/blob/ced181ff68f87eecd149c6d15b1f8b6887f17142/addon/-private/system/relationships/state/create.js#L16) a bug such that for `{ inverse: null }` relationships the relationship target is not checked at model creation time. However without `{ inverse: null }` we would get an error when trying to create a model with relationship to another model that doesn't exist. This PR tries to bring in consistent behaviour for such cases - perform a check for model type during model creation and throw an error if the model is not present in the store.
