### PR TITLE
Check if adapter#query is a wrapped function

### DIFF
--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -138,7 +138,10 @@ export function _query(adapter, store, modelName, query, recordArray) {
   let modelClass = store.modelFor(modelName); // adapter.query needs the class
 
   let promise;
-  if (adapter.query.length > 3) {
+  let createRecordArray = adapter.query.length > 3 ||
+    (adapter.query.wrappedFunction && adapter.query.wrappedFunction.length > 3);
+
+  if (createRecordArray) {
     recordArray = recordArray || store.recordArrayManager.createAdapterPopulatedRecordArray(modelName, query);
     promise = adapter.query(store, modelClass, query, recordArray);
   } else {


### PR DESCRIPTION
Currently the `if` statement always returns false because adapter#query is a wrappedFunction, which has length == 0.

This PR checks if the query is a wrappedFunction and if it is we'll check the length of that function.

I'm also wondering if we can get rid of the `if` statement and have the recordArray created and given to the query function in all cases. My guess is that the conditional guards around having to create and then later add models to the record array because there is a problem with the events that fire? @stefanpenner do you have any thoughts?