### PR TITLE
Update to use built-in debug code stripping functionality.

### DIFF
--- a/addon/-private/adapters/errors.js
+++ b/addon/-private/adapters/errors.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assert } from 'ember-data/-debug';
+import { assert } from '@ember/debug';
 
 import isEnabled from '../features';
 

--- a/addon/-private/system/internal-model-map.js
+++ b/addon/-private/system/internal-model-map.js
@@ -1,4 +1,4 @@
-import { assert, deprecate } from 'ember-data/-debug';
+import { assert, deprecate } from '@ember/debug';
 import InternalModel from './model/internal-model';
 
 /**

--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -2,7 +2,7 @@
   @module ember-data
 */
 import Ember from 'ember';
-import { assert } from 'ember-data/-debug';
+import { assert } from '@ember/debug';
 import { PromiseArray } from "./promise-proxies";
 import { _objectIsAlive } from "./store/common";
 import diffArray from './diff-array';

--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { deprecate, warn } from 'ember-data/-debug';
+import { deprecate, warn } from '@ember/debug';
 
 const get = Ember.get;
 const set = Ember.set;

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-import { assert, runInDebug } from 'ember-data/-debug';
+import { DEBUG } from '@glimmer/env';
+import { assert } from '@ember/debug';
 import RootState from "./states";
 import Relationships from "../relationships/state/create";
 import Snapshot from "../snapshot";
