### PR TITLE
cleanup: node-tests cleanup 

### DIFF
--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+const VersionChecker = require('ember-cli-version-checker');
 
 module.exports = function(blueprint) {
   blueprint.supportsAddon = function() {
@@ -10,10 +11,20 @@ module.exports = function(blueprint) {
     var type;
 
     var dependencies = this.project.dependencies();
-    if ('ember-cli-qunit' in dependencies) {
-      type = 'qunit';
+    if ('ember-qunit' in dependencies) {
+      type = 'qunit-rfc-232';
+
+    } else if ('ember-cli-qunit' in dependencies) {
+      let checker = new VersionChecker(this.project);
+      if (fs.existsSync(this.path + '/qunit-rfc-232-files') && checker.for('ember-cli-qunit', 'npm').gte('4.2.0')) {
+        type = 'qunit-rfc-232';
+      } else {
+        type = 'qunit';
+      }
+
     } else if ('ember-cli-mocha' in dependencies) {
       type = 'mocha';
+
     } else {
       this.ui.writeLine('Couldn\'t determine test style - using QUnit');
       type = 'qunit';

--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -1,6 +1,5 @@
 var fs = require('fs');
 var path = require('path');
-const VersionChecker = require('ember-cli-version-checker');
 
 module.exports = function(blueprint) {
   blueprint.supportsAddon = function() {
@@ -11,20 +10,10 @@ module.exports = function(blueprint) {
     var type;
 
     var dependencies = this.project.dependencies();
-    if ('ember-qunit' in dependencies) {
-      type = 'qunit-rfc-232';
-
-    } else if ('ember-cli-qunit' in dependencies) {
-      let checker = new VersionChecker(this.project);
-      if (fs.existsSync(this.path + '/qunit-rfc-232-files') && checker.for('ember-cli-qunit', 'npm').gte('4.2.0')) {
-        type = 'qunit-rfc-232';
-      } else {
-        type = 'qunit';
-      }
-
+    if ('ember-cli-qunit' in dependencies) {
+      type = 'qunit';
     } else if ('ember-cli-mocha' in dependencies) {
       type = 'mocha';
-
     } else {
       this.ui.writeLine('Couldn\'t determine test style - using QUnit');
       type = 'qunit';

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -1,23 +1,25 @@
-var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
-var setupTestHooks = blueprintHelpers.setupTestHooks;
-var emberNew = blueprintHelpers.emberNew;
-var emberGenerate = blueprintHelpers.emberGenerate;
-var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
-var modifyPackages = blueprintHelpers.modifyPackages;
+'use strict';
 
-var chai = require('ember-cli-blueprint-test-helpers/chai');
-var expect = chai.expect;
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerate = blueprintHelpers.emberGenerate;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+const modifyPackages = blueprintHelpers.modifyPackages;
 
-var SilentError = require('silent-error');
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
 
-var generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const SilentError = require('silent-error');
+
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const fixture = require('../helpers/fixture');
 
 describe('Acceptance: generate and destroy adapter blueprints', function() {
   setupTestHooks(this);
 
   it('adapter', function() {
-    var args = ['adapter', 'foo'];
+    let args = ['adapter', 'foo'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -31,7 +33,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
   });
 
   it('adapter extends application adapter if it exists', function() {
-    var args = ['adapter', 'foo'];
+    let args = ['adapter', 'foo'];
 
     return emberNew()
       .then(() => emberGenerate(['adapter', 'application']))
@@ -46,7 +48,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
   });
 
   it('adapter with --base-class', function() {
-    var args = ['adapter', 'foo', '--base-class=bar'];
+    let args = ['adapter', 'foo', '--base-class=bar'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -60,7 +62,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
   });
 
   xit('adapter throws when --base-class is same as name', function() {
-    var args = ['adapter', 'foo', '--base-class=foo'];
+    let args = ['adapter', 'foo', '--base-class=foo'];
 
     return emberNew()
       .then(() => expect(emberGenerate(args))
@@ -68,7 +70,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
   });
 
   it('adapter when is named "application"', function() {
-    var args = ['adapter', 'application'];
+    let args = ['adapter', 'application'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -82,7 +84,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
   });
 
   it('adapter-test', function() {
-    var args = ['adapter-test', 'foo'];
+    let args = ['adapter-test', 'foo'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -92,7 +94,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
   });
 
   it('adapter-test for mocha v0.12+', function() {
-    var args = ['adapter-test', 'foo'];
+    let args = ['adapter-test', 'foo'];
 
     return emberNew()
       .then(() => modifyPackages([

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -11,6 +11,7 @@ var expect = chai.expect;
 var SilentError = require('silent-error');
 
 var generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const fixture = require('../helpers/fixture');
 
 describe('Acceptance: generate and destroy adapter blueprints', function() {
   setupTestHooks(this);
@@ -25,7 +26,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
           .to.contain('export default DS.JSONAPIAdapter.extend({');
 
         expect(_file('tests/unit/adapters/foo-test.js'))
-          .to.contain('moduleFor(\'adapter:foo\'');
+        .to.equal(fixture('adapter-test/foo-default.js'));
       }));
   });
 
@@ -40,7 +41,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
           .to.contain('export default ApplicationAdapter.extend({');
 
         expect(_file('tests/unit/adapters/foo-test.js'))
-          .to.contain('moduleFor(\'adapter:foo\'');
+        .to.equal(fixture('adapter-test/foo-default.js'));
       }));
   });
 
@@ -54,7 +55,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
           .to.contain('export default BarAdapter.extend({');
 
         expect(_file('tests/unit/adapters/foo-test.js'))
-          .to.contain('moduleFor(\'adapter:foo\'');
+        .to.equal(fixture('adapter-test/foo-default.js'));
       }));
   });
 
@@ -76,7 +77,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
           .to.contain('export default DS.JSONAPIAdapter.extend({');
 
         expect(_file('tests/unit/adapters/application-test.js'))
-          .to.contain('moduleFor(\'adapter:application\'');
+        .to.equal(fixture('adapter-test/application-default.js'));
       }));
   });
 
@@ -86,7 +87,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/adapters/foo-test.js'))
-          .to.contain('moduleFor(\'adapter:foo\'');
+        .to.equal(fixture('adapter-test/foo-default.js'));
       }));
   });
 
