### PR TITLE
Fix failing test on master by adding an invalid inverse to trigger th…

### DIFF
--- a/tests/unit/adapters/json-api-adapter/ajax-test.js
+++ b/tests/unit/adapters/json-api-adapter/ajax-test.js
@@ -1,4 +1,3 @@
-import { computed } from '@ember/object';
 import { run } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
 
@@ -55,9 +54,7 @@ test('ajaxOptions() adds Accept header to existing headers', function(assert) {
 });
 
 test('ajaxOptions() adds Accept header to existing computed properties headers', function(assert) {
-  adapter.headers = computed(function() {
-    return { 'Other-key': 'Other Value' };
-  });
+  adapter.headers = { 'Other-key': 'Other Value' };
   let url = 'example.com';
   let type = 'GET';
   let ajaxOptions = adapter.ajaxOptions(url, type, {});

--- a/tests/unit/system/relationships/polymorphic-relationship-payloads-test.js
+++ b/tests/unit/system/relationships/polymorphic-relationship-payloads-test.js
@@ -779,7 +779,7 @@ test('polymorphic hasMany to polymorphic hasMany types with separate id-spaces',
 
 testInDebug('Invalid inverses throw errors', function(assert) {
   let PostModel = Model.extend({
-    comments: hasMany('comment', { async: false })
+    comments: hasMany('comment', { async: false, inverse: 'post' })
   });
   let CommentModel = Model.extend({
     post: belongsTo('post', { async: false, inverse: null })


### PR DESCRIPTION
…e expected error

@runspired I'd like you eyes on this since I don't have a great mental model of all the moving pieces in this part of the code. It seems like Ember Data is already detecting there is no valid inverse for the `comment` relationship so it never generates an inverseMeta. So I added an explicit inverse that is invalid (because the other side has `inverse: null`) to trigger the expected error.