### PR TITLE
Tidy up parse-reponse-headers

### DIFF
--- a/addon/-private/utils/parse-response-headers.js
+++ b/addon/-private/utils/parse-response-headers.js
@@ -8,17 +8,29 @@ export default function parseResponseHeaders(headersString) {
   }
 
   let headerPairs = headersString.split(CLRF);
+  for (let i = 0; i < headerPairs.length; i++) {
+    let header = headerPairs[i];
+    let j = 0;
+    let foundSep = false;
 
-  headerPairs.forEach((header) => {
-    let [field, ...value] = header.split(':');
+    for (; j < header.length; j++) {
+      if (header.charCodeAt(j) === 58 /* ':' */) {
+        foundSep = true;
+        break;
+      }
+    }
 
-    field = field.trim();
-    value = value.join(':').trim();
+    if (foundSep === false) {
+      break;
+    }
+
+    let field = header.substring(0, j).trim();
+    let value = header.substring(j + 1, header.length).trim();
 
     if (value) {
       headers[field] = value;
     }
-  });
+  }
 
   return headers;
 }


### PR DESCRIPTION
This aims to avoid the following overhead:

* forEach + closure  <-- this seems to be a-bit noisy on boot
* [field, …value] doesn’t really transpile nicely

More aggressive approach is possible, maybe someone else has time. This addresses the issues I noticed...