@@ -101,11 +102,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.12.0'))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/adapters/foo-test.js'))
-          .to.contain('import { describe, it } from \'mocha\';')
-          .to.contain('import { setupTest } from \'ember-mocha\';')
-          .to.contain('describe(\'Unit | Adapter | foo\', function() {')
-          .to.contain('setupTest(\'adapter:foo\',')
-          .to.contain('expect(adapter).to.be.ok;');
+        .to.equal(fixture('adapter-test/foo-mocha-0.12.js'));
       }));
   });
 });

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -26,7 +26,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
           .to.contain('export default DS.JSONAPIAdapter.extend({');
 
         expect(_file('tests/unit/adapters/foo-test.js'))
-        .to.equal(fixture('adapter-test/foo-default.js'));
+          .to.equal(fixture('adapter-test/foo-default.js'));
       }));
   });
 
@@ -41,7 +41,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
           .to.contain('export default ApplicationAdapter.extend({');
 
         expect(_file('tests/unit/adapters/foo-test.js'))
-        .to.equal(fixture('adapter-test/foo-default.js'));
+          .to.equal(fixture('adapter-test/foo-default.js'));
       }));
   });
 
@@ -55,7 +55,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
           .to.contain('export default BarAdapter.extend({');
 
         expect(_file('tests/unit/adapters/foo-test.js'))
-        .to.equal(fixture('adapter-test/foo-default.js'));
+          .to.equal(fixture('adapter-test/foo-default.js'));
       }));
   });
 

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -77,7 +77,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
           .to.contain('export default DS.JSONAPIAdapter.extend({');
 
         expect(_file('tests/unit/adapters/application-test.js'))
