### PR TITLE
Ensure we are properly testing multiple Ember versions.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "interactive": false
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: node_js
 sudo: false
+dist: trusty
 node_js:
   - "7"
 
@@ -8,15 +9,13 @@ cache:
   yarn: true
 
 before_install:
-  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
-  - "phantomjs --version"
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn global add phantomjs-prebuilt
+  - phantomjs --version
 
 install:
-  - yarn
-  - ./node_modules/.bin/bower install
+  - yarn install --no-lockfile --no-interactive
 
 script:
   - ./bin/lint-features

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -490,7 +490,11 @@ export default class InternalModel {
     this.dematerializeRecord();
 
     if (this._scheduledDestroy === null) {
-      this._scheduledDestroy = run.schedule('destroy', this, '_checkForOrphanedInternalModels');
+      // TODO: use run.schedule once we drop 1.13
+      if (!Ember.run.currentRunLoop) {
+        assert('You have turned on testing mode, which disabled the run-loop\'s autorun.\n                  You will need to wrap any code with asynchronous side-effects in a run', Ember.testing);
+      }
+      this._scheduledDestroy = Ember.run.backburner.schedule('destroy', this, '_checkForOrphanedInternalModels')
     }
   }
 

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -23,7 +23,7 @@ export default class ManyRelationship extends Relationship {
       }
       this.__loadingPromise.set('promise', promise)
     } else {
-      this.__loadingPromise = new PromiseManyArray({
+      this.__loadingPromise = PromiseManyArray.create({
         promise,
         content
       });

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -28,7 +28,10 @@ function getOwner(context) {
 
   if (owner && owner.lookupFactory && !owner._lookupFactory) {
     // `owner` is a container, we are just making this work
-    owner._lookupFactory = owner.lookupFactory;
+    owner._lookupFactory = function() {
+      return owner.lookupFactory(...arguments);
+    }
+
     owner.register = function() {
       let registry = owner.registry || owner._registry || owner;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,6 @@ install:
   # Typical npm stuff.
   - md C:\nc
   - appveyor-retry yarn install
-  # Workaround https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows
-  - yarn run bower
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,0 @@
-{
-  "name": "ember-data",
-  "license": "MIT",
-  "dependencies": {}
-}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,9 +3,8 @@ module.exports = {
   scenarios: [
     {
       name: 'default',
-      bower: {
-        dependencies: { }
-      }
+      bower: { },
+      npm: { }
     },
     {
       name: 'ember-1-13',
@@ -18,7 +17,9 @@ module.exports = {
         }
       },
       npm: {
-        'ember-source': null
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -32,7 +33,9 @@ module.exports = {
         }
       },
       npm: {
-        'ember-source': null
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -46,7 +49,9 @@ module.exports = {
         }
       },
       npm: {
-        'ember-source': null
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -60,7 +65,9 @@ module.exports = {
         }
       },
       npm: {
-        'ember-source': null
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -74,7 +81,9 @@ module.exports = {
         }
       },
       npm: {
-        'ember-source': null
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -88,7 +97,9 @@ module.exports = {
         }
       },
       npm: {
-        'ember-source': null
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -102,7 +113,9 @@ module.exports = {
         }
       },
       npm: {
-        'ember-source': null
+        devDependencies: {
+          'ember-source': null
+        }
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const merge = require('broccoli-merge-trees');
 const semver = require('semver');
 const version = require('./lib/version');
 const BroccoliDebug = require('broccoli-debug');
+const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 
 // allow toggling of heimdall instrumentation
 let INSTRUMENT_HEIMDALL = false;
@@ -213,6 +214,9 @@ module.exports = {
         production: app.bowerDirectory + '/ember-data/ember-data.prod.js'
       });
     }
+  },
+
+  cacheKeyForTree(treeType) {
+    return calculateCacheKeyForTree(treeType, this);
   }
 };
-

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "node-tests": "node node-tests/nodetest-runner.js",
     "test:optional-features": "ember test --environment=test-optional-features",
     "test:production": "ember test --environment=production",
-    "bower": "bower install",
     "production": "ember build --environment=production"
   },
   "author": "",
@@ -32,6 +31,7 @@
     "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-rollup": "^1.2.0",
+    "calculate-cache-key-for-tree": "^1.1.0",
     "chalk": "^1.1.1",
     "ember-cli-babel": "^6.4.1",
     "ember-cli-path-utils": "^1.0.0",
@@ -61,7 +61,6 @@
     "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
     "babel-plugin-transform-es2015-spread": "^6.22.0",
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-    "bower": "^1.6.5",
     "broccoli-asset-rev": "^2.4.5",
     "broccoli-concat": "^3.2.2",
     "broccoli-stew": "^1.4.2",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,11 +3,7 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-let App;
-
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
-App = Ember.Application.extend({
+const App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/helpers/model-factory-injection.js
+++ b/tests/helpers/model-factory-injection.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+
+let ORIGINAL_MODEL_FACTORY_INJECTIONS = Ember.MODEL_FACTORY_INJECTIONS;
+
+export function setup(value = true) {
+  if (!hasEmberVersion(2, 14)) {
+    Ember.MODEL_FACTORY_INJECTIONS = value;
+  }
+}
+
+export function reset() {
+  setup(ORIGINAL_MODEL_FACTORY_INJECTIONS);
+}

--- a/tests/helpers/model-factory-injection.js
+++ b/tests/helpers/model-factory-injection.js
@@ -1,9 +1,15 @@
 import Ember from 'ember';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
-let ORIGINAL_MODEL_FACTORY_INJECTIONS = Ember.MODEL_FACTORY_INJECTIONS;
+const ORIGINAL_MODEL_FACTORY_INJECTIONS = Ember.MODEL_FACTORY_INJECTIONS;
 
-export function setup(value = true) {
+export function setup(value) {
+  if (arguments.length > 0) {
+    value = arguments[0];
+  } else {
+    value = true;
+  }
+
   if (!hasEmberVersion(2, 14)) {
     Ember.MODEL_FACTORY_INJECTIONS = value;
   }

--- a/tests/integration/injection-test.js
+++ b/tests/integration/injection-test.js
@@ -1,10 +1,13 @@
+import {
+  setup as setupModelFactoryInjections,
+  reset as resetModelFactoryInjections
+} from 'dummy/tests/helpers/model-factory-injection';
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 import DS from 'ember-data';
 import { module, test } from 'qunit';
 
 let env, hasFactoryFor, originalLookupFactory, originalOwnerLookupFactory, originalFactoryFor;
-let originalMODEL_FACTORY_INJECTIONS = Ember.MODEL_FACTORY_INJECTIONS;
 const { run } = Ember;
 
 const model = {
@@ -79,7 +82,7 @@ test('modelFor', function(assert) {
 
 module('integration/injection eager injections', {
   setup() {
-    Ember.MODEL_FACTORY_INJECTIONS = true;
+    setupModelFactoryInjections();
     env = setupStore();
 
     env.registry.injection('model:foo', 'apple', 'service:apple');
@@ -90,7 +93,7 @@ module('integration/injection eager injections', {
 
   teardown() {
     // can be removed once we no longer support ember versions without lookupFactory
-    Ember.MODEL_FACTORY_INJECTIONS = originalMODEL_FACTORY_INJECTIONS;
+    resetModelFactoryInjections();
 
     run(env.store, 'destroy');
   }

--- a/tests/integration/records/relationship-changes-test.js
+++ b/tests/integration/records/relationship-changes-test.js
@@ -513,9 +513,24 @@ test('Calling push with relationship does not trigger observers if the relations
 });
 
 test('Calling push with relationship triggers willChange and didChange with detail when appending', function(assert) {
-  let person = null;
   let willChangeCount = 0;
   let didChangeCount = 0;
+
+  let observer = {
+    arrayWillChange(array, start, removing, adding) {
+      willChangeCount++;
+      assert.equal(start, 1, 'willChange.start');
+      assert.equal(removing, 0, 'willChange.removing');
+      assert.equal(adding, 1, 'willChange.adding');
+    },
+
+    arrayDidChange(array, start, removed, added) {
+      didChangeCount++;
+      assert.equal(start, 1, 'didChange.start');
+      assert.equal(removed, 0, 'didChange.removed');
+      assert.equal(added, 1, 'didChange.added');
+    }
+  };
 
   run(() => {
     store.push({
@@ -537,26 +552,13 @@ test('Calling push with relationship triggers willChange and didChange with deta
       ]
 
     });
-    person = store.peekRecord('person', 'wat');
-
-    this.arrayWillChange = (array, start, removing, adding) => {
-      willChangeCount++;
-      assert.equal(start, 1);
-      assert.equal(removing, 0);
-      assert.equal(adding, 1);
-    };
-    this.arrayDidChange = (array, start, removed, added) => {
-      didChangeCount++;
-      assert.equal(start, 1);
-      assert.equal(removed, 0);
-      assert.equal(added, 1);
-    };
-
-    person.get('siblings')
-    .then(siblings => {
-      siblings.addArrayObserver(this);
-    });
   });
+
+
+  let person = store.peekRecord('person', 'wat');
+  let siblings = run(() => person.get('siblings'));
+
+  siblings.addArrayObserver(observer);
 
   run(() => {
     store.push({
@@ -577,14 +579,13 @@ test('Calling push with relationship triggers willChange and didChange with deta
     });
   });
 
-  run(() => {
-    assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-    assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
-  });
+  assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
+  assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+
+  siblings.removeArrayObserver(observer);
 });
 
 test('Calling push with relationship triggers willChange and didChange with detail when truncating', function(assert) {
-  let person = null;
   let willChangeCount = 0;
   let didChangeCount = 0;
 
@@ -606,29 +607,29 @@ test('Calling push with relationship triggers willChange and didChange with deta
       included: [
         sibling1, sibling2
       ]
-
     });
-    person = store.peekRecord('person', 'wat');
+  });
 
-    this.arrayWillChange = (array, start, removing, adding) => {
+  let person = store.peekRecord('person', 'wat');
+  let siblings = run(() => person.get('siblings'));
+
+  let observer = {
+    arrayWillChange(array, start, removing, adding) {
       willChangeCount++;
       assert.equal(start, 1);
       assert.equal(removing, 1);
       assert.equal(adding, 0);
-    };
-    this.arrayDidChange = (array, start, removed, added) => {
+    },
+
+    arrayDidChange(array, start, removed, added) {
       didChangeCount++;
       assert.equal(start, 1);
       assert.equal(removed, 1);
       assert.equal(added, 0);
-    };
+    }
+  };
 
-    person.get('siblings')
-    .then(siblings => {
-      siblings.addArrayObserver(this);
-    });
-
-  });
+  siblings.addArrayObserver(observer);
 
   run(() => {
     store.push({
@@ -647,14 +648,13 @@ test('Calling push with relationship triggers willChange and didChange with deta
     });
   });
 
-  run(() => {
-    assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-    assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
-  });
+  assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
+  assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+
+  siblings.removeArrayObserver(observer);
 });
 
 test('Calling push with relationship triggers willChange and didChange with detail when inserting at front', function(assert) {
-  let person = null;
   let willChangeCount = 0;
   let didChangeCount = 0;
 
@@ -676,29 +676,28 @@ test('Calling push with relationship triggers willChange and didChange with deta
       included: [
         sibling2
       ]
-
     });
-    person = store.peekRecord('person', 'wat');
+  });
+  let person = store.peekRecord('person', 'wat');
 
-    this.arrayWillChange = (array, start, removing, adding) => {
+  let observer = {
+    arrayWillChange(array, start, removing, adding) {
       willChangeCount++;
       assert.equal(start, 0);
       assert.equal(removing, 0);
       assert.equal(adding, 1);
-    };
-    this.arrayDidChange = (array, start, removed, added) => {
+    },
+
+    arrayDidChange(array, start, removed, added) {
       didChangeCount++;
       assert.equal(start, 0);
       assert.equal(removed, 0);
       assert.equal(added, 1);
-    };
+    }
+  };
 
-    person.get('siblings')
-    .then(siblings => {
-      siblings.addArrayObserver(this);
-    });
-
-  });
+  let siblings = run(() => person.get('siblings'));
+  siblings.addArrayObserver(observer);
 
   run(() => {
     store.push({
@@ -719,14 +718,13 @@ test('Calling push with relationship triggers willChange and didChange with deta
     });
   });
 
-  run(() => {
-    assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-    assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
-  });
+  assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
+  assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+
+  siblings.removeArrayObserver(observer);
 });
 
 test('Calling push with relationship triggers willChange and didChange with detail when inserting in middle', function(assert) {
-  let person = null;
   let willChangeCount = 0;
   let didChangeCount = 0;
 
@@ -751,27 +749,25 @@ test('Calling push with relationship triggers willChange and didChange with deta
       ]
 
     });
-    person = store.peekRecord('person', 'wat');
-
-    this.arrayWillChange = (array, start, removing, adding) => {
+  });
+  let person = store.peekRecord('person', 'wat');
+  let observer = {
+    arrayWillChange(array, start, removing, adding) {
       willChangeCount++;
       assert.equal(start, 1);
       assert.equal(removing, 0);
       assert.equal(adding, 1);
-    };
-    this.arrayDidChange = (array, start, removed, added) => {
+    },
+    arrayDidChange(array, start, removed, added) {
       didChangeCount++;
       assert.equal(start, 1);
       assert.equal(removed, 0);
       assert.equal(added, 1);
-    };
+    }
+  };
 
-    person.get('siblings')
-    .then(siblings => {
-      siblings.addArrayObserver(this);
-    });
-
-  });
+  let siblings = run(() => person.get('siblings'));
+  siblings.addArrayObserver(observer);
 
   run(() => {
     store.push({
@@ -792,14 +788,13 @@ test('Calling push with relationship triggers willChange and didChange with deta
     });
   });
 
-  run(() => {
-    assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-    assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
-  });
+  assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
+  assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+
+  siblings.removeArrayObserver(observer);
 });
 
 test('Calling push with relationship triggers willChange and didChange with detail when replacing different length in middle', function(assert) {
-  let person = null;
   let willChangeCount = 0;
   let didChangeCount = 0;
 
@@ -823,30 +818,28 @@ test('Calling push with relationship triggers willChange and didChange with deta
         sibling2,
         sibling3
       ]
-
     });
-    person = store.peekRecord('person', 'wat');
+  });
 
-    this.arrayWillChange = (array, start, removing, adding) => {
+  let person = store.peekRecord('person', 'wat');
+  let observer = {
+    arrayWillChange(array, start, removing, adding) {
       willChangeCount++;
       assert.equal(start, 1);
       assert.equal(removing, 1);
       assert.equal(adding, 2);
-    };
+    },
 
-    this.arrayDidChange = (array, start, removed, added) => {
+    arrayDidChange(array, start, removed, added) {
       didChangeCount++;
       assert.equal(start, 1);
       assert.equal(removed, 1);
       assert.equal(added, 2);
-    };
+    }
+  };
 
-    person.get('siblings')
-    .then(siblings => {
-      siblings.addArrayObserver(this);
-    });
-
-  });
+  let siblings =  run(() => person.get('siblings'));
+  siblings.addArrayObserver(observer);
 
   run(() => {
     store.push({
@@ -868,10 +861,10 @@ test('Calling push with relationship triggers willChange and didChange with deta
     });
   });
 
-  run(() => {
-    assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-    assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
-  });
+  assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
+  assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+
+  siblings.removeArrayObserver(observer);
 });
 
 test('Calling push with updated belongsTo relationship trigger observer', function(assert) {

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -2,6 +2,10 @@ import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
+import {
+  setup as setupModelFactoryInjections,
+  reset as resetModelFactoryInjection
+} from 'dummy/tests/helpers/model-factory-injection';
 import {module, test} from 'qunit';
 
 import DS from 'ember-data';
@@ -82,6 +86,7 @@ module("integration/relationship/belongs_to Belongs-To Relationships", {
   },
 
   afterEach() {
+    resetModelFactoryInjection();
     run(env.container, 'destroy');
   }
 });
@@ -491,6 +496,7 @@ test("polymorphic belongsTo class-checks check the superclass when MODEL_FACTORY
 });
 
 test("the subclass in a polymorphic belongsTo relationship is an instanceof its superclass", function(assert) {
+  setupModelFactoryInjections(false);
   assert.expect(1);
   run(() => {
     let message = env.store.createRecord('message', { id: 1 });

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -11,7 +11,6 @@ const { attr, hasMany, belongsTo } = DS;
 const { hash } = RSVP;
 
 let env, store, User, Message, Post, Comment, Book, Chapter, Author, NewMessage;
-const injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
 
 module("integration/relationship/belongs_to Belongs-To Relationships", {
   beforeEach() {
@@ -83,7 +82,6 @@ module("integration/relationship/belongs_to Belongs-To Relationships", {
   },
 
   afterEach() {
-    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
     run(env.container, 'destroy');
   }
 });

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -1,5 +1,9 @@
 /*eslint no-unused-vars: ["error", { "args": "none", "varsIgnorePattern": "(page)" }]*/
 
+import {
+  setup as setupModelFactoryInjections,
+  reset as resetModelFactoryInjections
+} from 'dummy/tests/helpers/model-factory-injection';
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
@@ -1338,8 +1342,7 @@ test("When a polymorphic hasMany relationship is accessed, the store can call mu
 test("polymorphic hasMany type-checks check the superclass when MODEL_FACTORY_INJECTIONS is enabled", function(assert) {
   assert.expect(1);
 
-  let injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
-  Ember.MODEL_FACTORY_INJECTIONS = true;
+  setupModelFactoryInjections();
 
   try {
     run(function () {
@@ -1351,7 +1354,7 @@ test("polymorphic hasMany type-checks check the superclass when MODEL_FACTORY_IN
       assert.equal(igor.get('messages.firstObject.body'), "Well I thought the title was fine");
     });
   } finally {
-    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+    resetModelFactoryInjections();
   }
 });
 

--- a/tests/integration/relationships/polymorphic-mixins-belongs-to-test.js
+++ b/tests/integration/relationships/polymorphic-mixins-belongs-to-test.js
@@ -1,3 +1,8 @@
+import {
+  setup as setupModelFactoryInjections,
+  reset as resetModelFactoryInjections
+} from 'dummy/tests/helpers/model-factory-injection';
+
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
@@ -155,8 +160,7 @@ testInDebug("Setting the polymorphic belongsTo with an object that does not impl
 
 test("Setting the polymorphic belongsTo gets propagated to the inverse side - model injections true", function(assert) {
   assert.expect(2);
-  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
-  Ember.MODEL_FACTORY_INJECTIONS = true;
+  setupModelFactoryInjections();
 
   try {
     var user, video;
@@ -190,13 +194,12 @@ test("Setting the polymorphic belongsTo gets propagated to the inverse side - mo
       });
     });
   } finally {
-    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+    resetModelFactoryInjections();
   }
 });
 
 testInDebug("Setting the polymorphic belongsTo with an object that does not implement the mixin errors out - model injections true", function(assert) {
-  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
-  Ember.MODEL_FACTORY_INJECTIONS = true;
+  setupModelFactoryInjections();
 
   try {
     var user, video;
@@ -226,6 +229,6 @@ testInDebug("Setting the polymorphic belongsTo with an object that does not impl
       }, /You cannot add a record of modelClass 'not-message' to the 'user.bestMessage' relationship \(only 'message' allowed\)/);
     });
   } finally {
-    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+    resetModelFactoryInjections();
   }
 });

--- a/tests/integration/relationships/polymorphic-mixins-has-many-test.js
+++ b/tests/integration/relationships/polymorphic-mixins-has-many-test.js
@@ -1,3 +1,8 @@
+import {
+  setup as setupModelFactoryInjections,
+  reset as resetModelFactoryInjections
+} from 'dummy/tests/helpers/model-factory-injection';
+
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 
@@ -170,8 +175,7 @@ testInDebug("Pushing a an object that does not implement the mixin to the mixin 
 });
 
 test("Pushing to the hasMany reflects the change on the belongsTo side - model injections true", function(assert) {
-  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
-  Ember.MODEL_FACTORY_INJECTIONS = true;
+  setupModelFactoryInjections();
 
   try {
     var user, video;
@@ -209,7 +213,7 @@ test("Pushing to the hasMany reflects the change on the belongsTo side - model i
       });
     });
   } finally {
-    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+    resetModelFactoryInjections();
   }
 });
 
