### PR TITLE
[DISCUSSION] Provide an alternative to using `hasMany.[]` to react to reference changes.

### DIFF
--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -143,7 +143,6 @@ export default EmberObject.extend(MutableArray, Evented, {
   },
 
   flushCanonical(isInitialized = true) {
-    debugger;
     // It’s possible the parent side of the relationship may have been unloaded by this point
     if (!_objectIsAlive(this)) {
       return;

--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -143,6 +143,7 @@ export default EmberObject.extend(MutableArray, Evented, {
   },
 
   flushCanonical(isInitialized = true) {
+    debugger;
     // It’s possible the parent side of the relationship may have been unloaded by this point
     if (!_objectIsAlive(this)) {
       return;

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1116,6 +1116,7 @@ const Model = EmberObject.extend(Evented, {
     //TODO(Igor): Consider whether we could do this only if the record state is unloaded
 
     //Goes away once hasMany is double promisified
+    // debugger;
     this.notifyPropertyChange(key);
   },
 

--- a/addon/-private/system/references/has-many.js
+++ b/addon/-private/system/references/has-many.js
@@ -147,6 +147,7 @@ HasManyReference.prototype.link = function() {
    @return {Array} The ids in this has-many relationship
 */
 HasManyReference.prototype.ids = function() {
+  this.hasManyRelationship.manyArray;
   let members = this.hasManyRelationship.members.toArray();
 
   return members.map(function(internalModel) {

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -248,6 +248,7 @@ export default class ManyRelationship extends Relationship {
   }
 
   notifyHasManyChanged() {
+    // debugger;
     this.internalModel.notifyHasManyAdded(this.key);
   }
 

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -111,7 +111,6 @@ module("integration/relationships/has_many - Has-Many Relationships", {
 
 test("When an object is destroyed, it's hasMany parent is updated", function(assert) {
   assert.expect(3);
-  let done = assert.async();
 
   var Post = DS.Model.extend({
     comments: DS.hasMany('comment', { async: true }),
@@ -135,16 +134,9 @@ test("When an object is destroyed, it's hasMany parent is updated", function(ass
     })
   });
 
-  var commentId = 1;
   env.registry.register('adapter:comment', DS.RESTAdapter.extend({
     deleteRecord(record) {
       return Ember.RSVP.resolve();
-    },
-    updateRecord(record) {
-      return Ember.RSVP.resolve();
-    },
-    createRecord() {
-      return Ember.RSVP.resolve({ comments: { id: commentId++ }});
     }
   }));
 
@@ -168,15 +160,14 @@ test("When an object is destroyed, it's hasMany parent is updated", function(ass
   });
 
   run(function() {
-    env.store.findRecord('post', 1).then(function (post) {
+    return env.store.findRecord('post', 1).then(function (post) {
       assert.ok(post.get('hasComments'));
 
-      env.store.findRecord('comment', 1).then(function (comment) {
+      return env.store.findRecord('comment', 1).then(function (comment) {
         assert.ok(comment);
 
-        comment.destroyRecord().then(function() {
+        return comment.destroyRecord().then(function() {
           assert.notOk(post.get('hasComments'));
-          done();
         });
       });
     });


### PR DESCRIPTION
- Adds test for and resolves #4974 which has been a bug since ember-data `2.11`
- Improves failing test from #4976 but shows that this is a different issue.

This PR contains the sad tale of how making the `manyArray` for a record lazy has combined with the nature of how computed properties and property chains observe values to mega-troll our end user's ability to introspect state.  The fix contained here is dirty, and we should consider alternatives.

## The Bug

Imagine that you want to observe changes to the references (`{ type, id }`) held by a `hasMany`, and react to them without also triggering a fetch of the relationship.  Ember offers a tool that allows for observing changes to an array, while ember-data offers a tool for fetching a relationship by reference to avoid fetching it. 

*Example model*

```js
export default Model.extend({
  others: hasMany('other-model', { async: false, inverse: 'mine' }),
  
  hasOthers: computed('others.[]', function() {
    return this.hasMany('others').ids().length > 0;
  }),
  
  othersCount: computed('others.[]', function() {
    return this.hasMany('others').ids().length;
  })
});
```

As additional records are pushed into the store changing the content of `others`, these computed properties will not trigger.

[Twiddle](https://ember-twiddle.com/4a2d2c9571d5f5f40a386ce6b0a324df?openFiles=models.my-model.js%2C).

## The Underlying Problem

Because `manyArray` is crated lazily, the observation chain for `others.[]` sees an `undefined` value until something calls `get('others')`.  Because of this, until something accesses the relationship, changes to the array go unnoticed because there is no array to watch.

It could be argued that a computed property with a dependency that goes un-fetched is a code smell.  However, we have not provided another means for easily working with relationship references without forcing the fetch of the relationship.

It could also be argued that working on data in the store by reference is a separate view of the world than working on data via the model layer, and thus combining these separate views in this way is simply not supported. However, this would leave users that need to react to changes by reference but do not desire to force the relationship to load with no good avenue forward.

## The Dirty Fix

We could make accessing `hasManyReference.prototype.ids()` have the side-effect of materializing the `manyArray`. This solves the general case, but increases the mental overhead and can create spooky-action at a distance.

## A Long Term Proposal

We should make working with relationships by reference a first class feature of ember-data.