### PR TITLE
Defer to `record._{changedKeys,assign}` if present

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1,3 +1,4 @@
+import { assign, merge } from '@ember/polyfills';
 import ComputedProperty from '@ember/object/computed';
 import { setOwner } from '@ember/application';
 import { isNone } from '@ember/utils';
@@ -21,6 +22,9 @@ import {
   relatedTypesDescriptor,
   relationshipsDescriptor
 } from '../relationships/ext';
+import changedKeys from '../../utils/changed-keys'
+
+const emberAssign = assign || merge;
 
 /**
   @module ember-data
@@ -1121,6 +1125,14 @@ const Model = EmberObject.extend(Evented, {
 
   eachAttribute(callback, binding) {
     this.constructor.eachAttribute(callback, binding);
+  },
+
+  _assignAttributes(attributes, updates) {
+    return emberAssign(attributes, updates);
+  },
+
+  _changedKeys(data, attributes, inFlightAttributes, updates) {
+    return changedKeys(data, attributes, inFlightAttributes, updates);
   }
 });
 

--- a/addon/-private/utils/changed-keys.js
+++ b/addon/-private/utils/changed-keys.js
@@ -1,0 +1,37 @@
+import { assign, merge } from '@ember/polyfills';
+import { isEqual } from '@ember/utils';
+
+const emberAssign = assign || merge;
+
+export default function changedKeys(data, attributes, inFlightAttributes, updates) {
+  let changedKeys = [];
+
+  if (updates) {
+    let original, i, value, key;
+    let keys = Object.keys(updates);
+    let length = keys.length;
+    let hasAttrs = attributes !== null && Object.keys(attributes).length > 0;
+
+    original = emberAssign(Object.create(null), data);
+    original = emberAssign(original, inFlightAttributes);
+
+    for (i = 0; i < length; i++) {
+      key = keys[i];
+      value = updates[key];
+
+      // A value in _attributes means the user has a local change to
+      // this attributes. We never override this value when merging
+      // updates from the backend so we should not sent a change
+      // notification if the server value differs from the original.
+      if (hasAttrs === true && attributes[key] !== undefined) {
+        continue;
+      }
+
+      if (!isEqual(original[key], value)) {
+        changedKeys.push(key);
+      }
+    }
+  }
+
+  return changedKeys;
+}

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1,3 +1,4 @@
+import { assign, merge } from '@ember/polyfills';
 import { guidFor } from '@ember/object/internals';
 import { Promise as EmberPromise, resolve } from 'rsvp';
 import { set, get, observer, computed } from '@ember/object';
@@ -10,6 +11,8 @@ import { module, test } from 'qunit';
 import DS from 'ember-data';
 import { isEnabled } from 'ember-data/-private';
 import { getOwner } from 'ember-data/-private';
+
+const emberAssign = assign || merge;
 
 let Person, store, env;
 
@@ -1522,5 +1525,203 @@ test('accessing the model id without the get function should work when id is wat
     store.updateId(person._internalModel, { id: 'john' });
 
     assert.equal(person.id, 'john', 'new id should be correctly set.');
+  });
+});
+
+test('Model classes can provide their own key change semantics', function(assert) {
+  const Person = DS.Model.extend({
+    name: DS.attr('string'),
+    extra: DS.attr(),
+
+    _changedKeys(data, attributes, inFlightAttributes, updates) {
+      return Object.keys(updates).map(key => {
+        if (key === 'extra') {
+          // users may want to have a way of asserting that POJO attributes have
+          // not changed
+          return this.get('extra').id !== updates.extra.id && 'extra';
+        } else {
+          return this.get(key) !== updates[key] && key;
+        }
+      }).filter(Boolean);
+    }
+  });
+
+  let { store, adapter } = setupStore({
+    person: Person
+  });
+
+  adapter.updateRecord = function(store, type, snapshot) {
+    return Ember.RSVP.Promise.resolve({
+      data: {
+        id: 1,
+        type: 'person',
+        attributes: {
+          name: snapshot.attr('name'),
+          extra: emberAssign({}, snapshot.attr('extra'))
+        }
+      }
+    })
+  };
+
+  let changes = [];
+
+  function addToChanges(model, property) {
+    changes.push(property);
+  }
+
+  return run(() => {
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Edward Gibbon',
+          extra: {
+            id: 1,
+            prop: 'value'
+          }
+        }
+      }
+    });
+
+    let person = store.peekRecord('person', 1);
+
+    person.addObserver('name', addToChanges);
+    person.addObserver('extra', addToChanges);
+
+    assert.deepEqual(changes, [], 'no changes yet');
+
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Mr. Edward Gibbon',
+          extra: {
+            id: 1,
+            prop: 'next value same id'
+          }
+        }
+      }
+    });
+
+    assert.deepEqual(changes, ['name'], 'both props change but custom _changedKeys ignores one');
+    changes.splice(0, changes.length);
+
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Mr. Edward Gibbon',
+          extra: {
+            id: 2,
+            prop: 'next value same id'
+          }
+        }
+      }
+    });
+
+    assert.deepEqual(changes, ['extra'], 'custom _changedKeys acknowledges property change');
+    changes.splice(0, changes.length);
+
+    return person.save().then(() => {
+      assert.deepEqual(changes, [], 'custom _changedKeys ignores POJOs that are the same');
+    });
+  });
+});
+
+test('Model classes can provide their own attribute assignment semantics', function(assert) {
+  const Person = DS.Model.extend({
+    name: DS.attr('string'),
+    birthYear: DS.attr(),
+
+    _changedKeys(data, attributes, inFlightAttributes, updates) {
+      let keys = Object.keys(updates);
+      let changed = [];
+      // report all missing keys as changed
+      this.eachAttribute((key, meta) => {
+        if (keys.indexOf(key) === -1) {
+          changed.push(key);
+        }
+      });
+
+      // also all new keys
+      keys.forEach(key => {
+        if (!(key in this._internalModel._data)) {
+          changed.push(key);
+        }
+      });
+      return changed;
+    },
+
+    _assignAttributes(attributes, updates) {
+      // remove missing attributes, instsead of treating them as unchanged
+      return updates;
+    }
+  });
+
+  let { store, adapter } = setupStore({
+    person: Person
+  });
+
+  adapter.updateRecord = function(store, type, snapshot) {
+    return Ember.RSVP.Promise.resolve({
+      data: {
+        id: 1,
+        type: 'person',
+        attributes: {
+          name: snapshot.attr('name')
+        }
+      }
+    })
+  };
+
+  return run(() => {
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Edward Gibbon',
+          birthYear: 1737
+        }
+      }
+    });
+
+    assert.equal(person.get('name'), 'Edward Gibbon', 'get name');
+    assert.equal(person.get('birthYear'), 1737, 'get birthYear');
+
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Edward Gibbon'
+        }
+      }
+    });
+
+    assert.equal(person.get('name'), 'Edward Gibbon', 'get name');
+    assert.equal(person.get('birthYear'), undefined, 'get birthYear (removed)');
+
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Edward Gibbon',
+          birthYear: 1737
+        }
+      }
+    });
+
+    assert.equal(person.get('name'), 'Edward Gibbon', 'get name');
+    assert.equal(person.get('birthYear'), 1737, 'get birthYear');
+
+    return person.save().then(() => {
+      assert.equal(person.get('name'), 'Edward Gibbon', 'get name');
+      assert.equal(person.get('birthYear'), undefined, 'get birthYear (removed adapter response)');
+    });
   });
 });


### PR DESCRIPTION
This is a small step towards enabling a swappable model class which is useful for people who want to use ember data (and indeed even inter-op with DS.Model) but have less well-defined APIs or APIs that are large enough where defining their own DS.Model for each

It is private for now to enable experimentation.