### PR TITLE
Ignore included resources without that don't have a corresponding ember-data model

### DIFF
--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -152,11 +152,13 @@ const JSONAPISerializer = JSONSerializer.extend({
     }
 
     if (Array.isArray(documentHash.included)) {
-      let ret = new Array(documentHash.included.length);
-
+      let ret = new Array();
       for (let i = 0; i < documentHash.included.length; i++) {
         let included = documentHash.included[i];
-        ret[i] = this._normalizeResourceHelper(included);
+        let normalized = this._normalizeResourceHelper(included);
+        if (normalized !== null) { // can be null when unknown type is encountered
+          ret.push(normalized);
+        }
       }
 
       documentHash.included = ret;

--- a/tests/integration/serializers/json-api-serializer-test.js
+++ b/tests/integration/serializers/json-api-serializer-test.js
@@ -138,6 +138,71 @@ testInDebug('Warns when normalizing an unknown type', function(assert) {
   }, /Encountered a resource object with type "UnknownType", but no model was found for model name "unknown-type"/);
 });
 
+testInDebug('Warns when normalizing payload with unknown type included', function(assert) {
+  var documentHash = {
+    data: {
+      type: 'users',
+      id: '1',
+      attributes: {
+        'first-name': 'Yehuda',
+        'last-name': 'Katz'
+      },
+      relationships: {
+        company: {
+          data: { type: 'unknown-types', id: '2' }
+        }
+      }
+    },
+    included: [{
+      type: 'unknown-types',
+      id: '2',
+      attributes: {
+        name: 'WyKittens'
+      }
+    }]
+  };
+
+  assert.expectWarning(function() {
+    run(function() {
+      env.store.serializerFor('user').normalizeResponse(env.store, User, documentHash, '1', 'findRecord');
+    });
+  }, /Encountered a resource object with type "unknown-types", but no model was found for model name "unknown-type"/);
+});
+
+testInDebug('Warns but does not fail when pushing payload with unknown type included', function(assert) {
+  var documentHash = {
+    data: {
+      type: 'users',
+      id: '1',
+      attributes: {
+        'first-name': 'Yehuda',
+        'last-name': 'Katz'
+      },
+      relationships: {
+        company: {
+          data: { type: 'unknown-types', id: '2' }
+        }
+      }
+    },
+    included: [{
+      type: 'unknown-types',
+      id: '2',
+      attributes: {
+        name: 'WyKittens'
+      }
+    }]
+  };
+
+  assert.expectWarning(function() {
+    run(function() {
+      env.store.pushPayload(documentHash);
+    });
+  }, /Encountered a resource object with type "unknown-types", but no model was found for model name "unknown-type"/);
+
+  var user = store.peekRecord('user', 1);
+  assert.equal(get(user, 'firstName'), 'Yehuda', 'firstName is correct');
+});
+
 testInDebug('Warns when normalizing with type missing', function(assert) {
   var documentHash = {
     data: {


### PR DESCRIPTION
When the JSON API serializer encounters a resource with a type that doesn't resolve
to one of the application's Ember Data models, it replaces the object with `null` and
emits a warning. Prior to this commit, if that `null` was one of the sideloaded
(i.e. `included`) resources, the store would throw trying to ask for the `null`'s type.
This commit makes the serializer drop any nulls out of the list of included resources
to avoid this problem.

To summarize, if your API attempts to include resources that you don't have models for,
a warning will be emitted and they will be ignored.

Fixes #4568