@@ -1188,13 +1189,13 @@ export default class InternalModel {
     if (!reference) {
       let relationship = this._relationships.get(name);
 
-      runInDebug(() => {
+      if (DEBUG) {
         let modelName = this.modelName;
         assert(`There is no ${kind} relationship named '${name}' on a model of modelClass '${modelName}'`, relationship);
 
         let actualRelationshipKind = relationship.relationshipMeta.kind;
         assert(`You tried to get the '${name}' relationship on a '${modelName}' via record.${kind}('${name}'), but the relationship is of kind '${actualRelationshipKind}'. Use record.${actualRelationshipKind}('${name}') instead.`, actualRelationshipKind === kind);
-      });
+      }
 
       if (kind === "belongsTo") {
         reference = new BelongsToReference(this.store, this, relationship);

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-import { assert, deprecate, warn, runInDebug } from 'ember-data/-debug';
+import { DEBUG } from '@glimmer/env';
+import { assert, deprecate, warn } from '@ember/debug';
 import { PromiseObject } from "../promise-proxies";
 import Errors from "../model/errors";
 import isEnabled from '../../features';
@@ -1130,7 +1131,7 @@ Object.defineProperty(Model.prototype, 'data', {
   }
 });
 
-runInDebug(function() {
+if (DEBUG) {
   Model.reopen({
     init() {
       this._super(...arguments);
@@ -1140,7 +1141,7 @@ runInDebug(function() {
       }
     }
   });
-});
+}
 
 Model.reopenClass({
   isModel: true,
@@ -1875,7 +1876,7 @@ if (isEnabled('ds-rollback-attribute')) {
   });
 }
 
-runInDebug(() => {
+if (DEBUG) {
   Model.reopen({
     // This is a temporary solution until we refactor DS.Model to not
     // rely on the data property.
@@ -1923,7 +1924,7 @@ runInDebug(() => {
         meta.parentType = proto.constructor;
       }
     }
-  })
-});
+  });
+}
 
 export default Model;

--- a/addon/-private/system/model/states.js
+++ b/addon/-private/system/model/states.js
@@ -1,7 +1,7 @@
 /**
   @module ember-data
 */
-import { assert } from 'ember-data/-debug';
+import { assert } from '@ember/debug';
 
 /*
   This file encapsulates the various states that a record can transition

--- a/addon/-private/system/promise-proxies.js
+++ b/addon/-private/system/promise-proxies.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assert } from 'ember-data/-debug';
+import { assert } from '@ember/debug';
 
 const { get , RSVP: { Promise }} = Ember;
 

--- a/addon/-private/system/record-array-manager.js
+++ b/addon/-private/system/record-array-manager.js
@@ -8,7 +8,7 @@ import {
   FilteredRecordArray,
   AdapterPopulatedRecordArray
 } from "./record-arrays";
-import { assert } from 'ember-data/-debug';
+import { assert } from '@ember/debug';
 
 const {
   get,

--- a/addon/-private/system/references/belongs-to.js
+++ b/addon/-private/system/references/belongs-to.js
@@ -3,8 +3,8 @@ import Ember from 'ember';
 import Reference from './reference';
 
 import isEnabled from '../../features';
-import { assertPolymorphicType, deprecate } from 'ember-data/-debug';
-
+import { deprecate } from '@ember/debug';
+import { assertPolymorphicType } from 'ember-data/-debug';
 
 /**
    A BelongsToReference is a low level API that allows users and

--- a/addon/-private/system/references/has-many.js
+++ b/addon/-private/system/references/has-many.js
@@ -1,10 +1,8 @@
 import Ember from 'ember';
 import Reference from './reference';
-import {
-  assertPolymorphicType,
-  deprecate,
-  runInDebug
-} from 'ember-data/-debug';
+import { DEBUG } from '@glimmer/env';
+import { deprecate } from '@ember/debug';
+import { assertPolymorphicType } from 'ember-data/-debug';
 
 import isEnabled from '../../features';
 
@@ -278,10 +276,10 @@ HasManyReference.prototype.push = function(objectOrPromise) {
       internalModels = array.map((obj) => {
         let record = this.store.push(obj);
 
-        runInDebug(() => {
+        if (DEBUG) {
           let relationshipMeta = this.hasManyRelationship.relationshipMeta;
           assertPolymorphicType(this.internalModel, relationshipMeta, record._internalModel);
-        });
+        }
 
         return record._internalModel;
       });
@@ -289,12 +287,12 @@ HasManyReference.prototype.push = function(objectOrPromise) {
       let records = this.store.push(payload);
       internalModels = Ember.A(records).mapBy('_internalModel');
 
-      runInDebug(() => {
+      if (DEBUG) {
         internalModels.forEach((internalModel) => {
           let relationshipMeta = this.hasManyRelationship.relationshipMeta;
           assertPolymorphicType(this.internalModel, relationshipMeta, internalModel);
         });
-      });
+      }
     }
 
     this.hasManyRelationship.computeChanges(internalModels);

--- a/addon/-private/system/relationship-meta.js
+++ b/addon/-private/system/relationship-meta.js
@@ -1,6 +1,6 @@
 import {singularize} from 'ember-inflector';
 import normalizeModelName from './normalize-model-name';
-import { runInDebug } from 'ember-data/-debug';
+import { DEBUG } from '@glimmer/env';
 
 export function typeForRelationshipMeta(meta) {
   let modelName;
@@ -23,7 +23,9 @@ export function relationshipFromMeta(meta) {
     isRelationship: true
   };
 
-  runInDebug(() => result.parentType = meta.parentType);
+  if (DEBUG) {
+    result.parentType = meta.parentType;
+  }
 
   return result;
 }

--- a/addon/-private/system/relationships/belongs-to.js
+++ b/addon/-private/system/relationships/belongs-to.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assert, warn } from 'ember-data/-debug';
+import { assert, warn } from '@ember/debug';
 import normalizeModelName from "../normalize-model-name";
 
 /**

--- a/addon/-private/system/relationships/ext.js
+++ b/addon/-private/system/relationships/ext.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assert } from 'ember-data/-debug';
+import { assert } from '@ember/debug';
 import {
   typeForRelationshipMeta,
   relationshipFromMeta

--- a/addon/-private/system/relationships/has-many.js
+++ b/addon/-private/system/relationships/has-many.js
@@ -3,7 +3,7 @@
 */
 
 import Ember from 'ember';
-import { assert } from 'ember-data/-debug';
+import { assert } from '@ember/debug';
 import normalizeModelName from "../normalize-model-name";
 import isArrayLike from "../is-array-like";
 

--- a/addon/-private/system/relationships/relationship-payloads.js
+++ b/addon/-private/system/relationships/relationship-payloads.js
@@ -1,4 +1,4 @@
-import { assert } from 'ember-data/-debug';
+import { assert } from '@ember/debug';
 
 /**
   Manages the payloads for both sides of a single relationship, across all model
@@ -356,4 +356,3 @@ export default class RelationshipPayloads {
     }
   }
 }
-

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 import {
-  assertPolymorphicType,
   assert
-} from 'ember-data/-debug';
+} from '@ember/debug';
+import { assertPolymorphicType } from 'ember-data/-debug';
 import {
   PromiseObject
 } from "../../promise-proxies";

--- a/addon/-private/system/relationships/state/create.js
+++ b/addon/-private/system/relationships/state/create.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import ManyRelationship from "./has-many";
 import BelongsToRelationship from "./belongs-to";
-import { runInDebug } from 'ember-data/-debug';
+import { DEBUG } from '@glimmer/env';
 
 const { get } = Ember;
 
@@ -16,10 +16,8 @@ function createRelationshipFor(internalModel, relationshipMeta, store) {
 
   if (shouldFindInverse(relationshipMeta)) {
     inverse = internalModel.type.inverseFor(relationshipMeta.key, store);
-  } else {
-    runInDebug(() => {
-      internalModel.type.typeForRelationship(relationshipMeta.key, store);
-    });
+  } else if (DEBUG) {
+    internalModel.type.typeForRelationship(relationshipMeta.key, store);
   }
 
   if (inverse) {

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -1,4 +1,5 @@
-import { assert, assertPolymorphicType } from 'ember-data/-debug';
+import { assert } from '@ember/debug';
+import { assertPolymorphicType } from 'ember-data/-debug';
 import { PromiseManyArray } from '../../promise-proxies';
 import Relationship from './relationship';
 import OrderedSet from '../../ordered-set';

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -1,5 +1,5 @@
 /* global heimdall */
-import { assert, warn } from 'ember-data/-debug';
+import { assert, warn } from '@ember/debug';
 import OrderedSet from '../../ordered-set';
 import _normalizeLink from '../../normalize-link';
 

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -4,13 +4,13 @@
 
 import Ember from 'ember';
 import { InvalidError } from '../adapters/errors';
+import { instrument } from 'ember-data/-debug';
 import {
-  instrument,
   assert,
   deprecate,
-  warn,
-  runInDebug
-} from 'ember-data/-debug';
+  warn
+} from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
 import Model from './model/model';
 import normalizeModelName from "./normalize-model-name";
 import IdentityMap from './identity-map';
