### PR TITLE
[BUGFIX beta] Use @ember/ordered-set to avoid deprecations.

### DIFF
--- a/addon/-private/system/ordered-set.js
+++ b/addon/-private/system/ordered-set.js
@@ -1,7 +1,5 @@
+import EmberOrderedSet from '@ember/ordered-set';
 import { guidFor } from '@ember/object/internals';
-import Ember from 'ember';
-
-const EmberOrderedSet = Ember.OrderedSet;
 
 export default function OrderedSet() {
   this._super$constructor();

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@ember/ordered-set": "^1.0.0",
     "amd-name-resolver": "0.0.7",
     "babel-plugin-ember-modules-api-polyfill": "^1.4.2",
     "babel-plugin-feature-flags": "^0.3.1",

--- a/tests/integration/record-array-manager-test.js
+++ b/tests/integration/record-array-manager-test.js
@@ -1,7 +1,7 @@
 import { A } from '@ember/array';
 import { run } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
-import Ember from 'ember';
+import OrderedSet from '@ember/ordered-set';
 
 import { module, test } from 'qunit';
 
@@ -304,7 +304,7 @@ test('createRecordArray', function(assert) {
 test('createRecordArray \w optional content', function(assert) {
   let record = {};
   let internalModel = {
-    _recordArrays: new Ember.OrderedSet(),
+    _recordArrays: new OrderedSet(),
     getRecord() {
       return record;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@ember/ordered-set@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ember/ordered-set/-/ordered-set-1.0.0.tgz#cf9ab5fd7510bcad370370ebcded705f6d1c542b"
+  dependencies:
+    ember-cli-babel "6.12.0"
+    ember-compatibility-helpers "^1.0.0-beta.2"
+
 "@glimmer/di@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
@@ -560,6 +567,12 @@ babel-plugin-ember-modules-api-polyfill@^1.4.2:
 babel-plugin-ember-modules-api-polyfill@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.1.0.tgz#78848cc4fcc2274882a6c15cbb23fefcdc771301"
+  dependencies:
+    ember-rfc176-data "^0.3.0"
+
+babel-plugin-ember-modules-api-polyfill@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz#0c01f359658cfb9c797f705af6b09f6220205ae0"
   dependencies:
     ember-rfc176-data "^0.3.0"
 
@@ -2243,6 +2256,24 @@ ember-cli-app-version@^3.0.0:
     ember-cli-babel "^6.8.0"
     git-repo-version "0.4.1"
 
+ember-cli-babel@6.12.0:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz#3adcdbe1278da1fcd0b9038f1360cb4ac5d4414c"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.3.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.0"
+    semver "^5.4.1"
+
 ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.2.1:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
@@ -2613,6 +2644,14 @@ ember-cli@^2.11.1:
     validate-npm-package-name "^3.0.0"
     walk-sync "^0.3.0"
     yam "0.0.22"
+
+ember-compatibility-helpers@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.0.0-beta.2.tgz#00cb134af45f9562fa47a23f4da81a63aad41943"
+  dependencies:
+    babel-plugin-debug-macros "^0.1.11"
+    ember-cli-version-checker "^2.0.0"
+    semver "^5.4.1"
 
 ember-dev@emberjs/ember-dev#bcfb9c3487ec2fd58b932394a15ce16fd9cf7eed:
   version "0.0.0"
@@ -5843,6 +5882,10 @@ selenium-webdriver@2.48.2:
 semver@^4.1.0, semver@^4.3.1:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+
+semver@^5.4.1:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@~5.0.1:
   version "5.0.3"


### PR DESCRIPTION
Ember will deprecate usage of `Ember.OrderedSet` (likely in 3.2 or 3.3), and as part of that process the implementation has been extracted to an addon `@ember/ordered-set`. The addon intelligently avoids shipping duplicated implementations, and is compatible with newer _and_ older Ember versions.

Closes https://github.com/emberjs/data/issues/5254