### PR TITLE
[PERF] optimize updates to hasMany state

### DIFF
--- a/addon/-private/system/diff-array.js
+++ b/addon/-private/system/diff-array.js
@@ -2,6 +2,7 @@
   @namespace
   @method diffArray
   @private
+  @for DS
   @param {Array} oldArray the old array
   @param {Array} newArray the new array
   @return {hash} {

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -5,6 +5,8 @@ import Relationship from './relationship';
 import OrderedSet from '../../ordered-set';
 import ManyArray from '../../many-array';
 
+import diffArray from '../../diff-array';
+
 export default class ManyRelationship extends Relationship {
   constructor(store, internalModel, inverseKey, relationshipMeta) {
     super(store, internalModel, inverseKey, relationshipMeta);
@@ -19,6 +21,7 @@ export default class ManyRelationship extends Relationship {
     this._loadingPromise = null;
     this._willUpdateManyArray = false;
     this._pendingManyArrayUpdates = null;
+    this._removedInternalModels = null;
   }
 
   _updateLoadingPromise(promise, content) {
@@ -203,6 +206,11 @@ export default class ManyRelationship extends Relationship {
     if (!this.members.has(internalModel)) {
       return;
     }
+    // remember removals so we can deal with them in computeChanges
+    if (!this._removedInternalModels) {
+      this._removedInternalModels = new OrderedSet();
+    }
+    this._removedInternalModels.add(internalModel);
     super.removeInternalModelFromOwn(internalModel, idx);
     // note that ensuring the many array is created, via `this.manyArray`
     // (instead of `this._manyArray`) is intentional.
@@ -266,22 +274,75 @@ export default class ManyRelationship extends Relationship {
   }
 
   computeChanges(internalModels = []) {
-    let members = this.canonicalMembers;
-    let internalModelsToRemove = [];
-    let internalModelSet = setForArray(internalModels);
+    let members = this.canonicalMembers.toArray();
+    let removedSinceLastTime = this._removedInternalModels;
+    this._removedInternalModels = null; // clear it for next time
 
-    members.forEach(member => {
-      if (internalModelSet.has(member)) { return; }
+    let diff = diffArray(members, internalModels);
 
-      internalModelsToRemove.push(member);
+    if (diff.firstChangeIndex === null) {
+      // no changes found
+      if (removedSinceLastTime) {
+        // records that have been removed since last compute will need their inverses to be corrected
+        for (let i = 0, l = internalModels.length; i < l; i++) {
+          let record = internalModels[i];
+          if (removedSinceLastTime.has(record)) {
+            this.flushCanonicalLater();
+            break;
+          }
+        }
+      }
+      return;
+    }
+    let removedMembersSet = setForArray(members.slice(diff.firstChangeIndex, diff.firstChangeIndex + diff.removedCount));
+    let changeBlockSet = setForArray(internalModels.slice(diff.firstChangeIndex, diff.firstChangeIndex + diff.addedCount));
+
+    // remove members that were removed but not re-added
+    removedMembersSet.forEach(member => {
+      if (!changeBlockSet.has(member)) {
+        this.removeCanonicalInternalModel(member);
+      }
     });
 
-    this.removeCanonicalInternalModels(internalModelsToRemove);
+    let flushCanonicalLater = false;
 
-    for (let i = 0, l = internalModels.length; i < l; i++) {
-      let internalModel = internalModels[i];
-      this.removeCanonicalInternalModel(internalModel);
-      this.addCanonicalInternalModel(internalModel, i);
+    // --- deal with records before the change block
+    if (removedSinceLastTime) {
+      // records that have been removed since last compute will need their inverses to be corrected
+      for (let i = 0; i < diff.firstChangeIndex; i++) {
+        let record = internalModels[i];
+        if (removedSinceLastTime.has(record)) {
+          flushCanonicalLater = true;
+          break;
+        }
+      }
+    }
+    // --- deal with records in the change block
+    for (let i = diff.firstChangeIndex, l = diff.firstChangeIndex + diff.addedCount; i < l; i++) {
+      let record = internalModels[i];
+      if (members[i] !== record) {
+        if (removedMembersSet.has(record)) {
+          // this is a reorder
+          this.removeCanonicalInternalModel(record);
+        }
+        // reorder or insert
+        this.addCanonicalInternalModel(record, i);
+      }
+    }
+    // --- deal with records after the change block
+    if (!flushCanonicalLater && removedSinceLastTime) {
+      // records that have been removed since last compute will need their inverses to be corrected
+      for (let i = diff.firstChangeIndex + diff.addedCount, l = internalModels.length; i < l; i++) {
+        let record = internalModels[i];
+        if (removedSinceLastTime.has(record)) {
+          flushCanonicalLater = true;
+          break;
+        }
+      }
+    }
+
+    if (flushCanonicalLater) {
+      this.flushCanonicalLater();
     }
   }
 

--- a/tests/integration/records/relationship-changes-test.js
+++ b/tests/integration/records/relationship-changes-test.js
@@ -2,7 +2,6 @@ import { alias } from '@ember/object/computed';
 import { run } from '@ember/runloop';
 import EmberObject, { set, get } from '@ember/object';
 import setupStore from 'dummy/tests/helpers/store';
-
 import DS from 'ember-data';
 import { module, test } from 'qunit';
 
@@ -533,32 +532,26 @@ test('Calling push with relationship triggers willChange and didChange with deta
     }
   };
 
-  run(() => {
-    store.push({
-      data: {
-        type: 'person',
-        id: 'wat',
-        attributes: {
-          firstName: 'Yehuda',
-          lastName: 'Katz'
-        },
-        relationships: {
-          siblings: {
-            data: [sibling1Ref]
-          }
-        }
+  let person = run(() => store.push({
+    data: {
+      type: 'person',
+      id: 'wat',
+      attributes: {
+        firstName: 'Yehuda',
+        lastName: 'Katz'
       },
-      included: [
-        sibling1
-      ]
+      relationships: {
+        siblings: {
+          data: [sibling1Ref]
+        }
+      }
+    },
+    included: [
+      sibling1
+    ]
+  }));
 
-    });
-  });
-
-
-  let person = store.peekRecord('person', 'wat');
   let siblings = run(() => person.get('siblings'));
-
   siblings.addArrayObserver(observer);
 
   run(() => {
@@ -589,31 +582,26 @@ test('Calling push with relationship triggers willChange and didChange with deta
 test('Calling push with relationship triggers willChange and didChange with detail when truncating', function(assert) {
   let willChangeCount = 0;
   let didChangeCount = 0;
-
-  run(() => {
-    store.push({
-      data: {
-        type: 'person',
-        id: 'wat',
-        attributes: {
-          firstName: 'Yehuda',
-          lastName: 'Katz'
-        },
-        relationships: {
-          siblings: {
-            data: [sibling1Ref, sibling2Ref]
-          }
-        }
+  let person = run(() => store.push({
+    data: {
+      type: 'person',
+      id: 'wat',
+      attributes: {
+        firstName: 'Yehuda',
+        lastName: 'Katz'
       },
-      included: [
-        sibling1, sibling2
-      ]
-    });
-  });
+      relationships: {
+        siblings: {
+          data: [sibling1Ref, sibling2Ref]
+        }
+      }
+    },
+    included: [
+      sibling1, sibling2
+    ]
+  }));
 
-  let person = store.peekRecord('person', 'wat');
   let siblings = run(() => person.get('siblings'));
-
   let observer = {
     arrayWillChange(array, start, removing, adding) {
       willChangeCount++;
@@ -658,28 +646,24 @@ test('Calling push with relationship triggers willChange and didChange with deta
 test('Calling push with relationship triggers willChange and didChange with detail when inserting at front', function(assert) {
   let willChangeCount = 0;
   let didChangeCount = 0;
-
-  run(() => {
-    store.push({
-      data: {
-        type: 'person',
-        id: 'wat',
-        attributes: {
-          firstName: 'Yehuda',
-          lastName: 'Katz'
-        },
-        relationships: {
-          siblings: {
-            data: [sibling2Ref]
-          }
-        }
+  let person = run(() => store.push({
+    data: {
+      type: 'person',
+      id: 'wat',
+      attributes: {
+        firstName: 'Yehuda',
+        lastName: 'Katz'
       },
-      included: [
-        sibling2
-      ]
-    });
-  });
-  let person = store.peekRecord('person', 'wat');
+      relationships: {
+        siblings: {
+          data: [sibling2Ref]
+        }
+      }
+    },
+    included: [
+      sibling2
+    ]
+  }));
 
   let observer = {
     arrayWillChange(array, start, removing, adding) {

--- a/tests/unit/diff-array-test.js
+++ b/tests/unit/diff-array-test.js
@@ -1,5 +1,4 @@
 import { module, test } from 'qunit';
-
 import { diffArray } from 'ember-data/-private';
 
 module('unit/diff-array Diff Array tests', {


### PR DESCRIPTION
resolves #4150

On master:
With 5000 records, adding 1000 on the end with a `store.push` takes 250ms in `has-many.computeChanges`
Removing them again takes another 250ms

With this PR:
adding takes 37ms
removing takes 9ms