### PR TITLE
[BUGFIX beta] Implement `cacheKeyForTree` hook.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: node_js
 sudo: false
+dist: trusty
 node_js:
   - "7"
 
@@ -8,14 +9,13 @@ cache:
   yarn: true
 
 before_install:
-  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
-  - "phantomjs --version"
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn global add phantomjs-prebuilt
+  - phantomjs --version
 
 install:
-  - yarn
+  - yarn install --no-lockfile --no-interactive
   - ./node_modules/.bin/bower install
 
 script:

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const merge = require('broccoli-merge-trees');
 const semver = require('semver');
 const version = require('./lib/version');
 const BroccoliDebug = require('broccoli-debug');
+const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 
 // allow toggling of heimdall instrumentation
 let INSTRUMENT_HEIMDALL = false;
@@ -213,6 +214,9 @@ module.exports = {
         production: app.bowerDirectory + '/ember-data/ember-data.prod.js'
       });
     }
+  },
+
+  cacheKeyForTree(treeType) {
+    return calculateCacheKeyForTree(treeType, this);
   }
 };
-

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-rollup": "^1.2.0",
+    "calculate-cache-key-for-tree": "^1.1.0",
     "chalk": "^1.1.1",
     "ember-cli-babel": "^6.4.1",
     "ember-cli-path-utils": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,6 +1490,12 @@ calculate-cache-key-for-tree@^1.0.0:
   dependencies:
     json-stable-stringify "^1.0.1"
 
+calculate-cache-key-for-tree@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.1.0.tgz#0c3e42c9c134f3c9de5358c0f16793627ea976d6"
+  dependencies:
+    json-stable-stringify "^1.0.1"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"


### PR DESCRIPTION
This hook was added in [ember-cli/rfcs#90](https://github.com/ember-cli/rfcs/blob/master/complete/0090-addon-tree-caching.md), and essentially guarantees that a given tree returned by an addon is considered stable (or not).

In the case of Ember Data, we do not have different tree output based on our parent (project or addon).

Specifically, this implementation allows both an app _and_ a lazy engine to depend on `ember-data` without duplicating the `ember-data` assets in both the `assets/vendor.js` and `engine-dist/<engine-name>/assets/engine-vendor.js`.

Fixes https://github.com/ember-engines/ember-engines/issues/438.