@@ -217,8 +221,7 @@ test("Pushing to the hasMany reflects the change on the belongsTo side - model i
   Local edits
 */
 testInDebug("Pushing a an object that does not implement the mixin to the mixin accepting array errors out - model injections true", function(assert) {
-  var injectionValue = Ember.MODEL_FACTORY_INJECTIONS;
-  Ember.MODEL_FACTORY_INJECTIONS = true;
+  setupModelFactoryInjections();
 
   try {
     var user,notMessage;
@@ -255,7 +258,6 @@ testInDebug("Pushing a an object that does not implement the mixin to the mixin 
       });
     });
   } finally {
-    Ember.MODEL_FACTORY_INJECTIONS = injectionValue;
+    resetModelFactoryInjections();
   }
 });
-

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -5,8 +5,9 @@ import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
 import DS from 'ember-data';
 import { isEnabled } from 'ember-data/-private';
+import { getOwner } from 'ember-data/-private';
 
-const { get, getOwner, set, run } = Ember;
+const { get, set, run } = Ember;
 
 let Person, store, env;
 

--- a/tests/unit/promise-proxies-test.js
+++ b/tests/unit/promise-proxies-test.js
@@ -13,7 +13,7 @@ test('.reload should NOT leak the internal promise, rather return another promis
 
   content.reload = () => Ember.RSVP.Promise.resolve(content);
 
-  let array = new DS.PromiseManyArray({
+  let array = DS.PromiseManyArray.create({
     content
   });
 
@@ -32,7 +32,7 @@ test('.reload should be stable', function(assert) {
   content.reload = () => Ember.RSVP.Promise.resolve(content);
   let promise = Ember.RSVP.Promise.resolve(content);
 
-  let array = new DS.PromiseManyArray({
+  let array = DS.PromiseManyArray.create({
     promise
   });
 
@@ -75,7 +75,7 @@ test('.set to new promise should be like reload', function(assert) {
 
   let promise = Ember.RSVP.Promise.resolve(content);
 
-  let array = new DS.PromiseManyArray({
+  let array = DS.PromiseManyArray.create({
     promise
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,6 +1490,12 @@ calculate-cache-key-for-tree@^1.0.0:
   dependencies:
     json-stable-stringify "^1.0.1"
 
+calculate-cache-key-for-tree@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.1.0.tgz#0c3e42c9c134f3c9de5358c0f16793627ea976d6"
+  dependencies:
+    json-stable-stringify "^1.0.1"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"


### PR DESCRIPTION
Prior to this commit (since c2ca068) we were only testing ember-source@2.11. Even though we had a `config/ember-try.js` with many scenarios, none of them properly removed the `ember-source` version (even though ba7f46221 was specifically trying to do this :sob:).

The fundamental issue here is:

* `ember-try` supports removing packages, but requires that you specify them
  in the `dependencies` or `devDependencies` objects.  Since my changes in
  ba7f46221 added `"ember-source": null` to the root of the `npm` config
  it was completely ignored :disappointed:.
* `ember-source` emits a warning to the console when it is present **and**
  the bower package for `ember` is in use.  Unfortunately, this warning is
  a bit misleading (it doesn't tell you that the `ember-source` from `npm`
  will always win). The `ember-source` addon should be updated to throw an
  error when this misconfiguration is detected.
* `ember-cli` will **always** use `ember-source` if it is present, and
  completely ignore whatever is in `bower.json`. IMHO, this default was not
  correct and `ember-cli` should have done the same thing that `ember-data`
  did during its migration from bower to `npm`: if both packages are present
  default to `bower.json` version with a warning.

---

There are almost certainly failing tests in the various scenarios. I pushed this in a branch so that others can help track down and fix the various issues.