### PR TITLE
{release} [BUGFIX release] handle dupe relationship entries

### DIFF
--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -200,17 +200,25 @@ export default class ManyRelationship extends Relationship {
   }
 
   setInitialInternalModels(internalModels) {
-    if (!internalModels) {
+    if (Array.isArray(internalModels) === false || internalModels.length === 0) {
       return;
     }
 
-    let args = [0, this.canonicalState.length].concat(internalModels);
-    this.canonicalState.splice.apply(this.canonicalState, args);
-    internalModels.forEach(internalModel => {
+    let forCanonical = [];
+
+    for (let i = 0; i< internalModels.length; i++) {
+      let internalModel = internalModels[i];
+      if (this.canonicalMembers.has(internalModel)) {
+        continue;
+      }
+
+      forCanonical.push(internalModel);
       this.canonicalMembers.add(internalModel);
       this.members.add(internalModel);
       this.setupInverseRelationship(internalModel);
-    });
+    }
+
+    this.canonicalState.splice(0, this.canonicalState.length, ...forCanonical);
   }
 
   fetchLink() {


### PR DESCRIPTION
If a relationship was setup with duplicate entries, it would enter an
invalid state. Specifically, this.canonicalMembers and
this.canonicalState would be out of sync. Resulting in some sad things.

This was most likely introduced by https://github.com/emberjs/data/commit/f8304b23c792a1e74cefb63140e6ee1917cbdfa1#commitcomment-23256408