### PR TITLE
Sideloaded nested relationships stopped working

### DIFF
--- a/tests/integration/relationships/nested-relationship-test.js
+++ b/tests/integration/relationships/nested-relationship-test.js
@@ -1,0 +1,144 @@
+import setupStore from 'dummy/tests/helpers/store';
+import Ember from 'ember';
+
+import {module, test} from 'qunit';
+
+import DS from 'ember-data';
+
+var env, store, serializer, Elder, MiddleAger, Kid;
+const { get, run } = Ember;
+
+var attr = DS.attr;
+var hasMany = DS.hasMany;
+var belongsTo = DS.belongsTo;
+
+module('integration/relationships/nested_relationships_test - Nested relationships', {
+  beforeEach() {
+    Elder = DS.Model.extend({
+      name: attr('string'),
+      middleAgers: hasMany('middle-ager')
+    });
+
+    MiddleAger = DS.Model.extend({
+      name: attr('string'),
+      elder: belongsTo('elder'),
+      kids: hasMany('kid')
+    });
+
+    Kid = DS.Model.extend({
+      name: attr('string'),
+      middleAger: belongsTo('middle-ager')
+    });
+
+    env = setupStore({
+      elder: Elder,
+      'middle-ager': MiddleAger,
+      kid: Kid,
+      adapter: DS.JSONAPIAdapter
+    });
+
+    store = env.store;
+    serializer = env.serializer;
+  },
+
+  afterEach() {
+    run(env.container, 'destroy');
+  }
+});
+
+/*
+  Server loading tests
+*/
+
+test("Sideloaded nested relationships load correctly", function(assert) {
+  run(function () {
+    serializer.pushPayload(store, {
+      "data":[
+        {
+          "id":"1",
+          "type":"kids",
+          "links":{
+            "self":"/kids/1"
+          },
+          "attributes":{
+            "name":"Kid 1"
+          },
+          "relationships":{
+            "middle-ager":{
+              "links":{
+                "self":"/kids/1/relationships/middle-ager",
+                "related":"/kids/1/middle-ager"
+              },
+              "data":{
+                "type":"middle-agers",
+                "id":"1"
+              }
+            }
+          }
+        }
+      ],
+      "included":[
+        {
+          "id":"1",
+          "type":"middle-agers",
+          "links":{
+            "self":"/middle-ager/1"
+          },
+          "attributes":{
+            "name":"Middle Ager 1"
+          },
+          "relationships":{
+            "elder":{
+              "links":{
+                "self":"/middle-agers/1/relationships/elder",
+                "related":"/middle-agers/1/elder"
+              },
+              "data":{
+                "type":"elders",
+                "id":"1"
+              }
+            },
+            "kids":{
+              "links":{
+                "self":"/middle-agers/1/relationships/kids",
+                "related":"/middle-agers/1/kids"
+              }
+            }
+          }
+        },
+        {
+          "id":"1",
+          "type":"elders",
+          "links":{
+            "self":"/elders/1"
+          },
+          "attributes":{
+            "name":"Elder 1"
+          },
+          "relationships":{
+            "middle-agers":{
+              "links":{
+                "self":"/elders/1/relationships/middle-agers",
+                "related":"/elders/1/middle-agers"
+              }
+            }
+          }
+        }
+      ]
+    });
+  });
+  run(function() {
+    var kid = store.peekRecord('kid', 1);
+    kid.get('middleAger').then(function(middleAger) {
+      assert.ok(middleAger, 'MiddleAger relationship was set up correctly');
+      var middleAgerName = get(middleAger, 'name');
+      assert.equal(middleAgerName, 'Middle Ager 1', 'MiddleAger name is there');
+    });
+    kid.get('middleAger.elder').then(function(elder) {
+      assert.ok(elder, 'Elder relationship was set up correctly');
+      var elderName = get(elder, 'name');
+      assert.equal(elderName, 'Elder 1', 'Elder name is there');
+    });
+  });
+});
+


### PR DESCRIPTION
Say I was to load a model, sideloading parent models as well:
```
// app/routes/index.js
let kids = this.store.findAll('kid', { include: 'middle-ager.elder' })
return Ember.RSVP.hash({ kids })
```
Which generates this JSONAPI response:
<details>
  <summary> JSONAPI Response</summary>
  
```
{
  "data":[
    {
      "id":"1",
      "type":"kids",
      "links":{
        "self":"/kids/1"
      },
      "attributes":{
        "name":"Kid 1"
      },
      "relationships":{
        "middle-ager":{
          "links":{
            "self":"/kids/1/relationships/middle-ager",
            "related":"/kids/1/middle-ager"
          },
          "data":{
            "type":"middle-agers",
            "id":"1"
          }
        }
      }
    }
  ],
  "included":[
    {
      "id":"1",
      "type":"middle-agers",
      "links":{
        "self":"/middle-ager/1"
      },
      "attributes":{
        "name":"Middle Ager 1"
      },
      "relationships":{
        "elder":{
          "links":{
            "self":"/middle-agers/1/relationships/elder",
            "related":"/middle-agers/1/elder"
          },
          "data":{
            "type":"elders",
            "id":"1"
          }
        },
        "kids":{
          "links":{
            "self":"/middle-agers/1/relationships/kids",
            "related":"/middle-agers/1/kids"
          }
        }
      }
    },
    {
      "id":"1",
      "type":"elders",
      "links":{
        "self":"/elders/1"
      },
      "attributes":{
        "name":"Elder 1"
      },
      "relationships":{
        "middle-agers":{
          "links":{
            "self":"/elders/1/relationships/middle-agers",
            "related":"/elders/1/middle-agers"
          }
        }
      }
    }
  ]
}
```
</details>    
<p></p>

Then in a template:
```
{{#each model.kids as |kid|
  {{kid.name}} <!-- THIS IS OK -->
  {{kid.middleAger.name}} <!-- THIS IS OK -->
  {{kid.middleAger.elder.name}} <!-- THIS IS BROKEN -->
{{/each}}
```
It seems that accessing the nested model that is two levels deep no longer works.

This PR includes a test that replicates the issue.

### Versions effected:
`2.14.0-beta.1` - `2.16.0-canary`

This problem appears to have been introduced in this commit: [a38f408](https://github.com/emberjs/data/commit/a38f408202ef8fdc4d9b944956fc17945a69cd25)

### Versions not effected
 Anything below `2.13.2`

### Relevant Twiddles:

**ember-data 2.12.2 works fine:** [Twiddle](https://ember-twiddle.com/e718a1d5aeb0c988d522a9b20788fa76?openFiles=twiddle.json%2C) 
<sub>(ember-data 2.13.2 works fine too, but [twiddle does not work with ember-data 2.13.2 yet](https://github.com/ember-cli/ember-twiddle/issues/560)</sub>

**ember-data 2.14.10 does not work**: [Twiddle](https://ember-twiddle.com/c5a158fba8277c15e6b9b6f1a3872ccd?openFiles=twiddle.json%2C)

### Related issues
https://github.com/emberjs/data/issues/4982