-        .to.equal(fixture('adapter-test/application-default.js'));
+          .to.equal(fixture('adapter-test/application-default.js'));
       }));
   });
 
@@ -87,7 +87,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/adapters/foo-test.js'))
-        .to.equal(fixture('adapter-test/foo-default.js'));
+          .to.equal(fixture('adapter-test/foo-default.js'));
       }));
   });
 
@@ -102,7 +102,7 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.12.0'))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/adapters/foo-test.js'))
-        .to.equal(fixture('adapter-test/foo-mocha-0.12.js'));
+          .to.equal(fixture('adapter-test/foo-mocha-0.12.js'));
       }));
   });
 });

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -1,13 +1,15 @@
-var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
-var setupTestHooks = blueprintHelpers.setupTestHooks;
-var emberNew = blueprintHelpers.emberNew;
-var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
-var modifyPackages = blueprintHelpers.modifyPackages;
+'use strict';
 
-var chai = require('ember-cli-blueprint-test-helpers/chai');
-var expect = chai.expect;
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+const modifyPackages = blueprintHelpers.modifyPackages;
 
-var generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const fixture = require('../helpers/fixture');
 
 
@@ -15,7 +17,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
   setupTestHooks(this);
 
   it('model', function() {
-    var args = ['model', 'foo'];
+    let args = ['model', 'foo'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -29,7 +31,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
   });
 
   it('model with attrs', function() {
-    var args = [
+    let args = [
       'model',
       'foo',
       'misc',
@@ -62,7 +64,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
   });
 
   it('model with belongsTo', function() {
-    var args = ['model', 'comment', 'post:belongs-to', 'author:belongs-to:user'];
+    let args = ['model', 'comment', 'post:belongs-to', 'author:belongs-to:user'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -78,7 +80,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
   });
 
   it('model with hasMany', function() {
-    var args = ['model', 'post', 'comments:has-many', 'otherComments:has-many:comment'];
+    let args = ['model', 'post', 'comments:has-many', 'otherComments:has-many:comment'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -94,7 +96,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
   });
 
   it('model-test', function() {
-    var args = ['model-test', 'foo'];
+    let args = ['model-test', 'foo'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -104,7 +106,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
   });
 
   it('model-test for mocha v0.12+', function() {
-    var args = ['model-test', 'foo'];
+    let args = ['model-test', 'foo'];
 
     return emberNew()
       .then(() => modifyPackages([

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -89,7 +89,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           .to.contain('otherComments: DS.hasMany(\'comment\')');
 
         expect(_file('tests/unit/models/post-test.js'))
-        .to.equal(fixture('model-test/post-default.js'));
+          .to.equal(fixture('model-test/post-default.js'));
       }));
   });
 

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -57,7 +57,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           .to.contain('customAttr: DS.attr(\'custom-transform\')');
 
         expect(_file('tests/unit/models/foo-test.js'))
-        .to.equal(fixture('model-test/foo-default.js'));
+          .to.equal(fixture('model-test/foo-default.js'));
       }));
   });
 
@@ -73,7 +73,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           .to.contain('author: DS.belongsTo(\'user\')');
 
         expect(_file('tests/unit/models/comment-test.js'))
-        .to.equal(fixture('model-test/comment-default.js'));
+          .to.equal(fixture('model-test/comment-default.js'));
       }));
   });
 
@@ -99,7 +99,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/models/foo-test.js'))
-        .to.equal(fixture('model-test/foo-default.js'));
+          .to.equal(fixture('model-test/foo-default.js'));
       }));
   });
 
@@ -114,7 +114,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.12.0'))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/models/foo-test.js'))
-        .to.equal(fixture('model-test/foo-mocha-0.12.js'));
+          .to.equal(fixture('model-test/foo-mocha-0.12.js'));
       }));
   });
 });

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -8,6 +8,8 @@ var chai = require('ember-cli-blueprint-test-helpers/chai');
 var expect = chai.expect;
 
 var generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const fixture = require('../helpers/fixture');
