### PR TITLE
[BUGFIX] has-many relationship: set hasData when fetching link

### DIFF
--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -202,6 +202,7 @@ export default class ManyRelationship extends Relationship {
       this.store._backburner.join(() => {
         this.updateInternalModelsFromAdapter(records);
         this.manyArray.set('isLoaded', true);
+        this.setHasData(true);
       });
       return this.manyArray;
     });

--- a/tests/integration/references/has-many-test.js
+++ b/tests/integration/references/has-many-test.js
@@ -662,6 +662,40 @@ test("load() fetches link when remoteType is link", function(assert) {
   });
 });
 
+test("load() fetches link when remoteType is link but an empty set of records is returned", function(assert) {
+  env.adapter.findHasMany = function(store, snapshot, link) {
+    assert.equal(link, "/families/1/persons");
+
+    return Ember.RSVP.resolve({ data: [] });
+  };
+
+  let family;
+  run(() => {
+    family = env.store.push({
+      data: {
+        type: 'family',
+        id: 1,
+        relationships: {
+          persons: {
+            links: { related: '/families/1/persons' }
+          }
+        }
+      }
+    });
+  });
+
+  let personsReference = family.hasMany('persons');
+  assert.equal(personsReference.remoteType(), "link");
+
+  return run(() => {
+    return personsReference.load().then((records) => {
+      assert.ok(records instanceof DS.ManyArray, "push resolves with the referenced records");
+      assert.equal(get(records, 'length'), 0);
+      assert.equal(get(personsReference.value(), 'length'), 0);
+    });
+  });
+});
+
 test("load() - only a single find is triggered", function(assert) {
   var done = assert.async();
 


### PR DESCRIPTION
I believe this fixes #4845. The problem is that `setHasData` was only being called when at least one internal model was being added, which is not the case when the server returns an empty array.