### PR TITLE
fix notifyPropertyChange error causing backtracking re-render error

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -724,25 +724,27 @@ export default class InternalModel {
 
   notifyHasManyAdded(key, record, idx) {
     if (this.hasRecord) {
-      this._record.notifyHasManyAdded(key, record, idx);
+      Ember.run.join(() => this._record.notifyHasManyAdded(key, record, idx));
     }
   }
 
   notifyHasManyRemoved(key, record, idx) {
     if (this.hasRecord) {
-      this._record.notifyHasManyRemoved(key, record, idx);
+      Ember.run.join(() => this._record.notifyHasManyRemoved(key, record, idx));
     }
   }
 
   notifyBelongsToChanged(key, record) {
     if (this.hasRecord) {
-      this._record.notifyBelongsToChanged(key, record);
+      Ember.run.join(() => this._record.notifyBelongsToChanged(key, record));
     }
   }
 
   notifyPropertyChange(key) {
     if (this.hasRecord) {
+      Ember.beginPropertyChanges();
       this._record.notifyPropertyChange(key);
+      Ember.endPropertyChanges();
     }
   }
 

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1040,7 +1040,9 @@ const Model = Ember.Object.extend(Ember.Evented, {
   },
 
   notifyBelongsToChanged(key) {
+    Ember.beginPropertyChanges();
     this.notifyPropertyChange(key);
+    Ember.endPropertyChanges();
   },
   /**
    Given a callback, iterates over each of the relationships in the model,
@@ -1112,7 +1114,9 @@ const Model = Ember.Object.extend(Ember.Evented, {
     //TODO(Igor): Consider whether we could do this only if the record state is unloaded
 
     //Goes away once hasMany is double promisified
+    Ember.beginPropertyChanges();
     this.notifyPropertyChange(key);
+    Ember.endPropertyChanges();
   },
 
   eachAttribute(callback, binding) {

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -370,7 +370,9 @@ Store = Service.extend({
 
     // TODO @runspired this should also be coalesced into some form of internalModel.setState()
     internalModel.eachRelationship((key, descriptor) => {
-      internalModel._relationships.get(key).setHasData(true);
+      if (properties[key] !== undefined) {
+        internalModel._relationships.get(key).setHasData(true);
+      }
     });
 
     return record;

--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -54,7 +54,7 @@ const { camelize } = Ember.String;
   @namespace DS
   @extends DS.JSONSerializer
 */
-let RESTSerializer = JSONSerializer.extend({
+const RESTSerializer = JSONSerializer.extend({
 
   /**
    `keyForPolymorphicType` can be used to define a custom key when

--- a/tests/helpers/store.js
+++ b/tests/helpers/store.js
@@ -56,9 +56,13 @@ export default function setupStore(options) {
   registry.register('adapter:-rest', DS.RESTAdapter);
   registry.register('adapter:-json-api', DS.JSONAPIAdapter);
 
-  env.restSerializer = container.lookup('serializer:-rest');
+  registry.injection('serializer', 'store', 'service:store');
+
   env.store = container.lookup('service:store');
+  env.restSerializer = container.lookup('serializer:-rest');
+  env.restSerializer.store = env.store;
   env.serializer = env.store.serializerFor('-default');
+  env.serializer.store = env.store;
   env.adapter = env.store.get('defaultAdapter');
 
   return env;

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -955,26 +955,49 @@ test("belongsTo hasData sync not loaded", function(assert) {
   });
 });
 
-test("belongsTo hasData async created", function(assert) {
-  assert.expect(1);
+test("belongsTo hasData NOT created", function(assert) {
+  assert.expect(2);
 
   Book.reopen({
     author: belongsTo('author', { async: true })
   });
 
   run(() => {
+    let author = store.createRecord('author');
     let book = store.createRecord('book', { name: 'The Greatest Book' });
     let relationship = book._internalModel._relationships.get('author');
+
+    assert.equal(relationship.hasData, false, 'relationship does not have data');
+
+    book = store.createRecord('book', {
+      name: 'The Greatest Book',
+      author
+    });
+
+    relationship = book._internalModel._relationships.get('author');
+
     assert.equal(relationship.hasData, true, 'relationship has data');
   });
 });
 
 test("belongsTo hasData sync created", function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   run(() => {
-    let book = store.createRecord('book', { name: 'The Greatest Book' });
+    let author = store.createRecord('author');
+    let book = store.createRecord('book', {
+      name: 'The Greatest Book'
+    });
+
     let relationship = book._internalModel._relationships.get('author');
+    assert.equal(relationship.hasData, false, 'relationship does not have data');
+
+    book = store.createRecord('book', {
+      name: 'The Greatest Book',
+      author
+    });
+
+    relationship = book._internalModel._relationships.get('author');
     assert.equal(relationship.hasData, true, 'relationship has data');
   });
 });

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -2642,7 +2642,7 @@ test("hasMany hasData sync not loaded", function(assert) {
 });
 
 test("hasMany hasData async created", function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   Chapter.reopen({
     pages: hasMany('pages', { async: true })
@@ -2650,17 +2650,36 @@ test("hasMany hasData async created", function(assert) {
 
   run(() => {
     let chapter = store.createRecord('chapter', { title: 'The Story Begins' });
+    let page = store.createRecord('page');
+
     let relationship = chapter._internalModel._relationships.get('pages');
+    assert.equal(relationship.hasData, false, 'relationship does not have data');
+
+    chapter = store.createRecord('chapter', {
+      title: 'The Story Begins',
+      pages: [page]
+    });
+
+    relationship = chapter._internalModel._relationships.get('pages');
     assert.equal(relationship.hasData, true, 'relationship has data');
   });
 });
 
 test("hasMany hasData sync created", function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   run(() => {
     let chapter = store.createRecord('chapter', { title: 'The Story Begins' });
     let relationship = chapter._internalModel._relationships.get('pages');
+
+    assert.equal(relationship.hasData, false, 'relationship does not have data');
+
+    chapter = store.createRecord('chapter', {
+      title: 'The Story Begins',
+      pages: [store.createRecord('page')]
+    });
+    relationship = chapter._internalModel._relationships.get('pages');
+
     assert.equal(relationship.hasData, true, 'relationship has data');
   });
 });

--- a/tests/integration/relationships/inverse-relationships-test.js
+++ b/tests/integration/relationships/inverse-relationships-test.js
@@ -600,16 +600,17 @@ test("inverseFor short-circuits when inverse is null", function(assert) {
   });
 });
 
-testInDebug("Inverse null relationships with models that don't exist throw a nice error", function(assert) {
+testInDebug("Inverse null relationships with models that don't exist throw a nice error if trying to use that relationship", function(assert) {
   User = DS.Model.extend({
     post: DS.belongsTo('post', { inverse: null })
   });
 
-  var env = setupStore({ user: User });
+  let env = setupStore({ user: User });
 
-  assert.throws(function() {
-    run(function() {
-      env.store.createRecord('user');
-    });
+  assert.throws(() => {
+    run(() => env.store.createRecord('user', { post: {}}));
   }, /No model was found for 'post'/);
+
+  // but don't error if the relationship is not used
+  run(() => env.store.createRecord('user', {}));
 });

--- a/tests/integration/serializers/json-serializer-test.js
+++ b/tests/integration/serializers/json-serializer-test.js
@@ -40,12 +40,10 @@ module("integration/serializer/json - JSONSerializer", {
 });
 
 test("serialize doesn't include ID when includeId is false", function(assert) {
-  run(function() {
-    post = env.store.createRecord('post', { title: 'Rails is omakase' });
+  run(() => {
+    post = env.store.createRecord('post', { title: 'Rails is omakase', comments: [] });
   });
-  var json = {};
-
-  json = serializer.serialize(post._createSnapshot(), { includeId: false });
+  let json = serializer.serialize(post._createSnapshot(), { includeId: false });
 
   assert.deepEqual(json, {
     title: "Rails is omakase",
@@ -53,14 +51,26 @@ test("serialize doesn't include ID when includeId is false", function(assert) {
   });
 });
 
-test("serialize includes id when includeId is true", function(assert) {
-  run(function() {
+
+test("serialize doesn't include relationship if not aware of one", function(assert) {
+  run(() => {
     post = env.store.createRecord('post', { title: 'Rails is omakase' });
+  });
+
+  let json = serializer.serialize(post._createSnapshot());
+
+  assert.deepEqual(json, {
+    title: "Rails is omakase"
+  });
+});
+
+test("serialize includes id when includeId is true", function(assert) {
+  run(() => {
+    post = env.store.createRecord('post', { title: 'Rails is omakase', comments: [] });
     post.set('id', 'test');
   });
-  var json = {};
 
-  json = serializer.serialize(post._createSnapshot(), { includeId: true });
+  let json = serializer.serialize(post._createSnapshot(), { includeId: true });
 
   assert.deepEqual(json, {
     id: 'test',
@@ -71,12 +81,12 @@ test("serialize includes id when includeId is true", function(assert) {
 
 if (isEnabled("ds-serialize-id")) {
   test("serializeId", function(assert) {
-    run(function() {
+    run(() => {
       post = env.store.createRecord('post');
       post.set('id', 'test');
     });
-    var json = {};
 
+    let json = {};
     serializer.serializeId(post._createSnapshot(), json, 'id');
 
     assert.deepEqual(json, {
@@ -102,8 +112,7 @@ if (isEnabled("ds-serialize-id")) {
 
     assert.deepEqual(json, {
       id: 'TEST',
-      title: 'Rails is omakase',
-      comments: []
+      title: 'Rails is omakase'
     });
   });
 
@@ -122,8 +131,7 @@ if (isEnabled("ds-serialize-id")) {
 
     assert.deepEqual(json, {
       _ID_: 'test',
-      title: 'Rails is omakase',
-      comments: []
+      title: 'Rails is omakase'
     });
   });
 
@@ -289,12 +297,11 @@ if (isEnabled("ds-check-should-serialize-relationships")) {
 }
 
 test("serializeIntoHash", function(assert) {
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
+  run(() => {
+    post = env.store.createRecord('post', { title: "Rails is omakase", comments: [] });
   });
 
-  var json = {};
-
+  let json = {};
   serializer.serializeIntoHash(json, Post, post._createSnapshot());
 
   assert.deepEqual(json, {
@@ -308,8 +315,8 @@ test("serializePolymorphicType sync", function(assert) {
 
   env.registry.register('serializer:comment', DS.JSONSerializer.extend({
     serializePolymorphicType(record, json, relationship) {
-      var key = relationship.key;
-      var belongsTo = record.belongsTo(key);
+      let key = relationship.key;
+      let belongsTo = record.belongsTo(key);
       json[relationship.key + "TYPE"] = belongsTo.modelName;
 
       assert.ok(true, 'serializePolymorphicType is called when serialize a polymorphic belongsTo');

--- a/tests/integration/serializers/rest-serializer-test.js
+++ b/tests/integration/serializers/rest-serializer-test.js
@@ -659,7 +659,9 @@ test('serializeIntoHash uses payloadKeyFromModelName to normalize the payload ro
     }
   }));
 
-  env.container.lookup('serializer:home-planet').serializeIntoHash(json, HomePlanet, league._createSnapshot());
+  let serializer = env.store.serializerFor('home-planet');
+
+  serializer.serializeIntoHash(json, HomePlanet, league._createSnapshot());
 
   assert.deepEqual(json, {
     'home-planet': {


### PR DESCRIPTION
for async relationships referenced in templates

- works with json api adapter (w/ links)
- works w/ django rest adapter
- works active-model-adapter

fixes #4942

cc @stefanpenner @runspired (i believe u 2 have the most context on this)