### PR TITLE
[CLEANUP testing]: Remove PhantomJS from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,11 @@ cache:
   yarn: true
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME/.yarn/bin:$PATH
+- |
+    export DISPLAY=:99.0
+    sh -e /etc/init.d/xvfb start
+    curl -o- -L https://yarnpkg.com/install.sh | bash
+    export PATH=$HOME/.yarn/bin:$PATH
 
 install:
   - yarn install --no-lockfile --no-interactive

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ node_js:
   - "4"
   - "6"
 
+addons:
+  firefox: "latest"
+
 # hack to get after_success skipped in node 4
 matrix:
   exclude:
@@ -20,8 +23,6 @@ cache:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn global add phantomjs-prebuilt
-  - phantomjs --version
 
 install:
   - yarn install --no-lockfile --no-interactive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,9 @@ cache:
 install:
   # Get the latest stable version of Node 0.STABLE.latest
   - ps: Install-Product node $env:nodejs_version
-  # Install PhantomJS
-  - choco install phantomjs --version 2.0.0 -y
-  - set path=%path%;C:\ProgramData\chocolatey\lib\PhantomJS\tools\
   # Typical npm stuff.
-  - md C:\nc
   - appveyor-retry yarn install
+
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.

--- a/testem.js
+++ b/testem.js
@@ -5,10 +5,11 @@ module.exports = {
   "disable_watching": true,
   "reporter": "dot",
   "launch_in_ci": [
-    "PhantomJS"
+    "Firefox",
+    "Chrome"
   ],
   "launch_in_dev": [
-    "PhantomJS",
+    "Firefox",
     "Chrome"
-  ]
+  ],
 };


### PR DESCRIPTION
Testing on firefox and chrome by default
Equivalent to https://github.com/ember-cli/ember-cli/pull/7148
And in line with https://github.com/emberjs/rfcs/blob/master/text/0252-browser-support-changes.md