### PR TITLE
Don't notify relationships with links during initialization

### DIFF
--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -346,7 +346,7 @@ export default class Relationship {
     this.store._updateRelationshipState(this);
   }
 
-  updateLink(link) {
+  updateLink(link, initial) {
     heimdall.increment(updateLink);
     warn(`You pushed a record of type '${this.internalModel.modelName}' with a relationship '${this.key}' configured as 'async: false'. You've included a link but no primary data, this may be an error in your payload.`, this.isAsync || this.hasData , {
       id: 'ds.store.push-link-for-sync-relationship'
@@ -355,7 +355,10 @@ export default class Relationship {
 
     this.link = link;
     this.linkPromise = null;
-    this.internalModel.notifyPropertyChange(this.key);
+
+    if (!initial) {
+      this.internalModel.notifyPropertyChange(this.key);
+    }
   }
 
   findLink() {

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2873,7 +2873,7 @@ function setupRelationships(store, internalModel, data, modelNameToInverseMap) {
 
     if (relationshipRequiresNotification) {
       let relationshipData = data.relationships[relationshipName];
-      relationships.get(relationshipName).push(relationshipData);
+      relationships.get(relationshipName).push(relationshipData, false);
     }
 
     // in debug, assert payload validity eagerly

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -3334,3 +3334,34 @@ test("deleted records should stay deleted", function(assert) {
     );
   });
 });
+
+test("hasMany relationship with links doesn't trigger extra change notifications - #4942", function(assert) {
+  run(() => {
+    env.store.push({
+      data: {
+        type: 'book',
+        id: '1',
+        relationships: {
+          chapters: {
+            data: [{ type: 'chapter', id: '1' }],
+            links: { related: '/book/1/chapters' }
+          }
+        }
+      },
+      included: [{ type: 'chapter', id: '1' }]
+    });
+  });
+
+  let book = env.store.peekRecord('book', '1');
+  let count = 0;
+
+  book.addObserver('chapters', () => {
+    count++;
+  });
+
+  run(() => {
+    book.get('chapters');
+  });
+
+  assert.equal(count, 0);
+});


### PR DESCRIPTION
Fixes #4942.
Fixes #5023.
Fixes #5017.


I also took to the liberty of changing https://github.com/emberjs/data/compare/bugfix/4942?expand=1#diff-fd4c34d9a34dfde73cd3413128a3c973L2876 to be more explicit.

If this change is approved, we should reach out to people linking to this issue after a release is cut.
- [ ] https://github.com/travis-ci/travis-web/pull/1173
- [ ] https://github.com/acquia/ember-drupal-waterwheel/issues/6
- [ ] https://github.com/niklaslong/ember-has-many/commit/28708aaf88a2cc452f0b4546746456c2c097290b
- [ ] https://github.com/emberobserver/client/commit/7f4c39c30a8f80e9a4b75c964bb4e2c272e030fc
- [ ] https://github.com/fossasia/open-event-frontend/pull/399
- [ ] https://github.com/emberjs/ember.js/issues/13948#issuecomment-314464308
- [ ] https://github.com/rust-lang/crates.io/pull/893