### PR TITLE
Change setupStore helper default serializer to JSONAPISerializer

### DIFF
--- a/tests/helpers/store.js
+++ b/tests/helpers/store.js
@@ -49,7 +49,7 @@ export default function setupStore(options) {
   registry.optionsForType('adapter', { singleton: false });
   registry.register('adapter:-default', DS.Adapter);
 
-  registry.register('serializer:-default', DS.JSONSerializer);
+  registry.register('serializer:-default', DS.JSONAPISerializer);
   registry.register('serializer:-rest', DS.RESTSerializer);
 
   registry.register('adapter:-rest', DS.RESTAdapter);

--- a/tests/integration/adapter/find-all-test.js
+++ b/tests/integration/adapter/find-all-test.js
@@ -45,7 +45,9 @@ test("When all records for a type are requested, the store should call the adapt
       // this will get called twice
       assert.ok(true, "the adapter's findAll method should be invoked");
 
-      return resolve([{ id: 1, name: "Braaaahm Dale" }]);
+      return resolve({
+        data: [{ type: 'person', id: 1, attributes: { name: "Braaaahm Dale" }}]
+      });
     }
   }));
 
@@ -75,7 +77,9 @@ test("When all records for a type are requested, a rejection should reject the p
       if (count++ === 0) {
         return reject();
       } else {
-        return resolve([{ id: 1, name: "Braaaahm Dale" }]);
+        return resolve({
+          data: [{ type: 'person', id: 1, attributes: { name: "Braaaahm Dale" }}]
+        });
       }
     }
   }));
@@ -185,7 +189,9 @@ test("isUpdating is true while records are fetched", function(assert) {
 
   assert.equal(persons.get("isUpdating"), true);
 
-  findAllDeferred.resolve([{ id: 2 }]);
+  findAllDeferred.resolve({
+    data: [{ type: 'person', id: 2 }]
+  });
 });
 
 test("isUpdating is true while records are fetched in the background", function(assert) {
@@ -223,7 +229,9 @@ test("isUpdating is true while records are fetched in the background", function(
   assert.equal(persons.get("isUpdating"), true);
 
   run(function() {
-    findAllDeferred.resolve([{ id: 2 }]);
+    findAllDeferred.resolve({
+      data: [{ type: 'person', id: 2 }]
+    });
   });
 
   run(function() {


### PR DESCRIPTION
This is an incomplete PR working towards the change requested in https://github.com/emberjs/data/issues/4754, but it requires a good chunk of tests to be updated to resolve with json api format.

Before updating the remaining tests, I wanted to double check this is the intended direction.