### PR TITLE
[BUGFIX release] relationship [x, y] should not break on x.unloadRecord()

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -430,14 +430,10 @@ export default class InternalModel {
   */
   _directlyRelatedInternalModels() {
     let array = [];
-    this.type.eachRelationship((key, relationship) => {
-      if (this._relationships.has(key)) {
-        let relationship = this._relationships.get(key);
-        let localRelationships = relationship.members.toArray();
-        let serverRelationships = relationship.canonicalMembers.toArray();
-
-        array = array.concat(localRelationships, serverRelationships);
-      }
+    this._relationships.forEach((name, rel) => {
+      let local = rel.members.toArray();
+      let server = rel.canonicalMembers.toArray();
+      array = array.concat(local, server);
     });
     return array;
   }
@@ -491,6 +487,7 @@ export default class InternalModel {
   unloadRecord() {
     this.send('unloadRecord');
     this.dematerializeRecord();
+
     if (this._scheduledDestroy === null) {
       this._scheduledDestroy = run.schedule('destroy', this, '_checkForOrphanedInternalModels');
     }
@@ -510,6 +507,7 @@ export default class InternalModel {
     if (this.isDestroyed) { return; }
 
     this._cleanupOrphanedInternalModels();
+
   }
 
   _cleanupOrphanedInternalModels() {
@@ -532,6 +530,9 @@ export default class InternalModel {
     assert("Cannot destroy an internalModel while its record is materialized", !this._record || this._record.get('isDestroyed') || this._record.get('isDestroying'));
 
     this.store._internalModelDestroyed(this);
+
+    this._relationships.forEach((name, rel) => rel.destroy());
+
     this._isDestroyed = true;
   }
 
@@ -888,14 +889,10 @@ export default class InternalModel {
     @private
    */
   removeFromInverseRelationships(isNew = false) {
-    this.eachRelationship((name) => {
-      if (this._relationships.has(name)) {
-        let rel = this._relationships.get(name);
-
-        rel.removeCompletelyFromInverse();
-        if (isNew === true) {
-          rel.clear();
-        }
+    this._relationships.forEach((name, rel) => {
+      rel.removeCompletelyFromInverse();
+      if (isNew === true) {
+        rel.clear();
       }
     });
 
@@ -917,17 +914,28 @@ export default class InternalModel {
     and destroys any ManyArrays.
    */
   destroyRelationships() {
-    this.eachRelationship((name, relationship) => {
-      if (this._relationships.has(name)) {
-        let rel = this._relationships.get(name);
+    this._relationships.forEach((name, rel) => {
+      if (rel._inverseIsAsync()) {
+        rel.removeInternalModelFromInverse(this);
         rel.removeInverseRelationships();
+      } else {
+        rel.removeCompletelyFromInverse();
       }
     });
 
     let implicitRelationships = this._implicitRelationships;
     this.__implicitRelationships = null;
     Object.keys(implicitRelationships).forEach((key) => {
-      implicitRelationships[key].removeInverseRelationships();
+      let rel = implicitRelationships[key];
+
+      if (rel._inverseIsAsync()) {
+        rel.removeInternalModelFromInverse(this);
+        rel.removeInverseRelationships();
+      } else {
+        rel.removeCompletelyFromInverse();
+      }
+
+      rel.destroy();
     });
   }
 

--- a/addon/-private/system/relationships/state/create.js
+++ b/addon/-private/system/relationships/state/create.js
@@ -48,6 +48,13 @@ export default class Relationships {
     return !!this.initializedRelationships[key];
   }
 
+  forEach(cb) {
+    let rels = this.initializedRelationships;
+    Object.keys(rels).forEach(name => {
+      cb(name, rels[name]);
+    });
+  }
+
   get(key) {
     let relationships = this.initializedRelationships;
     let relationship = relationships[key];

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -287,6 +287,20 @@ export default class ManyRelationship extends Relationship {
       this.updateInternalModelsFromAdapter(internalModels);
     }
   }
+
+  destroy() {
+    super.destroy();
+    let manyArray = this._manyArray;
+    if (manyArray) {
+      manyArray.destroy();
+    }
+
+    let proxy = this.__loadingPromise;
+
+    if (proxy) {
+      proxy.destroy();
+    }
+  }
 }
 
 function setForArray(array) {

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -83,6 +83,13 @@ export default class Relationship {
     return this.internalModel.modelName;
   }
 
+  _inverseIsAsync() {
+    if (!this.inverseKey || !this.inverseInternalModel) {
+      return false;
+    }
+    return this.inverseInternalModel._relationships.get(this.inverseKey).isAsync;
+  }
+
   removeInverseRelationships() {
     if (!this.inverseKey) { return; }
 
@@ -174,7 +181,7 @@ export default class Relationship {
       let relationship = relationships[this.inverseKeyForImplicit];
       if (!relationship) {
         relationship = relationships[this.inverseKeyForImplicit] =
-          new Relationship(this.store, internalModel, this.key,  { options: {} });
+          new Relationship(this.store, internalModel, this.key,  { options: { async: this.isAsync } });
       }
       relationship.addCanonicalInternalModel(this.internalModel);
     }
@@ -215,7 +222,7 @@ export default class Relationship {
         internalModel._relationships.get(this.inverseKey).addInternalModel(this.internalModel);
       } else {
         if (!internalModel._implicitRelationships[this.inverseKeyForImplicit]) {
-          internalModel._implicitRelationships[this.inverseKeyForImplicit] = new Relationship(this.store, internalModel, this.key,  { options: {} });
+          internalModel._implicitRelationships[this.inverseKeyForImplicit] = new Relationship(this.store, internalModel, this.key,  { options: { async: this.isAsync } });
         }
         internalModel._implicitRelationships[this.inverseKeyForImplicit].addInternalModel(this.internalModel);
       }
@@ -453,4 +460,7 @@ export default class Relationship {
   }
 
   updateData() {}
+
+  destroy() {
+  }
 }

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -205,16 +205,17 @@ test("hasMany + canonical vs currentState + unloadRecord", function(assert) {
     env.store.peekRecord('user', 6).unloadRecord();
   });
 
-  assert.deepEqual(contacts.map(c => c.get('id')), ['2','3','4','5','6','7'], `user's contacts should have expected contacts`);
+  assert.deepEqual(contacts.map(c => c.get('id')), ['3','4','5','7'], `user's contacts should have expected contacts`);
   assert.equal(contacts, user.get('contacts'));
 
   run(() => {
     contacts.addObject(env.store.createRecord('user', { id: 8 }));
   });
 
-  assert.deepEqual(contacts.map(c => c.get('id')), ['2','3','4','5','6','7','8'], `user's contacts should have expected contacts`);
+  assert.deepEqual(contacts.map(c => c.get('id')), ['3','4','5','7','8'], `user's contacts should have expected contacts`);
   assert.equal(contacts, user.get('contacts'));
 });
+
 test("adapter.findMany only gets unique IDs even if duplicate IDs are present in the hasMany relationship", function(assert) {
   assert.expect(2);
 

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -134,6 +134,87 @@ test("When a hasMany relationship is accessed, the adapter's findMany method sho
   });
 });
 
+test("hasMany + canonical vs currentState + unloadRecord", function(assert) {
+  assert.expect(6);
+
+  let postData = {
+    type: 'user',
+    id: '1',
+    attributes: {
+      name: 'omg'
+    },
+    relationships: {
+      contacts: {
+        data: [
+          {
+            type: 'user',
+            id: 2
+          },
+          {
+            type: 'user',
+            id: 3
+          },
+          {
+            type: 'user',
+            id: 4
+          }
+        ]
+      }
+    }
+  };
+
+  run(() => {
+    env.store.push({
+      data: postData,
+      included: [
+        {
+          type: 'user',
+          id: 2
+        },
+        {
+          type: 'user',
+          id: 3
+        },
+        {
+          type: 'user',
+          id: 4
+        }
+      ]
+    });
+  });
+
+  let user = env.store.peekRecord('user', 1);
+  let contacts = user.get('contacts');
+
+  env.store.adapterFor('user').deleteRecord = function() {
+    return { data: { type: 'user', id: 2 } };
+  };
+
+  assert.deepEqual(contacts.map(c => c.get('id')), ['2','3','4'], 'user should have expected contacts');
+
+  run(() => {
+    contacts.addObject(env.store.createRecord('user', { id: 5 }));
+    contacts.addObject(env.store.createRecord('user', { id: 6 }));
+    contacts.addObject(env.store.createRecord('user', { id: 7 }));
+  });
+
+  assert.deepEqual(contacts.map(c => c.get('id')), ['2','3','4','5','6','7'], 'user should have expected contacts');
+
+  run(() => {
+    env.store.peekRecord('user', 2).unloadRecord();
+    env.store.peekRecord('user', 6).unloadRecord();
+  });
+
+  assert.deepEqual(contacts.map(c => c.get('id')), ['2','3','4','5','6','7'], `user's contacts should have expected contacts`);
+  assert.equal(contacts, user.get('contacts'));
+
+  run(() => {
+    contacts.addObject(env.store.createRecord('user', { id: 8 }));
+  });
+
+  assert.deepEqual(contacts.map(c => c.get('id')), ['2','3','4','5','6','7','8'], `user's contacts should have expected contacts`);
+  assert.equal(contacts, user.get('contacts'));
+});
 test("adapter.findMany only gets unique IDs even if duplicate IDs are present in the hasMany relationship", function(assert) {
   assert.expect(2);
 

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -201,7 +201,7 @@ test("destroying the store correctly cleans everything up", function(assert) {
 
   assert.equal(personWillDestroy.called.length, 1, 'expected person to have recieved willDestroy once');
   assert.equal(carWillDestroy.called.length, 1, 'expected car to recieve willDestroy once');
-  assert.equal(carsWillDestroy.called.length, 1, 'expected cars to recieve willDestroy once');
+  assert.equal(carsWillDestroy.called.length, 1, 'expected person.cars to recieve willDestroy once');
   assert.equal(adapterPopulatedPeopleWillDestroy.called.length, 1, 'expected adapterPopulatedPeople to recieve willDestroy once');
   assert.equal(filterdPeopleWillDestroy.called.length, 1, 'expected filterdPeople.willDestroy to have been called once');
 });


### PR DESCRIPTION
 
For an async relationship [x, y] with x.unloadRecord(), now adjusts only the relationship’s currentState, leaving that relationship’s canonical state alone, ensuring the existing client-side delete semantics are preserved. But when that relationship is reloaded, the canonicalState consulted.

For sync relationship [x, y] with x.unloadRecord(), both currentState and canonical state are updated. This is to mirror the client-side delete semantics. But since we cannot reload a sync relationship we must assume this to be the new canonical state and rely on subsequent `push` or `adapterPayloads` or manual `store.push` to update.

This aims to:

* [FIX] hasMany arrays never contain dematerialized records (so they no longer become broken)
* [FIX] using unloadRecord as a type of client side delete
* [PRESERVE] the garbage collector pass to cleanup orphaned models
* [PRESERVE] second access to a relationship which did contain an unloadRecord to cause a reload


note: if both sides of a relationships are unloaded, the above doesn’t apply. This is largely just when members of a loaded relationship are themselves unloaded.

[fixes #4986 #5052 #4987 #4996]