### PR TITLE
Handle invalid response (422) in rest adapter

### DIFF
--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -963,7 +963,7 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
     if (this.isSuccess(status, headers, payload)) {
       return payload;
     } else if (this.isInvalid(status, headers, payload)) {
-      return new InvalidError(payload.errors);
+      return new InvalidError([payload.errors]);
     }
 
     let errors          = this.normalizeErrorResponse(status, headers, payload);


### PR DESCRIPTION
Not sure if this is the full fix but this change fixed the issue for me.

According to the documentation for the Rest Serializer, errors with 422 should look like this:

```javascript
{
  "errors": {
    "msg": "Something went wrong"
  }
}
```

This resulted in an error being thrown:

"Assertion Failed: `AdapterError` expects json-api formatted errors array."