### PR TITLE
Multi-record experiment

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -624,7 +624,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
   */
   unloadRecord() {
     if (this.isDestroyed) { return; }
-    this._internalModel.unloadRecord();
+    this._internalModel.unloadRecord(this._modelName);
   },
 
   /**

--- a/addon/-private/system/record-arrays/record-array.js
+++ b/addon/-private/system/record-arrays/record-array.js
@@ -89,11 +89,11 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
    @property type
    @type DS.Model
    */
-  type: computed('modelName', function() {
-    if (!this.modelName) {
+  type: computed('recordModelName', function() {
+    if (!this.recordModelName) {
       return null;
     }
-    return this.store._modelFor(this.modelName);
+    return this.store._modelFor(this.recordModelName);
   }).readOnly(),
 
   /**
@@ -106,7 +106,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
   */
   objectAtContent(index) {
     let internalModel = get(this, 'content').objectAt(index);
-    return internalModel && internalModel.getRecord();
+    return internalModel && internalModel.getRecord(null, this.recordModelName);
   },
 
   /**
@@ -149,6 +149,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     is finished.
    */
   _update() {
+    // TODO Not sure what to do with these?
     return this.store.findAll(this.modelName, { reload: true });
   },
 
@@ -194,7 +195,7 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
     @return {DS.PromiseArray} promise
   */
   save() {
-    let promiseLabel = `DS: RecordArray#save ${this.modelName}`;
+    let promiseLabel = `DS: RecordArray#save ${this.internalModelName}`;
     let promise = Promise.all(this.invoke('save'), promiseLabel)
       .then(() => this, null, 'DS: RecordArray#save return RecordArray');
 

--- a/addon/-private/system/relationships/belongs-to.js
+++ b/addon/-private/system/relationships/belongs-to.js
@@ -115,7 +115,7 @@ export default function belongsTo(modelName, options) {
         });
       }
 
-      return this._internalModel._relationships.get(key).getRecord();
+      return this._internalModel._relationships.get(key).getRecord(userEnteredModelName);
     },
     set(key, value) {
       if (value === undefined) {

--- a/tests/integration/multi-record-test.js
+++ b/tests/integration/multi-record-test.js
@@ -1,0 +1,226 @@
+import {createStore} from 'dummy/tests/helpers/store';
+import Ember from 'ember';
+
+import {module, test} from 'qunit';
+
+import DS from 'ember-data';
+
+const { get, run, addObserver } = Ember;
+
+let Company, CompactCompany, Person, CompactPerson, initialPayload, updatePayload, store;
+
+module("integration/multi-record", {
+  beforeEach() {
+    initialPayload = {
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Tom Dale',
+          description: 'JavaScript thinkfluencer'
+        },
+        relationships: {
+          workplace: {
+            data: {
+              type: 'company',
+              id: '1'
+            }
+          }
+        }
+      },
+      included: [{
+        type: 'company',
+        id: '1',
+        attributes: {
+          name: 'Linkedin',
+          description: 'Linkedin description'
+        }
+      }]
+    };
+
+    updatePayload = {
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Yehuda Katz',
+          description: 'Tilde Co-Founder, OSS enthusiast and world traveler.'
+        },
+        relationships: {
+          workplace: {
+            data: {
+              type: 'company',
+              id: '1'
+            }
+          }
+        }
+      },
+      included: [{
+        type: 'company',
+        id: '1',
+        attributes: {
+          name: 'Tilde',
+          description: 'We\'re a small team of developers who are passionate about crafting great software.'
+        }
+      }]
+    };
+
+    Company = DS.Model.extend({
+      name: DS.attr('string'),
+      description: DS.attr('attr')
+    });
+    CompactCompany = DS.Model.extend({
+      name: DS.attr('string')
+    });
+    Person = DS.Model.extend({
+      name: DS.attr('string'),
+      description: DS.attr('string'),
+      workplace: DS.belongsTo('company')
+    });
+    CompactPerson = DS.Model.extend({
+      name: DS.attr('string'),
+      workplace: DS.belongsTo('compact-company')
+    });
+
+    store = createStore({
+      company: Company,
+      compactCompany: CompactCompany,
+      person: Person,
+      compactPerson: CompactPerson
+    });
+  },
+
+  afterEach() {
+    run(store, 'destroy');
+    Company = CompactCompany = Person = CompactPerson = initialPayload = updatePayload = null;
+  }
+});
+
+test("internalModel.getRecord() can return compact-person", function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+
+  assert.strictEqual(compactPerson.constructor, CompactPerson);
+  assert.equal(compactPerson.id, '1');
+  assert.equal(get(compactPerson, 'name'), 'Tom Dale');
+  assert.equal(get(compactPerson, 'description'), null);
+
+  run(() => {
+    // trigger an update to the record
+    store.push(updatePayload);
+  });
+
+  // the compact person should have been updated
+  assert.equal(get(compactPerson, 'name'), 'Yehuda Katz');
+  assert.equal(get(compactPerson, 'description'), null);
+});
+
+test("updating a model will notify all materialized records", function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+  let compactPersonNotified = false;
+
+  addObserver(compactPerson, 'description', () => {
+    compactPersonNotified = true;
+  });
+
+  run(() => {
+    // trigger an update to the record
+    store.push(updatePayload);
+  });
+
+  // the compact person should have been notified of changes
+  assert.ok(compactPersonNotified, 'Expected compact person record to have been notified');
+});
+
+test('unloadRecord should not dematerialize other records', function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+
+  run(() => {
+    personRecord.unloadRecord();
+  });
+
+  assert.notOk(get(compactPerson, 'isDestroyed'));
+  assert.notOk(get(personRecord._internalModel, 'isDestroyed'));
+});
+
+test('unloadRecord should dematerialize if there are no other records', function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+
+  run(() => {
+    compactPerson.unloadRecord();
+    personRecord.unloadRecord();
+  });
+
+  assert.ok(get(personRecord._internalModel, 'isDestroyed'));
+});
+
+test('all records transition to new state', function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+
+  run(() => {
+    personRecord.deleteRecord();
+  });
+
+  // deleting the person record should also mark the compactPerson for deletion as well
+  assert.equal(get(compactPerson, 'isDeleted'), true);
+});
+
+test('relationships loads specific relationship records', function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+  let compactCompany = run(() => {
+    return get(compactPerson, 'workplace');
+  });
+
+  assert.strictEqual(get(compactCompany, 'content').constructor, CompactCompany);
+  assert.equal(get(compactCompany, 'name'), 'Linkedin');
+});
+
+test('record arrays can handle different records', function(assert) {
+  run(() => {
+    return store.push(initialPayload);
+  });
+
+  let allPersons = store.recordArrayManager.liveRecordArrayFor('person');
+  let allCompactPersons = store.recordArrayManager.liveRecordArrayFor('person', 'compact-person');
+
+  assert.equal(get(allPersons, 'length'), 1);
+  assert.equal(get(allCompactPersons, 'length'), 1);
+
+  assert.strictEqual(allPersons.objectAt(0).constructor, Person);
+  assert.strictEqual(allCompactPersons.objectAt(0).constructor, CompactPerson);
+
+  // add one more person, modify updatePayload to use new id
+  updatePayload.data.id = '2';
+  run(() => {
+    store.push(updatePayload);
+  });
+
+  assert.equal(get(allPersons, 'length'), 2);
+  assert.equal(get(allCompactPersons, 'length'), 2);
+
+  assert.strictEqual(allPersons.objectAt(1).constructor, Person);
+  assert.strictEqual(allCompactPersons.objectAt(1).constructor, CompactPerson);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,6 +107,12 @@ amd-name-resolver@0.0.6:
   dependencies:
     ensure-posix-path "^1.0.1"
 
+amd-name-resolver@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz#814301adfe8a2f109f6e84d5e935196efb669615"
+  dependencies:
+    ensure-posix-path "^1.0.1"
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"


### PR DESCRIPTION
This is an experiment to see how easy is to change Ember Data to support multiple DS.Model per internal model. Each DS.Model will represent different view of the same data. Main use cases are data projections (think GraphQL) and [ember-data-model-fragments](https://github.com/lytics/ember-data-model-fragments).

Right now, there is no public API to do the feature. It has to be accessed through `InternalModel.getRecord()`. Once a different view is loaded for an internal model, all the types will be passed down correctly.

There are several places, which requires further investigation, but wanted to do first check to see whether there is interest in this.