### PR TITLE
Deprecate `store.updateId`

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1975,7 +1975,10 @@ Store = Service.extend({
   },
 
   updateId(internalModel, data) {
-    // TODO Deprecate this? Completely remove it?
+    deprecate('store.updateId was documented as private and will be removed.', false, {
+      id: 'ds.store.updateId',
+      until: '3.5'
+    });
     this._setRecordId(internalModel, coerceId(data.id));
   },
 


### PR DESCRIPTION
It was always private; so this is a cautious deprecation.