### PR TITLE
Preheat GUID_KEY on attr/belongsTo/hasMany meta for Ember.Map perf

### DIFF
--- a/addon/-private/system/relationships/belongs-to.js
+++ b/addon/-private/system/relationships/belongs-to.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import { assert, warn } from "ember-data/-private/debug";
 import normalizeModelName from "../normalize-model-name";
 
+let PreheatGuid = 0;
+
 /**
   `DS.belongsTo` is used to define One-To-One and One-To-Many
   relationships on a [DS.Model](/api/data/classes/DS.Model.html).
@@ -100,6 +102,9 @@ export default function belongsTo(modelName, options) {
     name: 'Belongs To',
     key: null
   };
+
+  // this exists for perf because meta is cached via Ember.Map which uses guid to key the Map
+  meta[Ember.GUID_KEY] = PreheatGuid++ + 'belongsTo';
 
   return Ember.computed({
     get(key) {

--- a/addon/-private/system/relationships/has-many.js
+++ b/addon/-private/system/relationships/has-many.js
@@ -9,6 +9,8 @@ import isArrayLike from "../is-array-like";
 
 const { get } = Ember;
 
+let PreheatGuid = 0;
+
 /**
   `DS.hasMany` is used to define One-To-Many and Many-To-Many
   relationships on a [DS.Model](/api/data/classes/DS.Model.html).
@@ -141,6 +143,9 @@ export default function hasMany(type, options) {
     name: 'Has Many',
     key: null
   };
+
+  // this exists for perf because meta is cached via Ember.Map which uses guid to key the Map
+  meta[Ember.GUID_KEY] = PreheatGuid++ + 'hasMany';
 
   return Ember.computed({
     get(key) {

--- a/addon/attr.js
+++ b/addon/attr.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import { deprecate } from 'ember-data/-private/debug';
 
+let PreheatGuid = 0;
+
 /**
   @module ember-data
 */
@@ -133,6 +135,9 @@ export default function attr(type, options) {
     isAttribute: true,
     options: options
   };
+
+  // this exists for perf because meta is cached via Ember.Map which uses guid to key the Map
+  meta[Ember.GUID_KEY] = PreheatGuid++ + 'attribute';
 
   return Ember.computed({
     get(key) {


### PR DESCRIPTION
While investigating the perf of a loop over each attribute and relationship, I noticed that we spent a particularly egregious amount of time in `Map.set` (in the screenshot this is the call to `set` within `(anonymous)`.  This was due to us always transitioning Meta in a more expensive manner than is necessary.

This PR preheats meta similar to how we preheat GUID_KEY for Ember.OrderedSet on `InternalModel`
 
<img width="471" alt="screen shot 2017-04-19 at 1 17 47 am" src="https://cloud.githubusercontent.com/assets/650309/25170757/79a87218-24a0-11e7-821d-0bac9ad6615d.png">
