### PR TITLE
Backport `ember-inflector` imports

### DIFF
--- a/addon/-private/adapters/build-url-mixin.js
+++ b/addon/-private/adapters/build-url-mixin.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { pluralize } from 'ember-inflector';
 
 const get = Ember.get;
 
@@ -420,11 +421,12 @@ export default Ember.Mixin.create({
 
     ```app/adapters/application.js
     import DS from 'ember-data';
+    import { pluralize } from 'ember-inflector';
 
     export default DS.RESTAdapter.extend({
       pathForType: function(modelName) {
         var decamelized = Ember.String.decamelize(modelName);
-        return Ember.String.pluralize(decamelized);
+        return pluralize(decamelized);
       }
     });
     ```
@@ -435,6 +437,6 @@ export default Ember.Mixin.create({
   **/
   pathForType(modelName) {
     let camelized = Ember.String.camelize(modelName);
-    return Ember.String.pluralize(camelized);
+    return pluralize(camelized);
   }
 });

--- a/addon/adapters/json-api.js
+++ b/addon/adapters/json-api.js
@@ -4,6 +4,7 @@
 */
 
 import Ember from 'ember';
+import { pluralize } from 'ember-inflector';
 import RESTAdapter from "./rest";
 import { isEnabled } from '../-private';
 import { instrument, deprecate } from 'ember-data/-debug';
@@ -257,7 +258,7 @@ const JSONAPIAdapter = RESTAdapter.extend({
 
   pathForType(modelName) {
     let dasherized = Ember.String.dasherize(modelName);
-    return Ember.String.pluralize(dasherized);
+    return pluralize(dasherized);
   },
 
   // TODO: Remove this once we have a better way to override HTTP verbs.

--- a/addon/serializers/json.js
+++ b/addon/serializers/json.js
@@ -959,6 +959,7 @@ const JSONSerializer = Serializer.extend({
 
     ```app/serializers/application.js
     import DS from 'ember-data';
+    import { singularize } from 'ember-inflector';
 
     export default DS.JSONSerializer.extend({
       serialize(snapshot, options) {
@@ -987,7 +988,7 @@ const JSONSerializer = Serializer.extend({
     }
 
     function serverHasManyName(name) {
-      return serverAttributeName(name.singularize()) + "_IDS";
+      return serverAttributeName(singularize(name)) + "_IDS";
     }
     ```
 

--- a/tests/integration/adapter/build-url-mixin-test.js
+++ b/tests/integration/adapter/build-url-mixin-test.js
@@ -1,5 +1,6 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
+import { pluralize } from 'ember-inflector';
 import { isEnabled } from 'ember-data/-private';
 
 import {module, test} from 'qunit';
@@ -183,7 +184,7 @@ test('buildURL - with camelized names', function(assert) {
   adapter.setProperties({
     pathForType(type) {
       var decamelized = Ember.String.decamelize(type);
-      return Ember.String.underscore(Ember.String.pluralize(decamelized));
+      return Ember.String.underscore(pluralize(decamelized));
     }
   });
 

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -1,5 +1,6 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
+import { singularize } from 'ember-inflector';
 
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
@@ -2087,7 +2088,7 @@ test('normalizeKey - to set up _ids and _id', function(assert) {
         var underscored = Ember.String.underscore(rel);
         return underscored + '_id';
       } else {
-        var singular = Ember.String.singularize(rel);
+        var singular = singularize(rel);
         return Ember.String.underscore(singular) + '_ids';
       }
     }

--- a/tests/integration/serializers/rest-serializer-test.js
+++ b/tests/integration/serializers/rest-serializer-test.js
@@ -1,5 +1,6 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
+import { singularize } from 'ember-inflector';
 
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
@@ -104,7 +105,7 @@ test("normalizeResponse with custom modelNameFromPayloadKey", function(assert) {
 
   env.restSerializer.modelNameFromPayloadKey = function(root) {
     var camelized = Ember.String.camelize(root);
-    return Ember.String.singularize(camelized);
+    return singularize(camelized);
   };
 
   var jsonHash = {
@@ -250,7 +251,7 @@ testInDebug("normalizeResponse warning with custom modelNameFromPayloadKey", fun
 
   // should not warn if a model is found.
   env.restSerializer.modelNameFromPayloadKey = function(root) {
-    return Ember.String.camelize(Ember.String.singularize(root));
+    return Ember.String.camelize(singularize(root));
   };
 
   jsonHash = {

--- a/tests/integration/serializers/rest-serializer-test.js
+++ b/tests/integration/serializers/rest-serializer-test.js
@@ -1,6 +1,6 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
-import { singularize } from 'ember-inflector';
+import Inflector, { singularize } from 'ember-inflector';
 
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {module, test} from 'qunit';
@@ -75,7 +75,7 @@ module("integration/serializer/rest - RESTSerializer", {
 
 test("modelNameFromPayloadKey returns always same modelName even for uncountable multi words keys", function(assert) {
   assert.expect(2);
-  Ember.Inflector.inflector.uncountable('words');
+  Inflector.inflector.uncountable('words');
   var expectedModelName = 'multi-words';
   assert.equal(env.restSerializer.modelNameFromPayloadKey('multi_words'), expectedModelName);
   assert.equal(env.restSerializer.modelNameFromPayloadKey('multi-words'), expectedModelName);


### PR DESCRIPTION
This PR backports https://github.com/emberjs/data/pull/5130 and https://github.com/emberjs/data/pull/5141 to the `release` branch to unblock https://github.com/emberjs/ember-inflector/pull/131

/cc @locks @rwjblue @stefanpenner 