### PR TITLE
Added missing DS references to DS.Model implementation examples

### DIFF
--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -25,8 +25,8 @@ const MapWithDefault = Ember.MapWithDefault;
   import DS from 'ember-data';
 
   export default DS.Model.extend({
-    username: attr('string'),
-    email: attr('string')
+    username: DS.attr('string'),
+    email: DS.attr('string')
   });
   ```
   And you attempted to save a record that did not validate on the backend:

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -653,8 +653,8 @@ const Model = Ember.Object.extend(Ember.Evented, {
     import DS from 'ember-data';
 
     export default DS.Model.extend({
-      name: attr('string'),
-      isAdmin: attr('boolean', {
+      name: DS.attr('string'),
+      isAdmin: DS.attr('boolean', {
         defaultValue: false
       })
     });
@@ -1669,9 +1669,9 @@ Model.reopenClass({
    import DS from 'ember-data';
 
    export default DS.Model.extend({
-      firstName: attr('string'),
-      lastName: attr('string'),
-      birthday: attr('date')
+      firstName: DS.attr('string'),
+      lastName: DS.attr('string'),
+      birthday: DS.attr('date')
     });
    ```
 
@@ -1723,9 +1723,9 @@ Model.reopenClass({
    import DS from 'ember-data';
 
    export default DS.Model.extend({
-      firstName: attr(),
-      lastName: attr('string'),
-      birthday: attr('date')
+      firstName: DS.attr(),
+      lastName: DS.attr('string'),
+      birthday: DS.attr('date')
     });
    ```
 
@@ -1784,9 +1784,9 @@ Model.reopenClass({
    import DS from 'ember-data';
 
    let Person = DS.Model.extend({
-      firstName: attr('string'),
-      lastName: attr('string'),
-      birthday: attr('date')
+      firstName: DS.attr('string'),
+      lastName: DS.attr('string'),
+      birthday: DS.attr('date')
     });
 
    Person.eachAttribute(function(name, meta) {
@@ -1835,9 +1835,9 @@ Model.reopenClass({
    import DS from 'ember-data';
 
    let Person = DS.Model.extend({
-      firstName: attr(),
-      lastName: attr('string'),
-      birthday: attr('date')
+      firstName: DS.attr(),
+      lastName: DS.attr('string'),
+      birthday: DS.attr('date')
     });
 
    Person.eachTransformedAttribute(function(name, type) {

--- a/addon/attr.js
+++ b/addon/attr.js
@@ -70,9 +70,9 @@ function getValue(record, key) {
   import DS from 'ember-data';
 
   export default DS.Model.extend({
-    username: attr('string'),
-    email: attr('string'),
-    settings: attr({
+    username: DS.attr('string'),
+    email: DS.attr('string'),
+    settings: DS.attr({
       defaultValue() {
         return {};
       }


### PR DESCRIPTION
This adds missing DS references to DS.Model implementation examples.

Locations affected:

1. http://emberjs.com/api/data/classes/DS.Errors.html
2. http://emberjs.com/api/data/classes/DS.Model.html#property_attributes
3. http://emberjs.com/api/data/classes/DS.Model.html#property_transformedAttributes
4. http://emberjs.com/api/data/classes/DS.Model.html#method_eachAttribute
5. http://emberjs.com/api/data/classes/DS.Model.html#method_eachTransformedAttribute
6. http://emberjs.com/api/data/classes/DS.Model.html#method_changedAttributes
7. http://emberjs.com/api/data/#method_attr