### PR TITLE
[BUGFIX beta] proxy `meta` on PromiseArray

### DIFF
--- a/addon/-private/system/promise-proxies.js
+++ b/addon/-private/system/promise-proxies.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import { assert } from '@ember/debug';
 
 const { get , RSVP: { Promise }} = Ember;
+const { computed: { reads } } = Ember;
 
 /**
   A `PromiseArray` is an object that acts like both an `Ember.Array`
@@ -32,7 +33,9 @@ const { get , RSVP: { Promise }} = Ember;
   @extends Ember.ArrayProxy
   @uses Ember.PromiseProxyMixin
 */
-export const PromiseArray = Ember.ArrayProxy.extend(Ember.PromiseProxyMixin);
+export const PromiseArray = Ember.ArrayProxy.extend(Ember.PromiseProxyMixin, {
+  meta: reads('content.meta')
+});
 
 /**
   A `PromiseObject` is an object that acts like both an `Ember.Object`

--- a/tests/integration/store/query-test.js
+++ b/tests/integration/store/query-test.js
@@ -1,0 +1,49 @@
+import setupStore from 'dummy/tests/helpers/store';
+import Ember from 'ember';
+import RSVP from 'rsvp';
+
+import { module, test } from 'qunit';
+
+import DS from 'ember-data';
+
+var Person, store, env;
+var run = Ember.run;
+
+module("integration/store/query", {
+  beforeEach() {
+    Person = DS.Model.extend();
+
+    env = setupStore({
+      person: Person
+    });
+
+    store = env.store;
+  },
+
+  afterEach() {
+    run(store, 'destroy');
+  }
+});
+
+test("meta is proxied correctly on the PromiseArray", function(assert) {
+  let defered = RSVP.defer();
+
+  env.registry.register('adapter:person', DS.Adapter.extend({
+    query(store, type, query) {
+      return defered.promise;
+    }
+  }));
+
+  let result;
+  run(function() {
+    result = store.query('person', {});
+  });
+
+  assert.equal(result.get('meta.foo'), undefined);
+
+  run(function() {
+    defered.resolve({ data: [], meta: { foo: 'bar' } });
+  });
+
+  assert.equal(result.get('meta.foo'), 'bar');
+});


### PR DESCRIPTION
This closes #5129.

I am unsure if this is the correct way to fix this or if something else is fishy...

Maybe it's because of this 🤔:

https://github.com/emberjs/data/blob/5fceead8acb53723bdf38daabad00aff093f390a/addon/-private/system/record-arrays/adapter-populated-record-array.js#L51-L52