### PR TITLE
[BUGFIX beta] Fix createRecord creating two records

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -334,7 +334,7 @@ export default class InternalModel {
     return this.currentState.dirtyType;
   }
 
-  getRecord(properties) {
+  getRecord() {
     if (!this._record && !this._isDematerializing) {
       heimdall.increment(materializeRecord);
       let token = heimdall.start('InternalModel.getRecord');
@@ -349,10 +349,6 @@ export default class InternalModel {
         isError: this.isError,
         adapterError: this.error
       };
-
-      if (typeof properties === 'object' && properties !== null) {
-        emberAssign(createOptions, properties);
-      }
 
       if (setOwner) {
         // ensure that `getOwner(this)` works inside a model instance

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -358,7 +358,8 @@ Store = Service.extend({
 
     let internalModel = this._buildInternalModel(normalizedModelName, properties.id);
     internalModel.loadedData();
-    let record = internalModel.getRecord(properties);
+    let record = internalModel.getRecord();
+    record.setProperties(properties);
 
     // TODO @runspired this should also be coalesced into some form of internalModel.setState()
     internalModel.eachRelationship((key, descriptor) => {

--- a/tests/integration/relationships/one-to-many-test.js
+++ b/tests/integration/relationships/one-to-many-test.js
@@ -1452,3 +1452,35 @@ test("Rollbacking attributes of a created record works correctly when the belong
   assert.equal(user.get('accounts.length'), 0, "User does not have the account anymore");
   assert.equal(account.get('user'), null, 'Account does not have the user anymore');
 });
+
+test("createRecord updates inverse record array which has observers", function(assert) {
+
+  env.adapter.findAll = () => {
+    return {
+      data: [{
+        id: '2',
+        type: 'user',
+        attributes: {
+          name: 'Stanley'
+        }
+      }]
+    }
+  };
+
+  return store.findAll('user').then(users => {
+    assert.equal(users.get('length'), 1, 'Exactly 1 user');
+
+    let user = users.get('firstObject');
+    assert.equal(user.get('messages.length'), 0, 'Record array is initially empty');
+
+    // set up an observer
+    user.addObserver('messages.@each.title', () => {});
+    user.get('messages.firstObject');
+
+    let message = run(() => store.createRecord('message', { user, title: 'EmberFest was great' }));
+    assert.equal(user.get('messages.length'), 1, 'The message is added to the record array');
+
+    let messageFromArray = user.get('messages.firstObject');
+    assert.equal(message, messageFromArray, 'Only one message should be created');
+  });
+});


### PR DESCRIPTION
Fixes #5359 and emberjs/ember.js#16258

Explained in #5364:
> Before this PR, it was possible to accidentally reify inverse relationships into an invalid state when combining createRecord with @each observers/CPs on an inverse relationship (see test). This would cause internalModel's getRecord to be called recursively with unexpected results. This problem became amplified in Ember 3.x because ArrayProxies now cache the result of objectAt, which lead us to caching the wrong invalid state.

This applies the workaround from https://github.com/emberjs/data/pull/5359#issuecomment-366880425 to create and cache the record _before_ setting any state which might update inverses.

cc @mmun 