### PR TITLE
[Model Data] Introduce `setRecordId` function in place of `updateId`

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -932,7 +932,7 @@ export default class InternalModel {
   setId(id) {
     assert('A record\'s id cannot be changed once it is in the loaded state', this.id === null || this.id === id || this.isNew());
     this.id = id;
-    if (this._record.get('id') !== id) {
+    if (this._record && this._record.get('id') !== id) {
       this._record.set('id', id);
     }
   }

--- a/addon/-private/system/model/model-data.js
+++ b/addon/-private/system/model/model-data.js
@@ -196,6 +196,11 @@ export default class ModelData {
       if (data.relationships) {
         this._setupRelationships(data);
       }
+      if (data.id) {
+        // didCommit provided an ID, notify the store of it
+        this.storeWrapper.setRecordId(this.modelName, data.id, this.clientId);
+        this.id = coerceId(data.id);
+      }
       data = data.attributes;
     }
     let changedKeys = this._changedKeys(data);

--- a/addon/-private/system/store/model-data-wrapper.js
+++ b/addon/-private/system/store/model-data-wrapper.js
@@ -56,6 +56,10 @@ export default class ModelDataWrapper {
     return this.store.modelDataFor(modelName, id, clientId);
   }
 
+  setRecordId(modelName, id, clientId) {
+    this.store.setRecordId(modelName, id, clientId);
+  }
+
   isRecordInUse(modelName, id, clientId) {
     let internalModel = this.store._getInternalModelForId(modelName, id, clientId);
     if (!internalModel) {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1462,7 +1462,7 @@ test('setting the id after model creation should correctly update the id', funct
   });
 });
 
-test('updating the id with store.updateId should correctly when the id property is watched', function(assert) {
+test('updating the id with store.setRecordId should correctly when the id property is watched', function(assert) {
   assert.expect(2);
 
   const Person = DS.Model.extend({
@@ -1480,7 +1480,7 @@ test('updating the id with store.updateId should correctly when the id property 
 
     assert.equal(person.get('id'), null, 'initial created model id should be null');
 
-    store.updateId(person._internalModel, { id: 'john' });
+    store.setRecordId('person', 'john', person._internalModel.clientId);
 
     assert.equal(person.get('id'), 'john', 'new id should be correctly set.');
   });
@@ -1504,7 +1504,7 @@ test('accessing the model id without the get function should work when id is wat
 
     assert.equal(person.get('id'), null, 'initial created model id should be null');
 
-    store.updateId(person._internalModel, { id: 'john' });
+    store.setRecordId('person', 'john', person._internalModel.clientId);
 
     assert.equal(person.id, 'john', 'new id should be correctly set.');
   });


### PR DESCRIPTION
This is small addition to the Model Data branch, which allows model datas to determine when they have received an ID from the server.

I've looked for tests to update, but it wasn't obvious where they should go. I'm looking for pointers in this regard.

cc @hjdivad @igorT 