### PR TITLE
Remove (unnecessary) ember-inflector peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,9 +111,6 @@
     "rimraf": "2.5.2",
     "rsvp": "4.7.0"
   },
-  "peerDependencies": {
-    "ember-inflector": "^2.0.0"
-  },
   "engines": {
     "node": ">= 4.0.0"
   },


### PR DESCRIPTION
When I install my project dependencies with Yarn, I get the following warning:

```
warning "ember-data@2.16.2" has unmet peer dependency "ember-inflector@^2.0.0".
```

It looks like the ember-inflector peer dependency [was added to `package.json`](https://github.com/emberjs/data/commit/86a3f574a265b24efec6d9fc8dc4f2f349039031) back when it was a dev dependency. ember-inflector [has since been upgraded to a direct dependency](https://github.com/emberjs/data/commit/4fab9abac9e7f510a95c2a6ae8dd84a22b26f5a0), so it no longer needs to be listed as a peer dependency as consuming applications get it automatically when they install ember-data.