### PR TITLE
Update AdapterPopulatedRecordArray to use links if available otherwise return null

### DIFF
--- a/addon/-private/system/record-arrays/adapter-populated-record-array.js
+++ b/addon/-private/system/record-arrays/adapter-populated-record-array.js
@@ -49,7 +49,7 @@ export default RecordArray.extend({
 
     this._super(...arguments);
     this.query = this.query || null;
-    this.links = null;
+    this.links = this.links || null;
   },
 
   replace() {

--- a/tests/unit/record-arrays/adapter-populated-record-array-test.js
+++ b/tests/unit/record-arrays/adapter-populated-record-array-test.js
@@ -51,7 +51,7 @@ test('custom initial state', function(assert) {
   assert.equal(recordArray.get('content'), content);
   assert.equal(recordArray.get('store'), store);
   assert.equal(recordArray.get('query'), 'some-query');
-  assert.strictEqual(recordArray.get('links'), null);
+  assert.strictEqual(recordArray.get('links'), 'foo');
 });
 
 test('#replace() throws error', function(assert) {


### PR DESCRIPTION
- Allows properly using the `links` value of a json-api response.
- (clone of https://github.com/emberjs/data/pull/5240)