### PR TITLE
make createRecord sync and remove unnecessary run usage in tests

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -338,25 +338,32 @@ Store = Service.extend({
     assert(`You need to pass a model name to the store's createRecord method`, isPresent(modelName));
     assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${modelName}`, typeof modelName === 'string');
 
-    return this._backburner.join(() => {
-      let normalizedModelName = normalizeModelName(modelName);
-      let properties = copy(inputProperties) || Object.create(null);
+    // This is wrapped in a `run.join` so that in test environments users do not need to manually wrap
+    //   calls to `createRecord`. The run loop usage here is because we batch the joining and updating
+    //   of record-arrays via ember's run loop, not our own.
+    //
+    //   to remove this, we would need to move to a new `async` API.
+    return emberRun.join(() => {
+      return this._backburner.join(() => {
+        let normalizedModelName = normalizeModelName(modelName);
+        let properties = copy(inputProperties) || Object.create(null);
 
-      // If the passed properties do not include a primary key,
-      // give the adapter an opportunity to generate one. Typically,
-      // client-side ID generators will use something like uuid.js
-      // to avoid conflicts.
+        // If the passed properties do not include a primary key,
+        // give the adapter an opportunity to generate one. Typically,
+        // client-side ID generators will use something like uuid.js
+        // to avoid conflicts.
 
-      if (isNone(properties.id)) {
-        properties.id = this._generateId(normalizedModelName, properties);
-      }
+        if (isNone(properties.id)) {
+          properties.id = this._generateId(normalizedModelName, properties);
+        }
 
-      // Coerce ID to a string
-      properties.id = coerceId(properties.id);
+        // Coerce ID to a string
+        properties.id = coerceId(properties.id);
 
-      let internalModel = this._buildInternalModel(normalizedModelName, properties.id);
-      internalModel.loadedData();
-      return internalModel.getRecord(properties);
+        let internalModel = this._buildInternalModel(normalizedModelName, properties.id);
+        internalModel.loadedData();
+        return internalModel.getRecord(properties);
+      });
     });
   },
 

--- a/blueprints/model-test/qunit-files/tests/unit/__path__/__test__.js
+++ b/blueprints/model-test/qunit-files/tests/unit/__path__/__test__.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
@@ -8,7 +7,7 @@ module('<%= friendlyTestDescription %>', function(hooks) {
   // Replace this with your real tests.
   test('it exists', function(assert) {
     let store = this.owner.lookup('service:store');
-    let model = run(() => store.createRecord('<%= dasherizedModuleName %>', {}));
+    let model = store.createRecord('<%= dasherizedModuleName %>', {});
     assert.ok(model);
   });
 });

--- a/blueprints/serializer-test/qunit-files/tests/unit/__path__/__test__.js
+++ b/blueprints/serializer-test/qunit-files/tests/unit/__path__/__test__.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
@@ -15,7 +14,7 @@ module('<%= friendlyTestDescription %>', function(hooks) {
 
   test('it serializes records', function(assert) {
     let store = this.owner.lookup('service:store');
-    let record = run(() => store.createRecord('<%= dasherizedModuleName %>', {}));
+    let record = store.createRecord('<%= dasherizedModuleName %>', {});
 
     let serializedRecord = record.serialize();
 

--- a/node-tests/fixtures/model-test/comment-default.js
+++ b/node-tests/fixtures/model-test/comment-default.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Unit | Model | comment', function(hooks) {
   setupTest(hooks);
@@ -8,7 +7,7 @@ module('Unit | Model | comment', function(hooks) {
   // Replace this with your real tests.
   test('it exists', function(assert) {
     let store = this.owner.lookup('service:store');
-    let model = run(() => store.createRecord('comment', {}));
+    let model = store.createRecord('comment', {});
     assert.ok(model);
   });
 });

--- a/node-tests/fixtures/model-test/foo-default.js
+++ b/node-tests/fixtures/model-test/foo-default.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Unit | Model | foo', function(hooks) {
   setupTest(hooks);
@@ -8,7 +7,7 @@ module('Unit | Model | foo', function(hooks) {
   // Replace this with your real tests.
   test('it exists', function(assert) {
     let store = this.owner.lookup('service:store');
-    let model = run(() => store.createRecord('foo', {}));
+    let model = store.createRecord('foo', {});
     assert.ok(model);
   });
 });

--- a/node-tests/fixtures/model-test/post-default.js
+++ b/node-tests/fixtures/model-test/post-default.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Unit | Model | post', function(hooks) {
   setupTest(hooks);
@@ -8,7 +7,7 @@ module('Unit | Model | post', function(hooks) {
   // Replace this with your real tests.
   test('it exists', function(assert) {
     let store = this.owner.lookup('service:store');
-    let model = run(() => store.createRecord('post', {}));
+    let model = store.createRecord('post', {});
     assert.ok(model);
   });
 });

--- a/node-tests/fixtures/model-test/rfc232.js
+++ b/node-tests/fixtures/model-test/rfc232.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Unit | Model | foo', function(hooks) {
   setupTest(hooks);
@@ -8,7 +7,7 @@ module('Unit | Model | foo', function(hooks) {
   // Replace this with your real tests.
   test('it exists', function(assert) {
     let store = this.owner.lookup('service:store');
-    let model = run(() => store.createRecord('foo', {}));
+    let model = store.createRecord('foo', {});
     assert.ok(model);
   });
 });

--- a/node-tests/fixtures/serializer-test/application-default.js
+++ b/node-tests/fixtures/serializer-test/application-default.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Unit | Serializer | application', function(hooks) {
   setupTest(hooks);
@@ -15,7 +14,7 @@ module('Unit | Serializer | application', function(hooks) {
 
   test('it serializes records', function(assert) {
     let store = this.owner.lookup('service:store');
-    let record = run(() => store.createRecord('application', {}));
+    let record = store.createRecord('application', {});
 
     let serializedRecord = record.serialize();
 

--- a/node-tests/fixtures/serializer-test/foo-default.js
+++ b/node-tests/fixtures/serializer-test/foo-default.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Unit | Serializer | foo', function(hooks) {
   setupTest(hooks);
@@ -15,7 +14,7 @@ module('Unit | Serializer | foo', function(hooks) {
 
   test('it serializes records', function(assert) {
     let store = this.owner.lookup('service:store');
-    let record = run(() => store.createRecord('foo', {}));
+    let record = store.createRecord('foo', {});
 
     let serializedRecord = record.serialize();
 

--- a/node-tests/fixtures/serializer-test/rfc232.js
+++ b/node-tests/fixtures/serializer-test/rfc232.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Unit | Serializer | foo', function(hooks) {
   setupTest(hooks);
@@ -15,7 +14,7 @@ module('Unit | Serializer | foo', function(hooks) {
 
   test('it serializes records', function(assert) {
     let store = this.owner.lookup('service:store');
-    let record = run(() => store.createRecord('foo', {}));
+    let record = store.createRecord('foo', {});
 
     let serializedRecord = record.serialize();
 

--- a/tests/integration/adapter/find-all-test.js
+++ b/tests/integration/adapter/find-all-test.js
@@ -144,9 +144,7 @@ test("When all records for a type are requested, records that are created on the
 
   assert.equal(get(allRecords, 'length'), 0, "precond - the record array's length is zero before any records are loaded");
 
-  run(() => {
-    store.createRecord('person', { name: "Carsten Nielsen" });
-  });
+  store.createRecord('person', { name: "Carsten Nielsen" });
 
   assert.equal(get(allRecords, 'length'), 1, "the record array's length is 1");
   assert.equal(allRecords.objectAt(0).get('name'), "Carsten Nielsen", "the first item in the record array is Carsten Nielsen");

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -256,11 +256,8 @@ test("createRecord - a payload with a new ID and data applies the updates", func
 });
 
 test("createRecord - a payload with a new ID and data applies the updates (with legacy singular name)", function(assert) {
-  let post;
   ajaxResponse({ post: { id: "1", name: "Dat Parley Letter" } });
-  run(function() {
-    post = store.createRecord('post', { name: "The Parley Letter" });
-  });
+  let post = store.createRecord('post', { name: "The Parley Letter" });
 
   return run(post, 'save').then(post => {
     assert.equal(passedUrl, "/posts");
@@ -297,7 +294,7 @@ test("createRecord - findMany doesn't overwrite owner", function(assert) {
   });
   let post = store.peekRecord('post', 1);
 
-  let comment = run(() => store.createRecord('comment', { name: "The Parley Letter" }));
+  let comment = store.createRecord('comment', { name: "The Parley Letter" });
 
   run(() => {
     post.get('comments').pushObject(comment);
@@ -315,7 +312,6 @@ test("createRecord - findMany doesn't overwrite owner", function(assert) {
 });
 
 test("createRecord - a serializer's primary key and attributes are consulted when building the payload", function(assert) {
-  let post;
   env.registry.register('serializer:post', DS.RESTSerializer.extend({
     primaryKey: '_id_',
 
@@ -326,9 +322,7 @@ test("createRecord - a serializer's primary key and attributes are consulted whe
 
   ajaxResponse();
 
-  run(() => {
-    post = store.createRecord('post', { id: "some-uuid", name: "The Parley Letter" });
-  });
+  let post = store.createRecord('post', { id: "some-uuid", name: "The Parley Letter" });
 
   return run(() =>
     post.save()
@@ -513,14 +507,11 @@ test("createRecord - a record on the many side of a hasMany relationship should 
 
 test("createRecord - sideloaded belongsTo relationships are both marked as loaded", function(assert) {
   assert.expect(4);
-  let post;
 
   Post.reopen({ comment: DS.belongsTo('comment', { async: false }) });
   Comment.reopen({ post: DS.belongsTo('post', { async: false }) });
 
-  run(() => {
-    post = store.createRecord('post', { name: "man" });
-  });
+  let post = store.createRecord('post', { name: "man" });
 
   ajaxResponse({
     posts: [{ id: 1, comment: 1, name: "marked" }],
@@ -556,10 +547,7 @@ test("createRecord - response can contain relationships the client doesn't yet k
   Post.reopen({ comments: DS.hasMany('comment', { async: false }) });
   Comment.reopen({ post: DS.belongsTo('post', { async: false }) });
 
-  let post;
-  run(() => {
-    post = store.createRecord('post', { name: "Rails is omakase" });
-  });
+  let post = store.createRecord('post', { name: "Rails is omakase" });
 
   return run(() => {
     return post.save().then(post => {
@@ -575,15 +563,11 @@ test("createRecord - response can contain relationships the client doesn't yet k
 });
 
 test("createRecord - relationships are not duplicated", function(assert) {
-  let post, comment;
-
   Post.reopen({ comments: DS.hasMany('comment', { async: false }) });
   Comment.reopen({ post: DS.belongsTo('post', { async: false }) });
 
-  run(() => {
-    post = store.createRecord('post', { name: "Tomtomhuda" });
-    comment = store.createRecord('comment', { id: 2, name: "Comment title" });
-  });
+  let post = store.createRecord('post', { name: "Tomtomhuda" });
+  let comment = store.createRecord('comment', { id: 2, name: "Comment title" });
 
   ajaxResponse({ post: [{ id: 1, name: "Rails is omakase", comments: [] }] });
 
@@ -989,7 +973,7 @@ test("deleteRecord - a payload with sidloaded updates pushes the updates when th
 });
 
 test("deleteRecord - deleting a newly created record should not throw an error", function(assert) {
-  let post = run(() => store.createRecord('post'));
+  let post = store.createRecord('post');
 
   return run(() => {
     post.deleteRecord();

--- a/tests/integration/adapter/serialize-test.js
+++ b/tests/integration/adapter/serialize-test.js
@@ -31,8 +31,6 @@ test("serialize() is delegated to the serializer", function(assert) {
     assert.deepEqual(options, { foo: 'bar' });
   };
 
-  run(() => {
-    let person = store.createRecord('person');
-    adapter.serialize(person._createSnapshot(), { foo: 'bar' });
-  });
+  let person = store.createRecord('person');
+  adapter.serialize(person._createSnapshot(), { foo: 'bar' });
 });

--- a/tests/integration/adapter/store-adapter-test.js
+++ b/tests/integration/adapter/store-adapter-test.js
@@ -117,12 +117,8 @@ test("by default, createRecords calls createRecord once per record", function(as
     });
   };
 
-  let tom, yehuda;
-
-  run(() => {
-    tom = store.createRecord('person', { name: "Tom Dale" });
-    yehuda = store.createRecord('person', { name: "Yehuda Katz" });
-  });
+  let tom = store.createRecord('person', { name: "Tom Dale" });
+  let yehuda = store.createRecord('person', { name: "Yehuda Katz" });
 
   let promise = run(() => {
     return hash({
@@ -502,9 +498,7 @@ test("if a created record is marked as invalid by the server, it enters an error
     }
   };
 
-  let yehuda = run(() => {
-    return store.createRecord('person', { id: 1, name: "Yehuda Katz" });
-  });
+  let yehuda = store.createRecord('person', { id: 1, name: "Yehuda Katz" });
   // Wrap this in an Ember.run so that all chained async behavior is set up
   // before flushing any scheduled behavior.
   return run(function() {
@@ -549,9 +543,7 @@ test("allows errors on arbitrary properties on create", function(assert) {
     }
   };
 
-  let yehuda = run(() => {
-    return store.createRecord('person', { id: 1, name: "Yehuda Katz" });
-  });
+  let yehuda = store.createRecord('person', { id: 1, name: "Yehuda Katz" });
 
   // Wrap this in an Ember.run so that all chained async behavior is set up
   // before flushing any scheduled behavior.
@@ -603,9 +595,7 @@ test("if a created record is marked as invalid by the server, you can attempt th
     }
   };
 
-  let yehuda = run(() => {
-    return store.createRecord('person', { id: 1, name: "Yehuda Katz" });
-  });
+  let yehuda = store.createRecord('person', { id: 1, name: "Yehuda Katz" });
 
   // Wrap this in an Ember.run so that all chained async behavior is set up
   // before flushing any scheduled behavior.
@@ -1094,7 +1084,7 @@ test("async hasMany always returns a promise", function(assert) {
     });
   };
 
-  let tom = run(() => store.createRecord('person', { name: "Tom Dale" }));
+  let tom = store.createRecord('person', { name: "Tom Dale" });
 
   run(() => {
     assert.ok(tom.get('dogs') instanceof DS.PromiseArray, "dogs is a promise before save");
@@ -1115,12 +1105,9 @@ test("createRecord receives a snapshot", function(assert) {
     return resolve();
   };
 
-  var person;
+  let record = store.createRecord('person', { name: "Tom Dale", id: 1 });
 
-  run(() => {
-    person = store.createRecord('person', { name: "Tom Dale", id: 1 });
-    person.save();
-  });
+  run(() => record.save());
 });
 
 test("updateRecord receives a snapshot", function(assert) {
@@ -1329,8 +1316,8 @@ test("record.save should pass adapterOptions to the createRecord method", functi
   };
 
   return run(() => {
-    let person = store.createRecord('person', { name: 'Tom' });
-    return person.save({ adapterOptions: { subscribe: true } });
+    store.createRecord('person', { name: 'Tom' })
+      .save({ adapterOptions: { subscribe: true } });
   });
 });
 

--- a/tests/integration/client-id-generation-test.js
+++ b/tests/integration/client-id-generation-test.js
@@ -56,11 +56,8 @@ test("If an adapter implements the `generateIdForRecord` method, the store shoul
     }
   };
 
-  let comment, post;
-  run(function() {
-    comment = env.store.createRecord('comment');
-    post = env.store.createRecord('post');
-  });
+  let comment = env.store.createRecord('comment');
+  let post = env.store.createRecord('post');
 
   assert.equal(get(comment, 'id'), 'id-1', "comment is assigned id 'id-1'");
   assert.equal(get(post, 'id'), 'id-2', "post is assigned id 'id-2'");
@@ -75,7 +72,6 @@ test("If an adapter implements the `generateIdForRecord` method, the store shoul
 
 test("empty string and undefined ids should coerce to null", function(assert) {
   assert.expect(6);
-  let comment, post;
   let idCount = 0;
   let id = 1;
   let ids = [undefined, ''];
@@ -90,10 +86,8 @@ test("empty string and undefined ids should coerce to null", function(assert) {
     return resolve({ data: { id: id++, type: type.modelName } });
   };
 
-  run(() => {
-    comment = env.store.createRecord('misc');
-    post = env.store.createRecord('misc');
-  });
+  let comment = env.store.createRecord('misc');
+  let post = env.store.createRecord('misc');
 
   assert.equal(get(comment, 'id'), null, "comment is assigned id 'null'");
   assert.equal(get(post, 'id'), null, "post is assigned id 'null'");

--- a/tests/integration/debug-adapter-test.js
+++ b/tests/integration/debug-adapter-test.js
@@ -141,9 +141,8 @@ test("Watching Records", function(assert) {
   assert.deepEqual(record.searchKeywords, ['1', 'Modified Post']);
   assert.deepEqual(record.color, 'blue');
 
-  run(function() {
-    post = store.createRecord('post', { id: '2', title: 'New Post' });
-  });
+  post = store.createRecord('post', { id: '2', title: 'New Post' });
+
   assert.equal(get(addedRecords, 'length'), 1);
   record = addedRecords[0];
   assert.deepEqual(record.columnValues, { id: '2', title: 'New Post' });

--- a/tests/integration/filter-test.js
+++ b/tests/integration/filter-test.js
@@ -196,9 +196,7 @@ test('a filtered record array includes created elements', function(assert) {
 
   assert.equal(get(recordArray, 'length'), 2, 'precond - The Record Array should have the filtered objects on it');
 
-  run(() => {
-    store.createRecord('person', { name: 'Scumbag Koz' });
-  });
+  store.createRecord('person', { name: 'Scumbag Koz' });
 
   assert.equal(get(recordArray, 'length'), 3, 'The record array has the new object on it');
 });
@@ -566,11 +564,9 @@ test('it is possible to filter created records by dirtiness', function(assert) {
     return store.filter('person', person => !person.get('hasDirtyAttributes'));
   });
 
-  let person = run(() => {
-    return store.createRecord('person', {
-      id: 1,
-      name: 'Tom Dale'
-    });
+  let person = store.createRecord('person', {
+    id: 1,
+    name: 'Tom Dale'
   });
 
   assert.equal(filter.get('length'), 0, 'the dirty record is not in the filter');
@@ -579,35 +575,6 @@ test('it is possible to filter created records by dirtiness', function(assert) {
     return person.save().then(person => {
       assert.equal(filter.get('length'), 1, 'the clean record is in the filter');
     });
-  });
-});
-
-test('it is possible to filter created records by isReloading', function(assert) {
-  customAdapter(env, DS.Adapter.extend({
-    findRecord(store, type, id, snapshot) {
-      return {
-        data: {
-          id: 1,
-          type: 'person',
-          attributes: {
-            name: 'Tom Dalle'
-          }
-        }
-      };
-    }
-  }));
-
-  let filter = store.filter('person', person => {
-    return !person.get('isReloading');
-  });
-
-  let person = store.createRecord('person', {
-    id: 1,
-    name: 'Tom Dale'
-  });
-
-  return person.reload().then(person => {
-    assert.equal(filter.get('length'), 1, 'the filter correctly returned a reloaded object');
   });
 });
 
@@ -632,9 +599,7 @@ function clientEdits(ids) {
 function clientCreates(names) {
   // wrap in an run to guarantee coalescence of the
   // iterated `set` calls.
-  edited = run(() => {
-    return names.map(name => store.createRecord('person', { name: 'Client-side ' + name }));
-  });
+  edited = names.map(name => store.createRecord('person', { name: 'Client-side ' + name }));
 }
 
 function serverResponds() {

--- a/tests/integration/injection-test.js
+++ b/tests/integration/injection-test.js
@@ -101,7 +101,7 @@ module('integration/injection eager injections', {
 });
 
 test('did inject', function(assert) {
-  let foo = run(() => env.store.createRecord('foo'));
+  let foo = env.store.createRecord('foo');
   let apple = foo.get('apple');
   let Apple = env.registry.registrations['service:apple'];
 

--- a/tests/integration/lifecycle-hooks-test.js
+++ b/tests/integration/lifecycle-hooks-test.js
@@ -33,7 +33,7 @@ test("When the adapter acknowledges that a record has been created, a `didCreate
     return resolve({ data: { id: 99, type: "person", attributes: { name: "Yehuda Katz" } } });
   };
 
-  let person = run(() => env.store.createRecord('person', { name: "Yehuda Katz" }));
+  let person = env.store.createRecord('person', { name: "Yehuda Katz" });
 
   person.on('didCreate', function() {
     assert.equal(this, person, "this is bound to the record");
@@ -52,7 +52,7 @@ test("When the adapter acknowledges that a record has been created without a new
     return resolve();
   };
 
-  let person = run(() => env.store.createRecord('person', { id: 99, name: "Yehuda Katz" }));
+  let person = env.store.createRecord('person', { id: 99, name: "Yehuda Katz" });
 
   person.on('didCreate', function() {
     assert.equal(this, person, "this is bound to the record");

--- a/tests/integration/record-array-test.js
+++ b/tests/integration/record-array-test.js
@@ -379,20 +379,15 @@ test('a newly created record is removed from a record array when it is deleted',
     tag: Tag
   });
   let recordArray = store.peekAll('person');
-  let scumbag = run(() => {
-    return store.createRecord('person', {
-      name: 'Scumbag Dale'
-    });
+  let scumbag = store.createRecord('person', {
+    name: 'Scumbag Dale'
   });
 
   assert.equal(get(recordArray, 'length'), 1, 'precond - record array already has the first created item');
 
-  // guarantee coalescence
-  run(() => {
-    store.createRecord('person', { name: 'p1' });
-    store.createRecord('person', { name: 'p2' });
-    store.createRecord('person', { name: 'p3' });
-  });
+  store.createRecord('person', { name: 'p1' });
+  store.createRecord('person', { name: 'p2' });
+  store.createRecord('person', { name: 'p3' });
 
   assert.equal(get(recordArray, 'length'), 4, 'precond - record array has the created item');
   assert.equal(recordArray.objectAt(0), scumbag, 'item at index 0 is record with id 1');

--- a/tests/integration/record-arrays/peeked-records-test.js
+++ b/tests/integration/record-arrays/peeked-records-test.js
@@ -105,10 +105,9 @@ test('peekAll in the same run-loop as push works as expected', function(assert) 
 test('newly created records notify the array as expected', function(assert) {
   let peekedRecordArray = run(() => store.peekAll('person'));
   let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
-
-  let aNewlyCreatedRecord = run(() => store.createRecord('person', {
+  let aNewlyCreatedRecord = store.createRecord('person', {
     name: 'James'
-  }));
+  });
 
   assert.watchedPropertyCounts(
     watcher,
@@ -130,10 +129,9 @@ test('newly created records notify the array as expected', function(assert) {
 test('immediately peeking newly created records works as expected', function(assert) {
   let peekedRecordArray = run(() => store.peekAll('person'));
   let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
-
-  let aNewlyCreatedRecord = run(() => store.createRecord('person', {
+  let aNewlyCreatedRecord = store.createRecord('person', {
     name: 'James'
-  }));
+  });
 
   assert.watchedPropertyCounts(
     watcher,
@@ -156,9 +154,9 @@ test('immediately peeking newly created records works as expected', function(ass
 test('unloading newly created records notify the array as expected', function(assert) {
   let peekedRecordArray = run(() => store.peekAll('person'));
   let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
-  let aNewlyCreatedRecord = run(() => store.createRecord('person', {
+  let aNewlyCreatedRecord = store.createRecord('person', {
     name: 'James'
-  }));
+  });
 
   assert.watchedPropertyCounts(
     watcher,
@@ -180,9 +178,9 @@ test('unloading newly created records notify the array as expected', function(as
 test('immediately peeking after unloading newly created records works as expected', function(assert) {
   let peekedRecordArray = run(() => store.peekAll('person'));
   let watcher = watchProperties(peekedRecordArray, ['length', '[]']);
-  let aNewlyCreatedRecord = run(() => store.createRecord('person', {
+  let aNewlyCreatedRecord = store.createRecord('person', {
     name: 'James'
-  }));
+  });
 
   assert.watchedPropertyCounts(
     watcher,

--- a/tests/integration/records/collection-save-test.js
+++ b/tests/integration/records/collection-save-test.js
@@ -25,10 +25,9 @@ module("integration/records/collection_save - Save Collection of Records", {
 test("Collection will resolve save on success", function(assert) {
   assert.expect(1);
   let id = 1;
-  run(() => {
-    env.store.createRecord('post', { title: 'Hello' });
-    env.store.createRecord('post', { title: 'World' });
-  });
+
+  env.store.createRecord('post', { title: 'Hello' });
+  env.store.createRecord('post', { title: 'World' });
 
   let posts = env.store.peekAll('post');
 
@@ -44,10 +43,8 @@ test("Collection will resolve save on success", function(assert) {
 });
 
 test("Collection will reject save on error", function(assert) {
-  run(() => {
-    env.store.createRecord('post', { title: 'Hello' });
-    env.store.createRecord('post', { title: 'World' });
-  });
+  env.store.createRecord('post', { title: 'Hello' });
+  env.store.createRecord('post', { title: 'World' });
 
   let posts = env.store.peekAll('post');
 
@@ -63,10 +60,8 @@ test("Collection will reject save on error", function(assert) {
 });
 
 test("Retry is allowed in a failure handler", function(assert) {
-  run(() => {
-    env.store.createRecord('post', { title: 'Hello' });
-    env.store.createRecord('post', { title: 'World' });
-  });
+  env.store.createRecord('post', { title: 'Hello' });
+  env.store.createRecord('post', { title: 'World' });
 
   let posts = env.store.peekAll('post');
 
@@ -99,10 +94,8 @@ test("Retry is allowed in a failure handler", function(assert) {
 test("Collection will reject save on invalid", function(assert) {
   assert.expect(1);
 
-  run(() => {
-    env.store.createRecord('post', { title: 'Hello' });
-    env.store.createRecord('post', { title: 'World' });
-  });
+  env.store.createRecord('post', { title: 'Hello' });
+  env.store.createRecord('post', { title: 'World' });
 
   let posts = env.store.peekAll('post');
 

--- a/tests/integration/records/delete-record-test.js
+++ b/tests/integration/records/delete-record-test.js
@@ -308,10 +308,8 @@ test("Will resolve destroy and save in same loop", function(assert) {
     });
   };
 
-  run(function() {
-    adam = env.store.createRecord('person', { name: 'Adam Sunderland' });
-    dave = env.store.createRecord('person', { name: 'Dave Sunderland' });
-  });
+  adam = env.store.createRecord('person', { name: 'Adam Sunderland' });
+  dave = env.store.createRecord('person', { name: 'Dave Sunderland' });
 
   run(function() {
     promises = [

--- a/tests/integration/records/error-test.js
+++ b/tests/integration/records/error-test.js
@@ -75,12 +75,10 @@ testInDebug('adding errors during root.loaded.created.invalid works', function(a
 testInDebug('adding errors root.loaded.created.invalid works', function(assert) {
   assert.expect(5);
 
-  var person = run(() => {
-    return store.createRecord('person', {
-      id: 'wat',
-      firstName: 'Yehuda',
-      lastName: 'Katz'
-    });
+  let person = store.createRecord('person', {
+    id: 'wat',
+    firstName: 'Yehuda',
+    lastName: 'Katz'
   });
 
   run(() => {
@@ -105,11 +103,9 @@ testInDebug('adding errors root.loaded.created.invalid works', function(assert) 
 testInDebug('adding errors root.loaded.created.invalid works add + remove + add', function(assert) {
   assert.expect(7);
 
-  var person = run(() => {
-    return store.createRecord('person', {
-      id: 'wat',
-      firstName: 'Yehuda'
-    });
+  let person = store.createRecord('person', {
+    id: 'wat',
+    firstName: 'Yehuda'
   });
 
   run(() => {
@@ -136,11 +132,9 @@ testInDebug('adding errors root.loaded.created.invalid works add + remove + add'
 testInDebug('adding errors root.loaded.created.invalid works add + (remove, add)', function(assert) {
   assert.expect(6);
 
-  var person = run(() => {
-    return store.createRecord('person', {
-      id: 'wat',
-      firstName: 'Yehuda'
-    });
+  let person = store.createRecord('person', {
+    id: 'wat',
+    firstName: 'Yehuda'
   });
 
   run(() => {

--- a/tests/integration/records/save-test.js
+++ b/tests/integration/records/save-test.js
@@ -24,10 +24,7 @@ module("integration/records/save - Save Record", {
 
 test("Will resolve save on success", function(assert) {
   assert.expect(4);
-  var post;
-  run(function() {
-    post = env.store.createRecord('post', { title: 'toto' });
-  });
+  let post = env.store.createRecord('post', { title: 'toto' });
 
   var deferred = defer();
   env.adapter.createRecord = function(store, type, snapshot) {
@@ -50,10 +47,7 @@ test("Will resolve save on success", function(assert) {
 });
 
 test("Will reject save on error", function(assert) {
-  var post;
-  run(function() {
-    post = env.store.createRecord('post', { title: 'toto' });
-  });
+  let post = env.store.createRecord('post', { title: 'toto' });
 
   env.adapter.createRecord = function(store, type, snapshot) {
     var error = new DS.InvalidError([{ title: 'not valid' }]);
@@ -69,10 +63,7 @@ test("Will reject save on error", function(assert) {
 });
 
 test("Retry is allowed in a failure handler", function(assert) {
-  var post;
-  run(function() {
-    post = env.store.createRecord('post', { title: 'toto' });
-  });
+  let post = env.store.createRecord('post', { title: 'toto' });
 
   var count = 0;
 
@@ -97,11 +88,7 @@ test("Retry is allowed in a failure handler", function(assert) {
 
 test("Repeated failed saves keeps the record in uncommited state", function(assert) {
   assert.expect(4);
-  var post;
-
-  run(function() {
-    post = env.store.createRecord('post', { title: 'toto' });
-  });
+  let post = env.store.createRecord('post', { title: 'toto' });
 
   env.adapter.createRecord = function(store, type, snapshot) {
     return reject();
@@ -122,11 +109,7 @@ test("Repeated failed saves keeps the record in uncommited state", function(asse
 
 test("Repeated failed saves with invalid error marks the record as invalid", function(assert) {
   assert.expect(2);
-  var post;
-
-  run(function() {
-    post = env.store.createRecord('post', { title: 'toto' });
-  });
+  let post = env.store.createRecord('post', { title: 'toto' });
 
   env.adapter.createRecord = function(store, type, snapshot) {
     var error = new DS.InvalidError([
@@ -152,11 +135,7 @@ test("Repeated failed saves with invalid error marks the record as invalid", fun
 
 test("Repeated failed saves with invalid error without payload marks the record as invalid", function(assert) {
   assert.expect(2);
-  var post;
-
-  run(function() {
-    post = env.store.createRecord('post', { title: 'toto' });
-  });
+  let post = env.store.createRecord('post', { title: 'toto' });
 
   env.adapter.createRecord = function(store, type, snapshot) {
     var error = new DS.InvalidError();
@@ -177,10 +156,7 @@ test("Repeated failed saves with invalid error without payload marks the record 
 
 test("Will reject save on invalid", function(assert) {
   assert.expect(1);
-  var post;
-  run(function() {
-    post = env.store.createRecord('post', { title: 'toto' });
-  });
+  let post = env.store.createRecord('post', { title: 'toto' });
 
   env.adapter.createRecord = function(store, type, snapshot) {
     var error = new DS.InvalidError([{ title: 'not valid' }]);

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -499,11 +499,10 @@ test("polymorphic belongsTo class-checks check the superclass when MODEL_FACTORY
 test("the subclass in a polymorphic belongsTo relationship is an instanceof its superclass", function(assert) {
   setupModelFactoryInjections(false);
   assert.expect(1);
-  run(() => {
-    let message = env.store.createRecord('message', { id: 1 });
-    let comment = env.store.createRecord('comment', { id: 2, message: message });
-    assert.ok(comment instanceof Message, 'a comment is an instance of a message');
-  });
+
+  let message = env.store.createRecord('message', { id: 1 });
+  let comment = env.store.createRecord('comment', { id: 2, message: message });
+  assert.ok(comment instanceof Message, 'a comment is an instance of a message');
 });
 
 test("relationshipsByName does not cache a factory", function(assert) {
@@ -969,16 +968,13 @@ test("Model's belongsTo relationship should not be created during model creation
 });
 
 test("Model's belongsTo relationship should be created during model creation if relationship passed in constructor", function(assert) {
-  let user, message;
-
-  run(() => {
-    message = env.store.createRecord('message');
-    user = env.store.createRecord('user', {
-      name: 'John Doe',
-      favouriteMessage: message
-    });
-    assert.ok(user._internalModel._relationships.has('favouriteMessage'), "Newly created record with relationships in params passed in its constructor should have relationships");
+  let message = env.store.createRecord('message');
+  let user = env.store.createRecord('user', {
+    name: 'John Doe',
+    favouriteMessage: message
   });
+
+  assert.ok(user._internalModel._relationships.has('favouriteMessage'), "Newly created record with relationships in params passed in its constructor should have relationships");
 });
 
 test("Model's belongsTo relationship should be created during 'set' method", function(assert) {

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -1515,13 +1515,10 @@ test("Polymorphic relationships with a hasMany is set up correctly on both sides
   Post.reopen({
     contact: DS.belongsTo('contact', { polymorphic: true, async: false })
   });
-  let email, post;
 
-  run(function () {
-    email = env.store.createRecord('email');
-    post = env.store.createRecord('post', {
-      contact: email
-    });
+  let email = env.store.createRecord('email');
+  let post = env.store.createRecord('post', {
+    contact: email
   });
 
   assert.equal(post.get('contact'), email, 'The polymorphic belongsTo is set up correctly');
@@ -1696,11 +1693,7 @@ test("A record can be removed from a polymorphic association", function(assert) 
 test("When a record is created on the client, its hasMany arrays should be in a loaded state", function(assert) {
   assert.expect(3);
 
-  let post;
-
-  run(function() {
-    post = env.store.createRecord('post');
-  });
+  let post = env.store.createRecord('post');
 
   assert.ok(get(post, 'isLoaded'), "The post should have isLoaded flag");
   let comments;
@@ -1720,9 +1713,7 @@ test("When a record is created on the client, its async hasMany arrays should be
     comments: DS.hasMany('comment', { async: true })
   });
 
-  let post = run(function() {
-    return env.store.createRecord('post');
-  });
+  let post = env.store.createRecord('post');
 
   assert.ok(get(post, 'isLoaded'), "The post should have isLoaded flag");
 
@@ -1737,9 +1728,8 @@ test("When a record is created on the client, its async hasMany arrays should be
 
 test("we can set records SYNC HM relationship", function(assert) {
   assert.expect(1);
-  let post = run(function() {
-    return env.store.createRecord('post');
-  });
+  let post = env.store.createRecord('post');
+
   run(function() {
     env.store.push({
       data: [{
@@ -1768,9 +1758,8 @@ test("We can set records ASYNC HM relationship", function(assert) {
     comments: DS.hasMany('comment', { async: true })
   });
 
-  let post = run(function() {
-    return env.store.createRecord('post');
-  });
+  let post = env.store.createRecord('post');
+
   run(function() {
     env.store.push({
       data: [{
@@ -2773,40 +2762,36 @@ test("hasMany hasData async created", function(assert) {
     pages: hasMany('pages', { async: true })
   });
 
-  run(() => {
-    let chapter = store.createRecord('chapter', { title: 'The Story Begins' });
-    let page = store.createRecord('page');
+  let chapter = store.createRecord('chapter', { title: 'The Story Begins' });
+  let page = store.createRecord('page');
 
-    let relationship = chapter._internalModel._relationships.get('pages');
-    assert.equal(relationship.hasData, false, 'relationship does not have data');
+  let relationship = chapter._internalModel._relationships.get('pages');
+  assert.equal(relationship.hasData, false, 'relationship does not have data');
 
-    chapter = store.createRecord('chapter', {
-      title: 'The Story Begins',
-      pages: [page]
-    });
-
-    relationship = chapter._internalModel._relationships.get('pages');
-    assert.equal(relationship.hasData, true, 'relationship has data');
+  chapter = store.createRecord('chapter', {
+    title: 'The Story Begins',
+    pages: [page]
   });
+
+  relationship = chapter._internalModel._relationships.get('pages');
+  assert.equal(relationship.hasData, true, 'relationship has data');
 });
 
 test("hasMany hasData sync created", function(assert) {
   assert.expect(2);
 
-  run(() => {
-    let chapter = store.createRecord('chapter', { title: 'The Story Begins' });
-    let relationship = chapter._internalModel._relationships.get('pages');
+  let chapter = store.createRecord('chapter', { title: 'The Story Begins' });
+  let relationship = chapter._internalModel._relationships.get('pages');
 
-    assert.equal(relationship.hasData, false, 'relationship does not have data');
+  assert.equal(relationship.hasData, false, 'relationship does not have data');
 
-    chapter = store.createRecord('chapter', {
-      title: 'The Story Begins',
-      pages: [store.createRecord('page')]
-    });
-    relationship = chapter._internalModel._relationships.get('pages');
-
-    assert.equal(relationship.hasData, true, 'relationship has data');
+  chapter = store.createRecord('chapter', {
+    title: 'The Story Begins',
+    pages: [store.createRecord('page')]
   });
+  relationship = chapter._internalModel._relationships.get('pages');
+
+  assert.equal(relationship.hasData, true, 'relationship has data');
 });
 
 test("Model's hasMany relationship should not be created during model creation", function(assert) {

--- a/tests/integration/relationships/inverse-relationships-test.js
+++ b/tests/integration/relationships/inverse-relationships-test.js
@@ -28,12 +28,9 @@ test("When a record is added to a has-many relationship, the inverse belongsTo i
 
   var env = setupStore({ post: Post, comment: Comment });
   var store = env.store;
-  var comment, post;
 
-  run(function() {
-    comment = store.createRecord('comment');
-    post = store.createRecord('post');
-  });
+  let comment = store.createRecord('comment');
+  let post = store.createRecord('post');
 
   assert.equal(comment.get('post'), null, "no post has been set on the comment");
 
@@ -59,12 +56,9 @@ test("Inverse relationships can be explicitly nullable", function(assert) {
     user: User,
     post: Post
   });
-  var user, post;
 
-  run(function() {
-    user = store.createRecord('user');
-    post = store.createRecord('post');
-  });
+  let user = store.createRecord('user');
+  let post = store.createRecord('post');
 
   assert.equal(user.inverseFor('posts').name, 'participants', 'User.posts inverse is Post.participants');
   assert.equal(post.inverseFor('lastParticipant'), null, 'Post.lastParticipant has no inverse');
@@ -87,12 +81,9 @@ test("Null inverses are excluded from potential relationship resolutions", funct
     user: User,
     post: Post
   });
-  let user, post;
 
-  run(function() {
-    user = store.createRecord('user');
-    post = store.createRecord('post');
-  });
+  let user = store.createRecord('user');
+  let post = store.createRecord('post');
 
   assert.equal(user.inverseFor('posts').name, 'participants', 'User.posts inverse is Post.participants');
   assert.equal(post.inverseFor('lastParticipant'), null, 'Post.lastParticipant has no inverse');
@@ -113,12 +104,9 @@ test("When a record is added to a has-many relationship, the inverse belongsTo c
 
   var env = setupStore({ post: Post, comment: Comment });
   var store = env.store;
-  var comment, post;
 
-  run(function() {
-    comment = store.createRecord('comment');
-    post = store.createRecord('post');
-  });
+  let comment = store.createRecord('comment');
+  let post = store.createRecord('post');
 
   assert.equal(comment.get('onePost'), null, "onePost has not been set on the comment");
   assert.equal(comment.get('twoPost'), null, "twoPost has not been set on the comment");
@@ -179,13 +167,11 @@ test("When setting a belongsTo, the OneToOne invariant is respected even when ot
 
   var env = setupStore({ post: Post, comment: Comment });
   var store = env.store;
-  var comment, post, post2;
 
-  run(function() {
-    comment = store.createRecord('comment');
-    post = store.createRecord('post');
-    post2 = store.createRecord('post');
-  });
+  let comment = store.createRecord('comment');
+  let post = store.createRecord('post');
+  let post2 = store.createRecord('post');
+
   run(function() {
     comment.set('post', post);
     post2.set('bestComment', null);
@@ -217,13 +203,10 @@ test("When setting a belongsTo, the OneToOne invariant is transitive", function(
     post: Post,
     comment: Comment
   });
-  var post, post2, comment;
 
-  run(function() {
-    comment = store.createRecord('comment');
-    post = store.createRecord('post');
-    post2 = store.createRecord('post');
-  });
+  let comment = store.createRecord('comment');
+  let post = store.createRecord('post');
+  let post2 = store.createRecord('post');
 
   run(function() {
     comment.set('post', post);
@@ -255,13 +238,12 @@ test("When setting a belongsTo, the OneToOne invariant is commutative", function
     post: Post,
     comment: Comment
   });
-  var post, comment, comment2;
+
+  let post = store.createRecord('post');
+  let comment = store.createRecord('comment');
+  let comment2 = store.createRecord('comment');
 
   run(function() {
-    post = store.createRecord('post');
-    comment = store.createRecord('comment');
-    comment2 = store.createRecord('comment');
-
     comment.set('post', post);
   });
 
@@ -290,13 +272,10 @@ test("OneToNone relationship works", function(assert) {
 
   var env = setupStore({ post: Post, comment: Comment });
   var store = env.store;
-  var comment, post1, post2;
 
-  run(function() {
-    comment = store.createRecord('comment');
-    post1 = store.createRecord('post');
-    post2 = store.createRecord('post');
-  });
+  let comment = store.createRecord('comment');
+  let post1 = store.createRecord('post');
+  let post2 = store.createRecord('post');
 
   run(function() {
     comment.set('post', post1);
@@ -335,12 +314,9 @@ test("When a record is added to or removed from a polymorphic has-many relations
 
   var env = setupStore({ user: User, message: Message, post: Post });
   var store = env.store;
-  var post, user;
 
-  run(function() {
-    post = store.createRecord('post');
-    user = store.createRecord('user');
-  });
+  let post = store.createRecord('post');
+  let user = store.createRecord('user');
 
   assert.equal(post.get('oneUser'), null, "oneUser has not been set on the user");
   assert.equal(post.get('twoUser'), null, "twoUser has not been set on the user");
@@ -381,16 +357,15 @@ test("When a record's belongsTo relationship is set, it can specify the inverse 
 
   var env = setupStore({ user: User, message: Message, post: Post });
   var store = env.store;
-  var user, post;
+
+  let user = store.createRecord('user');
+  let post = store.createRecord('post');
+
+  assert.equal(user.get('meMessages.length'), 0, "meMessages has no posts");
+  assert.equal(user.get('youMessages.length'), 0, "youMessages has no posts");
+  assert.equal(user.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
 
   run(function() {
-    user = store.createRecord('user');
-    post = store.createRecord('post');
-
-    assert.equal(user.get('meMessages.length'), 0, "meMessages has no posts");
-    assert.equal(user.get('youMessages.length'), 0, "youMessages has no posts");
-    assert.equal(user.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
-
     post.set('user', user);
   });
 
@@ -426,16 +401,15 @@ test("When a record's polymorphic belongsTo relationship is set, it can specify 
 
   var env = setupStore({ comment: Comment, message: Message, post: Post });
   var store = env.store;
-  var comment, post;
+
+  let comment = store.createRecord('comment');
+  let post = store.createRecord('post');
+
+  assert.equal(post.get('meMessages.length'), 0, "meMessages has no posts");
+  assert.equal(post.get('youMessages.length'), 0, "youMessages has no posts");
+  assert.equal(post.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
 
   run(function() {
-    comment = store.createRecord('comment');
-    post = store.createRecord('post');
-
-    assert.equal(post.get('meMessages.length'), 0, "meMessages has no posts");
-    assert.equal(post.get('youMessages.length'), 0, "youMessages has no posts");
-    assert.equal(post.get('everyoneWeKnowMessages.length'), 0, "everyoneWeKnowMessages has no posts");
-
     comment.set('message', post);
   });
 
@@ -462,9 +436,8 @@ testInDebug("Inverse relationships that don't exist throw a nice error for a has
 
   var env = setupStore({ post: Post, comment: Comment, user: User });
   var post;
-  run(function() {
-    env.store.createRecord('comment');
-  });
+
+  env.store.createRecord('comment');
 
   assert.expectAssertion(function() {
     run(function() {
@@ -484,9 +457,7 @@ testInDebug("Inverse relationships that don't exist throw a nice error for a bel
 
   var env = setupStore({ post: Post, comment: Comment, user: User });
   var post;
-  run(function() {
-    env.store.createRecord('user');
-  });
+  env.store.createRecord('user');
 
   assert.expectAssertion(function() {
     run(function() {
@@ -641,9 +612,9 @@ testInDebug("Inverse null relationships with models that don't exist throw a nic
   let env = setupStore({ user: User });
 
   assert.expectAssertion(() => {
-    run(() => env.store.createRecord('user', { post: {}}));
+    env.store.createRecord('user', { post: {}});
   }, /No model was found for/)
 
   // but don't error if the relationship is not used
-  run(() => env.store.createRecord('user', {}));
+  env.store.createRecord('user', {});
 });

--- a/tests/integration/relationships/one-to-many-test.js
+++ b/tests/integration/relationships/one-to-many-test.js
@@ -1477,7 +1477,7 @@ test("createRecord updates inverse record array which has observers", function(a
     user.addObserver('messages.@each.title', () => {});
     user.get('messages.firstObject');
 
-    let message = run(() => store.createRecord('message', { user, title: 'EmberFest was great' }));
+    let message = store.createRecord('message', { user, title: 'EmberFest was great' });
     assert.equal(user.get('messages.length'), 1, 'The message is added to the record array');
 
     let messageFromArray = user.get('messages.firstObject');

--- a/tests/integration/serializers/embedded-records-mixin-test.js
+++ b/tests/integration/serializers/embedded-records-mixin-test.js
@@ -8,9 +8,8 @@ import { module, test } from 'qunit';
 
 import DS from 'ember-data';
 
-var HomePlanet, SuperVillain, CommanderVillain, NormalMinion, EvilMinion, YellowMinion, RedMinion, SecretLab, SecretWeapon, BatCave, Comment,
-  league, superVillain, commanderVillain, evilMinion, yellowMinion, redMinion, secretWeapon, homePlanet, secretLab, env;
-var LightSaber;
+var HomePlanet, SuperVillain, CommanderVillain, NormalMinion, EvilMinion, YellowMinion, RedMinion,
+  SecretLab, SecretWeapon, BatCave, Comment, env, LightSaber;
 
 module("integration/embedded_records_mixin - EmbeddedRecordsMixin", {
   beforeEach() {
@@ -862,10 +861,7 @@ test("normalizeResponse with embedded objects of same type, but from separate at
 });
 
 test("serialize supports serialize:false on non-relationship properties", function(assert) {
-  var tom;
-  run(function() {
-    tom = env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", id: '1' });
-  });
+  let tom = env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", id: '1' });
 
   env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -886,11 +882,8 @@ test("serialize supports serialize:false on non-relationship properties", functi
 });
 
 test("serialize with embedded objects (hasMany relationship)", function(assert) {
-  var tom, league;
-  run(function() {
-    league = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
-    tom = env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
-  });
+  let league = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
+  let tom = env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
 
   env.registry.register('serializer:home-planet', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -918,11 +911,8 @@ test("serialize with embedded objects (hasMany relationship)", function(assert) 
 });
 
 test("serialize with embedded objects and a custom keyForAttribute (hasMany relationship)", function(assert) {
-  var tom, league;
-  run(function() {
-    league = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
-    tom = env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
-  });
+  let league = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
+  let tom = env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
 
   env.registry.register('serializer:home-planet', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     keyForRelationship(key) {
@@ -988,10 +978,8 @@ testInDebug("serialize with embedded objects (unknown hasMany relationship)", fu
 });
 
 test("serialize with embedded objects (hasMany relationship) supports serialize:false", function(assert) {
-  run(function() {
-    league = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
-    env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
-  });
+  let league = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
+  env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", homePlanet: league, id: '1' });
 
   env.registry.register('serializer:home-planet', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -1011,10 +999,8 @@ test("serialize with embedded objects (hasMany relationship) supports serialize:
 });
 
 test("serialize with (new) embedded objects (hasMany relationship)", function(assert) {
-  run(function() {
-    league = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
-    env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", homePlanet: league });
-  });
+  let league = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
+  env.store.createRecord('super-villain', { firstName: "Tom", lastName: "Dale", homePlanet: league });
 
   env.registry.register('serializer:home-planet', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -1039,10 +1025,11 @@ test("serialize with (new) embedded objects (hasMany relationship)", function(as
 });
 
 test("serialize with embedded objects (hasMany relationships, including related objects not embedded)", function(assert) {
+  let superVillain = env.store.createRecord('super-villain', { id: 1, firstName: "Super", lastName: "Villian" });
+  let evilMinion = env.store.createRecord('evil-minion', { id: 1, name: "Evil Minion", superVillian: superVillain });
+  let secretWeapon = env.store.createRecord('secret-weapon', { id: 1, name: "Secret Weapon", superVillain: superVillain });
+
   run(function() {
-    superVillain = env.store.createRecord('super-villain', { id: 1, firstName: "Super", lastName: "Villian" });
-    evilMinion = env.store.createRecord('evil-minion', { id: 1, name: "Evil Minion", superVillian: superVillain });
-    secretWeapon = env.store.createRecord('secret-weapon', { id: 1, name: "Secret Weapon", superVillain: superVillain });
     superVillain.get('evilMinions').pushObject(evilMinion);
     superVillain.get('secretWeapons').pushObject(secretWeapon);
   });
@@ -1074,11 +1061,9 @@ test("serialize with embedded objects (hasMany relationships, including related 
 });
 
 test("serialize has many relationship using the `ids-and-types` strategy", function(assert) {
-  run(function() {
-    yellowMinion = env.store.createRecord('yellow-minion', { id: 1, name: "Yellowy" });
-    redMinion = env.store.createRecord('red-minion', { id: 1, name: "Reddy" });
-    commanderVillain = env.store.createRecord('commander-villain', { id: 1, name: "Jeff", minions: [yellowMinion, redMinion] });
-  });
+  let yellowMinion = env.store.createRecord('yellow-minion', { id: 1, name: "Yellowy" });
+  let redMinion = env.store.createRecord('red-minion', { id: 1, name: "Reddy" });
+  let commanderVillain = env.store.createRecord('commander-villain', { id: 1, name: "Jeff", minions: [yellowMinion, redMinion] });
 
   env.registry.register('serializer:commander-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -1128,11 +1113,7 @@ test("normalizeResponse with embedded object (belongsTo relationship)", function
       secretWeapons: []
     }
   };
-  var json;
-
-  run(function() {
-    json = serializer.normalizeResponse(env.store, SuperVillain, json_hash, '1', 'findRecord');
-  });
+  let json = serializer.normalizeResponse(env.store, SuperVillain, json_hash, '1', 'findRecord');
 
   assert.deepEqual(json, {
     "data": {
@@ -1179,24 +1160,17 @@ test("serialize with embedded object (belongsTo relationship)", function(assert)
       secretLab: { embedded: 'always' }
     }
   }));
-  var serializer, json, tom;
-  run(function() {
-    serializer = env.store.serializerFor("super-villain");
 
-    // records with an id, persisted
+  // records with an id, persisted
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
 
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
-
-  run(function() {
-    json = serializer.serialize(tom._createSnapshot());
-  });
+  let json = env.store.serializerFor("super-villain").serialize(tom._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1221,31 +1195,26 @@ test("serialize with embedded object (polymorphic belongsTo relationship)", func
     secretLab: DS.belongsTo('secret-lab', { polymorphic: true })
   });
 
-  var json, tom;
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      {
-        id: "1",
-        firstName: "Tom",
-        lastName: "Dale",
-        secretLab: env.store.createRecord('bat-cave', {
-          id: "101",
-          minionCapacity: 5000,
-          vicinity: "California, USA",
-          infiltrated: true
-        }),
-        homePlanet: env.store.createRecord('home-planet', {
-          id: "123",
-          name: "Villain League"
-        })
-      }
-    );
-  });
+  let tom = env.store.createRecord(
+    'super-villain',
+    {
+      id: "1",
+      firstName: "Tom",
+      lastName: "Dale",
+      secretLab: env.store.createRecord('bat-cave', {
+        id: "101",
+        minionCapacity: 5000,
+        vicinity: "California, USA",
+        infiltrated: true
+      }),
+      homePlanet: env.store.createRecord('home-planet', {
+        id: "123",
+        name: "Villain League"
+      })
+    }
+  );
 
-  run(function() {
-    json = tom.serialize();
-  });
+  let json = tom.serialize();
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1275,21 +1244,15 @@ test("serialize with embedded object (belongsTo relationship) works with differe
   var serializer = env.store.serializerFor("super-villain");
 
   // records with an id, persisted
-  var tom, json;
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
 
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
-
-  run(function() {
-    json = serializer.serialize(tom._createSnapshot());
-  });
+  let json = serializer.serialize(tom._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1313,21 +1276,14 @@ test("serialize with embedded object (belongsTo relationship, new no id)", funct
   var serializer = env.store.serializerFor("super-villain");
 
   // records without ids, new
-  var tom, json;
-
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale",
-        secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
-
-  run(function() {
-    json = serializer.serialize(tom._createSnapshot());
-  });
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale",
+      secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
+  let json = serializer.serialize(tom._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1351,20 +1307,15 @@ test("serialize with embedded object (polymorphic belongsTo relationship) suppor
     }
   }));
 
-  var tom, json;
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord('bat-cave', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord('bat-cave', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
 
-  run(function() {
-    json = tom.serialize();
-  });
+  let json = tom.serialize();
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1386,20 +1337,15 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
     }
   }));
 
-  var tom, json;
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord('bat-cave', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord('bat-cave', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
 
-  run(function() {
-    json = tom.serialize();
-  });
+  let json = tom.serialize();
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1421,20 +1367,15 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
     }
   }));
 
-  var tom, json;
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord('bat-cave', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord('bat-cave', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
 
-  run(function() {
-    json = tom.serialize();
-  });
+  let json = tom.serialize();
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1454,21 +1395,15 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
   var serializer = env.store.serializerFor("super-villain");
 
   // records with an id, persisted
-  var tom, json;
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
 
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
-
-  run(function() {
-    json = serializer.serialize(tom._createSnapshot());
-  });
+  let json = serializer.serialize(tom._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1488,21 +1423,14 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
   var serializer = env.store.serializerFor("super-villain");
 
   // records with an id, persisted
-  var tom, json;
-
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
-
-  run(function() {
-    json = serializer.serialize(tom._createSnapshot());
-  });
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
+  let json = serializer.serialize(tom._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1522,21 +1450,14 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
   var serializer = env.store.serializerFor("super-villain");
 
   // records with an id, persisted
-  var tom, json;
-
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
-
-  run(function() {
-    json = serializer.serialize(tom._createSnapshot());
-  });
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
+  let json = serializer.serialize(tom._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1556,20 +1477,14 @@ test("serialize with embedded object (belongsTo relationship) supports serialize
 
 
   // records with an id, persisted
-  var tom, json;
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
-
-  run(function() {
-    json = serializer.serialize(tom._createSnapshot());
-  });
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
+  let json = serializer.serialize(tom._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1583,22 +1498,14 @@ test("serialize with embedded object (belongsTo relationship) serializes the id 
   var serializer = env.store.serializerFor("super-villain");
 
   // records with an id, persisted
-
-  var tom, json;
-
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
-
-  run(function() {
-    json = serializer.serialize(tom._createSnapshot());
-  });
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      secretLab: env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" }),
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
+  let json = serializer.serialize(tom._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1615,20 +1522,13 @@ test("when related record is not present, serialize embedded record (with a belo
     }
   }));
   var serializer = env.store.serializerFor("super-villain");
-  var tom, json;
-
-  run(function() {
-    tom = env.store.createRecord(
-      'super-villain',
-      { firstName: "Tom", lastName: "Dale", id: "1",
-        homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
-      }
-    );
-  });
-
-  run(function() {
-    json = serializer.serialize(tom._createSnapshot());
-  });
+  let tom = env.store.createRecord(
+    'super-villain',
+    { firstName: "Tom", lastName: "Dale", id: "1",
+      homePlanet: env.store.createRecord('home-planet', { name: "Villain League", id: "123" })
+    }
+  );
+  let json = serializer.serialize(tom._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(tom, "firstName"),
@@ -1998,13 +1898,15 @@ test("normalizeResponse with polymorphic belongsTo and custom primary key", func
 });
 
 test("Mixin can be used with RESTSerializer which does not define keyForAttribute", function(assert) {
+  let homePlanet = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
+  let secretLab = env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" });
+  let superVillain = env.store.createRecord('super-villain', {
+    id: "1", firstName: "Super", lastName: "Villian", homePlanet: homePlanet, secretLab: secretLab
+  });
+  let secretWeapon = env.store.createRecord('secret-weapon', { id: "1", name: "Secret Weapon", superVillain: superVillain });
+  let evilMinion;
+
   run(function() {
-    homePlanet = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
-    secretLab = env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" });
-    superVillain = env.store.createRecord('super-villain', {
-      id: "1", firstName: "Super", lastName: "Villian", homePlanet: homePlanet, secretLab: secretLab
-    });
-    secretWeapon = env.store.createRecord('secret-weapon', { id: "1", name: "Secret Weapon", superVillain: superVillain });
     superVillain.get('secretWeapons').pushObject(secretWeapon);
     evilMinion = env.store.createRecord('evil-minion', { id: "1", name: "Evil Minion", superVillian: superVillain });
     superVillain.get('evilMinions').pushObject(evilMinion);
@@ -2015,12 +1917,8 @@ test("Mixin can be used with RESTSerializer which does not define keyForAttribut
       evilMinions: { serialize: 'records', deserialize: 'records' }
     }
   }));
-  var serializer = env.store.serializerFor("super-villain");
-  var json;
-
-  run(function() {
-    json = serializer.serialize(superVillain._createSnapshot());
-  });
+  let serializer = env.store.serializerFor("super-villain");
+  let json = serializer.serialize(superVillain._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(superVillain, "firstName"),
@@ -2091,13 +1989,15 @@ test("normalize with custom belongsTo primary key", function(assert) {
 });
 
 test("serializing relationships with an embedded and without calls super when not attr not present", function(assert) {
+  let homePlanet = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
+  let secretLab = env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" });
+  let superVillain = env.store.createRecord('super-villain', {
+    id: "1", firstName: "Super", lastName: "Villian", homePlanet: homePlanet, secretLab: secretLab
+  });
+  let secretWeapon = env.store.createRecord('secret-weapon', { id: "1", name: "Secret Weapon", superVillain: superVillain });
+  let evilMinion;
+
   run(function() {
-    homePlanet = env.store.createRecord('home-planet', { name: "Villain League", id: "123" });
-    secretLab = env.store.createRecord('secret-lab', { minionCapacity: 5000, vicinity: "California, USA", id: "101" });
-    superVillain = env.store.createRecord('super-villain', {
-      id: "1", firstName: "Super", lastName: "Villian", homePlanet: homePlanet, secretLab: secretLab
-    });
-    secretWeapon = env.store.createRecord('secret-weapon', { id: "1", name: "Secret Weapon", superVillain: superVillain });
     superVillain.get('secretWeapons').pushObject(secretWeapon);
     evilMinion = env.store.createRecord('evil-minion', { id: "1", name: "Evil Minion", superVillian: superVillain });
     superVillain.get('evilMinions').pushObject(evilMinion);
@@ -2132,12 +2032,8 @@ test("serializing relationships with an embedded and without calls super when no
       // e.g. secretWeapons: { serialize: 'ids' }
     }
   }));
-  var serializer = env.store.serializerFor("super-villain");
-
-  var json;
-  run(function() {
-    json = serializer.serialize(superVillain._createSnapshot());
-  });
+  let serializer = env.store.serializerFor("super-villain");
+  let json = serializer.serialize(superVillain._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: get(superVillain, "firstName"),
@@ -2165,10 +2061,8 @@ test("serializing belongsTo correctly removes embedded foreign key", function(as
     superVillain: null
   });
 
-  run(function() {
-    secretWeapon = env.store.createRecord('secret-weapon', { name: "Secret Weapon" });
-    evilMinion = env.store.createRecord('evil-minion', { name: "Evil Minion", secretWeapon: secretWeapon });
-  });
+  let secretWeapon = env.store.createRecord('secret-weapon', { name: "Secret Weapon" });
+  let evilMinion = env.store.createRecord('evil-minion', { name: "Evil Minion", secretWeapon: secretWeapon });
 
   env.registry.register('serializer:evil-minion', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -2176,12 +2070,8 @@ test("serializing belongsTo correctly removes embedded foreign key", function(as
     }
   }));
 
-  var serializer = env.store.serializerFor("evil-minion");
-  var json;
-
-  run(function() {
-    json = serializer.serialize(evilMinion._createSnapshot());
-  });
+  let serializer = env.store.serializerFor("evil-minion");
+  let json = serializer.serialize(evilMinion._createSnapshot());
 
   assert.deepEqual(json, {
     name: "Evil Minion",
@@ -2193,10 +2083,8 @@ test("serializing belongsTo correctly removes embedded foreign key", function(as
 
 
 test("serializing embedded belongsTo respects remapped attrs key", function(assert) {
-  run(function() {
-    homePlanet = env.store.createRecord('home-planet', { name: "Hoth" });
-    superVillain = env.store.createRecord('super-villain', { firstName: "Ice", lastName: "Creature", homePlanet: homePlanet });
-  });
+  let homePlanet = env.store.createRecord('home-planet', { name: "Hoth" });
+  let superVillain = env.store.createRecord('super-villain', { firstName: "Ice", lastName: "Creature", homePlanet: homePlanet });
 
   env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -2204,12 +2092,8 @@ test("serializing embedded belongsTo respects remapped attrs key", function(asse
     }
   }));
 
-  var serializer = env.store.serializerFor("super-villain");
-  var json;
-
-  run(function() {
-    json = serializer.serialize(superVillain._createSnapshot());
-  });
+  let serializer = env.store.serializerFor("super-villain");
+  let json = serializer.serialize(superVillain._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: "Ice",
@@ -2222,10 +2106,8 @@ test("serializing embedded belongsTo respects remapped attrs key", function(asse
 });
 
 test("serializing embedded hasMany respects remapped attrs key", function(assert) {
-  run(function() {
-    homePlanet = env.store.createRecord('home-planet', { name: "Hoth" });
-    superVillain = env.store.createRecord('super-villain', { firstName: "Ice", lastName: "Creature", homePlanet: homePlanet });
-  });
+  let homePlanet = env.store.createRecord('home-planet', { name: "Hoth" });
+  env.store.createRecord('super-villain', { firstName: "Ice", lastName: "Creature", homePlanet: homePlanet });
 
   env.registry.register('serializer:home-planet', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -2240,13 +2122,8 @@ test("serializing embedded hasMany respects remapped attrs key", function(assert
     }
   }));
 
-
-  var serializer = env.store.serializerFor("home-planet");
-  var json;
-
-  run(function() {
-    json = serializer.serialize(homePlanet._createSnapshot());
-  });
+  let serializer = env.store.serializerFor("home-planet");
+  let json = serializer.serialize(homePlanet._createSnapshot());
 
   assert.deepEqual(json, {
     name: "Hoth",
@@ -2258,10 +2135,8 @@ test("serializing embedded hasMany respects remapped attrs key", function(assert
 });
 
 test("serializing id belongsTo respects remapped attrs key", function(assert) {
-  run(function() {
-    homePlanet = env.store.createRecord('home-planet', { name: "Hoth" });
-    superVillain = env.store.createRecord('super-villain', { firstName: "Ice", lastName: "Creature", homePlanet: homePlanet });
-  });
+  let homePlanet = env.store.createRecord('home-planet', { name: "Hoth" });
+  let superVillain = env.store.createRecord('super-villain', { firstName: "Ice", lastName: "Creature", homePlanet: homePlanet });
 
   env.registry.register('serializer:super-villain', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -2269,12 +2144,8 @@ test("serializing id belongsTo respects remapped attrs key", function(assert) {
     }
   }));
 
-  var serializer = env.store.serializerFor("super-villain");
-  var json;
-
-  run(function() {
-    json = serializer.serialize(superVillain._createSnapshot());
-  });
+  let serializer = env.store.serializerFor("super-villain");
+  let json = serializer.serialize(superVillain._createSnapshot());
 
   assert.deepEqual(json, {
     firstName: "Ice",
@@ -2285,10 +2156,8 @@ test("serializing id belongsTo respects remapped attrs key", function(assert) {
 });
 
 test("serializing ids hasMany respects remapped attrs key", function(assert) {
-  run(function() {
-    homePlanet = env.store.createRecord('home-planet', { name: "Hoth" });
-    superVillain = env.store.createRecord('super-villain', { firstName: "Ice", lastName: "Creature", homePlanet: homePlanet });
-  });
+  let homePlanet = env.store.createRecord('home-planet', { name: "Hoth" });
+  let superVillain = env.store.createRecord('super-villain', { firstName: "Ice", lastName: "Creature", homePlanet: homePlanet });
 
   env.registry.register('serializer:home-planet', DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
@@ -2303,13 +2172,8 @@ test("serializing ids hasMany respects remapped attrs key", function(assert) {
     }
   }));
 
-
-  var serializer = env.store.serializerFor("home-planet");
-  var json;
-
-  run(function() {
-    json = serializer.serialize(homePlanet._createSnapshot());
-  });
+  let serializer = env.store.serializerFor("home-planet");
+  let json = serializer.serialize(homePlanet._createSnapshot());
 
   assert.deepEqual(json, {
     name: "Hoth",

--- a/tests/integration/serializers/json-api-serializer-test.js
+++ b/tests/integration/serializers/json-api-serializer-test.js
@@ -314,13 +314,9 @@ test('Serializer should respect the attrs hash when serializing attributes with 
       'company-name': 'company_name'
     }
   }));
-  var project;
 
-  run(function() {
-    project = env.store.createRecord('project', { 'company-name': 'Tilde Inc.' });
-  });
-
-  var payload = env.store.serializerFor('project').serialize(project._createSnapshot());
+  let project = env.store.createRecord('project', { 'company-name': 'Tilde Inc.' });
+  let payload = env.store.serializerFor('project').serialize(project._createSnapshot());
 
   assert.equal(payload.data.attributes['company_name'], 'Tilde Inc.');
 });
@@ -340,10 +336,7 @@ test('options are passed to transform for serialization', function(assert) {
     })
   });
 
-  var user;
-  run(function() {
-    user = env.store.createRecord('user', { myCustomField: 'value' });
-  });
+  let user = env.store.createRecord('user', { myCustomField: 'value' });
 
   env.store.serializerFor('user').serialize(user._createSnapshot());
 });

--- a/tests/integration/serializers/json-serializer-test.js
+++ b/tests/integration/serializers/json-serializer-test.js
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 
 import DS from 'ember-data';
 
-var Post, post, Comment, comment, Favorite, favorite, env, serializer;
+var Post, Comment, Favorite, env, serializer;
 
 module("integration/serializer/json - JSONSerializer", {
   beforeEach() {
@@ -39,9 +39,7 @@ module("integration/serializer/json - JSONSerializer", {
 });
 
 test("serialize doesn't include ID when includeId is false", function(assert) {
-  run(() => {
-    post = env.store.createRecord('post', { title: 'Rails is omakase', comments: [] });
-  });
+  let post = env.store.createRecord('post', { title: 'Rails is omakase', comments: [] });
   let json = serializer.serialize(post._createSnapshot(), { includeId: false });
 
   assert.deepEqual(json, {
@@ -52,10 +50,7 @@ test("serialize doesn't include ID when includeId is false", function(assert) {
 
 
 test("serialize doesn't include relationship if not aware of one", function(assert) {
-  run(() => {
-    post = env.store.createRecord('post', { title: 'Rails is omakase' });
-  });
-
+  let post = env.store.createRecord('post', { title: 'Rails is omakase' });
   let json = serializer.serialize(post._createSnapshot());
 
   assert.deepEqual(json, {
@@ -64,8 +59,9 @@ test("serialize doesn't include relationship if not aware of one", function(asse
 });
 
 test("serialize includes id when includeId is true", function(assert) {
+  let post = env.store.createRecord('post', { title: 'Rails is omakase', comments: [] });
+
   run(() => {
-    post = env.store.createRecord('post', { title: 'Rails is omakase', comments: [] });
     post.set('id', 'test');
   });
 
@@ -79,10 +75,8 @@ test("serialize includes id when includeId is true", function(assert) {
 });
 
 test("serializeAttribute", function(assert) {
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
-  });
-  var json = {};
+  let post = env.store.createRecord('post', { title: "Rails is omakase" });
+  let json = {};
 
   serializer.serializeAttribute(post._createSnapshot(), json, "title", { type: "string" });
 
@@ -98,10 +92,8 @@ test("serializeAttribute respects keyForAttribute", function(assert) {
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
-  });
-  var json = {};
+  let post = env.store.createRecord('post', { title: "Rails is omakase" });
+  let json = {};
 
   env.store.serializerFor("post").serializeAttribute(post._createSnapshot(), json, "title", { type: "string" });
 
@@ -109,12 +101,9 @@ test("serializeAttribute respects keyForAttribute", function(assert) {
 });
 
 test("serializeBelongsTo", function(assert) {
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase", id: "1" });
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
-  });
-
-  var json = {};
+  let post = env.store.createRecord('post', { title: "Rails is omakase", id: "1" });
+  let comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
+  let json = {};
 
   serializer.serializeBelongsTo(comment._createSnapshot(), json, { key: "post", options: {} });
 
@@ -122,10 +111,8 @@ test("serializeBelongsTo", function(assert) {
 });
 
 test("serializeBelongsTo with null", function(assert) {
-  run(function() {
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: null });
-  });
-  var json = {};
+  let comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: null });
+  let json = {};
 
   serializer.serializeBelongsTo(comment._createSnapshot(), json, { key: "post", options: {} });
 
@@ -138,10 +125,8 @@ test("async serializeBelongsTo with null", function(assert) {
   Comment.reopen({
     post: DS.belongsTo('post', { async: true })
   });
-  run(function() {
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: null });
-  });
-  var json = {};
+  let comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: null });
+  let json = {};
 
   serializer.serializeBelongsTo(comment._createSnapshot(), json, { key: "post", options: {} });
 
@@ -156,11 +141,10 @@ test("serializeBelongsTo respects keyForRelationship", function(assert) {
       return key.toUpperCase();
     }
   }));
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase", id: "1" });
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
-  });
-  var json = {};
+
+  let post = env.store.createRecord('post', { title: "Rails is omakase", id: "1" });
+  let comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
+  let json = {};
 
   env.store.serializerFor("post").serializeBelongsTo(comment._createSnapshot(), json, { key: "post", options: {} });
 
@@ -176,17 +160,18 @@ test("serializeHasMany respects keyForRelationship", function(assert) {
     }
   }));
 
+  let post = env.store.createRecord('post', { title: "Rails is omakase", id: "1" });
+  let comment = env.store.createRecord('comment', {
+    body: "Omakase is delicious",
+    post: post,
+    id: "1"
+  });
+
   run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase", id: "1" });
-    comment = env.store.createRecord('comment', {
-      body: "Omakase is delicious",
-      post: post,
-      id: "1"
-    });
     post.get('comments').pushObject(comment);
   });
 
-  var json = {};
+  let json = {};
 
   env.store.serializerFor("post").serializeHasMany(post._createSnapshot(), json, { key: "comments", options: {} });
 
@@ -196,20 +181,16 @@ test("serializeHasMany respects keyForRelationship", function(assert) {
 });
 
 test("serializeHasMany omits unknown relationships on pushed record", function(assert) {
-
-  run(function() {
-    post = env.store.push({
-      data: {
-        id: "1",
-        type: "post",
-        attributes: {
-          title: "Rails is omakase"
-        }
+  let post = run(() => env.store.push({
+    data: {
+      id: "1",
+      type: "post",
+      attributes: {
+        title: "Rails is omakase"
       }
-    });
-  });
-
-  var json = {};
+    }
+  }));
+  let json = {};
 
   env.store.serializerFor("post").serializeHasMany(post._createSnapshot(), json, { key: "comments", options: {} });
 
@@ -217,11 +198,8 @@ test("serializeHasMany omits unknown relationships on pushed record", function(a
 });
 
 test("shouldSerializeHasMany", function(assert) {
-
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase", id: "1" });
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post, id: "1" });
-  });
+  let post = env.store.createRecord('post', { title: "Rails is omakase", id: "1" });
+  env.store.createRecord('comment', { body: "Omakase is delicious", post: post, id: "1" });
 
   var snapshot = post._createSnapshot();
   var relationship = snapshot.record.relationshipFor('comments');
@@ -233,11 +211,9 @@ test("shouldSerializeHasMany", function(assert) {
 });
 
 test("serializeIntoHash", function(assert) {
-  run(() => {
-    post = env.store.createRecord('post', { title: "Rails is omakase", comments: [] });
-  });
-
+  let post = env.store.createRecord('post', { title: "Rails is omakase", comments: [] });
   let json = {};
+
   serializer.serializeIntoHash(json, Post, post._createSnapshot());
 
   assert.deepEqual(json, {
@@ -259,10 +235,8 @@ test("serializePolymorphicType sync", function(assert) {
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { title: 'Rails is omakase', id: 1 });
-    comment = env.store.createRecord('comment', { body: 'Omakase is delicious', post: post });
-  });
+  let post = env.store.createRecord('post', { title: 'Rails is omakase', id: 1 });
+  let comment = env.store.createRecord('comment', { body: 'Omakase is delicious', post: post });
 
   env.store.serializerFor('comment').serializeBelongsTo(comment._createSnapshot(), {}, { key: 'post', options: { polymorphic: true } });
 });
@@ -280,10 +254,8 @@ test("serializePolymorphicType async", function(assert) {
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { title: 'Rails is omakase', id: 1 });
-    comment = env.store.createRecord('comment', { body: 'Omakase is delicious', post: post });
-  });
+  let post = env.store.createRecord('post', { title: 'Rails is omakase', id: 1 });
+  let comment = env.store.createRecord('comment', { body: 'Omakase is delicious', post: post });
 
   env.store.serializerFor('comment').serializeBelongsTo(comment._createSnapshot(), {}, { key: 'post', options: { async: true, polymorphic: true } });
 });
@@ -362,23 +334,18 @@ test('Serializer should respect the attrs hash when serializing records', functi
       parentPost: { key: "my_parent" }
     }
   }));
-  var parentPost;
 
-  run(function() {
-    env.store.push({
-      data: {
-        type: 'post',
-        id: '2',
-        attributes: {
-          title: "Rails is omakase"
-        }
+  let parentPost = run(() => env.store.push({
+    data: {
+      type: 'post',
+      id: '2',
+      attributes: {
+        title: "Rails is omakase"
       }
-    });
-    parentPost = env.store.peekRecord('post', 2);
-    post = env.store.createRecord('post', { title: "Rails is omakase", parentPost: parentPost });
-  });
-
-  var payload = env.store.serializerFor("post").serialize(post._createSnapshot());
+    }
+  }));
+  let post = env.store.createRecord('post', { title: "Rails is omakase", parentPost: parentPost });
+  let payload = env.store.serializerFor("post").serialize(post._createSnapshot());
 
   assert.equal(payload.title_payload_key, "Rails is omakase");
   assert.equal(payload.my_parent, '2');
@@ -470,11 +437,8 @@ test('Serializer respects `serialize: false` on the attrs hash', function(assert
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
-  });
-
-  var payload = env.store.serializerFor("post").serialize(post._createSnapshot());
+  let post = env.store.createRecord('post', { title: "Rails is omakase" });
+  let payload = env.store.serializerFor("post").serialize(post._createSnapshot());
 
   assert.ok(!payload.hasOwnProperty('title'), "Does not add the key to instance");
   assert.ok(!payload.hasOwnProperty('[object Object]'), "Does not add some random key like [object Object]");
@@ -488,10 +452,8 @@ test('Serializer respects `serialize: false` on the attrs hash for a `hasMany` p
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
-  });
+  let post = env.store.createRecord('post', { title: "Rails is omakase" });
+  env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
 
   var serializer = env.store.serializerFor("post");
   var serializedProperty = serializer.keyForRelationship('comments', 'hasMany');
@@ -508,10 +470,8 @@ test('Serializer respects `serialize: false` on the attrs hash for a `belongsTo`
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
-  });
+  let post = env.store.createRecord('post', { title: "Rails is omakase" });
+  let comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
 
   var serializer = env.store.serializerFor("comment");
   var serializedProperty = serializer.keyForRelationship('post', 'belongsTo');
@@ -528,10 +488,8 @@ test('Serializer respects `serialize: false` on the attrs hash for a `hasMany` p
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
-  });
+  let post = env.store.createRecord('post', { title: "Rails is omakase" });
+  env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
 
   var serializer = env.store.serializerFor("post");
   var serializedProperty = serializer.keyForRelationship('comments', 'hasMany');
@@ -548,10 +506,8 @@ test('Serializer respects `serialize: false` on the attrs hash for a `belongsTo`
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
-  });
+  let post = env.store.createRecord('post', { title: "Rails is omakase" });
+  let comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
 
   var serializer = env.store.serializerFor("comment");
   var serializedProperty = serializer.keyForRelationship('post', 'belongsTo');
@@ -568,9 +524,10 @@ test('Serializer respects `serialize: true` on the attrs hash for a `hasMany` pr
     }
   }));
 
+  let post = env.store.createRecord('post', { title: "Rails is omakase" });
+  let comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
+
   run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
     post.get('comments').pushObject(comment);
   });
 
@@ -589,10 +546,8 @@ test('Serializer respects `serialize: true` on the attrs hash for a `belongsTo` 
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { title: "Rails is omakase" });
-    comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
-  });
+  let post = env.store.createRecord('post', { title: "Rails is omakase" });
+  let comment = env.store.createRecord('comment', { body: "Omakase is delicious", post: post });
 
   var serializer = env.store.serializerFor("comment");
   var serializedProperty = serializer.keyForRelationship('post', 'belongsTo');
@@ -620,11 +575,8 @@ test("Serializer should merge attrs from superclasses", function(assert) {
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord("post", { title: "Rails is omakase", description: "Omakase is delicious", anotherString: "yet another string" });
-  });
-
-  var payload = env.store.serializerFor("post").serialize(post._createSnapshot());
+  let post = env.store.createRecord("post", { title: "Rails is omakase", description: "Omakase is delicious", anotherString: "yet another string" });
+  let payload = env.store.serializerFor("post").serialize(post._createSnapshot());
 
   assert.equal(payload.title_payload_key, "Rails is omakase");
   assert.equal(payload.description_payload_key, "Omakase is delicious");
@@ -637,11 +589,8 @@ test("Serializer should respect the primaryKey attribute when extracting records
     primaryKey: '_ID_'
   }));
 
-  var jsonHash = { "_ID_": 1, title: "Rails is omakase" };
-
-  run(function() {
-    post = env.store.serializerFor("post").normalizeResponse(env.store, Post, jsonHash, '1', 'findRecord');
-  });
+  let jsonHash = { "_ID_": 1, title: "Rails is omakase" };
+  let post = env.store.serializerFor("post").normalizeResponse(env.store, Post, jsonHash, '1', 'findRecord');
 
   assert.equal(post.data.id, "1");
   assert.equal(post.data.attributes.title, "Rails is omakase");
@@ -652,11 +601,8 @@ test("Serializer should respect the primaryKey attribute when serializing record
     primaryKey: '_ID_'
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { id: "1", title: "Rails is omakase" });
-  });
-
-  var payload = env.store.serializerFor("post").serialize(post._createSnapshot(), { includeId: true });
+  let post = env.store.createRecord('post', { id: "1", title: "Rails is omakase" });
+  let payload = env.store.serializerFor("post").serialize(post._createSnapshot(), { includeId: true });
 
   assert.equal(payload._ID_, "1");
 });
@@ -668,9 +614,8 @@ test("Serializer should respect keyForAttribute when extracting records", functi
     }
   }));
 
-  var jsonHash = { id: 1, TITLE: 'Rails is omakase' };
-
-  post = env.store.serializerFor("post").normalize(Post, jsonHash);
+  let jsonHash = { id: 1, TITLE: 'Rails is omakase' };
+  let post = env.store.serializerFor("post").normalize(Post, jsonHash);
 
   assert.equal(post.data.id, "1");
   assert.equal(post.data.attributes.title, "Rails is omakase");
@@ -683,9 +628,8 @@ test("Serializer should respect keyForRelationship when extracting records", fun
     }
   }));
 
-  var jsonHash = { id: 1, title: 'Rails is omakase', COMMENTS: ['1'] };
-
-  post = env.store.serializerFor("post").normalize(Post, jsonHash);
+  let jsonHash = { id: 1, title: 'Rails is omakase', COMMENTS: ['1'] };
+  let post = env.store.serializerFor("post").normalize(Post, jsonHash);
 
   assert.deepEqual(post.data.relationships.comments.data, [{ id: "1", type: "comment" }]);
 });
@@ -746,10 +690,8 @@ test('serializeBelongsTo with async polymorphic', function(assert) {
     }
   }));
 
-  run(function() {
-    post = env.store.createRecord('post', { title: 'Kitties are omakase', id: '1' });
-    favorite = env.store.createRecord('favorite', { post: post, id: '3' });
-  });
+  let post = env.store.createRecord('post', { title: 'Kitties are omakase', id: '1' });
+  let favorite = env.store.createRecord('favorite', { post: post, id: '3' });
 
   env.store.serializerFor('favorite').serializeBelongsTo(favorite._createSnapshot(), json, { key: 'post', options: { polymorphic: true, async: true } });
 
@@ -957,10 +899,7 @@ test('options are passed to transform for serialization', function(assert) {
     })
   });
 
-  var post;
-  run(function() {
-    post = env.store.createRecord('post', { custom: 'value' });
-  });
+  let post = env.store.createRecord('post', { custom: 'value' });
 
   serializer.serialize(post._createSnapshot());
 });

--- a/tests/integration/serializers/rest-serializer-test.js
+++ b/tests/integration/serializers/rest-serializer-test.js
@@ -4,10 +4,9 @@ import { run, bind } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { module, test } from 'qunit';
-
 import DS from 'ember-data';
 
-var HomePlanet, league, SuperVillain, EvilMinion, YellowMinion, DoomsdayDevice, Comment, Basket, Container, env;
+let HomePlanet, SuperVillain, EvilMinion, YellowMinion, DoomsdayDevice, Comment, Basket, Container, env;
 
 module("integration/serializer/rest - RESTSerializer", {
   beforeEach() {
@@ -271,13 +270,9 @@ testInDebug("normalizeResponse warning with custom modelNameFromPayloadKey", fun
 });
 
 test("serialize polymorphicType", function(assert) {
-  var tom, ray;
-  run(function() {
-    tom = env.store.createRecord('yellow-minion', { name: "Alex", id: "124" });
-    ray = env.store.createRecord('doomsday-device', { evilMinion: tom, name: "DeathRay" });
-  });
-
-  var json = env.restSerializer.serialize(ray._createSnapshot());
+  let tom = env.store.createRecord('yellow-minion', { name: "Alex", id: "124" });
+  let ray = env.store.createRecord('doomsday-device', { evilMinion: tom, name: "DeathRay" });
+  let json = env.restSerializer.serialize(ray._createSnapshot());
 
   assert.deepEqual(json, {
     name:  "DeathRay",
@@ -287,24 +282,16 @@ test("serialize polymorphicType", function(assert) {
 });
 
 test("serialize polymorphicType with decamelized modelName", function(assert) {
-  var tom, ray;
-  run(function() {
-    tom = env.store.createRecord('yellow-minion', { name: "Alex", id: "124" });
-    ray = env.store.createRecord('doomsday-device', { evilMinion: tom, name: "DeathRay" });
-  });
-
-  var json = env.restSerializer.serialize(ray._createSnapshot());
+  let tom = env.store.createRecord('yellow-minion', { name: "Alex", id: "124" });
+  let ray = env.store.createRecord('doomsday-device', { evilMinion: tom, name: "DeathRay" });
+  let json = env.restSerializer.serialize(ray._createSnapshot());
 
   assert.deepEqual(json["evilMinionType"], "yellowMinion");
 });
 
 test("serialize polymorphic when associated object is null", function(assert) {
-  var ray;
-  run(function() {
-    ray = env.store.createRecord('doomsday-device', { name: "DeathRay" });
-  });
-
-  var json = env.restSerializer.serialize(ray._createSnapshot());
+  let ray = env.store.createRecord('doomsday-device', { name: "DeathRay" });
+  let json = env.restSerializer.serialize(ray._createSnapshot());
 
   assert.deepEqual(json["evilMinionType"], null);
 });
@@ -415,10 +402,8 @@ test('normalize should allow for different levels of normalization - attributes'
 });
 
 test("serializeIntoHash", function(assert) {
-  run(function() {
-    league = env.store.createRecord('home-planet', { name: "Umber", id: "123" });
-  });
-  var json = {};
+  let league = env.store.createRecord('home-planet', { name: "Umber", id: "123" });
+  let json = {};
 
   env.restSerializer.serializeIntoHash(json, HomePlanet, league._createSnapshot());
 
@@ -430,10 +415,8 @@ test("serializeIntoHash", function(assert) {
 });
 
 test("serializeIntoHash with decamelized modelName", function(assert) {
-  run(function() {
-    league = env.store.createRecord('home-planet', { name: "Umber", id: "123" });
-  });
-  var json = {};
+  let league = env.store.createRecord('home-planet', { name: "Umber", id: "123" });
+  let json = {};
 
   env.restSerializer.serializeIntoHash(json, HomePlanet, league._createSnapshot());
 
@@ -445,14 +428,10 @@ test("serializeIntoHash with decamelized modelName", function(assert) {
 });
 
 test('serializeBelongsTo with async polymorphic', function(assert) {
-  var evilMinion, doomsdayDevice;
-  var json = {};
-  var expected = { evilMinion: '1', evilMinionType: 'evilMinion' };
-
-  run(function() {
-    evilMinion = env.store.createRecord('evil-minion', { id: 1, name: 'Tomster' });
-    doomsdayDevice = env.store.createRecord('doomsday-device', { id: 2, name: 'Yehuda', evilMinion: evilMinion });
-  });
+  let json = {};
+  let expected = { evilMinion: '1', evilMinionType: 'evilMinion' };
+  let evilMinion = env.store.createRecord('evil-minion', { id: 1, name: 'Tomster' });
+  let doomsdayDevice = env.store.createRecord('doomsday-device', { id: 2, name: 'Yehuda', evilMinion: evilMinion });
 
   env.restSerializer.serializeBelongsTo(doomsdayDevice._createSnapshot(), json, { key: 'evilMinion', options: { polymorphic: true, async: true } });
 
@@ -460,18 +439,15 @@ test('serializeBelongsTo with async polymorphic', function(assert) {
 });
 
 test('keyForPolymorphicType can be used to overwrite how the type of a polymorphic record is serialized', function(assert) {
-  var evilMinion, doomsdayDevice;
-  var json = {};
-  var expected = { evilMinion: '1', typeForEvilMinion: 'evilMinion' };
+  let json = {};
+  let expected = { evilMinion: '1', typeForEvilMinion: 'evilMinion' };
 
   env.restSerializer.keyForPolymorphicType = function() {
     return 'typeForEvilMinion';
   };
 
-  run(function() {
-    evilMinion = env.store.createRecord('evil-minion', { id: 1, name: 'Tomster' });
-    doomsdayDevice = env.store.createRecord('doomsday-device', { id: 2, name: 'Yehuda', evilMinion: evilMinion });
-  });
+  let evilMinion = env.store.createRecord('evil-minion', { id: 1, name: 'Tomster' });
+  let doomsdayDevice = env.store.createRecord('doomsday-device', { id: 2, name: 'Yehuda', evilMinion: evilMinion });
 
   env.restSerializer.serializeBelongsTo(doomsdayDevice._createSnapshot(), json, { key: 'evilMinion', options: { polymorphic: true, async: true } });
 
@@ -514,10 +490,9 @@ test('keyForPolymorphicType can be used to overwrite how the type of a polymorph
 });
 
 test('serializeIntoHash uses payloadKeyFromModelName to normalize the payload root key', function(assert) {
-  run(function() {
-    league = env.store.createRecord('home-planet', { name: "Umber", id: "123" });
-  });
-  var json = {};
+  let league = env.store.createRecord('home-planet', { name: "Umber", id: "123" });
+  let json = {};
+
   env.registry.register('serializer:home-planet', DS.RESTSerializer.extend({
     payloadKeyFromModelName(modelName) {
       return dasherize(modelName);

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -1008,7 +1008,7 @@ test('The store should trap exceptions that are thrown from adapter#createRecord
   };
 
   run(() => {
-    let car = store.createRecord('car')
+    let car = store.createRecord('car');
 
     car.save().catch(error => {
       assert.equal(error.message, 'Refusing to serialize')

--- a/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
+++ b/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
@@ -82,7 +82,7 @@ test('groupRecordsForFindMany works for encodeURIComponent-ified ids', function(
 });
 
 test('_stripIDFromURL works with id being encoded - #4190', function(assert) {
-  let record = run(() => store.createRecord('testRecord', { id: "id:123" }));
+  let record = store.createRecord('testRecord', { id: "id:123" });
   let adapter = store.adapterFor('testRecord');
   let snapshot = record._internalModel.createSnapshot();
   let strippedUrl = adapter._stripIDFromURL(store, snapshot);

--- a/tests/unit/debug-test.js
+++ b/tests/unit/debug-test.js
@@ -1,5 +1,4 @@
 import { computed } from '@ember/object';
-import { run } from '@ember/runloop';
 import { createStore } from 'dummy/tests/helpers/store';
 
 import { module, test } from 'qunit';
@@ -33,7 +32,7 @@ test('_debugInfo groups the attributes and relationships correctly', function(as
     user: User
   });
 
-  let record = run(() => store.createRecord('user'));
+  let record = store.createRecord('user');
 
   let propertyInfo = record._debugInfo().propertyInfo;
 
@@ -73,7 +72,7 @@ test('_debugInfo supports arbitray relationship types', function(assert) {
     user: User
   });
 
-  let record = run(() => store.createRecord('user'));
+  let record = store.createRecord('user');
 
   let propertyInfo = record._debugInfo().propertyInfo;
 

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -523,7 +523,7 @@ test("a DS.Model does not require an attribute type", function(assert) {
     tag: Tag
   });
 
-  let tag = run(() => store.createRecord('tag', { name: "test" }));
+  let tag = store.createRecord('tag', { name: "test" });
 
   assert.equal(get(tag, 'name'), 'test', 'the value is persisted');
 });
@@ -537,7 +537,7 @@ test('a DS.Model can have a defaultValue without an attribute type', function(as
     tag: Tag
   });
 
-  let tag = run(() => store.createRecord('tag'));
+  let tag = store.createRecord('tag');
 
   assert.equal(get(tag, 'name'), 'unknown', 'the default value is found');
 });
@@ -545,7 +545,7 @@ test('a DS.Model can have a defaultValue without an attribute type', function(as
 testInDebug('Calling attr() throws a warning', function(assert) {
   assert.expect(1);
 
-  let person = run(() => store.createRecord('person', { id: 1, name: 'TomHuda' }));
+  let person = store.createRecord('person', { id: 1, name: 'TomHuda' });
 
   assert.throws(() => {
     person.attr();
@@ -742,7 +742,7 @@ test('a DS.Model can have a defaultValue', function(assert) {
     tag: Tag
   });
 
-  let tag = run(() => store.createRecord('tag'));
+  let tag = store.createRecord('tag');
 
   assert.equal(get(tag, 'name'), 'unknown', 'the default value is found');
 
@@ -789,10 +789,8 @@ test('a defaultValue for an attribute can be a function', function(assert) {
     tag: Tag
   });
 
-  run(() => {
-    let tag = store.createRecord('tag');
-    assert.equal(get(tag, 'createdAt'), 'le default value', 'the defaultValue function is evaluated');
-  });
+  let tag = store.createRecord('tag');
+  assert.equal(get(tag, 'createdAt'), 'le default value', 'the defaultValue function is evaluated');
 });
 
 test('a defaultValue function gets the record, options, and key', function(assert) {
@@ -812,7 +810,7 @@ test('a defaultValue function gets the record, options, and key', function(asser
     tag: Tag
   });
 
-  let tag = run(() => store.createRecord('tag'));
+  let tag = store.createRecord('tag');
 
   get(tag, 'createdAt');
 });
@@ -826,7 +824,7 @@ testInDebug('a complex object defaultValue is deprecated', function(assert) {
     tag: Tag
   });
 
-  let tag = run(() => store.createRecord('tag'));
+  let tag = store.createRecord('tag');
 
   assert.expectAssertion(() => {
     get(tag, 'tagInfo');
@@ -854,7 +852,7 @@ test('setting a property to undefined on a newly created record should not impac
 
   assert.equal(get(tag, 'currentState.stateName'), 'root.loaded.created.uncommitted');
 
-  tag = run(() =>  store.createRecord('tag', { name: undefined }));
+  tag = store.createRecord('tag', { name: undefined });
 
   assert.equal(get(tag, 'currentState.stateName'), 'root.loaded.created.uncommitted');
 });
@@ -932,7 +930,7 @@ test("a listener can be added to a record", function(assert) {
   let count = 0;
   let F = function() { count++; };
 
-  let record = run(() => store.createRecord('person'));
+  let record = store.createRecord('person');
 
   record.on('event!', F);
   run(() => record.trigger('event!'));
@@ -947,7 +945,7 @@ test("a listener can be added to a record", function(assert) {
 test('when an event is triggered on a record the method with the same name is invoked with arguments', function(assert) {
   let count = 0;
   let F = function() { count++; };
-  let record = run(() => store.createRecord('person'));
+  let record = store.createRecord('person');
 
   record.eventNamedMethod = F;
 
@@ -959,7 +957,7 @@ test('when an event is triggered on a record the method with the same name is in
 test('when a method is invoked from an event with the same name the arguments are passed through', function(assert) {
   let eventMethodArgs = null;
   let F = function() { eventMethodArgs = arguments; };
-  let record = run(() => store.createRecord('person'));
+  let record = store.createRecord('person');
 
   record.eventThatTriggersMethod = F;
 
@@ -1147,7 +1145,7 @@ testInDebug(`don't allow setting`, function(assert) {
     person: Person
   });
 
-  let record = run(() => store.createRecord('person'));
+  let record = store.createRecord('person');
 
   assert.expectAssertion(() => {
     run(() => {
@@ -1188,7 +1186,7 @@ test('A DS.Model can be JSONified', function(assert) {
   });
 
   let store = createStore({ person: Person });
-  let record = run(() => store.createRecord('person', { name: 'TomHuda' }));
+  let record = store.createRecord('person', { name: 'TomHuda' });
 
   assert.deepEqual(record.toJSON(), { data: { type: 'people', attributes: { name: 'TomHuda' } } });
 });
@@ -1202,9 +1200,7 @@ testInDebug('A subclass of DS.Model can not use the `data` property', function(a
   let store = createStore({ person: Person });
 
   assert.expectAssertion(() => {
-    run(() => {
-      store.createRecord('person', { name: 'TomHuda' });
-    });
+    store.createRecord('person', { name: 'TomHuda' });
   }, /`data` is a reserved property name on DS.Model objects/);
 });
 
@@ -1217,9 +1213,7 @@ testInDebug('A subclass of DS.Model can not use the `store` property', function(
   let store = createStore({ retailer: Retailer });
 
   assert.expectAssertion(() => {
-    run(() => {
-      store.createRecord('retailer', { name: 'Buy n Large' });
-    });
+    store.createRecord('retailer', { name: 'Buy n Large' });
   }, /`store` is a reserved property name on DS.Model objects/);
 });
 
@@ -1235,9 +1229,7 @@ testInDebug('A subclass of DS.Model can not use reserved properties', function(a
     let store = createStore({ post: Post });
 
     assert.expectAssertion(() => {
-      run(() => {
-        store.createRecord('post', {});
-      });
+      store.createRecord('post', {});
     }, /is a reserved property name on DS.Model objects/);
   });
 });
@@ -1248,12 +1240,11 @@ test('Pushing a record into the store should transition it to the loaded state',
   });
 
   let store = createStore({ person: Person });
+  let person = store.createRecord('person', { id: 1, name: 'TomHuda' });
+
+  assert.equal(person.get('isNew'), true, 'createRecord should put records into the new state');
 
   run(() => {
-    let person = store.createRecord('person', { id: 1, name: 'TomHuda' });
-
-    assert.equal(person.get('isNew'), true, 'createRecord should put records into the new state');
-
     store.push({
       data: {
         type: 'person',
@@ -1332,7 +1323,7 @@ test('internalModel is ready by `init`', function(assert) {
   let { store } = setupStore({ person: Person });
 
   assert.equal(nameDidChange, 0, 'observer should not trigger on create');
-  let person = run(() => store.createRecord('person'));
+  let person = store.createRecord('person');
   assert.equal(person.get('name'), 'my-name-set-in-init');
 });
 
@@ -1352,7 +1343,7 @@ test('accessing attributes in the initializer should not throw an error', functi
     person: Person
   });
 
-  run(() => store.createRecord('person'));
+  store.createRecord('person');
 });
 
 test('setting the id after model creation should correctly update the id', function(assert) {
@@ -1366,11 +1357,11 @@ test('setting the id after model creation should correctly update the id', funct
     person: Person
   });
 
+  let person = store.createRecord('person');
+
+  assert.equal(person.get('id'), null, 'initial created model id should be null');
+
   run(() => {
-    let person = store.createRecord('person');
-
-    assert.equal(person.get('id'), null, 'initial created model id should be null');
-
     person.set('id', 'john');
 
     assert.equal(person.get('id'), 'john', 'new id should be correctly set.');

--- a/tests/unit/model/lifecycle-callbacks-test.js
+++ b/tests/unit/model/lifecycle-callbacks-test.js
@@ -136,8 +136,7 @@ test('a record receives a didCreate callback when it has finished updating', fun
   });
 
   assert.equal(callCount, 0, 'precond - didCreate callback was not called yet');
-  let person = run(() => store.createRecord('person', { id: 69, name: 'Newt Gingrich' }));
-
+  let person = store.createRecord('person', { id: 69, name: 'Newt Gingrich' });
 
   return run(() => {
     return person.save().then(() => {
@@ -216,7 +215,7 @@ test('an uncommited record also receives a didDelete callback when it is deleted
     person: Person
   });
 
-  let person = run(() => store.createRecord('person', { name: 'Tomster' }));
+  let person = store.createRecord('person', { name: 'Tomster' });
 
   assert.equal(callCount, 0, 'precond - didDelete callback was not called yet');
 

--- a/tests/unit/model/merge-test.js
+++ b/tests/unit/model/merge-test.js
@@ -31,7 +31,7 @@ test('When a record is in flight, changes can be made', function(assert) {
     person: Person
   });
 
-  let person = run(() => store.createRecord('person', { name: 'Tom Dale' }));
+  let person = store.createRecord('person', { name: 'Tom Dale' });
 
   // Make sure saving isn't resolved synchronously
   return run(() => {

--- a/tests/unit/model/relationships-test.js
+++ b/tests/unit/model/relationships-test.js
@@ -1,5 +1,4 @@
 import { get } from '@ember/object';
-import { run } from '@ember/runloop';
 import { createStore } from 'dummy/tests/helpers/store';
 
 import { module, test } from 'qunit';
@@ -28,10 +27,8 @@ module('unit/model/relationships - DS.Model', {
 });
 
 test('exposes a hash of the relationships on a model', function(assert) {
-  run(() => {
-    store.createRecord('person');
-    store.createRecord('occupation');
-  });
+  store.createRecord('person');
+  store.createRecord('occupation');
 
   let relationships = get(Person, 'relationships');
   assert.deepEqual(relationships.get('person'), [

--- a/tests/unit/model/relationships/belongs-to-test.js
+++ b/tests/unit/model/relationships/belongs-to-test.js
@@ -290,10 +290,10 @@ test('calling createRecord and passing in an undefined value for a relationship 
   let { store } = env;
   env.adapter.shouldBackgroundReloadRecord = () => false;
 
-  run(() => store.createRecord('person', { id: 1, tag: undefined }));
+  store.createRecord('person', { id: '1', tag: undefined });
 
   return run(() => {
-    return store.findRecord('person', 1).then(person => {
+    return store.findRecord('person', '1').then(person => {
       assert.strictEqual(person.get('tag'), null, 'undefined values should return null relationships');
     });
   });
@@ -585,10 +585,7 @@ test('DS.belongsTo should be async by default', function(assert) {
 
   let env = setupStore({ tag: Tag, person: Person });
   let { store }  = env;
+  let person = store.createRecord('person');
 
-  run(() => {
-    let person = store.createRecord('person');
-
-    assert.ok(person.get('tag') instanceof DS.PromiseObject, 'tag should be an async relationship');
-  });
+  assert.ok(person.get('tag') instanceof DS.PromiseObject, 'tag should be an async relationship');
 });

--- a/tests/unit/model/relationships/has-many-test.js
+++ b/tests/unit/model/relationships/has-many-test.js
@@ -1865,16 +1865,13 @@ test('it is possible to add an item to a relationship, remove it, then add it ag
 
   let env = setupStore({ tag: Tag, person: Person });
   let { store } = env;
-  let person, tag1, tag2, tag3, tags;
+  let person = store.createRecord('person');
+  let tag1 = store.createRecord('tag');
+  let tag2 = store.createRecord('tag');
+  let tag3 = store.createRecord('tag');
+  let tags = get(person, 'tags');
 
   run(() => {
-    person = store.createRecord('person');
-    tag1 = store.createRecord('tag');
-    tag2 = store.createRecord('tag');
-    tag3 = store.createRecord('tag');
-
-    tags = get(person, 'tags');
-
     tags.pushObjects([tag1, tag2, tag3]);
     tags.removeObject(tag2);
   });
@@ -1905,11 +1902,9 @@ test("DS.hasMany is async by default", function(assert) {
   });
 
   let { store } = setupStore({ tag: Tag, person: Person });
+  let tag = store.createRecord('tag');
 
-  run(() => {
-    let tag = store.createRecord('tag');
-    assert.ok(tag.get('people') instanceof DS.PromiseArray, 'people should be an async relationship');
-  });
+  assert.ok(tag.get('people') instanceof DS.PromiseArray, 'people should be an async relationship');
 });
 
 test('DS.hasMany is stable', function(assert) {
@@ -1925,7 +1920,7 @@ test('DS.hasMany is stable', function(assert) {
 
   let { store } = setupStore({ tag: Tag, person: Person });
 
-  let tag = run(() => store.createRecord('tag'));
+  let tag = store.createRecord('tag');
   let people = tag.get('people');
   let peopleCached = tag.get('people');
 
@@ -1954,7 +1949,7 @@ test('DS.hasMany proxy is destroyed', function(assert) {
 
   let { store } = setupStore({ tag: Tag, person: Person });
 
-  let tag = run(() => store.createRecord('tag'));
+  let tag = store.createRecord('tag');
   let peopleProxy = tag.get('people');
 
   return peopleProxy.then(people => {
@@ -1987,7 +1982,7 @@ test('DS.ManyArray is lazy', function(assert) {
   });
 
   let env = setupStore({ tag: Tag, person: Person });
-  let tag = run(() => env.store.createRecord('tag'));
+  let tag = env.store.createRecord('tag');
   let hasManyRelationship = tag.hasMany('people').hasManyRelationship;
 
   assert.ok(!hasManyRelationship._manyArray);
@@ -2001,7 +1996,7 @@ test('DS.ManyArray is lazy', function(assert) {
   assert.equal(peopleDidChange, 0, 'expect people hasMany to not emit a change event (after access, but after the current run loop)');
   assert.ok(hasManyRelationship._manyArray instanceof DS.ManyArray);
 
-  let person = run(() => env.store.createRecord('person'));
+  let person = env.store.createRecord('person');
 
   run(() => {
     assert.equal(peopleDidChange, 0, 'expect people hasMany to not emit a change event (before access)');
@@ -2017,12 +2012,8 @@ testInDebug('throws assertion if of not set with an array', function(assert) {
   });
 
   let { store }= setupStore({ tag: Tag, person: Person });
-  let tag, person;
-
-  run(() => {
-    tag = store.createRecord('tag');
-    person = store.createRecord('person');
-  });
+  let tag = store.createRecord('tag');
+  let person = store.createRecord('person');
 
   run(() => {
     assert.expectAssertion(() => {
@@ -2048,12 +2039,8 @@ testInDebug('checks if passed array only contains instances of DS.Model', functi
     };
   };
 
-  let tag, person;
-
-  run(() => {
-    tag = env.store.createRecord('tag');
-    person = env.store.findRecord('person', 1);
-  });
+  let tag = env.store.createRecord('tag');
+  let person = run(() => env.store.findRecord('person', 1));
 
   run(() => {
     assert.expectAssertion(() => {

--- a/tests/unit/model/rollback-attributes-test.js
+++ b/tests/unit/model/rollback-attributes-test.js
@@ -218,7 +218,7 @@ test(`a deleted record's attributes can be rollbacked if it fails to save, recor
 });
 
 test(`new record's attributes can be rollbacked`, function(assert) {
-  let person = run(() => store.createRecord('person', { id: 1 }));
+  let person = store.createRecord('person', { id: 1 });
 
   assert.equal(person.get('isNew'), true, 'must be new');
   assert.equal(person.get('hasDirtyAttributes'), true, 'must be dirty');
@@ -248,7 +248,7 @@ test(`invalid new record's attributes can be rollbacked`, function(assert) {
 
   env = setupStore({ person: Person, adapter: adapter });
 
-  let person = run(() => env.store.createRecord('person', { id: 1 }));
+  let person = env.store.createRecord('person', { id: 1 });
 
   assert.equal(person.get('isNew'), true, 'must be new');
   assert.equal(person.get('hasDirtyAttributes'), true, 'must be dirty');

--- a/tests/unit/store/adapter-interop-test.js
+++ b/tests/unit/store/adapter-interop-test.js
@@ -337,7 +337,7 @@ test('a new record of a particular type is created via store.createRecord(type)'
     person: Person
   });
 
-  let person = run(() => store.createRecord('person'));
+  let person = store.createRecord('person');
 
   assert.equal(get(person, 'isLoaded'), true, 'A newly created record is loaded');
   assert.equal(get(person, 'isNew'), true, 'A newly created record is new');
@@ -363,12 +363,10 @@ testInDebug("a new record with a specific id can't be created if this id is alre
     person: Person
   });
 
-  run(() => store.createRecord('person', { id: 5 }));
+  store.createRecord('person', { id: 5 });
 
   assert.expectAssertion(() => {
-    run(() => {
-      store.createRecord('person', { id: 5 });
-    });
+    store.createRecord('person', { id: 5 });
   }, /The id 5 has already been used with another record for modelClass 'person'/);
 });
 
@@ -381,7 +379,7 @@ test('an initial data hash can be provided via store.createRecord(type, hash)', 
     person: Person
   });
 
-  let person = run(() => store.createRecord('person', { name: 'Brohuda Katz' }));
+  let person = store.createRecord('person', { name: 'Brohuda Katz' });
 
   assert.equal(get(person, 'isLoaded'), true, 'A newly created record is loaded');
   assert.equal(get(person, 'isNew'), true, 'A newly created record is new');
@@ -650,12 +648,8 @@ test('records should have their ids updated when the adapter returns the id data
   });
 
   let people = store.peekAll('person');
-  let tom, yehuda;
-
-  run(() => {
-    tom = store.createRecord('person', { name: 'Tom Dale' });
-    yehuda = store.createRecord('person', { name: 'Yehuda Katz' });
-  });
+  let tom = store.createRecord('person', { name: 'Tom Dale' });
+  let yehuda = store.createRecord('person', { name: 'Yehuda Katz' });
 
   return run(() => {
     return all([
@@ -678,7 +672,7 @@ test('store.fetchMany should always return a promise', function(assert) {
     person: Person
   });
 
-  run(() => store.createRecord('person'));
+  store.createRecord('person')
 
   let records = [];
   let results = run(() => store._scheduleFetchMany(records));
@@ -723,7 +717,7 @@ test('store._scheduleFetchMany should not resolve until all the records are reso
     phone: Phone
   });
 
-  run(() => store.createRecord('test'));
+  store.createRecord('test');
 
   let internalModels = [
     store._internalModelForId('test', 10),

--- a/tests/unit/store/create-record-test.js
+++ b/tests/unit/store/create-record-test.js
@@ -84,9 +84,7 @@ test(`doesn't modify passed in properties hash`, function(assert) {
     author
   };
 
-  run(() => {
-    store.createRecord('post', properties);
-  });
+  store.createRecord('post', properties);
 
   assert.deepEqual(properties, propertiesClone, 'The properties hash is not modified');
 });
@@ -136,8 +134,7 @@ module('unit/store/createRecord - Store with models by dash', {
 
 test('creating a record by dasherize string finds the model', function(assert) {
   let attributes = { foo: 'bar' };
-
-  let record = run(() => store.createRecord('some-thing', attributes));
+  let record = store.createRecord('some-thing', attributes);
 
   assert.equal(record.get('foo'), attributes.foo, 'The record is created');
   assert.equal(store.modelFor('some-thing').modelName, 'some-thing');

--- a/tests/unit/store/unload-test.js
+++ b/tests/unit/store/unload-test.js
@@ -102,7 +102,7 @@ test('unload a record', function(assert) {
 });
 
 test('unload followed by create of the same type + id', function(assert) {
-  let record = run(() => store.createRecord('record', { id: 1 }));
+  let record = store.createRecord('record', { id: 1 });
 
   assert.ok(store.recordForId('record', 1) === record, 'record should exactly equal');
 


### PR DESCRIPTION
refactor all the test usage or run-wrapping for createRecord, we really should run prettier

resolves #5247 because I <3 @rwjblue 