### PR TITLE
[PERF] Model.prototype.didDefineProperty only in dev

### DIFF
--- a/addon/-private/system/relationship-meta.js
+++ b/addon/-private/system/relationship-meta.js
@@ -1,5 +1,6 @@
 import {singularize} from 'ember-inflector';
 import normalizeModelName from './normalize-model-name';
+import { runInDebug } from 'ember-data/-private/debug';
 
 export function typeForRelationshipMeta(meta) {
   let modelName;
@@ -12,7 +13,7 @@ export function typeForRelationshipMeta(meta) {
 }
 
 export function relationshipFromMeta(meta) {
-  return {
+  let result = {
     key:  meta.key,
     kind: meta.kind,
     type: typeForRelationshipMeta(meta),
@@ -21,4 +22,8 @@ export function relationshipFromMeta(meta) {
     parentType: meta.parentType,
     isRelationship: true
   };
+
+  runInDebug(() => result.parentType = meta.parentType);
+
+  return result;
 }

--- a/addon/-private/system/relationships/ext.js
+++ b/addon/-private/system/relationships/ext.js
@@ -51,10 +51,10 @@ export const relatedTypesDescriptor = Ember.computed(function() {
       meta.key = name;
       modelName = typeForRelationshipMeta(meta);
 
-      assert("You specified a hasMany (" + meta.type + ") on " + meta.parentType + " but " + meta.type + " was not found.", modelName);
+      assert(`You specified a hasMany (${meta.type}) on ${meta.parentType} but ${meta.type} was not found.`, modelName);
 
       if (!types.includes(modelName)) {
-        assert("Trying to sideload " + name + " on " + this.toString() + " but the type doesn't exist.", !!modelName);
+        assert(`Trying to sideload ${name} on ${this.toString()} but the type doesn't exist.`, !!modelName);
         types.push(modelName);
       }
     }

--- a/tests/helpers/test-in-debug.js
+++ b/tests/helpers/test-in-debug.js
@@ -1,10 +1,13 @@
-import { runInDebug } from 'ember-data/-private/debug';
+import require from 'require';
 import { test, skip } from 'qunit';
 
 export default function testInDebug() {
   let isDebug = false;
 
-  runInDebug(() => isDebug = true);
+  // TODO: this should be debug-stripped...
+  if (require.has('ember-data/-private/debug')) {
+    require('ember-data/-private/debug').runInDebug(() => isDebug = true);
+  }
 
   if (isDebug) {
     test(...arguments);


### PR DESCRIPTION
`meta.parentType` (which is produced by) `didDefineProperty` is only required for development assertions. As development assertions are stripped in prod, this `didDefineProperty` can also be stripped