### PR TITLE
test: pushing data with included payload, multiple has-many pointing …

### DIFF
--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -1539,3 +1539,97 @@ test("belongsTo relationship with links doesn't trigger extra change notificatio
 
   assert.equal(count, 0);
 });
+
+test("multiple hasMany-belongsTo relationship to the same model", function(assert) {
+  Author.reopen({
+    favoriteBooks: hasMany('book', { async: false })
+  });
+
+  Book.reopen({
+    author: belongsTo('author', { async: false, inverse: null })
+  });
+
+  // Works
+  // run(() => {
+  //   env.store.push({
+  //     data: {
+  //       type: 'author',
+  //       id: '1',
+  //       relationships: {
+  //         favoriteBooks: {
+  //           data: [{ type: 'book', id: '1' }]
+  //         },
+  //         books: {
+  //           data: [{ type: 'book', id: '2' }]
+  //         }
+  //       }
+  //     }
+  //   });
+  //   env.store.push({
+  //     data: [
+  //       {
+  //         type: 'book',
+  //         id: '1',
+  //         relationships: {
+  //           author: {
+  //             data: { type: 'author', id: '1' }
+  //           }
+  //         }
+  //       },
+  //       {
+  //         type: 'book',
+  //         id: '2',
+  //         relationships: {
+  //           author: {
+  //             data: { type: 'author', id: '1' }
+  //           }
+  //         }
+  //       }
+  //     ]
+  //   });
+  // });
+
+  run(() => {
+    env.store.push({
+      data: {
+        type: 'author',
+        id: '1',
+        relationships: {
+          favoriteBooks: {
+            data: [{ type: 'book', id: '1' }]
+          },
+          books: {
+            data: [{ type: 'book', id: '2' }]
+          }
+        }
+      },
+      included: [
+        {
+          type: 'book',
+          id: '1',
+          relationships: {
+            author: {
+              data: { type: 'author', id: '1' }
+            }
+          }
+        },
+        {
+          type: 'book',
+          id: '2',
+          relationships: {
+            author: {
+              data: { type: 'author', id: '1' }
+            }
+          }
+        }
+      ]
+    });
+  });
+
+  let book = env.store.peekRecord('book', '1');
+  let author = env.store.peekRecord('author', '1');
+  run(() => {
+    assert.ok(author.get('favoriteBooks').includes(book));
+    assert.equal(book.get('author.id'), author.get('id'));
+  });
+});


### PR DESCRIPTION
…to the same model, leads to belongsTo not working

Don't know how to fix this 😞 .
It used to work (at least in 2.12.2).

@hjdivad I think this is related to the refactoring you did concerning the relationships. I try to debug, and I find that the RelationshipPayload looks like inconsistent.
It looks weird to me that the cache entry for `book:author` in the `RelationshipPayloadsManager` contains such a pending payload :
```
["author", "1", "books", data: {type: "book", id: "2"}]
```

Well, I just found out that for this type of relation, ember-data behaves correctly if I explicitly set the inverse to null on both sides of the associations.
If not, then ember-data is somehow doing a mess with the payload manager, probably when guessing inverses.

So I guess it's not a bug, I'm closing, but maybe this could help someone else struggling with this kind of issue.
