### PR TITLE
Fix and tests for unloadRecord => findRecord issue

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1127,6 +1127,10 @@ Store = Service.extend({
 
     if (!internalModel) {
       internalModel = this._buildInternalModel(modelName, trueId);
+    } else {
+      // if we already have an internalModel, we need to ensure any async teardown is cancelled
+      //   since we want it again.
+      internalModel.cancelDestroy();
     }
 
     return internalModel;


### PR DESCRIPTION
The underlying issue was that the internalModel was not cleaning up it's `destroy` call and flags when being rematerialized immediately.