### PR TITLE
[DOC release] Fix documentation syntax in attr

### DIFF
--- a/addon/attr.js
+++ b/addon/attr.js
@@ -36,7 +36,7 @@ function hasValue(record, key) {
   supported options are:
 
   - `defaultValue`: Pass a string or a function to be called to set the attribute
-                    to a default value if none is supplied.
+  to a default value if none is supplied.
 
   Example
 


### PR DESCRIPTION
Due to the indentation in the description of the `defaultValue` bullet point, our markdown renderer is considering it to be a code block. I did a quick patch, but haven't verified how it renders yet.

Repro: https://www.emberjs.com/api/ember-data/3.0/classes/DS/methods/attr?anchor=attr