### PR TITLE
[BUGFIX beta] Ensure Engines can boot without error.

### DIFF
--- a/addon/instance-initializers/initialize-store-service.js
+++ b/addon/instance-initializers/initialize-store-service.js
@@ -5,15 +5,20 @@ import { deprecate } from '@ember/debug';
   store.
 
   @method initializeStoreService
-  @param {Ember.ApplicationInstance} applicationOrRegistry
+  @param {Ember.ApplicationInstance | Ember.EngineInstance} instance
 */
-export default function initializeStoreService(application) {
-  const container = application.lookup ? application : application.container;
+export default function initializeStoreService(instance) {
+  // instance.lookup supports Ember 2.1 and higher
+  // instance.container supports Ember 1.11 - 2.0
+  const container = instance.lookup ? instance : instance.container;
 
   // Eagerly generate the store so defaultStore is populated.
   container.lookup('service:store');
 
-  deprecateOldEmberDataInitializers(application.application.constructor.initializers);
+  // In Ember 2.4+ instance.base is the `Ember.Application` or `Ember.Engine` instance
+  // In Ember 1.11 - 2.3 we fallback to `instance.application`
+  let base = instance.base || instance.application;
+  deprecateOldEmberDataInitializers(base.constructor.initializers);
 }
 
 const DEPRECATED_INITIALIZER_NAMES = ['data-adapter', 'injectStore', 'transforms', 'store'];

--- a/addon/instance-initializers/initialize-store-service.js
+++ b/addon/instance-initializers/initialize-store-service.js
@@ -1,4 +1,7 @@
 import { deprecate } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+
+let deprecateOldEmberDataInitializers;
 
 /*
   Configures a registry for use with an Ember-Data
@@ -15,45 +18,49 @@ export default function initializeStoreService(instance) {
   // Eagerly generate the store so defaultStore is populated.
   container.lookup('service:store');
 
-  // In Ember 2.4+ instance.base is the `Ember.Application` or `Ember.Engine` instance
-  // In Ember 1.11 - 2.3 we fallback to `instance.application`
-  let base = instance.base || instance.application;
-  deprecateOldEmberDataInitializers(base.constructor.initializers);
-}
-
-const DEPRECATED_INITIALIZER_NAMES = ['data-adapter', 'injectStore', 'transforms', 'store'];
-
-function matchesDeprecatedInititalizer(name) {
-  return DEPRECATED_INITIALIZER_NAMES.indexOf(name) !== -1;
-}
-
-function deprecateOldEmberDataInitializers(initializers) {
-  // collect all of the initializers
-  let keys = Object.keys(initializers);
-
-  for (let i = 0; i < keys.length; i++) {
-    let name = keys[i];
-
-    // filter out all of the Ember Data initializer. We have some
-    // deprecated initializers that depend on other deprecated
-    // initializers which may trigger the deprecation warning
-    // unintentionally.
-    if (!matchesDeprecatedInititalizer(name)) {
-      warnForDeprecatedInitializers(initializers[name]);
-    }
+  if (DEBUG) {
+    // In Ember 2.4+ instance.base is the `Ember.Application` or `Ember.Engine` instance
+    // In Ember 1.11 - 2.3 we fallback to `instance.application`
+    let base = instance.base || instance.application;
+    deprecateOldEmberDataInitializers(base.constructor.initializers);
   }
 }
 
-function warnForDeprecatedInitializers(initializer) {
-  let deprecatedBeforeInitializer = matchesDeprecatedInititalizer(initializer.before);
-  let deprecatedAfterInitializer = matchesDeprecatedInititalizer(initializer.after);
-  let deprecatedProp = deprecatedBeforeInitializer ? 'before' : 'after';
+if (DEBUG) {
+  const DEPRECATED_INITIALIZER_NAMES = ['data-adapter', 'injectStore', 'transforms', 'store'];
 
-  deprecate(
-    `The initializer \`${initializer[deprecatedProp]}\` has been deprecated. Please update your \`${initializer.name}\` initializer to use use \`${deprecatedProp}: \'ember-data\'\` instead.`,
-    !(deprecatedBeforeInitializer || deprecatedAfterInitializer),
-    {
-      id: 'ds.deprecated-initializers',
-      until: '3.0.0'
-    })
+  let matchesDeprecatedInititalizer = function matchesDeprecatedInititalizer(name) {
+    return DEPRECATED_INITIALIZER_NAMES.indexOf(name) !== -1;
+  };
+
+  let warnForDeprecatedInitializers = function warnForDeprecatedInitializers(initializer) {
+    let deprecatedBeforeInitializer = matchesDeprecatedInititalizer(initializer.before);
+    let deprecatedAfterInitializer = matchesDeprecatedInititalizer(initializer.after);
+    let deprecatedProp = deprecatedBeforeInitializer ? 'before' : 'after';
+
+    deprecate(
+      `The initializer \`${initializer[deprecatedProp]}\` has been deprecated. Please update your \`${initializer.name}\` initializer to use use \`${deprecatedProp}: \'ember-data\'\` instead.`,
+      !(deprecatedBeforeInitializer || deprecatedAfterInitializer),
+      {
+        id: 'ds.deprecated-initializers',
+        until: '3.0.0'
+      });
+  };
+
+  deprecateOldEmberDataInitializers = function deprecateOldEmberDataInitializers(initializers) {
+    // collect all of the initializers
+    let keys = Object.keys(initializers);
+
+    for (let i = 0; i < keys.length; i++) {
+      let name = keys[i];
+
+      // filter out all of the Ember Data initializer. We have some
+      // deprecated initializers that depend on other deprecated
+      // initializers which may trigger the deprecation warning
+      // unintentionally.
+      if (!matchesDeprecatedInititalizer(name)) {
+        warnForDeprecatedInitializers(initializers[name]);
+      }
+    }
+  };
 }


### PR DESCRIPTION
The argument passed into `instance-initializers` is _either_ an `Ember.ApplicationInstance` instance _or_ a `Ember.EngineInstance` instance. The `.application` property is only present on `Ember.ApplicationInstance`'s.

This change adds some inline comments around the various conditionals and swaps the logic to use `instance.base` when present and avoid erroring if neither `.base` or `.application` is present.

A follow up PR will be made targeting `release` branch (because this won't cherry-pick easily).

---

Also, note, the second commit is not _required_ but it does strip the deprecation related code in production builds which is kinda nice...

---

Addresses #4968