### PR TITLE
[DOC] Remove parameter from BelongsToReference.value

### DIFF
--- a/addon/-private/system/references/belongs-to.js
+++ b/addon/-private/system/references/belongs-to.js
@@ -308,7 +308,6 @@ BelongsToReference.prototype.push = function(objectOrPromise) {
     ```
 
    @method value
-   @param {Object|Promise} objectOrPromise a promise that resolves to a JSONAPI document object describing the new value of this relationship.
    @return {DS.Model} the record in this relationship
 */
 BelongsToReference.prototype.value = function() {


### PR DESCRIPTION
`BelongsToReference.prototype.value` does not appear to actually take any parameters.