### PR TITLE
[BUGFIX release] Fix global build

### DIFF
--- a/app/initializers/ember-data.js
+++ b/app/initializers/ember-data.js
@@ -1,5 +1,5 @@
 import setupContainer from 'ember-data/setup-container';
-import 'ember-data/index';
+import 'ember-data';
 
 /*
 


### PR DESCRIPTION
The global build of ember-data has been broken since https://github.com/emberjs/data/pull/4823.
When `ember-data.js` is loaded, the following error is occured:
```
Uncaught Error: Could not find module `ember-data/index` imported from `ember-data/initializers/ember-data`
```

A reproduction code is just simple:
```
<!DOCTYPE html>
<html>
  <head>
    <script src="http://builds.emberjs.com/tags/v2.13.1/ember.prod.js"></script>
    <script src="http://builds.emberjs.com/tags/v2.14.3/ember-data.js"></script>
  </head>
  <body>
    <h1>Hello, Ember!</h1>
  </body>
</html>
```

The reason of this error is that the broccoli builds the module named "*/index" into `*` for global build.
But loader.js couldn't resolve `ember-data/index` as `ember-data`.

So the `ember-data/index` module should be to as just `ember-data` to be
compatible with NPM package and global.