### PR TITLE
[DOC] Fixup DS.Store.pushPayload example

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2493,7 +2493,7 @@ Store = Service.extend({
     ```
 
     ```js
-    store.pushPayload('comment', pushData); // Will use the application serializer
+    store.pushPayload(pushData); // Will use the application serializer
     store.pushPayload('post', pushData); // Will use the post serializer
     ```
 


### PR DESCRIPTION
The application serializer is used when a model name is not given. We already have one example where a model name is given and specify that the corresponding serializer will be used.