### PR TITLE
Stable has many promise proxy

### DIFF
--- a/addon/-private/system/promise-proxies.js
+++ b/addon/-private/system/promise-proxies.js
@@ -103,11 +103,9 @@ export function proxyToContent(method) {
 
 export const PromiseManyArray = PromiseArray.extend({
   reload() {
-    //I don't think this should ever happen right now, but worth guarding if we refactor the async relationships
     assert('You are trying to reload an async manyArray before it has been created', get(this, 'content'));
-    return PromiseManyArray.create({
-      promise: get(this, 'content').reload()
-    });
+    this.set('promise', this.get('content').reload())
+    return this;
   },
 
   createRecord: proxyToContent('createRecord'),

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -10,6 +10,7 @@ export default class ManyRelationship extends Relationship {
     this.belongsToType = relationshipMeta.type;
     this.canonicalState = [];
     this.isPolymorphic = relationshipMeta.options.polymorphic;
+    this._manyArray = null;
   }
 
   get manyArray() {

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -1,8 +1,8 @@
-import { assert, assertPolymorphicType } from "ember-data/-private/debug";
-import { PromiseManyArray, promiseManyArray } from "../../promise-proxies";
-import Relationship from "./relationship";
-import OrderedSet from "../../ordered-set";
-import ManyArray from "../../many-array";
+import { assert, assertPolymorphicType } from 'ember-data/-private/debug';
+import { PromiseManyArray } from '../../promise-proxies';
+import Relationship from './relationship';
+import OrderedSet from '../../ordered-set';
+import ManyArray from '../../many-array';
 
 export default class ManyRelationship extends Relationship {
   constructor(store, record, inverseKey, relationshipMeta) {
@@ -11,6 +11,24 @@ export default class ManyRelationship extends Relationship {
     this.canonicalState = [];
     this.isPolymorphic = relationshipMeta.options.polymorphic;
     this._manyArray = null;
+    this.__loadingPromise = null;
+  }
+
+  get _loadingPromise() { return this.__loadingPromise; }
+  _updateLoadingPromise(promise, content) {
+    if (this.__loadingPromise) {
+      if (content) {
+        this.__loadingPromise.set('content', content)
+      }
+      this.__loadingPromise.set('promise', promise)
+    } else {
+      this.__loadingPromise = new PromiseManyArray({
+        promise,
+        content
+      });
+    }
+
+    return this.__loadingPromise;
   }
 
   get manyArray() {
@@ -33,6 +51,10 @@ export default class ManyRelationship extends Relationship {
     if (this._manyArray) {
       this._manyArray.destroy();
       this._manyArray = null;
+    }
+
+    if (this._loadingPromise) {
+      this._loadingPromise.destroy();
     }
   }
 
@@ -126,13 +148,15 @@ export default class ManyRelationship extends Relationship {
       }
     }
 
+    let promise;
     if (this.link) {
-      this._loadingPromise = promiseManyArray(this.fetchLink(), 'Reload with link');
-      return this._loadingPromise;
+      promise = this.fetchLink();
     } else {
-      this._loadingPromise = promiseManyArray(this.store._scheduleFetchMany(manyArray.currentState).then(() => manyArray), 'Reload with ids');
-      return this._loadingPromise;
+      promise = this.store._scheduleFetchMany(manyArray.currentState).then(() => manyArray);
     }
+
+    this._updateLoadingPromise(promise);
+    return this._loadingPromise;
   }
 
   computeChanges(records) {
@@ -190,7 +214,7 @@ export default class ManyRelationship extends Relationship {
     //TODO(Igor) sync server here, once our syncing is not stupid
     let manyArray = this.manyArray;
     if (this.isAsync) {
-      var promise;
+      let promise;
       if (this.link) {
         if (this.hasLoaded) {
           promise = this.findRecords();
@@ -200,11 +224,7 @@ export default class ManyRelationship extends Relationship {
       } else {
         promise = this.findRecords();
       }
-      this._loadingPromise = PromiseManyArray.create({
-        content: manyArray,
-        promise: promise
-      });
-      return this._loadingPromise;
+      return this._updateLoadingPromise(promise, manyArray);
     } else {
       assert(`You looked up the '${this.key}' relationship on a '${this.record.type.modelName}' with id ${this.record.id} but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async ('DS.hasMany({ async: true })')`, manyArray.isEvery('isEmpty', false));
 

--- a/tests/unit/promise-proxies-test.js
+++ b/tests/unit/promise-proxies-test.js
@@ -13,8 +13,8 @@ test('.reload should NOT leak the internal promise, rather return another promis
 
   content.reload = () => Ember.RSVP.Promise.resolve(content);
 
-  let array = DS.PromiseManyArray.create({
-    content: content
+  let array = new DS.PromiseManyArray({
+    content
   });
 
   let reloaded = array.reload();
@@ -23,3 +23,90 @@ test('.reload should NOT leak the internal promise, rather return another promis
 
   return reloaded.then(value => assert.equal(content, value));
 });
+
+test('.reload should be stable', function(assert) {
+  assert.expect(19);
+
+  let content = Ember.A();
+
+  content.reload = () => Ember.RSVP.Promise.resolve(content);
+  let promise = Ember.RSVP.Promise.resolve(content);
+
+  let array = new DS.PromiseManyArray({
+    promise
+  });
+
+  assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+  assert.equal(array.get('isPending'), true, 'should be pending');
+  assert.equal(array.get('isSettled'), false, 'should NOT be settled');
+  assert.equal(array.get('isFulfilled'), false, 'should NOT be fulfilled');
+
+  return array.then(() => {
+    assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+    assert.equal(array.get('isPending'), false, 'should NOT be pending');
+    assert.equal(array.get('isSettled'), true, 'should be settled');
+    assert.equal(array.get('isFulfilled'), true, 'should be fulfilled');
+
+    let reloaded = array.reload();
+
+    assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+    assert.equal(array.get('isPending'), true, 'should be pending');
+    assert.equal(array.get('isSettled'), false, 'should NOT be settled');
+    assert.equal(array.get('isFulfilled'), false, 'should NOT be fulfilled');
+
+    assert.ok(reloaded instanceof DS.PromiseManyArray);
+    assert.equal(reloaded, array);
+
+    return reloaded.then(value => {
+      assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+      assert.equal(array.get('isPending'), false, 'should NOT be pending');
+      assert.equal(array.get('isSettled'), true, 'should be settled');
+      assert.equal(array.get('isFulfilled'), true, 'should be fulfilled');
+
+      assert.equal(content, value);
+    });
+  });
+});
+
+test('.set to new promise should be like reload', function(assert) {
+  assert.expect(18);
+
+  let content = Ember.A([1,2,3]);
+
+  let promise = Ember.RSVP.Promise.resolve(content);
+
+  let array = new DS.PromiseManyArray({
+    promise
+  });
+
+  assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+  assert.equal(array.get('isPending'), true, 'should be pending');
+  assert.equal(array.get('isSettled'), false, 'should NOT be settled');
+  assert.equal(array.get('isFulfilled'), false, 'should NOT be fulfilled');
+
+  return array.then(() => {
+    assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+    assert.equal(array.get('isPending'), false, 'should NOT be pending');
+    assert.equal(array.get('isSettled'), true, 'should be settled');
+    assert.equal(array.get('isFulfilled'), true, 'should be fulfilled');
+
+    array.set('promise', Ember.RSVP.Promise.resolve(content));
+
+    assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+    assert.equal(array.get('isPending'), true, 'should be pending');
+    assert.equal(array.get('isSettled'), false, 'should NOT be settled');
+    assert.equal(array.get('isFulfilled'), false, 'should NOT be fulfilled');
+
+    assert.ok(array instanceof DS.PromiseManyArray);
+
+    return array.then(value => {
+      assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+      assert.equal(array.get('isPending'), false, 'should NOT be pending');
+      assert.equal(array.get('isSettled'), true, 'should be settled');
+      assert.equal(array.get('isFulfilled'), true, 'should be fulfilled');
+
+      assert.equal(content, value);
+    });
+  });
+});
+


### PR DESCRIPTION
- [x] fixes memory leak: https://github.com/emberjs/data/issues/4826
- [x] prevents needless re-render, allowing glimmer to diff rather then constantly having to blow away `each`'s which `each` across relationships.