### PR TITLE
[BUGFIX BETA] Added `system/store/container-instance-cache` to the -private export

### DIFF
--- a/addon/-private/index.js
+++ b/addon/-private/index.js
@@ -28,10 +28,12 @@ export { default as coerceId } from './system/coerce-id';
 export { default as parseResponseHeaders } from './utils/parse-response-headers';
 
 // should be private ?
-export { default as RootState } from './system/model/states';
 export { default as global } from './global';
 export { default as isEnabled } from './features';
+// `ember-data-model-fragments` relies on `RootState`, `InternalModel` and `ContainerInstanceCache`
+export { default as RootState } from './system/model/states';
 export { default as InternalModel } from './system/model/internal-model';
+export { default as ContainerInstanceCache } from './system/store/container-instance-cache';
 
 export {
   PromiseArray,

--- a/tests/unit/private-test.js
+++ b/tests/unit/private-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { ContainerInstanceCache, InternalModel, RootState } from 'ember-data/-private';
+
+module('-private');
+
+test('`ContainerInstanceCache` is accessible via private import', function(assert) {
+  assert.ok(!!ContainerInstanceCache);
+});
+
+test('`InternalModel` is accessible via private import', function(assert) {
+  assert.ok(!!InternalModel);
+});
+
+test('`RootState` is accessible via private import', function(assert) {
+  assert.ok(!!RootState);
+});


### PR DESCRIPTION
I'm sure adding more things to the `-private` export is 😢 . Unfortunately we need access to this class in [ember-data-model-fragments](https://github.com/lytics/ember-data-model-fragments/blob/master/addon/ext.js#L331-L360). There was previously a discussion about alternative approaches, but we settled on monkey patching this class (https://github.com/lytics/ember-data-model-fragments/issues/224). 