### PR TITLE
[BUGFIX release] Ensure Engines can boot without error.

### DIFF
--- a/addon/-private/instance-initializers/initialize-store-service.js
+++ b/addon/-private/instance-initializers/initialize-store-service.js
@@ -4,15 +4,20 @@ import { deprecate } from 'ember-data/-private/debug';
   store.
 
   @method initializeStoreService
-  @param {Ember.ApplicationInstance} applicationOrRegistry
+  @param {Ember.ApplicationInstance | Ember.EngineInstance} instance
 */
-export default function initializeStoreService(application) {
-  let container = application.lookup ? application : application.container;
+export default function initializeStoreService(instance) {
+  // instance.lookup supports Ember 2.1 and higher
+  // instance.container supports Ember 1.11 - 2.0
+  const container = instance.lookup ? instance : instance.container;
+
   // Eagerly generate the store so defaultStore is populated.
   container.lookup('service:store');
 
-  let initializers = application.application.constructor.initializers;
-  deprecateOldEmberDataInitializers(initializers)
+  // In Ember 2.4+ instance.base is the `Ember.Application` or `Ember.Engine` instance
+  // In Ember 1.11 - 2.3 we fallback to `instance.application`
+  let base = instance.base || instance.application;
+  deprecateOldEmberDataInitializers(base.constructor.initializers);
 }
 
 


### PR DESCRIPTION
The argument passed into `instance-initializers` is _either_ an `Ember.ApplicationInstance` instance _or_ a `Ember.EngineInstance` instance. The `.application` property is only present on `Ember.ApplicationInstance`'s.

This change adds some inline comments around the various conditionals and swaps the logic to use `instance.base` when present and avoid erroring if neither `.base` or `.application` is present.

---

This mirrors the functionality changes made in #4969, but targets `release` branch.

Closes https://github.com/emberjs/data/pull/4968