### PR TITLE
Improve naming around internal constructs (record vs internal model)

### DIFF
--- a/addon/-private/system/identity-map.js
+++ b/addon/-private/system/identity-map.js
@@ -1,4 +1,5 @@
-import RecordMap from './record-map';
+import InternalModelMap from './internal-model-map';
+
 
 /**
  `IdentityMap` is a custom storage map for records by modelName
@@ -13,37 +14,37 @@ export default class IdentityMap {
   }
 
   /**
-   Retrieves the `RecordMap` for a given modelName,
+   Retrieves the `InternalModelMap` for a given modelName,
    creating one if one did not already exist. This is
    similar to `getWithDefault` or `get` on a `MapWithDefault`
 
    @method retrieve
    @param modelName a previously normalized modelName
-   @returns {RecordMap} the RecordMap for the given modelName
+   @returns {InternalModelMap} the InternalModelMap for the given modelName
    */
   retrieve(modelName) {
-    let recordMap = this._map[modelName];
+    let map = this._map[modelName];
 
-    if (!recordMap) {
-      recordMap = this._map[modelName] = new RecordMap(modelName);
+    if (!map) {
+      map = this._map[modelName] = new InternalModelMap(modelName);
     }
 
-    return recordMap;
+    return map;
   }
 
   /**
    Clears the contents of all known `RecordMaps`, but does
-   not remove the RecordMap instances.
+   not remove the InternalModelMap instances.
 
    @method clear
    */
   clear() {
-    let recordMaps = this._map;
-    let keys = Object.keys(recordMaps);
+    let map = this._map;
+    let keys = Object.keys(map);
 
     for (let i = 0; i < keys.length; i++) {
       let key = keys[i];
-      recordMaps[key].clear();
+      map[key].clear();
     }
   }
 }

--- a/addon/-private/system/internal-model-map.js
+++ b/addon/-private/system/internal-model-map.js
@@ -2,20 +2,20 @@ import { assert, deprecate } from "ember-data/-private/debug";
 import InternalModel from './model/internal-model';
 
 /**
- `RecordMap` is a custom storage map for records of a given modelName
+ `InternalModelMap` is a custom storage map for internalModels of a given modelName
  used by `IdentityMap`.
 
- It was extracted from an implicit pojo based "record map" and preserves
+ It was extracted from an implicit pojo based "internalModel map" and preserves
  that interface while we work towards a more official API.
 
- @class RecordMap
+ @class InternalModelMap
  @private
  */