+
 
 describe('Acceptance: generate and destroy model blueprints', function() {
   setupTestHooks(this);
@@ -19,10 +21,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/models/foo.js'))
           .to.contain('import DS from \'ember-data\';')
-          .to.contain('export default DS.Model.extend(')
+          .to.contain('export default DS.Model.extend(');
 
         expect(_file('tests/unit/models/foo-test.js'))
-          .to.contain('moduleForModel(\'foo\'');
+          .to.equal(fixture('model-test/foo-default.js'));
       }));
   });
 
@@ -52,10 +54,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           .to.contain('someObject: DS.attr(\'object\')')
           .to.contain('age: DS.attr(\'number\')')
           .to.contain('name: DS.attr(\'string\')')
-          .to.contain('customAttr: DS.attr(\'custom-transform\')')
+          .to.contain('customAttr: DS.attr(\'custom-transform\')');
 
         expect(_file('tests/unit/models/foo-test.js'))
-          .to.contain('moduleForModel(\'foo\'');
+        .to.equal(fixture('model-test/foo-default.js'));
       }));
   });
 
@@ -68,11 +70,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           .to.contain('import DS from \'ember-data\';')
           .to.contain('export default DS.Model.extend(')
           .to.contain('post: DS.belongsTo(\'post\')')
-          .to.contain('author: DS.belongsTo(\'user\')')
+          .to.contain('author: DS.belongsTo(\'user\')');
 
         expect(_file('tests/unit/models/comment-test.js'))
-          .to.contain('moduleForModel(\'comment\'')
-          .to.contain('needs: [\'model:post\', \'model:user\']');
+        .to.equal(fixture('model-test/comment-default.js'));
       }));
   });
 
@@ -85,11 +86,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           .to.contain('import DS from \'ember-data\';')
           .to.contain('export default DS.Model.extend(')
           .to.contain('comments: DS.hasMany(\'comment\')')
-          .to.contain('otherComments: DS.hasMany(\'comment\')')
+          .to.contain('otherComments: DS.hasMany(\'comment\')');
 
         expect(_file('tests/unit/models/post-test.js'))
-          .to.contain('moduleForModel(\'post\'')
-          .to.contain('needs: [\'model:comment\']');
+        .to.equal(fixture('model-test/post-default.js'));
       }));
   });
 
@@ -99,7 +99,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/models/foo-test.js'))
-          .to.contain('moduleForModel(\'foo\'');
+        .to.equal(fixture('model-test/foo-default.js'));
       }));
   });
 
@@ -114,11 +114,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.12.0'))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/models/foo-test.js'))
-          .to.contain('import { describe, it } from \'mocha\';')
-          .to.contain('import { setupModelTest } from \'ember-mocha\';')
-          .to.contain('describe(\'Unit | Model | foo\', function() {')
-          .to.contain('setupModelTest(\'foo\',')
-          .to.contain('expect(model).to.be.ok;');
+        .to.equal(fixture('model-test/foo-mocha-0.12.js'));
       }));
   });
 });

--- a/node-tests/blueprints/serializer-test.js
+++ b/node-tests/blueprints/serializer-test.js
@@ -87,7 +87,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/serializers/foo-test.js'))
-        .to.equal(fixture('serializer-test/foo-default.js'));
+          .to.equal(fixture('serializer-test/foo-default.js'));
       }));
   });
 

--- a/node-tests/blueprints/serializer-test.js
+++ b/node-tests/blueprints/serializer-test.js
@@ -11,6 +11,7 @@ var expect = chai.expect;
 var SilentError = require('silent-error');
 
 var generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const fixture = require('../helpers/fixture');
 
 describe('Acceptance: generate and destroy serializer blueprints', function() {
   setupTestHooks(this);
@@ -25,7 +26,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
           .to.contain('export default DS.JSONAPISerializer.extend(');
 
         expect(_file('tests/unit/serializers/foo-test.js'))
-          .to.contain('moduleForModel(\'foo\'');
+          .to.equal(fixture('serializer-test/foo-default.js'));
       }));
   });
 
