### PR TITLE
[BUGFIX beta] Fix broccoli-babel-transpiler cache warnings

### DIFF
--- a/lib/stripped-build-plugins.js
+++ b/lib/stripped-build-plugins.js
@@ -75,9 +75,8 @@ module.exports = function(environment) {
   // ensures that a `baseDir` property is present on the babel plugins
   // that we will be using, this prevents ember-cli-babel/broccoli-babel-transpiler
   // from opting out of caching (and printing a giant warning)
-  plugins.forEach(Plugin => {
-    addBaseDir(Plugin);
-  });
+  plugins.forEach((pluginWithOptions) => addBaseDir(pluginWithOptions[0]));
+
 
   return { plugins, postTransformPlugins };
 };


### PR DESCRIPTION
Latest ember-data@2.16 was still having "opting out of cache" warnings.
cc @rwjblue 