### PR TITLE
[DEV-BUGFIX] Fix instrumentation when running in production

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ function isProductionEnv() {
   return isProd && !isTest;
 }
 
+function isInstrumentedBuild() {
+  return INSTRUMENT_HEIMDALL;
+}
+
 module.exports = {
   name: 'ember-data',
 
@@ -137,7 +141,7 @@ module.exports = {
     let withoutPrivate = new Funnel(treeWithVersion, {
       exclude: [
         '-private',
-        isProductionEnv() ? '-debug' : false
+        isProductionEnv() && !isInstrumentedBuild() ? '-debug' : false
       ].filter(Boolean),
 
       destDir: 'ember-data'

--- a/lib/stripped-build-plugins.js
+++ b/lib/stripped-build-plugins.js
@@ -33,7 +33,6 @@ module.exports = function(environment) {
   var featuresJsonPath = __dirname + '/../config/features.json';
   var featuresJson = fs.readFileSync(featuresJsonPath, { encoding: 'utf8' });
   var features = JSON.parse(featuresJson);
-  var strippedImports = {};
   var filteredImports = {};
 
   // TODO explicitly set all features which are not enabled to `false`, so
@@ -55,25 +54,21 @@ module.exports = function(environment) {
 
   if (process.env.INSTRUMENT_HEIMDALL === 'false') {
     plugins.push([StripHeimdall]);
-    uniqueAdd(strippedImports, 'ember-data/-debug', ['instrument']);
+    uniqueAdd(filteredImports, 'ember-data/-debug', ['instrument']);
   } else {
     console.warn('NOT STRIPPING HEIMDALL');
   }
 
   if (/production/.test(environment) || process.env.INSTRUMENT_HEIMDALL === 'true') {
     postTransformPlugins.push([StripClassCallCheck]);
-    uniqueAdd(strippedImports, 'ember-data/-debug', [
+    uniqueAdd(filteredImports, 'ember-data/-debug', [
       'assertPolymorphicType'
     ]);
   }
 
-  Object.keys(strippedImports).forEach((k) => {
-    filteredImports[k] = true;
-  });
-
   plugins.push(
     [FilterImports, filteredImports],
-    [StripFilteredImports, strippedImports],
+    [StripFilteredImports, filteredImports],
     [TransformBlockScoping, { 'throwIfClosureRequired': true }]
   );
 

--- a/lib/stripped-build-plugins.js
+++ b/lib/stripped-build-plugins.js
@@ -33,6 +33,7 @@ module.exports = function(environment) {
   var featuresJsonPath = __dirname + '/../config/features.json';
   var featuresJson = fs.readFileSync(featuresJsonPath, { encoding: 'utf8' });
   var features = JSON.parse(featuresJson);
+  var strippedImports = {};
   var filteredImports = {};
 
   // TODO explicitly set all features which are not enabled to `false`, so
@@ -54,21 +55,25 @@ module.exports = function(environment) {
 
   if (process.env.INSTRUMENT_HEIMDALL === 'false') {
     plugins.push([StripHeimdall]);
-    uniqueAdd(filteredImports, 'ember-data/-debug', ['instrument']);
+    uniqueAdd(strippedImports, 'ember-data/-debug', ['instrument']);
   } else {
     console.warn('NOT STRIPPING HEIMDALL');
   }
 
   if (/production/.test(environment) || process.env.INSTRUMENT_HEIMDALL === 'true') {
     postTransformPlugins.push([StripClassCallCheck]);
-    uniqueAdd(filteredImports, 'ember-data/-debug', [
+    uniqueAdd(strippedImports, 'ember-data/-debug', [
       'assertPolymorphicType'
     ]);
   }
 
+  Object.keys(strippedImports).forEach((k) => {
+    filteredImports[k] = true;
+  });
+
   plugins.push(
     [FilterImports, filteredImports],
-    [StripFilteredImports, filteredImports],
+    [StripFilteredImports, strippedImports],
     [TransformBlockScoping, { 'throwIfClosureRequired': true }]
   );
 


### PR DESCRIPTION
Previously production builds would fail to include `ember-data/-debug` when instrumentation is active; however, the `instrument` function helper is required in this case.