### PR TITLE
[BUGFIX] Fix store.createRecord with belongsTo when model has @each o…

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -338,10 +338,6 @@ export default class InternalModel {
         adapterError: this.error
       };
 
-      if (typeof properties === 'object' && properties !== null) {
-        emberAssign(createOptions, properties);
-      }
-
       if (setOwner) {
         // ensure that `getOwner(this)` works inside a model instance
         setOwner(createOptions, getOwner(this.store));
@@ -350,6 +346,7 @@ export default class InternalModel {
       }
 
       this._record = this.store.modelFactoryFor(this.modelName).create(createOptions);
+      this._record.setProperties(properties);
 
       this._triggerDeferredTriggers();
       heimdall.stop(token);


### PR DESCRIPTION
When passing belongsTo relationship during create (on Model with property using @each observer) the InternalModel.getRecord actually recurses on itself thus calling the modelFactory create 2 times. This is only happening when there is something watching a path on the created model using the @each observer.

This test and fix ensures the create is only called once.