### PR TITLE
[DOC release] Docs for has-many, belongs-to ref meta

### DIFF
--- a/addon/-private/system/references/belongs-to.js
+++ b/addon/-private/system/references/belongs-to.js
@@ -189,7 +189,7 @@ BelongsToReference.prototype.link = function() {
     ```
 
    @method meta
-   @return {Object} The meta information for the belongs-oo relationship.
+   @return {Object} The meta information for the belongs-to relationship.
 */
 BelongsToReference.prototype.meta = function() {
   return this.belongsToRelationship.meta;

--- a/addon/-private/system/references/has-many.js
+++ b/addon/-private/system/references/has-many.js
@@ -158,8 +158,7 @@ HasManyReference.prototype.ids = function() {
 };
 
 /**
-   The link Ember Data will use to fetch or reload this has-many
-   relationship.
+   The meta data for the has-many relationship.
 
    Example
 


### PR DESCRIPTION
Change the description of the DS.HasManyReference.meta to match the text for the DS.BelongsToReference.meta docs (incorrectly described returning link information before).

Fix a typo in return description for DS.BelongsToReference.meta