### PR TITLE
[BUGFIX release] restore internalModels GUID_KEY’s

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -119,7 +119,10 @@ export default class InternalModel {
   constructor(modelName, id, store, data) {
     heimdall.increment(new_InternalModel);
     this.id = id;
-    this._internalId = InternalModelReferenceId++;
+
+    // this ensure ordered set can quickly identify this as unique
+    this[Ember.GUID_KEY] = InternalModelReferenceId++ + 'internal-model';
+
     this.store = store;
     this.modelName = modelName;
     this._loadingPromise = null;


### PR DESCRIPTION
Without this, adding an internalModel to an orderd set will result in a new [GUID_KEY] prop being added, but using defineProperty https://github.com/emberjs/ember.js/blob/master/packages/ember-utils/lib/guid.js#L187. Both causing a shape change, and a potentially costly defProp.

Restoring this restores that, and addresses a category of OrderdSet related performance issues.


@rwjblue / @runspired 