### PR TITLE
Failing test for #5125 and attempted fix

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1979,6 +1979,11 @@ Store = Service.extend({
       return;
     }
 
+    let existingInternalModel = this._existingInternalModelForId(modelName, id);
+
+    assert(`'${modelName}' was saved to the server, but the response returned the new id '${id}', which has already been used with another record.'`,
+      isNone(existingInternalModel) || existingInternalModel === internalModel);
+
     this._internalModelsFor(internalModel.modelName).set(id, internalModel);
 
     internalModel.setId(id);
@@ -2559,15 +2564,7 @@ Store = Service.extend({
 
     assert(`You can no longer pass a modelClass as the first argument to store._buildInternalModel. Pass modelName instead.`, typeof modelName === 'string');
 
-    let internalModels = this._internalModelsFor(modelName);
-    let existingInternalModel = internalModels.get(id);
-
-    if (existingInternalModel && existingInternalModel.hasScheduledDestroy()) {
-      // unloadRecord is async, if one attempts to unload + then sync create,
-      // we must ensure the unload is complete before starting the create
-      existingInternalModel.destroySync();
-      existingInternalModel = null;
-    }
+    let existingInternalModel = this._existingInternalModelForId(modelName, id);
 
     assert(`The id ${id} has already been used with another record for modelClass '${modelName}'.`, !existingInternalModel);
 
@@ -2575,8 +2572,20 @@ Store = Service.extend({
     // instances with the injections applied
     let internalModel = new InternalModel(modelName, id, this, data);
 
-    internalModels.add(internalModel, id);
+    this._internalModelsFor(modelName).add(internalModel, id);
 
+    return internalModel;
+  },
+
+  _existingInternalModelForId(modelName, id) {
+    let internalModel = this._internalModelsFor(modelName).get(id);
+
+    if (internalModel && internalModel.hasScheduledDestroy()) {
+      // unloadRecord is async, if one attempts to unload + then sync create,
+      // we must ensure the unload is complete before starting the create
+      internalModel.destroySync();
+      internalModel = null;
+    }
     return internalModel;
   },
 

--- a/tests/integration/records/unload-test.js
+++ b/tests/integration/records/unload-test.js
@@ -735,3 +735,31 @@ test("after unloading a record, the record can be fetched again soon there after
 
   assert.equal(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded after findRecord');
 });
+
+test('after unloading a record, the record can be saved again immediately', function (assert) {
+  assert.expect(0);
+
+  const store = env.store;
+  const data = {
+    data: {
+      type: 'person',
+      id: '1',
+      attributes: {
+        name: 'Adam Sunderland'
+      }
+    }
+  };
+
+  env.adapter.createRecord = () => Ember.RSVP.Promise.resolve(data);
+
+  run(() => {
+    // add an initial record with id '1' to the store
+    store.push(data);
+
+    // unload the initial record
+    store.peekRecord('person', '1').unloadRecord();
+
+    // create a new record that will again get id '1' from the backend
+    store.createRecord('person').save();
+  });
+});


### PR DESCRIPTION
Add a failing test for https://github.com/emberjs/data/issues/5125 and make an attempt at fixing the issue.

It seems that internal models scheduled for destruction also need to be destroyed synchronously in didSaveRecord(), similar to as it's already done in createRecord(). 
