### PR TITLE
[BUGFIX beta] Normalize model names during `push`

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2009,7 +2009,8 @@ Store = Service.extend({
   */
   _load(data) {
     heimdall.increment(_load);
-    let internalModel = this._internalModelForId(data.type, data.id);
+    let modelName = normalizeModelName(data.type);
+    let internalModel = this._internalModelForId(modelName, data.id);
 
     let isUpdate = internalModel.currentState.isEmpty === false;
 

--- a/tests/integration/record-array-test.js
+++ b/tests/integration/record-array-test.js
@@ -119,6 +119,42 @@ test('acts as a live query', function(assert) {
   assert.equal(get(recordArray, 'lastObject.name'), 'brohuda');
 });
 
+test('acts as a live query (normalized names)', function (assert) {
+  let store = createStore({
+    person: Person,
+    Person: Person
+  });
+
+  let recordArray = store.peekAll('Person');
+
+  run(() => {
+    store.push({
+      data: {
+        type: 'Person',
+        id: '1',
+        attributes: {
+          name: 'John Churchill'
+        }
+      }
+    });
+  });
+
+  assert.deepEqual(recordArray.mapBy('name'), ['John Churchill']);
+
+  run(() => {
+    store.push({
+      data: {
+        type: 'Person',
+        id: '2',
+        attributes: {
+          name: 'Winston Churchill'
+        }
+      }
+    });
+  });
+  assert.deepEqual(recordArray.mapBy('name'), ['John Churchill', 'Winston Churchill']);
+});
+
 test('stops updating when destroyed', function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
Model names are normalized (so eg `store.peekRecord('fooBar',1) === store.peekRecord('foo-bar', 1)`) at most of the store API (`peekRecord`,`findRecord` &c.) but notably absent is `push`.

This adds back model name normalization to push