### PR TITLE
[BUGFIX] record.data is intimate API that we need to deprecate

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1129,7 +1129,8 @@ const Model = EmberObject.extend(Evented, {
  */
 Object.defineProperty(Model.prototype, 'data', {
   get() {
-    return this._internalModel._data;
+    // TODO deprecate this!!!!!!!!!!! it's private but intimate
+    return this._internalModel._modelData._data;
   }
 });
 


### PR DESCRIPTION
This just fixes the accessor. We should actually deprecate this though.