@@ -40,7 +41,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
           .to.contain('export default ApplicationSerializer.extend({');
 
         expect(_file('tests/unit/serializers/foo-test.js'))
-          .to.contain('moduleForModel(\'foo\'');
+          .to.equal(fixture('serializer-test/foo-default.js'));
       }));
   });
 
@@ -54,7 +55,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
           .to.contain('export default BarSerializer.extend({');
 
         expect(_file('tests/unit/serializers/foo-test.js'))
-          .to.contain('moduleForModel(\'foo\'');
+          .to.equal(fixture('serializer-test/foo-default.js'));
       }));
   });
 
@@ -76,7 +77,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
           .to.contain('export default DS.JSONAPISerializer.extend({');
 
         expect(_file('tests/unit/serializers/application-test.js'))
-          .to.contain('moduleForModel(\'application\'');
+        .to.equal(fixture('serializer-test/application-default.js'));
       }));
   });
 
@@ -86,7 +87,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/serializers/foo-test.js'))
-          .to.contain('moduleForModel(\'foo\'');
+        .to.equal(fixture('serializer-test/foo-default.js'));
       }));
   });
 
@@ -101,12 +102,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.12.0'))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/serializers/foo-test.js'))
-          .to.contain('import { describe, it } from \'mocha\';')
-          .to.contain('import { setupModelTest } from \'ember-mocha\';')
-          .to.contain('describe(\'Unit | Serializer | foo\', function() {')
-          .to.contain('setupModelTest(\'foo\', {')
-          .to.contain('needs: [\'serializer:foo\']')
-          .to.contain('expect(serializedRecord).to.be.ok;');
+          .to.equal(fixture('serializer-test/foo-mocha-0.12.js'));
       }));
   });
 });

--- a/node-tests/blueprints/serializer-test.js
+++ b/node-tests/blueprints/serializer-test.js
@@ -1,23 +1,25 @@
-var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
-var setupTestHooks = blueprintHelpers.setupTestHooks;
-var emberNew = blueprintHelpers.emberNew;
-var emberGenerate = blueprintHelpers.emberGenerate;
-var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
-var modifyPackages = blueprintHelpers.modifyPackages;
+'use strict';
 
-var chai = require('ember-cli-blueprint-test-helpers/chai');
-var expect = chai.expect;
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerate = blueprintHelpers.emberGenerate;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+const modifyPackages = blueprintHelpers.modifyPackages;
 
-var SilentError = require('silent-error');
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
 
