### PR TITLE
Refactor Travis setup to leverage stages...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ node_js:
   - "4"
   - "6"
 
+addons:
+  chrome: stable
+
 # hack to get after_success skipped in node 4
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,24 +11,66 @@ addons:
 cache:
   yarn: true
 
+stages:
+  - test
+  - additional tests
+  - older version tests
+  - deploy
+
+jobs:
+  fail_fast: true
+
+  include:
+    # runs tests with current locked deps and linting
+    - stage: test
+      env: NAME=test                  # used only to make Travis UI show description
+      script:
+        - ./bin/lint-features
+        - yarn test
+    - env: NAME=floating dependencies # used only to make Travis UI show description
+      install: yarn install --no-lockfile --non-interactive
+      script: yarn test
+
+    - stage: additional tests
+      env: NAME=optional-features     # used only to make Travis UI show description
+      install: yarn install
+      script: yarn test:optional-features
+
+    - env: NAME=production            # used only to make Travis UI show description
+      install: yarn install
+      script: yarn test:production
+
+    - env: NAME=node-tests            # used only to make Travis UI show description
+      install: yarn install
+      script: yarn test:node
+
+    # runs tests against each supported Ember version
+    - stage: older version tests
+      env: EMBER_TRY_SCENARIO=ember-lts-2.12
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.16
+    - env: EMBER_TRY_SCENARIO=ember-release
+    - env: EMBER_TRY_SCENARIO=ember-beta
+    - env: EMBER_TRY_SCENARIO=ember-canary
+
+    - stage: deploy
+      if: branch IN (master, beta, release) OR tag IS present
+      env: NAME=publish                # used only to make Travis UI show description
+      install: yarn install
+      script:
+        - yarn build:production
+        - "./bin/publish-builds"
+
+
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn global add phantomjs-prebuilt
-  - phantomjs --version
 
 install:
-  - yarn install --no-lockfile --no-interactive
+  - yarn install
 
 script:
-  - ./bin/lint-features
-  - yarn run test
-  - yarn run test:optional-features
-  - yarn run test:production
-  - yarn run node-tests
-after_success:
-  - yarn run production
-  - "./bin/publish-builds"
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup
+
 env:
   global:
   - BROCCOLI_ENV="production"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,15 @@ jobs:
       script:
         - ./bin/lint-features
         - yarn test
-    - env: NAME=floating dependencies # used only to make Travis UI show description
-      install: yarn install --no-lockfile --non-interactive
-      script: yarn test
 
     - stage: additional tests
       env: NAME=optional-features     # used only to make Travis UI show description
       install: yarn install
       script: yarn test:optional-features
+
+    - env: NAME=floating dependencies # used only to make Travis UI show description
+      install: yarn install --no-lockfile --non-interactive
+      script: yarn test
 
     - env: NAME=production            # used only to make Travis UI show description
       install: yarn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,9 @@ sudo: false
 dist: trusty
 node_js:
   - "4"
-  - "6"
 
 addons:
   chrome: stable
-
-# hack to get after_success skipped in node 4
-matrix:
-  exclude:
-    - node_js: "4"
-  include:
-    - node_js: "4"
-      after_success: skip
 
 cache:
   yarn: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,6 @@ cache:
 install:
   # Get the latest stable version of Node 0.STABLE.latest
   - ps: Install-Product node $env:nodejs_version
-  # Install PhantomJS
-  - choco install phantomjs --version 2.0.0 -y
-  - set path=%path%;C:\ProgramData\chocolatey\lib\PhantomJS\tools\
   # Typical npm stuff.
   - md C:\nc
   - appveyor-retry yarn install
@@ -23,9 +20,9 @@ install:
 test_script:
   # Output useful info for debugging.
   - cmd: yarn test
-  - cmd: yarn run test:optional-features
-  - cmd: yarn run test:production
-  - cmd: yarn run node-tests
+  - cmd: yarn test:optional-features
+  - cmd: yarn test:production
+  - cmd: yarn node-tests
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.
-  - cmd: yarn run test-appveyor
+  - cmd: yarn test
   - cmd: yarn run test:optional-features
   - cmd: yarn run test:production
   - cmd: yarn run node-tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ test_script:
   - cmd: yarn test
   - cmd: yarn test:optional-features
   - cmd: yarn test:production
-  - cmd: yarn node-tests
+  - cmd: yarn test:node
 
 # Don't actually build.
 build: off

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -26,9 +26,6 @@ module.exports = function(defaults) {
         // while ember-data strips itself, ember does not currently
         [StripClassCallCheck]
       ]
