### PR TITLE
[BUGFIX FEAT] Preserve local hasMany changes during flushCanonical

### DIFF
--- a/addon/-private/system/diff-array.js
+++ b/addon/-private/system/diff-array.js
@@ -1,3 +1,4 @@
+import OrderedSet from './ordered-set';
 /**
   @namespace
   @method diffArray
@@ -11,7 +12,7 @@
       removedCount: <integer>       // 0 if no change
     }
 */
-export default function diffArray(oldArray, newArray) {
+export function diffArray(oldArray, newArray) {
   const oldLength = oldArray.length;
   const newLength = newArray.length;
 
@@ -57,3 +58,95 @@ export default function diffArray(oldArray, newArray) {
     removedCount
   };
 }
+
+export function setForArray(array) {
+  let set = new OrderedSet();
+
+  if (array) {
+    for (let i=0, l=array.length; i<l; i++) {
+      set.add(array[i]);
+    }
+  }
+
+  return set;
+}
+
+export function computeChanges(oldArray, newArray, removalSet) {
+  let changeset = {
+    changes: false,
+    additions: [],
+    removals: []
+  };
+
+  let diff = diffArray(oldArray, newArray);
+
+  if (diff.firstChangeIndex === null) {
+    // no changes found
+    if (removalSet) {
+      // records that have been removed since last compute will need their inverses to be corrected
+      for (let i = 0, l = newArray.length; i < l; i++) {
+        let record = newArray[i];
+        if (removalSet.has(record)) {
+          changeset.changes = true;
+          break;
+        }
+      }
+    }
+
+    return changeset;
+  }
+
+  let removedMembersSet = setForArray(oldArray.slice(diff.firstChangeIndex, diff.firstChangeIndex + diff.removedCount));
+  let changeBlockSet = setForArray(newArray.slice(diff.firstChangeIndex, diff.firstChangeIndex + diff.addedCount));
+
+  // remove members that were removed but not re-added
+  removedMembersSet.forEach(member => {
+    if (!changeBlockSet.has(member)) {
+      changeset.removals.push(member);
+    }
+  });
+
+  let flushCanonicalLater = false;
+
+  // --- deal with records before the change block
+  if (removalSet) {
+    // records that have been removed since last compute will need their inverses to be corrected
+    for (let i = 0; i < diff.firstChangeIndex; i++) {
+      let record = newArray[i];
+      if (removalSet.has(record)) {
+        changeset.changes = true;
+        break;
+      }
+    }
+  }
+
+  // --- deal with records in the change block
+  for (let i = diff.firstChangeIndex, l = diff.firstChangeIndex + diff.addedCount; i < l; i++) {
+    let record = newArray[i];
+    if (oldArray[i] !== record) {
+      changeset.changes = true;
+      if (removedMembersSet.has(record)) {
+        // this is a reorder
+        changeset.removals.push(record);
+      }
+      // reorder or insert
+      changeset.additions.push(record, i);
+    }
+  }
+
+  // --- deal with records after the change block
+  if (!flushCanonicalLater && removalSet) {
+    // records that have been removed since last compute will need their inverses to be corrected
+    for (let i = diff.firstChangeIndex + diff.addedCount, l = newArray.length; i < l; i++) {
+      let record = newArray[i];
+      if (removalSet.has(record)) {
+        changeset.changes = true;
+        break;
+      }
+    }
+  }
+
+  return changeset;
+}
+
+export default diffArray;

--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -136,9 +136,7 @@ export default EmberObject.extend(MutableArray, Evented, {
   },
 
   objectAt(index) {
-    if (this.relationship._willUpdateManyArray) {
-      this.relationship._flushPendingManyArrayUpdates();
-    }
+    this.relationship._flushPendingManyArrayUpdates();
     let internalModel = this.currentState[index];
     if (internalModel === undefined) { return; }
 
@@ -150,17 +148,8 @@ export default EmberObject.extend(MutableArray, Evented, {
     if (!_objectIsAlive(this)) {
       return;
     }
-    let toSet = this.canonicalState;
-
-    //a hack for not removing new records
-    //TODO remove once we have proper diffing
-    let newInternalModels = this.currentState.filter(
-      // only add new internalModels which are not yet in the canonical state of this
-      // relationship (a new internalModel can be in the canonical state if it has
-      // been 'acknowleged' to be in the relationship via a store.push)
-      (internalModel) => internalModel.isNew() && toSet.indexOf(internalModel) === -1
-    );
-    toSet = toSet.concat(newInternalModels);
+    this.relationship._flushPendingManyArrayUpdates();
+    let toSet = this.relationship.members.list.slice();
 
     // diff to find changes
     let diff = diffArray(this.currentState, toSet);

--- a/tests/integration/records/relationship-changes-test.js
+++ b/tests/integration/records/relationship-changes-test.js
@@ -668,16 +668,16 @@ test('Calling push with relationship triggers willChange and didChange with deta
   let observer = {
     arrayWillChange(array, start, removing, adding) {
       willChangeCount++;
-      assert.equal(start, 0);
-      assert.equal(removing, 0);
-      assert.equal(adding, 1);
+      assert.equal(start, 0, 'change will start at the beginning');
+      assert.equal(removing, 0, 'we have no removals');
+      assert.equal(adding, 1, 'we have one insertion');
     },
 
     arrayDidChange(array, start, removed, added) {
       didChangeCount++;
-      assert.equal(start, 0);
-      assert.equal(removed, 0);
-      assert.equal(added, 1);
+      assert.equal(start, 0, 'change did start at the beginning');
+      assert.equal(removed, 0, 'change had no removals');
+      assert.equal(added, 1, 'change had one insertion');
     }
   };
 

--- a/tests/integration/relationships/many-to-many-test.js
+++ b/tests/integration/relationships/many-to-many-test.js
@@ -1,13 +1,10 @@
 /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "(ada)" }]*/
 
 import { resolve, Promise as EmberPromise } from 'rsvp';
-
 import { run } from '@ember/runloop';
-
+import { get } from '@ember/object';
 import setupStore from 'dummy/tests/helpers/store';
-
 import { module, test } from 'qunit';
-
 import DS from 'ember-data';
 
 const { attr, hasMany } = DS;
@@ -615,5 +612,11 @@ test("Re-loading a removed record should re add it to the relationship when the 
     });
   });
 
-  assert.equal(account.get('users.length'), 2, 'Accounts were updated correctly');
+  let state = account.hasMany('users').hasManyRelationship.canonicalMembers.list;
+  let users = account.get('users');
+
+  assert.equal(users.get('length'), 1, 'Accounts were updated correctly (ui state)');
+  assert.deepEqual(users.map(r => get(r, 'id')), ['1'], 'Accounts were updated correctly (ui state)');
+  assert.equal(state.length, 2, 'Accounts were updated correctly (server state)');
+  assert.deepEqual(state.map(r => r.id), ['1', '2'], 'Accounts were updated correctly (server state)');
 });


### PR DESCRIPTION
resolves #5269 

When new data comes in via `store.push` for a many array, and
`ManyArray.prototype.flushCanonical` is invoked:
  - new, unpersisted records added to the relationship are correctly not discarded, but
  - persisted records added to the relationship are erroneously discarded
  - new, unpersisted removals from the relationship are erroneously discarded

paired with @rwjblue, fix and additional test by @runspired 