### PR TITLE
Fix ember-data Node 4.x builds

### DIFF
--- a/lib/stripped-build-plugins.js
+++ b/lib/stripped-build-plugins.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var path = require('path');
 var fs            = require('fs');
 var FilterImports = require('babel-plugin-filter-imports');


### PR DESCRIPTION
FastBoot builds are [breaking again](https://travis-ci.org/ember-fastboot/ember-cli-fastboot/builds/279059158?utm_source=github_status&utm_medium=notification). I will open a seperate issue to enable Node 4.x in travis in ember data and would be happy to spend cycles fixing anything in ember data to make it compatible with Node 4.x.

cc: @rwjblue @stefanpenner 