-var generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const SilentError = require('silent-error');
+
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const fixture = require('../helpers/fixture');
 
 describe('Acceptance: generate and destroy serializer blueprints', function() {
   setupTestHooks(this);
 
   it('serializer', function() {
-    var args = ['serializer', 'foo'];
+    let args = ['serializer', 'foo'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -31,7 +33,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
   });
 
   it('serializer extends application serializer if it exists', function() {
-    var args = ['serializer', 'foo'];
+    let args = ['serializer', 'foo'];
 
     return emberNew()
       .then(() => emberGenerate(['serializer', 'application']))
@@ -46,7 +48,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
   });
 
   it('serializer with --base-class', function() {
-    var args = ['serializer', 'foo', '--base-class=bar'];
+    let args = ['serializer', 'foo', '--base-class=bar'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -60,7 +62,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
   });
 
   xit('serializer throws when --base-class is same as name', function() {
-    var args = ['serializer', 'foo', '--base-class=foo'];
+    let args = ['serializer', 'foo', '--base-class=foo'];
 
     return emberNew()
       .then(() => expect(emberGenerate(args))
@@ -68,7 +70,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
   });
 
   it('serializer when is named "application"', function() {
-    var args = ['serializer', 'application'];
+    let args = ['serializer', 'application'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -82,7 +84,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
   });
 
   it('serializer-test', function() {
-    var args = ['serializer-test', 'foo'];
+    let args = ['serializer-test', 'foo'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -92,7 +94,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
   });
 
  it('serializer-test for mocha v0.12+', function() {
-    var args = ['serializer-test', 'foo'];
+    let args = ['serializer-test', 'foo'];
 
     return emberNew()
       .then(() => modifyPackages([

--- a/node-tests/blueprints/serializer-test.js
+++ b/node-tests/blueprints/serializer-test.js
@@ -77,7 +77,7 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
           .to.contain('export default DS.JSONAPISerializer.extend({');
 
         expect(_file('tests/unit/serializers/application-test.js'))
-        .to.equal(fixture('serializer-test/application-default.js'));
+          .to.equal(fixture('serializer-test/application-default.js'));
       }));
   });
 

--- a/node-tests/blueprints/transform-test.js
+++ b/node-tests/blueprints/transform-test.js
@@ -1,20 +1,22 @@
-var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
-var setupTestHooks = blueprintHelpers.setupTestHooks;
-var emberNew = blueprintHelpers.emberNew;
-var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
-var modifyPackages = blueprintHelpers.modifyPackages;
+'use strict';
 
-var chai = require('ember-cli-blueprint-test-helpers/chai');
-var expect = chai.expect;
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+const modifyPackages = blueprintHelpers.modifyPackages;
 
-var generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const fixture = require('../helpers/fixture');
 
 describe('Acceptance: generate and destroy transform blueprints', function() {
   setupTestHooks(this);
 
   it('transform', function() {
-    var args = ['transform', 'foo'];
+    let args = ['transform', 'foo'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -30,7 +32,7 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
   });
 
   it('transforms-test', function() {
-    var args = ['transform-test', 'foo'];
+    let args = ['transform-test', 'foo'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
@@ -40,7 +42,7 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
   });
 
   it('transform-test for mocha v0.12+', function() {
-    var args = ['transform-test', 'foo'];
+    let args = ['transform-test', 'foo'];
 
     return emberNew()
       .then(() => modifyPackages([

--- a/node-tests/blueprints/transform-test.js
+++ b/node-tests/blueprints/transform-test.js
@@ -8,6 +8,7 @@ var chai = require('ember-cli-blueprint-test-helpers/chai');
 var expect = chai.expect;
 
 var generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const fixture = require('../helpers/fixture');
 
 describe('Acceptance: generate and destroy transform blueprints', function() {
   setupTestHooks(this);
@@ -24,7 +25,7 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
           .to.contain('serialize(deserialized) {');
 
         expect(_file('tests/unit/transforms/foo-test.js'))
-          .to.contain('moduleFor(\'transform:foo\'');
+          .to.equal(fixture('transform-test/default.js'));
       }));
   });
 
@@ -34,7 +35,7 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/transforms/foo-test.js'))
-          .to.contain('moduleFor(\'transform:foo\'');
+          .to.equal(fixture('transform-test/default.js'));
       }));
   });
 
@@ -49,11 +50,7 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
       .then(() => generateFakePackageManifest('ember-cli-mocha', '0.12.0'))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/transforms/foo-test.js'))
-          .to.contain('import { describe, it } from \'mocha\';')
-          .to.contain('import { setupTest } from \'ember-mocha\';')
-          .to.contain('describe(\'Unit | Transform | foo\', function() {')
-          .to.contain('setupTest(\'transform:foo\',')
-          .to.contain('expect(transform).to.be.ok;');
+          .to.equal(fixture('transform-test/mocha-0.12.js'));
       }));
   });
 });

--- a/node-tests/fixtures/adapter-test/application-default.js
+++ b/node-tests/fixtures/adapter-test/application-default.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:application', 'Unit | Adapter | application', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/node-tests/fixtures/adapter-test/foo-default.js
+++ b/node-tests/fixtures/adapter-test/foo-default.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:foo', 'Unit | Adapter | foo', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/node-tests/fixtures/adapter-test/foo-mocha-0.12.js
+++ b/node-tests/fixtures/adapter-test/foo-mocha-0.12.js
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Adapter | foo', function() {
+  setupTest('adapter:foo', {
+    // Specify the other units that are required for this test.
+    // needs: ['serializer:foo']
+  });
+
+  // Replace this with your real tests.
+  it('exists', function() {
+    let adapter = this.subject();
+    expect(adapter).to.be.ok;
+  });
+});

