### PR TITLE
[BUGFIX release] Load many2many relationships correctly

### DIFF
--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -209,7 +209,7 @@ export default class ManyRelationship extends Relationship {
 
     for (let i = 0; i< internalModels.length; i++) {
       let internalModel = internalModels[i];
-      if (this.canonicalMembers.has(internalModel)) {
+      if (forCanonical.indexOf(internalModel) !== -1) {
         continue;
       }
 

--- a/tests/unit/model/relationships/has-many-test.js
+++ b/tests/unit/model/relationships/has-many-test.js
@@ -477,6 +477,136 @@ test('hasMany with duplicates from payload', function(assert) {
   });
 });
 
+test('many2many loads both sides #5140', function(assert) {
+  assert.expect(3);
+
+  const Tag = DS.Model.extend({
+    name: DS.attr('string'),
+    people: DS.hasMany('person', { async: false })
+  });
+
+  Tag.reopenClass({
+    toString() {
+      return 'tag';
+    }
+  });
+
+  const Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tags: DS.hasMany('tags', { async: false })
+  });
+
+  Person.reopenClass({
+    toString() {
+      return 'person';
+    }
+  });
+
+  let env = setupStore({ tag: Tag, person: Person });
+  let { store } = env;
+
+  run(() => {
+    // first we push in data with the relationship
+    store.push({
+      data: [
+        {
+          type: 'person',
+          id: 1,
+          attributes: {
+            name: 'David J. Hamilton'
+          },
+          relationships: {
+            tags: [{
+              data: {
+                type: 'tag',
+                id: 1
+              }
+            },
+            {
+              data: {
+                type: 'tag',
+                id: 2
+              }
+            }]
+          }
+        },
+        {
+          type: 'person',
+          id: 2,
+          attributes: {
+            name: 'Gerald Dempsey Posey'
+          },
+          relationships: {
+            tags: [{
+              data: {
+                type: 'tag',
+                id: 1
+              }
+            },
+            {
+              data: {
+                type: 'tag',
+                id: 2
+              }
+            }]
+          }
+        },
+        {
+          type: 'tag',
+          id: 1,
+          attributes: {
+            name: 'whatever'
+          },
+          relationships: {
+            people: {
+              data: [
+                {
+                  type: 'person',
+                  id: 1
+                },
+                {
+                  type: 'person',
+                  id: 2
+                }
+              ]
+            }
+          }
+        },
+        {
+          type: 'tag',
+          id: 2,
+          attributes: {
+            name: 'nothing'
+          },
+          relationships: {
+            people: {
+              data: [
+                {
+                  type: 'person',
+                  id: 1
+                },
+                {
+                  type: 'person',
+                  id: 2
+                }
+              ]
+            }
+          }
+        }
+      ]
+    });
+  });
+
+  run(() => {
+    let tag = store.peekRecord('tag', 1);
+    assert.equal(tag.get('people.length'), 2, 'relationship does contain all data');
+    let person1 = store.peekRecord('person', 1);
+    assert.equal(person1.get('tags.length'), 2, 'relationship does contain all data');
+    let person2 = store.peekRecord('person', 2);
+    assert.equal(person2.get('tags.length'), 2, 'relationship does contain all data');
+  });
+});
+
 test('hasMany with explicit null works even when the inverse was set to not null', function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
Fair warning, I really don't know what this fix does. I think the original commit I'm patching had a small logic error that this fixes, but I hope @stefanpenner (who did the original work) can verify that. This change does fix the issue I was seeing though so I'm hopeful it is correct.

When a many2many relationship exists and more than one related item is
included in the relationship ensure that both sides load completely.

This issue was introduced in e430edee24591afa562167c6f5775b61d1031b75

Fixes #5140