### PR TITLE
[BUGFIX beta] Avoid `isEmpty` for known object types.

### DIFF
--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -2,7 +2,6 @@ import { mapBy, not } from '@ember/object/computed';
 import Evented from '@ember/object/evented';
 import ArrayProxy from '@ember/array/proxy';
 import { set, get, computed } from '@ember/object';
-import { isEmpty } from '@ember/utils';
 import { makeArray, A } from '@ember/array';
 import MapWithDefault from '@ember/map/with-default';
 import { deprecate, warn } from '@ember/debug';
@@ -186,7 +185,7 @@ export default ArrayProxy.extend(Evented, {
   */
   unknownProperty(attribute) {
     let errors = this.errorsFor(attribute);
-    if (isEmpty(errors)) { return undefined; }
+    if (errors.length === 0) { return undefined; }
     return errors;
   },
 
@@ -425,6 +424,6 @@ export default ArrayProxy.extend(Evented, {
     @return {Boolean} true if there some errors on given attribute
   */
   has(attribute) {
-    return !isEmpty(this.errorsFor(attribute));
+    return this.errorsFor(attribute).length > 0;
   }
 });

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -2,7 +2,7 @@ import { assign, merge } from '@ember/polyfills';
 import { set, get } from '@ember/object';
 import { copy } from '@ember/object/internals';
 import EmberError from '@ember/error';
-import { isEqual, isEmpty } from '@ember/utils';
+import { isEqual } from '@ember/utils';
 import { setOwner } from '@ember/application';
 import { run } from '@ember/runloop';
 import RSVP, { Promise } from 'rsvp';
@@ -1095,7 +1095,7 @@ export default class InternalModel {
   hasErrors() {
     let errors = get(this.getRecord(), 'errors');
 
-    return !isEmpty(errors);
+    return errors.get('length') > 0;
   }
 
   // FOR USE DURING COMMIT PROCESS

--- a/addon/-private/system/store/serializer-response.js
+++ b/addon/-private/system/store/serializer-response.js
@@ -1,4 +1,3 @@
-import { isEmpty } from '@ember/utils';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 
@@ -79,7 +78,7 @@ export function normalizeResponseHelper(serializer, store, modelClass, payload, 
   if (DEBUG) {
     validationErrors = validateDocumentStructure(normalizedResponse);
   }
-  assert(`normalizeResponse must return a valid JSON API document:\n\t* ${validationErrors.join('\n\t* ')}`, isEmpty(validationErrors));
+  assert(`normalizeResponse must return a valid JSON API document:\n\t* ${validationErrors.join('\n\t* ')}`, validationErrors.length === 0);
 
   return normalizedResponse;
 }

--- a/addon/transforms/number.js
+++ b/addon/transforms/number.js
@@ -1,4 +1,3 @@
-import { isEmpty as empty } from '@ember/utils';
 import Transform from './transform';
 
 function isNumber(value) {
@@ -31,7 +30,7 @@ export default Transform.extend({
   deserialize(serialized) {
     let transformed;
 
-    if (empty(serialized)) {
+    if (serialized === '' || serialized === null || serialized === undefined) {
       return null;
     } else {
       transformed = Number(serialized);
@@ -43,7 +42,7 @@ export default Transform.extend({
   serialize(deserialized) {
     let transformed;
 
-    if (empty(deserialized)) {
+    if (deserialized === '' || deserialized === null || deserialized === undefined) {
       return null;
     } else {
       transformed = Number(deserialized);

--- a/tests/unit/model/rollback-attributes-test.js
+++ b/tests/unit/model/rollback-attributes-test.js
@@ -1,4 +1,4 @@
-import { isEmpty, isPresent } from '@ember/utils';
+import { isPresent } from '@ember/utils';
 import { addObserver } from '@ember/object/observers';
 import { Promise as EmberPromise, reject } from 'rsvp';
 import { run, later } from '@ember/runloop';
@@ -402,7 +402,7 @@ test("invalid record's attributes can be rollbacked", function(assert) {
 
       assert.equal(dog.get('hasDirtyAttributes'), false, 'must not be dirty');
       assert.equal(dog.get('name'), 'Pluto');
-      assert.ok(isEmpty(dog.get('errors.name')));
+      assert.notOk(dog.get('errors.name'));
       assert.ok(dog.get('isValid'));
     });
   });
@@ -477,7 +477,7 @@ test(`invalid record's attributes rolled back to correct state after set`, funct
       assert.equal(dog.get('name'), 'Pluto');
       assert.equal(dog.get('breed'), 'Disney');
       assert.equal(dog.get('hasDirtyAttributes'), false, 'must not be dirty');
-      assert.ok(isEmpty(dog.get('errors.name')));
+      assert.notOk(dog.get('errors.name'));
       assert.ok(dog.get('isValid'));
     });
   });


### PR DESCRIPTION
`Ember.isEmpty` does **a lot of things**, there is no reason to use it when you are operating on known data types.

**_Use the platform..._**