### PR TITLE
Support for multiple records on top of same data

### DIFF
--- a/addon/-private/system/internal-model-map.js
+++ b/addon/-private/system/internal-model-map.js
@@ -103,7 +103,7 @@ export default class InternalModelMap {
 
     for (let i = 0; i < models.length; i++) {
       let model = models[i];
-      model.unloadRecord();
+      model.unloadRecords();
     }
 
     this._metadata = null;

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -624,7 +624,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
   */
   unloadRecord() {
     if (this.isDestroyed) { return; }
-    this._internalModel.unloadRecord();
+    this._internalModel.unloadRecord(this);
   },
 
   /**

--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -42,7 +42,7 @@ export function _find(adapter, store, modelClass, id, internalModel, options) {
   }, error => {
     internalModel.notFound();
     if (internalModel.isEmpty()) {
-      internalModel.unloadRecord();
+      internalModel.unloadRecords();
     }
 
     throw error;

--- a/tests/unit/model/multi-record-test.js
+++ b/tests/unit/model/multi-record-test.js
@@ -1,0 +1,147 @@
+import {createStore} from 'dummy/tests/helpers/store';
+import Ember from 'ember';
+
+import {module, test} from 'qunit';
+
+import DS from 'ember-data';
+
+const { get, run, addObserver } = Ember;
+
+let Person, CompactPerson, initialPayload, updatePayload, store;
+
+module("unit/model/multi-record", {
+  beforeEach() {
+    initialPayload = {
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Tom Dale',
+          description: 'JavaScript thinkfluencer'
+        }
+      },
+      included: []
+    };
+
+    updatePayload = {
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Yehuda Katz',
+          description: 'Tilde Co-Founder, OSS enthusiast and world traveler.'
+        }
+      },
+      included: []
+    };
+
+    Person = DS.Model.extend({
+      name: DS.attr('string'),
+      description: DS.attr('string'),
+      workplace: DS.belongsTo('company')
+    });
+    CompactPerson = DS.Model.extend({
+      name: DS.attr('string'),
+      workplace: DS.belongsTo('compact-company')
+    });
+
+    store = createStore({
+      person: Person,
+      compactPerson: CompactPerson
+    });
+  },
+
+  afterEach() {
+    run(store, 'destroy');
+    Person = CompactPerson = initialPayload = updatePayload = null;
+  }
+});
+
+test("internalModel.getRecord() can return compact-person", function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+
+  assert.strictEqual(compactPerson.constructor, CompactPerson);
+  assert.equal(compactPerson.id, '1');
+  assert.equal(get(compactPerson, 'name'), 'Tom Dale');
+  assert.equal(get(compactPerson, 'description'), null);
+
+  run(() => {
+    // trigger an update to the record
+    store.push(updatePayload);
+  });
+
+  // the compact person should have been updated
+  assert.equal(get(compactPerson, 'name'), 'Yehuda Katz');
+  assert.equal(get(compactPerson, 'description'), null);
+});
+
+test("updating a model will notify all materialized records", function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+  let compactPersonNotified = false;
+
+  addObserver(compactPerson, 'description', () => {
+    compactPersonNotified = true;
+  });
+
+  run(() => {
+    // trigger an update to the record
+    store.push(updatePayload);
+  });
+
+  // the compact person should have been notified of changes
+  assert.ok(compactPersonNotified, 'Expected compact person record to have been notified');
+});
+
+test('unloadRecord should not dematerialize other records', function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+
+  run(() => {
+    personRecord.unloadRecord();
+  });
+
+  assert.notOk(get(compactPerson, 'isDestroyed'));
+  assert.notOk(get(personRecord._internalModel, 'isDestroyed'));
+});
+
+test('unloadRecord should dematerialize if there are no other records', function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+
+  run(() => {
+    compactPerson.unloadRecord();
+    personRecord.unloadRecord();
+  });
+
+  assert.ok(get(personRecord._internalModel, 'isDestroyed'));
+});
+
+test('all records transition to new state', function(assert) {
+  let personRecord = run(() => {
+    return store.push(initialPayload);
+  });
+
+  let compactPerson = personRecord._internalModel.getRecord(null, 'compact-person');
+
+  run(() => {
+    personRecord.deleteRecord();
+  });
+
+  // deleting the person record should also mark the compactPerson for deletion as well
+  assert.equal(get(compactPerson, 'isDeleted'), true);
+});
+


### PR DESCRIPTION
Right now, Ember Data has one-to-one mapping between an InternalModel and the actual `DS.Model`, which the application uses. There are two use cases, where this has is a drawback:
- GraphQL fragments and any other technology, which allows projection over the data
- The `ember-data-model-fragments`, which uses `_fragments` property to store the extra models, which have been created for a given internal model

If we refactor InternalModel to support multiple records than these use cases can use semi-public API to build upon instead of monkey patching Ember Data.

I'm looking for any comments on the feasibility of this refactor and whether it is something, we would like to have in Ember Data.

Note: The PR is not complete as there are:
- [ ] more tests to be written
- [ ] figure out what to do with the triggers
- [ ] fix the firing of `unloadRecord`
- [ ] put it behind a feature flag