### PR TITLE
[BUGFIX] resolve issues with RecordArray sync for peekAll

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -293,6 +293,7 @@ export default class InternalModel {
     // models to rematerialize their records.
 
     return this._isDematerializing ||
+      this.hasScheduledDestroy() ||
       this.isDestroyed ||
       this.currentState.stateName === 'root.deleted.saved' ||
       this.isEmpty();
@@ -381,9 +382,10 @@ export default class InternalModel {
       this._isDematerializing = true;
       this._record.destroy();
       this.destroyRelationships();
-      this.updateRecordArrays();
       this.resetRecord();
     }
+
+    this.updateRecordArrays();
   }
 
   deleteRecord() {

--- a/addon/-private/system/record-array-manager.js
+++ b/addon/-private/system/record-array-manager.js
@@ -62,7 +62,6 @@ export default class RecordArrayManager {
     this._liveRecordArrays = Object.create(null);
     this._pending = Object.create(null);
     this._adapterPopulatedRecordArrays = [];
-    this._nextManagerFlush = null;
   }
 
   recordDidChange(internalModel) {
@@ -94,7 +93,7 @@ export default class RecordArrayManager {
       return;
     }
 
-    this._nextManagerFlush = emberRun.schedule('actions', this, this._flush);
+    emberRun.schedule('actions', this, this._flush);
   }
 
   _flushPendingInternalModelsForModelName(modelName, internalModels) {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ember-publisher": "0.0.7",
     "ember-qunit-assert-helpers": "^0.2.1",
     "ember-resolver": "^4.1.0",
-    "ember-source": "~2.18.0",
+    "ember-source": "~3.0.0",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^0.2.23",
     "ember-watson": "^0.7.0",

--- a/tests/helpers/watch-property.js
+++ b/tests/helpers/watch-property.js
@@ -1,0 +1,144 @@
+import Ember from 'ember';
+import QUnit from 'qunit';
+
+const {
+  addObserver,
+  removeObserver
+} = Ember;
+
+function makeCounter() {
+  let count = 0;
+  const counter = Object.create(null);
+  counter.reset = function resetCounter() { count = 0; };
+
+  Object.defineProperty(counter, 'count', {
+    get() { return count; },
+    set() {},
+    configurable: false,
+    enumerable: true
+  });
+
+  Object.freeze(counter);
+
+  function increment() {
+    count++;
+  }
+
+  return { counter, increment };
+}
+
+export function watchProperty(obj, propertyName) {
+  let { counter, increment } = makeCounter();
+
+  function observe() {
+    increment();
+  }
+
+  addObserver(obj, propertyName, observe);
+
+  function unwatch() {
+    removeObserver(obj, propertyName, observe);
+  }
+
+  return { counter, unwatch };
+}
+
+export function watchProperties(obj, propertyNames) {
+  let watched = {};
+  let counters = {};
+
+  if (!Array.isArray(propertyNames)) {
+    throw new Error(`Must call watchProperties with an array of propertyNames to watch, received ${propertyNames}`);
+  }
+
+  for (let i = 0; i < propertyNames.length; i++) {
+    let propertyName = propertyNames[i];
+
+    if (watched[propertyName] !== undefined) {
+      throw new Error(`Cannot watch the same property ${propertyName} more than once`);
+    }
+
+    let { counter, increment } = makeCounter();
+    watched[propertyName] = increment;
+    counters[propertyName] = counter;
+
+    addObserver(obj, propertyName, increment);
+  }
+
+  function unwatch() {
+    Object.keys(watched).forEach((propertyName) => {
+      removeObserver(obj, propertyName, watched[propertyName]);
+    });
+  }
+
+  return { counters, unwatch };
+}
+
+QUnit.assert.watchedPropertyCounts = function assertWatchedPropertyCount(watchedObject, expectedCounts, label = '') {
+  if (!watchedObject || !watchedObject.counters) {
+    throw new Error('Expected to receive the return value of watchProperties: an object containing counters');
+  }
+
+  let counters = watchedObject.counters;
+
+  Object.keys(expectedCounts).forEach((propertyName) => {
+    let counter = counters[propertyName];
+    let expectedCount = expectedCounts[propertyName];
+    let assertionText = label;
+
+    if (Array.isArray(expectedCount)) {
+      label = expectedCount[1];
+      expectedCount = expectedCount[0];
+    }
+
+    assertionText += ` | Expected ${expectedCount} change notifications for ${propertyName} but recieved ${counter.count}`;
+
+    if (counter === undefined) {
+      throw new Error(`Cannot assert expected count for ${propertyName} as there is no watcher for that property`);
+    }
+
+    this.pushResult({
+      result: counter.count === expectedCount,
+      actual: counter.count,
+      expected: expectedCount,
+      message: assertionText
+    });
+  });
+};
+
+QUnit.assert.watchedPropertyCount = function assertWatchedPropertyCount(watcher, expectedCount, label) {
+  let counter;
+  if (!watcher) {
+    throw new Error(`Expected to receive a watcher`);
+  }
+
+  // this allows us to handle watchers passed in from a watchProperties return hash
+  if (!watcher.counter && watcher.count !== undefined) {
+    counter = watcher;
+  } else {
+    counter = watcher.counter;
+  }
+
+  this.pushResult({
+    result: counter.count === expectedCount,
+    actual: counter.count,
+    expected: expectedCount,
+    message: label
+  });
+};
+
+QUnit.assert.dirties = function assertDirties(options, updateMethodCallback, label) {
+  let { object: obj, property, count } = options;
+  count = typeof count === 'number' ? count : 1;
+  let { counter, unwatch } = watchProperty(obj, property);
+  updateMethodCallback();
+  this.pushResult({
+    result: counter.count === count,
+    actual: counter.count,
+    expected: count,
+    message: label
+  });
+  unwatch();
+};
+
+

--- a/tests/integration/record-arrays/peeked-records-test.js
+++ b/tests/integration/record-arrays/peeked-records-test.js
@@ -1,10 +1,9 @@
 import { run } from '@ember/runloop';
-import { watchProperties } from '../../helpers/watch-property';
 import { createStore } from 'dummy/tests/helpers/store';
-
 import { module, test } from 'qunit';
-
 import DS from 'ember-data';
+import { get } from '@ember/object';
+import { watchProperties } from '../../helpers/watch-property';
 
 let store;
 
@@ -199,5 +198,67 @@ test('immediately peeking after unloading newly created records works as expecte
     watcher,
     { length: 2, '[]': 2 },
     'RecordArray state when a new record is unloaded'
+  );
+});
+
+test('unloadAll followed by peekAll in the same run-loop works as expected', function(assert) {
+  let peekedRecordArray = run(() => store.peekAll('person'));
+  let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
+
+  run(() => {
+    store.push({
+      data: [
+        {
+          type: 'person',
+          id: '1',
+          attributes: {
+            name: 'John'
+          }
+        },
+        {
+          type: 'person',
+          id: '2',
+          attributes: {
+            name: 'Joe'
+          }
+        }
+      ]
+    });
+  });
+
+  run(() => {
+    store.peekAll('person');
+
+    assert.watchedPropertyCounts(
+      watcher,
+      { length: 1, '[]': 1 },
+      'RecordArray state after a single push with multiple records to add'
+    );
+
+    store.unloadAll('person');
+
+    assert.watchedPropertyCounts(
+      watcher,
+      { length: 1, '[]': 1 },
+      'RecordArray state after unloadAll has not changed yet'
+    );
+
+    assert.equal(get(peekedRecordArray, 'length'), 2, 'Array length is unchanged before the next peek');
+
+    store.peekAll('person');
+
+    assert.equal(get(peekedRecordArray, 'length'), 0, 'We no longer have any array content');
+
+    assert.watchedPropertyCounts(
+      watcher,
+      { length: 2, '[]': 2 },
+      'RecordArray state after a follow up peekAll reflects unload changes'
+    );
+  });
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 2, '[]': 2 },
+    'RecordArray state has not changed any further'
   );
 });

