### PR TITLE
[WIP] Ambient type information

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,140 @@
+// tslint:disable:max-classes-per-file
+declare module "ember-data/types" {
+  /**
+   * A mapping type for resolving model names into model types.
+   * For now, users need to explicitly define this type in their project,
+   * and their interface will be merged with this one.
+   *
+   * Example:
+   *
+   *  declare module 'ember-data/types' {
+   *    import { BlogPost } from 'my-app/models/blog-post';
+   *    import { User } from 'my-app/models/user';
+   *
+   *    interface RecordTypeMap {
+   *      user: User;
+   *      'blog-post': BlogPost;
+   *    }
+   *    interface TransformsMap {
+   *      csv: string[];
+   *    }
+   *  }
+   */
+  /* tslint:disable-next-line no-empty-interface */
+  interface RecordTypeMap {}
+  /**
+   * A mapping type for resolving attribute type names to attribute types.
+   * This is set up for attribute types supported by ember-data by default,
+   * but if users wish to define their own transforms, and have them work
+   * with TypeScript, they may merge additional properties into this interface
+   *
+   * Example:
+   *
+   *  declare module 'ember-data/types' {
+   *    interface TransformsMap {
+   *      csv: string[];
+   *    }
+   *  }
+   */
+  interface TransformsMap {
+    string: string;
+    number: number;
+    boolean: boolean;
+    date: Date;
+  }
+}
+
+declare module "ember-data" {
+  import ArrayProxy from "@ember/array/proxy";
+  import EmberObject from "@ember/object";
+  import ComputedProperty from "@ember/object/computed";
+  import { RecordTypeMap, TransformsMap } from "ember-data/types";
+  import { Promise } from "rsvp";
+
+  namespace DS {
+    /// MODEL
+    class Model extends EmberObject {
+      public id: string | number;
+    }
+
+    /// STORE
+    class Store extends EmberObject {
+      public query<S extends keyof RecordTypeMap>(
+        modelName: S,
+        queryParams: any
+      ): Promise<ArrayProxy<RecordTypeMap[S]>>;
+
+      public createRecord<S extends keyof RecordTypeMap>(
+        modelName: S,
+        params?: Partial<RecordTypeMap[S]>
+      ): RecordTypeMap[S];
+      public findRecord<S extends keyof RecordTypeMap>(
+        modelName: S,
+        id: string | number
+      ): Promise<RecordTypeMap[S]>;
+      public findAll<S extends keyof RecordTypeMap>(
+        modelName: S
+      ): Promise<ArrayProxy<RecordTypeMap[S]>>;
+    }
+    /// ATTR
+    interface AttrOptions<T> {
+      defaultValue?: T | (() => T);
+    }
+
+    function attr<S extends keyof TransformsMap>(
+      type: S,
+      options?: AttrOptions<TransformsMap[S]>
+    ): ComputedProperty<TransformsMap[S]>;
+
+    /// RELATIONSHIPS
+    interface RelationshipOptions<To> {
+      inverse?: keyof To;
+    }
+
+    export function hasMany<S extends keyof RecordTypeMap>(
+      modelName: S,
+      relationshipOptions?: RelationshipOptions<RecordTypeMap[S]>
+    ): ComputedProperty<ArrayProxy<RecordTypeMap[S]>>;
+    export function belongsTo<S extends keyof RecordTypeMap>(
+      modelName: S,
+      relationshipOptions?: RelationshipOptions<RecordTypeMap[S]>
+    ): ComputedProperty<RecordTypeMap[S]>;
+  }
+  export default DS;
+}
+
+/**
+ * Inject the `store` service onto Route and Controller types
+ */
+declare module "ember" {
+  import Store from "ember-data/store";
+  namespace Ember {
+    interface Route {
+      store: ComputedProperty<Store>;
+    }
+    interface Controller {
+      store: ComputedProperty<Store>;
+    }
+  }
+}
+
+declare module "ember-data/model" {
+  import DS from "ember-data";
+  export default DS.Model;
+}
+
+declare module "ember-data/store" {
+  import DS from "ember-data";
+  export default DS.Store;
+}
+
+declare module "ember-data/attr" {
+  import DS from "ember-data";
+  export default DS.attr;
+}
+
+declare module "ember-data/relationships" {
+  import DS from "ember-data";
+  export const hasMany: typeof DS.hasMany;
+  export const belongsTo: typeof DS.belongsTo;
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "silent-error": "^1.0.0"
   },
   "devDependencies": {
+    "@types/ember": "^2.8.3",
     "babel-plugin-debug-macros": "^0.1.7",
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-es2015-classes": "^6.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,22 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
+"@types/ember@^2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@types/ember/-/ember-2.8.3.tgz#f6a8549b727d752f6e4e0aeb6074b460a309aa79"
+  dependencies:
+    "@types/handlebars" "*"
+    "@types/jquery" "*"
+    "@types/rsvp" "*"
+
+"@types/handlebars@*":
+  version "4.0.36"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.36.tgz#ff57c77fa1ab6713bb446534ddc4d979707a3a79"
+
+"@types/jquery@*":
+  version "3.2.16"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.2.16.tgz#04419c404a3194350e7d3f339a90e72c88db3111"
+
 "@types/node@*":
   version "8.0.44"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.44.tgz#5c39800fda4b76dab39a5f28fda676fc500015ac"
@@ -23,6 +39,10 @@
 "@types/rimraf@^0.0.28":
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-0.0.28.tgz#5562519bc7963caca8abf7f128cae3b594d41d06"
+
+"@types/rsvp@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/rsvp/-/rsvp-4.0.0.tgz#6c59d84bb5ea8a4fd11ec3d7aa748710e0e5e373"
 
 "@types/tape@^4.2.29":
   version "4.2.30"


### PR DESCRIPTION
This is a far-from-complete initial pass at adding ambient type information for ember-data.

Currently, in order to resolve model names to types in places like...
```ts
class AllPostsRoute extends Route {
  
  model(): Promise<ArrayProxy<BlogPost>> {
    return this.store.findAll('blog-post');
  }

}

class BlogPost extends DS.Model {
 
 author: ComputedProperty<User> = hasMany('user')

}
```
Users have to create a little `RecordTypeMap` mapping in their project (see below). Additional transforms for `attr` types can be specified here as well via a `TransformsMap` mapping, and the ambient types in this branch will take them into account when validating constraints.

##### app/ember-data.custom.d.ts
```ts
declare module 'ember-data/types' {
  import { BlogPost } from 'my-app/models/blog-post';
  import { User } from 'mikenorth/models/user';

  interface RecordTypeMap {
    user: User;
    'blog-post': BlogPost;
  }
  interface TransformsMap {
    csv: string[];
  }
}

```

I'll periodically update this as I flesh things out. If users wish to try these in their project right now, just create a file called `app/ember-data.d.ts` identical to the `index.d.ts` from this branch.