### PR TITLE
[DOC release] Add missing ` in urlsForFindMany description

### DIFF
--- a/addon/-private/adapters/build-url-mixin.js
+++ b/addon/-private/adapters/build-url-mixin.js
@@ -214,7 +214,7 @@ export default Ember.Mixin.create({
   },
 
   /**
-   Builds a URL for coalesceing multiple `store.findRecord(type, id)
+   Builds a URL for coalesceing multiple `store.findRecord(type, id)`
    records into 1 request when the adapter's `coalesceFindRequests`
    property is true.
 


### PR DESCRIPTION
![screen shot 2017-04-14 at 2 59 05 pm](https://cloud.githubusercontent.com/assets/71852/25057249/ed0600da-2122-11e7-9c13-50c715383be6.png)
