### PR TITLE
[BUGFIX canary] ensure context is applied in the iife

### DIFF
--- a/lib/javascripts.js
+++ b/lib/javascripts.js
@@ -52,7 +52,7 @@ function collapse(tree, outputFileName) {
     inputFiles: ['license.js', 'loader.js', '**/*.js'],
     outputFile: '/' + outputFileName,
     header: '(function(){ \n"use strict";\n',
-    footer: '\nrequire("ember-data");\nrequire("ember-load-initializers")["default"](Ember.Application, "ember-data");\n' + dsGlobal + '})(this);\n' + emberDataShims
+    footer: '\nrequire("ember-data");\nrequire("ember-load-initializers")["default"](Ember.Application, "ember-data");\n' + dsGlobal + '}).call(this);\n' + emberDataShims
   });
 }
 


### PR DESCRIPTION
The last PR used `)(this)` vs `).call(this)`, which is needed to set the context correctly.