### PR TITLE
[BUGFIX beta] Fix development build relationship caching.

### DIFF
--- a/addon/-private/system/relationships/ext.js
+++ b/addon/-private/system/relationships/ext.js
@@ -2,7 +2,6 @@ import { A } from '@ember/array';
 import { computed } from '@ember/object';
 import MapWithDefault from '@ember/map/with-default';
 import Map from '@ember/map';
-import Ember from 'ember';
 import { assert } from '@ember/debug';
 import {
   typeForRelationshipMeta,
@@ -10,10 +9,6 @@ import {
 } from "../relationship-meta";
 
 export const relationshipsDescriptor = computed(function() {
-  if (Ember.testing === true && relationshipsDescriptor._cacheable === true) {
-    relationshipsDescriptor._cacheable = false;
-  }
-
   let map = new MapWithDefault({
     defaultValue() { return []; }
   });
@@ -37,10 +32,6 @@ export const relationshipsDescriptor = computed(function() {
 }).readOnly();
 
 export const relatedTypesDescriptor = computed(function() {
-  if (Ember.testing === true && relatedTypesDescriptor._cacheable === true) {
-    relatedTypesDescriptor._cacheable = false;
-  }
-
   let modelName;
   let types = A();
 

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -2,7 +2,6 @@ import { get } from '@ember/object';
 import { run } from '@ember/runloop';
 import RSVP, { resolve } from 'rsvp';
 import setupStore from 'dummy/tests/helpers/store';
-import Ember from 'ember';
 
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import {
@@ -540,78 +539,6 @@ test("relationshipsByName does not cache a factory", function(assert) {
 
   assert.equal(messageModelFromRelationType, messageModelFromStore,
         "model factory based on relationship type matches the model based on store.modelFor");
-});
-
-function getDescriptor(object, key) {
-  var meta = Ember.meta(object);
-  var mixins = (meta && meta._mixins) || {};
-  for (let key in mixins) {
-    let klass = mixins[key]
-    if (!klass.properties) {
-      continue;
-    }
-    let descriptor = klass.properties[key];
-    if (descriptor) {
-      return descriptor;
-    }
-  }
-  // Fallback to grabbing the descriptor off of the object for old
-  // versions of Ember
-  return object[key];
-}
-
-test("relationshipsByName is cached in production", function(assert) {
-  let model = store.modelFor('user');
-  let oldTesting = Ember.testing;
-  //We set the cacheable to true because that is the default state for any CP and then assert that it
-  //did not get dynamically changed when accessed
-  let relationshipsByName = getDescriptor(model, 'relationshipsByName');
-  let oldCacheable = relationshipsByName._cacheable;
-  relationshipsByName._cacheable = true;
-  Ember.testing = false;
-  try {
-    assert.equal(get(model, 'relationshipsByName'), get(model, 'relationshipsByName'), 'relationshipsByName are cached');
-    assert.equal(get(model, 'relationshipsByName'), get(model, 'relationshipsByName'), 'relationshipsByName are cached');
-  } finally {
-    Ember.testing = oldTesting;
-    relationshipsByName._cacheable = oldCacheable;
-  }
-});
-
-test("relatedTypes is cached in production", function(assert) {
-  let model = store.modelFor('user');
-  let oldTesting = Ember.testing;
-  //We set the cacheable to true because that is the default state for any CP and then assert that it
-  //did not get dynamically changed when accessed
-  let relatedTypes = getDescriptor(model, 'relatedTypes');
-  let oldCacheable = relatedTypes._cacheable;
-  relatedTypes._cacheable = true;
-  Ember.testing = false;
-  try {
-    assert.equal(get(model, 'relatedTypes'), get(model, 'relatedTypes'), 'relatedTypes are cached');
-    assert.equal(get(model, 'relatedTypes'), get(model, 'relatedTypes'), 'relatedTypes are cached');
-  } finally {
-    Ember.testing = oldTesting;
-    relatedTypes._cacheable = oldCacheable;
-  }
-});
-
-test("relationships is cached in production", function(assert) {
-  let model = store.modelFor('user');
-  let oldTesting = Ember.testing;
-  //We set the cacheable to true because that is the default state for any CP and then assert that it
-  //did not get dynamically changed when accessed
-  let relationships = getDescriptor(model, 'relationships');
-  let oldCacheable = relationships._cacheable;
-  relationships._cacheable = true;
-  Ember.testing = false;
-  try {
-    assert.equal(get(model, 'relationships'), get(model, 'relationships'), 'relationships are cached');
-    assert.equal(get(model, 'relationships'), get(model, 'relationships'), 'relationships are cached');
-  } finally {
-    Ember.testing = oldTesting;
-    relationships._cacheable = oldCacheable;
-  }
 });
 
 test("relationship changes shouldn’t cause async fetches", function(assert) {


### PR DESCRIPTION
The previous implementation was intending to cache relationships when in the production environment, but avoid caching them in development.  Unfortunately, this code was factored in a way that relied on mutating internal private state of the underlying `Ember.ComputedProperty` instance when `Ember.testing` was true (which was used as a way to determine prod vs non-prod).

When this code was introduced (2014-12-02 in https://github.com/emberjs/data/pull/2530), setting `_cacheable` on a `ComputedProperty` instance would have worked as intended, however a refactor in Ember (ironically one day prior in https://github.com/emberjs/ember.js/pull/9489, but on Ember's canary channel) deprecated using `_cacheable` or `.cacheable()` (in favor of opting out of caching via `.volatile()`). Later support for `_cacheable` was completely removed in https://github.com/emberjs/ember.js/pull/12036 leading up to Ember 2.0.0.

This PR refactors the code a bit, so that we no longer need to mutate the computed property after creation and allows us to avoid some gnarliness...