### PR TITLE
[BUGFIX] Fix issues with links

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@
 module.exports = {
   root: true,
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2017,
     sourceType: 'module',
   },
   extends: 'eslint:recommended',

--- a/addon/-private/system/relationships/relationship-payloads-manager.js
+++ b/addon/-private/system/relationships/relationship-payloads-manager.js
@@ -203,7 +203,7 @@ export default class RelationshipPayloadsManager {
     }
 
     let lhsKey = `${modelName}:${relationshipName}`;
-    let rhsKey = `${inverseModelName}:${inverseRelationshipName}`;
+    let rhsKey = inverseRelationshipMeta ? `${inverseModelName}:${inverseRelationshipName}` : null;
 
     // populate the cache for both sides of the relationship, as they both use
     // the same `RelationshipPayloads`.
@@ -211,16 +211,20 @@ export default class RelationshipPayloadsManager {
     // This works out better than creating a single common key, because to
     // compute that key we would need to do work to look up the inverse
     //
-    return this._cache[lhsKey] =
-      this._cache[rhsKey] =
-      new RelationshipPayloads(
-        this._store,
-        modelName,
-        relationshipName,
-        relationshipMeta,
-        inverseModelName,
-        inverseRelationshipName,
-        inverseRelationshipMeta
-      );
+    const newRelationship = new RelationshipPayloads(
+      this._store,
+      modelName,
+      relationshipName,
+      relationshipMeta,
+      inverseModelName,
+      inverseRelationshipName,
+      inverseRelationshipMeta
+    );
+
+    this._cache[lhsKey] = newRelationship;
+    if (rhsKey && !this._cache[rhsKey]) {
+      this._cache[rhsKey] = newRelationship;
+    }
+    return newRelationship;
   }
 }

