### PR TITLE
support multiple adapters in belongsTo and hasMany

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1184,7 +1184,7 @@ Store = Service.extend({
     @return {Promise} promise
   */
   findHasMany(internalModel, link, relationship) {
-    let adapter = this.adapterFor(internalModel.modelName);
+    let adapter = this.adapterFor(relationship.type);
 
     assert(`You tried to load a hasMany relationship but you have no adapter (for ${internalModel.modelName})`, adapter);
     assert(`You tried to load a hasMany relationship from a specified 'link' in the original payload but your adapter does not implement 'findHasMany'`, typeof adapter.findHasMany === 'function');
@@ -1201,7 +1201,7 @@ Store = Service.extend({
     @return {Promise} promise
   */
   findBelongsTo(internalModel, link, relationship) {
-    let adapter = this.adapterFor(internalModel.modelName);
+    let adapter = this.adapterFor(relationship.type);
 
     assert(`You tried to load a belongsTo relationship but you have no adapter (for ${internalModel.modelName})`, adapter);
     assert(`You tried to load a belongsTo relationship from a specified 'link' in the original payload but your adapter does not implement 'findBelongsTo'`, typeof adapter.findBelongsTo === 'function');

--- a/tests/unit/store/finders-test.js
+++ b/tests/unit/store/finders-test.js
@@ -97,7 +97,7 @@ test('findHasMany does not load a serializer until the adapter promise resolves'
 
   let deferedFind = defer();
 
-  this.env.registry.register('adapter:person', DS.Adapter.extend({
+  this.env.registry.register('adapter:dog', DS.Adapter.extend({
     findHasMany: () => deferedFind.promise
   }));
 
@@ -149,7 +149,7 @@ test('findBelongsTo does not load a serializer until the adapter promise resolve
 
   let deferedFind = defer();
 
-  this.env.registry.register('adapter:person', DS.Adapter.extend({
+  this.env.registry.register('adapter:dog', DS.Adapter.extend({
     findBelongsTo: () => deferedFind.promise
   }));
 
@@ -282,4 +282,3 @@ test('queryRecord does not load a serializer until the adapter promise resolves'
     });
   });
 });
-


### PR DESCRIPTION
Currently the adapter to use for loading records in a belongsTo or hasMany is determined by the model that has the association. This makes it so that if you have different adapters for the two models the wrong one is used to load the associated models, resulting in incorrect headers, etc.

For example if I have an `Author` configured to use `RESTAdapter` with a hasMany for `Book` that uses `JSONAPIAdapter` you will get the `JSONAPIAdapter` if you do `store.findRecord('book', 1)` but the `RESTAdapter` if you do `author.get('books')`. In this case the result is that when calling `findRecord` you get the expected `Accept` header of `application/vnd.api+json` where when you use the `hasMany` you get `application/json` instead.

[Ember Twiddle](https://ember-twiddle.com/4b4d6f29d238fb611be705b02b85c90d?openFiles=templates.application.hbs%2C)
