### PR TITLE
Prevent build issues when linking ember-source.

### DIFF
--- a/lib/stripped-build-plugins.js
+++ b/lib/stripped-build-plugins.js
@@ -1,13 +1,15 @@
 'use strict';
 
 var path = require('path');
-var fs            = require('fs');
-var FilterImports = require('babel-plugin-filter-imports');
-var FeatureFlags  = require('babel-plugin-feature-flags');
-var StripHeimdall = require('babel6-plugin-strip-heimdall');
-var StripClassCallCheck = require('babel6-plugin-strip-class-callcheck');
+var fs = require('fs');
+var resolve = require('resolve');
+
+var FilterImports = requireBabelPlugin('babel-plugin-filter-imports');
+var FeatureFlags  = requireBabelPlugin('babel-plugin-feature-flags');
+var StripHeimdall = requireBabelPlugin('babel6-plugin-strip-heimdall');
+var StripClassCallCheck = requireBabelPlugin('babel6-plugin-strip-class-callcheck');
 var StripFilteredImports = require('./transforms/babel-plugin-remove-imports');
-var TransformBlockScoping = require('babel-plugin-transform-es2015-block-scoping');
+var TransformBlockScoping = requireBabelPlugin('babel-plugin-transform-es2015-block-scoping');
 
 function uniqueAdd(obj, key, values) {
   var a = obj[key] = obj[key] || [];
@@ -19,14 +21,26 @@ function uniqueAdd(obj, key, values) {
   }
 }
 
-function addBaseDir(Plugin) {
+// ensures that a `baseDir` property is present on the babel plugins
+// that we will be using, this prevents ember-cli-babel/broccoli-babel-transpiler
+// from opting out of caching (and printing a giant warning)
+function requireBabelPlugin(packageName) {
+  var Plugin = require(packageName);
+  var PluginPath = resolve.sync(packageName + '/package.json', { basedir: __dirname });
+
+  return addBaseDir(Plugin, path.dirname(PluginPath));
+}
+
+function addBaseDir(Plugin, baseDir) {
   let type = typeof Plugin;
 
   if (type === 'function' && !Plugin.baseDir) {
-    Plugin.baseDir = () => path.join(__dirname, '..');
+    Plugin.baseDir = () => baseDir;
   } else if (type === 'object' && Plugin !== null && Plugin.default) {
-    addBaseDir(Plugin.default);
+    addBaseDir(Plugin.default, baseDir);
   }
+
+  return Plugin;
 }
 
 module.exports = function(environment) {
@@ -71,12 +85,6 @@ module.exports = function(environment) {
     [StripFilteredImports, filteredImports],
     [TransformBlockScoping, { 'throwIfClosureRequired': true }]
   );
-
-  // ensures that a `baseDir` property is present on the babel plugins
-  // that we will be using, this prevents ember-cli-babel/broccoli-babel-transpiler
-  // from opting out of caching (and printing a giant warning)
-  plugins.forEach((pluginWithOptions) => addBaseDir(pluginWithOptions[0]));
-
 
   return { plugins, postTransformPlugins };
 };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "heimdalljs": "^0.3.0",
     "inflection": "^1.8.0",
     "npm-git-info": "^1.0.0",
+    "resolve": "^1.5.0",
     "semver": "^5.1.0",
     "silent-error": "^1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,6 +5668,12 @@ resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.0, 
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
+
 responselike@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"


### PR DESCRIPTION
Prior to this, we used our ember-data's own dirname as the default `baseDir` for any of our custom babel plugins. This baseDir is used to traverse all JS files in all deps (recursively) and ensure that if any of them are changed, the transpilation cache is invalidated.

Once we swapped to using ember-source as an npm package this meant that we would be stating/hashing all files inside of `node_modules/ember-source/**`. When using `npm link ember-source` this leads to a JS max heap errors (because of `node_modules/ember-source/tmp/**` being _MASSIVE_).

This fixes that specific issue, by using the **correct** basedir for each individual plugin.

/cc @mmun