### PR TITLE
[BUGFIX] inverseFor should respect inverse: null

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -35,7 +35,7 @@ function findPossibleInverses(type, inverseType, name, relationshipsSoFar) {
   let relationships = relationshipMap.get(type.modelName).filter(relationship => {
     let optionsForRelationship = inverseType.metaForProperty(relationship.name).options;
 
-    if (!optionsForRelationship.inverse) {
+    if (!optionsForRelationship.inverse && optionsForRelationship.inverse !== null) {
       return true;
     }
 

--- a/tests/integration/relationships/inverse-relationships-test.js
+++ b/tests/integration/relationships/inverse-relationships-test.js
@@ -7,6 +7,12 @@ import { module, test } from 'qunit';
 
 import DS from 'ember-data';
 
+let {
+  Model,
+  hasMany,
+  belongsTo
+} = DS;
+
 var Post, Comment, Message, User;
 
 module('integration/relationships/inverse_relationships - Inverse Relationships');
@@ -54,6 +60,34 @@ test("Inverse relationships can be explicitly nullable", function(assert) {
     post: Post
   });
   var user, post;
+
+  run(function() {
+    user = store.createRecord('user');
+    post = store.createRecord('post');
+  });
+
+  assert.equal(user.inverseFor('posts').name, 'participants', 'User.posts inverse is Post.participants');
+  assert.equal(post.inverseFor('lastParticipant'), null, 'Post.lastParticipant has no inverse');
+  assert.equal(post.inverseFor('participants').name, 'posts', 'Post.participants inverse is User.posts');
+});
+
+test("Null inverses are excluded from potential relationship resolutions", function(assert) {
+  User = Model.extend();
+
+  Post = Model.extend({
+    lastParticipant: belongsTo('user', { inverse: null, async: false }),
+    participants: hasMany('user', { async: false })
+  });
+
+  User.reopen({
+    posts: hasMany('post', { async: false })
+  });
+
+  let store = createStore({
+    user: User,
+    post: Post
+  });
+  let user, post;
 
   run(function() {
     user = store.createRecord('user');

--- a/tests/integration/serializers/json-serializer-test.js
+++ b/tests/integration/serializers/json-serializer-test.js
@@ -18,10 +18,10 @@ module("integration/serializer/json - JSONSerializer", {
     });
     Comment = DS.Model.extend({
       body: DS.attr('string'),
-      post: DS.belongsTo('post', { async: false })
+      post: DS.belongsTo('post', { inverse: null, async: false })
     });
     Favorite = DS.Model.extend({
-      post: DS.belongsTo('post', { async: true, polymorphic: true })
+      post: DS.belongsTo('post', { inverse: null, async: true, polymorphic: true })
     });
     env = setupStore({
       post:     Post,
@@ -237,7 +237,12 @@ test("serializeHasMany respects keyForRelationship", function(assert) {
 
   run(function() {
     post = env.store.createRecord('post', { title: "Rails is omakase", id: "1" });
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post, id: "1" });
+    comment = env.store.createRecord('comment', {
+      body: "Omakase is delicious",
+      post: post,
+      id: "1"
+    });
+    post.get('comments').pushObject(comment);
   });
 
   var json = {};
@@ -635,6 +640,7 @@ test('Serializer respects `serialize: true` on the attrs hash for a `hasMany` pr
   run(function() {
     post = env.store.createRecord('post', { title: "Rails is omakase" });
     comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
+    post.get('comments').pushObject(comment);
   });
 
   var serializer = env.store.serializerFor("post");


### PR DESCRIPTION
While working on #5230 I discovered that our current resolution strategy for `inverseFor` would improperly allow relationships that specify `inverse: null` to still be matched.  This addresses that, adds a test, and fixes two tests that depended upon this bug.