### PR TITLE
[BUGFIX DEPRECATE] fixes and deprecates when a user re-exports a model multiple places for use

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2124,7 +2124,7 @@ Store = Service.extend({
        */
       if (klass.modelName && klass.modelName !== modelName) {
         throw new Error(
-          `Ember Data found a Model for ${modelName} but it the class ` +
+          `Ember Data found a Model for ${modelName} but the class ` +
           `already had the modelName ${klass.modelName}.\n\n` +
           'This likely means that you are re-exporting a Model.\n\n' +
           `Replace:\n\texport { default } from './${klass.modelName}';\nwith:\n\t` +

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2137,8 +2137,12 @@ Store = Service.extend({
           until: '3.0'
         });
 
-        const extendedKlass = klass.extend();
-        owner.register(`model:${modelName}`, extendedKlass);
+        // simple (cheaper) extend that @krisselden says we can do
+        //  but which means `modelFor(<modelName>).extend() will not work
+        class extendedKlass extends klass {}
+        const typeStr = `model:${modelName}`;
+        owner.unregister(typeStr);
+        owner.register(typeStr, extendedKlass);
 
         const factory = this.modelFactoryFor(modelName);
         klass = hasFactoryFor ? factory.class : factory;

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2115,8 +2115,23 @@ Store = Service.extend({
 
       assert(`'${inspect(klass)}' does not appear to be an ember-data model`, klass.isModel);
 
-      // TODO: deprecate this
-      klass.modelName = klass.modelName || modelName;
+      // TODO: deprecate klass.modelName
+      /*
+        In test environments it is common to re-use the same base model in multiple
+        tests and register it each time. Since that seems convenient and good
+        to continue allowing this ignores the case where modelName is set but is
+         the same.
+       */
+      if (klass.modelName && klass.modelName !== modelName) {
+        throw new Error(
+          `Ember Data found a Model for ${modelName} but it the class ` +
+          `already had the modelName ${klass.modelName}.\n\n` +
+          'This likely means that you are re-exporting a Model.\n\n' +
+          `Replace:\n\texport { default } from './${klass.modelName}';\nwith:\n\t` +
+          `import Model from './${klass.modelName}';\n\n\texport default Model.extend();`
+        );
+      }
+      klass.modelName = modelName;
 
       this._modelFactoryCache[modelName] = factory;
     }

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2110,7 +2110,7 @@ Store = Service.extend({
         throw new EmberError(`No model was found for '${modelName}'`);
       }
 
-      // interopt with the future
+      // interop with the future
       const hasFactoryFor = getOwner(this).factoryFor;
       let klass = hasFactoryFor ? factory.class : factory;
 
@@ -2123,7 +2123,7 @@ Store = Service.extend({
         to continue allowing this ignores the case where modelName is set but is
          the same.
        */
-      if (hasFactoryFor && klass.modelName && klass.modelName !== modelName) {
+      if (klass.modelName && klass.modelName !== modelName) {
         const Message =
           `Ember Data found a Model for ${modelName} but the class ` +
           `already had the modelName ${klass.modelName}.\n\n` +
@@ -2131,12 +2131,17 @@ Store = Service.extend({
           `Replace:\n\texport { default } from './${klass.modelName}';\nwith:\n\t` +
           `import Model from './${klass.modelName}';\n\n\texport default Model.extend();`;
 
-        klass = factory.class = klass.extend();
+        if (hasFactoryFor) {
+          klass = factory.class = klass.extend();
+        } else {
+          klass = factory = klass.extend();
+        }
 
         deprecate(Message, false, {
           id: 'ds.store.modelfor-double-extend',
           until: '3.0'
         });
+
       }
       klass.modelName = modelName;
 

--- a/testem.js
+++ b/testem.js
@@ -8,7 +8,7 @@ module.exports = {
     "PhantomJS"
   ],
   "launch_in_dev": [
-    "PhantomJS",
+   // "PhantomJS",
     "Chrome"
   ]
 };

--- a/testem.js
+++ b/testem.js
@@ -8,7 +8,7 @@ module.exports = {
     "PhantomJS"
   ],
   "launch_in_dev": [
-   // "PhantomJS",
+    "PhantomJS",
     "Chrome"
   ]
 };

--- a/tests/helpers/store.js
+++ b/tests/helpers/store.js
@@ -38,7 +38,9 @@ export default function setupStore(options) {
   }
 
   for (let prop in options) {
-    registry.register('model:' + Ember.String.dasherize(prop), options[prop]);
+    if (options.hasOwnProperty(prop)) {
+      registry.register('model:' + Ember.String.dasherize(prop), options[prop]);
+    }
   }
 
   registry.register('service:store', DS.Store.extend({

--- a/tests/unit/store/model-for-test.js
+++ b/tests/unit/store/model-for-test.js
@@ -9,12 +9,13 @@ let container, store, registry, env;
 
 const { camelize, dasherize } = Ember.String;
 const { run } = Ember;
+const { Model } = DS;
 
 module('unit/store/model_for - DS.Store#modelFor', {
   beforeEach() {
     env = setupStore({
-      blogPost: DS.Model.extend(),
-      'blog.post': DS.Model.extend()
+      blogPost: Model.extend(),
+      'blog.post': Model.extend()
     });
     store = env.store;
     container = env.container;
@@ -34,6 +35,24 @@ test('when fetching factory from string, sets a normalized key as modelName', fu
 
   assert.equal(registry.normalize('some.post'), 'some-post', 'precond - container camelizes');
   assert.equal(store.modelFor('blog.post').modelName, 'blog.post', 'modelName is normalized to dasherized');
+});
+
+test('when fetching factory from string, it errors if modelName was already set.', function(assert) {
+  const modelName = 'original';
+  const extendedModelName = 'reexport';
+  const BaseModel = Model.extend({});
+
+  // simulate `export { default } from './base-model';`
+  const ExtendedModel = BaseModel;
+
+  env.registry.register(`model:${modelName}`, BaseModel);
+  env.registry.register(`model:${extendedModelName}`, ExtendedModel);
+
+  let resolvedBaseModel = store.modelFor(modelName);
+  assert.equal(resolvedBaseModel.modelName, modelName, 'We set modelName correctly');
+  assert.throws(() => {
+    store.modelFor(extendedModelName);
+  }, /re-export/, 'We receive an assertion about the re-export');
 });
 
 test('when fetching factory from string and dashing normalizer, sets a normalized key as modelName', function(assert) {

--- a/tests/unit/store/model-for-test.js
+++ b/tests/unit/store/model-for-test.js
@@ -50,9 +50,9 @@ test('when fetching factory from string, it errors if modelName was already set.
 
   let resolvedBaseModel = store.modelFor(modelName);
   assert.equal(resolvedBaseModel.modelName, modelName, 'We set modelName correctly');
-  assert.throws(() => {
+  assert.expectDeprecation(() => {
     store.modelFor(extendedModelName);
-  }, /re-export/, 'We receive an assertion about the re-export');
+  }, /re-export/, 'We receive a deprecation about the re-export');
 });
 
 test('when fetching factory from string and dashing normalizer, sets a normalized key as modelName', function(assert) {


### PR DESCRIPTION
@bmac If good this should be backported to release and beta.

This twiddle demonstrates the issue: https://ember-twiddle.com/035a072e1818f48c09ac9a38f13b1773?openFiles=twiddle.json%2C

All Ember versions prior to 2.12 work with all ED versions. Beginning in 2.12 (I think we fussed with double extend) this begins breaking in ED.

We can temporarily fix this with a deprecation by extending the class ourselves.