### PR TITLE
{backport beta} Beta backport 5144

### DIFF
--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -205,21 +205,18 @@ export default class ManyRelationship extends Relationship {
       return;
     }
 
-    let forCanonical = [];
-
     for (let i = 0; i< internalModels.length; i++) {
       let internalModel = internalModels[i];
       if (this.canonicalMembers.has(internalModel)) {
         continue;
       }
 
-      forCanonical.push(internalModel);
       this.canonicalMembers.add(internalModel);
       this.members.add(internalModel);
       this.setupInverseRelationship(internalModel);
     }
 
-    this.canonicalState.splice(0, this.canonicalState.length, ...forCanonical);
+    this.canonicalState = this.canonicalMembers.toArray();
   }
 
   fetchLink() {


### PR DESCRIPTION
When a many2many relationship exists and more than one related item is
included in the relationship ensure that both sides load completely.

This issue was introduced in e430edee24591afa562167c6f5775b61d1031b75