### PR TITLE
Simplify Backburner Usage

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -366,7 +366,6 @@ export default class InternalModel {
 
   setupData(data) {
     heimdall.increment(setupData);
-    let token = heimdall.start('setupData');
     let changedKeys = this._changedKeys(data.attributes);
     assign(this._data, data.attributes);
     this.pushedData();
@@ -374,7 +373,6 @@ export default class InternalModel {
       this.record._notifyProperties(changedKeys);
     }
     this.didInitializeData();
-    heimdall.stop(token);
   }
 
   becameReady() {

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -24,7 +24,6 @@ const {
   inspect,
   isEmpty,
   isEqual,
-  run: emberRun,
   setOwner,
   RSVP,
   RSVP: { Promise }

--- a/addon/-private/system/model/states.js
+++ b/addon/-private/system/model/states.js
@@ -180,7 +180,7 @@ function didSetProperty(internalModel, context) {
     internalModel.send('becomeDirty');
   }
 
-  internalModel.updateRecordArraysLater();
+  internalModel.updateRecordArrays();
 }
 
 // Implementation notes:

--- a/addon/-private/system/relationships/state/create.js
+++ b/addon/-private/system/relationships/state/create.js
@@ -51,13 +51,18 @@ export default class Relationships {
 
   get(key) {
     let relationships = this.initializedRelationships;
-    let internalModel = this.internalModel;
-    let relationshipsByName = get(internalModel.type, 'relationshipsByName');
+    let relationship = relationships[key];
 
-    if (!relationships[key] && relationshipsByName.get(key)) {
-      relationships[key] = createRelationshipFor(internalModel, relationshipsByName.get(key), internalModel.store);
+    if (!relationship) {
+      let internalModel = this.internalModel;
+      let relationshipsByName = get(internalModel.type, 'relationshipsByName');
+      let rel = relationshipsByName.get(key);
+
+      if (rel) {
+        relationship = relationships[key] = createRelationshipFor(internalModel, rel, internalModel.store);
+      }
     }
 
-    return relationships[key];
+    return relationship;
   }
 }

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -127,30 +127,20 @@ export default class ManyRelationship extends Relationship {
   }
 
   computeChanges(records) {
-    var members = this.canonicalMembers;
-    var recordsToRemove = [];
-    var length;
-    var record;
-    var i;
-
-    records = setForArray(records);
+    let members = this.canonicalMembers;
+    let recordsToRemove = [];
+    let recordSet = setForArray(records);
 
     members.forEach(function(member) {
-      if (records.has(member)) { return; }
+      if (recordSet.has(member)) { return; }
 
       recordsToRemove.push(member);
     });
 
     this.removeCanonicalRecords(recordsToRemove);
 
-    // Using records.toArray() since currently using
-    // removeRecord can modify length, messing stuff up
-    // forEach since it directly looks at "length" each
-    // iteration
-    records = records.toArray();
-    length = records.length;
-    for (i = 0; i < length; i++) {
-      record = records[i];
+    for (let i = 0, l = records.length; i < l; i++) {
+      let record = records[i];
       this.removeCanonicalRecord(record);
       this.addCanonicalRecord(record, i);
     }

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -183,7 +183,7 @@ export default class Relationship {
         }
         record._implicitRelationships[this.inverseKeyForImplicit].addRecord(this.record);
       }
-      this.record.updateRecordArraysLater();
+      this.record.updateRecordArrays();
     }
     this.setHasData(true);
   }
@@ -257,7 +257,7 @@ export default class Relationship {
       return;
     }
     this.willSync = true;
-    this.store._backburner.join(() => this.store._backburner.schedule('syncRelationships', this, this.flushCanonical));
+    this.store._updateRelationshipState(this);
   }
 
   updateLink(link) {

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -235,18 +235,20 @@ export default class Relationship {
 
   flushCanonical() {
     heimdall.increment(flushCanonical);
+    let list = this.members.list;
     this.willSync = false;
     //a hack for not removing new records
     //TODO remove once we have proper diffing
     var newRecords = [];
-    for (var i = 0; i < this.members.list.length; i++) {
-      if (this.members.list[i].isNew()) {
-        newRecords.push(this.members.list[i]);
+    for (let i = 0; i < list.length; i++) {
+      if (list[i].isNew()) {
+        newRecords.push(list[i]);
       }
     }
+
     //TODO(Igor) make this less abysmally slow
     this.members = this.canonicalMembers.copy();
-    for (i = 0; i < newRecords.length; i++) {
+    for (let i = 0; i < newRecords.length; i++) {
       this.members.add(newRecords[i]);
     }
   }

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1793,24 +1793,6 @@ Store = Service.extend({
     return this.hasRecordForId(modelName, id);
   },
 
-  // ............
-  // . UPDATING .
-  // ............
-
-  /**
-    If the adapter updates attributes the record will notify
-    the store to update its  membership in any filters.
-    To avoid thrashing, this method is invoked only once per
-    run loop per record.
-
-    @method _dataWasUpdated
-    @private
-    @param {InternalModel} internalModel
-  */
-  _dataWasUpdated(internalModel) {
-    throw new Error('dont');
-    this.recordArrayManager.recordDidChange(internalModel);
-  },
 
   // ..............
   // . PERSISTING .

--- a/tests/dummy/app/routes/query/route.js
+++ b/tests/dummy/app/routes/query/route.js
@@ -24,6 +24,8 @@ export default Route.extend({
     let modelName = params.modelName;
     delete params.modelName;
 
+    heimdall.enableTimelineFeatures();
+
     let token = heimdall.start('ember-data');
     return this.get('store').query(modelName, params)
       .then((records) => {

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -600,20 +600,25 @@ testInDebug('calling push with hasMany relationship the value must be an array',
 
   invalidValues.forEach(function(invalidValue) {
     assert.throws(function() {
-      run(function() {
-        store.push({
-          data: {
-            type: 'person',
-            id: '1',
-            relationships: {
-              phoneNumbers: {
-                data: invalidValue
+      try {
+        run(function () {
+          store.push({
+            data: {
+              type: 'person',
+              id: '1',
+              relationships: {
+                phoneNumbers: {
+                  data: invalidValue
+                }
               }
             }
-          }
+          });
         });
-      });
-    }, /must be an array/);
+      } catch (e) {
+        store._pushedInternalModels.length = 0;
+        throw e;
+      }
+    }, /must be an array/, `Expect that '${Ember.inspect(invalidValue)}' is not an array`);
   });
 });
 


### PR DESCRIPTION
TL;DR spin up less, schedule less, batch more things, cleaner profiles :)

In a query returning 238 records 34 of which are primary records, this resulted in:

- ember’s run.schedule 105 times => 2x
- ember’s run.join 2 times => 1x
- ED’s schedule 274 times => 2x
- ED’s join 274 times => 2x


~~Right now this fails on the tests around support for preloading relationships when doing findRecord, digging in on that.~~

~~Also includes some additional instrumentation stuff that's part of a different PR + some additions to that instrumentation I'll need to back out.~~

~~I appear to have pushed this far enough we get failing tests around pushing hasMany's with invalid values. I think something likely just ended up dropping out of the same run loop, investigating.~~

~~There's still a little bit of low hanging fruit on this.~~