### PR TITLE
[BUGFIX beta] Update DS.Errors#unknownProperty to return `undefined`.

### DIFF
--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -186,7 +186,7 @@ export default ArrayProxy.extend(Evented, {
   */
   unknownProperty(attribute) {
     let errors = this.errorsFor(attribute);
-    if (isEmpty(errors)) { return null; }
+    if (isEmpty(errors)) { return undefined; }
     return errors;
   },
 


### PR DESCRIPTION
In Ember 3.1+ any object that has an `unknownProperty` will throw an error if its `unknownProperty` returns any value other than `undefined` and the property is accessed via `obj.someProperty` (instead of `obj.get('someProperty')` or `Ember.get(obj, 'someProperty')`).