### PR TITLE
[BUGFIX beta] Avoid cache related warnings during builds.

### DIFF
--- a/lib/stripped-build-plugins.js
+++ b/lib/stripped-build-plugins.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var fs            = require('fs');
 var FilterImports = require('babel-plugin-filter-imports');
 var FeatureFlags  = require('babel-plugin-feature-flags');
@@ -13,6 +14,16 @@ function uniqueAdd(obj, key, values) {
     if (a.indexOf(values[i]) === -1) {
       a.push(values[i]);
     }
+  }
+}
+
+function addBaseDir(Plugin) {
+  let type = typeof Plugin;
+
+  if (type === 'function' && !Plugin.baseDir) {
+    Plugin.baseDir = () => path.join(__dirname, '..');
+  } else if (type === 'object' && Plugin !== null && Plugin.default) {
+    addBaseDir(Plugin.default);
   }
 }
 
@@ -58,6 +69,13 @@ module.exports = function(environment) {
     [StripFilteredImports, filteredImports],
     [TransformBlockScoping, { 'throwIfClosureRequired': true }]
   );
+
+  // ensures that a `baseDir` property is present on the babel plugins
+  // that we will be using, this prevents ember-cli-babel/broccoli-babel-transpiler
+  // from opting out of caching (and printing a giant warning)
+  plugins.forEach(Plugin => {
+    addBaseDir(Plugin);
+  });
 
   return { plugins, postTransformPlugins };
 };


### PR DESCRIPTION
broccoli-babel-transpiler (which we use by way of ember-cli-babel) requires that all plugins have a `.baseDir` function which broccoli-babel-transpiler uses to ensure that it can properly invalidate the cached output of each transpiled file. If `.baseDir` is not present broccoli-babel-transpiler does the only "safe" thing and completely opts out of this caching system and prints a very loud warning message.

This commit ensures that the few custom plugins that we are using are properly setup with a `.baseDir`.

Fixes #5164