-export default class RecordMap {
+export default class InternalModelMap {
   constructor(modelName) {
     this.modelName = modelName;
-    this._idToRecord = Object.create(null);
-    this._records = [];
+    this._idToModel = Object.create(null);
+    this._models = [];
     this._metadata = null;
   }
 
@@ -23,11 +23,11 @@ export default class RecordMap {
     A "map" of records based on their ID for this modelName
    */
   get idToRecord() {
-    deprecate('Use of RecordMap.idToRecord is deprecated, use RecordMap.get(id) instead.', false, {
+    deprecate('Use of InternalModelMap.idToRecord is deprecated, use InternalModelMap.get(id) instead.', false, {
       id: 'ds.record-map.idToRecord',
       until: '2.13'
     });
-    return this._idToRecord;
+    return this._idToModel;
   }
 
   /**
@@ -36,62 +36,62 @@ export default class RecordMap {
    * @returns {InternalModel}
    */
   get(id) {
-    let r = this._idToRecord[id];
+    let r = this._idToModel[id];
     return r;
   }
 
   has(id) {
-    return !!this._idToRecord[id];
+    return !!this._idToModel[id];
   }
 
   get length() {
-    return this._records.length;
+    return this._models.length;
   }
 
   set(id, internalModel) {
     assert(`You cannot index an internalModel by an empty id'`, id);
     assert(`You cannot set an index for an internalModel to something other than an internalModel`, internalModel instanceof InternalModel);
-    assert(`You cannot set an index for an internalModel that is not in the RecordMap`, this.contains(internalModel));
+    assert(`You cannot set an index for an internalModel that is not in the InternalModelMap`, this.contains(internalModel));
     assert(`You cannot update the id index of an InternalModel once set. Attempted to update ${id}.`, !this.has(id) || this.get(id) === internalModel);
 
-    this._idToRecord[id] = internalModel;
+    this._idToModel[id] = internalModel;
   }
 
   add(internalModel, id) {
-    assert(`You cannot re-add an already present InternalModel to the RecordMap.`, !this.contains(internalModel));
+    assert(`You cannot re-add an already present InternalModel to the InternalModelMap.`, !this.contains(internalModel));
 
     if (id) {
-      this._idToRecord[id] = internalModel;
+      this._idToModel[id] = internalModel;
     }
 
-    this._records.push(internalModel);
+    this._models.push(internalModel);
   }
 
   remove(internalModel, id) {
     if (id) {
-      delete this._idToRecord[id];
+      delete this._idToModel[id];
     }
 
-    let loc = this._records.indexOf(internalModel);
+    let loc = this._models.indexOf(internalModel);
 
     if (loc !== -1) {
-      this._records.splice(loc, 1);
+      this._models.splice(loc, 1);
     }
   }
 
   contains(internalModel) {
-    return this._records.indexOf(internalModel) !== -1;
+    return this._models.indexOf(internalModel) !== -1;
   }
 
   /**
-   An array of all records of this modelName
+   An array of all models of this modelName
    */
-  get records() {
-    return this._records;
+  get models() {
+    return this._models;
   }
 
   /**
-   * meta information about records
+   * meta information about internalModels
    */
   get metadata() {
     return this._metadata || (this._metadata = Object.create(null));
@@ -103,23 +103,22 @@ export default class RecordMap {
    @deprecated
    */
   get type() {
-    throw new Error('RecordMap.type is no longer available');
+    throw new Error('InternalModelMap.type is no longer available');
   }
 
   /**
-   Destroy all records in the recordMap and wipe metadata.
+   Destroy all models in the internalModelTest and wipe metadata.
 
    @method clear
    */
   clear() {
-    if (this._records) {
-      let records = this._records;
-      this._records = [];
-      let record;
+    if (this._models) {
+      let models = this._models;
+      this._models = [];
 
-      for (let i = 0; i < records.length; i++) {
-        record = records[i];
-        record.unloadRecord();
+      for (let i = 0; i < models.length; i++) {
+        let model = models[i];
+        model.unloadRecord();
       }
     }
 

--- a/addon/-private/system/record-array-manager.js
+++ b/addon/-private/system/record-array-manager.js
@@ -226,8 +226,8 @@ export default class RecordArrayManager {
   syncLiveRecordArray(array, modelName) {
     assert(`recordArrayManger.syncLiveRecordArray expects modelName not modelClass as the second param`, typeof modelName === 'string');
     let hasNoPotentialDeletions = this.changedRecords.length === 0;
-    let recordMap = this.store._recordMapFor(modelName);
-    let hasNoInsertionsOrRemovals = recordMap.length === array.length;
+    let map = this.store._internalModelsFor(modelName);
+    let hasNoInsertionsOrRemovals = map.length === array.length;
 
     /*
       Ideally the recordArrayManager has knowledge of the changes to be applied to
@@ -245,15 +245,14 @@ export default class RecordArrayManager {
   populateLiveRecordArray(array, modelName) {
     assert(`recordArrayManger.populateLiveRecordArray expects modelName not modelClass as the second param`, typeof modelName === 'string');
     heimdall.increment(populateLiveRecordArray);
-    let recordMap = this.store._recordMapFor(modelName);
-    let records = recordMap.records;
-    let record;
+    let modelMap = this.store._internalModelsFor(modelName);
+    let internalModels = modelMap.models;
 
-    for (let i = 0; i < records.length; i++) {
-      record = records[i];
+    for (let i = 0; i < internalModels.length; i++) {
+      let internalModel = internalModels[i];
 
-      if (!record.isDeleted() && !record.isEmpty()) {
-        this._addInternalModelToRecordArray(array, record);
+      if (!internalModel.isDeleted() && !internalModel.isEmpty()) {
+        this._addInternalModelToRecordArray(array, internalModel);
       }
     }
   }
@@ -273,15 +272,14 @@ export default class RecordArrayManager {
   updateFilter(array, modelName, filter) {
     assert(`recordArrayManger.updateFilter expects modelName not modelClass as the second param, received ${modelName}`, typeof modelName === 'string');
     heimdall.increment(updateFilter);
-    let recordMap = this.store._recordMapFor(modelName);
-    let records = recordMap.records;
-    let record;
+    let modelMap = this.store._internalModelsFor(modelName);
+    let internalModels = modelMap.models;
 
-    for (let i = 0; i < records.length; i++) {
-      record = records[i];
+    for (let i = 0; i < internalModels.length; i++) {
+      let internalModel = internalModels[i];
 
-      if (!record.isDeleted() && !record.isEmpty()) {
-        this.updateFilterRecordArray(array, filter, modelName, record);
+      if (!internalModel.isDeleted() && !internalModel.isEmpty()) {
+        this.updateFilterRecordArray(array, filter, modelName, internalModel);
       }
     }
   }

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -112,7 +112,7 @@ const {
   peekAll,
   peekRecord,
   serializerFor,
-  _recordMapFor
+  _internalModelsFor
 } = heimdall.registerMonitor('store',
   '_generateId',
   '_internalModelForId',
@@ -129,7 +129,7 @@ const {
   'peekAll',
   'peekRecord',
   'serializerFor',
-  '_recordMapFor'
+  '_internalModelsFor'
 );
 
 /**
@@ -1101,7 +1101,7 @@ Store = Service.extend({
     let normalizedModelName = normalizeModelName(modelName);
 
     let trueId = coerceId(id);
-    let internalModel = this._recordMapFor(normalizedModelName).get(trueId);
+    let internalModel = this._internalModelsFor(normalizedModelName).get(trueId);
 
     return !!internalModel && internalModel.isLoaded();
   },
@@ -1126,7 +1126,7 @@ Store = Service.extend({
   _internalModelForId(modelName, id) {
     heimdall.increment(_internalModelForId);
     let trueId = coerceId(id);
-    let internalModel = this._recordMapFor(modelName).get(trueId);
+    let internalModel = this._internalModelsFor(modelName).get(trueId);
 
     if (!internalModel) {
       internalModel = this.buildInternalModel(modelName, trueId);
@@ -1612,7 +1612,7 @@ Store = Service.extend({
   */
   _fetchAll(modelName, array, options = {}) {
     let adapter = this.adapterFor(modelName);
-    let sinceToken = this._recordMapFor(modelName).metadata.since;
+    let sinceToken = this._internalModelsFor(modelName).metadata.since;
 
     assert(`You tried to load all records but you have no adapter (for ${modelName})`, adapter);
     assert(`You tried to load all records but your adapter does not implement 'findAll'`, typeof adapter.findAll === 'function');
@@ -1710,7 +1710,7 @@ Store = Service.extend({
       this._identityMap.clear();
     } else {
       let normalizedModelName = normalizeModelName(modelName);
-      this._recordMapFor(normalizedModelName).clear();
+      this._internalModelsFor(normalizedModelName).clear();
     }
   },
 
@@ -1968,7 +1968,7 @@ Store = Service.extend({
       return;
     }
 
-    this._recordMapFor(internalModel.modelName).set(id, internalModel);
+    this._internalModelsFor(internalModel.modelName).set(id, internalModel);
 
     internalModel.setId(id);
   },
@@ -1976,13 +1976,13 @@ Store = Service.extend({
   /**
     Returns a map of IDs to client IDs for a given modelName.
 
-    @method _recordMapFor
+    @method _internalModelsFor
     @private
     @param {String} modelName
     @return {Object} recordMap
   */
-  _recordMapFor(modelName) {
-    heimdall.increment(_recordMapFor);
+  _internalModelsFor(modelName) {
+    heimdall.increment(_internalModelsFor);
     return this._identityMap.retrieve(modelName);
   },
 
@@ -2538,7 +2538,7 @@ Store = Service.extend({
 
     assert(`You can no longer pass a modelClass as the first argument to store.buildInternalModel. Pass modelName instead.`, typeof modelName === 'string');
 
-    let recordMap = this._recordMapFor(modelName);
+    let recordMap = this._internalModelsFor(modelName);
 
     assert(`The id ${id} has already been used with another record for modelClass '${modelName}'.`, !id || !recordMap.get(id));
 
@@ -2569,7 +2569,7 @@ Store = Service.extend({
     @param {InternalModel} internalModel
   */
   _removeFromIdMap(internalModel) {
-    let recordMap = this._recordMapFor(internalModel.modelName);
+    let recordMap = this._internalModelsFor(internalModel.modelName);
     let id = internalModel.id;
 
     recordMap.remove(internalModel, id);

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -557,9 +557,9 @@ test("createRecord - response can contain relationships the client doesn't yet k
   run(function() {
     post.save().then(assert.wait(function(post) {
       assert.equal(post.get('comments.firstObject.post'), post, "the comments are related to the correct post model");
-      assert.equal(store._recordMapFor('post').records.length, 1, "There should only be one post record in the store");
+      assert.equal(store._internalModelsFor('post').models.length, 1, "There should only be one post record in the store");
 
-      var postRecords = store._recordMapFor('post').records;
+      var postRecords = store._internalModelsFor('post').models;
       for (var i = 0; i < postRecords.length; i++) {
         assert.equal(post, postRecords[i].getRecord(), "The object in the identity map is the same");
       }

--- a/tests/integration/records/rematerialize-test.js
+++ b/tests/integration/records/rematerialize-test.js
@@ -105,14 +105,14 @@ test("a sync belongs to relationship to an unloaded record can restore that reco
   assert.equal(person.get('cars.length'), 1, 'The inital length of cars is correct');
 
   assert.equal(env.store.hasRecordForId('person', 1), true, 'The person is in the store');
-  assert.equal(env.store._recordMapFor('person').has(1), true, 'The person internalModel is loaded');
+  assert.equal(env.store._internalModelsFor('person').has(1), true, 'The person internalModel is loaded');
 
   run(function() {
     person.unloadRecord();
   });
 
   assert.equal(env.store.hasRecordForId('person', 1), false, 'The person is unloaded');
-  assert.equal(env.store._recordMapFor('person').has(1), true, 'The person internalModel is retained');
+  assert.equal(env.store._internalModelsFor('person').has(1), true, 'The person internalModel is retained');
 
   run(() => {
     env.store.push({
@@ -215,9 +215,9 @@ test("an async has many relationship to an unloaded record can restore that reco
   let boaty = env.store.peekRecord('boat', 1);
 
   assert.equal(env.store.hasRecordForId('person', 1), true, 'The person is in the store');
-  assert.equal(env.store._recordMapFor('person').has(1), true, 'The person internalModel is loaded');
+  assert.equal(env.store._internalModelsFor('person').has(1), true, 'The person internalModel is loaded');
   assert.equal(env.store.hasRecordForId('boat', 1), true, 'The boat is in the store');
-  assert.equal(env.store._recordMapFor('boat').has(1), true, 'The boat internalModel is loaded');
+  assert.equal(env.store._internalModelsFor('boat').has(1), true, 'The boat internalModel is loaded');
 
   let boats = run(() => {
     return adam.get('boats');
@@ -230,7 +230,7 @@ test("an async has many relationship to an unloaded record can restore that reco
   });
 
   assert.equal(env.store.hasRecordForId('boat', 1), false, 'The boat is unloaded');
-  assert.equal(env.store._recordMapFor('boat').has(1), true, 'The boat internalModel is retained');
+  assert.equal(env.store._internalModelsFor('boat').has(1), true, 'The boat internalModel is retained');
 
   let rematerializedBoaty = run(() => {
     return rematerializedBoaty = adam.get('boats').objectAt(1);
@@ -241,5 +241,5 @@ test("an async has many relationship to an unloaded record can restore that reco
   assert.notEqual(rematerializedBoaty, boaty, 'the boat is rematerialized, not recycled');
 
   assert.equal(env.store.hasRecordForId('boat', 1), true, 'The boat is loaded');
-  assert.equal(env.store._recordMapFor('boat').has(1), true, 'The boat internalModel is retained');
+  assert.equal(env.store._internalModelsFor('boat').has(1), true, 'The boat internalModel is retained');
 });

--- a/tests/integration/records/unload-test.js
+++ b/tests/integration/records/unload-test.js
@@ -72,14 +72,14 @@ test("can unload a single record", function(assert) {
   });
 
   assert.equal(env.store.peekAll('person').get('length'), 1, 'one person record loaded');
-  assert.equal(env.store._recordMapFor('person').length, 1, 'one person internalModel loaded');
+  assert.equal(env.store._internalModelsFor('person').length, 1, 'one person internalModel loaded');
 
   Ember.run(function() {
     adam.unloadRecord();
   });
 
   assert.equal(env.store.peekAll('person').get('length'), 0, 'no person records');
-  assert.equal(env.store._recordMapFor('person').length, 0, 'no person internalModels');
+  assert.equal(env.store._internalModelsFor('person').length, 0, 'no person internalModels');
 });
 
 test("can unload all records for a given type", function(assert) {
@@ -124,9 +124,9 @@ test("can unload all records for a given type", function(assert) {
   });
 
   assert.equal(env.store.peekAll('person').get('length'), 2, 'two person records loaded');
-  assert.equal(env.store._recordMapFor('person').length, 2, 'two person internalModels loaded');
+  assert.equal(env.store._internalModelsFor('person').length, 2, 'two person internalModels loaded');
   assert.equal(env.store.peekAll('car').get('length'), 1, 'one car record loaded');
-  assert.equal(env.store._recordMapFor('car').length, 1, 'one car internalModel loaded');
+  assert.equal(env.store._internalModelsFor('car').length, 1, 'one car internalModel loaded');
 
   Ember.run(function() {
     env.store.unloadAll('person');
@@ -134,8 +134,8 @@ test("can unload all records for a given type", function(assert) {
 
   assert.equal(env.store.peekAll('person').get('length'), 0);
   assert.equal(env.store.peekAll('car').get('length'), 1);
-  assert.equal(env.store._recordMapFor('person').length, 0, 'zero person internalModels loaded');
-  assert.equal(env.store._recordMapFor('car').length, 1, 'one car internalModel loaded');
+  assert.equal(env.store._internalModelsFor('person').length, 0, 'zero person internalModels loaded');
+  assert.equal(env.store._internalModelsFor('car').length, 1, 'one car internalModel loaded');
 });
 
 test("can unload all records", function(assert) {
@@ -180,9 +180,9 @@ test("can unload all records", function(assert) {
   });
 
   assert.equal(env.store.peekAll('person').get('length'), 2, 'two person records loaded');
-  assert.equal(env.store._recordMapFor('person').length, 2, 'two person internalModels loaded');
+  assert.equal(env.store._internalModelsFor('person').length, 2, 'two person internalModels loaded');
   assert.equal(env.store.peekAll('car').get('length'), 1, 'one car record loaded');
-  assert.equal(env.store._recordMapFor('car').length, 1, 'one car internalModel loaded');
+  assert.equal(env.store._internalModelsFor('car').length, 1, 'one car internalModel loaded');
 
   Ember.run(function() {
     env.store.unloadAll();
@@ -190,8 +190,8 @@ test("can unload all records", function(assert) {
 
   assert.equal(env.store.peekAll('person').get('length'), 0);
   assert.equal(env.store.peekAll('car').get('length'), 0);
-  assert.equal(env.store._recordMapFor('person').length, 0, 'zero person internalModels loaded');
-  assert.equal(env.store._recordMapFor('car').length, 0, 'zero car internalModels loaded');
+  assert.equal(env.store._internalModelsFor('person').length, 0, 'zero person internalModels loaded');
+  assert.equal(env.store._internalModelsFor('car').length, 0, 'zero car internalModels loaded');
 });
 
 test("removes findAllCache after unloading all records", function(assert) {
@@ -219,7 +219,7 @@ test("removes findAllCache after unloading all records", function(assert) {
   });
 
   assert.equal(env.store.peekAll('person').get('length'), 2, 'two person records loaded');
-  assert.equal(env.store._recordMapFor('person').length, 2, 'two person internalModels loaded');
+  assert.equal(env.store._internalModelsFor('person').length, 2, 'two person internalModels loaded');
 
   Ember.run(function() {
     env.store.peekAll('person');
@@ -227,7 +227,7 @@ test("removes findAllCache after unloading all records", function(assert) {
   });
 
   assert.equal(env.store.peekAll('person').get('length'), 0, 'zero person records loaded');
-  assert.equal(env.store._recordMapFor('person').length, 0, 'zero person internalModels loaded');
+  assert.equal(env.store._internalModelsFor('person').length, 0, 'zero person internalModels loaded');
 });
 
 test("unloading all records also updates record array from peekAll()", function(assert) {
@@ -322,12 +322,12 @@ test('unloading a disconnected subgraph clears the relevant internal models', fu
   });
 
   assert.equal(
-    env.store._recordMapFor('person').records.length,
+    env.store._internalModelsFor('person').models.length,
     1,
     'one person record is loaded'
   );
   assert.equal(
-    env.store._recordMapFor('car').records.length,
+    env.store._internalModelsFor('car').models.length,
     2,
     'two car records are loaded'
   );
@@ -362,8 +362,8 @@ test('unloading a disconnected subgraph clears the relevant internal models', fu
     env.store.peekRecord('car', 2).unloadRecord();
   });
 
-  assert.equal(env.store._recordMapFor('person').records.length, 0);
-  assert.equal(env.store._recordMapFor('car').records.length, 0);
+  assert.equal(env.store._internalModelsFor('person').models.length, 0);
+  assert.equal(env.store._internalModelsFor('car').models.length, 0);
 
   assert.equal(checkOrphanCalls, 3, 'each internalModel checks for cleanup');
   assert.equal(cleanupOrphanCalls, 1, 'cleanup only happens once');


### PR DESCRIPTION
* This was super confusing before
* This does not change any public APIs