### PR TITLE
[FEAT] improved assertions for invalid relationship payloads

### DIFF
--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -1,5 +1,5 @@
 import { Promise as EmberPromise } from 'rsvp';
-import { assert, inspect } from '@ember/debug';
+import { assert } from '@ember/debug';
 import { assertPolymorphicType } from 'ember-data/-debug';
 import {
   PromiseBelongsTo
@@ -233,7 +233,6 @@ export default class BelongsToRelationship extends Relationship {
   }
 
   updateData(data, initial) {
-    assert(`Ember Data expected the data for the ${this.key} relationship on a ${this.internalModel.toString()} to be in a JSON API format and include an \`id\` and \`type\` property but it found ${inspect(data)}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`, data === null || data.id !== undefined && data.type !== undefined);
     let internalModel = this.store._pushResourceIdentifier(this, data);
     if (initial) {
       this.setInitialCanonicalInternalModel(internalModel);

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2677,11 +2677,7 @@ Store = Service.extend({
     if (isNone(resourceIdentifier)) {
       return;
     }
-    assert(`A ${relationship.internalModel.modelName} record was pushed into the store with the value of ${relationship.key} being '${JSON.stringify(resourceIdentifier)}', but ${relationship.key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(resourceIdentifier));
-    assert(
-      `Ember Data expected the data for the ${relationship.key} relationship on a ${relationship.internalModel.toString()} to be in a JSON API format and include an \`id\` and \`type\` property but it found '${JSON.stringify(resourceIdentifier)}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`,
-      resourceIdentifier === null || (coerceId(resourceIdentifier.id) && resourceIdentifier.type)
-    );
+    assertRelationshipData(this, relationship.internalModel, resourceIdentifier, relationship.relationshipMeta);
 
     return this._internalModelForId(resourceIdentifier.type, resourceIdentifier.id);
   },
@@ -2912,28 +2908,6 @@ function setupRelationships(store, internalModel, data, modelNameToInverseMap) {
         return;
       }
 
-      // eslint-disable-next-line no-inner-declarations
-      function assertRelationshipData(store, internalModel, data, meta) {
-        assert(
-          `Encountered a relationship identifier without a type for the ${meta.kind} relationship '${meta.key}' on ${internalModel}, expected a json-api identifier with type '${meta.type}'.`,
-          data === null || (typeof data.type === 'string' && data.type.length)
-        );
-        assert(
-          `Encountered a relationship identifier without an id for the ${meta.kind} relationship '${meta.key}' on ${internalModel}, expected a json-api identifier.`,
-          data === null || data.id || data.id === 0
-        );
-        assert(
-          `Encountered a relationship identifier with type '${
-            data.type
-            }' for the ${meta.kind} relationship '${meta.key}' on ${
-            internalModel
-            }, Expected a json-api identifier with type '${
-            meta.type
-            }'. No model was found for '${data.type}'.`,
-          data === null || !data.type || store._hasModelFor(data.type)
-        );
-      }
-
       if (relationshipData.links) {
         let isAsync = relationshipMeta.options && relationshipMeta.options.async !== false;
         warn(`You pushed a record of type '${internalModel.modelName}' with a relationship '${relationshipName}' configured as 'async: false'. You've included a link but no primary data, this may be an error in your payload.`, isAsync || relationshipData.data , {
@@ -2941,7 +2915,6 @@ function setupRelationships(store, internalModel, data, modelNameToInverseMap) {
         });
       } else if (relationshipData.data) {
         if (relationshipMeta.kind === 'belongsTo') {
-          assert(`A ${internalModel.modelName} record was pushed into the store with the value of ${relationshipName} being ${inspect(relationshipData.data)}, but ${relationshipName} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(relationshipData.data));
           assertRelationshipData(store, internalModel, relationshipData.data, relationshipMeta);
         } else if (relationshipMeta.kind === 'hasMany') {
           assert(`A ${internalModel.modelName} record was pushed into the store with the value of ${relationshipName} being '${inspect(relationshipData.data)}', but ${relationshipName} is a hasMany relationship so the value must be an array. You should probably check your data payload or serializer.`, Array.isArray(relationshipData.data));
@@ -2954,6 +2927,28 @@ function setupRelationships(store, internalModel, data, modelNameToInverseMap) {
       }
     }
   });
+}
+
+function assertRelationshipData(store, internalModel, data, meta) {
+  assert(`A ${internalModel.modelName} record was pushed into the store with the value of ${meta.key} being '${JSON.stringify(data)}', but ${meta.key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(data));
+  assert(
+    `Encountered a relationship identifier without a type for the ${meta.kind} relationship '${meta.key}' on ${internalModel}, expected a json-api identifier with type '${meta.type}' but found '${JSON.stringify(data)}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`,
+    data === null || (typeof data.type === 'string' && data.type.length)
+  );
+  assert(
+    `Encountered a relationship identifier without an id for the ${meta.kind} relationship '${meta.key}' on ${internalModel}, expected a json-api identifier but found '${JSON.stringify(data)}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`,
+    data === null || coerceId(data.id)
+  );
+  assert(
+    `Encountered a relationship identifier with type '${
+      data.type
+      }' for the ${meta.kind} relationship '${meta.key}' on ${
+      internalModel
+      }, Expected a json-api identifier with type '${
+      meta.type
+      }'. No model was found for '${data.type}'.`,
+    data === null || !data.type || store._hasModelFor(data.type)
+  );
 }
 
 export { Store };

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2677,9 +2677,9 @@ Store = Service.extend({
     if (isNone(resourceIdentifier)) {
       return;
     }
-    assert(`A ${relationship.internalModel.modelName} record was pushed into the store with the value of ${relationship.key} being ${inspect(resourceIdentifier)}, but ${relationship.key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(resourceIdentifier));
+    assert(`A ${relationship.internalModel.modelName} record was pushed into the store with the value of ${relationship.key} being '${JSON.stringify(resourceIdentifier)}', but ${relationship.key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(resourceIdentifier));
     assert(
-      `Ember Data expected the data for the ${relationship.key} relationship on a ${relationship.internalModel.toString()} to be in a JSON API format and include an \`id\` and \`type\` property but it found ${inspect(resourceIdentifier)}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`,
+      `Ember Data expected the data for the ${relationship.key} relationship on a ${relationship.internalModel.toString()} to be in a JSON API format and include an \`id\` and \`type\` property but it found '${JSON.stringify(resourceIdentifier)}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`,
       resourceIdentifier === null || (resourceIdentifier.id && resourceIdentifier.type)
     );
 

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2680,7 +2680,7 @@ Store = Service.extend({
     assert(`A ${relationship.internalModel.modelName} record was pushed into the store with the value of ${relationship.key} being '${JSON.stringify(resourceIdentifier)}', but ${relationship.key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(resourceIdentifier));
     assert(
       `Ember Data expected the data for the ${relationship.key} relationship on a ${relationship.internalModel.toString()} to be in a JSON API format and include an \`id\` and \`type\` property but it found '${JSON.stringify(resourceIdentifier)}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`,
-      resourceIdentifier === null || (resourceIdentifier.id && resourceIdentifier.type)
+      resourceIdentifier === null || (coerceId(resourceIdentifier.id) && resourceIdentifier.type)
     );
 
     return this._internalModelForId(resourceIdentifier.type, resourceIdentifier.id);

--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -2677,10 +2677,12 @@ Store = Service.extend({
     if (isNone(resourceIdentifier)) {
       return;
     }
-
     assert(`A ${relationship.internalModel.modelName} record was pushed into the store with the value of ${relationship.key} being ${inspect(resourceIdentifier)}, but ${relationship.key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(resourceIdentifier));
+    assert(
+      `Ember Data expected the data for the ${relationship.key} relationship on a ${relationship.internalModel.toString()} to be in a JSON API format and include an \`id\` and \`type\` property but it found ${inspect(resourceIdentifier)}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`,
+      resourceIdentifier === null || (resourceIdentifier.id && resourceIdentifier.type)
+    );
 
-    //TODO:Better asserts
     return this._internalModelForId(resourceIdentifier.type, resourceIdentifier.id);
   },
 

--- a/addon/-record-data-rfc-private/system/model/model-data.js
+++ b/addon/-record-data-rfc-private/system/model/model-data.js
@@ -103,28 +103,6 @@ export default class ModelData {
           continue;
         }
 
-        // eslint-disable-next-line no-inner-declarations
-        function assertRelationshipData(store, modelData, data, meta) {
-          assert(
-            `Encountered a relationship identifier without a type for the ${meta.kind} relationship '${meta.key}' on ${modelData}, expected a json-api identifier with type '${meta.type}'.`,
-            data === null || (typeof data.type === 'string' && data.type.length)
-          );
-          assert(
-            `Encountered a relationship identifier without an id for the ${meta.kind} relationship '${meta.key}' on ${modelData}, expected a json-api identifier.`,
-            data === null || data.id || data.id === 0
-          );
-          assert(
-            `Encountered a relationship identifier with type '${
-                data.type
-              }' for the ${meta.kind} relationship '${meta.key}' on ${
-                modelData
-              }, Expected a json-api identifier with type '${
-                meta.type
-              }'. No model was found for '${data.type}'.`,
-            data === null || !data.type || store._hasModelFor(data.type)
-          );
-        }
-
         if (relationshipData.links) {
           let isAsync = relationshipMeta.options && relationshipMeta.options.async !== false;
           warn(`You pushed a record of type '${this.modelName}' with a relationship '${relationshipName}' configured as 'async: false'. You've included a link but no primary data, this may be an error in your payload.`, isAsync || relationshipData.data , {
@@ -666,6 +644,28 @@ if (isEnabled('ds-rollback-attribute')) {
       return this._data[key];
     }
   };
+}
+
+function assertRelationshipData(store, modelData, data, meta) {
+  assert(`A ${modelData.modelName} record was pushed into the store with the value of ${meta.key} being '${JSON.stringify(data)}', but ${meta.key} is a belongsTo relationship so the value must not be an array. You should probably check your data payload or serializer.`, !Array.isArray(data));
+  assert(
+    `Encountered a relationship identifier without a type for the ${meta.kind} relationship '${meta.key}' on ${modelData}, expected a json-api identifier with type '${meta.type}' but found '${JSON.stringify(data)}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`,
+    data === null || (typeof data.type === 'string' && data.type.length)
+  );
+  assert(
+    `Encountered a relationship identifier without an id for the ${meta.kind} relationship '${meta.key}' on ${modelData}, expected a json-api identifier but found '${JSON.stringify(data)}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`,
+    data === null || coerceId(data.id)
+  );
+  assert(
+    `Encountered a relationship identifier with type '${
+      data.type
+      }' for the ${meta.kind} relationship '${meta.key}' on ${
+      modelData
+      }, Expected a json-api identifier with type '${
+      meta.type
+      }'. No model was found for '${data.type}'.`,
+    data === null || !data.type || store._hasModelFor(data.type)
+  );
 }
 
 // Handle dematerialization for relationship `rel`.  In all cases, notify the

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -207,7 +207,7 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
   });
 });
 
-test("Invalid belongsTo relationship identifiers throw errors", function(assert) {
+testInDebug("Invalid belongsTo relationship identifiers throw errors", function(assert) {
   assert.expect(2);
   let { store } = env;
 

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -212,50 +212,51 @@ testInDebug("Invalid belongsTo relationship identifiers throw errors", function(
   let { store } = env;
 
   // test null id
-  let post = run(() => store.push({
-    data: {
-      id: '1',
-      type: 'post',
-      relationships: {
-        user: {
-          data: {
-            id: null,
-            type: 'user'
-          }
-        }
-      }
-    }
-  }));
-
   assert.expectAssertion(
     () => {
-      run(() => post.get('user'));
+      run(() => {
+        let post = store.push({
+          data: {
+            id: '1',
+            type: 'post',
+            relationships: {
+              user: {
+                data: {
+                  id: null,
+                  type: 'user'
+                }
+              }
+            }
+          }
+        });
+        post.get('user');
+      });
     },
-    'Assertion Failed: Ember Data expected the data for the user relationship on a <post:1> to be in a JSON API format and include an `id` and `type` property but it found \'{\"id\":null,\"type\":\"user\"}\'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.'
+    `Assertion Failed: Encountered a relationship identifier without an id for the belongsTo relationship 'user' on <post:1>, expected a json-api identifier but found '{"id":null,"type":"user"}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`
   );
 
   // test missing type
-  // test null id
-  post = run(() => store.push({
-    data: {
-      id: '2',
-      type: 'post',
-      relationships: {
-        user: {
-          data: {
-            id: '1',
-            type: null
-          }
-        }
-      }
-    }
-  }));
-
   assert.expectAssertion(
     () => {
-      run(() => post.get('user'));
+      run(() => {
+        let post = store.push({
+          data: {
+            id: '2',
+            type: 'post',
+            relationships: {
+              user: {
+                data: {
+                  id: '1',
+                  type: null
+                }
+              }
+            }
+          }
+        });
+        post.get('user');
+      });
     },
-    'Assertion Failed: Ember Data expected the data for the user relationship on a <post:2> to be in a JSON API format and include an `id` and `type` property but it found \'{\"id\":\"1\",\"type\":null}\'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.'
+    `Assertion Failed: Encountered a relationship identifier without a type for the belongsTo relationship 'user' on <post:2>, expected a json-api identifier with type 'user' but found '{"id":"1","type":null}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`
   );
 });
 

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -207,6 +207,58 @@ test("The store can materialize a non loaded monomorphic belongsTo association",
   });
 });
 
+test("Invalid belongsTo relationship identifiers throw errors", function(assert) {
+  assert.expect(2);
+  let { store } = env;
+
+  // test null id
+  let post = run(() => store.push({
+    data: {
+      id: '1',
+      type: 'post',
+      relationships: {
+        user: {
+          data: {
+            id: null,
+            type: 'user'
+          }
+        }
+      }
+    }
+  }));
+
+  assert.expectAssertion(
+    () => {
+      run(() => post.get('user'));
+    },
+    "Assertion Failed: Ember Data expected the data for the user relationship on a <post:1> to be in a JSON API format and include an `id` and `type` property but it found {id: null, type: user}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format."
+  );
+
+  // test missing type
+  // test null id
+  post = run(() => store.push({
+    data: {
+      id: '2',
+      type: 'post',
+      relationships: {
+        user: {
+          data: {
+            id: '1',
+            type: null
+          }
+        }
+      }
+    }
+  }));
+
+  assert.expectAssertion(
+    () => {
+      run(() => post.get('user'));
+    },
+    "Assertion Failed: Ember Data expected the data for the user relationship on a <post:2> to be in a JSON API format and include an `id` and `type` property but it found {id: 1, type: null}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format."
+  );
+});
+
 testInDebug("Only a record of the same modelClass can be used with a monomorphic belongsTo relationship", function(assert) {
   assert.expect(1);
   env.adapter.shouldBackgroundReloadRecord = () => false;

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -231,7 +231,7 @@ testInDebug("Invalid belongsTo relationship identifiers throw errors", function(
     () => {
       run(() => post.get('user'));
     },
-    "Assertion Failed: Ember Data expected the data for the user relationship on a <post:1> to be in a JSON API format and include an `id` and `type` property but it found {id: null, type: user}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format."
+    'Assertion Failed: Ember Data expected the data for the user relationship on a <post:1> to be in a JSON API format and include an `id` and `type` property but it found \'{\"id\":null,\"type\":\"user\"}\'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.'
   );
 
   // test missing type
@@ -255,7 +255,7 @@ testInDebug("Invalid belongsTo relationship identifiers throw errors", function(
     () => {
       run(() => post.get('user'));
     },
-    "Assertion Failed: Ember Data expected the data for the user relationship on a <post:2> to be in a JSON API format and include an `id` and `type` property but it found {id: 1, type: null}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format."
+    'Assertion Failed: Ember Data expected the data for the user relationship on a <post:2> to be in a JSON API format and include an `id` and `type` property but it found \'{\"id\":\"1\",\"type\":null}\'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.'
   );
 });
 

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -131,7 +131,7 @@ testInDebug("Invalid hasMany relationship identifiers throw errors", function(as
     () => {
       run(() => post.get('comments'));
     },
-    "Assertion Failed: Ember Data expected the data for the comments relationship on a <post:1> to be in a JSON API format and include an `id` and `type` property but it found {id: null, type: comment}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format."
+    'Assertion Failed: Ember Data expected the data for the comments relationship on a <post:1> to be in a JSON API format and include an `id` and `type` property but it found \'{\"id\":null,\"type\":\"comment\"}\'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.'
   );
 
   // test missing type
@@ -154,7 +154,7 @@ testInDebug("Invalid hasMany relationship identifiers throw errors", function(as
     () => {
       run(() => post.get('comments'));
     },
-    "Assertion Failed: Ember Data expected the data for the comments relationship on a <post:2> to be in a JSON API format and include an `id` and `type` property but it found {id: 1, type: null}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format."
+    'Assertion Failed: Ember Data expected the data for the comments relationship on a <post:2> to be in a JSON API format and include an `id` and `type` property but it found \'{\"id\":\"1\",\"type\":null}\'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.'
   );
 });
 

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -108,7 +108,7 @@ module("integration/relationships/has_many - Has-Many Relationships", {
   }
 });
 
-test("Invalid hasMany relationship identifiers throw errors", function(assert) {
+testInDebug("Invalid hasMany relationship identifiers throw errors", function(assert) {
   assert.expect(2);
   let { store } = env;
 

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -113,48 +113,50 @@ testInDebug("Invalid hasMany relationship identifiers throw errors", function(as
   let { store } = env;
 
   // test null id
-  let post = run(() => store.push({
-    data: {
-      id: '1',
-      type: 'post',
-      relationships: {
-        comments: {
-          data: [
-            { id: null, type: 'comment' }
-          ]
-        }
-      }
-    }
-  }));
-
   assert.expectAssertion(
     () => {
-      run(() => post.get('comments'));
+      run(() => {
+        let post = store.push({
+          data: {
+            id: '1',
+            type: 'post',
+            relationships: {
+              comments: {
+                data: [
+                  { id: null, type: 'comment' }
+                ]
+              }
+            }
+          }
+        });
+
+        post.get('comments');
+      });
     },
-    'Assertion Failed: Ember Data expected the data for the comments relationship on a <post:1> to be in a JSON API format and include an `id` and `type` property but it found \'{\"id\":null,\"type\":\"comment\"}\'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.'
+    `Assertion Failed: Encountered a relationship identifier without an id for the hasMany relationship 'comments' on <post:1>, expected a json-api identifier but found '{"id":null,"type":"comment"}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`
   );
 
   // test missing type
-  // test null id
-  post = run(() => store.push({
-    data: {
-      id: '2',
-      type: 'post',
-      relationships: {
-        comments: {
-          data: [
-            { id: '1', type: null }
-          ]
-        }
-      }
-    }
-  }));
-
   assert.expectAssertion(
     () => {
-      run(() => post.get('comments'));
+      run(() => {
+        let post = store.push({
+          data: {
+            id: '2',
+            type: 'post',
+            relationships: {
+              comments: {
+                data: [
+                  { id: '1', type: null }
+                ]
+              }
+            }
+          }
+        });
+        post.get('comments')
+      });
     },
-    'Assertion Failed: Ember Data expected the data for the comments relationship on a <post:2> to be in a JSON API format and include an `id` and `type` property but it found \'{\"id\":\"1\",\"type\":null}\'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.'
+    `Assertion Failed: Encountered a relationship identifier without a type for the hasMany relationship 'comments' on <post:2>, expected a json-api identifier with type 'comment' but found '{"id":"1","type":null}'. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format.`
   );
 });
 

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -108,6 +108,56 @@ module("integration/relationships/has_many - Has-Many Relationships", {
   }
 });
 
+test("Invalid hasMany relationship identifiers throw errors", function(assert) {
+  assert.expect(2);
+  let { store } = env;
+
+  // test null id
+  let post = run(() => store.push({
+    data: {
+      id: '1',
+      type: 'post',
+      relationships: {
+        comments: {
+          data: [
+            { id: null, type: 'comment' }
+          ]
+        }
+      }
+    }
+  }));
+
+  assert.expectAssertion(
+    () => {
+      run(() => post.get('comments'));
+    },
+    "Assertion Failed: Ember Data expected the data for the comments relationship on a <post:1> to be in a JSON API format and include an `id` and `type` property but it found {id: null, type: comment}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format."
+  );
+
+  // test missing type
+  // test null id
+  post = run(() => store.push({
+    data: {
+      id: '2',
+      type: 'post',
+      relationships: {
+        comments: {
+          data: [
+            { id: '1', type: null }
+          ]
+        }
+      }
+    }
+  }));
+
+  assert.expectAssertion(
+    () => {
+      run(() => post.get('comments'));
+    },
+    "Assertion Failed: Ember Data expected the data for the comments relationship on a <post:2> to be in a JSON API format and include an `id` and `type` property but it found {id: 1, type: null}. Please check your serializer and make sure it is serializing the relationship payload into a JSON API format."
+  );
+});
+
 test("When a hasMany relationship is accessed, the adapter's findMany method should not be called if all the records in the relationship are already loaded", function(assert) {
   assert.expect(0);
 


### PR DESCRIPTION
Previously pushing an invalid relationship payload from a `has-many` would not error while a `belongs-to` would but was untested. Added tests for both.