--- a/node-tests/fixtures/model-test/comment-default.js
+++ b/node-tests/fixtures/model-test/comment-default.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('comment', 'Unit | Model | comment', {
+  // Specify the other units that are required for this test.
+  needs: ['model:post', 'model:user']
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/node-tests/fixtures/model-test/foo-default.js
+++ b/node-tests/fixtures/model-test/foo-default.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('foo', 'Unit | Model | foo', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/node-tests/fixtures/model-test/foo-mocha-0.12.js
+++ b/node-tests/fixtures/model-test/foo-mocha-0.12.js
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupModelTest } from 'ember-mocha';
 
-describe('<%= friendlyDescription %>', function() {
-  setupModelTest('<%= dasherizedModuleName %>', {
+describe('Unit | Model | foo', function() {
+  setupModelTest('foo', {
     // Specify the other units that are required for this test.
-  <%= typeof needs !== 'undefined' ? needs : '' %>
+    needs: []
   });
 
   // Replace this with your real tests.

--- a/node-tests/fixtures/model-test/post-default.js
+++ b/node-tests/fixtures/model-test/post-default.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('post', 'Unit | Model | post', {
+  // Specify the other units that are required for this test.
+  needs: ['model:comment']
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/node-tests/fixtures/serializer-test/application-default.js
+++ b/node-tests/fixtures/serializer-test/application-default.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('application', 'Unit | Serializer | application', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:application']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/node-tests/fixtures/serializer-test/foo-default.js
+++ b/node-tests/fixtures/serializer-test/foo-default.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('foo', 'Unit | Serializer | foo', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/node-tests/fixtures/serializer-test/foo-mocha-0.12.js
+++ b/node-tests/fixtures/serializer-test/foo-mocha-0.12.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupModelTest } from 'ember-mocha';
+
+describe('Unit | Serializer | foo', function() {
+  setupModelTest('foo', {
+    // Specify the other units that are required for this test.
+    needs: ['serializer:foo']
+  });
+
+  // Replace this with your real tests.
+  it('serializes records', function() {
+    let record = this.subject();
+
+    let serializedRecord = record.serialize();
+
+    expect(serializedRecord).to.be.ok;
+  });
+});

--- a/node-tests/fixtures/transform-test/default.js
+++ b/node-tests/fixtures/transform-test/default.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('transform:foo', 'Unit | Transform | foo', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let transform = this.subject();
+  assert.ok(transform);
+});

--- a/node-tests/fixtures/transform-test/mocha-0.12.js
+++ b/node-tests/fixtures/transform-test/mocha-0.12.js
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Transform | foo', function() {
+  setupTest('transform:foo', {
+    // Specify the other units that are required for this test.
+    // needs: ['transform:foo']
+  });
+
+  // Replace this with your real tests.
+  it('exists', function() {
+    let transform = this.subject();
+    expect(transform).to.be.ok;
+  });
+});

--- a/node-tests/helpers/fixture.js
+++ b/node-tests/helpers/fixture.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const path = require('path');
+const file = require('ember-cli-blueprint-test-helpers/chai').file;
+
+module.exports = function(filePath) {
+  return file(path.join(__dirname, '../fixtures', filePath));
+};


### PR DESCRIPTION
Making moving some of the assertion logic into files, and using strict mode so it's more in line with https://github.com/emberjs/ember.js/tree/master/node-tests

Will make https://github.com/emberjs/data/issues/5292 easier to implement