### PR TITLE
Dont serialize new belongsTo records

### DIFF
--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -555,7 +555,7 @@ const JSONAPISerializer = JSONSerializer.extend({
 
     if (this._canSerialize(key)) {
       let belongsTo = snapshot.belongsTo(key);
-      if (belongsTo !== undefined) {
+      if (belongsTo !== undefined && !belongsTo.record.get("isNew")) {
 
         json.relationships = json.relationships || {};
 

--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -555,8 +555,9 @@ const JSONAPISerializer = JSONSerializer.extend({
 
     if (this._canSerialize(key)) {
       let belongsTo = snapshot.belongsTo(key);
-      if (belongsTo !== undefined && !belongsTo.record.get("isNew")) {
+      let belongsToIsNotNew = belongsTo && belongsTo.record && !belongsTo.record.get('isNew');
 
+      if (belongsTo === null || belongsToIsNotNew) {
         json.relationships = json.relationships || {};
 
         let payloadKey = this._getMappedKey(key, snapshot.type);

--- a/tests/integration/serializers/json-api-serializer-test.js
+++ b/tests/integration/serializers/json-api-serializer-test.js
@@ -358,6 +358,30 @@ testInDebug('Warns when defining extractMeta()', function(assert) {
   }, /You've defined 'extractMeta' in/);
 });
 
+test('a belongsTo relationship with a new record is not included in relationships', function(assert) {
+  run(function() {
+    serializer.pushPayload(store, {
+      data: {
+        type: 'handles',
+        id: 1
+      }
+    });
+
+    let handle = store.peekRecord('handle', 1);
+
+    let user = store.createRecord('user');
+    handle.set('user', user);
+
+    let serialized = handle.serialize({ includeId: true });
+    assert.deepEqual(serialized, {
+      data: {
+        type: 'handles',
+        id: '1'
+      }
+    });
+  });
+});
+
 testInDebug('JSON warns when combined with EmbeddedRecordsMixin', function(assert) {
   assert.expectWarning(function() {
     DS.JSONAPISerializer.extend(DS.EmbeddedRecordsMixin).create();

--- a/tests/integration/serializers/json-api-serializer-test.js
+++ b/tests/integration/serializers/json-api-serializer-test.js
@@ -358,7 +358,55 @@ testInDebug('Warns when defining extractMeta()', function(assert) {
   }, /You've defined 'extractMeta' in/);
 });
 
-test('a belongsTo relationship with a new record is not included in relationships', function(assert) {
+test('a belongsTo relationship that is not set will not be in the relationships key', function(assert) {
+  run(function() {
+    serializer.pushPayload(store, {
+      data: {
+        type: 'handles',
+        id: 1
+      }
+    });
+
+    let handle = store.peekRecord('handle', 1);
+
+    let serialized = handle.serialize({ includeId: true });
+    assert.deepEqual(serialized, {
+      data: {
+        type: 'handles',
+        id: '1'
+      }
+    });
+  });
+});
+
+test('a belongsTo relationship that is set to null will show as null in the relationships key', function(assert) {
+  run(function() {
+    serializer.pushPayload(store, {
+      data: {
+        type: 'handles',
+        id: 1
+      }
+    });
+
+    let handle = store.peekRecord('handle', 1);
+    handle.set('user', null);
+
+    let serialized = handle.serialize({ includeId: true });
+    assert.deepEqual(serialized, {
+      data: {
+        type: 'handles',
+        id: '1',
+        relationships: {
+          user: {
+            data: null
+          }
+        }
+      }
+    });
+  });
+});
+
+test('a belongsTo relationship set to a new record will not show in the relationships key', function(assert) {
   run(function() {
     serializer.pushPayload(store, {
       data: {


### PR DESCRIPTION
Currently when saving a model with an unsaved `belognsTo` a null id is used in the JSON:API document. 

For example

```js
let user = this.store.createRecord('user');
let details = this.store.createRecord('user-details', { user });

user.save();
```

Generates this post payload:

```js
{
  data: {
    type: 'users',
    id: '1',
    relationships: {
      user-details: {
        data: {
          type: 'user-details',
          id: null
        }
      }
    }
  }
}
```

According to the spec this is an invalid payload:

![image](https://user-images.githubusercontent.com/89411/34625314-4296e68e-f226-11e7-885a-63df42f6aba7.png)

![pasted image at 2018_01_05 01_02 pm](https://user-images.githubusercontent.com/89411/34625326-4b3ac38c-f226-11e7-84bc-3157471e1dcd.png)

This PR addresses this by not including the belongsTo that is unsaved in the relationship key.

I took this existing PR  and updated it to fit @wecc's comment: https://github.com/emberjs/data/pull/4500. Big thanks to @pangratz 



