### PR TITLE
Lazy snapshot.type

### DIFF
--- a/addon/-private/system/snapshot-record-array.js
+++ b/addon/-private/system/snapshot-record-array.js
@@ -10,149 +10,152 @@
   @param {Array} snapshots An array of snapshots
   @param {Object} meta
 */
-export default function SnapshotRecordArray(recordArray, meta, options = {}) {
-  /**
-    An array of snapshots
-    @private
-    @property _snapshots
-    @type {Array}
-  */
-  this._snapshots = null;
-  /**
-    An array of records
-    @private
-    @property _recordArray
-    @type {Array}
-  */
-  this._recordArray = recordArray;
+export default class SnapshotRecordArray {
+  constructor(recordArray, meta, options = {}) {
+    /**
+      An array of snapshots
+      @private
+      @property _snapshots
+      @type {Array}
+    */
+    this._snapshots = null;
 
-  /**
-    Number of records in the array
+    /**
+      An array of records
+      @private
+      @property _recordArray
+      @type {Array}
+    */
+    this._recordArray = recordArray;
 
-    Example
+    /**
+      Number of records in the array
 
-    ```app/adapters/post.js
-    import DS from 'ember-data'
+      Example
 
-    export default DS.JSONAPIAdapter.extend({
-      shouldReloadAll(store, snapshotRecordArray) {
-        return !snapshotRecordArray.length;
-      },
-    });
-    ```
+      ```app/adapters/post.js
+      import DS from 'ember-data'
 
-    @property length
-    @type {Number}
-  */
-  this.length = recordArray.get('length');
+      export default DS.JSONAPIAdapter.extend({
+        shouldReloadAll(store, snapshotRecordArray) {
+          return !snapshotRecordArray.length;
+        },
+      });
+      ```
 
-  /**
-    The type of the underlying records for the snapshots in the array, as a DS.Model
-    @property type
-    @type {DS.Model}
-  */
-  this.type = recordArray.get('type');
+      @property length
+      @type {Number}
+    */
+    this.length = recordArray.get('length');
 
-  /**
-    Meta objects for the record array.
+    /**
+      The type of the underlying records for the snapshots in the array, as a DS.Model
+      @property type
+      @type {DS.Model}
+    */
+    this.type = recordArray.get('type');
 
-    Example
+    /**
+      Meta objects for the record array.
 
-    ```app/adapters/post.js
-    import DS from 'ember-data'
+      Example
 
-    export default DS.JSONAPIAdapter.extend({
-      shouldReloadAll(store, snapshotRecordArray) {
-        var lastRequestTime = snapshotRecordArray.meta.lastRequestTime;
-        var twentyMinutes = 20 * 60 * 1000;
-        return Date.now() > lastRequestTime + twentyMinutes;
-      },
-    });
-    ```
+      ```app/adapters/post.js
+      import DS from 'ember-data'
 
-    @property meta
-    @type {Object}
-  */
-  this.meta = meta;
+      export default DS.JSONAPIAdapter.extend({
+        shouldReloadAll(store, snapshotRecordArray) {
+          var lastRequestTime = snapshotRecordArray.meta.lastRequestTime;
+          var twentyMinutes = 20 * 60 * 1000;
+          return Date.now() > lastRequestTime + twentyMinutes;
+        },
+      });
+      ```
 
-  /**
-    A hash of adapter options passed into the store method for this request.
+      @property meta
+      @type {Object}
+    */
+    this.meta = meta;
 
-    Example
+    /**
+      A hash of adapter options passed into the store method for this request.
 
-    ```app/adapters/post.js
-    import MyCustomAdapter from './custom-adapter';
+      Example
 
-    export default MyCustomAdapter.extend({
-      findAll(store, type, sinceToken, snapshotRecordArray) {
-        if (snapshotRecordArray.adapterOptions.subscribe) {
+      ```app/adapters/post.js
+      import MyCustomAdapter from './custom-adapter';
+
+      export default MyCustomAdapter.extend({
+        findAll(store, type, sinceToken, snapshotRecordArray) {
+          if (snapshotRecordArray.adapterOptions.subscribe) {
+            // ...
+          }
           // ...
         }
-        // ...
+      });
+      ```
+
+      @property adapterOptions
+      @type {Object}
+    */
+    this.adapterOptions = options.adapterOptions;
+
+    /**
+      The relationships to include for this request.
+
+      Example
+
+      ```app/adapters/application.js
+      import DS from 'ember-data';
+
+      export default DS.Adapter.extend({
+        findAll(store, type, snapshotRecordArray) {
+          var url = `/${type.modelName}?include=${encodeURIComponent(snapshotRecordArray.include)}`;
+
+          return fetch(url).then((response) => response.json())
+        }
+      });
+
+      @property include
+      @type {String|Array}
+    */
+    this.include = options.include;
+  }
+
+  /**
+    Get snapshots of the underlying record array
+
+    Example
+
+    ```app/adapters/post.js
+    import DS from 'ember-data'
+
+    export default DS.JSONAPIAdapter.extend({
+      shouldReloadAll(store, snapshotArray) {
+        var snapshots = snapshotArray.snapshots();
+
+        return snapshots.any(function(ticketSnapshot) {
+          var timeDiff = moment().diff(ticketSnapshot.attr('lastAccessedAt'), 'minutes');
+          if (timeDiff > 20) {
+            return true;
+          } else {
+            return false;
+          }
+        });
       }
     });
     ```
 
-    @property adapterOptions
-    @type {Object}
+    @method snapshots
+    @return {Array} Array of snapshots
   */
-  this.adapterOptions = options.adapterOptions;
-
-  /**
-    The relationships to include for this request.
-
-    Example
-
-    ```app/adapters/application.js
-    import DS from 'ember-data';
-
-    export default DS.Adapter.extend({
-      findAll(store, type, snapshotRecordArray) {
-        var url = `/${type.modelName}?include=${encodeURIComponent(snapshotRecordArray.include)}`;
-
-        return fetch(url).then((response) => response.json())
-      }
-    });
-
-    @property include
-    @type {String|Array}
-  */
-  this.include = options.include;
-}
-
-/**
-  Get snapshots of the underlying record array
-
-  Example
-
-  ```app/adapters/post.js
-  import DS from 'ember-data'
-
-  export default DS.JSONAPIAdapter.extend({
-    shouldReloadAll(store, snapshotArray) {
-      var snapshots = snapshotArray.snapshots();
-
-      return snapshots.any(function(ticketSnapshot) {
-        var timeDiff = moment().diff(ticketSnapshot.attr('lastAccessedAt'), 'minutes');
-        if (timeDiff > 20) {
-          return true;
-        } else {
-          return false;
-        }
-      });
+  snapshots() {
+    if (this._snapshots !== null) {
+      return this._snapshots;
     }
-  });
-  ```
 
-  @method snapshots
-  @return {Array} Array of snapshots
-*/
-SnapshotRecordArray.prototype.snapshots = function() {
-  if (this._snapshots !== null) {
+    this._snapshots = this._recordArray._takeSnapshot();
+
     return this._snapshots;
   }
-
-  this._snapshots = this._recordArray._takeSnapshot();
-
-  return this._snapshots;
-};
+}

--- a/addon/-private/system/snapshot-record-array.js
+++ b/addon/-private/system/snapshot-record-array.js
@@ -48,12 +48,7 @@ export default class SnapshotRecordArray {
     */
     this.length = recordArray.get('length');
 
-    /**
-      The type of the underlying records for the snapshots in the array, as a DS.Model
-      @property type
-      @type {DS.Model}
-    */
-    this.type = recordArray.get('type');
+    this._type = null;
 
     /**
       Meta objects for the record array.
@@ -120,6 +115,15 @@ export default class SnapshotRecordArray {
       @type {String|Array}
     */
     this.include = options.include;
+  }
+
+  /**
+    The type of the underlying records for the snapshots in the array, as a DS.Model
+    @property type
+    @type {DS.Model}
+  */
+  get type() {
+    return this._type || (this._type = this._recordArray.get('type'));
   }
 
   /**

--- a/addon/-private/system/snapshot.js
+++ b/addon/-private/system/snapshot.js
@@ -66,17 +66,6 @@ export default class Snapshot {
     this.include = options.include;
 
     /**
-     The type of the underlying record for this snapshot, as a DS.Model.
-
-     @property type
-     @type {DS.Model}
-     */
-    // TODO @runspired we should deprecate this in favor of modelClass but only once
-    // we've cleaned up the internals enough that a public change to follow suite is
-    // uncontroversial.
-    this.type = internalModel.modelClass;
-
-    /**
      The name of the type of the underlying record for this snapshot, as a string.
 
      @property modelName
@@ -85,6 +74,19 @@ export default class Snapshot {
     this.modelName = internalModel.modelName;
 
     this._changedAttributes = record.changedAttributes();
+  }
+
+  /**
+   The type of the underlying record for this snapshot, as a DS.Model.
+
+   @property type
+   @type {DS.Model}
+   */
+  get type() {
+    // TODO @runspired we should deprecate this in favor of modelClass but only once
+    // we've cleaned up the internals enough that a public change to follow suite is
+    // uncontroversial.
+    return this._internalModel.modelClass;
   }
 
   /**

--- a/tests/integration/snapshot-test.js
+++ b/tests/integration/snapshot-test.js
@@ -75,6 +75,37 @@ test("snapshot.id, snapshot.type and snapshot.modelName returns correctly", func
   });
 });
 
+test('snapshot.type loads the class lazily', function(assert) {
+  assert.expect(3);
+
+  let postClassLoaded = false;
+  let modelFor = env.store._modelFor;
+  env.store._modelFor = (name) => {
+    if (name === 'post') {
+      postClassLoaded = true;
+    }
+    return modelFor.call(env.store, name);
+  };
+
+  run(function() {
+    env.store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        attributes: {
+          title: 'Hello World'
+        }
+      }
+    });
+    let postInternalModel = env.store._internalModelForId('post', 1);
+    let snapshot = postInternalModel.createSnapshot();
+
+    assert.equal(false, postClassLoaded, 'model class is not eagerly loaded');
+    assert.equal(snapshot.type, Post, 'type is correct');
+    assert.equal(true, postClassLoaded, 'model class is loaded');
+  });
+});
+
 test("snapshot.attr() does not change when record changes", function(assert) {
   assert.expect(2);
 

--- a/tests/unit/system/snapshot-record-array-test.js
+++ b/tests/unit/system/snapshot-record-array-test.js
@@ -47,3 +47,27 @@ test('#snapshot', function(assert) {
   assert.equal(snapshot.snapshots(), snapshotTaken, 'should return the exact same snapshot');
   assert.equal(didTakeSnapshot, 1, 'still only one snapshot should have been taken');
 });
+
+test('SnapshotRecordArray.type loads the class lazily', function(assert) {
+  let array = Ember.A([1, 2]);
+  let typeLoaded = false;
+
+  Object.defineProperty(array, 'type', {
+    get() {
+      typeLoaded = true;
+      return 'some type';
+    }
+  });
+
+  let meta = { };
+  let options = {
+    adapterOptions: 'some options',
+    include: 'include me'
+  };
+
+  let snapshot = new SnapshotRecordArray(array, meta, options);
+
+  assert.equal(false, typeLoaded, 'model class is not eager loaded');
+  assert.equal(snapshot.type, 'some type');
+  assert.equal(true, typeLoaded, 'model class is loaded');
+});


### PR DESCRIPTION
Make snapshot.type and snapshotRecordArray.type load classes lazily, so we don't pay the cost of loading the classes if we don't need to.