### PR TITLE
[DOC release] Fix doc for `diffArray`

### DIFF
--- a/addon/-private/system/diff-array.js
+++ b/addon/-private/system/diff-array.js
@@ -1,7 +1,7 @@
 /**
   @namespace
-  @method diff-array
-  @for DS
+  @method diffArray
+  @private
   @param {Array} oldArray the old array
   @param {Array} newArray the new array
   @return {hash} {


### PR DESCRIPTION
- Fix method name from `diff-array` to `diffArray`
- This is not a public method