### PR TITLE
[FEAT BUGFIX] resolves issues with links and data in relationships

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -354,7 +354,6 @@ export default class InternalModel {
       if (properties !== undefined) {
         assert(`You passed '${properties}' as properties for record creation instead of an object.`, typeof properties === 'object' && properties !== null);
         let classFields = this.getFields();
-        let relationships = this._relationships;
         let propertyNames = Object.keys(properties);
 
         for (let i = 0; i < propertyNames.length; i++) {
@@ -373,11 +372,9 @@ export default class InternalModel {
               break;
             case 'belongsTo':
               this.setDirtyBelongsTo(name, propertyValue);
-              relationships.get(name).setHasRelationshipDataProperty(true);
               break;
             case 'hasMany':
               this.setDirtyHasMany(name, propertyValue);
-              relationships.get(name).setHasRelationshipDataProperty(true);
               break;
             default:
               createOptions[name] = propertyValue;

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -354,6 +354,7 @@ export default class InternalModel {
       if (properties !== undefined) {
         assert(`You passed '${properties}' as properties for record creation instead of an object.`, typeof properties === 'object' && properties !== null);
         let classFields = this.getFields();
+        let relationships = this._relationships;
         let propertyNames = Object.keys(properties);
 
         for (let i = 0; i < propertyNames.length; i++) {
@@ -372,9 +373,13 @@ export default class InternalModel {
               break;
             case 'belongsTo':
               this.setDirtyBelongsTo(name, propertyValue);
+              relationships.get(name).setHasAnyRelationshipData(true);
+              relationships.get(name).setRelationshipIsEmpty(false);
               break;
             case 'hasMany':
               this.setDirtyHasMany(name, propertyValue);
+              relationships.get(name).setHasAnyRelationshipData(true);
+              relationships.get(name).setRelationshipIsEmpty(false);
               break;
             default:
               createOptions[name] = propertyValue;

--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -373,11 +373,11 @@ export default class InternalModel {
               break;
             case 'belongsTo':
               this.setDirtyBelongsTo(name, propertyValue);
-              relationships.get(name).setHasData(true);
+              relationships.get(name).setHasRelationshipDataProperty(true);
               break;
             case 'hasMany':
               this.setDirtyHasMany(name, propertyValue);
-              relationships.get(name).setHasData(true);
+              relationships.get(name).setHasRelationshipDataProperty(true);
               break;
             default:
               createOptions[name] = propertyValue;

--- a/addon/-private/system/promise-proxies.js
+++ b/addon/-private/system/promise-proxies.js
@@ -82,6 +82,21 @@ export function promiseArray(promise, label) {
   });
 }
 
+export function proxyToContent(method) {
+  return function() {
+    return get(this, 'content')[method](...arguments);
+  };
+}
+
+export const PromiseBelongsTo = PromiseObject.extend({
+  reload() {
+    assert('You are trying to reload an async belongsTo before it has been created', get(this, 'content'));
+    this.get('_belongsToState').reload();
+
+    return this;
+  }
+});
+
 /**
   A PromiseManyArray is a PromiseArray that also proxies certain method calls
   to the underlying manyArray.
@@ -99,13 +114,6 @@ export function promiseArray(promise, label) {
   @namespace DS
   @extends Ember.ArrayProxy
 */
-
-export function proxyToContent(method) {
-  return function() {
-    return get(this, 'content')[method](...arguments);
-  };
-}
-
 export const PromiseManyArray = PromiseArray.extend({
   reload() {
     assert('You are trying to reload an async manyArray before it has been created', get(this, 'content'));

--- a/addon/-private/system/promise-proxies.js
+++ b/addon/-private/system/promise-proxies.js
@@ -89,8 +89,6 @@ export function proxyToContent(method) {
 }
 
 export const PromiseBelongsTo = PromiseObject.extend({
-  meta: reads('content.meta'),
-
   reload() {
     assert('You are trying to reload an async belongsTo before it has been created', this.get('content') !== undefined);
     this.get('_belongsToState').reload();

--- a/addon/-private/system/promise-proxies.js
+++ b/addon/-private/system/promise-proxies.js
@@ -89,8 +89,10 @@ export function proxyToContent(method) {
 }
 
 export const PromiseBelongsTo = PromiseObject.extend({
+  meta: reads('content.meta'),
+
   reload() {
-    assert('You are trying to reload an async belongsTo before it has been created', get(this, 'content'));
+    assert('You are trying to reload an async belongsTo before it has been created', this.get('content') !== undefined);
     this.get('_belongsToState').reload();
 
     return this;
@@ -115,9 +117,11 @@ export const PromiseBelongsTo = PromiseObject.extend({
   @extends Ember.ArrayProxy
 */
 export const PromiseManyArray = PromiseArray.extend({
+  link: reads('content.link'),
+
   reload() {
     assert('You are trying to reload an async manyArray before it has been created', get(this, 'content'));
-    this.set('promise', this.get('content').reload())
+    this.set('promise', this.get('content').reload());
     return this;
   },
 

--- a/addon/-private/system/references/has-many.js
+++ b/addon/-private/system/references/has-many.js
@@ -258,7 +258,7 @@ export default class HasManyReference extends Reference {
   }
 
   _isLoaded() {
-    let hasRelationshipDataProperty = get(this.hasManyRelationship, 'hasRelationshipDataProperty');
+    let hasRelationshipDataProperty = get(this.hasManyRelationship, 'hasAnyRelationshipData');
     if (!hasRelationshipDataProperty) {
       return false;
     }

--- a/addon/-private/system/references/has-many.js
+++ b/addon/-private/system/references/has-many.js
@@ -258,8 +258,8 @@ export default class HasManyReference extends Reference {
   }
 
   _isLoaded() {
-    let hasData = get(this.hasManyRelationship, 'hasData');
-    if (!hasData) {
+    let hasRelationshipDataProperty = get(this.hasManyRelationship, 'hasRelationshipDataProperty');
+    if (!hasRelationshipDataProperty) {
       return false;
     }
 

--- a/addon/-private/system/relationships/relationship-payloads.js
+++ b/addon/-private/system/relationships/relationship-payloads.js
@@ -2,7 +2,7 @@ import { assert } from '@ember/debug';
 
 /**
  * Merge data,meta,links information forward to the next payload
- * if required.
+ * if required. Latest data will always win.
  *
  * @param oldPayload
  * @param newPayload
@@ -12,6 +12,17 @@ function mergeForwardPayload(oldPayload, newPayload) {
     newPayload.data = oldPayload.data;
   }
 
+  /*
+    _partialData is has-many relationship data that has been discovered via
+     inverses in the absence of canonical `data` availability from the primary
+     payload.
+
+    We can't merge this data into `data` as that would trick has-many relationships
+     into believing they know their complete membership. Anytime we find canonical
+     data from the primary record, this partial data is discarded. If no canonical
+     data is ever discovered, the partial data will be loaded by the relationship
+     in a way that correctly preserves the `stale` relationship state.
+   */
   if (newPayload.data === undefined && oldPayload && oldPayload._partialData !== undefined) {
     newPayload._partialData = oldPayload._partialData;
   }

--- a/addon/-private/system/relationships/relationship-payloads.js
+++ b/addon/-private/system/relationships/relationship-payloads.js
@@ -125,16 +125,13 @@ export default class RelationshipPayloads {
    */
   get(modelName, id, relationshipName) {
     this._flushPending();
-    let payload;
 
     if (this._isLHS(modelName, relationshipName)) {
-      payload = this.lhs_payloads.get(modelName, id);
+      return this.lhs_payloads.get(modelName, id);
     } else {
       assert(`${modelName}:${relationshipName} is not either side of this relationship, ${this._relInfo.lhs_key}<->${this._relInfo.rhs_key}`, this._isRHS(modelName, relationshipName));
-      payload = this.rhs_payloads.get(modelName, id);
+      return this.rhs_payloads.get(modelName, id);
     }
-
-    return payload;
   }
 
   /**

--- a/addon/-private/system/relationships/relationship-payloads.js
+++ b/addon/-private/system/relationships/relationship-payloads.js
@@ -9,7 +9,7 @@ import { assert } from '@ember/debug';
  */
 function mergeForwardPayload(oldPayload, newPayload) {
   if (oldPayload && oldPayload.data !== undefined && newPayload.data === undefined) {
-    newPayload.data = oldPayload.data;
+    // newPayload.data = oldPayload.data;
   }
 
   if (oldPayload && oldPayload.meta !== undefined && newPayload.meta === undefined) {
@@ -362,11 +362,12 @@ export default class RelationshipPayloads {
       if (inverseIsMany) {
         let existingData = existingPayload.data;
 
-        if (!existingData) {
-          existingData = existingPayload.data = [];
+        // in the case of a hasMany
+        // we do not want create a `data` array where there was none before
+        // if we also have links, which this would indicate
+        if (existingData) {
+          existingData.push(inversePayload.data);
         }
-
-        existingData.push(inversePayload.data);
       } else {
         mergeForwardPayload(existingPayload, inversePayload);
         inversePayloadMap.set(resourceIdentifier.type, resourceIdentifier.id, inversePayload);

--- a/addon/-private/system/relationships/relationship-payloads.js
+++ b/addon/-private/system/relationships/relationship-payloads.js
@@ -288,7 +288,8 @@ export default class RelationshipPayloads {
     return a && b &&
       a.type === b.type &&
       a.id === b.id &&
-      !Array.isArray(a);
+      !Array.isArray(a) &&
+      !Array.isArray(b);
   }
 
   /**

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -212,6 +212,7 @@ export default class BelongsToRelationship extends Relationship {
     }
 
     let promise;
+    this.setRelationshipIsStale(true);
 
     if (this.link) {
       promise = this.fetchLink();

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -21,8 +21,9 @@ export default class BelongsToRelationship extends Relationship {
     } else if (this.inverseInternalModel) {
       this.removeInternalModel(this.inverseInternalModel);
     }
-    this.setHasData(true);
+    this.setHasRelationshipDataProperty(true);
     this.setHasLoaded(true);
+    this.setHasLocalData(!this.localStateIsEmpty());
   }
 
   setCanonicalInternalModel(internalModel) {
@@ -165,12 +166,8 @@ export default class BelongsToRelationship extends Relationship {
     //TODO(Igor) flushCanonical here once our syncing is not stupid
     if (this.isAsync) {
       let promise;
-      if (this.link) {
-        if (this.hasLoaded) {
-          promise = this.findRecord();
-        } else {
-          promise = this.findLink().then(() => this.findRecord());
-        }
+      if (this._shouldFindViaLink()) {
+        promise = this.findLink().then(() => this.findRecord());
       } else {
         promise = this.findRecord();
       }
@@ -202,6 +199,12 @@ export default class BelongsToRelationship extends Relationship {
     }
 
     return this.findRecord();
+  }
+
+  localStateIsEmpty() {
+    let internalModel = this.inverseInternalModel;
+
+    return !internalModel  || internalModel.isEmpty();
   }
 
   updateData(data, initial) {

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -167,6 +167,7 @@ export default class BelongsToRelationship extends Relationship {
     //TODO(Igor) flushCanonical here once our syncing is not stupid
     if (this.isAsync) {
       let promise;
+
       if (this._shouldFindViaLink()) {
         promise = this.findLink().then(() => this.findRecord());
       } else {

--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -9,8 +9,6 @@ import Relationship from "./relationship";
 export default class BelongsToRelationship extends Relationship {
   constructor(store, internalModel, inverseKey, relationshipMeta) {
     super(store, internalModel, inverseKey, relationshipMeta);
-    this.internalModel = internalModel;
-    this.key = relationshipMeta.key;
     this.inverseInternalModel = null;
     this.canonicalState = null;
     this._loadingPromise = null;
@@ -22,9 +20,10 @@ export default class BelongsToRelationship extends Relationship {
     } else if (this.inverseInternalModel) {
       this.removeInternalModel(this.inverseInternalModel);
     }
-    this.setHasRelationshipDataProperty(true);
-    this.setHasLoaded(true);
-    this.setHasLocalData(!this.localStateIsEmpty());
+    this.setHasAnyRelationshipData(true);
+    this.setRelationshipIsStale(false);
+    this.setRelationshipIsEmpty(false);
+    this.setHasRelatedResources(!this.localStateIsEmpty());
   }
 
   setCanonicalInternalModel(internalModel) {

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -16,26 +16,25 @@ export default class ManyRelationship extends Relationship {
     // we create a new many array, but in the interim it will be updated if
     // inverse internal models are unloaded.
     this._retainedManyArray = null;
-    this.__loadingPromise = null;
+    this._loadingPromise = null;
     this._willUpdateManyArray = false;
     this._pendingManyArrayUpdates = null;
   }
 
-  get _loadingPromise() { return this.__loadingPromise; }
   _updateLoadingPromise(promise, content) {
-    if (this.__loadingPromise) {
+    if (this._loadingPromise) {
       if (content) {
-        this.__loadingPromise.set('content', content)
+        this._loadingPromise.set('content', content)
       }
-      this.__loadingPromise.set('promise', promise)
+      this._loadingPromise.set('promise', promise)
     } else {
-      this.__loadingPromise = PromiseManyArray.create({
+      this._loadingPromise = PromiseManyArray.create({
         promise,
         content
       });
     }
 
-    return this.__loadingPromise;
+    return this._loadingPromise;
   }
 
   get manyArray() {
@@ -353,13 +352,7 @@ export default class ManyRelationship extends Relationship {
     } else {
       assert(`You looked up the '${this.key}' relationship on a '${this.internalModel.type.modelName}' with id ${this.internalModel.id} but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async ('DS.hasMany({ async: true })')`, manyArray.isEvery('isEmpty', false));
 
-      //TODO(Igor) WTF DO I DO HERE?
-      // TODO @runspired equal WTFs to Igor
-      if (!manyArray.get('isDestroyed')) {
-        manyArray.set('isLoaded', true);
-      } else {
-        throw new Error('WTF am I doing here?!');
-      }
+      manyArray.set('isLoaded', true);
 
       return manyArray;
     }
@@ -396,11 +389,11 @@ export default class ManyRelationship extends Relationship {
       this._manyArray = null;
     }
 
-    let proxy = this.__loadingPromise;
+    let proxy = this._loadingPromise;
 
     if (proxy) {
       proxy.destroy();
-      this.__loadingPromise = null;
+      this._loadingPromise = null;
     }
   }
 }

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -246,14 +246,10 @@ export default class ManyRelationship extends Relationship {
 
   reload() {
     let manyArray = this.manyArray;
-    let manyArrayLoadedState = manyArray.get('isLoaded');
 
     if (this._loadingPromise) {
       if (this._loadingPromise.get('isPending')) {
         return this._loadingPromise;
-      }
-      if (this._loadingPromise.get('isRejected')) {
-        manyArray.set('isLoaded', manyArrayLoadedState);
       }
     }
 

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -253,6 +253,8 @@ export default class ManyRelationship extends Relationship {
       }
     }
 
+    this.setRelationshipIsStale(true);
+
     let promise;
     if (this.link) {
       promise = this.fetchLink();

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -338,13 +338,16 @@ export default class ManyRelationship extends Relationship {
   getRecords() {
     //TODO(Igor) sync server here, once our syncing is not stupid
     let manyArray = this.manyArray;
+
     if (this.isAsync) {
       let promise;
+
       if (this._shouldFindViaLink()) {
         promise = this.findLink().then(() => this.findRecords());
       } else {
         promise = this.findRecords();
       }
+
       return this._updateLoadingPromise(promise, manyArray);
     } else {
       assert(`You looked up the '${this.key}' relationship on a '${this.internalModel.type.modelName}' with id ${this.internalModel.id} but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async ('DS.hasMany({ async: true })')`, manyArray.isEvery('isEmpty', false));
@@ -353,7 +356,10 @@ export default class ManyRelationship extends Relationship {
       // TODO @runspired equal WTFs to Igor
       if (!manyArray.get('isDestroyed')) {
         manyArray.set('isLoaded', true);
+      } else {
+        throw new Error('WTF am I doing here?!');
       }
+
       return manyArray;
     }
   }
@@ -372,7 +378,7 @@ export default class ManyRelationship extends Relationship {
     let internalModels = manyArray.currentState;
     let manyArrayIsLoaded = manyArray.get('isLoaded');
 
-    if (!manyArrayIsLoaded) {
+    if (!manyArrayIsLoaded && internalModels.length) {
       manyArrayIsLoaded = internalModels.reduce((hasNoEmptyModel, i) => {
         return hasNoEmptyModel && !i.isEmpty();
       }, true);

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -311,7 +311,6 @@ export default class ManyRelationship extends Relationship {
       this.store._backburner.join(() => {
         this.updateInternalModelsFromAdapter(records);
         this.manyArray.set('isLoaded', true);
-        this.setHasRelationshipDataProperty(true);
       });
       return this.manyArray;
     });

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -120,6 +120,14 @@ export default class Relationship {
     this.hasAnyRelationshipData = false;
 
     /*
+      Flag that indicates whether an empty relationship is explicitly empty
+        (signaled by push giving us an empty array or null relationship)
+        e.g. an API response has told us that this relationship is empty.
+
+      Thus far, it does not appear that we actually need this flag; however,
+        @runspired has found it invaluable when debugging relationship tests
+        to determine whether (and why if so) we are in an incorrect state.
+
       true when
         => we receive a push with explicit empty (`[]` or `null`)
         => we have received no signal about what data belongs in this relationship

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -148,16 +148,6 @@ export default class Relationship {
     this.hasRelatedResources = false;
   }
 
-  _inverseIsAsync() {
-    let inverseMeta = this._inverseMeta;
-    if (!inverseMeta) {
-      return false;
-    }
-
-    let inverseAsync = inverseMeta.options.async;
-    return typeof inverseAsync === 'undefined' ? true : inverseAsync;
-  }
-
   _inverseIsSync() {
     let inverseMeta = this._inverseMeta;
     if (!inverseMeta) {

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -132,6 +132,8 @@ export default class Relationship {
 
   inverseDidDematerialize(inverseInternalModel) {
     this.linkPromise = null;
+    this.setHasLocalData(false);
+
     if (!this.isAsync) {
       // unloading inverse of a sync relationship is treated as a client-side
       // delete, so actually remove the models don't merely invalidate the cp
@@ -557,7 +559,15 @@ export default class Relationship {
       }
 
       if (initial) {
-        this.setHasLocalData(!this.localStateIsEmpty());
+        // we don't check for empty arrays because due to
+        //  the way we currently setup relationships we
+        //  always have an array even when we were given
+        //  no relationship data property
+        let relationshipIsEmpty = payload.data === null;
+
+        this.setHasLocalData(
+          relationshipIsEmpty || !this.localStateIsEmpty()
+        );
       }
     }
 

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -566,6 +566,8 @@ export default class Relationship {
     if (payload.data !== undefined) {
       hasRelationshipDataProperty = true;
       this.updateData(payload.data, initial);
+    } else if (payload._partialData !== undefined) {
+      this.updateData(payload._partialData, initial);
     }
 
     if (payload.links && payload.links.related) {

--- a/addon/-private/system/snapshot.js
+++ b/addon/-private/system/snapshot.js
@@ -198,7 +198,7 @@ export default class Snapshot {
    */
   belongsTo(keyName, options) {
     let id = options && options.id;
-    let relationship, inverseInternalModel, hasData;
+    let relationship, inverseInternalModel, hasRelationshipDataProperty;
     let result;
 
     if (id && keyName in this._belongsToIds) {
@@ -214,10 +214,10 @@ export default class Snapshot {
       throw new EmberError("Model '" + inspect(this.record) + "' has no belongsTo relationship named '" + keyName + "' defined.");
     }
 
-    hasData = get(relationship, 'hasData');
+    hasRelationshipDataProperty = get(relationship, 'hasRelationshipDataProperty');
     inverseInternalModel = get(relationship, 'inverseInternalModel');
 
-    if (hasData) {
+    if (hasRelationshipDataProperty) {
       if (inverseInternalModel && !inverseInternalModel.isDeleted()) {
         if (id) {
           result = get(inverseInternalModel, 'id');
@@ -269,7 +269,7 @@ export default class Snapshot {
    */
   hasMany(keyName, options) {
     let ids = options && options.ids;
-    let relationship, members, hasData;
+    let relationship, members, hasRelationshipDataProperty;
     let results;
 
     if (ids && keyName in this._hasManyIds) {
@@ -285,10 +285,10 @@ export default class Snapshot {
       throw new EmberError("Model '" + inspect(this.record) + "' has no hasMany relationship named '" + keyName + "' defined.");
     }
 
-    hasData = get(relationship, 'hasData');
+    hasRelationshipDataProperty = get(relationship, 'hasRelationshipDataProperty');
     members = get(relationship, 'members');
 
-    if (hasData) {
+    if (hasRelationshipDataProperty) {
       results = [];
       members.forEach((member) => {
         if (!member.isDeleted()) {

--- a/addon/-private/system/snapshot.js
+++ b/addon/-private/system/snapshot.js
@@ -198,7 +198,7 @@ export default class Snapshot {
    */
   belongsTo(keyName, options) {
     let id = options && options.id;
-    let relationship, inverseInternalModel, hasRelationshipDataProperty;
+    let relationship;
     let result;
 
     if (id && keyName in this._belongsToIds) {
@@ -214,10 +214,12 @@ export default class Snapshot {
       throw new EmberError("Model '" + inspect(this.record) + "' has no belongsTo relationship named '" + keyName + "' defined.");
     }
 
-    hasRelationshipDataProperty = get(relationship, 'hasAnyRelationshipData');
-    inverseInternalModel = get(relationship, 'inverseInternalModel');
+    let {
+      hasAnyRelationshipData,
+      inverseInternalModel
+    } = relationship;
 
-    if (hasRelationshipDataProperty) {
+    if (hasAnyRelationshipData) {
       if (inverseInternalModel && !inverseInternalModel.isDeleted()) {
         if (id) {
           result = get(inverseInternalModel, 'id');
@@ -269,7 +271,7 @@ export default class Snapshot {
    */
   hasMany(keyName, options) {
     let ids = options && options.ids;
-    let relationship, members, hasRelationshipDataProperty;
+    let relationship;
     let results;
 
     if (ids && keyName in this._hasManyIds) {
@@ -285,10 +287,12 @@ export default class Snapshot {
       throw new EmberError("Model '" + inspect(this.record) + "' has no hasMany relationship named '" + keyName + "' defined.");
     }
 
-    hasRelationshipDataProperty = get(relationship, 'hasAnyRelationshipData');
-    members = get(relationship, 'members');
+    let {
+      hasAnyRelationshipData,
+      members
+    } = relationship;
 
-    if (hasRelationshipDataProperty) {
+    if (hasAnyRelationshipData) {
       results = [];
       members.forEach((member) => {
         if (!member.isDeleted()) {

--- a/addon/-private/system/snapshot.js
+++ b/addon/-private/system/snapshot.js
@@ -214,7 +214,7 @@ export default class Snapshot {
       throw new EmberError("Model '" + inspect(this.record) + "' has no belongsTo relationship named '" + keyName + "' defined.");
     }
 
-    hasRelationshipDataProperty = get(relationship, 'hasRelationshipDataProperty');
+    hasRelationshipDataProperty = get(relationship, 'hasAnyRelationshipData');
     inverseInternalModel = get(relationship, 'inverseInternalModel');
 
     if (hasRelationshipDataProperty) {
@@ -285,7 +285,7 @@ export default class Snapshot {
       throw new EmberError("Model '" + inspect(this.record) + "' has no hasMany relationship named '" + keyName + "' defined.");
     }
 
-    hasRelationshipDataProperty = get(relationship, 'hasRelationshipDataProperty');
+    hasRelationshipDataProperty = get(relationship, 'hasAnyRelationshipData');
     members = get(relationship, 'members');
 
     if (hasRelationshipDataProperty) {

--- a/tests/integration/adapter/json-api-adapter-test.js
+++ b/tests/integration/adapter/json-api-adapter-test.js
@@ -59,7 +59,7 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', {
     });
 
     env = setupStore({
-      adapter: DS.JSONAPIAdapter,
+      adapter: DS.JSONAPIAdapter.extend(),
 
       'user': User,
       'post': Post,

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -804,7 +804,7 @@ testInDebug("Passing a model as type to belongsTo should not work", function(ass
   }, /The first argument to DS.belongsTo must be a string/);
 });
 
-test("belongsTo hasRelationshipDataProperty async loaded", function(assert) {
+test("belongsTo hasAnyRelationshipData async loaded", function(assert) {
   assert.expect(1);
 
   Book.reopen({
@@ -827,12 +827,12 @@ test("belongsTo hasRelationshipDataProperty async loaded", function(assert) {
   return run(() => {
     return store.findRecord('book', 1).then(book => {
       let relationship = book._internalModel._relationships.get('author');
-      assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
+      assert.equal(relationship.hasAnyRelationshipData, true, 'relationship has data');
     });
   });
 });
 
-test("belongsTo hasRelationshipDataProperty sync loaded", function(assert) {
+test("belongsTo hasAnyRelationshipData sync loaded", function(assert) {
   assert.expect(1);
 
   env.adapter.findRecord = function(store, type, id, snapshot) {
@@ -851,12 +851,12 @@ test("belongsTo hasRelationshipDataProperty sync loaded", function(assert) {
   return run(() => {
     return store.findRecord('book', 1).then(book => {
       let relationship = book._internalModel._relationships.get('author');
-      assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
+      assert.equal(relationship.hasAnyRelationshipData, true, 'relationship has data');
     });
   });
 });
 
-test("belongsTo hasRelationshipDataProperty async not loaded", function(assert) {
+test("belongsTo hasAnyRelationshipData async not loaded", function(assert) {
   assert.expect(1);
 
   Book.reopen({
@@ -879,12 +879,12 @@ test("belongsTo hasRelationshipDataProperty async not loaded", function(assert) 
   return run(() => {
     return store.findRecord('book', 1).then(book => {
       let relationship = book._internalModel._relationships.get('author');
-      assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
+      assert.equal(relationship.hasAnyRelationshipData, false, 'relationship does not have data');
     });
   });
 });
 
-test("belongsTo hasRelationshipDataProperty sync not loaded", function(assert) {
+test("belongsTo hasAnyRelationshipData sync not loaded", function(assert) {
   assert.expect(1);
 
   env.adapter.findRecord = function(store, type, id, snapshot) {
@@ -900,12 +900,12 @@ test("belongsTo hasRelationshipDataProperty sync not loaded", function(assert) {
   return run(() => {
     return store.findRecord('book', 1).then(book => {
       let relationship = book._internalModel._relationships.get('author');
-      assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
+      assert.equal(relationship.hasAnyRelationshipData, false, 'relationship does not have data');
     });
   });
 });
 
-test("belongsTo hasRelationshipDataProperty NOT created", function(assert) {
+test("belongsTo hasAnyRelationshipData NOT created", function(assert) {
   assert.expect(2);
 
   Book.reopen({
@@ -917,7 +917,7 @@ test("belongsTo hasRelationshipDataProperty NOT created", function(assert) {
     let book = store.createRecord('book', { name: 'The Greatest Book' });
     let relationship = book._internalModel._relationships.get('author');
 
-    assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
+    assert.equal(relationship.hasAnyRelationshipData, false, 'relationship does not have data');
 
     book = store.createRecord('book', {
       name: 'The Greatest Book',
@@ -926,11 +926,11 @@ test("belongsTo hasRelationshipDataProperty NOT created", function(assert) {
 
     relationship = book._internalModel._relationships.get('author');
 
-    assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
+    assert.equal(relationship.hasAnyRelationshipData, true, 'relationship has data');
   });
 });
 
-test("belongsTo hasRelationshipDataProperty sync created", function(assert) {
+test("belongsTo hasAnyRelationshipData sync created", function(assert) {
   assert.expect(2);
 
   run(() => {
@@ -940,7 +940,7 @@ test("belongsTo hasRelationshipDataProperty sync created", function(assert) {
     });
 
     let relationship = book._internalModel._relationships.get('author');
-    assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
+    assert.equal(relationship.hasAnyRelationshipData, false, 'relationship does not have data');
 
     book = store.createRecord('book', {
       name: 'The Greatest Book',
@@ -948,7 +948,7 @@ test("belongsTo hasRelationshipDataProperty sync created", function(assert) {
     });
 
     relationship = book._internalModel._relationships.get('author');
-    assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
+    assert.equal(relationship.hasAnyRelationshipData, true, 'relationship has data');
   });
 });
 

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -1380,9 +1380,9 @@ test("A belongsTo relationship can be reloaded using the reference if it was fet
   });
 });
 
-test("A sync belongsTo relationship can be reloaded using a reference if it was fetched via id", function(assert) {
+test("A synchronous belongsTo relationship can be reloaded using a reference if it was fetched via id", function(assert) {
   Chapter.reopen({
-    book: DS.belongsTo()
+    book: DS.belongsTo({ async: false })
   });
 
   let chapter;
@@ -1390,10 +1390,10 @@ test("A sync belongsTo relationship can be reloaded using a reference if it was 
     chapter = env.store.push({
       data: {
         type: 'chapter',
-        id: 1,
+        id: '1',
         relationships: {
           book: {
-            data: { type: 'book', id: 1 }
+            data: { type: 'book', id: '1' }
           }
         }
       }
@@ -1401,7 +1401,7 @@ test("A sync belongsTo relationship can be reloaded using a reference if it was 
     env.store.push({
       data: {
         type: 'book',
-        id: 1,
+        id: '1',
         attributes: {
           name: "book title"
         }
@@ -1412,7 +1412,7 @@ test("A sync belongsTo relationship can be reloaded using a reference if it was 
   env.adapter.findRecord = function() {
     return resolve({
       data: {
-        id: 1,
+        id: '1',
         type: 'book',
         attributes: { name: 'updated book title' }
       }

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -43,12 +43,12 @@ module("integration/relationship/belongs_to Belongs-To Relationships", {
     Book = DS.Model.extend({
       name: attr('string'),
       author: belongsTo('author', { async: false }),
-      chapters: hasMany('chapters', { async: false })
+      chapters: hasMany('chapters', { async: false, inverse: 'book' })
     });
 
     Chapter = DS.Model.extend({
       title: attr('string'),
-      book: belongsTo('book', { async: false })
+      book: belongsTo('book', { async: false, inverse: 'chapters' })
     });
 
     Author = DS.Model.extend({
@@ -804,7 +804,7 @@ testInDebug("Passing a model as type to belongsTo should not work", function(ass
   }, /The first argument to DS.belongsTo must be a string/);
 });
 
-test("belongsTo hasData async loaded", function(assert) {
+test("belongsTo hasRelationshipDataProperty async loaded", function(assert) {
   assert.expect(1);
 
   Book.reopen({
@@ -827,12 +827,12 @@ test("belongsTo hasData async loaded", function(assert) {
   return run(() => {
     return store.findRecord('book', 1).then(book => {
       let relationship = book._internalModel._relationships.get('author');
-      assert.equal(relationship.hasData, true, 'relationship has data');
+      assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
     });
   });
 });
 
-test("belongsTo hasData sync loaded", function(assert) {
+test("belongsTo hasRelationshipDataProperty sync loaded", function(assert) {
   assert.expect(1);
 
   env.adapter.findRecord = function(store, type, id, snapshot) {
@@ -851,12 +851,12 @@ test("belongsTo hasData sync loaded", function(assert) {
   return run(() => {
     return store.findRecord('book', 1).then(book => {
       let relationship = book._internalModel._relationships.get('author');
-      assert.equal(relationship.hasData, true, 'relationship has data');
+      assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
     });
   });
 });
 
-test("belongsTo hasData async not loaded", function(assert) {
+test("belongsTo hasRelationshipDataProperty async not loaded", function(assert) {
   assert.expect(1);
 
   Book.reopen({
@@ -879,12 +879,12 @@ test("belongsTo hasData async not loaded", function(assert) {
   return run(() => {
     return store.findRecord('book', 1).then(book => {
       let relationship = book._internalModel._relationships.get('author');
-      assert.equal(relationship.hasData, false, 'relationship does not have data');
+      assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
     });
   });
 });
 
-test("belongsTo hasData sync not loaded", function(assert) {
+test("belongsTo hasRelationshipDataProperty sync not loaded", function(assert) {
   assert.expect(1);
 
   env.adapter.findRecord = function(store, type, id, snapshot) {
@@ -900,12 +900,12 @@ test("belongsTo hasData sync not loaded", function(assert) {
   return run(() => {
     return store.findRecord('book', 1).then(book => {
       let relationship = book._internalModel._relationships.get('author');
-      assert.equal(relationship.hasData, false, 'relationship does not have data');
+      assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
     });
   });
 });
 
-test("belongsTo hasData NOT created", function(assert) {
+test("belongsTo hasRelationshipDataProperty NOT created", function(assert) {
   assert.expect(2);
 
   Book.reopen({
@@ -917,7 +917,7 @@ test("belongsTo hasData NOT created", function(assert) {
     let book = store.createRecord('book', { name: 'The Greatest Book' });
     let relationship = book._internalModel._relationships.get('author');
 
-    assert.equal(relationship.hasData, false, 'relationship does not have data');
+    assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
 
     book = store.createRecord('book', {
       name: 'The Greatest Book',
@@ -926,11 +926,11 @@ test("belongsTo hasData NOT created", function(assert) {
 
     relationship = book._internalModel._relationships.get('author');
 
-    assert.equal(relationship.hasData, true, 'relationship has data');
+    assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
   });
 });
 
-test("belongsTo hasData sync created", function(assert) {
+test("belongsTo hasRelationshipDataProperty sync created", function(assert) {
   assert.expect(2);
 
   run(() => {
@@ -940,7 +940,7 @@ test("belongsTo hasData sync created", function(assert) {
     });
 
     let relationship = book._internalModel._relationships.get('author');
-    assert.equal(relationship.hasData, false, 'relationship does not have data');
+    assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
 
     book = store.createRecord('book', {
       name: 'The Greatest Book',
@@ -948,7 +948,7 @@ test("belongsTo hasData sync created", function(assert) {
     });
 
     relationship = book._internalModel._relationships.get('author');
-    assert.equal(relationship.hasData, true, 'relationship has data');
+    assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
   });
 });
 
@@ -998,7 +998,7 @@ test("Model's belongsTo relationship should be created during 'get' method", fun
   });
 });
 
-test("Related link should be fetched when no local data is present", function(assert) {
+test("Related link should be fetched when no relationship data is present", function(assert) {
   assert.expect(3);
 
   Book.reopen({
@@ -1010,7 +1010,7 @@ test("Related link should be fetched when no local data is present", function(as
     assert.ok(true, "The adapter's findBelongsTo method should be called");
     return resolve({
       data: {
-        id: 1,
+        id: '1',
         type: 'author',
         attributes: { name: 'This is author' }
       }
@@ -1038,18 +1038,15 @@ test("Related link should be fetched when no local data is present", function(as
   });
 });
 
-test("Local data should take precedence over related link", function(assert) {
-  assert.expect(1);
+test("Related link should take precedence over relationship data if no local record data is available", function(assert) {
+  assert.expect(2);
 
   Book.reopen({
     author: DS.belongsTo('author', { async: true })
   });
 
   env.adapter.findBelongsTo = function(store, snapshot, url, relationship) {
-    assert.ok(false, "The adapter's findBelongsTo method should not be called");
-  };
-
-  env.adapter.findRecord = function(store, type, id, snapshot) {
+    assert.ok(true, "The adapter's findBelongsTo method should be called");
     return resolve({
       data: {
         id: 1,
@@ -1057,6 +1054,10 @@ test("Local data should take precedence over related link", function(assert) {
         attributes: { name: 'This is author' }
       }
     });
+  };
+
+  env.adapter.findRecord = function() {
+    assert.ok(false, "The adapter's findRecord method should not be called");
   };
 
   return run(() => {
@@ -1073,6 +1074,51 @@ test("Local data should take precedence over related link", function(assert) {
           }
         }
       }
+    });
+
+    return book.get('author').then(author => {
+      assert.equal(author.get('name'), 'This is author', 'author name is correct');
+    });
+  });
+});
+
+test("Relationship data should take precedence over related link when local record data is available", function(assert) {
+  assert.expect(1);
+
+  Book.reopen({
+    author: DS.belongsTo('author', { async: true })
+  });
+
+  env.adapter.shouldBackgroundReloadRecord = () => { return false; };
+  env.adapter.findBelongsTo = function(store, snapshot, url, relationship) {
+    assert.ok(false, "The adapter's findBelongsTo method should not be called");
+  };
+
+  env.adapter.findRecord = function(store, type, id, snapshot) {
+    assert.ok(false, "The adapter's findRecord method should not be called");
+  };
+
+  return run(() => {
+    let book = env.store.push({
+      data: {
+        type: 'book',
+        id: '1',
+        relationships: {
+          author: {
+            links: {
+              related: 'author'
+            },
+            data: { type: 'author', id: '1' }
+          }
+        }
+      },
+      included: [
+        {
+          id: '1',
+          type: 'author',
+          attributes: { name: 'This is author' }
+        }
+      ]
     });
 
     return book.get('author').then(author => {
@@ -1140,7 +1186,7 @@ test("New related link should take precedence over local data", function(assert)
   });
 });
 
-test("Updated related link should take precedence over local data", function(assert) {
+test("Updated related link should take precedence over relationship data and local record data", function(assert) {
   assert.expect(4);
 
   Book.reopen({
@@ -1152,9 +1198,11 @@ test("Updated related link should take precedence over local data", function(ass
     assert.ok(true, "The adapter's findBelongsTo method should be called");
     return resolve({
       data: {
-        id: 1,
+        id: '1',
         type: 'author',
-        attributes: { name: 'This is updated author' }
+        attributes: {
+          name: 'This is updated author'
+        }
       }
     });
   };
@@ -1177,18 +1225,21 @@ test("Updated related link should take precedence over local data", function(ass
           }
         }
       },
-      included: [{
-        type: 'author',
-        id: '1',
-        attributes: {
-          name: 'This is author'
+      included: [
+        {
+          type: 'author',
+          id: '1',
+          attributes: {
+            name: 'This is author'
+          }
         }
-      }]
+      ]
     });
 
     return book.get('author').then((author) => {
       assert.equal(author.get('name'), 'This is author', 'author name is correct');
     }).then(() => {
+
       env.store.push({
         data: {
           type: 'book',

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -2648,7 +2648,7 @@ test("adding and removing records from hasMany relationship #2666", function(ass
   });
 });
 
-test("hasMany hasRelationshipDataProperty async loaded", function(assert) {
+test("hasMany hasAnyRelationshipData async loaded", function(assert) {
   assert.expect(1);
 
   Chapter.reopen({
@@ -2673,12 +2673,12 @@ test("hasMany hasRelationshipDataProperty async loaded", function(assert) {
   return run(() => {
     return store.findRecord('chapter', 1).then(chapter => {
       let relationship = chapter._internalModel._relationships.get('pages');
-      assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
+      assert.equal(relationship.hasAnyRelationshipData, true, 'relationship has data');
     });
   });
 });
 
-test("hasMany hasRelationshipDataProperty sync loaded", function(assert) {
+test("hasMany hasAnyRelationshipData sync loaded", function(assert) {
   assert.expect(1);
 
   env.adapter.findRecord = function(store, type, id, snapshot) {
@@ -2699,12 +2699,12 @@ test("hasMany hasRelationshipDataProperty sync loaded", function(assert) {
   return run(() => {
     return store.findRecord('chapter', 1).then(chapter => {
       let relationship = chapter._internalModel._relationships.get('pages');
-      assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
+      assert.equal(relationship.hasAnyRelationshipData, true, 'relationship has data');
     });
   });
 });
 
-test("hasMany hasRelationshipDataProperty async not loaded", function(assert) {
+test("hasMany hasAnyRelationshipData async not loaded", function(assert) {
   assert.expect(1);
 
   Chapter.reopen({
@@ -2729,12 +2729,12 @@ test("hasMany hasRelationshipDataProperty async not loaded", function(assert) {
   return run(() => {
     return store.findRecord('chapter', 1).then(chapter => {
       let relationship = chapter._internalModel._relationships.get('pages');
-      assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
+      assert.equal(relationship.hasAnyRelationshipData, false, 'relationship does not have data');
     });
   });
 });
 
-test("hasMany hasRelationshipDataProperty sync not loaded", function(assert) {
+test("hasMany hasAnyRelationshipData sync not loaded", function(assert) {
   assert.expect(1);
 
   env.adapter.findRecord = function(store, type, id, snapshot) {
@@ -2750,12 +2750,12 @@ test("hasMany hasRelationshipDataProperty sync not loaded", function(assert) {
   return run(() => {
     return store.findRecord('chapter', 1).then(chapter => {
       let relationship = chapter._internalModel._relationships.get('pages');
-      assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
+      assert.equal(relationship.hasAnyRelationshipData, false, 'relationship does not have data');
     });
   });
 });
 
-test("hasMany hasRelationshipDataProperty async created", function(assert) {
+test("hasMany hasAnyRelationshipData async created", function(assert) {
   assert.expect(2);
 
   Chapter.reopen({
@@ -2766,7 +2766,7 @@ test("hasMany hasRelationshipDataProperty async created", function(assert) {
   let page = store.createRecord('page');
 
   let relationship = chapter._internalModel._relationships.get('pages');
-  assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
+  assert.equal(relationship.hasAnyRelationshipData, false, 'relationship does not have data');
 
   chapter = store.createRecord('chapter', {
     title: 'The Story Begins',
@@ -2774,16 +2774,16 @@ test("hasMany hasRelationshipDataProperty async created", function(assert) {
   });
 
   relationship = chapter._internalModel._relationships.get('pages');
-  assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
+  assert.equal(relationship.hasAnyRelationshipData, true, 'relationship has data');
 });
 
-test("hasMany hasRelationshipDataProperty sync created", function(assert) {
+test("hasMany hasAnyRelationshipData sync created", function(assert) {
   assert.expect(2);
 
   let chapter = store.createRecord('chapter', { title: 'The Story Begins' });
   let relationship = chapter._internalModel._relationships.get('pages');
 
-  assert.equal(relationship.hasRelationshipDataProperty, false, 'relationship does not have data');
+  assert.equal(relationship.hasAnyRelationshipData, false, 'relationship does not have data');
 
   chapter = store.createRecord('chapter', {
     title: 'The Story Begins',
@@ -2791,7 +2791,7 @@ test("hasMany hasRelationshipDataProperty sync created", function(assert) {
   });
   relationship = chapter._internalModel._relationships.get('pages');
 
-  assert.equal(relationship.hasRelationshipDataProperty, true, 'relationship has data');
+  assert.equal(relationship.hasAnyRelationshipData, true, 'relationship has data');
 });
 
 test("Model's hasMany relationship should not be created during model creation", function(assert) {

--- a/tests/integration/relationships/json-api-links-test.js
+++ b/tests/integration/relationships/json-api-links-test.js
@@ -108,7 +108,7 @@ test("Pushing child record should not mark parent:children as loaded", function 
   });
 
   let Parent = DS.Model.extend({
-    children: hasMany('child')
+    children: hasMany('child', { inverse: 'parent' })
   });
 
   env = setupStore({
@@ -154,7 +154,7 @@ test("Pushing child record should not mark parent:children as loaded", function 
       }
     });
 
-    assert.equal(parent.hasMany('children').hasManyRelationship.relationshipIsStale, false, 'parent should think that children still needs to be loaded');
+    assert.equal(parent.hasMany('children').hasManyRelationship.relationshipIsStale, true, 'parent should think that children still needs to be loaded');
   });
 });
 
@@ -975,68 +975,6 @@ shouldFetchLinkTests('a link and data (not available in the store)', {
   }
 });
 
-shouldFetchLinkTests('a link and empty data (`data: []` or `data: null`), true inverse unloaded', {
-  user: {
-    data: {
-      type: 'user',
-      id: '1',
-      attributes: {
-        name: '@runspired'
-      },
-      relationships: {
-        pets: {
-          links: {
-            related: './runspired/pets'
-          },
-          data: []
-        },
-        home: {
-          links: {
-            related: './runspired/address'
-          },
-          data: null
-        }
-      }
-    }
-  },
-  pets: {
-    data: [
-      {
-        type: 'pet',
-        id: '1',
-        attributes: {
-          name: 'Shen'
-        },
-        relationships: {
-          owner: {
-            data: {
-              type: 'user',
-              id: '1'
-            }
-          }
-        }
-      }
-    ]
-  },
-  home: {
-    data: {
-      type: 'home',
-      id: '1',
-      attributes: {
-        address: 'Oakland, Ca'
-      },
-      relationships: {
-        owner: {
-          data: {
-            type: 'user',
-            id: '1'
-          }
-        }
-      }
-    }
-  }
-});
-
 /*
   Used for situations when initially we have data, but reload/missing data
   situations should be done via link
@@ -1284,6 +1222,68 @@ shouldReloadWithLinkTests('a link and empty data (`data: []` or `data: null`), t
           },
           links: {
             related: './user/1'
+          }
+        }
+      }
+    }
+  }
+});
+
+shouldReloadWithLinkTests('a link and empty data (`data: []` or `data: null`), true inverse unloaded', {
+  user: {
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {
+        pets: {
+          links: {
+            related: './runspired/pets'
+          },
+          data: []
+        },
+        home: {
+          links: {
+            related: './runspired/address'
+          },
+          data: null
+        }
+      }
+    }
+  },
+  pets: {
+    data: [
+      {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    ]
+  },
+  home: {
+    data: {
+      type: 'home',
+      id: '1',
+      attributes: {
+        address: 'Oakland, Ca'
+      },
+      relationships: {
+        owner: {
+          data: {
+            type: 'user',
+            id: '1'
           }
         }
       }
@@ -1851,8 +1851,8 @@ test('We should not fetch a hasMany relationship with links that we know is empt
   let user1Payload = {
     data: {
       type: 'user',
-        id: '1',
-        attributes: {
+      id: '1',
+      attributes: {
         name: '@runspired'
       },
       relationships: {

--- a/tests/integration/relationships/json-api-links-test.js
+++ b/tests/integration/relationships/json-api-links-test.js
@@ -1,0 +1,1728 @@
+import { run } from '@ember/runloop';
+import { get } from '@ember/object';
+import Ember from 'ember';
+import { resolve } from 'rsvp';
+import setupStore from 'dummy/tests/helpers/store';
+import {
+  reset as resetModelFactoryInjection
+} from 'dummy/tests/helpers/model-factory-injection';
+import { module, test } from 'qunit';
+import DS from 'ember-data';
+import JSONAPIAdapter from "ember-data/adapters/json-api";
+
+const { copy } = Ember;
+const { Model, attr, hasMany, belongsTo } = DS;
+
+let env, User, Organisation;
+
+module("integration/relationship/json-api-links | Relationship state updates", {
+  beforeEach() {},
+
+  afterEach() {
+    resetModelFactoryInjection();
+    run(env.container, 'destroy');
+  }
+});
+
+test("Loading link with inverse:null on other model caches the two ends separately", function (assert) {
+  User = DS.Model.extend({
+    organisation: belongsTo('organisation', { inverse: null })
+  });
+
+  Organisation = DS.Model.extend({
+    adminUsers: hasMany('user')
+  });
+
+  env = setupStore({
+    user: User,
+    organisation: Organisation
+  });
+
+  env.registry.optionsForType('serializer', { singleton: false });
+  env.registry.optionsForType('adapter', { singleton: false });
+
+  const store = env.store;
+
+  User = store.modelFor('user');
+  Organisation = store.modelFor('organisation');
+
+  env.registry.register('adapter:user', DS.JSONAPISerializer.extend({
+    findRecord(store, type, id) {
+      return resolve({
+        data: {
+          id,
+          type: 'user',
+          relationships: {
+            organisation: {
+              data: { id: 1, type: 'organisation' }
+            }
+          }
+        }
+      });
+    }
+  }));
+
+  env.registry.register('adapter:organisation', DS.JSONAPISerializer.extend({
+    findRecord(store, type, id) {
+      return resolve({
+        data: {
+          type: 'organisation',
+          id,
+          relationships: {
+            'admin-users': {
+              links: {
+                related: '/org-admins'
+              }
+            }
+          }
+        }
+      });
+    }
+  }));
+
+  return run(() => {
+    return store.findRecord('user', 1)
+      .then(user1 => {
+        assert.ok(user1, 'user should be populated');
+
+        return store.findRecord('organisation', 2)
+          .then(org2FromFind => {
+            assert.equal(user1.belongsTo('organisation').remoteType(), 'id', `user's belongsTo is based on id`);
+            assert.equal(user1.belongsTo('organisation').id(), 1, `user's belongsTo has its id populated`);
+
+            return user1.get('organisation')
+              .then(orgFromUser => {
+                assert.equal(user1.belongsTo('organisation').belongsToRelationship.hasLoaded, true, 'user should have loaded its belongsTo relationship');
+
+                assert.ok(org2FromFind, 'organisation we found should be populated');
+                assert.ok(orgFromUser, 'user\'s organisation should be populated');
+              })
+          })
+      })
+  });
+});
+
+test("Pushing child record should not mark parent:children as loaded", function (assert) {
+  let Child = DS.Model.extend({
+    parent: belongsTo('parent', { inverse: 'children' })
+  });
+
+  let Parent = DS.Model.extend({
+    children: hasMany('child')
+  });
+
+  env = setupStore({
+    parent: Parent,
+    child: Child
+  });
+
+  env.registry.optionsForType('serializer', { singleton: false });
+  env.registry.optionsForType('adapter', { singleton: false });
+
+  const store = env.store;
+
+  Parent = store.modelFor('parent');
+  Child = store.modelFor('child');
+
+  return run(() => {
+    const parent = store.push({
+      data: {
+        id: 'p1',
+        type: 'parent',
+        relationships: {
+          children: {
+            links: {
+              related: '/parent/1/children'
+            }
+          }
+        }
+      }
+    });
+
+    store.push({
+      data: {
+        id: 'c1',
+        type: 'child',
+        relationships: {
+          parent: {
+            data: {
+              id: 'p1',
+              type: 'parent'
+            }
+          }
+        }
+      }
+    });
+
+    assert.equal(parent.hasMany('children').hasManyRelationship.hasLoaded, false, 'parent should think that children still needs to be loaded');
+  });
+});
+
+test("pushing has-many payloads with data (no links), then more data (no links) works as expected", function(assert) {
+  const User = Model.extend({
+    pets: hasMany('pet', { async: true, inverse: 'owner' })
+  });
+  const Pet = Model.extend({
+    owner: belongsTo('user', { async: false, inverse: 'pets' })
+  });
+  const Adapter = JSONAPIAdapter.extend({
+    findHasMany() {
+      assert.ok(false, 'We dont fetch a link when we havent given a link');
+    },
+    findMany() {
+      assert.ok(false, 'adapter findMany called instead of using findRecord');
+    },
+    findRecord(_, __, id) {
+      assert.ok(id !== '1', `adapter findRecord called for all IDs except "1", called for "${id}"`);
+      return resolve({
+        data: {
+          type: 'pet',
+          id,
+          relationships: {
+            owner: {
+              data: { type: 'user', id: '1' }
+            }
+          }
+        }
+      });
+    }
+  });
+
+  env = setupStore({
+    adapter: Adapter,
+    user: User,
+    pet: Pet
+  });
+
+  let { store } = env;
+
+  // push data, no links
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '1' }
+          ]
+        }
+      }
+    }
+  }));
+
+  // push links, no data
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '2' },
+            { type: 'pet', id: '3' }
+          ]
+        }
+      }
+    }
+  }));
+
+  let Chris = run(() => store.peekRecord('user', '1'));
+  run(() => get(Chris, 'pets'));
+});
+
+test("pushing has-many payloads with data (no links), then links (no data) works as expected", function(assert) {
+  const User = Model.extend({
+    pets: hasMany('pet', { async: true, inverse: 'owner' })
+  });
+  const Pet = Model.extend({
+    owner: belongsTo('user', { async: false, inverse: 'pets' })
+  });
+  const Adapter = JSONAPIAdapter.extend({
+    findHasMany(_, __, link) {
+      assert.ok(link === './user/1/pets', 'We fetched via the correct link');
+      return resolve({
+        data: [
+          {
+            type: 'pet',
+            id: '1',
+            relationships: {
+              owner: {
+                data: { type: 'user', id: '1' }
+              }
+            }
+          },
+          {
+            type: 'pet',
+            id: '2',
+            relationships: {
+              owner: {
+                data: { type: 'user', id: '1' }
+              }
+            }
+          }
+        ]
+      });
+    },
+    findMany() {
+      assert.ok(false, 'adapter findMany called instead of using findHasMany with a link');
+    },
+    findRecord() {
+      assert.ok(false, 'adapter findRecord called instead of using findHasMany with a link');
+    }
+  });
+
+  env = setupStore({
+    adapter: Adapter,
+    user: User,
+    pet: Pet
+  });
+
+  let { store } = env;
+
+  // push data, no links
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '1' }
+          ]
+        }
+      }
+    }
+  }));
+
+  // push links, no data
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          links: {
+            related: './user/1/pets'
+          }
+        }
+      }
+    }
+  }));
+
+  let Chris = run(() => store.peekRecord('user', '1'));
+  run(() => get(Chris, 'pets'));
+});
+
+test("pushing has-many payloads with links (no data), then data (no links) works as expected", function(assert) {
+  const User = Model.extend({
+    pets: hasMany('pet', { async: true, inverse: 'owner' })
+  });
+  const Pet = Model.extend({
+    owner: belongsTo('user', { async: false, inverse: 'pets' })
+  });
+  const Adapter = JSONAPIAdapter.extend({
+    findHasMany(_, __, link) {
+      assert.ok(link === './user/1/pets', 'We fetched via the correct link');
+      return resolve({
+        data: [
+          {
+            type: 'pet',
+            id: '1',
+            relationships: {
+              owner: {
+                data: { type: 'user', id: '1' }
+              }
+            }
+          },
+          {
+            type: 'pet',
+            id: '2',
+            relationships: {
+              owner: {
+                data: { type: 'user', id: '1' }
+              }
+            }
+          }
+        ]
+      });
+    },
+    findMany() {
+      assert.ok(false, 'adapter findMany called instead of using findHasMany with a link');
+    },
+    findRecord() {
+      assert.ok(false, 'adapter findRecord called instead of using findHasMany with a link');
+    }
+  });
+
+  env = setupStore({
+    adapter: Adapter,
+    user: User,
+    pet: Pet
+  });
+
+  let { store } = env;
+
+  // push links, no data
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          links: {
+            related: './user/1/pets'
+          }
+        }
+      }
+    }
+  }));
+
+  // push data, no links
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '1' }
+          ]
+        }
+      }
+    }
+  }));
+
+  let Chris = run(() => store.peekRecord('user', '1'));
+
+  // we expect to still use the link info
+  run(() => get(Chris, 'pets'));
+});
+
+test("pushing has-many payloads with links, then links again works as expected", function(assert) {
+  const User = Model.extend({
+    pets: hasMany('pet', { async: true, inverse: 'owner' })
+  });
+  const Pet = Model.extend({
+    owner: belongsTo('user', { async: false, inverse: 'pets' })
+  });
+  const Adapter = JSONAPIAdapter.extend({
+    findHasMany(_, __, link) {
+      assert.ok(link === './user/1/pets', 'We fetched via the correct link');
+      return resolve({
+        data: [
+          {
+            type: 'pet',
+            id: '1',
+            relationships: {
+              owner: {
+                data: { type: 'user', id: '1' }
+              }
+            }
+          },
+          {
+            type: 'pet',
+            id: '2',
+            relationships: {
+              owner: {
+                data: { type: 'user', id: '1' }
+              }
+            }
+          }
+        ]
+      });
+    },
+    findMany() {
+      assert.ok(false, 'adapter findMany called instead of using findHasMany with a link');
+    },
+    findRecord() {
+      assert.ok(false, 'adapter findRecord called instead of using findHasMany with a link');
+    }
+  });
+
+  env = setupStore({
+    adapter: Adapter,
+    user: User,
+    pet: Pet
+  });
+
+  let { store } = env;
+
+  // push links, no data
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          links: {
+            related: './user/1/not-pets'
+          }
+        }
+      }
+    }
+  }));
+
+  // push data, no links
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          links: {
+            related: './user/1/pets'
+          }
+        }
+      }
+    }
+  }));
+
+  let Chris = run(() => store.peekRecord('user', '1'));
+
+  // we expect to use the link info from the second push
+  run(() => get(Chris, 'pets'));
+});
+
+test("pushing has-many payloads with links and data works as expected", function(assert) {
+  const User = Model.extend({
+    pets: hasMany('pet', { async: true, inverse: 'owner' })
+  });
+  const Pet = Model.extend({
+    owner: belongsTo('user', { async: false, inverse: 'pets' })
+  });
+  const Adapter = JSONAPIAdapter.extend({
+    findHasMany(_, __, link) {
+      assert.ok(link === './user/1/pets', 'We fetched via the correct link');
+      return resolve({
+        data: [
+          {
+            type: 'pet',
+            id: '1',
+            relationships: {
+              owner: {
+                data: { type: 'user', id: '1' }
+              }
+            }
+          },
+          {
+            type: 'pet',
+            id: '2',
+            relationships: {
+              owner: {
+                data: { type: 'user', id: '1' }
+              }
+            }
+          }
+        ]
+      });
+    },
+    findMany() {
+      assert.ok(false, 'adapter findMany called instead of using findHasMany with a link');
+    },
+    findRecord() {
+      assert.ok(false, 'adapter findRecord called instead of using findHasMany with a link');
+    }
+  });
+
+  env = setupStore({
+    adapter: Adapter,
+    user: User,
+    pet: Pet
+  });
+
+  let { store } = env;
+
+  // push data and links
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '1' }
+          ],
+          links: {
+            related: './user/1/pets'
+          }
+        }
+      }
+    }
+  }));
+
+  let Chris = run(() => store.peekRecord('user', '1'));
+  run(() => get(Chris, 'pets'));
+});
+
+test("pushing has-many payloads with links, then one with links and data works as expected", function(assert) {
+  const User = Model.extend({
+    pets: hasMany('pet', { async: true, inverse: 'owner' })
+  });
+  const Pet = Model.extend({
+    owner: belongsTo('user', { async: false, inverse: 'pets' })
+  });
+  const Adapter = JSONAPIAdapter.extend({
+    findHasMany(_, __, link) {
+      assert.ok(link === './user/1/pets', 'We fetched via the correct link');
+      return resolve({
+        data: [
+          {
+            type: 'pet',
+            id: '1',
+            relationships: {
+              owner: {
+                data: { type: 'user', id: '1' }
+              }
+            }
+          },
+          {
+            type: 'pet',
+            id: '2',
+            relationships: {
+              owner: {
+                data: { type: 'user', id: '1' }
+              }
+            }
+          }
+        ]
+      });
+    },
+    findMany() {
+      assert.ok(false, 'adapter findMany called instead of using findHasMany with a link');
+    },
+    findRecord() {
+      assert.ok(false, 'adapter findRecord called instead of using findHasMany with a link');
+    }
+  });
+
+  env = setupStore({
+    adapter: Adapter,
+    user: User,
+    pet: Pet
+  });
+
+  let { store } = env;
+
+  // push data, no links
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '1' }
+          ]
+        }
+      }
+    }
+  }));
+
+  // push links and data
+  run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '1' },
+            { type: 'pet', id: '2' },
+            { type: 'pet', id: '3' }
+          ],
+          links: {
+            related: './user/1/pets'
+          }
+        }
+      }
+    }
+  }));
+
+  let Chris = run(() => store.peekRecord('user', '1'));
+  run(() => get(Chris, 'pets'));
+});
+
+module("integration/relationship/json-api-links | Relationship fetching", {
+  beforeEach() {
+    const User = Model.extend({
+      name: attr(),
+      pets: hasMany('pet', { async: true, inverse: 'owner' }),
+      home: belongsTo('home', { async: true, inverse: 'owner' })
+    });
+    const Home = Model.extend({
+      address: attr(),
+      owner: belongsTo('user', { async: false, inverse: 'home' })
+    });
+    const Pet = Model.extend({
+      name: attr(),
+      owner: belongsTo('user', { async: false, inverse: 'pets' })
+    });
+    const Adapter = JSONAPIAdapter.extend();
+
+    env = setupStore({
+      adapter: Adapter,
+      user: User,
+      pet: Pet,
+      home: Home
+    });
+  },
+
+  afterEach() {
+    resetModelFactoryInjection();
+    run(env.container, 'destroy');
+  }
+});
+
+/*
+Tests:
+
+Fetches Link
+- get/reload hasMany with a link (no data)
+- get/reload hasMany with a link and data (not available in store)
+- get/reload hasMany with a link and empty data (`data: []`)
+
+Uses Link for Reload
+- get/reload hasMany with a link and data (available in store)
+
+Does Not Use Link (as there is none)
+- get/reload hasMany with data, no links
+- get/reload hasMany with no data, no links
+*/
+
+/*
+  Used for situations when even initially we should fetch via link
+ */
+function shouldFetchLinkTests(description, payloads) {
+  test(`get+reload hasMany with ${description}`, function(assert) {
+    assert.expect(3);
+    let { store, adapter } = env;
+
+    adapter.shouldBackgroundReloadRecord = () => false;
+    adapter.findRecord = () => {
+      assert.ok(false, 'We should not call findRecord');
+    };
+    adapter.findMany = () => {
+      assert.ok(false, 'We should not call findMany');
+    };
+    adapter.findHasMany = (_, __, link) => {
+      assert.ok(
+        link === payloads.user.data.relationships.pets.links.related,
+        'We fetched the appropriate link'
+      );
+      return resolve(copy(payloads.pets, true));
+    };
+
+    // setup user
+    let user = run(() => store.push(copy(payloads.user, true)));
+    let pets = run(() => user.get('pets'));
+
+    assert.ok(!!pets, 'We found our pets');
+
+    run(() => pets.reload());
+  });
+  test(`get+unload+get hasMany with ${description}`, function(assert) {
+    assert.expect(3);
+    let { store, adapter } = env;
+
+    adapter.shouldBackgroundReloadRecord = () => false;
+    adapter.findRecord = () => {
+      assert.ok(false, 'We should not call findRecord');
+    };
+    adapter.findMany = () => {
+      assert.ok(false, 'We should not call findMany');
+    };
+    adapter.findHasMany = (_, __, link) => {
+      assert.ok(
+        link === payloads.user.data.relationships.pets.links.related,
+        'We fetched the appropriate link'
+      );
+      return resolve(copy(payloads.pets, true));
+    };
+
+    // setup user
+    let user = run(() => store.push(copy(payloads.user, true)));
+    let pets = run(() => user.get('pets'));
+
+    assert.ok(!!pets, 'We found our pets');
+
+    run(() => pets.objectAt(0).unloadRecord());
+    run(() => user.get('pets'));
+  });
+  test(`get+reload belongsTo with ${description}`, function(assert) {
+    assert.expect(3);
+    let { store, adapter } = env;
+
+    adapter.shouldBackgroundReloadRecord = () => false;
+    adapter.findRecord = () => {
+      assert.ok(false, 'We should not call findRecord');
+    };
+    adapter.findMany = () => {
+      assert.ok(false, 'We should not call findMany');
+    };
+    adapter.findBelongsTo = (_, __, link) => {
+      assert.ok(
+        link === payloads.user.data.relationships.home.links.related,
+        'We fetched the appropriate link'
+      );
+      return resolve(copy(payloads.home, true));
+    };
+
+    // setup user
+    let user = run(() => store.push(copy(payloads.user, true)));
+    let home = run(() => user.get('home'));
+
+    assert.ok(!!home, 'We found our home');
+
+    run(() => home.then(h => h.reload()));
+  });
+  test(`get+unload+get belongsTo with ${description}`, function(assert) {
+    assert.expect(3);
+    let { store, adapter } = env;
+
+    adapter.shouldBackgroundReloadRecord = () => false;
+    adapter.findRecord = () => {
+      assert.ok(false, 'We should not call findRecord');
+    };
+    adapter.findMany = () => {
+      assert.ok(false, 'We should not call findMany');
+    };
+    adapter.findBelongsTo = (_, __, link) => {
+      assert.ok(
+        link === payloads.user.data.relationships.home.links.related,
+        'We fetched the appropriate link'
+      );
+      return resolve(copy(payloads.home, true));
+    };
+
+    // setup user
+    let user = run(() => store.push(copy(payloads.user, true)));
+    let home = run(() => user.get('home'));
+
+    assert.ok(!!home, 'We found our home');
+
+    run(() => home.then(h => h.unloadRecord()));
+    run(() => user.get('home'));
+  });
+}
+
+shouldFetchLinkTests('a link (no data)', {
+  user: {
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {
+        pets: {
+          links: {
+            related: './runspired/pets'
+          }
+        },
+        home: {
+          links: {
+            related: './runspired/address'
+          }
+        }
+      }
+    }
+  },
+  pets: {
+    data: [
+      {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    ]
+  },
+  home: {
+    data: {
+      type: 'home',
+      id: '1',
+      attributes: {
+        address: 'Oakland, Ca'
+      },
+      relationships: {
+        owner: {
+          data: {
+            type: 'user',
+            id: '1'
+          }
+        }
+      }
+    }
+  }
+});
+
+shouldFetchLinkTests('a link and data (not available in the store)', {
+  user: {
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {
+        pets: {
+          links: {
+            related: './runspired/pets'
+          },
+          data: [
+            { type: 'pet', id: '1' }
+          ]
+        },
+        home: {
+          links: {
+            related: './runspired/address'
+          },
+          data: { type: 'home', id: '1' }
+        }
+      }
+    }
+  },
+  pets: {
+    data: [
+      {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    ]
+  },
+  home: {
+    data: {
+      type: 'home',
+      id: '1',
+      attributes: {
+        address: 'Oakland, Ca'
+      },
+      relationships: {
+        owner: {
+          data: {
+            type: 'user',
+            id: '1'
+          }
+        }
+      }
+    }
+  }
+});
+
+shouldFetchLinkTests('a link and empty data (`data: []` or `data: null`)', {
+  user: {
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {
+        pets: {
+          links: {
+            related: './runspired/pets'
+          },
+          data: []
+        },
+        home: {
+          links: {
+            related: './runspired/address'
+          },
+          data: null
+        }
+      }
+    }
+  },
+  pets: {
+    data: [
+      {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    ]
+  },
+  home: {
+    data: {
+      type: 'home',
+      id: '1',
+      attributes: {
+        address: 'Oakland, Ca'
+      },
+      relationships: {
+        owner: {
+          data: {
+            type: 'user',
+            id: '1'
+          }
+        }
+      }
+    }
+  }
+});
+
+/*
+  Used for situations when initially we have data, but reload/missing data
+  situations should be done via link
+ */
+function shouldReloadWithLinkTests(description, payloads) {
+  test(`get+reload hasMany with ${description}`, function(assert) {
+    assert.expect(2);
+    let { store, adapter } = env;
+
+    adapter.shouldBackgroundReloadRecord = () => false;
+    adapter.findRecord = () => {
+      assert.ok(false, 'We should not call findRecord');
+    };
+    adapter.findMany = () => {
+      assert.ok(false, 'We should not call findMany');
+    };
+    adapter.findHasMany = (_, __, link) => {
+      assert.ok(
+        link === payloads.user.data.relationships.pets.links.related,
+        'We fetched the appropriate link'
+      );
+      return resolve(copy(payloads.pets, true));
+    };
+
+    // setup user and pets
+    let user = run(() => store.push(copy(payloads.user, true)));
+    run(() => store.push(copy(payloads.pets, true)));
+    let pets = run(() => user.get('pets'));
+
+    assert.ok(!!pets, 'We found our pets');
+
+    run(() => pets.reload());
+  });
+  test(`get+unload+get hasMany with ${description}`, function(assert) {
+    assert.expect(2);
+    let { store, adapter } = env;
+
+    adapter.shouldBackgroundReloadRecord = () => false;
+    adapter.findRecord = () => {
+      assert.ok(false, 'We should not call findRecord');
+    };
+    adapter.findMany = () => {
+      assert.ok(false, 'We should not call findMany');
+    };
+    adapter.findHasMany = (_, __, link) => {
+      assert.ok(
+        link === payloads.user.data.relationships.pets.links.related,
+        'We fetched the appropriate link'
+      );
+      return resolve(copy(payloads.pets, true));
+    };
+
+    // setup user and pets
+    let user = run(() => store.push(copy(payloads.user, true)));
+    run(() => store.push(copy(payloads.pets, true)));
+    let pets = run(() => user.get('pets'));
+
+    assert.ok(!!pets, 'We found our pets');
+
+    run(() => pets.objectAt(0).unloadRecord());
+    run(() => user.get('pets'));
+  });
+  test(`get+reload belongsTo with ${description}`, function(assert) {
+    assert.expect(2);
+    let { store, adapter } = env;
+
+    adapter.shouldBackgroundReloadRecord = () => false;
+    adapter.findRecord = () => {
+      assert.ok(false, 'We should not call findRecord');
+    };
+    adapter.findMany = () => {
+      assert.ok(false, 'We should not call findMany');
+    };
+    adapter.findBelongsTo = (_, __, link) => {
+      assert.ok(
+        link === payloads.user.data.relationships.home.links.related,
+        'We fetched the appropriate link'
+      );
+      return resolve(copy(payloads.home, true));
+    };
+
+    // setup user and home
+    let user = run(() => store.push(copy(payloads.user, true)));
+    run(() => store.push(copy(payloads.home, true)));
+    let home = run(() => user.get('home'));
+
+    assert.ok(!!home, 'We found our home');
+
+    run(() => home.then(h => h.reload()));
+  });
+  test(`get+unload+get belongsTo with ${description}`, function(assert) {
+    assert.expect(2);
+    let { store, adapter } = env;
+
+    adapter.shouldBackgroundReloadRecord = () => false;
+    adapter.findRecord = () => {
+      assert.ok(false, 'We should not call findRecord');
+    };
+    adapter.findMany = () => {
+      assert.ok(false, 'We should not call findMany');
+    };
+    adapter.findBelongsTo = (_, __, link) => {
+      assert.ok(
+        link === payloads.user.data.relationships.home.links.related,
+        'We fetched the appropriate link'
+      );
+      return resolve(copy(payloads.home, true));
+    };
+
+    // setup user
+    let user = run(() => store.push(copy(payloads.user, true)));
+    run(() => store.push(copy(payloads.home, true)));
+    let home = run(() => user.get('home'));
+
+    assert.ok(!!home, 'We found our home');
+
+    run(() => home.then(h => h.unloadRecord()));
+    run(() => user.get('home'));
+  });
+}
+
+shouldReloadWithLinkTests('a link and data (available in the store)', {
+  user: {
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {
+        pets: {
+          links: {
+            related: './runspired/pets'
+          },
+          data: [
+            { type: 'pet', id: '1' }
+          ]
+        },
+        home: {
+          links: {
+            related: './runspired/address'
+          },
+          data: { type: 'home', id: '1' }
+        }
+      }
+    }
+  },
+  pets: {
+    data: [
+      {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    ]
+  },
+  home: {
+    data: {
+      type: 'home',
+      id: '1',
+      attributes: {
+        address: 'Oakland, Ca'
+      },
+      relationships: {
+        owner: {
+          data: {
+            type: 'user',
+            id: '1'
+          }
+        }
+      }
+    }
+  }
+});
+
+/*
+  Ad Hoc Situations when we don't have a link
+ */
+
+// data, no links
+test(`get+reload hasMany with data, no links`, function(assert) {
+  assert.expect(3);
+  let { store, adapter } = env;
+
+  adapter.shouldBackgroundReloadRecord = () => false;
+  adapter.findRecord = () => {
+    assert.ok(true, 'We should call findRecord');
+    return resolve({
+      data: {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    });
+  };
+  adapter.findMany = () => {
+    assert.ok(false, 'We should not call findMany');
+  };
+  adapter.findHasMany = () => {
+    assert.ok(false, 'We should not call findHasMany');
+  };
+
+  // setup user
+  let user = run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '1' }
+          ]
+        },
+        home: {
+          data: { type: 'home', id: '1' }
+        }
+      }
+    }
+  }));
+  let pets = run(() => user.get('pets'));
+
+  assert.ok(!!pets, 'We found our pets');
+
+  run(() => pets.reload());
+});
+test(`get+unload+get hasMany with data, no links`, function(assert) {
+  assert.expect(3);
+  let { store, adapter } = env;
+
+  adapter.shouldBackgroundReloadRecord = () => false;
+  adapter.findRecord = () => {
+    assert.ok(true, 'We should call findRecord');
+    return resolve({
+      data: {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    });
+  };
+  adapter.findMany = () => {
+    assert.ok(false, 'We should not call findMany');
+  };
+  adapter.findHasMany = () => {
+    assert.ok(false, 'We should not call findHasMany');
+  };
+
+  // setup user
+  let user = run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '1' }
+          ]
+        },
+        home: {
+          data: { type: 'home', id: '1' }
+        }
+      }
+    }
+  }));
+  let pets = run(() => user.get('pets'));
+
+  assert.ok(!!pets, 'We found our pets');
+
+  run(() => pets.objectAt(0).unloadRecord());
+  run(() => user.get('pets'));
+});
+test(`get+reload belongsTo with data, no links`, function(assert) {
+  assert.expect(3);
+  let { store, adapter } = env;
+
+  adapter.shouldBackgroundReloadRecord = () => false;
+  adapter.findRecord = () => {
+    assert.ok(true, 'We should call findRecord');
+    return resolve({
+      data: {
+        type: 'home',
+        id: '1',
+        attributes: {
+          address: 'Oakland, CA'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    });
+  };
+  adapter.findMany = () => {
+    assert.ok(false, 'We should not call findMany');
+  };
+  adapter.findHasMany = () => {
+    assert.ok(false, 'We should not call findHasMany');
+  };
+
+
+  // setup user
+  let user = run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '1' }
+          ]
+        },
+        home: {
+          data: { type: 'home', id: '1' }
+        }
+      }
+    }
+  }));
+  let home = run(() => user.get('home'));
+
+  assert.ok(!!home, 'We found our home');
+
+  run(() => home.then(h => h.reload()));
+});
+test(`get+unload+get belongsTo with data, no links`, function(assert) {
+  assert.expect(3);
+  let { store, adapter } = env;
+
+  adapter.shouldBackgroundReloadRecord = () => false;
+  adapter.findRecord = () => {
+    assert.ok(true, 'We should call findRecord');
+    return resolve({
+      data: {
+        type: 'home',
+        id: '1',
+        attributes: {
+          address: 'Oakland, Ca'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    });
+  };
+  adapter.findMany = () => {
+    assert.ok(false, 'We should not call findMany');
+  };
+  adapter.findHasMany = () => {
+    assert.ok(false, 'We should not call findHasMany');
+  };
+
+
+  // setup user
+  let user = run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {
+        pets: {
+          data: [
+            { type: 'pet', id: '1' }
+          ]
+        },
+        home: {
+          data: { type: 'home', id: '1' }
+        }
+      }
+    }
+  }));
+  let home = run(() => user.get('home'));
+
+  assert.ok(!!home, 'We found our home');
+
+  run(() => home.then(h => h.unloadRecord()));
+  run(() => user.get('home'));
+});
+
+// missing data setup from the other side, no links
+test(`get+reload hasMany with missing data setup from the other side, no links`, function(assert) {
+  assert.expect(2);
+  let { store, adapter } = env;
+
+  adapter.shouldBackgroundReloadRecord = () => false;
+  adapter.findRecord = () => {
+    assert.ok(true, 'We should call findRecord');
+    return resolve({
+      data: {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    });
+  };
+  adapter.findMany = () => {
+    assert.ok(false, 'We should not call findMany');
+  };
+  adapter.findHasMany = () => {
+    assert.ok(false, 'We should not call findHasMany');
+  };
+
+  // setup user and pet
+  let user = run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {}
+    },
+    included: [
+      {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    ]
+  }));
+  let pets = run(() => user.get('pets'));
+
+  assert.ok(!!pets, 'We found our pets');
+
+  run(() => pets.reload());
+});
+test(`get+unload+get hasMany with missing data setup from the other side, no links`, function(assert) {
+  assert.expect(2);
+  let { store, adapter } = env;
+  adapter.shouldBackgroundReloadRecord = () => false;
+  adapter.findRecord = () => {
+    assert.ok(true, 'We should call findRecord');
+    return resolve({
+      data: {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    });
+  };
+  adapter.findMany = () => {
+    assert.ok(false, 'We should not call findMany');
+  };
+  adapter.findHasMany = () => {
+    assert.ok(false, 'We should not call findHasMany');
+  };
+
+  // setup user and pet
+  let user = run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {}
+    },
+    included: [
+      {
+        type: 'pet',
+        id: '1',
+        attributes: {
+          name: 'Shen'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    ]
+  }));
+  let pets = run(() => user.get('pets'));
+
+  assert.ok(!!pets, 'We found our pets');
+
+  run(() => pets.objectAt(0).unloadRecord());
+  run(() => user.get('pets'));
+});
+test(`get+reload belongsTo with missing data setup from the other side, no links`, function(assert) {
+  assert.expect(2);
+  let { store, adapter } = env;
+
+  adapter.shouldBackgroundReloadRecord = () => false;
+  adapter.findRecord = () => {
+    assert.ok(true, 'We should call findRecord');
+    return resolve({
+      data: {
+        type: 'home',
+        id: '1',
+        attributes: {
+          address: 'Oakland, CA'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    });
+  };
+  adapter.findMany = () => {
+    assert.ok(false, 'We should not call findMany');
+  };
+  adapter.findHasMany = () => {
+    assert.ok(false, 'We should not call findHasMany');
+  };
+
+  // setup user and home
+  let user = run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {}
+    },
+    included: [
+      {
+        type: 'home',
+        id: '1',
+        attributes: {
+          address: 'Oakland, CA'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    ]
+  }));
+  let home = run(() => user.get('home'));
+
+  assert.ok(!!home, 'We found our home');
+
+  run(() => home.then(h => h.reload()));
+});
+test(`get+unload+get belongsTo with missing data setup from the other side, no links`, function(assert) {
+  assert.expect(2);
+  let { store, adapter } = env;
+
+  adapter.shouldBackgroundReloadRecord = () => false;
+  adapter.findRecord = () => {
+    assert.ok(true, 'We should call findRecord');
+    return resolve({
+      data: {
+        type: 'home',
+        id: '1',
+        attributes: {
+          address: 'Oakland, CA'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    });
+  };
+  adapter.findMany = () => {
+    assert.ok(false, 'We should not call findMany');
+  };
+  adapter.findHasMany = () => {
+    assert.ok(false, 'We should not call findHasMany');
+  };
+
+  // setup user and home
+  let user = run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {}
+    },
+    included: [
+      {
+        type: 'home',
+        id: '1',
+        attributes: {
+          address: 'Oakland, CA'
+        },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    ]
+  }));
+  let home = run(() => user.get('home'));
+
+  assert.ok(!!home, 'We found our home');
+
+  run(() => home.then(h => h.unloadRecord()));
+  run(() => user.get('home'));
+});
+
+// empty data, no links
+test(`get+reload hasMany with empty data, no links`, function(assert) {
+  assert.expect(1);
+  let { store, adapter } = env;
+
+  adapter.shouldBackgroundReloadRecord = () => false;
+  adapter.findRecord = () => {
+    assert.ok(false, 'We should not call findRecord');
+  };
+  adapter.findMany = () => {
+    assert.ok(false, 'We should not call findMany');
+  };
+  adapter.findHasMany = () => {
+    assert.ok(false, 'We should not call findHasMany');
+  };
+
+  // setup user
+  let user = run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: {
+        name: '@runspired'
+      },
+      relationships: {
+        pets: {
+          data: []
+        },
+        home: {
+          data: null
+        }
+      }
+    }
+  }));
+  let pets = run(() => user.get('pets'));
+
+  assert.ok(!!pets, 'We found our pets');
+
+  run(() => pets.reload());
+});

--- a/tests/integration/relationships/json-api-links-test.js
+++ b/tests/integration/relationships/json-api-links-test.js
@@ -774,7 +774,7 @@ function shouldFetchLinkTests(description, payloads) {
 
     assert.ok(!!home, 'We found our home');
 
-    run(() => home.then(h => h.reload()));
+    run(() => home.reload());
   });
   test(`get+unload+get belongsTo with ${description}`, function(assert) {
     assert.expect(3);
@@ -1080,7 +1080,7 @@ function shouldReloadWithLinkTests(description, payloads) {
 
     assert.ok(!!home, 'We found our home');
 
-    run(() => home.then(h => h.reload()));
+    run(() => home.reload());
   });
   test(`get+unload+get belongsTo with ${description}`, function(assert) {
     assert.expect(2);
@@ -1356,7 +1356,7 @@ test(`get+reload belongsTo with data, no links`, function(assert) {
 
   assert.ok(!!home, 'We found our home');
 
-  run(() => home.then(h => h.reload()));
+  run(() => home.reload());
 });
 test(`get+unload+get belongsTo with data, no links`, function(assert) {
   assert.expect(3);
@@ -1616,7 +1616,7 @@ test(`get+reload belongsTo with missing data setup from the other side, no links
 
   assert.ok(!!home, 'We found our home');
 
-  run(() => home.then(h => h.reload()));
+  run(() => home.reload());
 });
 test(`get+unload+get belongsTo with missing data setup from the other side, no links`, function(assert) {
   assert.expect(2);

--- a/tests/integration/relationships/json-api-links-test.js
+++ b/tests/integration/relationships/json-api-links-test.js
@@ -6,7 +6,7 @@ import setupStore from 'dummy/tests/helpers/store';
 import {
   reset as resetModelFactoryInjection
 } from 'dummy/tests/helpers/model-factory-injection';
-import { module, test, todo } from 'qunit';
+import { module, test } from 'qunit';
 import DS from 'ember-data';
 import JSONAPIAdapter from "ember-data/adapters/json-api";
 
@@ -30,7 +30,7 @@ test("Loading link with inverse:null on other model caches the two ends separate
   });
 
   Organisation = DS.Model.extend({
-    adminUsers: hasMany('user')
+    adminUsers: hasMany('user', { inverse: null })
   });
 
   env = setupStore({
@@ -92,7 +92,7 @@ test("Loading link with inverse:null on other model caches the two ends separate
 
             return user1.get('organisation')
               .then(orgFromUser => {
-                assert.equal(user1.belongsTo('organisation').belongsToRelationship.hasLoaded, true, 'user should have loaded its belongsTo relationship');
+                assert.equal(user1.belongsTo('organisation').belongsToRelationship.relationshipIsStale, false, 'user should have loaded its belongsTo relationship');
 
                 assert.ok(org2FromFind, 'organisation we found should be populated');
                 assert.ok(orgFromUser, 'user\'s organisation should be populated');
@@ -154,7 +154,7 @@ test("Pushing child record should not mark parent:children as loaded", function 
       }
     });
 
-    assert.equal(parent.hasMany('children').hasManyRelationship.hasLoaded, false, 'parent should think that children still needs to be loaded');
+    assert.equal(parent.hasMany('children').hasManyRelationship.relationshipIsStale, false, 'parent should think that children still needs to be loaded');
   });
 });
 
@@ -1844,7 +1844,7 @@ test(`get+reload hasMany with empty data, no links`, function(assert) {
 /*
   Ad hoc situations where we do have a link
  */
-todo('We should not fetch a hasMany relationship with links that we know is empty', function(assert) {
+test('We should not fetch a hasMany relationship with links that we know is empty', function(assert) {
   assert.expect(1);
   let { store, adapter } = env;
 

--- a/tests/integration/relationships/many-to-many-test.js
+++ b/tests/integration/relationships/many-to-many-test.js
@@ -145,10 +145,9 @@ test("Fetching a hasMany where a record was removed reflects on the other hasMan
         },
         relationships: {
           topics: {
-            data: [{
-              id: '2',
-              type: 'topic'
-            }]
+            data: [
+              { id: '2', type: 'topic' }
+            ]
           }
         }
       }

--- a/tests/integration/relationships/nested-relationship-test.js
+++ b/tests/integration/relationships/nested-relationship-test.js
@@ -8,7 +8,7 @@ import DS from 'ember-data';
 
 const { attr, hasMany, belongsTo } = DS;
 
-let env, store, serializer, Elder, MiddleAger, Kid;
+let env, store, Elder, MiddleAger, Kid;
 
 module('integration/relationships/nested_relationships_test - Nested relationships', {
   beforeEach() {
@@ -36,7 +36,6 @@ module('integration/relationships/nested_relationships_test - Nested relationshi
     });
 
     store = env.store;
-    serializer = env.serializer;
   },
 
   afterEach() {
@@ -49,36 +48,35 @@ module('integration/relationships/nested_relationships_test - Nested relationshi
 */
 
 test('Sideloaded nested relationships load correctly', function(assert) {
+  env.adapter.shouldBackgroundReloadRecord = () => { return false; };
   run(() => {
-    serializer.pushPayload(store, {
-      data: [
-        {
-          id: '1',
-          type: 'kids',
-          links: {
-            self: '/kids/1'
-          },
-          attributes: {
-            name: 'Kid 1'
-          },
-          relationships: {
-            'middle-ager': {
-              links: {
-                self: '/kids/1/relationships/middle-ager',
-                related: '/kids/1/middle-ager'
-              },
-              data:{
-                type: 'middle-agers',
-                id: '1'
-              }
+    store.push({
+      data: {
+        id: '1',
+        type: 'kid',
+        links: {
+          self: '/kids/1'
+        },
+        attributes: {
+          name: 'Kid 1'
+        },
+        relationships: {
+          middleAger: {
+            links: {
+              self: '/kids/1/relationships/middle-ager',
+              related: '/kids/1/middle-ager'
+            },
+            data:{
+              type: 'middle-ager',
+              id: '1'
             }
           }
         }
-      ],
+      },
       included: [
         {
           id: '1',
-          type: 'middle-agers',
+          type: 'middle-ager',
           links: {
             self: '/middle-ager/1'
           },
@@ -92,7 +90,7 @@ test('Sideloaded nested relationships load correctly', function(assert) {
                 related: '/middle-agers/1/elder'
               },
               data: {
-                type: 'elders',
+                type: 'elder',
                 id: '1'
               }
             },
@@ -100,14 +98,20 @@ test('Sideloaded nested relationships load correctly', function(assert) {
               links: {
                 self: '/middle-agers/1/relationships/kids',
                 related: '/middle-agers/1/kids'
-              }
+              },
+              data: [
+                {
+                  type: 'kid',
+                  id: '1'
+                }
+              ]
             }
           }
         },
 
         {
           id: '1',
-          type: 'elders',
+          type: 'elder',
           links: {
             self: '/elders/1'
           },
@@ -115,7 +119,7 @@ test('Sideloaded nested relationships load correctly', function(assert) {
             name: 'Elder 1'
           },
           relationships: {
-            'middle-agers': {
+            middleAger: {
               links: {
                 self: '/elders/1/relationships/middle-agers',
                 related: '/elders/1/middle-agers'
@@ -128,7 +132,7 @@ test('Sideloaded nested relationships load correctly', function(assert) {
   });
 
   return run(() => {
-    let kid = store.peekRecord('kid', 1);
+    let kid = store.peekRecord('kid', '1');
 
     return kid.get('middleAger').then(middleAger => {
       assert.ok(middleAger, 'MiddleAger relationship was set up correctly');

--- a/tests/integration/relationships/one-to-many-test.js
+++ b/tests/integration/relationships/one-to-many-test.js
@@ -487,9 +487,13 @@ test("Fetching the hasMany that doesn't contain the belongsTo, sets the belongsT
 });
 
 test("Fetching the hasMany that doesn't contain the belongsTo, sets the belongsTo to null - sync", function(assert) {
-  var account;
+  let account1;
+  let account2;
+  let user;
+
   run(function () {
-    store.push({
+    // tell the store user:1 has account:1
+    user = store.push({
       data: {
         id: '1',
         type: 'user',
@@ -498,15 +502,16 @@ test("Fetching the hasMany that doesn't contain the belongsTo, sets the belongsT
         },
         relationships: {
           accounts: {
-            data: [{
-              id: '1',
-              type: 'account'
-            }]
+            data: [
+              { id: '1', type: 'account' }
+            ]
           }
         }
       }
     });
-    account = store.push({
+
+    // tell the store account:1 has user:1
+    account1 = store.push({
       data: {
         id: '1',
         type: 'account',
@@ -515,15 +520,14 @@ test("Fetching the hasMany that doesn't contain the belongsTo, sets the belongsT
         },
         relationships: {
           user: {
-            data: {
-              id: '1',
-              type: 'user'
-            }
+            data: { id: '1', type: 'user' }
           }
         }
       }
     });
-    store.push({
+
+    // tell the store account:2 has no user
+    account2 = store.push({
       data: {
         id: '2',
         type: 'account',
@@ -532,6 +536,8 @@ test("Fetching the hasMany that doesn't contain the belongsTo, sets the belongsT
         }
       }
     });
+
+    // tell the store user:1 has account:2 and not account:1
     store.push({
       data: {
         id: '1',
@@ -541,10 +547,9 @@ test("Fetching the hasMany that doesn't contain the belongsTo, sets the belongsT
         },
         relationships: {
           accounts: {
-            data: [{
-              id: '2',
-              type: 'account'
-            }]
+            data: [
+              { id: '2', type: 'account' }
+            ]
           }
         }
       }
@@ -552,7 +557,8 @@ test("Fetching the hasMany that doesn't contain the belongsTo, sets the belongsT
   });
 
   run(function() {
-    assert.equal(account.get('user'), null, 'User was removed correctly');
+    assert.ok(account1.get('user') === null, 'User was removed correctly');
+    assert.ok(account2.get('user') === user, 'User was added correctly');
   });
 });
 

--- a/tests/integration/snapshot-test.js
+++ b/tests/integration/snapshot-test.js
@@ -2,7 +2,7 @@ import { resolve } from 'rsvp';
 import { run } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
 
-import { module, test, skip } from 'qunit';
+import { module, test, todo } from 'qunit';
 
 import DS from 'ember-data';
 
@@ -80,7 +80,7 @@ test("snapshot.id, snapshot.type and snapshot.modelName returns correctly", func
 //  there may be strategies via which we can snapshot known attributes
 //  only if no record exists yet, since we would then know for sure
 //  that this snapshot is not being used for a `.save()`.
-skip('snapshot.type loads the class lazily', function(assert) {
+todo('snapshot.type loads the class lazily', function(assert) {
   assert.expect(3);
 
   let postClassLoaded = false;

--- a/tests/integration/snapshot-test.js
+++ b/tests/integration/snapshot-test.js
@@ -2,7 +2,7 @@ import { resolve } from 'rsvp';
 import { run } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
 
-import { module, test, todo } from 'qunit';
+import { module, test, skip } from 'qunit';
 
 import DS from 'ember-data';
 
@@ -75,12 +75,12 @@ test("snapshot.id, snapshot.type and snapshot.modelName returns correctly", func
   });
 });
 
-// skipped because snapshot creation requires using `eachAttribute`
+// TODO'd because snapshot creation requires using `eachAttribute`
 //  which as an approach requires that we MUST load the class.
 //  there may be strategies via which we can snapshot known attributes
 //  only if no record exists yet, since we would then know for sure
 //  that this snapshot is not being used for a `.save()`.
-todo('snapshot.type loads the class lazily', function(assert) {
+skip('snapshot.type loads the class lazily', function(assert) {
   assert.expect(3);
 
   let postClassLoaded = false;

--- a/tests/unit/model/relationships/has-many-test.js
+++ b/tests/unit/model/relationships/has-many-test.js
@@ -2005,6 +2005,78 @@ test('DS.ManyArray is lazy', function(assert) {
   });
 });
 
+test('fetch hasMany loads full relationship after a parent and child have been loaded', function(assert) {
+  assert.expect(4);
+
+  const Tag = DS.Model.extend({
+    name: DS.attr('string'),
+    person: DS.belongsTo('person', { async: true, inverse: 'tags' })
+  });
+
+  const Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tags: DS.hasMany('tag', { async: true, inverse: 'person' })
+  });
+
+  let env = setupStore({ tag: Tag, person: Person });
+  let { store } = env;
+
+  env.adapter.findHasMany = function(store, snapshot, url, relationship) {
+    assert.equal(relationship.key, 'tags', 'relationship should be tags');
+
+    return { data: [
+      { id: 1, type: 'tag', attributes: { name: 'first' } },
+      { id: 2, type: 'tag', attributes: { name: 'second' } },
+      { id: 3, type: 'tag', attributes: { name: 'third' } }
+    ]};
+  };
+
+  env.adapter.findRecord = function(store, type, id, snapshot) {
+    if (type === Person) {
+      return {
+        data: {
+          id: 1,
+          type: 'person',
+          attributes: { name: 'Watson' },
+          relationships: {
+            tags: { links: { related: 'person/1/tags'} }
+          }
+        }
+      };
+    } else if (type === Tag) {
+      return {
+        data: {
+          id: 2,
+          type: 'tag',
+          attributes: { name: 'second' },
+          relationships: {
+            person: {
+              data: { id: 1, type: 'person'}
+            }
+          }
+        }
+      };
+    } else {
+      assert.true(false, 'wrong type')
+    }
+  };
+
+  return run(() => {
+    return store.findRecord('person', 1).then(person => {
+      assert.equal(get(person, 'name'), 'Watson', 'The person is now loaded');
+
+      // when I remove this findRecord the test passes
+      return store.findRecord('tag', 2).then(tag => {
+        assert.equal(get(tag, 'name'), 'second', 'The tag is now loaded');
+
+        return run(() => person.get('tags').then(tags => {
+          assert.equal(get(tags, 'length'), 3, 'the tags are all loaded');
+        }));
+      });
+    });
+  });
+});
+
 testInDebug('throws assertion if of not set with an array', function(assert) {
   const Person = DS.Model.extend();
   const Tag = DS.Model.extend({

--- a/tests/unit/system/relationships/relationship-payloads-test.js
+++ b/tests/unit/system/relationships/relationship-payloads-test.js
@@ -2,7 +2,7 @@ import { get } from '@ember/object';
 import { RelationshipPayloadsManager } from 'ember-data/-private';
 import DS from 'ember-data';
 import setupStore from 'dummy/tests/helpers/store';
-import { module, test, todo } from 'qunit';
+import { module, test } from 'qunit';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { run } from '@ember/runloop';
 import {
@@ -41,7 +41,7 @@ module('unit/system/relationships/relationship-payloads', {
       purpose: Purpose
     });
 
-    let store = this.env.store;
+    let store = this.store = this.env.store;
 
     this.relationshipPayloadsManager = new RelationshipPayloadsManager(store);
   },
@@ -162,8 +162,6 @@ testInDebug('unload asserts the passed modelName and relationshipName refer to t
   }, 'brand-of-catnip:purpose is not either side of this relationship, user:purpose<->purpose:user');
 });
 
-let env;
-
 module("Unit | Relationship Payloads | Merge Forward Links & Meta", {
   beforeEach() {
     const User = Model.extend({
@@ -195,7 +193,7 @@ module("Unit | Relationship Payloads | Merge Forward Links & Meta", {
   }
 });
 
-todo('links and meta for hasMany inverses are not overwritten', function(assert) {
+test('links and meta for hasMany inverses are not overwritten', function(assert) {
   let { store } = this;
 
   // user:1 with pet:1 pet:2 and home:1 and links and meta for both
@@ -301,27 +299,26 @@ todo('links and meta for hasMany inverses are not overwritten', function(assert)
     ]
   }));
 
-  let user1home = run(() => user1.get('home'));
-  let user1pets = run(() => user1.get('pets'));
-  let home1owners = run(() => home1.get('owners'));
+  run(() => user1.get('home'));
+  run(() => user1.get('pets'));
+  run(() => home1.get('owners'));
 
-  // we currently proxy meta, but not links
-  assert.equal(
-    user1home.get('meta'),
+  assert.deepEqual(
+    user1.belongsTo('home').belongsToRelationship.meta,
     {
       slogan: 'home is where the <3 emoji is'
     },
     `We merged forward meta for user 1's home`
   );
-  assert.equal(
-    home1owners.get('meta'),
+  assert.deepEqual(
+    home1.hasMany('owners').hasManyRelationship.meta,
     {
       slogan: 'what is woof?'
     },
     `We merged forward meta for home 1's owners`
   );
-  assert.equal(
-    user1pets.get('meta'),
+  assert.deepEqual(
+    user1.hasMany('pets').hasManyRelationship.meta,
     {
       slogan: 'catz rewl rawr'
     },

--- a/tests/unit/system/relationships/relationship-payloads-test.js
+++ b/tests/unit/system/relationships/relationship-payloads-test.js
@@ -1,36 +1,54 @@
 import { get } from '@ember/object';
 import { RelationshipPayloadsManager } from 'ember-data/-private';
 import DS from 'ember-data';
-import { createStore } from 'dummy/tests/helpers/store';
-import { module, test } from 'qunit';
+import setupStore from 'dummy/tests/helpers/store';
+import { module, test, todo } from 'qunit';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
+import { run } from '@ember/runloop';
+import {
+  reset as resetModelFactoryInjection
+} from 'dummy/tests/helpers/model-factory-injection';
+
+const {
+  belongsTo,
+  hasMany,
+  attr,
+  Model
+} = DS;
 
 module('unit/system/relationships/relationship-payloads', {
   beforeEach() {
-    const User = DS.Model.extend({
-      purpose: DS.belongsTo('purpose', { inverse: 'user' }),
-      hobbies: DS.hasMany('hobby', { inverse: 'user'}),
-      friends: DS.hasMany('user', { inverse: 'friends' })
+    const User = Model.extend({
+      purpose: belongsTo('purpose', { inverse: 'user' }),
+      hobbies: hasMany('hobby', { inverse: 'user'}),
+      friends: hasMany('user', { inverse: 'friends' })
     });
     User.toString = () => 'User';
 
-    const Hobby = DS.Model.extend({
-      user: DS.belongsTo('user', { inverse: 'hobbies' })
+    const Hobby = Model.extend({
+      user: belongsTo('user', { inverse: 'hobbies' })
     });
     Hobby.toString = () => 'Hobby';
 
-    const Purpose = DS.Model.extend({
-      user: DS.belongsTo('user', { inverse: 'purpose' })
+    const Purpose = Model.extend({
+      user: belongsTo('user', { inverse: 'purpose' })
     });
     Purpose.toString = () => 'Purpose';
 
-    let store = this.store = createStore({
+    this.env = setupStore({
       user: User,
       Hobby: Hobby,
       purpose: Purpose
     });
 
+    let store = this.env.store;
+
     this.relationshipPayloadsManager = new RelationshipPayloadsManager(store);
+  },
+
+  afterEach() {
+    resetModelFactoryInjection();
+    run(this.env.container, 'destroy');
   }
 });
 
@@ -144,3 +162,186 @@ testInDebug('unload asserts the passed modelName and relationshipName refer to t
   }, 'brand-of-catnip:purpose is not either side of this relationship, user:purpose<->purpose:user');
 });
 
+let env;
+
+module("Unit | Relationship Payloads | Merge Forward Links & Meta", {
+  beforeEach() {
+    const User = Model.extend({
+      name: attr(),
+      pets: hasMany('pet', { async: true, inverse: 'owner' }),
+      home: belongsTo('home', { async: true, inverse: 'owners' })
+    });
+    const Home = Model.extend({
+      address: attr(),
+      owners: hasMany('user', { async: true, inverse: 'home' })
+    });
+    const Pet = Model.extend({
+      name: attr(),
+      owner: belongsTo('user', { async: false, inverse: 'pets' })
+    });
+
+    this.env = setupStore({
+      user: User,
+      pet: Pet,
+      home: Home
+    });
+
+    this.store = this.env.store;
+  },
+
+  afterEach() {
+    resetModelFactoryInjection();
+    run(this.env.container, 'destroy');
+  }
+});
+
+todo('links and meta for hasMany inverses are not overwritten', function(assert) {
+  let { store } = this;
+
+  // user:1 with pet:1 pet:2 and home:1 and links and meta for both
+  let user1 = run(() => store.push({
+    data: {
+      type: 'user',
+      id: '1',
+      attributes: { name: '@runspired ' },
+      relationships: {
+        home: {
+          links: {
+            related: './runspired/home'
+          },
+          data: {
+            type: 'home',
+            id: '1'
+          },
+          meta: {
+            slogan: 'home is where the <3 emoji is'
+          }
+        },
+        pets: {
+          links: {
+            related: './runspired/pets'
+          },
+          data: [
+            { type: 'pet', id: '1' },
+            { type: 'pet', id: '2' }
+          ],
+          meta: {
+            slogan: 'catz rewl rawr'
+          }
+        }
+      }
+    }
+  }));
+
+  // home:1 with user:1 user:2 and links and meta
+  // user:2 sideloaded to prevent needing to fetch
+  let home1 = run(() => store.push({
+    data: {
+      type: 'home',
+      id: '1',
+      attributes: { address: 'Oakland, CA' },
+      relationships: {
+        owners: {
+          links: {
+            related: './home/1/owners'
+          },
+          data: [
+            { type: 'user', id: '2' },
+            { type: 'user', id: '1' }
+          ],
+          meta: {
+            slogan: 'what is woof?'
+          }
+        }
+      }
+    },
+    included: [
+      {
+        type: 'user',
+        id: '2',
+        attribute: { name: '@hjdivad' },
+        relationships: {
+          home: {
+            data: { type: 'home', id: '1' }
+          }
+        }
+      }
+    ]
+  }));
+
+  // Toss a couple of pets in for good measure
+  run(() => store.push({
+    data: [
+      {
+        type: 'pet',
+        id:'1',
+        attributes: { name: 'Shen' },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      },
+      {
+        type: 'pet',
+        id:'2',
+        attributes: { name: 'Rambo' },
+        relationships: {
+          owner: {
+            data: {
+              type: 'user',
+              id: '1'
+            }
+          }
+        }
+      }
+    ]
+  }));
+
+  let user1home = run(() => user1.get('home'));
+  let user1pets = run(() => user1.get('pets'));
+  let home1owners = run(() => home1.get('owners'));
+
+  // we currently proxy meta, but not links
+  assert.equal(
+    user1home.get('meta'),
+    {
+      slogan: 'home is where the <3 emoji is'
+    },
+    `We merged forward meta for user 1's home`
+  );
+  assert.equal(
+    home1owners.get('meta'),
+    {
+      slogan: 'what is woof?'
+    },
+    `We merged forward meta for home 1's owners`
+  );
+  assert.equal(
+    user1pets.get('meta'),
+    {
+      slogan: 'catz rewl rawr'
+    },
+    `We merged forward meta for user 1's pets`
+  );
+
+  // check the link as best we can
+  assert.equal(
+    user1.belongsTo('home').belongsToRelationship.link,
+    './runspired/home',
+    `We merged forward links for user 1's home`
+  );
+  assert.equal(
+    user1.hasMany('pets').hasManyRelationship.link,
+    './runspired/pets',
+    `We merged forward links for user 1's pets`
+  );
+  assert.equal(
+    home1.hasMany('owners').hasManyRelationship.link,
+    './home/1/owners',
+    `We merged forward links for home 1's owners`
+  );
+});


### PR DESCRIPTION
**Description**

This PR includes two fixes for links and a suite of new tests to accompany them.

The first addresses a shortcoming of the lazy-relationships work which caused `meta` and `links` information to be lossy. We now "merge forward" meta and links information on relationship payloads when necessary.  We also now handle data for `has-many` relationships discovered via their inverse in a special way (see `_partialData`). This avoids us losing information about whether the membership should be considered complete or not. 

The second addresses the situation in which both `data` and `links` are present for a relationship. We now ALWAYS prefer to fetch/re-fetch relationship data via a link if present.  To achieve this, we now do a minimal amount of book-keeping on whether the relationship should be considered available locally, or must be refetched.

**General Warning**

This PR cleans up some previously poorly spec'd behavior, which means that it may cause some minor breakage to apps using `links` that had found work-arounds for the `mixing links and data` issue.

Because it fixes our ability to use `links` for relationships in general, folks that implemented workarounds for relationships expecting their links to never be used might be particularly surprised.  Ideally things will `"just work"™` in most situations for these folks, and they can delete their workarounds.

**Resolves and/or supplants**

- Resolves #5423 
- Resolves #5351
- Resolves #5274 
- Resolves #5257 
- Resolves #5235 
- Resolves #5211 
- Resolves #5209 
- Resolves #5143 
- Resolves #4997 
- Resolves #4991 
- Resolves #4954  
- Resolves #4889 
- Resolves #4712 
- Resolves #4292 
- Resolves #4099
- Resolves #3115  

It additionally advances the status of #2905 and #2162 

