### PR TITLE
remove isPrimaryType’s reliance on modelName

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2338,6 +2338,7 @@ Store = Service.extend({
 
   _hasModelFor(modelName) {
     let owner = getOwner(this);
+    modelName = normalizeModelName(modelName);
 
     if (owner.factoryFor) {
       return !!owner.factoryFor(`model:${modelName}`);

--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -183,7 +183,7 @@ let RESTSerializer = JSONSerializer.extend({
       included: []
     };
 
-    let modelClass = store._modelFor(modelName);
+    let modelClass = store.modelFor(modelName);
     let serializer = store.serializerFor(modelName);
 
     Ember.makeArray(arrayHash).forEach((hash) => {
@@ -373,8 +373,7 @@ let RESTSerializer = JSONSerializer.extend({
   },
 
   isPrimaryType(store, typeName, primaryTypeClass) {
-    let typeClass = store.modelFor(typeName);
-    return typeClass.modelName === primaryTypeClass.modelName;
+    return store.modelFor(typeName) === primaryTypeClass;
   },
 
   /**

--- a/tests/integration/serializers/rest-serializer-test.js
+++ b/tests/integration/serializers/rest-serializer-test.js
@@ -109,8 +109,17 @@ test("normalizeResponse with custom modelNameFromPayloadKey", function(assert) {
   };
 
   var jsonHash = {
-    home_planets: [{ id: "1", name: "Umber", superVillains: [1] }],
-    super_villains: [{ id: "1", firstName: "Tom", lastName: "Dale", homePlanet: "1" }]
+    home_planets: [{
+      id: "1",
+      name: "Umber",
+      superVillains: [1]
+    }],
+    super_villains: [{
+      id: "1",
+      firstName: "Tom",
+      lastName: "Dale",
+      homePlanet: "1"
+    }]
   };
   var array;
 
@@ -277,7 +286,6 @@ test("serialize polymorphicType", function(assert) {
 });
 
 test("serialize polymorphicType with decamelized modelName", function(assert) {
-  YellowMinion.modelName = 'yellow-minion';
   var tom, ray;
   run(function() {
     tom = env.store.createRecord('yellow-minion', { name: "Alex", id: "124" });
@@ -529,7 +537,6 @@ test("serializeIntoHash", function(assert) {
 });
 
 test("serializeIntoHash with decamelized modelName", function(assert) {
-  HomePlanet.modelName = 'home-planet';
   run(function() {
     league = env.store.createRecord('home-planet', { name: "Umber", id: "123" });
   });

--- a/tests/unit/store/has-model-for-test.js
+++ b/tests/unit/store/has-model-for-test.js
@@ -1,0 +1,20 @@
+import {createStore} from 'dummy/tests/helpers/store';
+import {module, test} from 'qunit';
+import DS from 'ember-data';
+
+let store;
+
+module('unit/store/has-model-For', {
+  beforeEach() {
+    store = createStore({
+      adapter: DS.Adapter.extend(),
+      'one-foo':  DS.Model.extend({}),
+      'two-foo': DS.Model.extend({})
+    });
+  }
+});
+
+test(`hasModelFor correctly normalizes`, function(assert) {
+  assert.equal(store._hasModelFor('oneFoo'), true);
+  assert.equal(store._hasModelFor('twoFoo'). true);
+});


### PR DESCRIPTION
* when interacting with a user-provided modelName, always be sure to normalize it.