### PR TITLE
[FEAT] FASTBOOT SHOEBOX - Use actions queue so rehydration works

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -793,7 +793,7 @@ Store = Service.extend({
 
     internalModel.loadingData(promise);
     if (this._pendingFetch.size === 0) {
-      emberRun.schedule('afterRender', this, this.flushAllPendingFetches);
+      emberRun.schedule('actions', this, this.flushAllPendingFetches);
     }
 
     this._pendingFetch.get(modelName).push(pendingFetchItem);
@@ -872,9 +872,15 @@ Store = Service.extend({
       }
 
       if (missingInternalModels.length) {
-        warn('Ember Data expected to find records with the following ids in the adapter response but they were missing: ' + inspect(missingInternalModels.map(r => r.id)), false, {
-          id: 'ds.store.missing-records-from-adapter'
-        });
+        warn(
+          'Ember Data expected to find records with the following ids in the adapter response but they were missing: [ "' +
+            missingInternalModels.map(r => r.id).join('", "') +
+            '" ]',
+          false,
+          {
+            id: 'ds.store.missing-records-from-adapter'
+          }
+        );
         rejectInternalModels(missingInternalModels);
       }
     }

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -352,6 +352,9 @@ test('it should cache attributes', function(assert) {
   });
 
   const store = createStore({
+    adapter: DS.JSONAPIAdapter.extend({
+      shouldBackgroundReloadRecord: () => false
+    }),
     post: Post
   });
 
@@ -366,7 +369,7 @@ test('it should cache attributes', function(assert) {
       }
     });
 
-    return store.findRecord('post', 1).then(record => {
+    return store.findRecord('post', '1').then(record => {
       record.set('updatedAt', date);
 
       assert.deepEqual(date, get(record, 'updatedAt'), 'setting a date returns the same date');


### PR DESCRIPTION
Fastboot Shoebox rehydration works at the adapter level, waiting until `afterRender` to flush fetches means that we can't rehydrate properly on the initial render. This fixes that for the common case of routes, but likely does not fix anything for components that fetch data.

cc @krisselden 