### PR TITLE
Do not access container if Ember.getOwner exists.

### DIFF
--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -22,9 +22,7 @@ function getOwner(context) {
 
   if (Ember.getOwner) {
     owner = Ember.getOwner(context);
-  }
-
-  if (!owner && context.container) {
+  } else if (context.container) {
     owner = context.container;
   }
 


### PR DESCRIPTION
Fixes broken tests on master