### PR TITLE
[DOC release] Document DS.HasManyReference.ids

### DIFF
--- a/addon/-private/system/references/has-many.js
+++ b/addon/-private/system/references/has-many.js
@@ -146,7 +146,7 @@ HasManyReference.prototype.link = function() {
    commentsRef.ids(); // ['1']
    ```
 
-   @method remoteType
+   @method ids
    @return {Array} The ids in this has-many relationship
 */
 HasManyReference.prototype.ids = function() {


### PR DESCRIPTION
The existing inline doc incorrectly marks the method name as
`remoteType`.