--- a/addon/-private/system/relationships/relationship-payloads.js
+++ b/addon/-private/system/relationships/relationship-payloads.js
@@ -151,10 +151,11 @@ export default class RelationshipPayloads {
 
     let payloadsToBeProcessed = this._pendingPayloads.splice(0, this._pendingPayloads.length);
     for (let i=0; i<payloadsToBeProcessed.length; ++i) {
-      let modelName = payloadsToBeProcessed[i][0];
-      let id = payloadsToBeProcessed[i][1];
-      let relationshipName = payloadsToBeProcessed[i][2];
-      let relationshipData = payloadsToBeProcessed[i][3];
+      const payload = payloadsToBeProcessed[i];
+      let modelName = payload[0];
+      let id = payload[1];
+      let relationshipName = payload[2];
+      let relationshipData = payload[3];
 
       // TODO: maybe delay this allocation slightly?
       let inverseRelationshipData = {
@@ -289,6 +290,10 @@ export default class RelationshipPayloads {
       } else {
         inverseIdToPayloads[inverseId] = inversePayload;
       }
+    } else if (existingPayload && existingPayload.links) {
+      // the inverse relationship hasn't been populated yet
+      // so we can't overwrite it
+      return;
     } else {
       // first time we're populating the inverse side
       //

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -3377,3 +3377,79 @@ test("hasMany relationship with links doesn't trigger extra change notifications
 
   assert.equal(count, 0);
 });
+
+test("A hasMany relationship with a link will trigger the link request even if a inverse related object is pushed to the store", function(assert) {
+  Post.reopen({
+    comments: DS.hasMany('comment', { async: true })
+  });
+
+  Comment.reopen({
+    message: DS.belongsTo('post', { async: true})
+  });
+
+  const postID = '1';
+
+  run(function() {
+    // load a record with a link hasMany relationship
+    env.store.push({
+      data: {
+        type: 'post',
+        id: postID,
+        relationships: {
+          comments: {
+            links: {
+              related: '/posts/1/comments'
+            }
+          }
+        }
+      }
+    });
+
+    // if a related comment is pushed into the store,
+    // the post.comments.link will not be requested
+    //
+    // If this comment is not inserted into the store, everything works properly
+    env.store.push({
+      data: {
+        type: 'comment',
+        id: '1',
+        attributes: { body: "First" },
+        relationships: {
+          message: {
+            data: { type: 'post', id: postID }
+          }
+        }
+      }
+    });
+
+    env.adapter.findRecord = function(store, type, id, snapshot) {
+      throw new Error(`findRecord for ${type} should not be called`);
+    };
+
+    let hasManyCounter = 0;
+    env.adapter.findHasMany = function(store, snapshot, link, relationship) {
+      assert.equal(relationship.type, 'comment', "findHasMany relationship type was Comment");
+      assert.equal(relationship.key, 'comments', "findHasMany relationship key was comments");
+      assert.equal(link, "/posts/1/comments", "findHasMany link was /posts/1/comments");
+      hasManyCounter++;
+
+      return resolve({ data: [
+        { id: 1, type: 'comment', attributes: { body: "First" } },
+        { id: 2, type: 'comment', attributes: { body: "Second" } }
+      ]});
+    };
+
+    const post = env.store.peekRecord('post', postID);
+    post.get('comments').then(function(comments) {
+      assert.equal(comments.get('isLoaded'), true, "comments are loaded");
+      assert.equal(hasManyCounter, 1, "link was requested");
+      assert.equal(comments.get('length'), 2, "comments have 2 length");
+
+      post.hasMany('comments').reload().then(function(comments) {
+        assert.equal(comments.get('isLoaded'), true, "comments are loaded");
+        assert.equal(hasManyCounter, 2, "link was requested");
+        assert.equal(comments.get('length'), 2, "comments have 2 length");
+      });
+    });
+  });
+});

--- a/tests/integration/relationships/json-api-links-test.js
+++ b/tests/integration/relationships/json-api-links-test.js
@@ -1,0 +1,166 @@
+import { run } from '@ember/runloop';
+import { Promise } from 'rsvp';
+import setupStore from 'dummy/tests/helpers/store';
+
+import {
+  reset as resetModelFactoryInjection
+} from 'dummy/tests/helpers/model-factory-injection';
+import { module, test } from 'qunit';
+
+import DS from 'ember-data';
+
+const { hasMany, belongsTo } = DS;
+
+let env, User, Organisation;
+
+module("integration/relationship/json-api-links Relationships loaded by links", {
+  beforeEach() {
+  },
+
+  afterEach() {
+    resetModelFactoryInjection();
+    run(env.container, 'destroy');
+  }
+});
+
+test("Loading link with inverse:null on other model caches the two ends separately", function (assert) {
+  User = DS.Model.extend({
+    organisation: belongsTo('organisation', { inverse: null })
+  });
+
+  Organisation = DS.Model.extend({
+    adminUsers: hasMany('user')
+  });
+
+  env = setupStore({
+    user: User,
+    organisation: Organisation
+  });
+
+  env.registry.optionsForType('serializer', { singleton: false });
+  env.registry.optionsForType('adapter', { singleton: false });
+
+  const store = env.store;
+
+  User = store.modelFor('user');
+  Organisation = store.modelFor('organisation');
+
+  env.registry.register('adapter:user', DS.JSONAPISerializer.extend({
+    findRecord(store, type, id) {
+      return new Promise((resolve) => {
+        run.later(() => {
+          resolve({
+            data: {
+              id,
+              type: 'user',
+              relationships: {
+                organisation: {
+                  data: { id: 1, type: 'organisation' }
+                }
+              }
+            }
+          })
+        }, 10);
+      });
+    }
+  }));
+
+  env.registry.register('adapter:organisation', DS.JSONAPISerializer.extend({
+    findRecord(store, type, id) {
+      return new Promise((resolve) => {
+        run.later(() => {
+          resolve({
+            data: {
+              type: 'organisation',
+              id,
+              relationships: {
+                'admin-users': {
+                  links: {
+                    related: '/org-admins'
+                  }
+                }
+              }
+            }
+          })
+        }, 10);
+      });
+    }
+  }));
+
+  return run(() => {
+    return store.findRecord('user', 1)
+      .then(user1 => {
+        assert.ok(user1, 'user should be populated');
+
+        return store.findRecord('organisation', 2)
+          .then(org2FromFind => {
+            assert.equal(user1.belongsTo('organisation').remoteType(), 'id', `user's belongsTo is based on id`);
+            assert.equal(user1.belongsTo('organisation').id(), 1, `user's belongsTo has its id populated`);
+
+            return user1.get('organisation')
+              .then(orgFromUser => {
+                assert.equal(user1.belongsTo('organisation').belongsToRelationship.hasLoaded, true, 'user should have loaded its belongsTo relationship');
+
+                assert.ok(org2FromFind, 'organisation we found should be populated');
+                assert.ok(orgFromUser, 'user\'s organisation should be populated');
+              })
+          })
+      })
+  });
+});
+
+test("Pushing child record should not mark parent:children as loaded", function (assert) {
+  let Child = DS.Model.extend({
+    parent: belongsTo('parent', { inverse: 'children' })
+  });
+
+  let Parent = DS.Model.extend({
+    children: hasMany('child')
+  });
+
+  env = setupStore({
+    parent: Parent,
+    child: Child
+  });
+
+  env.registry.optionsForType('serializer', { singleton: false });
+  env.registry.optionsForType('adapter', { singleton: false });
+
+  const store = env.store;
+
+  Parent = store.modelFor('parent');
+  Child = store.modelFor('child');
+
+  return run(() => {
+    const parent = store.push({
+      data: {
+        id: 'p1',
+        type: 'parent',
+        relationships: {
+          children: {
+            links: {
+              related: '/parent/1/children'
+            }
+          }
+        }
+      }
+    });
+
+    store.push({
+      data: {
+        id: 'c1',
+        type: 'child',
+        relationships: {
+          parent: {
+            data: {
+              id: 'p1',
+              type: 'parent'
+            }
+          }
+        }
+      }
+    });
+
+    assert.equal(parent.hasMany('children').hasManyRelationship.hasLoaded, false, 'parent should think that children still needs to be loaded');
+  });
+});

--- a/tests/integration/relationships/json-api-links-test.js
+++ b/tests/integration/relationships/json-api-links-test.js
@@ -1,5 +1,5 @@
 import { run } from '@ember/runloop';
-import { Promise } from 'rsvp';
+import { resolve } from 'rsvp';
 import setupStore from 'dummy/tests/helpers/store';
 
 import {
@@ -47,42 +47,34 @@ test("Loading link with inverse:null on other model caches the two ends separate
 
   env.registry.register('adapter:user', DS.JSONAPISerializer.extend({
     findRecord(store, type, id) {
-      return new Promise((resolve) => {
-        run.later(() => {
-          resolve({
-            data: {
-              id,
-              type: 'user',
-              relationships: {
-                organisation: {
-                  data: { id: 1, type: 'organisation' }
-                }
-              }
+      return resolve({
+        data: {
+          id,
+          type: 'user',
+          relationships: {
+            organisation: {
+              data: { id: 1, type: 'organisation' }
             }
-          })
-        }, 10);
+          }
+        }
       });
     }
   }));
 
   env.registry.register('adapter:organisation', DS.JSONAPISerializer.extend({
     findRecord(store, type, id) {
-      return new Promise((resolve) => {
-        run.later(() => {
-          resolve({
-            data: {
-              type: 'organisation',
-              id,
-              relationships: {
-                'admin-users': {
-                  links: {
-                    related: '/org-admins'
-                  }
-                }
+      return resolve({
+        data: {
+          type: 'organisation',
+          id,
+          relationships: {
+            'admin-users': {
+              links: {
+                related: '/org-admins'
               }
             }
-          })
-        }, 10);
+          }
+        }
       });
     }
   }));

--- a/tests/integration/relationships/nested-relationship-test.js
+++ b/tests/integration/relationships/nested-relationship-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import DS from 'ember-data';
 import Ember from 'ember';
 
-const { RSVP: { Promise } } = Ember;
+const { RSVP: { resolve } } = Ember;
 const { attr, hasMany, belongsTo } = DS;
 
 let env, store, serializer, Elder, MiddleAger, Kid;

--- a/tests/integration/relationships/nested-relationship-test.js
+++ b/tests/integration/relationships/nested-relationship-test.js
@@ -5,7 +5,9 @@ import setupStore from 'dummy/tests/helpers/store';
 import { module, test } from 'qunit';
 
 import DS from 'ember-data';
+import Ember from 'ember';
 
+const { RSVP: { Promise } } = Ember;
 const { attr, hasMany, belongsTo } = DS;
 
 let env, store, serializer, Elder, MiddleAger, Kid;
@@ -34,6 +36,25 @@ module('integration/relationships/nested_relationships_test - Nested relationshi
       kid: Kid,
       adapter: DS.JSONAPIAdapter
     });
+
+    env.registry.register('adapter:middle-ager', DS.JSONAPIAdapter.extend({
+      findHasMany (store, snapshot, url, relationship) {
+        return new Promise((resolve) => {
+          run.later(() => {
+            if (url === '/middle-agers/1/kids') {
+              resolve({
+                data: [{
+                  id: 1,
+                  type: 'kid'
+                }]
+              });
+            } else {
+              resolve({ data: [] });
+            }
+          }, 10);
+        });
+      }
+    }));
 
     store = env.store;
     serializer = env.serializer;

--- a/tests/integration/relationships/nested-relationship-test.js
+++ b/tests/integration/relationships/nested-relationship-test.js
@@ -39,20 +39,14 @@ module('integration/relationships/nested_relationships_test - Nested relationshi
 
     env.registry.register('adapter:middle-ager', DS.JSONAPIAdapter.extend({
       findHasMany (store, snapshot, url, relationship) {
-        return new Promise((resolve) => {
-          run.later(() => {
-            if (url === '/middle-agers/1/kids') {
-              resolve({
-                data: [{
-                  id: 1,
-                  type: 'kid'
-                }]
-              });
-            } else {
-              resolve({ data: [] });
-            }
-          }, 10);
-        });
+        let data = [];
+        if (url === '/middle-agers/1/kids') {
+          data.push({
+            id: 1,
+            type: 'kid'
+          });
+        }
+        return resolve({ data });
       }
     }));
 


### PR DESCRIPTION
Fix issue #5209 and #5211

when one end of a relationship is marked {inverse:null} keep the two relationships separate in the cache and don't create the ":" cache entry

minor optimisation in relationship-payloads.js - don't scan an array multiple times

In RelationshipPayloads, don't overwrite an inverse relationship if it's got links instead of data

Fixup nested relationships test which now needs to download its links

This should be backported to 2.14,15,16