### PR TITLE
[BUGFIX] guard hasMany#object-at-undefined against out-of-bounds access

### DIFF
--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -137,9 +137,9 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
     let object = this.currentState[index];
     //Ember observers such as 'firstObject', 'lastObject' might do out of bounds accesses
     if (object === undefined) {
-      warn(`ManyArray#objectAt(index) return undefined for index '${index}'. See https://github.com/emberjs/data/issues/4758`, false, {
-        id: 'ds.many-array.object-at-undefined'
-      });
+      warn(`ManyArray#objectAt(index) return undefined for index '${index}'. See https://github.com/emberjs/data/issues/4758`,
+           (index ===0 || index === this.currentState.length - 1),
+           { id: 'ds.many-array.object-at-undefined' });
       return;
     }
 

--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -138,6 +138,11 @@ export default Ember.Object.extend(Ember.MutableArray, Ember.Evented, {
     //Ember observers such as 'firstObject', 'lastObject' might do out of bounds accesses
     if (object === undefined) {
       warn(`ManyArray#objectAt(index) return undefined for index '${index}'. See https://github.com/emberjs/data/issues/4758`,
+          // firstObject and lastObject are re-fetched on every array change.
+          // As long as this remains true, warning about out of bounds checks
+          // here is not actionable.
+          //
+          // see https://github.com/emberjs/ember.js/issues/14843
            (index ===0 || index === this.currentState.length - 1),
            { id: 'ds.many-array.object-at-undefined' });
       return;

--- a/tests/unit/many-array-test.js
+++ b/tests/unit/many-array-test.js
@@ -47,6 +47,41 @@ module('unit/many_array - DS.ManyArray', {
   }
 });
 
+test('objectAt warns for out of bounds index, except for firstObject and lastObject', function(assert) {
+  return run(() => {
+    store.push({
+      data: [{
+        type: 'post',
+        id: '3',
+        attributes: {
+          title: 'A framework for creating ambitious web applications'
+        },
+        relationships: {
+          tags: {
+            data: []
+          }
+        }
+      }]
+    });
+
+    let tags = store.peekRecord('post', 3).get('tags');
+
+    assert.expectWarning(() => {
+      tags.objectAt(24601);
+    }, `ManyArray#objectAt(index) return undefined for index '24601'. See https://github.com/emberjs/data/issues/4758`);
+
+    assert.expectNoWarning(() => {
+      // firstObject and lastObject are re-fetched on every array change.  As
+      // long as this remains true, warning about out of bounds checks here is
+      // not actionable.
+      //
+      // see https://github.com/emberjs/ember.js/issues/14843
+      tags.get('firstObject');
+      tags.get('lastObject');
+    });
+  });
+});
+
 test('manyArray.save() calls save() on all records', function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
`firstObject` and `lastObject` are greedy, causing this warning to trigger often unnecessarily.