### PR TITLE
[doc beta]document extractRelationship in json-api.js

### DIFF
--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -301,6 +301,15 @@ const JSONAPISerializer = JSONSerializer.extend({
     return attributes;
   },
 
+  /**
+     Returns a relationship formatted as a JSON-API "relationship object".
+
+     http://jsonapi.org/format/#document-resource-object-relationships
+
+     @method extractRelationship
+     @param {Object} relationshipHash
+     @return {Object}
+  */
   extractRelationship(relationshipHash) {
 
     if (typeOf(relationshipHash.data) === 'object') {
@@ -321,6 +330,16 @@ const JSONAPISerializer = JSONSerializer.extend({
     return relationshipHash;
   },
 
+  /**
+     Returns the resource's relationships formatted as a JSON-API "relationships object".
+
+     http://jsonapi.org/format/#document-resource-object-relationships
+
+     @method extractRelationships
+     @param {Object} modelClass
+     @param {Object} resourceHash
+     @return {Object}
+  */
   extractRelationships(modelClass, resourceHash) {
     let relationships = {};
 


### PR DESCRIPTION
In response to https://github.com/ember-learn/ember-api-docs/issues/399

`extractRelationship` has different args for `JSONAPISerializer` than `JSONSerializer`.  Since `JSONAPISerializer.extractRelationship` is not documented the apidocs show `JSONSerializer.extractRelationship` instead, leading to confusion.  This pr simply adds documentation reflecting correct arguments to `extractRelationship`, and also adds `extractRelationships` documentation (so source link goes to the correct implementation.

#### Before:
![image](https://user-images.githubusercontent.com/3609063/34029487-8a8ef99e-e12e-11e7-9988-a50bf9ec28b3.png)

#### After:
![image](https://user-images.githubusercontent.com/3609063/34029551-cbd407fa-e12e-11e7-87d7-df98fae9fcc3.png)
