### PR TITLE
[BUGFIX canary] don't prematurely nullify props

### DIFF
--- a/addon/-private/system/store/container-instance-cache.js
+++ b/addon/-private/system/store/container-instance-cache.js
@@ -1,6 +1,6 @@
 /* global heimdall */
 import Ember from 'ember';
-const { set, run } = Ember;
+const { set } = Ember;
 
 const  {
   __get,

--- a/addon/-private/system/store/container-instance-cache.js
+++ b/addon/-private/system/store/container-instance-cache.js
@@ -1,6 +1,6 @@
 /* global heimdall */
 import Ember from 'ember';
-const { set } = Ember;
+const { set, run } = Ember;
 
 const  {
   __get,
@@ -33,6 +33,8 @@ const  {
 */
 export default class ContainerInstanceCache {
   constructor(owner, store) {
+    this.isDestroying = false;
+    this.isDestroyed = false;
     this._owner = owner;
     this._store = store;
     this._namespaces = {
@@ -111,11 +113,10 @@ export default class ContainerInstanceCache {
   }
 
   destroy() {
+    this.isDestroying = true;
     this.destroyCache(this._namespaces.adapter);
     this.destroyCache(this._namespaces.serializer);
-    this._namespaces = null;
-    this._store = null;
-    this._owner = null;
+    this.isDestroyed = true;
   }
 
   toString() {


### PR DESCRIPTION
 don't prematurely nullify props on the container-instance-cache. the cache's `destroy` method is called during the store's `willDestroy` meaning it may still be required before the Application has completed cleanup.