### PR TITLE
[BUGFIX release] restore unloadRecord + createRecord

### DIFF
--- a/tests/unit/store/unload-test.js
+++ b/tests/unit/store/unload-test.js
@@ -100,6 +100,18 @@ test('unload a record', function(assert) {
   });
 });
 
+test('unload followed by create of the same type + id', function(assert) {
+  let record = run(() => store.createRecord('record', { id: 1 }));
+
+  assert.ok(store.recordForId('record', 1) === record, 'record should exactly equal');
+
+  return run(() => {
+    record.unloadRecord();
+    let createdRecord = store.createRecord('record', { id: 1 });
+    assert.ok(record !== createdRecord, 'newly created record is fresh (and was created)');
+  });
+});
+
 module("DS.Store - unload record with relationships");
 
 test('can commit store after unload record with relationships', function(assert) {


### PR DESCRIPTION
The following should be possible:

```js
const record = store.find(‘record’, 1);
record.unloadRecord();
store.createRecord(‘record’, 1);
```

before this commit, the `createRecord` would fail,
as the `record` would not yet be fully unloaded, 
and its ID would still be reserved.