### PR TITLE
[BUGFIX beta] Rename `relationship.destroy` to `removeInverseRelationships`

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -875,12 +875,12 @@ export default class InternalModel {
       if (this._relationships.has(name)) {
         let rel = this._relationships.get(name);
         rel.clear();
-        rel.destroy();
+        rel.removeInverseRelationships();
       }
     });
     Object.keys(this._implicitRelationships).forEach((key) => {
       this._implicitRelationships[key].clear();
-      this._implicitRelationships[key].destroy();
+      this._implicitRelationships[key].removeInverseRelationships();
     });
   }
 
@@ -888,11 +888,11 @@ export default class InternalModel {
     this.eachRelationship((name, relationship) => {
       if (this._relationships.has(name)) {
         let rel = this._relationships.get(name);
-        rel.destroy();
+        rel.removeInverseRelationships();
       }
     });
     Object.keys(this._implicitRelationships).forEach((key) => {
-      this._implicitRelationships[key].destroy();
+      this._implicitRelationships[key].removeInverseRelationships();
     });
   }
 

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -46,8 +46,8 @@ export default class ManyRelationship extends Relationship {
     return this._manyArray;
   }
 
-  destroy() {
-    super.destroy();
+  removeInverseRelationships() {
+    super.removeInverseRelationships();
     if (this._manyArray) {
       this._manyArray.destroy();
       this._manyArray = null;

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -85,7 +85,7 @@ export default class Relationship {
     return this.internalModel.modelName;
   }
 
-  destroy() {
+  removeInverseRelationships() {
     if (!this.inverseKey) { return; }
 
     let allMembers =


### PR DESCRIPTION
Fixes https://github.com/emberjs/data/issues/4752

The semantics of destroy have changed since https://github.com/emberjs/data/commit/2f18405a4785486f3bd7c865ca1096ea44e2c184. This PR renames the method to convey better what it does.