-    },
-    'ember-cli-babel': {
-      includePolyfill: true
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall",
-    "test-appveyor": "ember test",
+    "test": "ember test",
+    "test:all": "ember try:each",
+    "test:production": "ember test --environment=production",
     "node-tests": "node node-tests/nodetest-runner.js",
     "test:optional-features": "ember test --environment=test-optional-features",
-    "test:production": "ember test --environment=production",
     "production": "ember build --environment=production"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   },
   "scripts": {
     "build": "ember build",
+    "build:production": "ember build --environment=production",
     "start": "ember server",
     "test": "ember test",
     "test:all": "ember try:each",
+    "test:node": "node node-tests/nodetest-runner.js",
     "test:production": "ember test --environment=production",
-    "node-tests": "node node-tests/nodetest-runner.js",
-    "test:optional-features": "ember test --environment=test-optional-features",
-    "production": "ember build --environment=production"
+    "test:optional-features": "ember test --environment=test-optional-features"
   },
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "ember-resolver": "^4.1.0",
     "ember-source": "~2.11.0",
     "ember-source-channel-url": "^1.0.1",
+    "ember-try": "^0.2.23",
     "ember-watson": "^0.7.0",
     "express": "^4.14.0",
     "faker": "^3.1.0",

--- a/testem.js
+++ b/testem.js
@@ -5,10 +5,21 @@ module.exports = {
   "disable_watching": true,
   "reporter": "dot",
   "launch_in_ci": [
-    "PhantomJS"
+    "Chrome"
   ],
   "launch_in_dev": [
-    "PhantomJS",
     "Chrome"
-  ]
+  ],
+  browser_args: {
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900',
+        '--no-sandbox'
+      ]
+    }
+  }
 };

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -503,7 +503,7 @@ test('Calling pushPayload allows partial updates with raw JSON', function(assert
   assert.equal(person.get('lastName'), 'Jackson', 'existing fields are untouched');
 });
 
-test('calling push without data argument as an object raises an error', function(assert) {
+testInDebug('calling push without data argument as an object raises an error', function(assert) {
   let invalidValues = [
     null,
     1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,6 +2732,15 @@ ember-try-config@^2.0.1:
     rsvp "^3.2.1"
     semver "^5.1.0"
 
+ember-try-config@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-try-config/-/ember-try-config-2.2.0.tgz#6be0af6c71949813e02ac793564fddbf8336b807"
+  dependencies:
+    lodash "^4.6.1"
+    node-fetch "^1.3.3"
+    rsvp "^3.2.1"
+    semver "^5.1.0"
+
 ember-try@^0.2.15:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/ember-try/-/ember-try-0.2.17.tgz#0ffff687630291b4cf94f5b196e728c1a92d8aec"
@@ -2742,6 +2751,23 @@ ember-try@^0.2.15:
     debug "^2.2.0"
     ember-cli-version-checker "^1.1.6"
     ember-try-config "^2.0.1"
+    extend "^3.0.0"
+    fs-extra "^0.26.0"
+    promise-map-series "^0.2.1"
+    resolve "^1.1.6"
+    rimraf "^2.3.2"
+    rsvp "^3.0.17"
+    semver "^5.1.0"
+
+ember-try@^0.2.23:
+  version "0.2.23"
+  resolved "https://registry.yarnpkg.com/ember-try/-/ember-try-0.2.23.tgz#39b57141b4907541d0ac8b503d211e6946b08718"
+  dependencies:
+    chalk "^1.0.0"
+    cli-table2 "^0.2.0"
+    core-object "^1.1.0"
+    debug "^2.2.0"
+    ember-try-config "^2.2.0"
     extend "^3.0.0"
     fs-extra "^0.26.0"
     promise-map-series "^0.2.1"


### PR DESCRIPTION
Using the new(ish) stages feature from Travis allows us to fail early (and avoid wasting CI resources) when a "simple" `ember test` with locked deps does not pass.

As you can see in the screenshot below:

![screenshot](https://monosnap.com/file/w41o4iuYhB5MQ6X9pmrDBI6A1QJ64r.png)

The first stage is `test`, and it uses our specific `yarn.lock` to run `ember test`.  If that build fails, nothing else is ran.  If it succeeds 4 more builds are kicked off (production tests, optional-features, node-tests, floating dependencies). If any of those builds fail, nothing else is ran. Then it moves on to testing various Ember versions...