### PR TITLE
Don't calculate `_changedKeys` pointlessly

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -518,9 +518,15 @@ export default class InternalModel {
 
   setupData(data) {
     heimdall.increment(setupData);
-    let changedKeys = this._changedKeys(data.attributes);
+    let changedKeys;
+
+    if (this.hasRecord) {
+      changedKeys = this._changedKeys(data.attributes);
+    }
+
     assign(this._data, data.attributes);
     this.pushedData();
+
     if (this.hasRecord) {
       this.record._notifyProperties(changedKeys);
     }


### PR DESCRIPTION
If the internal model has no record, we won't do anything with the changes, so let's not waste cycles calculating them.