### PR TITLE
Add a better error message when malformatted JSON API is pushed into …

### DIFF
--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -175,6 +175,7 @@ export default class BelongsToRelationship extends Relationship {
   }
 
   updateData(data, initial) {
+    assert(`Ember Data expected the data for the ${this.key} relationship on a ${this.internalModel.toString()} to be in a JSON API format and include an \`id\` and \`type\` property but it found ${Ember.inspect(data)}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`, data === null || data.id !== undefined && data.type !== undefined);
     let internalModel = this.store._pushResourceIdentifier(this, data);
     if (initial) {
       this.setInitialCanonicalRecord(internalModel);

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -1364,3 +1364,22 @@ test("A belongsTo relationship can be reloaded using a reference if it was fetch
     });
   });
 });
+
+testInDebug("A belongsTo relationship warns if malformatted data is pushed into the store", function(assert) {
+  assert.expectAssertion(function() {
+    run(function() {
+      let chapter = env.store.push({
+        data: {
+          type: 'chapter',
+          id: 1,
+          relationships: {
+            book: {
+              data: { id: 1, name: 'The Gallic Wars' }
+            }
+          }
+        }
+      });
+      chapter.get('book');
+    });
+  }, /expected the data for the book relationship on a <chapter:1> to be in a JSON API format/);
+});


### PR DESCRIPTION
…the store for a belongs to relationships.

Closes #4906