### PR TITLE
Avoid mutating model factory in _modelForMixin.

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2049,16 +2049,17 @@ Store = Service.extend({
     }
 
     if (mixin) {
+      let ModelForMixin = Model.extend(mixin);
+      ModelForMixin.reopenClass({
+        __isMixin: true,
+        __mixin: mixin
+      });
+
       //Cache the class as a model
-      owner.register('model:' + normalizedModelName, Model.extend(mixin));
-    }
-    let factory = this.modelFactoryFor(normalizedModelName);
-    if (factory) {
-      factory.__isMixin = true;
-      factory.__mixin = mixin;
+      owner.register('model:' + normalizedModelName, ModelForMixin);
     }
 
-    return factory;
+    return this.modelFactoryFor(normalizedModelName);
   },
 
   /**


### PR DESCRIPTION
With the upcoming `factory-for` work it is likely that mutating the result of `modelFactoryFor` will throw an error.  This is a minor refactoring to avoid needing to mutate the return value (since we can simply do the work before registering).

Addresses one of the issues mentioned in https://github.com/emberjs/data/issues/4807#issuecomment-281091810.