--- a/tests/integration/record-arrays/peeked-records-test.js
+++ b/tests/integration/record-arrays/peeked-records-test.js
@@ -3,6 +3,7 @@ import { createStore } from 'dummy/tests/helpers/store';
 import { module, test } from 'qunit';
 import DS from 'ember-data';
 import { get } from '@ember/object';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import { watchProperties } from '../../helpers/watch-property';
 
 let store;
@@ -418,10 +419,15 @@ test('unloading filtered records', function(assert) {
   run(() => {
     people.objectAt(0).unloadRecord();
 
-    assert.equal(get(people, 'length'), 2, 'Unload does not complete until the end of the loop');
-    assert.ok(get(people.objectAt(0), 'name'), 'Scumbag John', 'John is still the first object until the end of the loop');
+    if (hasEmberVersion(3, 0)) {
+      assert.equal(get(people, 'length'), 2, 'Unload does not complete until the end of the loop');
+      assert.equal(get(people.objectAt(0), 'name'), 'Scumbag John', 'John is still the first object until the end of the loop');
+    } else {
+      assert.equal(get(people, 'length'), 2, 'Unload does not complete until the end of the loop');
+      assert.equal(people.objectAt(0), undefined, 'John is still the first object until the end of the loop');
+    }
   });
 
   assert.equal(get(people, 'length'), 1, 'Unloaded record removed from the array');
-  assert.ok(get(people.objectAt(0), 'name'), 'Scumbag Joe', 'Joe shifted down after the unload');
+  assert.equal(get(people.objectAt(0), 'name'), 'Scumbag Joe', 'Joe shifted down after the unload');
 });

