### PR TITLE
Give Model a static toString method

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1860,6 +1860,16 @@ Model.reopenClass({
     get(this, 'transformedAttributes').forEach((type, name) => {
       callback.call(binding, name, type);
     });
+  },
+
+  /**
+   Returns the name of the model class.
+
+   @method toString
+   @static
+   */
+  toString() {
+    return `model:${get(this, 'modelName')}`;
   }
 });
 

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -19,7 +19,6 @@ module('unit/model - DS.Model', {
       isDrugAddict: DS.attr('boolean'),
       isArchived: DS.attr()
     });
-    Person.toString =  () => 'person';
 
     env = setupStore({
       adapter: DS.JSONAPIAdapter,
@@ -271,7 +270,7 @@ test("a record's id is included in its toString representation", function(assert
     });
 
     return store.findRecord('person', 1).then(record => {
-      assert.equal(record.toString(), `<model:${record.constructor.modelName}:${Ember.guidFor(record)}:1>`, 'reports id in toString');
+      assert.equal(record.toString(), `<model:${record.constructor.modelName}:${guidFor(record)}:1>`, 'reports id in toString');
     });
   });
 });

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -271,7 +271,7 @@ test("a record's id is included in its toString representation", function(assert
     });
 
     return store.findRecord('person', 1).then(record => {
-      assert.equal(record.toString(), `<person:${guidFor(record)}:1>`, 'reports id in toString');
+      assert.equal(record.toString(), `<model:${record.constructor.modelName}:${Ember.guidFor(record)}:1>`, 'reports id in toString');
     });
   });
 });


### PR DESCRIPTION
This changes the dreaded `(unknown mixin)` to something like `model:person`.

This will make things like this error much more useful:

> Error: Assertion Failed: You defined the 'run' relationship on (unknown mixin), but multiple possible inverse relationships of type (unknown mixin) were found on (unknown mixin). Look at http://emberjs.com/guides/models/defining-models/#toc_explicit-inverses for how to explicitly specify inverses