### PR TITLE
[DOC] Make model.unloadRecord public

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -587,7 +587,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
   },
 
   /**
-    Unloads the record from the store. Only non-dirty records can be unloaded.
+    Unloads the record from the store. This will cause the record to be destroyed and freed up for garbage collection.
 
     @method unloadRecord
   */

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -587,8 +587,9 @@ const Model = Ember.Object.extend(Ember.Evented, {
   },
 
   /**
+    Unloads the record from the store. Only non-dirty records can be unloaded.
+
     @method unloadRecord
-    @private
   */
   unloadRecord() {
     if (this.isDestroyed) { return; }


### PR DESCRIPTION
`store.unloadRecord` says that it's there for symmetry, meaning the model should have a similar public method.

cc @bmac