### PR TITLE
[DOC release] Update doc for deprecated function.

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -196,7 +196,7 @@ const {
 
   Note: When creating a new record using any of the above methods
   Ember Data will update `DS.RecordArray`s such as those returned by
-  `store#peekAll()`, `store#findAll()` or `store#filter()`. This means any
+  `store#peekAll()` or `store#findAll()`. This means any
   data bindings or computed properties that depend on the RecordArray
   will automatically be synced to include the new or updated record
   values.


### PR DESCRIPTION
 - store#filter() is now [deprecated](https://github.com/emberjs/data/blob/master/addon/-private/system/store.js#L1785)
 - Don't suggest it's usage