### PR TITLE
[FEAT BUGFIX] enable canonical state updates to deleted records

### DIFF
--- a/addon/-private/system/model/states.js
+++ b/addon/-private/system/model/states.js
@@ -701,7 +701,8 @@ const RootState = {
       },
 
       willCommit() { },
-      didCommit()  { }
+      didCommit()  { },
+      pushedData() {}
     },
 
     invalid: {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -599,19 +599,15 @@ test('supports canonical updates via pushedData in root.deleted.saved', function
   });
 
   run(() => {
-    try {
-      store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          attributes: {
-            isArchived: true
-          }
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          isArchived: true
         }
-      });
-    } catch (e) {
-      assert.ok(false, e);
-    }
+      }
+    });
 
     let currentState = record._internalModel.currentState;
 
@@ -653,12 +649,9 @@ test('Does not support dirtying in root.deleted.saved', function(assert) {
   });
 
   run(() => {
-    try {
+    assert.expectAssertion(() => {
       set(record, 'isArchived', true);
-      assert.ok(false, 'Was unable to dirty a deleted record');
-    } catch (e) {
-      assert.ok(true, e.message);
-    }
+    }, /Attempted to handle event `didSetProperty` on <person:1> while in state root.deleted.saved. Called with {name: isArchived, oldValue: false, originalValue: false, value: true}./);
 
     let currentState = record._internalModel.currentState;
 


### PR DESCRIPTION
resolves #4995
replaces #5231 

**Problem**

Records in the `root.deleted.saved` state currently error if new data is received from the server for the record while the record is still in the store.

For instance, a user may desire the following flow, which is now possible with this PR:

```
=> signal deletion (send actual `DELETE` request)
=> update ui state to isDeleting
=> receive notice of actual deletion
=> update ui state to isDeleted
=> unload
```

**Use Case**

Sometimes deletions are "soft deletes", and sometimes deletions may be queued on the server and the deleted state not reflect immediately in other requests.

**2.13 Regression**

Prior to 2.13 we would unload records whose deletion had been persisted. While this enabled folks to push server updates back into the store for either use case above, this would create a new record in the `root.loaded.saved` state, which is also unexpected.

**This Fix**

This fix enables canonical (but not dirty) state updates to `root.deleted.saved` records to still occur.  Records are still available to the UI until the user opts to call `unloadRecord`. This means that end users may themselves decide whether they want to unload and treat these records as `undeleted` again, or maintain the deleted state.

**Soft Delete**

User's desiring `soft delete` aka `archiving` with the ability to resurrect a model should not be using `deleteRecord` or `destroyRecord`. While this PR will make soft-deletions via this mechanism work *slightly* better up until the point that resurrection is desired, users should instead fire an action to update a flag of their own making, and only fire a DELETE for a permanent deletion.