### PR TITLE
[BUGFIX BETA]: Fixed export regression. `ember-data/transform` to be default.

### DIFF
--- a/addon/transform.js
+++ b/addon/transform.js
@@ -1,1 +1,1 @@
-export { Transform } from './-private';
+export { default } from './transforms/transform';


### PR DESCRIPTION
@stefanpenner made reference to this in the original PR (https://github.com/emberjs/data/commit/24f41209b7ab9978bcdf029e50e3e62564d0b50f#commitcomment-22121947), but I think it was just overlooked. Either way this created a regression for us when using: `import Transform from 'ember-data/transform';`.