--- a/tests/integration/record-arrays/unload-peeked-records-test.js
+++ b/tests/integration/record-arrays/unload-peeked-records-test.js
@@ -1,0 +1,203 @@
+import { run } from '@ember/runloop';
+import { watchProperties } from '../../helpers/watch-property';
+import { createStore } from 'dummy/tests/helpers/store';
+
+import { module, test } from 'qunit';
+
+import DS from 'ember-data';
+
+let store;
+
+const Person = DS.Model.extend({
+  name: DS.attr('string'),
+  toString() {
+    return `<Person#${this.get('id')}>`;
+  }
+});
+
+module('integration/unload-peeked-records', {
+  beforeEach() {
+    store = createStore({
+      person: Person
+    });
+  }
+});
+
+test('repeated calls to peekAll in separate run-loops works as expected', function(assert) {
+  let peekedRecordArray = run(() => store.peekAll('person'));
+  let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
+
+  run(() => store.push({
+    data: [
+      {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'John'
+        }
+      },
+      {
+        type: 'person',
+        id: '2',
+        attributes: {
+          name: 'Joe'
+        }
+      }
+    ]
+  }));
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 1, '[]': 1 },
+    'RecordArray state after a single push with multiple records to add'
+  );
+
+  run(() => store.peekAll('person'));
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 1, '[]': 1 },
+    'RecordArray state has not changed after another call to peek'
+  );
+});
+
+test('peekAll in the same run-loop as push works as expected', function(assert) {
+  let peekedRecordArray = run(() => store.peekAll('person'));
+  let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
+
+  run(() => {
+    store.push({
+      data: [
+        {
+          type: 'person',
+          id: '1',
+          attributes: {
+            name: 'John'
+          }
+        },
+        {
+          type: 'person',
+          id: '2',
+          attributes: {
+            name: 'Joe'
+          }
+        }
+      ]
+    });
+    store.peekAll('person');
+  });
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 1, '[]': 1 },
+    'RecordArray state after a single push with multiple records to add'
+  );
+
+  run(() => store.peekAll('person'));
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 1, '[]': 1 },
+    'RecordArray state has not changed after another call to peek'
+  );
+});
+
+test('newly created records notify the array as expected', function(assert) {
+  let peekedRecordArray = run(() => store.peekAll('person'));
+  let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
+
+  let aNewlyCreatedRecord = run(() => store.createRecord('person', {
+    name: 'James'
+  }));
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 1, '[]': 1 },
+    'RecordArray state when a new record is created'
+  );
+
+  run(() => {
+    aNewlyCreatedRecord.unloadRecord();
+  });
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 2, '[]': 2 },
+    'RecordArray state when a new record is unloaded'
+  );
+});
+
+test('immediately peeking newly created records works as expected', function(assert) {
+  let peekedRecordArray = run(() => store.peekAll('person'));
+  let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
+
+  let aNewlyCreatedRecord = run(() => store.createRecord('person', {
+    name: 'James'
+  }));
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 1, '[]': 1 },
+    'RecordArray state when a new record is created'
+  );
+
+  run(() => {
+    aNewlyCreatedRecord.unloadRecord();
+    store.peekAll('person');
+  });
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 2, '[]': 2 },
+    'RecordArray state when a new record is unloaded'
+  );
+});
+
+test('unloading newly created records notify the array as expected', function(assert) {
+  let peekedRecordArray = run(() => store.peekAll('person'));
+  let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
+  let aNewlyCreatedRecord = run(() => store.createRecord('person', {
+    name: 'James'
+  }));
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 1, '[]': 1 },
+    'RecordArray state when a new record is created'
+  );
+
+  run(() => {
+    aNewlyCreatedRecord.unloadRecord();
+  });
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 2, '[]': 2 },
+    'RecordArray state when a new record is unloaded'
+  );
+});
+
+test('immediately peeking after unloading newly created records works as expected', function(assert) {
+  let peekedRecordArray = run(() => store.peekAll('person'));
+  let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
+  let aNewlyCreatedRecord = run(() => store.createRecord('person', {
+    name: 'James'
+  }));
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 1, '[]': 1 },
+    'RecordArray state when a new record is created'
+  );
+
+  run(() => {
+    aNewlyCreatedRecord.unloadRecord();
+    store.peekAll('person');
+  });
+
+  assert.watchedPropertyCounts(
+    watcher,
+    { length: 2, '[]': 2 },
+    'RecordArray state when a new record is unloaded'
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,9 +2969,9 @@ ember-source-channel-url@^1.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@~2.18.0:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.18.2.tgz#75d00eef5488bfe504044b025c752ba924eaf87f"
+ember-source@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.0.0.tgz#51811cae98d2ceec53bcfbaa876d02b2b5b2159f"
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
@@ -2980,7 +2980,6 @@ ember-source@~2.18.0:
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-test-info "^1.0.0"
     ember-cli-valid-component-name "^1.0.0"
     ember-cli-version-checker "^2.1.0"
     ember-router-generator "^1.2.3"
@@ -4695,7 +4694,7 @@ jmespath@0.15.0:
 
 jquery@^3.2.1:
   version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+  resolved "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
 js-reporters@1.2.1:
   version "1.2.1"


### PR DESCRIPTION
This PR resolves issues with ensuring that RecordArray is correctly synced for peekAll.

Resolves #5271 
Resolves #5167 
Resolves #5175
Resolves #5111 / #5157 

It also includes tests and a fix for #5350 and #5025 / #5095  wherein non-materialized records would remain in live-record-arrays and filtered record arrays upon unload.

Resolves #5025 

cc @tylerturdenpants @igorT @hjdivad @workmanw 