### PR TITLE
Loose es6 class

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,7 @@ module.exports = {
 
     this.options.babel = this.options.babel || {};
     add(this.options.babel, 'blacklist', ['es6.modules', 'useStrict']);
+    add(this.options.babel, 'loose', ['es6.classes']);
     add(this.options.babel, 'plugins', require('./lib/stripped-build-plugins')(process.env.EMBER_ENV));
 
     this._hasSetupBabelOptions = true;


### PR DESCRIPTION

make ES6.Classes loose
* makes profiling easier (methods are not called value)
* appears to be a slight performance improvement (although not the motivator)