### PR TITLE
Stefs cleanup (and some test suite memory leak fixes)

### DIFF
--- a/tests/integration/debug-adapter-test.js
+++ b/tests/integration/debug-adapter-test.js
@@ -8,10 +8,12 @@ var App, store, debugAdapter;
 var get = Ember.get;
 var run = Ember.run;
 
-module("DS.DebugAdapter", {
+module('DS.DebugAdapter', {
   beforeEach() {
     Ember.run(function() {
-      App = Ember.Application.create();
+      App = Ember.Application.extend({
+        toString() { return 'debug-app'; }
+      }).create();
 
       App.StoreService = DS.Store.extend({});
 
@@ -49,6 +51,7 @@ module("DS.DebugAdapter", {
   },
   afterEach() {
     run(App, App.destroy);
+    App = store = null;
   }
 });
 

--- a/tests/unit/many-array-test.js
+++ b/tests/unit/many-array-test.js
@@ -106,25 +106,26 @@ test('manyArray trigger arrayContentChange functions with the correct values', f
   let willChangeRemoveAmt;
   let willChangeAddAmt;
 
-  let originalArrayContentWillChange = DS.ManyArray.prototype.arrayContentWillChange;
-  let originalArrayContentDidChange = DS.ManyArray.prototype.arrayContentDidChange;
+  let originalArrayContentWillChange = DS.ManyArray.proto().arrayContentWillChange;
+  let originalArrayContentDidChange = DS.ManyArray.proto().arrayContentDidChange;
 
-  DS.ManyArray.reopen({
-    arrayContentWillChange(startIdx, removeAmt, addAmt) {
-      willChangeStartIdx = startIdx;
-      willChangeRemoveAmt = removeAmt;
-      willChangeAddAmt = addAmt;
+  // override DS.ManyArray temp (cleanup occures in afterTest);
 
-      return this._super(...arguments);
-    },
-    arrayContentDidChange(startIdx, removeAmt, addAmt) {
-      assert.equal(startIdx, willChangeStartIdx, 'WillChange and DidChange startIdx should match');
-      assert.equal(removeAmt, willChangeRemoveAmt, 'WillChange and DidChange removeAmt should match');
-      assert.equal(addAmt, willChangeAddAmt, 'WillChange and DidChange addAmt should match');
+  DS.ManyArray.proto().arrayContentWillChange = function(startIdx, removeAmt, addAmt)  {
+    willChangeStartIdx = startIdx;
+    willChangeRemoveAmt = removeAmt;
+    willChangeAddAmt = addAmt;
 
-      return this._super(...arguments);
-    }
-  });
+    return originalArrayContentWillChange.apply(this, arguments);
+  };
+
+  DS.ManyArray.proto().arrayContentDidChange = function(startIdx, removeAmt, addAmt) {
+    assert.equal(startIdx, willChangeStartIdx, 'WillChange and DidChange startIdx should match');
+    assert.equal(removeAmt, willChangeRemoveAmt, 'WillChange and DidChange removeAmt should match');
+    assert.equal(addAmt, willChangeAddAmt, 'WillChange and DidChange addAmt should match');
+
+    return originalArrayContentDidChange.apply(this, arguments);
+  };
 
   try {
     run(() => {
@@ -181,11 +182,8 @@ test('manyArray trigger arrayContentChange functions with the correct values', f
         }
       });
     });
-
   } finally {
-    DS.ManyArray.reopen({
-      arrayContentWillChange: originalArrayContentWillChange,
-      arrayContentDidChange: originalArrayContentDidChange
-    });
+    DS.ManyArray.proto().arrayContentWillChange = originalArrayContentWillChange;
+    DS.ManyArray.proto().arrayContentDidChange = originalArrayContentDidChange;
   }
 });

--- a/tests/unit/model/lifecycle-callbacks-test.js
+++ b/tests/unit/model/lifecycle-callbacks-test.js
@@ -282,6 +282,7 @@ test('a record receives a becameInvalid callback when it became invalid', functi
       assert.ok(reason.isAdapterError, 'reason should have been an adapter error');
       assert.equal(reason.errors.length, 1, 'reason should have one error');
       assert.equal(reason.errors[0].title, 'Invalid Attribute');
+      assert.equal(callCount, 1, 'becameInvalid called after invalidating');
     });
   });
 });

--- a/tests/unit/model/lifecycle-callbacks-test.js
+++ b/tests/unit/model/lifecycle-callbacks-test.js
@@ -282,7 +282,6 @@ test('a record receives a becameInvalid callback when it became invalid', functi
       assert.ok(reason.isAdapterError, 'reason should have been an adapter error');
       assert.equal(reason.errors.length, 1, 'reason should have one error');
       assert.equal(reason.errors[0].title, 'Invalid Attribute');
-      assert.equal(callCount, 1, 'becameInvalid called after invalidating');
     });
   });
 });


### PR DESCRIPTION
Noticed 8 containers leaked to the end of the test suite, this PR fixes 5 of them (2 of them are yet upstream). This leaves us with 1, and that one appears strange/tricky (will investigate next).

also found these leaks:

* https://github.com/tildeio/rsvp.js/pull/446 <-- caused us to leak 2 containers
* https://github.com/stefanpenner/es6-promise

---

The goal of this, is to be sure our own test suite can be used (at-least manually) to detect leaks/tests. So if we can have our test suite not leak, it will be easier to catch leaks going forward (like the 2 RSVP / ES6 promise leaks).