### PR TITLE
blueprints/transform-test: Add RFC232 variants

### DIFF
--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -1,5 +1,8 @@
-var fs = require('fs');
-var path = require('path');
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const VersionChecker = require('ember-cli-version-checker');
 
 module.exports = function(blueprint) {
   blueprint.supportsAddon = function() {
@@ -7,13 +10,23 @@ module.exports = function(blueprint) {
   };
 
   blueprint.filesPath = function() {
-    var type;
+    let type;
 
-    var dependencies = this.project.dependencies();
-    if ('ember-cli-qunit' in dependencies) {
-      type = 'qunit';
+    let dependencies = this.project.dependencies();
+    if ('ember-qunit' in dependencies) {
+      type = 'qunit-rfc-232';
+
+    } else if ('ember-cli-qunit' in dependencies) {
+      let checker = new VersionChecker(this.project);
+      if (fs.existsSync(this.path + '/qunit-rfc-232-files') && checker.for('ember-cli-qunit', 'npm').gte('4.2.0')) {
+        type = 'qunit-rfc-232';
+      } else {
+        type = 'qunit';
+      }
+
     } else if ('ember-cli-mocha' in dependencies) {
       type = 'mocha';
+
     } else {
       this.ui.writeLine('Couldn\'t determine test style - using QUnit');
       type = 'qunit';

--- a/blueprints/transform-test/qunit-rfc-232-files/tests/unit/__path__/__test__.js
+++ b/blueprints/transform-test/qunit-rfc-232-files/tests/unit/__path__/__test__.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('transform:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let transform = this.owner.lookup('transform:<%= dasherizedModuleName %>');
+    assert.ok(transform);
+  });
+});

--- a/node-tests/blueprints/transform-test.js
+++ b/node-tests/blueprints/transform-test.js
@@ -15,11 +15,16 @@ const fixture = require('../helpers/fixture');
 describe('Acceptance: generate and destroy transform blueprints', function() {
   setupTestHooks(this);
 
-  it('transform', function() {
-    let args = ['transform', 'foo'];
+  describe('in app', function() {
+    beforeEach(function() {
+      return emberNew();
+    });
 
-    return emberNew()
-      .then(() => emberGenerateDestroy(args, _file => {
+
+    it('transform', function() {
+      let args = ['transform', 'foo'];
+
+      return emberGenerateDestroy(args, _file => {
         expect(_file('app/transforms/foo.js'))
           .to.contain('import DS from \'ember-data\';')
           .to.contain('export default DS.Transform.extend(')
@@ -28,31 +33,49 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
 
         expect(_file('tests/unit/transforms/foo-test.js'))
           .to.equal(fixture('transform-test/default.js'));
-      }));
-  });
+      });
+    });
 
-  it('transforms-test', function() {
-    let args = ['transform-test', 'foo'];
+    it('transform-test', function() {
+      let args = ['transform-test', 'foo'];
 
-    return emberNew()
-      .then(() => emberGenerateDestroy(args, _file => {
+      return emberGenerateDestroy(args, _file => {
         expect(_file('tests/unit/transforms/foo-test.js'))
           .to.equal(fixture('transform-test/default.js'));
-      }));
-  });
+      });
+    });
 
-  it('transform-test for mocha v0.12+', function() {
-    let args = ['transform-test', 'foo'];
+    describe('transform-test with ember-cli-qunit@4.2.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.2.0');
+      });
 
-    return emberNew()
-      .then(() => modifyPackages([
-        {name: 'ember-cli-qunit', delete: true},
-        {name: 'ember-cli-mocha', dev: true}
-      ]))
-      .then(() => generateFakePackageManifest('ember-cli-mocha', '0.12.0'))
-      .then(() => emberGenerateDestroy(args, _file => {
-        expect(_file('tests/unit/transforms/foo-test.js'))
-          .to.equal(fixture('transform-test/mocha-0.12.js'));
-      }));
+      it('transform-test-test foo', function() {
+        return emberGenerateDestroy(['transform-test', 'foo'], _file => {
+          expect(_file('tests/unit/transforms/foo-test.js'))
+            .to.equal(fixture('transform-test/rfc232.js'));
+        });
+      });
+    });
+
+
+    describe('with ember-cli-mocha v0.12+', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-cli-mocha', dev: true }
+        ]);
+        generateFakePackageManifest('ember-cli-mocha', '0.12.0');
+      });
+
+      it('transform-test for mocha v0.12+', function() {
+        let args = ['transform-test', 'foo'];
+
+        return emberGenerateDestroy(args, _file => {
+          expect(_file('tests/unit/transforms/foo-test.js'))
+            .to.equal(fixture('transform-test/mocha-0.12.js'));
+        });
+      });
+    });
   });
 });

--- a/node-tests/fixtures/transform-test/rfc232.js
+++ b/node-tests/fixtures/transform-test/rfc232.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('transform:foo', 'Unit | Transform | foo', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let transform = this.owner.lookup('transform:foo');
+    assert.ok(transform);
+  });
+});


### PR DESCRIPTION
`transform-test` & `test-framework.js` tasks from https://github.com/emberjs/data/issues/5292

Updates the `test-framework-detector` to be analagous to https://github.com/emberjs/ember.js/blob/master/blueprints/test-framework-detector.js