### PR TITLE
failed test: createRecord creates two records on ember 3.0

### DIFF
--- a/tests/integration/relationships/one-to-many-test.js
+++ b/tests/integration/relationships/one-to-many-test.js
@@ -1452,3 +1452,35 @@ test("Rollbacking attributes of a created record works correctly when the belong
   assert.equal(user.get('accounts.length'), 0, "User does not have the account anymore");
   assert.equal(account.get('user'), null, 'Account does not have the user anymore');
 });
+
+test("createRecord updates inverse record array which has observers", function(assert) {
+
+  env.adapter.findAll = () => {
+    return {
+      data: [{
+        id: '2',
+        type: 'user',
+        attributes: {
+          name: 'Stanley'
+        }
+      }]
+    }
+  };
+
+  return store.findAll('user').then(users => {
+    assert.equal(users.get('length'), 1, 'Exactly 1 user');
+
+    let user = users.get('firstObject');
+    assert.equal(user.get('messages.length'), 0, 'Record array is initially empty');
+
+    // set up an observer
+    user.addObserver('messages.@each.title', () => {});
+    user.get('messages.firstObject');
+
+    let message = run(() => store.createRecord('message', { user, title: 'EmberFest was great' }));
+    assert.equal(user.get('messages.length'), 1, 'The message is added to the record array');
+
+    let messageFromArray = user.get('messages.firstObject');
+    assert.equal(message, messageFromArray, 'Only one message should be created');
+  });
+});


### PR DESCRIPTION
After upgrading ember from 2.18.2 to 3.0, _with ember-data unchanged_ at version 2.18.1, a call to `createRecord` creates 2 records.

It happens under these conditions:
1. The call to `createRecord` sets up a relationship which has an inverse
2. The inverse array is being observed (e.g. used in a template)

Here's a shortened example of the problem:
```js
const Post = Model.extend({
  comments: hasMany('comment')
});
const Comment = Model.extend({
  post: belongsTo('post')
});

// non-working example
let post = this.get('model');
let comment = this.store.createRecord('comment', { post });
comment === post.get('comments.firstObject'); // false!! actually 2 comments were created
```

It works if you set up the relationship _after_ construction:
```js
// workaround
let post = this.get('model');
let comment = this.store.createRecord('comment');
comment.set('post', post); // don't pass directly to createRecord
comment === post.get('comments.firstObject'); // true
```

It also works if nobody is observing the `comments` array.

The stack trace explains why: `createRecord` updates the inverse record array synchronously before actually creating the record
```
create (container.js:420)
create (container.js:178)       <<<============
getRecord (-private.js:6597)
objectAt (-private.js:4180)
objectAt (array.js:50)
objectAtContent (array_proxy.js:110)
objectAt (array_proxy.js:149)
objectAt (array.js:50)
addObserverForContentKey (array.js:600)
arrayDidChange (array.js:554)
arrayContentDidChange (array.js:105)
_emberMetal.Mixin.create._Mixin$create.arrayContentDidChange (array.js:281)
exports.default._object.default.extend._EmberObject$extend._arrangedContentArrayDidChange (array_proxy.js:221)
applyStr (ember-utils.js:528)
sendEvent (ember-metal.js:257)
arrayContentDidChange (array.js:108)
_emberMetal.Mixin.create._Mixin$create.arrayContentDidChange (array.js:281)
internalReplace (-private.js:4224)
_addInternalModels (-private.js:4240)
addInternalModel (-private.js:4412)
addInternalModel (-private.js:3745)
addInternalModel (-private.js:4733)
setInternalModel (-private.js:4646)
set (-private.js:12386)
computedPropertySet (ember-metal.js:3456)
computedPropertySetWithSuspend (ember-metal.js:3438)
computedPropertySetEntry (ember-metal.js:3416)
Class (core_object.js:100)
_ClassMixinProps.create (core_object.js:277)
create (container.js:420)
create (container.js:178)       <<<============
getRecord (-private.js:6597)
createRecord (-private.js:9922)
```
