### PR TITLE
[BUGFIX] Fix flushing of pending saves, that include a deleted record

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1870,7 +1870,8 @@ Store = Service.extend({
       let operation;
 
       if (internalModel.currentState.stateName === 'root.deleted.saved') {
-        return resolver.resolve();
+        resolver.resolve();
+        continue;
       } else if (internalModel.isNew()) {
         operation = 'createRecord';
       } else if (internalModel.isDeleted()) {

--- a/tests/integration/records/delete-record-test.js
+++ b/tests/integration/records/delete-record-test.js
@@ -289,3 +289,29 @@ test("Destroying an invalid newly created record should remove it from the store
   assert.equal(get(record, 'currentState.stateName'), 'root.deleted.saved');
   assert.equal(get(store.peekAll('person'), 'length'), 0, 'The new person should be removed from the store');
 });
+
+test("Will resolve destroy and save in same loop", function(assert) {
+  let adam, dave;
+  let promises;
+
+  assert.expect(1);
+
+  env.adapter.createRecord = function() {
+    assert.ok(true, 'save operation resolves');
+    return Ember.RSVP.Promise.resolve({ id: 123 });
+  };
+
+  run(function() {
+    adam = env.store.createRecord('person', { name: 'Adam Sunderland' });
+    dave = env.store.createRecord('person', { name: 'Dave Sunderland' });
+  });
+
+  run(function() {
+    promises = [
+      adam.destroyRecord(),
+      dave.save()
+    ];
+  });
+
+  return Ember.RSVP.all(promises);
+});


### PR DESCRIPTION
Fixes #4993 

Seems the regression was introduced with #4668, by refactoring from a `forEach` loop to a `for` loop, where we cannot simply `return` anymore: https://github.com/emberjs/data/commit/063b3e500e31a711d81253a893f8668558e86808#diff-fd4c34d9a34dfde73cd3413128a3c973R1866