### PR TITLE
[BUGFIX release] Setup internal model's _record before assigning relationships

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -343,7 +343,7 @@ export default class InternalModel {
       // instances with the injections applied
       let createOptions = {
         store: this.store,
-        _internalModel: this,
+        __setupInternalModel: this,
         id: this.id,
         currentState: this.currentState,
         isError: this.isError,
@@ -361,7 +361,7 @@ export default class InternalModel {
         createOptions.container = this.store.container;
       }
 
-      this._record = this.store.modelFactoryFor(this.modelName).create(createOptions);
+      this.store.modelFactoryFor(this.modelName).create(createOptions);
 
       this._triggerDeferredTriggers();
       heimdall.stop(token);

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -91,6 +91,12 @@ const Model = EmberObject.extend(Evented, {
   __defineNonEnumerable(property) {
     this[property.name] = property.descriptor.value;
   },
+  __setupInternalModel: computed({
+    set(key, internalModel) {
+      internalModel._record = this;
+      this._internalModel = internalModel;
+    }
+  }),
 
   /**
     If this property is `true` the record is in the `empty`


### PR DESCRIPTION
Fixes #5359 and https://github.com/emberjs/ember.js/issues/16258.

Before this PR, it was possible to accidentally reify inverse relationships into an invalid state when combining `createRecord` with `@each` observers/CPs on an inverse relationship (see test). This would cause internalModel's `getRecord` to be called recursively with unexpected results. This problem became amplified in Ember 3.x because ArrayProxies now cache the result of `objectAt`, which lead us to caching the wrong invalid state.

This fix ensures that `_internalModel._record` is setup immediately, before any reification happens, to avoid ever entering an invalid state.