### PR TITLE
[BUGFIX] keep local state after a deletion

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -715,7 +715,7 @@ export default class InternalModel {
     heimdall.increment(send);
     let currentState = this.currentState;
 
-    if (typeof currentState[name] !== 'function') {
+    if (!currentState[name]) {
       this._unhandledEvent(currentState, name, context);
     }
 
@@ -725,12 +725,6 @@ export default class InternalModel {
   notifyHasManyAdded(key, record, idx) {
     if (this.hasRecord) {
       this._record.notifyHasManyAdded(key, record, idx);
-    }
-  }
-
-  notifyHasManyRemoved(key, record, idx) {
-    if (this.hasRecord) {
-      this._record.notifyHasManyRemoved(key, record, idx);
     }
   }
 
@@ -768,7 +762,7 @@ export default class InternalModel {
     }
 
     if (this.isNew()) {
-      this.clearRelationships(true);
+      this.clearRelationships();
     }
 
     if (this.isValid()) {
@@ -885,28 +879,38 @@ export default class InternalModel {
     @method clearRelationships
     @private
   */
-  clearRelationships(resetAll = false) {
+  clearRelationships() {
     this.eachRelationship((name, relationship) => {
       if (this._relationships.has(name)) {
         let rel = this._relationships.get(name);
 
-        if (resetAll === true) {
-          rel.clear();
-          rel.removeInverseRelationships();
-        } else {
-          rel.unloadInverseInternalModel(this);
-        }
+        rel.clear();
+        rel.removeInverseRelationships();
       }
     });
     Object.keys(this._implicitRelationships).forEach((key) => {
       let rel = this._implicitRelationships[key];
 
-      if (resetAll === true) {
-        rel.clear();
-        rel.removeInverseRelationships();
-      } else {
-        rel.unloadInverseInternalModel(this);
+      rel.clear();
+      rel.removeInverseRelationships();
+    });
+  }
+
+  /*
+    @method unloadDeletedRecordFromRelationships
+   */
+  unloadDeletedRecordFromRelationships() {
+    this.eachRelationship((name) => {
+      if (this._relationships.has(name)) {
+        let rel = this._relationships.get(name);
+
+        rel.unloadDeletedInverseInternalModel(this);
       }
+    });
+    Object.keys(this._implicitRelationships).forEach((key) => {
+      let rel = this._implicitRelationships[key];
+
+      rel.unloadDeletedInverseInternalModel(this);
     });
   }
 

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -715,7 +715,7 @@ export default class InternalModel {
     heimdall.increment(send);
     let currentState = this.currentState;
 
-    if (!currentState[name]) {
+    if (typeof currentState[name] !== 'function') {
       this._unhandledEvent(currentState, name, context);
     }
 
@@ -768,7 +768,7 @@ export default class InternalModel {
     }
 
     if (this.isNew()) {
-      this.clearRelationships();
+      this.clearRelationships(true);
     }
 
     if (this.isValid()) {
@@ -885,17 +885,28 @@ export default class InternalModel {
     @method clearRelationships
     @private
   */
-  clearRelationships() {
+  clearRelationships(resetAll = false) {
     this.eachRelationship((name, relationship) => {
       if (this._relationships.has(name)) {
         let rel = this._relationships.get(name);
-        rel.clear();
-        rel.removeInverseRelationships();
+
+        if (resetAll === true) {
+          rel.clear();
+          rel.removeInverseRelationships();
+        } else {
+          rel.unloadInverseInternalModel(this);
+        }
       }
     });
     Object.keys(this._implicitRelationships).forEach((key) => {
-      this._implicitRelationships[key].clear();
-      this._implicitRelationships[key].removeInverseRelationships();
+      let rel = this._implicitRelationships[key];
+
+      if (resetAll === true) {
+        rel.clear();
+        rel.removeInverseRelationships();
+      } else {
+        rel.unloadInverseInternalModel(this);
+      }
     });
   }
 

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -762,7 +762,7 @@ export default class InternalModel {
     }
 
     if (this.isNew()) {
-      this._resetAllRelationshipsToEmpty();
+      this.removeFromInverseRelationships(true);
     }
 
     if (this.isValid()) {
@@ -876,50 +876,36 @@ export default class InternalModel {
   }
 
   /*
-    This method should only be called by records in the `isNew()` state.
-    It will completely reset all relationships to an empty state and remove
-    the record from any associated inverses as well.
+   This method should only be called by records in the `isNew()` state OR once the record
+   has been deleted and that deletion has been persisted.
 
-    @method _resetAllRelationshipsToEmpty
-    @private
-  */
-  _resetAllRelationshipsToEmpty() {
-    this.eachRelationship((name, relationship) => {
-      if (this._relationships.has(name)) {
-        let rel = this._relationships.get(name);
+   It will remove this record from any associated relationships.
 
-        rel.clear();
-        rel.removeInverseRelationships();
-      }
-    });
-    Object.keys(this._implicitRelationships).forEach((key) => {
-      let rel = this._implicitRelationships[key];
-
-      rel.clear();
-      rel.removeInverseRelationships();
-    });
-  }
-
-  /*
-    This method should only be called once the record has been deleted
-    and that deletion has been persisted. It will remove this record from
-    any associated relationships.
+   It will completely reset all relationships to an empty state and remove
+   the record from any associated inverses as well.
 
     @method removeFromInverseRelationships
+    @param {Boolean} isNew whether to unload from the `isNew` perspective
     @private
    */
-  removeFromInverseRelationships() {
+  removeFromInverseRelationships(isNew = false) {
     this.eachRelationship((name) => {
       if (this._relationships.has(name)) {
         let rel = this._relationships.get(name);
 
         rel.removeDeletedInternalModelFromInverse();
+        if (isNew === true) {
+          rel.clear();
+        }
       }
     });
     Object.keys(this._implicitRelationships).forEach((key) => {
       let rel = this._implicitRelationships[key];
 
       rel.removeDeletedInternalModelFromInverse();
+      if (isNew === true) {
+        rel.clear();
+      }
     });
   }
 

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -905,10 +905,10 @@ export default class InternalModel {
     and that deletion has been persisted. It will remove this record from
     any associated relationships.
 
-    @method unloadDeletedRecordFromRelationships
+    @method removeFromInverseRelationships
     @private
    */
-  unloadDeletedRecordFromRelationships() {
+  removeFromInverseRelationships() {
     this.eachRelationship((name) => {
       if (this._relationships.has(name)) {
         let rel = this._relationships.get(name);

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -885,14 +885,14 @@ export default class InternalModel {
         let rel = this._relationships.get(name);
 
         rel.clear();
-        // rel.removeInverseRelationships();
+        rel.removeInverseRelationships();
       }
     });
     Object.keys(this._implicitRelationships).forEach((key) => {
       let rel = this._implicitRelationships[key];
 
       rel.clear();
-      // rel.removeInverseRelationships();
+      rel.removeInverseRelationships();
     });
   }
 

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -881,8 +881,8 @@ export default class InternalModel {
 
    It will remove this record from any associated relationships.
 
-   If `isNew` is true (default false), it will completely reset all relationships
-   to an empty state as well.
+   If `isNew` is true (default false), it will also completely reset all
+    relationships to an empty state as well.
 
     @method removeFromInverseRelationships
     @param {Boolean} isNew whether to unload from the `isNew` perspective
@@ -893,7 +893,7 @@ export default class InternalModel {
       if (this._relationships.has(name)) {
         let rel = this._relationships.get(name);
 
-        rel.removeDeletedInternalModelFromInverse();
+        rel.removeCompletelyFromInverse();
         if (isNew === true) {
           rel.clear();
         }
@@ -902,13 +902,17 @@ export default class InternalModel {
     Object.keys(this._implicitRelationships).forEach((key) => {
       let rel = this._implicitRelationships[key];
 
-      rel.removeDeletedInternalModelFromInverse();
+      rel.removeCompletelyFromInverse();
       if (isNew === true) {
         rel.clear();
       }
     });
   }
 
+  /*
+    Notify all inverses that this internalModel has been dematerialized
+    and destroys any ManyArrays.
+   */
   destroyRelationships() {
     this.eachRelationship((name, relationship) => {
       if (this._relationships.has(name)) {
@@ -992,6 +996,8 @@ export default class InternalModel {
   }
 
   /*
+    Used to notify the store to update FilteredRecordArray membership.
+
     @method updateRecordArrays
     @private
   */

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -913,13 +913,13 @@ export default class InternalModel {
       if (this._relationships.has(name)) {
         let rel = this._relationships.get(name);
 
-        rel.removeDeletedInternalModelFromInverse(this);
+        rel.removeDeletedInternalModelFromInverse();
       }
     });
     Object.keys(this._implicitRelationships).forEach((key) => {
       let rel = this._implicitRelationships[key];
 
-      rel.removeDeletedInternalModelFromInverse(this);
+      rel.removeDeletedInternalModelFromInverse();
     });
   }
 

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -881,8 +881,8 @@ export default class InternalModel {
 
    It will remove this record from any associated relationships.
 
-   It will completely reset all relationships to an empty state and remove
-   the record from any associated inverses as well.
+   If `isNew` is true (default false), it will completely reset all relationships
+   to an empty state as well.
 
     @method removeFromInverseRelationships
     @param {Boolean} isNew whether to unload from the `isNew` perspective

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -762,7 +762,7 @@ export default class InternalModel {
     }
 
     if (this.isNew()) {
-      this.clearRelationships();
+      this._resetAllRelationshipsToEmpty();
     }
 
     if (this.isValid()) {
@@ -876,10 +876,14 @@ export default class InternalModel {
   }
 
   /*
-    @method clearRelationships
+    This method should only be called by records in the `isNew()` state.
+    It will completely reset all relationships to an empty state and remove
+    the record from any associated inverses as well.
+
+    @method _resetAllRelationshipsToEmpty
     @private
   */
-  clearRelationships() {
+  _resetAllRelationshipsToEmpty() {
     this.eachRelationship((name, relationship) => {
       if (this._relationships.has(name)) {
         let rel = this._relationships.get(name);
@@ -897,20 +901,25 @@ export default class InternalModel {
   }
 
   /*
+    This method should only be called once the record has been deleted
+    and that deletion has been persisted. It will remove this record from
+    any associated relationships.
+
     @method unloadDeletedRecordFromRelationships
+    @private
    */
   unloadDeletedRecordFromRelationships() {
     this.eachRelationship((name) => {
       if (this._relationships.has(name)) {
         let rel = this._relationships.get(name);
 
-        rel.unloadDeletedInverseInternalModel(this);
+        rel.removeDeletedInternalModelFromInverse(this);
       }
     });
     Object.keys(this._implicitRelationships).forEach((key) => {
       let rel = this._implicitRelationships[key];
 
-      rel.unloadDeletedInverseInternalModel(this);
+      rel.removeDeletedInternalModelFromInverse(this);
     });
   }
 

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -885,14 +885,14 @@ export default class InternalModel {
         let rel = this._relationships.get(name);
 
         rel.clear();
-        rel.removeInverseRelationships();
+        // rel.removeInverseRelationships();
       }
     });
     Object.keys(this._implicitRelationships).forEach((key) => {
       let rel = this._implicitRelationships[key];
 
       rel.clear();
-      rel.removeInverseRelationships();
+      // rel.removeInverseRelationships();
     });
   }
 

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1118,8 +1118,8 @@ const Model = Ember.Object.extend(Ember.Evented, {
   notifyHasManyRemoved(key) {
     // We need to notifyPropertyChange in the removing case to flush ui state
     //  Goes away if we remove/improve the outer PromiseProxy on async relationships
-    // this.notifyPropertyChange(key);
-    this.notifyPropertyChange(`${key}.length`);
+    //  Notifying `${key}.length` does not work here
+    this.get(key).notifyPropertyChange('length');
   },
 
   eachAttribute(callback, binding) {

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1118,7 +1118,8 @@ const Model = Ember.Object.extend(Ember.Evented, {
   notifyHasManyRemoved(key) {
     // We need to notifyPropertyChange in the removing case to flush ui state
     //  Goes away if we remove/improve the outer PromiseProxy on async relationships
-    //  Notifying `${key}.length` does not work here
+    //  Notifying `${key}` or `${key}.length` does not work here, notifying `content`
+    //  after `get(key)` also works but this wont always be an async relationship.
     this.get(key).notifyPropertyChange('length');
   },
 

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1115,6 +1115,13 @@ const Model = Ember.Object.extend(Ember.Evented, {
     this.notifyPropertyChange(key);
   },
 
+  notifyHasManyRemoved(key) {
+    // We need to notifyPropertyChange in the removing case to flush ui state
+    //  Goes away if we remove/improve the outer PromiseProxy on async relationships
+    // this.notifyPropertyChange(key);
+    this.notifyPropertyChange(`${key}.length`);
+  },
+
   eachAttribute(callback, binding) {
     this.constructor.eachAttribute(callback, binding);
   }

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1115,14 +1115,6 @@ const Model = Ember.Object.extend(Ember.Evented, {
     this.notifyPropertyChange(key);
   },
 
-  notifyHasManyRemoved(key) {
-    // We need to notifyPropertyChange in the removing case to flush ui state
-    //  Goes away if we remove/improve the outer PromiseProxy on async relationships
-    //  Notifying `${key}` or `${key}.length` does not work here, notifying `content`
-    //  after `get(key)` also works but this wont always be an async relationship.
-    this.get(key).notifyPropertyChange('length');
-  },
-
   eachAttribute(callback, binding) {
     this.constructor.eachAttribute(callback, binding);
   }

--- a/addon/-private/system/model/states.js
+++ b/addon/-private/system/model/states.js
@@ -671,7 +671,7 @@ const RootState = {
       isDirty: false,
 
       setup(internalModel) {
-        internalModel.unloadDeletedRecordFromRelationships();
+        internalModel.removeFromInverseRelationships();
       },
 
       invokeLifecycleCallbacks(internalModel) {

--- a/addon/-private/system/model/states.js
+++ b/addon/-private/system/model/states.js
@@ -671,7 +671,7 @@ const RootState = {
       isDirty: false,
 
       setup(internalModel) {
-        internalModel.clearRelationships();
+        internalModel.unloadDeletedRecordFromRelationships();
       },
 
       invokeLifecycleCallbacks(internalModel) {

--- a/addon/-private/system/record-array-manager.js
+++ b/addon/-private/system/record-array-manager.js
@@ -88,7 +88,7 @@ export default class RecordArrayManager {
       return;
     }
 
-    internalModel._pendingRecordArrayManagerFlush = true
+    internalModel._pendingRecordArrayManagerFlush = true;
 
     let pending = this._pending;
     let models = pending[modelName] = pending[modelName] || [];

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -63,8 +63,8 @@ export default class BelongsToRelationship extends Relationship {
     this.notifyBelongsToChanged();
   }
 
-  removeDeletedInternalModelFromOwn(internalModel) {
-    super.removeDeletedInternalModelFromOwn(internalModel);
+  removeCompletelyFromOwn(internalModel) {
+    super.removeCompletelyFromOwn(internalModel);
 
     if (this.canonicalState === internalModel) {
       this.canonicalState = null;

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -63,8 +63,8 @@ export default class BelongsToRelationship extends Relationship {
     this.notifyBelongsToChanged();
   }
 
-  unloadDeletedInverseInternalModelFromOwn(internalModel) {
-    super.unloadDeletedInverseInternalModelFromOwn(internalModel);
+  removeDeletedInternalModelFromOwn(internalModel) {
+    super.removeDeletedInternalModelFromOwn(internalModel);
     let didChange = false;
 
     if (this.canonicalState === internalModel) {

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -65,19 +65,13 @@ export default class BelongsToRelationship extends Relationship {
 
   removeDeletedInternalModelFromOwn(internalModel) {
     super.removeDeletedInternalModelFromOwn(internalModel);
-    let didChange = false;
 
     if (this.canonicalState === internalModel) {
       this.canonicalState = null;
-      didChange = true;
     }
 
     if (this.inverseInternalModel === internalModel) {
-      this.inverseInternalModel = this.canonicalState;
-      didChange = true;
-    }
-
-    if (didChange === true) {
+      this.inverseInternalModel = null;
       this.notifyBelongsToChanged();
     }
   }

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -63,6 +63,25 @@ export default class BelongsToRelationship extends Relationship {
     this.notifyBelongsToChanged();
   }
 
+  unloadInverseInternalModelFromOwn(internalModel) {
+    super.unloadInverseInternalModelFromOwn(internalModel);
+    let didChange = false;
+
+    if (this.canonicalState === internalModel) {
+      this.canonicalState = null;
+      didChange = true;
+    }
+
+    if (this.inverseInternalModel === internalModel) {
+      this.inverseInternalModel = this.canonicalState;
+      didChange = true;
+    }
+
+    if (didChange === true) {
+      this.notifyBelongsToChanged();
+    }
+  }
+
   flushCanonical() {
     //temporary fix to not remove newly created records if server returned null.
     //TODO remove once we have proper diffing

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -63,8 +63,8 @@ export default class BelongsToRelationship extends Relationship {
     this.notifyBelongsToChanged();
   }
 
-  unloadInverseInternalModelFromOwn(internalModel) {
-    super.unloadInverseInternalModelFromOwn(internalModel);
+  unloadDeletedInverseInternalModelFromOwn(internalModel) {
+    super.unloadDeletedInverseInternalModelFromOwn(internalModel);
     let didChange = false;
 
     if (this.canonicalState === internalModel) {

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -111,8 +111,8 @@ export default class ManyRelationship extends Relationship {
     super.removeCanonicalInternalModelFromOwn(internalModel, idx);
   }
 
-  unloadInverseInternalModelFromOwn(internalModel) {
-    super.unloadInverseInternalModelFromOwn(internalModel);
+  unloadDeletedInverseInternalModelFromOwn(internalModel) {
+    super.unloadDeletedInverseInternalModelFromOwn(internalModel);
 
     const canonicalIndex = this.canonicalState.indexOf(internalModel);
 
@@ -123,16 +123,10 @@ export default class ManyRelationship extends Relationship {
     const manyArray = this._manyArray;
 
     if (manyArray) {
-      const currentState = manyArray.currentState;
-      const idx = currentState.indexOf(internalModel);
+      const idx = manyArray.currentState.indexOf(internalModel);
 
       if (idx !== -1) {
-        currentState.splice(idx, 1);
-
-        manyArray.set('length', currentState.length);
-        manyArray.notifyPropertyChange('length');
-
-        this.internalModel.notifyHasManyRemoved(this.key, internalModel, idx);
+        manyArray.internalReplace(idx, 1);
       }
     }
   }

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -111,8 +111,8 @@ export default class ManyRelationship extends Relationship {
     super.removeCanonicalInternalModelFromOwn(internalModel, idx);
   }
 
-  removeDeletedInternalModelFromOwn(internalModel) {
-    super.removeDeletedInternalModelFromOwn(internalModel);
+  removeCompletelyFromOwn(internalModel) {
+    super.removeCompletelyFromOwn(internalModel);
 
     const canonicalIndex = this.canonicalState.indexOf(internalModel);
 

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -111,6 +111,31 @@ export default class ManyRelationship extends Relationship {
     super.removeCanonicalInternalModelFromOwn(internalModel, idx);
   }
 
+  unloadInverseInternalModelFromOwn(internalModel) {
+    super.unloadInverseInternalModelFromOwn(internalModel);
+
+    const canonicalIndex = this.canonicalState.indexOf(internalModel);
+
+    if (canonicalIndex !== -1) {
+      this.canonicalState.splice(canonicalIndex, 1);
+    }
+
+    const manyArray = this._manyArray;
+
+    if (manyArray) {
+      const currentState = manyArray.currentState;
+      const idx = currentState.indexOf(internalModel);
+
+      if (idx !== -1) {
+        currentState.splice(idx, 1);
+        manyArray.set('length', currentState.length);
+        manyArray.notifyPropertyChange('length');
+
+        this.internalModel.notifyHasManyRemoved(this.key, internalModel, idx);
+      }
+    }
+  }
+
   flushCanonical() {
     if (this._manyArray) {
       this._manyArray.flushCanonical();

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -128,6 +128,7 @@ export default class ManyRelationship extends Relationship {
 
       if (idx !== -1) {
         currentState.splice(idx, 1);
+
         manyArray.set('length', currentState.length);
         manyArray.notifyPropertyChange('length');
 

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -111,8 +111,8 @@ export default class ManyRelationship extends Relationship {
     super.removeCanonicalInternalModelFromOwn(internalModel, idx);
   }
 
-  unloadDeletedInverseInternalModelFromOwn(internalModel) {
-    super.unloadDeletedInverseInternalModelFromOwn(internalModel);
+  removeDeletedInternalModelFromOwn(internalModel) {
+    super.removeDeletedInternalModelFromOwn(internalModel);
 
     const canonicalIndex = this.canonicalState.indexOf(internalModel);
 

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -250,7 +250,6 @@ export default class Relationship {
   removeInternalModelFromOwn(internalModel) {
     heimdall.increment(removeInternalModelFromOwn);
     this.members.delete(internalModel);
-    this.notifyRecordRelationshipRemoved(internalModel);
     this.internalModel.updateRecordArrays();
   }
 
@@ -302,8 +301,6 @@ export default class Relationship {
   removeDeletedInternalModelFromOwn(internalModel) {
     this.canonicalMembers.delete(internalModel);
     this.members.delete(internalModel);
-    this.notifyRecordRelationshipRemoved(internalModel);
-    // this.internalModel.updateRecordArrays();
   }
 
   flushCanonical() {
@@ -366,7 +363,6 @@ export default class Relationship {
   }
 
   notifyRecordRelationshipAdded() { }
-  notifyRecordRelationshipRemoved() { }
 
   /*
    `hasData` for a relationship is a flag to indicate if we consider the

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -277,12 +277,13 @@ export default class Relationship {
     @method removeDeletedInternalModelFromInverse
     @private
    */
-  removeDeletedInternalModelFromInverse(internalModel) {
+  removeDeletedInternalModelFromInverse() {
     if (!this.inverseKey) { return; }
 
     // we actually want a union of members and canonicalMembers
     // they should be disjoint but currently are not due to a bug
     let seen = Object.create(null);
+    const internalModel = this.indernalModel;
 
     const unload = inverseInternalModel => {
       const id = guidFor(inverseInternalModel);

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -270,13 +270,13 @@ export default class Relationship {
 
   /*
     Call this method once a record deletion has been persisted
-    to purge it from both current and canonical state of all
+    to purge it from BOTH current and canonical state of all
     relationships.
 
-    @method removeDeletedInternalModelFromInverse
+    @method removeCompletelyFromInverse
     @private
    */
-  removeDeletedInternalModelFromInverse() {
+  removeCompletelyFromInverse() {
     if (!this.inverseKey) { return; }
 
     // we actually want a union of members and canonicalMembers
@@ -289,7 +289,7 @@ export default class Relationship {
 
       if (seen[id] === undefined) {
         const relationship = inverseInternalModel._relationships.get(this.inverseKey);
-        relationship.removeDeletedInternalModelFromOwn(internalModel);
+        relationship.removeCompletelyFromOwn(internalModel);
         seen[id] = true;
       }
     };
@@ -298,9 +298,16 @@ export default class Relationship {
     this.canonicalMembers.forEach(unload);
   }
 
-  removeDeletedInternalModelFromOwn(internalModel) {
+  /*
+    Removes the given internalModel from BOTH canonical AND current state.
+
+    This method is useful when either a deletion or a rollback on a new record
+    needs to entirely purge itself from an inverse relationship.
+   */
+  removeCompletelyFromOwn(internalModel) {
     this.canonicalMembers.delete(internalModel);
     this.members.delete(internalModel);
+    this.internalModel.updateRecordArrays();
   }
 
   flushCanonical() {

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -281,13 +281,13 @@ export default class Relationship {
 
       if (seen[id] === undefined) {
         const relationship = inverseInternalModel._relationships.get(this.inverseKey);
-        relationship.unloadInverseInternalModelFromOwn(internalModel);
+        relationship.unloadDeletedInverseInternalModelFromOwn(internalModel);
         seen[id] = true;
       }
     };
 
     this.members.forEach(unload);
-    this.canonicalMembers(unload);
+    this.canonicalMembers.forEach(unload);
   }
 
   unloadDeletedInverseInternalModelFromOwn(internalModel) {

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -283,7 +283,7 @@ export default class Relationship {
     // we actually want a union of members and canonicalMembers
     // they should be disjoint but currently are not due to a bug
     let seen = Object.create(null);
-    const internalModel = this.indernalModel;
+    const internalModel = this.internalModel;
 
     const unload = inverseInternalModel => {
       const id = guidFor(inverseInternalModel);

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -266,18 +266,7 @@ export default class Relationship {
     this.flushCanonicalLater();
   }
 
-  unloadInverseInternalModel(internalModel) {
-    this.unloadInverseInternalModelFromOwn(internalModel);
-    this.unloadInverseInternalModelFromInverses(internalModel);
-  }
-
-  unloadInverseInternalModelFromOwn(internalModel) {
-    this.canonicalMembers.delete(internalModel);
-    this.members.delete(internalModel);
-    this.notifyRecordRelationshipRemoved(internalModel);
-  }
-
-  unloadInverseInternalModelFromInverses(internalModel) {
+  unloadDeletedInverseInternalModel(internalModel) {
     if (!this.inverseKey) { return; }
 
     let allMembers =
@@ -287,8 +276,14 @@ export default class Relationship {
 
     allMembers.forEach(inverseInternalModel => {
       let relationship = inverseInternalModel._relationships.get(this.inverseKey);
-      relationship.unloadInverseInternalModelFromOwn(internalModel);
+      relationship.unloadDeletedInverseInternalModelFromOwn(internalModel);
     });
+  }
+
+  unloadDeletedInverseInternalModelFromOwn(internalModel) {
+    this.canonicalMembers.delete(internalModel);
+    this.members.delete(internalModel);
+    this.notifyRecordRelationshipRemoved(internalModel);
   }
 
   flushCanonical() {

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -303,6 +303,7 @@ export default class Relationship {
     this.canonicalMembers.delete(internalModel);
     this.members.delete(internalModel);
     this.notifyRecordRelationshipRemoved(internalModel);
+    // this.internalModel.updateRecordArrays();
   }
 
   flushCanonical() {

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -269,7 +269,15 @@ export default class Relationship {
     this.flushCanonicalLater();
   }
 
-  unloadDeletedInverseInternalModel(internalModel) {
+  /*
+    Call this method once a record deletion has been persisted
+    to purge it from both current and canonical state of all
+    relationships.
+
+    @method removeDeletedInternalModelFromInverse
+    @private
+   */
+  removeDeletedInternalModelFromInverse(internalModel) {
     if (!this.inverseKey) { return; }
 
     // we actually want a union of members and canonicalMembers
@@ -281,7 +289,7 @@ export default class Relationship {
 
       if (seen[id] === undefined) {
         const relationship = inverseInternalModel._relationships.get(this.inverseKey);
-        relationship.unloadDeletedInverseInternalModelFromOwn(internalModel);
+        relationship.removeDeletedInternalModelFromOwn(internalModel);
         seen[id] = true;
       }
     };
@@ -290,7 +298,7 @@ export default class Relationship {
     this.canonicalMembers.forEach(unload);
   }
 
-  unloadDeletedInverseInternalModelFromOwn(internalModel) {
+  removeDeletedInternalModelFromOwn(internalModel) {
     this.canonicalMembers.delete(internalModel);
     this.members.delete(internalModel);
     this.notifyRecordRelationshipRemoved(internalModel);

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -2520,7 +2520,9 @@ test("adding and removing records from hasMany relationship #2666", function(ass
         return comments.get('lastObject').destroyRecord();
       }).then(() => {
         let comments = post.get('comments');
-        assert.equal(comments.get('length'), 3, "Comments count after destroy");
+        let length = comments.get('length');
+
+        assert.equal(length, 3, "Comments count after destroy");
 
         // Add another comment #4
         let comment = env.store.createRecord('comment');

--- a/tests/unit/model/relationships/has-many-test.js
+++ b/tests/unit/model/relationships/has-many-test.js
@@ -980,13 +980,13 @@ test('new items added to a hasMany relationship are not cleared by a delete', fu
   const rebel = store.peekRecord('pet', '3');
 
   assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
-  assert.equal(get(pets, 'length'), 1, 'precond - relationship has only one pet to start');
+  assert.deepEqual(pets.map(p => get(p, 'id')), ['1'], 'precond - relationship has the correct pets to start');
 
   run(() => {
     pets.pushObjects([rambo, rebel]);
   });
 
-  assert.equal(get(pets, 'length'), 3, 'precond2 - relationship now has three pets');
+  assert.deepEqual(pets.map(p => get(p, 'id')), ['1', '2', '3'], 'precond2 - relationship now has the correct three pets');
 
   run(() => {
     return shen.destroyRecord({})
@@ -995,7 +995,7 @@ test('new items added to a hasMany relationship are not cleared by a delete', fu
       });
   });
 
-  assert.equal(get(pets, 'length'), 2, 'relationship now has two pets');
+  assert.deepEqual(pets.map(p => get(p, 'id')), ['2', '3'], 'relationship now has the correct two pets');
 });
 
 test('new items added to an async hasMany relationship are not cleared by a delete', function(assert) {
@@ -1074,19 +1074,19 @@ test('new items added to an async hasMany relationship are not cleared by a dele
       const rebel = store.peekRecord('pet', '3');
 
       assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
-      assert.equal(get(pets, 'length'), 1, 'precond - relationship has only one pet to start');
+      assert.deepEqual(pets.map(p => get(p, 'id')), ['1'], 'precond - relationship has the correct pet to start');
       assert.equal(get(petsProxy, 'length'), 1, 'precond - proxy has only one pet to start');
 
       pets.pushObjects([rambo, rebel]);
 
-      assert.equal(get(pets, 'length'), 3, 'precond2 - relationship now has three pets');
+      assert.deepEqual(pets.map(p => get(p, 'id')), ['1', '2', '3'], 'precond2 - relationship now has the correct three pets');
       assert.equal(get(petsProxy, 'length'), 3, 'precond2 - proxy now reflects three pets');
 
       return shen.destroyRecord({})
         .then(() => {
           shen.unloadRecord();
 
-          assert.equal(get(pets, 'length'), 2, 'relationship now has two pets');
+          assert.deepEqual(pets.map(p => get(p, 'id')), ['2', '3'], 'relationship now has the correct two pets');
           assert.equal(get(petsProxy, 'length'), 2, 'proxy now reflects two pets');
         });
     });
@@ -1257,7 +1257,7 @@ test('new items added to an async belongsTo relationship are not cleared by a de
   });
 });
 
-test('deleting an item that is the current state of a belongsTo restores canonicalState', function(assert) {
+test('deleting an item that is the current state of a belongsTo clears currentState', function(assert) {
   assert.expect(4);
 
   const Person = DS.Model.extend({
@@ -1334,7 +1334,7 @@ test('deleting an item that is the current state of a belongsTo restores canonic
         rambo.unloadRecord();
 
         dog = person.get('dog');
-        assert.equal(dog, shen, 'The canonical state of the belongsTo was restored after the delete');
+        assert.equal(dog, null, 'The current state of the belongsTo was clearer');
       });
   });
 });
@@ -1348,8 +1348,8 @@ test('deleting an item that is the current state of a belongsTo restores canonic
   the parent record's hasMany is a situation in which this limitation will be encountered should other
   local changes to the relationship still exist.
  */
-test('returning new hasMany relationship info from a delete supplements local state', function(assert) {
-  assert.expect(5);
+test('[ASSERTS KNOWN LIMITATION STILL EXISTS] returning new hasMany relationship info from a delete clears local state', function(assert) {
+  assert.expect(4);
 
   const Person = DS.Model.extend({
     name: DS.attr('string'),
@@ -1437,17 +1437,16 @@ test('returning new hasMany relationship info from a delete supplements local st
   const pets = run(() => person.get('pets'));
 
   const shen = store.peekRecord('pet', '1');
-  const rambo = store.peekRecord('pet', '2');
   const rebel = store.peekRecord('pet', '3');
 
   assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
-  assert.equal(get(pets, 'length'), 2, 'precond - relationship has only one pet to start');
+  assert.deepEqual(pets.map(p => get(p, 'id')), ['1', '2'], 'precond - relationship has the correct pets to start');
 
   run(() => {
     pets.pushObjects([rebel]);
   });
 
-  assert.equal(get(pets, 'length'), 3, 'precond2 - relationship now has three pets');
+  assert.deepEqual(pets.map(p => get(p, 'id')), ['1', '2', '3'], 'precond2 - relationship now has the correct three pets');
 
   return run(() => {
     return shen.destroyRecord({})
@@ -1455,8 +1454,7 @@ test('returning new hasMany relationship info from a delete supplements local st
         shen.unloadRecord();
 
         // were ember-data to now preserve local edits during a relationship push, this would be '2'
-        assert.equal(get(pets, 'length'), 1, 'relationship now has one pet');
-        assert.equal(pets.objectAt(0), rambo, 'the expected pet remains');
+        assert.deepEqual(pets.map(p => get(p, 'id')), ['2'], 'relationship now has only one pet, we lost the local change');
       });
   });
 });

--- a/tests/unit/model/relationships/has-many-test.js
+++ b/tests/unit/model/relationships/has-many-test.js
@@ -906,8 +906,7 @@ test('it is possible to add a new item to a relationship', function(assert) {
   });
 });
 
-
-test('new items added to a relationship are not cleared by a delete', function(assert) {
+test('new items added to a hasMany relationship are not cleared by a delete', function(assert) {
   assert.expect(4);
 
   const Person = DS.Model.extend({
@@ -999,6 +998,476 @@ test('new items added to a relationship are not cleared by a delete', function(a
   assert.equal(get(pets, 'length'), 2, 'relationship now has two pets');
 });
 
+test('new items added to an async hasMany relationship are not cleared by a delete', function(assert) {
+  assert.expect(7);
+
+  const Person = DS.Model.extend({
+    name: DS.attr('string'),
+    pets: DS.hasMany('pet', { async: true, inverse: null })
+  });
+
+  const Pet = DS.Model.extend({
+    name: DS.attr('string'),
+    person: DS.belongsTo('person', { async: false, inverse: null })
+  });
+
+  let env = setupStore({
+    person: Person,
+    pet: Pet
+  });
+  env.adapter.shouldBackgroundReloadRecord = () => false;
+  env.adapter.deleteRecord = () => {
+    return Ember.RSVP.Promise.resolve({ data: null });
+  };
+
+  let { store } = env;
+
+  run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Chris Thoburn'
+        },
+        relationships: {
+          pets: {
+            data: [
+              { type: 'pet', id: '1' }
+            ]
+          }
+        }
+      },
+      included: [
+        {
+          type: 'pet',
+          id: '1',
+          attributes: {
+            name: 'Shenanigans'
+          }
+        },
+        {
+          type: 'pet',
+          id: '2',
+          attributes: {
+            name: 'Rambunctious'
+          }
+        },
+        {
+          type: 'pet',
+          id: '3',
+          attributes: {
+            name: 'Rebel'
+          }
+        }
+      ]
+    });
+  });
+
+  return run(() => {
+    const person = store.peekRecord('person', '1');
+    const petsProxy = person.get('pets');
+
+    petsProxy.then((pets) => {
+      const shen = pets.objectAt(0);
+      const rambo = store.peekRecord('pet', '2');
+      const rebel = store.peekRecord('pet', '3');
+
+      assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+      assert.equal(get(pets, 'length'), 1, 'precond - relationship has only one pet to start');
+      assert.equal(get(petsProxy, 'length'), 1, 'precond - proxy has only one pet to start');
+
+      run(() => {
+        pets.pushObjects([rambo, rebel]);
+      });
+
+      assert.equal(get(pets, 'length'), 3, 'precond2 - relationship now has three pets');
+      assert.equal(get(petsProxy, 'length'), 3, 'precond2 - proxy now reflects three pets');
+
+      run(() => {
+        shen.destroyRecord({})
+          .then(() => {
+            shen.unloadRecord();
+          });
+      });
+
+      assert.equal(get(pets, 'length'), 2, 'relationship now has two pets');
+      assert.equal(get(petsProxy, 'length'), 2, 'proxy now reflects two pets');
+    });
+  });
+});
+
+test('new items added to a belongsTo relationship are not cleared by a delete', function(assert) {
+  assert.expect(4);
+
+  const Person = DS.Model.extend({
+    name: DS.attr('string'),
+    dog: DS.belongsTo('dog', { async: false, inverse: null })
+  });
+
+  const Dog = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  let env = setupStore({
+    person: Person,
+    dog: Dog
+  });
+  env.adapter.shouldBackgroundReloadRecord = () => false;
+  env.adapter.deleteRecord = () => {
+    return Ember.RSVP.Promise.resolve({ data: null });
+  };
+
+  let { store } = env;
+
+  run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Chris Thoburn'
+        },
+        relationships: {
+          dog: {
+            data: { type: 'dog', id: '1' }
+          }
+        }
+      },
+      included: [
+        {
+          type: 'dog',
+          id: '1',
+          attributes: {
+            name: 'Shenanigans'
+          }
+        },
+        {
+          type: 'dog',
+          id: '2',
+          attributes: {
+            name: 'Rambunctious'
+          }
+        }
+      ]
+    });
+  });
+
+  const person = store.peekRecord('person', '1');
+  let dog = run(() => person.get('dog'));
+  const shen = store.peekRecord('dog', '1');
+  const rambo = store.peekRecord('dog', '2');
+
+  assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
+  assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
+
+  run(() => {
+    person.set('dog', rambo);
+  });
+
+  dog = person.get('dog');
+  assert.equal(dog, rambo, 'precond2 - relationship was updated');
+
+  run(() => {
+    shen.destroyRecord({})
+      .then(() => {
+        shen.unloadRecord();
+      });
+  });
+
+  dog = person.get('dog');
+  assert.equal(dog, rambo, 'The currentState of the belongsTo was preserved after the delete');
+});
+
+test('new items added to an async belongsTo relationship are not cleared by a delete', function(assert) {
+  assert.expect(4);
+
+  const Person = DS.Model.extend({
+    name: DS.attr('string'),
+    dog: DS.belongsTo('dog', { async: true, inverse: null })
+  });
+
+  const Dog = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  let env = setupStore({
+    person: Person,
+    dog: Dog
+  });
+  env.adapter.shouldBackgroundReloadRecord = () => false;
+  env.adapter.deleteRecord = () => {
+    return Ember.RSVP.Promise.resolve({ data: null });
+  };
+
+  let { store } = env;
+
+  run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Chris Thoburn'
+        },
+        relationships: {
+          dog: {
+            data: { type: 'dog', id: '1' }
+          }
+        }
+      },
+      included: [
+        {
+          type: 'dog',
+          id: '1',
+          attributes: {
+            name: 'Shenanigans'
+          }
+        },
+        {
+          type: 'dog',
+          id: '2',
+          attributes: {
+            name: 'Rambunctious'
+          }
+        }
+      ]
+    });
+  });
+
+  return run(() => {
+    const person = store.peekRecord('person', '1');
+    const shen = store.peekRecord('dog', '1');
+    const rambo = store.peekRecord('dog', '2');
+
+    return person.get('dog').then((dog) => {
+      assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
+      assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
+
+      run(() => {
+        person.set('dog', rambo);
+      });
+
+      dog = person.get('dog.content');
+
+      assert.ok(dog === rambo, 'precond2 - relationship was updated');
+
+      run(() => {
+        shen.destroyRecord({})
+          .then(() => {
+            shen.unloadRecord();
+          });
+      });
+
+      dog = person.get('dog.content');
+      assert.ok(dog === rambo, 'The currentState of the belongsTo was preserved after the delete');
+    });
+  });
+});
+
+test('deleting an item that is the current state of a belongsTo restores canonicalState', function(assert) {
+  assert.expect(4);
+
+  const Person = DS.Model.extend({
+    name: DS.attr('string'),
+    dog: DS.belongsTo('dog', { async: false, inverse: null })
+  });
+
+  const Dog = DS.Model.extend({
+    name: DS.attr('string')
+  });
+
+  let env = setupStore({
+    person: Person,
+    dog: Dog
+  });
+  env.adapter.shouldBackgroundReloadRecord = () => false;
+  env.adapter.deleteRecord = () => {
+    return Ember.RSVP.Promise.resolve({ data: null });
+  };
+
+  let { store } = env;
+
+  run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Chris Thoburn'
+        },
+        relationships: {
+          dog: {
+            data: { type: 'dog', id: '1' }
+          }
+        }
+      },
+      included: [
+        {
+          type: 'dog',
+          id: '1',
+          attributes: {
+            name: 'Shenanigans'
+          }
+        },
+        {
+          type: 'dog',
+          id: '2',
+          attributes: {
+            name: 'Rambunctious'
+          }
+        }
+      ]
+    });
+  });
+
+  const person = store.peekRecord('person', '1');
+  let dog = run(() => person.get('dog'));
+  const shen = store.peekRecord('dog', '1');
+  const rambo = store.peekRecord('dog', '2');
+
+  assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
+  assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
+
+  run(() => {
+    person.set('dog', rambo);
+  });
+
+  dog = person.get('dog');
+  assert.equal(dog, rambo, 'precond2 - relationship was updated');
+
+  run(() => {
+    rambo.destroyRecord({})
+      .then(() => {
+        rambo.unloadRecord();
+      });
+  });
+
+  dog = person.get('dog');
+  assert.equal(dog, shen, 'The canonical state of the belongsTo was restored after the delete');
+});
+
+/*
+  This test, when passing, affirms that a known limitation of ember-data still exists.
+
+  When pushing new data into the store, ember-data is currently incapable of knowing whether
+  a relationship has been persisted. In order to update relationship state effectively, ember-data
+  blindly "flushes canonical" state, removing any `currentState` changes. A delete that sideloads
+  the parent record's hasMany is a situation in which this limitation will be encountered should other
+  local changes to the relationship still exist.
+ */
+test('returning new hasMany relationship info from a delete supplements local state', function(assert) {
+  assert.expect(5);
+
+  const Person = DS.Model.extend({
+    name: DS.attr('string'),
+    pets: DS.hasMany('pet', { async: false, inverse: null })
+  });
+
+  const Pet = DS.Model.extend({
+    name: DS.attr('string'),
+    person: DS.belongsTo('person', { async: false, inverse: null })
+  });
+
+  let env = setupStore({
+    person: Person,
+    pet: Pet
+  });
+  env.adapter.shouldBackgroundReloadRecord = () => false;
+  env.adapter.deleteRecord = () => {
+    return Ember.RSVP.Promise.resolve({
+      data: null,
+      included: [
+        {
+          type: 'person',
+          id: '1',
+          attributes: {
+            name: 'Chris Thoburn'
+          },
+          relationships: {
+            pets: {
+              data: [
+                { type: 'pet', id: '2' }
+              ]
+            }
+          }
+        }
+      ]
+    });
+  };
+
+  let { store } = env;
+
+  run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Chris Thoburn'
+        },
+        relationships: {
+          pets: {
+            data: [
+              { type: 'pet', id: '1' },
+              { type: 'pet', id: '2' }
+            ]
+          }
+        }
+      },
+      included: [
+        {
+          type: 'pet',
+          id: '1',
+          attributes: {
+            name: 'Shenanigans'
+          }
+        },
+        {
+          type: 'pet',
+          id: '2',
+          attributes: {
+            name: 'Rambunctious'
+          }
+        },
+        {
+          type: 'pet',
+          id: '3',
+          attributes: {
+            name: 'Rebel'
+          }
+        }
+      ]
+    });
+  });
+
+  const person = store.peekRecord('person', '1');
+  const pets = run(() => person.get('pets'));
+
+  const shen = store.peekRecord('pet', '1');
+  const rambo = store.peekRecord('pet', '2');
+  const rebel = store.peekRecord('pet', '3');
+
+  assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+  assert.equal(get(pets, 'length'), 2, 'precond - relationship has only one pet to start');
+
+  run(() => {
+    pets.pushObjects([rebel]);
+  });
+
+  assert.equal(get(pets, 'length'), 3, 'precond2 - relationship now has three pets');
+
+  run(() => {
+    shen.destroyRecord({})
+      .then(() => {
+        shen.unloadRecord();
+      });
+  });
+
+  // were ember-data to now preserve local edits during a relationship push, this would be '2'
+  assert.equal(get(pets, 'length'), 1, 'relationship now has one pet');
+  assert.equal(pets.objectAt(0), rambo, 'the expected pet remains');
+});
 
 test('possible to replace items in a relationship using setObjects w/ Ember Enumerable Array/Object as the argument (GH-2533)', function(assert) {
   assert.expect(2);


### PR DESCRIPTION
If this approach is deemed good, this should be backported to beta and release.

This addresses an issue uncovered by the work to improve relationships: deleting a relationship results in a call to `flushCanonical` which erases any other local changes made. We can prevent local edits being removed for the common case (delete returning no additional data).

cc @igorT @hjdivad @stefanpenner for review