### PR TITLE
Update assert against nulls

### DIFF
--- a/tests/integration/adapter/json-api-adapter-test.js
+++ b/tests/integration/adapter/json-api-adapter-test.js
@@ -968,7 +968,7 @@ test('fetching a belongsTo relationship link that returns null', function(assert
       return post.get('author');
     }).then(author => {
       assert.equal(passedUrl[1], 'http://example.com/post/1/author');
-      assert.equal(author, null);
+      assert.strictEqual(author, null);
     });
   });
 });

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -889,7 +889,7 @@ test("deleteRecord - an empty payload is a basic success", function(assert) {
   }).then(post => {
     assert.equal(passedUrl, "/posts/1");
     assert.equal(passedVerb, "DELETE");
-    assert.equal(passedHash, undefined);
+    assert.strictEqual(passedHash, undefined);
 
     assert.equal(post.get('hasDirtyAttributes'), false, "the post isn't dirty anymore");
     assert.equal(post.get('isDeleted'), true, "the post is now deleted");
@@ -946,7 +946,7 @@ test("deleteRecord - a payload with sideloaded updates pushes the updates", func
   }).then(post => {
     assert.equal(passedUrl, "/posts/1");
     assert.equal(passedVerb, "DELETE");
-    assert.equal(passedHash, undefined);
+    assert.strictEqual(passedHash, undefined);
 
     assert.equal(post.get('hasDirtyAttributes'), false, "the post isn't dirty anymore");
     assert.equal(post.get('isDeleted'), true, "the post is now deleted");
@@ -978,7 +978,7 @@ test("deleteRecord - a payload with sidloaded updates pushes the updates when th
   }).then(post => {
     assert.equal(passedUrl, "/posts/1");
     assert.equal(passedVerb, "DELETE");
-    assert.equal(passedHash, undefined);
+    assert.strictEqual(passedHash, undefined);
 
     assert.equal(post.get('hasDirtyAttributes'), false, "the original post isn't dirty anymore");
     assert.equal(post.get('isDeleted'), true, "the original post is now deleted");
@@ -1738,7 +1738,7 @@ test("findHasMany - returning an array populates the array", function(assert) {
   }).then(comments => {
     assert.equal(passedUrl, '/posts/1/comments');
     assert.equal(passedVerb, 'GET');
-    assert.equal(passedHash, undefined);
+    assert.strictEqual(passedHash, undefined);
 
     let comment1 = store.peekRecord('comment', 1);
     let comment2 = store.peekRecord('comment', 2);

--- a/tests/integration/polymorphic-belongs-to-test.js
+++ b/tests/integration/polymorphic-belongs-to-test.js
@@ -84,7 +84,7 @@ test('using store.push with a null value for a payload in relationships sets the
   };
 
   run(() => store.push(payloadThatResetsBelongToRelationship));
-  assert.equal(book.get('author'), null);
+  assert.strictEqual(book.get('author'), null);
 });
 
 test('using store.push with a null value for a payload in relationships sets the Models relationship to null - async relationship', (assert) => {
@@ -134,6 +134,6 @@ test('using store.push with a null value for a payload in relationships sets the
     run(() => store.push(payloadThatResetsBelongToRelationship));
     return book.get('author');
   }).then(author => {
-    assert.equal(author, null);
+    assert.strictEqual(author, null);
   });
 });

--- a/tests/integration/records/save-test.js
+++ b/tests/integration/records/save-test.js
@@ -38,7 +38,7 @@ test("Will resolve save on success", function(assert) {
     var saved = post.save();
 
     // `save` returns a PromiseObject which allows to call get on it
-    assert.equal(saved.get('id'), undefined);
+    assert.strictEqual(saved.get('id'), undefined);
 
     deferred.resolve({ data: { id: 123, type: 'post' } });
     saved.then(function(model) {

--- a/tests/integration/relationships/inverse-relationships-test.js
+++ b/tests/integration/relationships/inverse-relationships-test.js
@@ -159,14 +159,14 @@ test("When setting a belongsTo, the OneToOne invariant is respected even when ot
 
   assert.equal(comment.get('post'), post);
   assert.equal(post.get('bestComment'), comment);
-  assert.equal(post2.get('bestComment'), null);
+  assert.strictEqual(post2.get('bestComment'), null);
 
   run(function() {
     comment.set('post', post2);
   });
 
   assert.equal(comment.get('post'), post2);
-  assert.equal(post.get('bestComment'), null);
+  assert.strictEqual(post.get('bestComment'), null);
   assert.equal(post2.get('bestComment'), comment);
 });
 
@@ -197,14 +197,14 @@ test("When setting a belongsTo, the OneToOne invariant is transitive", function(
 
   assert.equal(comment.get('post'), post);
   assert.equal(post.get('bestComment'), comment);
-  assert.equal(post2.get('bestComment'), null);
+  assert.strictEqual(post2.get('bestComment'), null);
 
   run(function() {
     post2.set('bestComment', comment);
   });
 
   assert.equal(comment.get('post'), post2);
-  assert.equal(post.get('bestComment'), null);
+  assert.strictEqual(post.get('bestComment'), null);
   assert.equal(post2.get('bestComment'), comment);
 });
 
@@ -233,13 +233,13 @@ test("When setting a belongsTo, the OneToOne invariant is commutative", function
 
   assert.equal(comment.get('post'), post);
   assert.equal(post.get('bestComment'), comment);
-  assert.equal(comment2.get('post'), null);
+  assert.strictEqual(comment2.get('post'), null);
 
   run(function() {
     post.set('bestComment', comment2);
   });
 
-  assert.equal(comment.get('post'), null);
+  assert.strictEqual(comment.get('post'), null);
   assert.equal(post.get('bestComment'), comment2);
   assert.equal(comment2.get('post'), post);
 });

--- a/tests/integration/store/query-test.js
+++ b/tests/integration/store/query-test.js
@@ -39,7 +39,7 @@ test("meta is proxied correctly on the PromiseArray", function(assert) {
     result = store.query('person', {});
   });
 
-  assert.equal(result.get('meta.foo'), undefined);
+  assert.notOk(result.get('meta.foo'), 'precond: meta is not yet set');
 
   run(function() {
     defered.resolve({ data: [], meta: { foo: 'bar' } });

--- a/tests/unit/diff-array-test.js
+++ b/tests/unit/diff-array-test.js
@@ -20,21 +20,21 @@ const z = "zzz";
 
 test('diff array returns no change given two empty arrays', function(assert) {
   const result = diffArray([], []);
-  assert.equal(result.firstChangeIndex, null);
+  assert.strictEqual(result.firstChangeIndex, null);
   assert.equal(result.addedCount, 0);
   assert.equal(result.removedCount, 0);
 });
 
 test('diff array returns no change given two identical arrays length 1', function(assert) {
   const result = diffArray([a], [a]);
-  assert.equal(result.firstChangeIndex, null);
+  assert.strictEqual(result.firstChangeIndex, null);
   assert.equal(result.addedCount, 0);
   assert.equal(result.removedCount, 0);
 });
 
 test('diff array returns no change given two identical arrays length 3', function(assert) {
   const result = diffArray([a,b,c], [a,b,c]);
-  assert.equal(result.firstChangeIndex, null);
+  assert.strictEqual(result.firstChangeIndex, null);
   assert.equal(result.addedCount, 0);
   assert.equal(result.removedCount, 0);
 });

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -930,7 +930,7 @@ testInDebug('a null defaultValue is not deprecated', function(assert) {
   let tag = run(() => store.createRecord('tag'));
 
   assert.expectNoDeprecation();
-  assert.equal(get(tag, 'tagInfo'), null);
+  assert.strictEqual(get(tag, 'tagInfo'), null);
 });
 
 test('setting a property to undefined on a newly created record should not impact the current state', function(assert) {

--- a/tests/unit/model/rollback-attributes-test.js
+++ b/tests/unit/model/rollback-attributes-test.js
@@ -70,7 +70,7 @@ test('changes to unassigned attributes can be rolled back', function(assert) {
 
   run(() => person.rollbackAttributes());
 
-  assert.equal(person.get('firstName'), undefined);
+  assert.strictEqual(person.get('firstName'), undefined);
   assert.equal(person.get('hasDirtyAttributes'), false);
 });
 

--- a/tests/unit/record-arrays/adapter-populated-record-array-test.js
+++ b/tests/unit/record-arrays/adapter-populated-record-array-test.js
@@ -28,9 +28,9 @@ test('default initial state', function(assert) {
   assert.equal(recordArray.get('isLoaded'), false, 'expected isLoaded to be false');
   assert.equal(recordArray.get('modelName'), 'recordType');
   assert.deepEqual(recordArray.get('content'), []);
-  assert.equal(recordArray.get('query'), null);
-  assert.equal(recordArray.get('store'), null);
-  assert.equal(recordArray.get('links'), null);
+  assert.strictEqual(recordArray.get('query'), null);
+  assert.strictEqual(recordArray.get('store'), null);
+  assert.strictEqual(recordArray.get('links'), null);
 });
 
 test('custom initial state', function(assert) {
@@ -51,7 +51,7 @@ test('custom initial state', function(assert) {
   assert.equal(recordArray.get('content'), content);
   assert.equal(recordArray.get('store'), store);
   assert.equal(recordArray.get('query'), 'some-query');
-  assert.equal(recordArray.get('links'), null);
+  assert.strictEqual(recordArray.get('links'), null);
 });
 
 test('#replace() throws error', function(assert) {

--- a/tests/unit/record-arrays/filtered-record-array-test.js
+++ b/tests/unit/record-arrays/filtered-record-array-test.js
@@ -14,9 +14,9 @@ test('default initial state', function(assert) {
 
   assert.equal(get(recordArray, 'isLoaded'), true);
   assert.equal(get(recordArray, 'modelName'), 'recordType');
-  assert.equal(get(recordArray, 'content'), null);
-  assert.equal(get(recordArray, 'filterFunction'), null);
-  assert.equal(get(recordArray, 'store'), null);
+  assert.strictEqual(get(recordArray, 'content'), null);
+  assert.strictEqual(get(recordArray, 'filterFunction'), null);
+  assert.strictEqual(get(recordArray, 'store'), null);
 });
 
 test('custom initial state', function(assert) {

--- a/tests/unit/record-arrays/record-array-test.js
+++ b/tests/unit/record-arrays/record-array-test.js
@@ -15,8 +15,8 @@ test('default initial state', function(assert) {
   assert.equal(get(recordArray, 'isLoaded'), false);
   assert.equal(get(recordArray, 'isUpdating'), false);
   assert.equal(get(recordArray, 'modelName'), 'recordType');
-  assert.equal(get(recordArray, 'content'), null);
-  assert.equal(get(recordArray, 'store'), null);
+  assert.strictEqual(get(recordArray, 'content'), null);
+  assert.strictEqual(get(recordArray, 'store'), null);
 });
 
 test('custom initial state', function(assert) {
@@ -281,7 +281,7 @@ test('#destroy', function(assert) {
   assert.equal(didDissociatieFromOwnRecords, 1, 'after destroy, we should have dissociated from own record array');
   recordArray.destroy();
 
-  assert.equal(get(recordArray, 'content'), null);
+  assert.strictEqual(get(recordArray, 'content'), null);
   assert.equal(get(recordArray, 'length'), 0, 'after destroy we should have no length');
   assert.equal(get(recordArray, 'isDestroyed'), true, 'should be destroyed');
 });
@@ -352,7 +352,7 @@ test('#destroy', function(assert) {
   assert.equal(didDissociatieFromOwnRecords, 1, 'after destroy, we should have dissociated from own record array');
   recordArray.destroy();
 
-  assert.equal(get(recordArray, 'content'), null);
+  assert.strictEqual(get(recordArray, 'content'), null);
   assert.equal(get(recordArray, 'length'), 0, 'after destroy we should have no length');
   assert.equal(get(recordArray, 'isDestroyed'), true, 'should be destroyed');
 });

--- a/tests/unit/record-arrays/record-array-test.js
+++ b/tests/unit/record-arrays/record-array-test.js
@@ -60,7 +60,7 @@ test('#objectAtContent', function(assert) {
   assert.equal(recordArray.objectAtContent(0), 'foo');
   assert.equal(recordArray.objectAtContent(1), 'bar');
   assert.equal(recordArray.objectAtContent(2), 'baz');
-  assert.equal(recordArray.objectAtContent(3), undefined);
+  assert.strictEqual(recordArray.objectAtContent(3), undefined);
 });
 
 test('#update', function(assert) {

--- a/tests/unit/store/adapter-interop-test.js
+++ b/tests/unit/store/adapter-interop-test.js
@@ -1126,7 +1126,7 @@ test('store should not reload a record when `shouldBackgroundReloadRecord` is fa
     });
 
     return store.findRecord('person', 1).then(record => {
-      assert.equal(record.get('name'), undefined);
+      assert.strictEqual(record.get('name'), undefined);
     });
   });
 });
@@ -1164,7 +1164,7 @@ test('store should reload the record in the background when `shouldBackgroundRel
     });
 
     return store.findRecord('person', 1).then(record => {
-      assert.equal(record.get('name'), undefined);
+      assert.strictEqual(record.get('name'), undefined);
     });
   });
 
@@ -1292,7 +1292,7 @@ test('store should not reload all records when `shouldBackgroundReloadAll` is fa
 
   return run(() => {
     return store.findAll('person').then(records => {
-      assert.equal(records.get('firstObject'), undefined);
+      assert.strictEqual(records.get('firstObject'), undefined);
     });
   });
 });
@@ -1327,7 +1327,7 @@ test('store should reload all records in the background when `shouldBackgroundRe
 
   let done = run(() => {
     return store.findAll('person').then(records => {
-      assert.equal(records.get('firstObject.name'), undefined);
+      assert.strictEqual(records.get('firstObject.name'), undefined);
     });
   });
 

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -67,7 +67,7 @@ test('Changed attributes are reset when matching data is pushed', function(asser
   run(() => person.set('firstName', 'updated first name'));
 
   assert.equal(person.get('firstName'), 'updated first name');
-  assert.equal(person.get('lastName'), undefined);
+  assert.strictEqual(person.get('lastName'), undefined);
   assert.equal(person.get('currentState.stateName'), 'root.loaded.updated.uncommitted');
   assert.deepEqual(person.changedAttributes().firstName, ['original first name', 'updated first name']);
 

--- a/tests/unit/transform/boolean-test.js
+++ b/tests/unit/transform/boolean-test.js
@@ -7,8 +7,8 @@ module('unit/transform - DS.BooleanTransform');
 test("#serialize", function(assert) {
   let transform = new DS.BooleanTransform();
 
-  assert.equal(transform.serialize(null, { allowNull: true }), null);
-  assert.equal(transform.serialize(undefined, { allowNull: true }), null);
+  assert.strictEqual(transform.serialize(null, { allowNull: true }), null);
+  assert.strictEqual(transform.serialize(undefined, { allowNull: true }), null);
 
   assert.equal(transform.serialize(null, { allowNull: false }), false);
   assert.equal(transform.serialize(undefined, { allowNull: false }), false);
@@ -23,8 +23,8 @@ test("#serialize", function(assert) {
 test('#deserialize', function(assert) {
   let transform = new DS.BooleanTransform();
 
-  assert.equal(transform.deserialize(null, { allowNull: true }), null);
-  assert.equal(transform.deserialize(undefined, { allowNull: true }), null);
+  assert.strictEqual(transform.deserialize(null, { allowNull: true }), null);
+  assert.strictEqual(transform.deserialize(undefined, { allowNull: true }), null);
 
   assert.equal(transform.deserialize(null, { allowNull: false }), false);
   assert.equal(transform.deserialize(undefined, { allowNull: false }), false);

--- a/tests/unit/transform/date-test.js
+++ b/tests/unit/transform/date-test.js
@@ -14,9 +14,9 @@ let date = new Date(dateString);
 test('#serialize', function(assert) {
   let transform = new DS.DateTransform();
 
-  assert.equal(transform.serialize(null), null);
-  assert.equal(transform.serialize(undefined), null);
-  assert.equal(transform.serialize(new Date('invalid')), null);
+  assert.strictEqual(transform.serialize(null), null);
+  assert.strictEqual(transform.serialize(undefined), null);
+  assert.strictEqual(transform.serialize(new Date('invalid')), null);
 
   assert.equal(transform.serialize(date), dateString);
 });
@@ -31,10 +31,10 @@ test('#deserialize', function(assert) {
   assert.equal(transform.deserialize(dateInMillis).valueOf(), dateInMillis);
 
   // from other
-  assert.equal(transform.deserialize({}), null);
+  assert.strictEqual(transform.deserialize({}), null);
 
   // from none
-  assert.equal(transform.deserialize(null), null);
+  assert.strictEqual(transform.deserialize(null), null);
   assert.equal(transform.deserialize(undefined), null);
 });
 

--- a/tests/unit/transform/date-test.js
+++ b/tests/unit/transform/date-test.js
@@ -35,7 +35,7 @@ test('#deserialize', function(assert) {
 
   // from none
   assert.strictEqual(transform.deserialize(null), null);
-  assert.equal(transform.deserialize(undefined), null);
+  assert.strictEqual(transform.deserialize(undefined), undefined);
 });
 
 testInDebug('#deserialize with different offset formats', function(assert) {

--- a/tests/unit/transform/number-test.js
+++ b/tests/unit/transform/number-test.js
@@ -7,25 +7,25 @@ module('unit/transform - DS.NumberTransform');
 test('#serialize', function(assert) {
   let transform = new DS.NumberTransform();
 
-  assert.equal(transform.serialize(null), null);
-  assert.equal(transform.serialize(undefined), null);
+  assert.strictEqual(transform.serialize(null), null);
+  assert.strictEqual(transform.serialize(undefined), null);
   assert.equal(transform.serialize("1.1"), 1.1);
   assert.equal(transform.serialize(1.1), 1.1);
   assert.equal(transform.serialize(new Number(1.1)), 1.1);
-  assert.equal(transform.serialize(NaN), null);
-  assert.equal(transform.serialize(Infinity), null);
-  assert.equal(transform.serialize(-Infinity), null);
+  assert.strictEqual(transform.serialize(NaN), null);
+  assert.strictEqual(transform.serialize(Infinity), null);
+  assert.strictEqual(transform.serialize(-Infinity), null);
 });
 
 test('#deserialize', function(assert) {
   let transform = new DS.NumberTransform();
 
-  assert.equal(transform.deserialize(null), null);
-  assert.equal(transform.deserialize(undefined), null);
+  assert.strictEqual(transform.deserialize(null), null);
+  assert.strictEqual(transform.deserialize(undefined), null);
   assert.equal(transform.deserialize('1.1'), 1.1);
   assert.equal(transform.deserialize(1.1), 1.1);
   assert.equal(transform.deserialize(new Number(1.1)), 1.1);
-  assert.equal(transform.deserialize(NaN), null);
-  assert.equal(transform.deserialize(Infinity), null);
-  assert.equal(transform.deserialize(-Infinity), null);
+  assert.strictEqual(transform.deserialize(NaN), null);
+  assert.strictEqual(transform.deserialize(Infinity), null);
+  assert.strictEqual(transform.deserialize(-Infinity), null);
 });

--- a/tests/unit/transform/string-test.js
+++ b/tests/unit/transform/string-test.js
@@ -7,8 +7,8 @@ module('unit/transform - DS.StringTransform');
 test('#serialize', function(assert) {
   let transform = new DS.StringTransform();
 
-  assert.equal(transform.serialize(null), null);
-  assert.equal(transform.serialize(undefined), null);
+  assert.strictEqual(transform.serialize(null), null);
+  assert.strictEqual(transform.serialize(undefined), null);
 
   assert.equal(transform.serialize('foo'), 'foo');
   assert.equal(transform.serialize(1), '1');
@@ -17,8 +17,8 @@ test('#serialize', function(assert) {
 test('#deserialize', function(assert) {
   let transform = new DS.StringTransform();
 
-  assert.equal(transform.deserialize(null), null);
-  assert.equal(transform.deserialize(undefined), null);
+  assert.strictEqual(transform.deserialize(null), null);
+  assert.strictEqual(transform.deserialize(undefined), null);
 
   assert.equal(transform.deserialize('foo'), 'foo');
   assert.equal(transform.deserialize(1), '1');


### PR DESCRIPTION
Does this make sense? Basically this is to prevent us from future :trollface:ing like reported in #5207. I am unsure if this is a good idea or if we should update the tests to use `assert.ok` / `assert.notOk` instead 🤔 . Basically just did a search and replace...