### PR TITLE
store: pass original snapshots to adapter#findMany

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -907,6 +907,10 @@ Store = Service.extend({
       // But since the _findMany() finder is a store method we need to get the
       // records from the grouped snapshots even though the _findMany() finder
       // will once again convert the records to snapshots for adapter.findMany()
+      //
+      // However, this makes it impossible to pass on adapter options like `include`, as
+      // described in #5050. Therefore, we make an exception for _findMany() and pass
+      // the snapshots.
       let snapshots = new Array(totalItems);
       for (let i = 0; i < totalItems; i++) {
         let internalModel = internalModels[i];
@@ -931,7 +935,7 @@ Store = Service.extend({
 
         if (totalInGroup > 1) {
           (function(groupedInternalModels, group) {
-            _findMany(adapter, store, modelName, ids, groupedInternalModels, group)
+            _findMany(adapter, store, modelName, ids, group)
               .then(function(foundInternalModels) {
                 handleFoundRecords(foundInternalModels, groupedInternalModels);
               })

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -909,7 +909,9 @@ Store = Service.extend({
       // will once again convert the records to snapshots for adapter.findMany()
       let snapshots = new Array(totalItems);
       for (let i = 0; i < totalItems; i++) {
-        snapshots[i] = internalModels[i].createSnapshot();
+        let internalModel = internalModels[i];
+        let pendingItem = seeking[internalModel.id];
+        snapshots[i] = internalModel.createSnapshot(pendingItem.options);
       }
 
       let groups = adapter.groupRecordsForFindMany(this, snapshots);
@@ -928,15 +930,15 @@ Store = Service.extend({
         }
 
         if (totalInGroup > 1) {
-          (function(groupedInternalModels) {
-            _findMany(adapter, store, modelName, ids, groupedInternalModels)
+          (function(groupedInternalModels, group) {
+            _findMany(adapter, store, modelName, ids, groupedInternalModels, group)
               .then(function(foundInternalModels) {
                 handleFoundRecords(foundInternalModels, groupedInternalModels);
               })
               .catch(function(error) {
                 rejectInternalModels(groupedInternalModels, error);
               });
-          }(groupedInternalModels));
+          }(groupedInternalModels, group));
         } else if (ids.length === 1) {
           var pair = seeking[groupedInternalModels[0].id];
           _fetchRecord(pair);

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -52,13 +52,8 @@ export function _find(adapter, store, modelClass, id, internalModel, options) {
   }, `DS: Extract payload of '${modelName}'`);
 }
 
-export function _findMany(adapter, store, modelName, ids, internalModels, snapshots) {
+export function _findMany(adapter, store, modelName, ids, snapshots) {
   if (DEBUG) { incrementRequestCount(); }
-  if (snapshots) {
-    snapshots = A(snapshots);
-  } else {
-    snapshots = A(internalModels).invoke('createSnapshot');
-  }
   let modelClass = store.modelFor(modelName); // `adapter.findMany` gets the modelClass still
   let promise = adapter.findMany(store, modelClass, ids, snapshots);
   let label = `DS: Handle Adapter#findMany of '${modelName}'`;

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -1,4 +1,3 @@
-import { A } from '@ember/array';
 import { Promise } from 'rsvp';
 import { assert, warn } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
@@ -55,7 +54,7 @@ export function _find(adapter, store, modelClass, id, internalModel, options) {
 export function _findMany(adapter, store, modelName, ids, snapshots) {
   if (DEBUG) { incrementRequestCount(); }
   let modelClass = store.modelFor(modelName); // `adapter.findMany` gets the modelClass still
-  let promise = adapter.findMany(store, modelClass, ids, A(snapshots));
+  let promise = adapter.findMany(store, modelClass, ids, snapshots);
   let label = `DS: Handle Adapter#findMany of '${modelName}'`;
 
   if (promise === undefined) {

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -1,4 +1,3 @@
-import { A } from '@ember/array';
 import { Promise } from 'rsvp';
 import { assert, warn } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -52,9 +52,13 @@ export function _find(adapter, store, modelClass, id, internalModel, options) {
   }, `DS: Extract payload of '${modelName}'`);
 }
 
-export function _findMany(adapter, store, modelName, ids, internalModels) {
+export function _findMany(adapter, store, modelName, ids, internalModels, snapshots) {
   if (DEBUG) { incrementRequestCount(); }
-  let snapshots = A(internalModels).invoke('createSnapshot');
+  if (snapshots) {
+    snapshots = A(snapshots);
+  } else {
+    snapshots = A(internalModels).invoke('createSnapshot');
+  }
   let modelClass = store.modelFor(modelName); // `adapter.findMany` gets the modelClass still
   let promise = adapter.findMany(store, modelClass, ids, snapshots);
   let label = `DS: Handle Adapter#findMany of '${modelName}'`;

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -1,3 +1,4 @@
+import { A } from '@ember/array';
 import { Promise } from 'rsvp';
 import { assert, warn } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
@@ -54,7 +55,7 @@ export function _find(adapter, store, modelClass, id, internalModel, options) {
 export function _findMany(adapter, store, modelName, ids, snapshots) {
   if (DEBUG) { incrementRequestCount(); }
   let modelClass = store.modelFor(modelName); // `adapter.findMany` gets the modelClass still
-  let promise = adapter.findMany(store, modelClass, ids, snapshots);
+  let promise = adapter.findMany(store, modelClass, ids, A(snapshots));
   let label = `DS: Handle Adapter#findMany of '${modelName}'`;
 
   if (promise === undefined) {

--- a/tests/integration/adapter/build-url-mixin-test.js
+++ b/tests/integration/adapter/build-url-mixin-test.js
@@ -222,7 +222,7 @@ test('buildURL - buildURL takes the records from findMany', function(assert) {
 
   adapter.buildURL = function(type, ids, snapshots) {
     if (Array.isArray(snapshots)) {
-      return "/posts/" + snapshots.get('firstObject').belongsTo('post', { id: true }) + '/comments/';
+      return "/posts/" + snapshots[0].belongsTo('post', { id: true }) + '/comments/';
     }
     return "";
   };

--- a/tests/unit/store/adapter-interop-test.js
+++ b/tests/unit/store/adapter-interop-test.js
@@ -109,7 +109,7 @@ test('Calling Store#findRecord multiple times coalesces the calls into a adapter
   });
 });
 
-test('Coalesced Store#findRecord requests retain the `include` adapter option in the snapshots passed to adapter#findMany', function(assert) {
+test('Coalesced Store#findRecord requests retain the `include` adapter option in the snapshots passed to adapter#findMany and  adapter#findRecord', function(assert) {
   const includedResourcesForIds = {
     1: 'someResource',
     2: 'differentResource',

--- a/tests/unit/store/adapter-interop-test.js
+++ b/tests/unit/store/adapter-interop-test.js
@@ -133,7 +133,7 @@ test('Coalesced Store#findRecord requests retain the `include` adapter option in
         )
       });
 
-      return Ember.RSVP.resolve({
+      return resolve({
         data: snapshots.map(({ id }) => ({ id, type: type.modelName }))
       });
     },
@@ -145,7 +145,7 @@ test('Coalesced Store#findRecord requests retain the `include` adapter option in
         `Snapshot #${snapshot.id} retains the 'include' adapter option in #findRecord`
       )
 
-      return Ember.RSVP.resolve({
+      return resolve({
         data: { id, type: type.modelName }
       });
     },
@@ -160,7 +160,7 @@ test('Coalesced Store#findRecord requests retain the `include` adapter option in
   });
 
   return run(() =>
-    Ember.RSVP.all(
+    all(
       Object.entries(includedResourcesForIds).map(
         ([id, include]) => store.findRecord('test', id, { include })
       )

--- a/tests/unit/store/adapter-interop-test.js
+++ b/tests/unit/store/adapter-interop-test.js
@@ -130,7 +130,7 @@ test('Coalesced Store#findRecord requests retain the `include` adapter option in
           snapshot.include,
           includedResourcesForIds[snapshot.id],
           `Snapshot #${snapshot.id} retains the 'include' adapter option in #findMany`
-        )
+        );
       });
 
       return resolve({
@@ -143,7 +143,7 @@ test('Coalesced Store#findRecord requests retain the `include` adapter option in
         snapshot.include,
         includedResourcesForIds[snapshot.id],
         `Snapshot #${snapshot.id} retains the 'include' adapter option in #findRecord`
-      )
+      );
 
       return resolve({
         data: { id, type: type.modelName }


### PR DESCRIPTION
This test demos the bug described in #5050.

As suggested by @runspired on Slack, I also added a bugfix.

I only have a rudimentary idea about Ember Data internals, so please excuse me, if this is not the correct solution to the problem. I feel that it is kind of convoluted, but that stems from the fact that `store#_flushPendingFetchForType(pendingFetchItems, modelName)` converts to and from internal models and snapshots multiple times, as is stated in [a code comment](https://github.com/emberjs/data/blob/e1699cbb488445ad578b02a053e7f621bbbb3f85/addon/-private/system/store.js#L919-L928):

> TODO: Improve records => snapshots => records => snapshots
>
> We want to provide records to all store methods and snapshots to all
> adapter methods. To make sure we're doing that we're providing an array
> of snapshots to adapter.groupRecordsForFindMany(), which in turn will
> return grouped snapshots instead of grouped records.
>
> But since the _findMany() finder is a store method we need to get the
> records from the grouped snapshots even though the _findMany() finder
> will once again convert the records to snapshots for adapter.findMany()