### PR TITLE
Fix docs link in DS.Serializer

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -17,7 +17,7 @@ import EmberObject from '@ember/object';
     * `normalize()`
 
   For an example implementation, see
-  [DS.JSONSerializer](DS.JSONSerializer.html), the included JSON serializer.
+  [DS.JSONSerializer](DS.JSONSerializer), the included JSON serializer.
 
   @class Serializer
   @namespace DS


### PR DESCRIPTION
When rendered, this links to https://www.emberjs.com/api/ember-data/2.15/classes/DS.JSONSerializer.html - which 404's. Correct link doesn't have the `.html`.