### PR TITLE
[BUGFIX release] Fix `Model.modelName` inheritance with Ember 3.2+.

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2144,7 +2144,10 @@ Store = Service.extend({
       assert(`'${inspect(klass)}' does not appear to be an ember-data model`, klass.isModel);
 
       // TODO: deprecate this
-      klass.modelName = klass.modelName || modelName;
+      let hasOwnModelNameSet = klass.modelName && klass.hasOwnProperty('modelName');
+      if (!hasOwnModelNameSet) {
+        klass.modelName = modelName;
+      }
 
       this._modelFactoryCache[modelName] = factory;
     }

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -18,6 +18,7 @@ module('unit/model - DS.Model', {
       name: DS.attr('string'),
       isDrugAddict: DS.attr('boolean')
     });
+    Person.toString =  () => 'person';
 
     env = setupStore({
       person: Person
@@ -268,7 +269,7 @@ test("a record's id is included in its toString representation", function(assert
     });
 
     return store.findRecord('person', 1).then(record => {
-      assert.equal(record.toString(), `<(subclass of DS.Model):${guidFor(record)}:1>`, 'reports id in toString');
+      assert.equal(record.toString(), `<person:${guidFor(record)}:1>`, 'reports id in toString');
     });
   });
 });


### PR DESCRIPTION
On Ember 3.2 and higher, Ember uses "real" inheritance when an `Ember.Object` is `.extend()`ed. This means that in 3.2 and higher the `ModelClassHere.modelName` property is now being inherited (where previously each `.extend()` reset the value to `null`).

The fix here ensures that each `ModelClass.extend()` gets its own `modelName`...