### PR TITLE
[BUGFIX release] createRecord should only setup relationships it has …

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -370,7 +370,9 @@ Store = Service.extend({
 
     // TODO @runspired this should also be coalesced into some form of internalModel.setState()
     internalModel.eachRelationship((key, descriptor) => {
-      internalModel._relationships.get(key).setHasData(true);
+      if (properties[key] !== undefined) {
+        internalModel._relationships.get(key).setHasData(true);
+      }
     });
 
     return record;

--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -54,7 +54,7 @@ const { camelize } = Ember.String;
   @namespace DS
   @extends DS.JSONSerializer
 */
-let RESTSerializer = JSONSerializer.extend({
+const RESTSerializer = JSONSerializer.extend({
 
   /**
    `keyForPolymorphicType` can be used to define a custom key when

--- a/tests/helpers/store.js
+++ b/tests/helpers/store.js
@@ -56,9 +56,13 @@ export default function setupStore(options) {
   registry.register('adapter:-rest', DS.RESTAdapter);
   registry.register('adapter:-json-api', DS.JSONAPIAdapter);
 
-  env.restSerializer = container.lookup('serializer:-rest');
+  registry.injection('serializer', 'store', 'service:store');
+
   env.store = container.lookup('service:store');
+  env.restSerializer = container.lookup('serializer:-rest');
+  env.restSerializer.store = env.store;
   env.serializer = env.store.serializerFor('-default');
+  env.serializer.store = env.store;
   env.adapter = env.store.get('defaultAdapter');
 
   return env;

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -955,26 +955,49 @@ test("belongsTo hasData sync not loaded", function(assert) {
   });
 });
 
-test("belongsTo hasData async created", function(assert) {
-  assert.expect(1);
+test("belongsTo hasData NOT created", function(assert) {
+  assert.expect(2);
 
   Book.reopen({
     author: belongsTo('author', { async: true })
   });
 
   run(() => {
+    let author = store.createRecord('author');
     let book = store.createRecord('book', { name: 'The Greatest Book' });
     let relationship = book._internalModel._relationships.get('author');
+
+    assert.equal(relationship.hasData, false, 'relationship does not have data');
+
+    book = store.createRecord('book', {
+      name: 'The Greatest Book',
+      author
+    });
+
+    relationship = book._internalModel._relationships.get('author');
+
     assert.equal(relationship.hasData, true, 'relationship has data');
   });
 });
 
 test("belongsTo hasData sync created", function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   run(() => {
-    let book = store.createRecord('book', { name: 'The Greatest Book' });
+    let author = store.createRecord('author');
+    let book = store.createRecord('book', {
+      name: 'The Greatest Book'
+    });
+
     let relationship = book._internalModel._relationships.get('author');
+    assert.equal(relationship.hasData, false, 'relationship does not have data');
+
+    book = store.createRecord('book', {
+      name: 'The Greatest Book',
+      author
+    });
+
+    relationship = book._internalModel._relationships.get('author');
     assert.equal(relationship.hasData, true, 'relationship has data');
   });
 });

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -2560,7 +2560,7 @@ test("hasMany hasData sync not loaded", function(assert) {
 });
 
 test("hasMany hasData async created", function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   Chapter.reopen({
     pages: hasMany('pages', { async: true })
@@ -2568,17 +2568,36 @@ test("hasMany hasData async created", function(assert) {
 
   run(() => {
     let chapter = store.createRecord('chapter', { title: 'The Story Begins' });
+    let page = store.createRecord('page');
+
     let relationship = chapter._internalModel._relationships.get('pages');
+    assert.equal(relationship.hasData, false, 'relationship does not have data');
+
+    chapter = store.createRecord('chapter', {
+      title: 'The Story Begins',
+      pages: [page]
+    });
+
+    relationship = chapter._internalModel._relationships.get('pages');
     assert.equal(relationship.hasData, true, 'relationship has data');
   });
 });
 
 test("hasMany hasData sync created", function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   run(() => {
     let chapter = store.createRecord('chapter', { title: 'The Story Begins' });
     let relationship = chapter._internalModel._relationships.get('pages');
+
+    assert.equal(relationship.hasData, false, 'relationship does not have data');
+
+    chapter = store.createRecord('chapter', {
+      title: 'The Story Begins',
+      pages: [store.createRecord('page')]
+    });
+    relationship = chapter._internalModel._relationships.get('pages');
+
     assert.equal(relationship.hasData, true, 'relationship has data');
   });
 });

--- a/tests/integration/relationships/inverse-relationships-test.js
+++ b/tests/integration/relationships/inverse-relationships-test.js
@@ -600,16 +600,17 @@ test("inverseFor short-circuits when inverse is null", function(assert) {
   });
 });
 
-testInDebug("Inverse null relationships with models that don't exist throw a nice error", function(assert) {
+testInDebug("Inverse null relationships with models that don't exist throw a nice error if trying to use that relationship", function(assert) {
   User = DS.Model.extend({
     post: DS.belongsTo('post', { inverse: null })
   });
 
-  var env = setupStore({ user: User });
+  let env = setupStore({ user: User });
 
-  assert.throws(function() {
-    run(function() {
-      env.store.createRecord('user');
-    });
+  assert.throws(() => {
+    run(() => env.store.createRecord('user', { post: {}}));
   }, /No model was found for 'post'/);
+
+  // but don't error if the relationship is not used
+  run(() => env.store.createRecord('user', {}));
 });

--- a/tests/integration/serializers/json-serializer-test.js
+++ b/tests/integration/serializers/json-serializer-test.js
@@ -40,12 +40,10 @@ module("integration/serializer/json - JSONSerializer", {
 });
 
 test("serialize doesn't include ID when includeId is false", function(assert) {
-  run(function() {
-    post = env.store.createRecord('post', { title: 'Rails is omakase' });
+  run(() => {
+    post = env.store.createRecord('post', { title: 'Rails is omakase', comments: [] });
   });
-  var json = {};
-
-  json = serializer.serialize(post._createSnapshot(), { includeId: false });
+  let json = serializer.serialize(post._createSnapshot(), { includeId: false });
 
   assert.deepEqual(json, {
     title: "Rails is omakase",
@@ -53,14 +51,26 @@ test("serialize doesn't include ID when includeId is false", function(assert) {
   });
 });
 
-test("serialize includes id when includeId is true", function(assert) {
-  run(function() {
+
+test("serialize doesn't include relationship if not aware of one", function(assert) {
+  run(() => {
     post = env.store.createRecord('post', { title: 'Rails is omakase' });
+  });
+
+  let json = serializer.serialize(post._createSnapshot());
+
+  assert.deepEqual(json, {
+    title: "Rails is omakase"
+  });
+});
+
+test("serialize includes id when includeId is true", function(assert) {
+  run(() => {
+    post = env.store.createRecord('post', { title: 'Rails is omakase', comments: [] });
     post.set('id', 'test');
   });
-  var json = {};
 
-  json = serializer.serialize(post._createSnapshot(), { includeId: true });
+  let json = serializer.serialize(post._createSnapshot(), { includeId: true });
 
   assert.deepEqual(json, {
     id: 'test',
@@ -71,12 +81,12 @@ test("serialize includes id when includeId is true", function(assert) {
 
 if (isEnabled("ds-serialize-id")) {
   test("serializeId", function(assert) {
-    run(function() {
+    run(() => {
       post = env.store.createRecord('post');
       post.set('id', 'test');
     });
-    var json = {};
 
+    let json = {};
     serializer.serializeId(post._createSnapshot(), json, 'id');
 
     assert.deepEqual(json, {
@@ -102,8 +112,7 @@ if (isEnabled("ds-serialize-id")) {
 
     assert.deepEqual(json, {
       id: 'TEST',
-      title: 'Rails is omakase',
-      comments: []
+      title: 'Rails is omakase'
     });
   });
 
@@ -122,8 +131,7 @@ if (isEnabled("ds-serialize-id")) {
 
     assert.deepEqual(json, {
       _ID_: 'test',
-      title: 'Rails is omakase',
-      comments: []
+      title: 'Rails is omakase'
     });
   });
 
@@ -289,12 +297,11 @@ if (isEnabled("ds-check-should-serialize-relationships")) {
 }
 
 test("serializeIntoHash", function(assert) {
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
+  run(() => {
+    post = env.store.createRecord('post', { title: "Rails is omakase", comments: [] });
   });
 
-  var json = {};
-
+  let json = {};
   serializer.serializeIntoHash(json, Post, post._createSnapshot());
 
   assert.deepEqual(json, {
@@ -308,8 +315,8 @@ test("serializePolymorphicType sync", function(assert) {
 
   env.registry.register('serializer:comment', DS.JSONSerializer.extend({
     serializePolymorphicType(record, json, relationship) {
-      var key = relationship.key;
-      var belongsTo = record.belongsTo(key);
+      let key = relationship.key;
+      let belongsTo = record.belongsTo(key);
       json[relationship.key + "TYPE"] = belongsTo.modelName;
 
       assert.ok(true, 'serializePolymorphicType is called when serialize a polymorphic belongsTo');

--- a/tests/integration/serializers/rest-serializer-test.js
+++ b/tests/integration/serializers/rest-serializer-test.js
@@ -659,7 +659,9 @@ test('serializeIntoHash uses payloadKeyFromModelName to normalize the payload ro
     }
   }));
 
-  env.container.lookup('serializer:home-planet').serializeIntoHash(json, HomePlanet, league._createSnapshot());
+  let serializer = env.store.serializerFor('home-planet');
+
+  serializer.serializeIntoHash(json, HomePlanet, league._createSnapshot());
 
   assert.deepEqual(json, {
     'home-planet': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,17 +4,17 @@
 
 "@glimmer/di@^0.2.0":
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
+  resolved "https://registry.npmjs.org/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
 
-"@glimmer/resolver@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.3.1.tgz#41069345b6f41beb0948cc35d8e4aa60adcadfc5"
+"@glimmer/resolver@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/@glimmer/resolver/-/resolver-0.4.0.tgz#7fe8709342064f144c14c06088d6dc4070ad7d1d"
   dependencies:
     "@glimmer/di" "^0.2.0"
 
 "@types/node@*", "@types/node@^7.0.5":
-  version "7.0.32"
-  resolved "https://registry.npmjs.org/@types/node/-/node-7.0.32.tgz#6afe6c66520a4c316623a14aef123908d01b4bba"
+  version "7.0.33"
+  resolved "https://registry.npmjs.org/@types/node/-/node-7.0.33.tgz#ae3c53ad01d7e9d62c7f1a85c5f7500d59b9d25b"
 
 "@types/rimraf@^0.0.28":
   version "0.0.28"
@@ -128,6 +128,10 @@ ansi-regex@^0.2.0, ansi-regex@^0.2.1:
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
 ansi-styles@^1.1.0:
   version "1.1.0"
@@ -255,9 +259,21 @@ async-disk-cache@^1.2.1:
     rsvp "^3.0.18"
     username-sync "1.0.1"
 
+async-promise-queue@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.3.tgz#70c9c37635620f894978814b6c65e6e14e2573ee"
+  dependencies:
+    async "^2.4.1"
+
 async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.npmjs.org/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+
+async@^2.4.1:
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
+  dependencies:
+    lodash "^4.14.0"
 
 async@~0.2.9:
   version "0.2.10"
@@ -268,10 +284,10 @@ async@~0.9.0:
   resolved "https://registry.npmjs.org/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
 aws-sdk@^2.0.9:
-  version "2.75.0"
-  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.75.0.tgz#f78802e46f95b7044a094da259057dd8d5d8da17"
+  version "2.80.0"
+  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.80.0.tgz#61ced747eb981609483aec53e8d654d3cc9d1435"
   dependencies:
-    buffer "5.0.6"
+    buffer "4.9.1"
     crypto-browserify "1.0.9"
     jmespath "0.15.0"
     querystring "0.2.0"
@@ -502,7 +518,7 @@ babel-plugin-dead-code-elimination@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz#5f7c451274dcd7cccdbfbb3e0b85dd28121f0f65"
 
-babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.7:
+babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.7:
   version "0.1.10"
   resolved "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.10.tgz#dd077ad6e1cc0a8f9bbc6405c561392ebfc9a01c"
   dependencies:
@@ -1048,28 +1064,34 @@ broccoli-asset-rewrite@^1.1.0:
     broccoli-filter "^1.2.3"
 
 broccoli-babel-transpiler@^5.5.0, broccoli-babel-transpiler@^5.6.2:
-  version "5.6.2"
-  resolved "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.6.2.tgz#958c72e43575b2f0a862a5096dba1ce1ebc7d74d"
+  version "5.7.1"
+  resolved "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.1.tgz#e10d831faed1c57e37272e4223748ba71a7926d1"
   dependencies:
     babel-core "^5.0.0"
     broccoli-funnel "^1.0.0"
     broccoli-merge-trees "^1.0.0"
-    broccoli-persistent-filter "^1.0.1"
+    broccoli-persistent-filter "^1.4.2"
     clone "^0.2.0"
     hash-for-dep "^1.0.2"
+    heimdalljs-logger "^0.1.7"
     json-stable-stringify "^1.0.0"
+    rsvp "^3.5.0"
+    workerpool "^2.2.1"
 
 broccoli-babel-transpiler@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.0.0.tgz#a52c5404bf36236849da503b011fd41fe64a00a2"
+  version "6.1.1"
+  resolved "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.1.tgz#938f470e1ddb47047a77ef5e38f34c21de0e85a8"
   dependencies:
     babel-core "^6.14.0"
     broccoli-funnel "^1.0.0"
     broccoli-merge-trees "^1.0.0"
-    broccoli-persistent-filter "^1.0.1"
+    broccoli-persistent-filter "^1.4.0"
     clone "^2.0.0"
     hash-for-dep "^1.0.2"
+    heimdalljs-logger "^0.1.7"
     json-stable-stringify "^1.0.0"
+    rsvp "^3.5.0"
+    workerpool "^2.2.1"
 
 broccoli-brocfile-loader@^0.18.0:
   version "0.18.0"
@@ -1078,8 +1100,8 @@ broccoli-brocfile-loader@^0.18.0:
     findup-sync "^0.4.2"
 
 broccoli-builder@^0.18.3:
-  version "0.18.5"
-  resolved "https://registry.npmjs.org/broccoli-builder/-/broccoli-builder-0.18.5.tgz#fb09687d99b869942e4405a2e4f4499272cfc5f2"
+  version "0.18.8"
+  resolved "https://registry.npmjs.org/broccoli-builder/-/broccoli-builder-0.18.8.tgz#fe54694d544c3cdfdb01028e802eeca65749a879"
   dependencies:
     heimdalljs "^0.2.0"
     promise-map-series "^0.2.1"
@@ -1087,19 +1109,6 @@ broccoli-builder@^0.18.3:
     rimraf "^2.2.8"
     rsvp "^3.0.17"
     silent-error "^1.0.1"
-
-broccoli-caching-writer@^2.0.4, broccoli-caching-writer@~2.0.1:
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.0.4.tgz#d995d7d1977292e498f78df05887230fcb4a5e2c"
-  dependencies:
-    broccoli-kitchen-sink-helpers "^0.2.5"
-    broccoli-plugin "1.1.0"
-    debug "^2.1.1"
-    lodash-node "^3.2.0"
-    rimraf "^2.2.8"
-    rsvp "^3.0.17"
-    symlink-or-copy "^1.0.0"
-    walk-sync "^0.2.0"
 
 broccoli-caching-writer@^2.2.0, broccoli-caching-writer@^2.3.1:
   version "2.3.1"
@@ -1111,6 +1120,30 @@ broccoli-caching-writer@^2.2.0, broccoli-caching-writer@^2.3.1:
     rimraf "^2.2.8"
     rsvp "^3.0.17"
     walk-sync "^0.2.5"
+
+broccoli-caching-writer@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-3.0.3.tgz#0bd2c96a9738d6a6ab590f07ba35c5157d7db476"
+  dependencies:
+    broccoli-kitchen-sink-helpers "^0.3.1"
+    broccoli-plugin "^1.2.1"
+    debug "^2.1.1"
+    rimraf "^2.2.8"
+    rsvp "^3.0.17"
+    walk-sync "^0.3.0"
+
+broccoli-caching-writer@~2.0.1:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.0.4.tgz#d995d7d1977292e498f78df05887230fcb4a5e2c"
+  dependencies:
+    broccoli-kitchen-sink-helpers "^0.2.5"
+    broccoli-plugin "1.1.0"
+    debug "^2.1.1"
+    lodash-node "^3.2.0"
+    rimraf "^2.2.8"
+    rsvp "^3.0.17"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.2.0"
 
 broccoli-clean-css@^1.1.0:
   version "1.1.0"
@@ -1152,10 +1185,10 @@ broccoli-concat@^3.2.2:
     walk-sync "^0.3.1"
 
 broccoli-config-loader@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/broccoli-config-loader/-/broccoli-config-loader-1.0.0.tgz#c3cf5ecfaffc04338c6f1d5d38dc36baeaa131ba"
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/broccoli-config-loader/-/broccoli-config-loader-1.0.1.tgz#d10aaf8ebc0cb45c1da5baa82720e1d88d28c80a"
   dependencies:
-    broccoli-caching-writer "^2.0.4"
+    broccoli-caching-writer "^3.0.3"
 
 broccoli-config-replace@^1.1.2:
   version "1.1.2"
@@ -1280,23 +1313,24 @@ broccoli-merge-trees@~0.2.3:
     symlink-or-copy "^1.0.0"
 
 broccoli-middleware@^1.0.0-beta.8:
-  version "1.0.0-beta.11"
-  resolved "https://registry.npmjs.org/broccoli-middleware/-/broccoli-middleware-1.0.0-beta.11.tgz#5f633276c7905d2debf6fb78b18291f560fd4ba1"
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/broccoli-middleware/-/broccoli-middleware-1.0.0.tgz#92f4e1fb9a791ea986245a7077f35cc648dab097"
   dependencies:
     handlebars "^4.0.4"
     mime "^1.2.11"
 
-broccoli-persistent-filter@^1.0.1, broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.3.1.tgz#d02556a135c77dfb859bba7844bc3539be7168e1"
+broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.2.0, broccoli-persistent-filter@^1.4.0, broccoli-persistent-filter@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.2.tgz#17af1278a25ff2556f9d7d23e115accfad3a7ce7"
   dependencies:
     async-disk-cache "^1.2.1"
+    async-promise-queue "^1.0.3"
     broccoli-plugin "^1.0.0"
+    crypto "0.0.3"
     fs-tree-diff "^0.5.2"
     hash-for-dep "^1.0.2"
     heimdalljs "^0.2.1"
     heimdalljs-logger "^0.1.7"
-    md5-hex "^1.0.2"
     mkdirp "^0.5.1"
     promise-map-series "^0.2.1"
     rimraf "^2.6.1"
@@ -1428,12 +1462,13 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer@5.0.6:
-  version "5.0.6"
-  resolved "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz#2ea669f7eec0b6eda05b08f8b5ff661b28573588"
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -1490,8 +1525,8 @@ can-symlink@^1.0.0:
     tmp "0.0.28"
 
 caniuse-lite@^1.0.30000684:
-  version "1.0.30000693"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000693.tgz#c9c6298697c71fdf6cb13eefe8aa93926f2f8613"
+  version "1.0.30000696"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000696.tgz#30f2695d2a01a0dfd779a26ab83f4d134b3da5cc"
 
 capture-exit@^1.1.0:
   version "1.2.0"
@@ -1696,10 +1731,8 @@ commander@2.8.x:
     graceful-readlink ">= 1.0.0"
 
 commander@^2.5.0, commander@^2.6.0:
-  version "2.9.0"
-  resolved "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
+  version "2.11.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 commander@~2.1.0:
   version "2.1.0"
@@ -1848,7 +1881,7 @@ core-object@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/core-object/-/core-object-1.1.0.tgz#86d63918733cf9da1a5aae729e62c0a88e66ad0a"
 
-core-object@^3.0.0:
+core-object@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/core-object/-/core-object-3.1.3.tgz#df399b3311bdb0c909e8aae8929fc3c1c4b25880"
   dependencies:
@@ -1880,6 +1913,10 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
+crypto@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz#470a81b86be4c5ee17acc8207a1f5315ae20dbb0"
+
 ctype@0.5.3:
   version "0.5.3"
   resolved "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz#82c18c2461f74114ef16c135224ad0b9144ca12f"
@@ -1889,6 +1926,10 @@ d@1:
   resolved "https://registry.npmjs.org/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
   dependencies:
     es5-ext "^0.10.9"
+
+dag-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
 
 debug@2, debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@~2.6.7:
   version "2.6.8"
@@ -2038,8 +2079,8 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.3.14:
-  version "1.3.14"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz#64af0f9efd3c3c6acd57d71f83b49ca7ee9c4b43"
+  version "1.3.15"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.15.tgz#08397934891cbcfaebbd18b82a95b5a481138369"
 
 ember-ajax@^2.4.1:
   version "2.5.6"
@@ -2065,9 +2106,9 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.5, ember-c
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.4.1:
-  version "6.4.1"
-  resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.4.1.tgz#785a1c24fe3250eb0776b1ab3cee857863b44542"
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.1:
+  version "6.5.1"
+  resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.5.1.tgz#37eaab592523938f8d52fc9d30bd0f56fc1c6599"
   dependencies:
     amd-name-resolver "0.0.6"
     babel-plugin-debug-macros "^0.1.10"
@@ -2314,7 +2355,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0:
+ember-cli-version-checker@1.3.1, ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
@@ -2328,8 +2369,8 @@ ember-cli-version-checker@^2.0.0:
     semver "^5.3.0"
 
 ember-cli@^2.11.1:
-  version "2.13.2"
-  resolved "https://registry.npmjs.org/ember-cli/-/ember-cli-2.13.2.tgz#a561f08e69b184fa3175f706cced299c0d1684e5"
+  version "2.13.3"
+  resolved "https://registry.npmjs.org/ember-cli/-/ember-cli-2.13.3.tgz#1918500e6280a68be017aca9b69937f6782a24b8"
   dependencies:
     amd-name-resolver "0.0.6"
     babel-plugin-transform-es2015-modules-amd "^6.24.0"
@@ -2354,7 +2395,8 @@ ember-cli@^2.11.1:
     compression "^1.4.4"
     configstore "^3.0.0"
     console-ui "^1.0.2"
-    core-object "^3.0.0"
+    core-object "^3.1.3"
+    dag-map "^2.0.2"
     diff "^3.2.0"
     ember-cli-broccoli-sane-watcher "^2.0.4"
     ember-cli-get-component-path-option "^1.0.0"
@@ -2364,7 +2406,7 @@ ember-cli@^2.11.1:
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-preprocess-registry "^3.1.0"
     ember-cli-string-utils "^1.0.0"
-    ember-try "^0.2.14"
+    ember-try "^0.2.15"
     ensure-posix-path "^1.0.2"
     escape-string-regexp "^1.0.3"
     execa "^0.6.0"
@@ -2464,17 +2506,17 @@ ember-qunit@^0.4.18:
   dependencies:
     ember-test-helpers "^0.5.32"
 
-ember-resolver@^4.1.3:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ember-resolver/-/ember-resolver-4.1.0.tgz#f02aeb2f1f2e944ed47e085412a7b84f759d11df"
+ember-resolver@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/ember-resolver/-/ember-resolver-4.2.1.tgz#d8aa7de8444ec9b688aa97a5ddbb58c3b949194b"
   dependencies:
-    "@glimmer/resolver" "^0.3.0"
-    babel-plugin-debug-macros "^0.1.1"
+    "@glimmer/resolver" "0.4.0"
+    babel-plugin-debug-macros "^0.1.10"
     broccoli-funnel "^1.1.0"
     broccoli-merge-trees "^2.0.0"
-    ember-cli-babel "^6.0.0-beta.7"
-    ember-cli-version-checker "^1.1.6"
-    resolve "^1.3.2"
+    ember-cli-babel "^6.3.0"
+    ember-cli-version-checker "1.3.1"
+    resolve "^1.3.3"
 
 ember-router-generator@^1.0.0:
   version "1.2.3"
@@ -2522,7 +2564,7 @@ ember-try-config@^2.0.1:
     rsvp "^3.2.1"
     semver "^5.1.0"
 
-ember-try@^0.2.14:
+ember-try@^0.2.15:
   version "0.2.15"
   resolved "https://registry.npmjs.org/ember-try/-/ember-try-0.2.15.tgz#559c756058717595babe70068e541625bd5e210a"
   dependencies:
@@ -3476,8 +3518,8 @@ homedir-polyfill@^1.0.0:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.1.5:
-  version "2.4.2"
-  resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
 http-errors@~1.6.1:
   version "1.6.1"
@@ -3814,8 +3856,8 @@ js-tokens@1.0.1:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz#cc435a5c8b94ad15acb7983140fc80182c89aeae"
 
 js-tokens@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
   version "3.8.4"
@@ -3965,7 +4007,7 @@ load-json-file@^1.0.0:
 
 loader.js@^4.5.0:
   version "4.5.1"
-  resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.5.1.tgz#c15ab15a6b8376bd4fbf7ea56f8d76cc557331da"
+  resolved "https://registry.npmjs.org/loader.js/-/loader.js-4.5.1.tgz#c15ab15a6b8376bd4fbf7ea56f8d76cc557331da"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -4160,7 +4202,7 @@ lodash@^3.10.0, lodash@^3.10.1, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.16.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4237,7 +4279,7 @@ matcher-collection@^1.0.0, matcher-collection@^1.0.1:
   dependencies:
     minimatch "^3.0.2"
 
-md5-hex@^1.0.2, md5-hex@^1.2.1, md5-hex@^1.3.0:
+md5-hex@^1.2.1, md5-hex@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4"
   dependencies:
@@ -4486,8 +4528,8 @@ nopt@^3.0.3, nopt@^3.0.6:
     abbrev "1"
 
 normalize-package-data@^2.3.2:
-  version "2.3.8"
-  resolved "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz#d819eda2a9dedbd1ffa563ea4071d936782295bb"
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
     hosted-git-info "^2.1.4"
     is-builtin-module "^1.0.0"
@@ -4518,8 +4560,8 @@ npm-run-path@^2.0.0:
     path-key "^2.0.0"
 
 npmlog@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   dependencies:
     are-we-there-yet "~1.1.2"
     console-control-strings "~1.1.0"
@@ -4538,7 +4580,7 @@ object-assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -4911,15 +4953,15 @@ read-pkg@^1.0.0:
     path-type "^1.0.0"
 
 readable-stream@^2, readable-stream@^2.0.6, readable-stream@^2.2.2:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz#5a04df05e4f57fe3f0dc68fdd11dc5c97c7e6f4d"
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.0"
-    string_decoder "~1.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
 readable-stream@~1.0.2:
@@ -5107,7 +5149,7 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.0, resolve@^1.3.2, resolve@^1.3.3:
+resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.0, resolve@^1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
@@ -5126,13 +5168,13 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2.5.2, rimraf@^2.4.3, rimraf@^2.4.4:
+rimraf@2.5.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4:
   version "2.5.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz#62ba947fa4c0b4363839aefecd4f0fbad6059726"
   dependencies:
     glob "^7.0.0"
 
-rimraf@^2.1.4, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.1, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@^2.1.4, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.4.1, rimraf@^2.5.1, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
@@ -5156,17 +5198,9 @@ route-recognizer@^0.2.3:
   version "0.2.10"
   resolved "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.2.10.tgz#024b2283c2e68d13a7c7f5173a5924645e8902df"
 
-rsvp@3.6.0:
+rsvp@3.6.0, rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.4.0, rsvp@^3.5.0:
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.0.tgz#666dfffa715f7e10eef76f4d1e56fb2566fce5c3"
-
-rsvp@^3.0.14, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.4.0:
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/rsvp/-/rsvp-3.5.0.tgz#a62c573a4ae4e1dfd0697ebc6242e79c681eaa34"
-
-rsvp@^3.0.16, rsvp@^3.0.6, rsvp@~3.2.1:
-  version "3.2.1"
-  resolved "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"
+  resolved "https://registry.npmjs.org/rsvp/-/rsvp-3.6.0.tgz#666dfffa715f7e10eef76f4d1e56fb2566fce5c3"
 
 rsvp@~3.0.6:
   version "3.0.21"
@@ -5175,6 +5209,10 @@ rsvp@~3.0.6:
 rsvp@~3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/rsvp/-/rsvp-3.1.0.tgz#19d96e71315f3ddbc57c4c62a6db898adb64d791"
+
+rsvp@~3.2.1:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"
 
 run-async@^0.1.0:
   version "0.1.0"
@@ -5196,7 +5234,7 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
-safe-buffer@~5.1.0:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -5486,17 +5524,17 @@ string-width@^1.0.1, string-width@^1.0.2:
     strip-ansi "^3.0.0"
 
 string-width@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz#030664561fc146c9423ec7d978fe2457437fe6d0"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^3.0.0"
+    strip-ansi "^4.0.0"
 
 string_decoder@0.10, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-string_decoder@~1.0.0:
+string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
@@ -5525,6 +5563,12 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -5931,6 +5975,12 @@ wordwrap@~0.0.2:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
+workerpool@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/workerpool/-/workerpool-2.2.1.tgz#41ebff11d5859da948fdb2c850b57da69240988a"
+  dependencies:
+    object-assign "^4.1.1"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
…data for

relationships should in theory now only be accessed if they are used (`set` or `get`). This should mitigate the large number of test failures see during upgrade due to to https://github.com/emberjs/data/blob/e6cb564bdb33da4b3c15c3c668dc4b1fdafdf190/addon/-private/system/relationships/state/create.js#L20

If this doesn't actually fix the issue in enough cases, we can always turn that assert into a warn or something. But I would love a failing test for the exact case that remains (if one exists) to be 100% sure. As I would prefer to not loose a good assertion unless we must.