### PR TITLE
allow saving a new record to return a existing record

### DIFF
--- a/addon/-private/system/internal-model-map.js
+++ b/addon/-private/system/internal-model-map.js
@@ -52,7 +52,10 @@ export default class InternalModelMap {
     assert(`You cannot index an internalModel by an empty id'`, id);
     assert(`You cannot set an index for an internalModel to something other than an internalModel`, internalModel instanceof InternalModel);
     assert(`You cannot set an index for an internalModel that is not in the InternalModelMap`, this.contains(internalModel));
-    assert(`You cannot update the id index of an InternalModel once set. Attempted to update ${id}.`, !this.has(id) || this.get(id) === internalModel);
+
+    if (this.has(id)) {
+      this.remove(internalModel, id);
+    }
 
     this._idToModel[id] = internalModel;
   }

--- a/tests/integration/records/save-test.js
+++ b/tests/integration/records/save-test.js
@@ -194,3 +194,37 @@ test("Will reject save on invalid", function(assert) {
     });
   });
 });
+
+test("Creating a new record that returns a duplicate record updates duplicate record", function(assert) {
+  assert.expect(3);
+  var store = env.store;
+  var post;
+  run(function() {
+    store.push({
+      data: {
+        id: '1',
+        type: 'post',
+        attributes: {
+          title: 'Existing post title'
+        }
+      }
+    });
+    post = env.store.createRecord('post');
+  });
+
+  env.adapter.createRecord = function(store, type, snapshot) {
+    return Ember.RSVP.resolve({
+      id: '1',
+      title: 'updated title'
+    });
+  };
+
+  run(function() {
+    post.save().then(function() {
+      var all = store.peekAll('post');
+      assert.equal(post.get('id'), '1', 'The duplicate post ID loaded');
+      assert.equal(post.get('title'), 'updated title', 'it updates payload of loaded record');
+      assert.equal(all.get('length'), 1, "doesn't update count");
+    });
+  });
+});


### PR DESCRIPTION
This fixes an issue #4972 that I am having. I am thinking this should probably be an addon something like adding findOrCreate to the store.   