### PR TITLE
Skip ember try on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.
-  - cmd: yarn run test
+  - cmd: yarn run test-appveyor
   - cmd: yarn run test:optional-features
   - cmd: yarn run test:production
   - cmd: yarn run node-tests

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "ember build",
     "start": "ember server",
     "test": "ember try:testall",
+    "test-appveyor": "ember test",
     "node-tests": "node node-tests/nodetest-runner.js",
     "test:optional-features": "ember test --environment=test-optional-features",
     "test:production": "ember test --environment=production",


### PR DESCRIPTION
Appveyor seems to be getting stuck when ember try switches between scenarios. Lets try disabling it on appveyor (ember try scenarios will still always run on travis).