### PR TITLE
[BUGFIX beta] invalid record becomes loaded when property is reset

### DIFF
--- a/addon/-private/system/model/states.js
+++ b/addon/-private/system/model/states.js
@@ -434,6 +434,13 @@ function assertAgainstUnloadRecord(internalModel) {
   assert("You can only unload a record which is not inFlight. `" + internalModel + "`", false);
 }
 
+updatedState.invalid.becameValid = function(internalModel) {
+  // we're eagerly transition into the loaded.saved state, even though we could
+  // be still dirty; but the setup hook of the loaded.saved state checks for
+  // dirty attributes and transitions into the corresponding dirty state
+  internalModel.transitionTo('loaded.saved');
+};
+
 updatedState.inFlight.unloadRecord = assertAgainstUnloadRecord;
 
 updatedState.uncommitted.deleteRecord = function(internalModel) {


### PR DESCRIPTION
If an invalid property of an existing record is reset, it should transition the record back to the loaded state.

This closes #5201