@@ -1660,7 +1660,7 @@ Store = Service.extend({
   },
 
   didUpdateAll(modelName) {
-    deprecate('didUpdateAll was documented as private and will be removed in the next version of Ember Data.');
+    deprecate('didUpdateAll was documented as private and will be removed in the next version of Ember Data.', false, { id: 'ember-data.didUpdateAll', until: '2.17.0' });
     return this._didUpdateAll(modelName);
   },
 
@@ -2372,7 +2372,7 @@ Store = Service.extend({
     assert(`You must include an 'id' for ${modelName} in an object passed to 'push'`, data.id !== null && data.id !== undefined && data.id !== '');
     assert(`You tried to push data with a type '${modelName}' but no model could be found with that name.`, this._hasModelFor(modelName));
 
-    runInDebug(() => {
+    if (DEBUG) {
       // If ENV.DS_WARN_ON_UNKNOWN_KEYS is set to true and the payload
       // contains unknown attributes or relationships, log a warning.
 
@@ -2393,7 +2393,7 @@ Store = Service.extend({
         let unknownRelationshipsMessage = `The payload for '${modelName}' contains these unknown relationships: ${unknownRelationships}. Make sure they've been defined in your model.`;
         warn(unknownRelationshipsMessage, unknownRelationships.length === 0, { id: 'ds.store.unknown-keys-in-payload' });
       }
-    });
+    }
 
     // Actually load the record into the store.
     let internalModel = this._load(data);
@@ -2573,7 +2573,7 @@ Store = Service.extend({
   },
 
   buildInternalModel(modelName, id, data) {
-    deprecate('buildInternalModel was documented as private and will be removed in the next version of Ember Data.');
+    deprecate('buildInternalModel was documented as private and will be removed in the next version of Ember Data.', false, { id: 'ember-data.buildInternalModel', until: '2.17.0' });
     return this._buildInternalModel(modelName, id, data);
   },
 
@@ -2869,7 +2869,7 @@ function setupRelationships(store, internalModel, data, modelNameToInverseMap) {
     }
 
     // in debug, assert payload validity eagerly
-    runInDebug(() => {
+    if (DEBUG) {
       let relationshipMeta = get(internalModel.type, 'relationshipsByName').get(relationshipName);
       let relationshipData = data.relationships[relationshipName];
       if (!relationshipData || !relationshipMeta) {
@@ -2888,7 +2888,7 @@ function setupRelationships(store, internalModel, data, modelNameToInverseMap) {
           assert(`A ${internalModel.type.modelName} record was pushed into the store with the value of ${relationshipName} being '${inspect(relationshipData.data)}', but ${relationshipName} is a hasMany relationship so the value must be an array. You should probably check your data payload or serializer.`, Array.isArray(relationshipData.data));
         }
       }
-    });
+    }
   });
 }
 

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assert, warn } from 'ember-data/-debug';
+import { assert, warn } from '@ember/debug';
 import {
   _bind,
   _guard,

--- a/addon/-private/system/store/serializer-response.js
+++ b/addon/-private/system/store/serializer-response.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-import { assert, runInDebug } from 'ember-data/-debug';
+import { assert } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
 
 /*
   This is a helper method that validates a JSON API top-level document
@@ -75,9 +76,9 @@ export function validateDocumentStructure(doc) {
 export function normalizeResponseHelper(serializer, store, modelClass, payload, id, requestType) {
   let normalizedResponse = serializer.normalizeResponse(store, modelClass, payload, id, requestType);
   let validationErrors = [];
-  runInDebug(() => {
+  if (DEBUG) {
     validationErrors = validateDocumentStructure(normalizedResponse);
-  });
+  }
   assert(`normalizeResponse must return a valid JSON API document:\n\t* ${validationErrors.join('\n\t* ')}`, Ember.isEmpty(validationErrors));
 
   return normalizedResponse;

--- a/addon/adapters/json-api.js
+++ b/addon/adapters/json-api.js
@@ -6,7 +6,8 @@
 import Ember from 'ember';
 import RESTAdapter from "./rest";
 import { isEnabled } from '../-private';
-import { instrument, deprecate } from 'ember-data/-debug';
+import { deprecate } from '@ember/debug';
+import { instrument } from 'ember-data/-debug';
 
 /**
   The `JSONAPIAdapter` is the default adapter used by Ember Data. It

--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -19,7 +19,10 @@ import {
   TimeoutError,
   AbortError
 } from '../-private';
-import { instrument, runInDebug, warn, deprecate } from 'ember-data/-debug';
+import { instrument } from 'ember-data/-debug';
+import { warn, deprecate } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+
 
 const {
   MapWithDefault,
@@ -1502,13 +1505,13 @@ function ajaxSuccess(adapter, jqXHR, payload, requestData) {
 }
 
 function ajaxError(adapter, jqXHR, requestData, responseData) {
-  runInDebug(function() {
+  if (DEBUG) {
     let message = `The server returned an empty string for ${requestData.method} ${requestData.url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
     let validJSONString = !(responseData.textStatus === "parsererror" && jqXHR.responseText === "");
     warn(message, validJSONString, {
       id: 'ds.adapter.returned-empty-string-as-JSON'
     });
-  });
+  }
 
   let error;
 

--- a/addon/attr.js
+++ b/addon/attr.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { deprecate } from 'ember-data/-debug';
+import { deprecate } from '@ember/debug';
 
 /**
   @module ember-data

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,5 +1,5 @@
 import Ember from "ember";
-import { deprecate } from 'ember-data/-debug';
+import { deprecate } from '@ember/debug';
 
 /**
   Ember Data

--- a/addon/instance-initializers/initialize-store-service.js
+++ b/addon/instance-initializers/initialize-store-service.js
@@ -1,4 +1,4 @@
-import { deprecate } from 'ember-data/-debug';
+import { deprecate } from '@ember/debug';
 
 /*
   Configures a registry for use with an Ember-Data

--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { warn } from 'ember-data/-debug';
+import { warn } from '@ember/debug';
 
 const get = Ember.get;
 const set = Ember.set;

--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -4,7 +4,9 @@
 
 import Ember from 'ember';
 import { pluralize, singularize } from 'ember-inflector';
-import { assert, deprecate, runInDebug, warn } from 'ember-data/-debug';
+import { assert, deprecate, warn } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+
 import JSONSerializer from './json';
 import { normalizeModelName, isEnabled } from '../-private';
 
@@ -286,11 +288,11 @@ const JSONAPISerializer = JSONSerializer.extend({
         if (resourceHash.attributes[attributeKey] !== undefined) {
           attributes[key] = resourceHash.attributes[attributeKey];
         }
-        runInDebug(() => {
+        if (DEBUG) {
           if (resourceHash.attributes[attributeKey] === undefined && resourceHash.attributes[key] !== undefined) {
             assert(`Your payload for '${modelClass.modelName}' contains '${key}', but your serializer is setup to look for '${attributeKey}'. This is most likely because Ember Data's JSON API serializer dasherizes attribute keys by default. You should subclass JSONAPISerializer and implement 'keyForAttribute(key) { return key; }' to prevent Ember Data from customizing your attribute keys.`, false);
           }
-        });
+        }
       });
     }
 
@@ -329,11 +331,11 @@ const JSONAPISerializer = JSONSerializer.extend({
           relationships[key] = this.extractRelationship(relationshipHash);
 
         }
-        runInDebug(() => {
+        if (DEBUG) {
           if (resourceHash.relationships[relationshipKey] === undefined && resourceHash.relationships[key] !== undefined) {
             assert(`Your payload for '${modelClass.modelName}' contains '${key}', but your serializer is setup to look for '${relationshipKey}'. This is most likely because Ember Data's JSON API serializer dasherizes relationship keys by default. You should subclass JSONAPISerializer and implement 'keyForRelationship(key) { return key; }' to prevent Ember Data from customizing your relationship keys.`, false);
           }
-        });
+        }
       });
     }
 
@@ -734,7 +736,7 @@ if (isEnabled("ds-payload-type-hooks")) {
 
 }
 
-runInDebug(function() {
+if (DEBUG) {
   JSONAPISerializer.reopen({
     willMergeMixin(props) {
       let constructor = this.constructor;
@@ -752,6 +754,6 @@ runInDebug(function() {
       return `Encountered a resource object with type "${originalType}", but no model was found for model name "${modelName}" (resolved model name using '${this.constructor.toString()}.${usedLookup}("${originalType}")').`;
     }
   });
-});
+}
 
 export default JSONAPISerializer;

--- a/addon/serializers/json.js
+++ b/addon/serializers/json.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { assert, deprecate, warn } from 'ember-data/-debug';
+import { assert, deprecate, warn } from '@ember/debug';
 import Serializer from "../serializer";
 import {
   getOwner,

--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -4,7 +4,9 @@
 
 import Ember from 'ember';
 import { singularize } from "ember-inflector";
-import { assert, deprecate, runInDebug, warn } from 'ember-data/-debug';
+import { assert, deprecate, warn } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+
 import JSONSerializer from "../serializers/json";
 import { coerceId, modelHasAttributeOrRelationshipNamedType, normalizeModelName, isEnabled } from '../-private';
 
@@ -298,7 +300,7 @@ let RESTSerializer = JSONSerializer.extend({
         continue;
       }
 
-      runInDebug(function() {
+      if (DEBUG) {
         let isQueryRecordAnArray = requestType === 'queryRecord' && isPrimary && Array.isArray(value);
         let message = "The adapter returned an array for the primary data of a `queryRecord` response. This is deprecated as `queryRecord` should return a single record.";
 
@@ -306,7 +308,7 @@ let RESTSerializer = JSONSerializer.extend({
           id: 'ds.serializer.rest.queryRecord-array-response',
           until: '3.0'
         });
-      });
+      }
 
       /*
         Support primary data as an object instead of an array.
@@ -972,12 +974,12 @@ if (isEnabled("ds-payload-type-hooks")) {
 
 }
 
-runInDebug(function() {
+if (DEBUG) {
   RESTSerializer.reopen({
     warnMessageNoModelForKey(prop, typeKey) {
       return 'Encountered "' + prop + '" in payload, but no model was found for model name "' + typeKey + '" (resolved model name using ' + this.constructor.toString() + '.modelNameFromPayloadKey("' + prop + '"))';
     }
   });
-});
+}
 
 export default RESTSerializer;

--- a/addon/transforms/date.js
+++ b/addon/transforms/date.js
@@ -1,6 +1,6 @@
 import Transform from './transform';
 import Ember from 'ember';
-import { deprecate } from 'ember-data/-debug';
+import { deprecate } from '@ember/debug';
 
 Ember.Date = Ember.Date || {};
 

--- a/lib/babel-build.js
+++ b/lib/babel-build.js
@@ -1,6 +1,30 @@
+'use strict';
+
 var babel = require('broccoli-babel-transpiler');
 var path  = require('path');
 var moduleResolve = require('amd-name-resolver').moduleResolve;
+
+function getDebugMacroPlugins() {
+  const DebugMacros = require('babel-plugin-debug-macros').default;
+  const isProduction = process.env.EMBER_ENV === 'production';
+
+  let options = {
+    envFlags: {
+      source: '@glimmer/env',
+      flags: { DEBUG: !isProduction, CI: !!process.env.CI }
+    },
+
+    externalizeHelpers: {
+      global: 'Ember'
+    },
+
+    debugTools: {
+      source: '@ember/debug'
+    }
+  };
+
+  return [DebugMacros, options];
+}
 
 function babelOptions(libraryName, _options) {
   _options = _options || {};
@@ -25,6 +49,7 @@ function babelOptions(libraryName, _options) {
   });
 
   options.plugins = options.plugins.concat([
+    getDebugMacroPlugins(),
     ['transform-es2015-modules-amd', { noInterop: true, loose: true }],
     'transform-es2015-arrow-functions',
     'transform-es2015-computed-properties',

--- a/lib/stripped-build-plugins.js
+++ b/lib/stripped-build-plugins.js
@@ -49,20 +49,13 @@ module.exports = function(environment) {
   if (environment === 'production' || process.env.INSTRUMENT_HEIMDALL === 'true') {
     postTransformPlugins.push([StripClassCallCheck]);
     uniqueAdd(filteredImports, 'ember-data/-debug', [
-      'assert',
-      'assertPolymorphicType',
-      'debug',
-      'deprecate',
-      'info',
-      'runInDebug',
-      'warn',
-      'debugSeal'
+      'assertPolymorphicType'
     ]);
   }
 
   plugins.push(
     [FilterImports, filteredImports],
-    ['transform-es2015-block-scoping', { 'throwIfClosureRequired': true }]
+    [TransformBlockScoping, { 'throwIfClosureRequired': true }]
   );
 
   if (environment === 'production') {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "testem": "1.15.0"
   },
   "devDependencies": {
+    "babel-plugin-debug-macros": "^0.1.7",
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
     "babel-plugin-transform-es2015-classes": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-rollup": "^1.2.0",
     "chalk": "^1.1.1",
-    "ember-cli-babel": "^6.0.0-beta.10",
+    "ember-cli-babel": "^6.1.0",
     "ember-cli-path-utils": "^1.0.0",
     "ember-cli-string-utils": "^1.0.0",
     "ember-cli-test-info": "^1.0.0",

--- a/tests/helpers/test-in-debug.js
+++ b/tests/helpers/test-in-debug.js
@@ -1,15 +1,8 @@
-import require from 'require';
+import { DEBUG } from '@glimmer/env';
 import { test, skip } from 'qunit';
 
 export default function testInDebug() {
-  let isDebug = false;
-
-  // TODO: this should be debug-stripped...
-  if (require.has('ember-data/-debug')) {
-    require('ember-data/-debug').runInDebug(() => isDebug = true);
-  }
-
-  if (isDebug) {
+  if (DEBUG) {
     test(...arguments);
   } else {
     skip(...arguments);

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,7 +515,7 @@ babel-plugin-dead-code-elimination@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz#5f7c451274dcd7cccdbfbb3e0b85dd28121f0f65"
 
-babel-plugin-debug-macros@^0.1.6:
+babel-plugin-debug-macros@^0.1.6, babel-plugin-debug-macros@^0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.7.tgz#69f5a3dc7d72f781354f18c611a3b007bb223511"
   dependencies:
@@ -2136,22 +2136,7 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.5, ember-c
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.10, ember-cli-babel@^6.0.0-beta.7:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.1.0.tgz#d9c83a7d0c67cc8a3ccb9bd082971c3593e54fad"
-  dependencies:
-    amd-name-resolver "0.0.6"
-    babel-plugin-debug-macros "^0.1.6"
-    babel-plugin-transform-es2015-modules-amd "^6.24.0"
-    babel-polyfill "^6.16.0"
-    babel-preset-env "^1.2.0"
-    broccoli-babel-transpiler "^6.0.0"
-    broccoli-funnel "^1.0.0"
-    broccoli-source "^1.1.0"
-    clone "^2.0.0"
-    ember-cli-version-checker "^1.2.0"
-
-ember-cli-babel@^6.1.0:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.1.0.tgz#d9c83a7d0c67cc8a3ccb9bd082971c3593e54fad"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,6 +2151,21 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.10, ember-cli-babel@^6.0.0-b
     clone "^2.0.0"
     ember-cli-version-checker "^1.2.0"
 
+ember-cli-babel@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.1.0.tgz#d9c83a7d0c67cc8a3ccb9bd082971c3593e54fad"
+  dependencies:
+    amd-name-resolver "0.0.6"
+    babel-plugin-debug-macros "^0.1.6"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.2.0"
+    broccoli-babel-transpiler "^6.0.0"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^1.2.0"
+
 ember-cli-blueprint-test-helpers@0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/ember-cli-blueprint-test-helpers/-/ember-cli-blueprint-test-helpers-0.11.0.tgz#252530b7d1e3e93c01526cad08cc6b184a967487"


### PR DESCRIPTION
This functionality is now baked into ember-cli-babel (as of 6.1.0).