### PR TITLE
[CLEANUP] PERF prevent duplicate recordArrayManager signals on push o…

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -358,7 +358,6 @@ export default class InternalModel {
 
   resetRecord() {
     this._record = null;
-    this.dataHasInitialized = false;
     this.isReloading = false;
     this.error = null;
     this.currentState = RootState.empty;
@@ -592,18 +591,6 @@ export default class InternalModel {
     if (this.hasRecord) {
       this._record._notifyProperties(changedKeys);
     }
-    this.didInitializeData();
-  }
-
-  becameReady() {
-    this.store.recordArrayManager.recordWasLoaded(this);
-  }
-
-  didInitializeData() {
-    if (!this.dataHasInitialized) {
-      this.becameReady();
-      this.dataHasInitialized = true;
-    }
   }
 
   get isDestroyed() {
@@ -638,7 +625,6 @@ export default class InternalModel {
   */
   loadedData() {
     this.send('loadedData');
-    this.didInitializeData();
   }
 
   /*
@@ -783,14 +769,6 @@ export default class InternalModel {
     if (get(this, 'isError')) {
       this._inFlightAttributes = null;
       this.didCleanError();
-    }
-
-    //Eventually rollback will always work for relationships
-    //For now we support it only out of deleted state, because we
-    //have an explicit way of knowing when the server acked the relationship change
-    if (this.isDeleted()) {
-      //TODO: Should probably move this to the state machine somehow
-      this.becameReady();
     }
 
     if (this.isNew()) {

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2017,9 +2017,15 @@ Store = Service.extend({
     heimdall.increment(_load);
     let internalModel = this._internalModelForId(data.type, data.id);
 
+    let isUpdate = internalModel.currentState.isEmpty === false;
+
     internalModel.setupData(data);
 
-    this.recordArrayManager.recordDidChange(internalModel);
+    if (isUpdate) {
+      this.recordArrayManager.recordDidChange(internalModel);
+    } else {
+      this.recordArrayManager.recordWasLoaded(internalModel);
+    }
 
     return internalModel;
   },


### PR DESCRIPTION
…f a new record

* if the record is new, ensure only 1 recordWasLoaded is called (after setup)
* if the record is existing, ensure only 1 recordDidChange is called (after setup)
* decouple InternalModel slightly more from recordArrayManager
* remove now defunct code