### PR TITLE
[CLEANUP BUGFIX] fix model and factory lookup

### DIFF
--- a/addon/-private/system/model/internal-model.js
+++ b/addon/-private/system/model/internal-model.js
@@ -172,7 +172,7 @@ export default class InternalModel {
   }
 
   get modelClass() {
-    return this._modelClass || (this._modelClass = this.store._modelFor(this.modelName));
+    return this._modelClass || (this._modelClass = this.store.modelFor(this.modelName));
   }
 
   get type() {
@@ -391,7 +391,7 @@ export default class InternalModel {
         createOptions.container = this.store.container;
       }
 
-      this._record = this.store.modelFactoryFor(this.modelName).create(createOptions);
+      this._record = this.store._modelFactoryFor(this.modelName).create(createOptions);
 
       this._triggerDeferredTriggers();
       heimdall.stop(token);

--- a/addon/-private/system/record-arrays/record-array.js
+++ b/addon/-private/system/record-arrays/record-array.js
@@ -95,7 +95,7 @@ export default ArrayProxy.extend(Evented, {
     if (!this.modelName) {
       return null;
     }
-    return this.store._modelFor(this.modelName);
+    return this.store.modelFor(this.modelName);
   }).readOnly(),
 
   /**

--- a/addon/-private/system/relationships/relationship-payloads-manager.js
+++ b/addon/-private/system/relationships/relationship-payloads-manager.js
@@ -128,7 +128,7 @@ export default class RelationshipPayloadsManager {
     @method
   */
   unload(modelName, id) {
-    let modelClass = this._store._modelFor(modelName);
+    let modelClass = this._store.modelFor(modelName);
     let relationshipsByName = get(modelClass, 'relationshipsByName');
     relationshipsByName.forEach((_, relationshipName) => {
       let relationshipPayloads = this._getRelationshipPayloads(modelName, relationshipName, false);
@@ -189,7 +189,7 @@ export default class RelationshipPayloadsManager {
       return cached;
     }
 
-    let modelClass = store._modelFor(modelName);
+    let modelClass = store.modelFor(modelName);
     let relationshipsByName = get(modelClass, 'relationshipsByName');
 
     // CASE: We don't have a relationship at all

--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -202,7 +202,7 @@ const JSONAPISerializer = JSONSerializer.extend({
       return null;
     }
 
-    let modelClass = this.store._modelFor(modelName);
+    let modelClass = this.store.modelFor(modelName);
     let serializer = this.store.serializerFor(modelName);
     let { data } = serializer.normalize(modelClass, resourceHash);
     return data;

--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -267,7 +267,7 @@ const RESTSerializer = JSONSerializer.extend({
       }
 
       var typeName = this.modelNameFromPayloadKey(modelName);
-      if (!store.modelFactoryFor(typeName)) {
+      if (!store._hasModelFor(typeName)) {
         warn(this.warnMessageNoModelForKey(modelName, typeName), false, {
           id: 'ds.serializer.model-for-key-missing'
         });
@@ -395,7 +395,7 @@ const RESTSerializer = JSONSerializer.extend({
 
     for (var prop in payload) {
       var modelName = this.modelNameFromPayloadKey(prop);
-      if (!store.modelFactoryFor(modelName)) {
+      if (!store._hasModelFor(modelName)) {
         warn(this.warnMessageNoModelForKey(prop, modelName), false, {
           id: 'ds.serializer.model-for-key-missing'
         });

--- a/tests/integration/injection-test.js
+++ b/tests/integration/injection-test.js
@@ -67,7 +67,7 @@ module('integration/injection factoryFor enabled', {
 });
 
 test('modelFactoryFor', function(assert) {
-  const modelFactory = env.store.modelFactoryFor('super-villain');
+  const modelFactory = env.store._modelFactoryFor('super-villain');
 
   assert.equal(modelFactory, hasFactoryFor ? factory : model, 'expected the factory itself to be returned');
 });

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -261,18 +261,18 @@ test("a record's id is included in its toString representation", function(assert
   assert.expect(1);
   env.adapter.shouldBackgroundReloadRecord = () => false;
 
-  return run(() => {
-    store.push({
-      data: {
-        type: 'person',
-        id: '1'
-      }
-    });
+  let person = run(() => store.push({
+    data: {
+      type: 'person',
+      id: '1'
+    }
+  }));
 
-    return store.findRecord('person', 1).then(record => {
-      assert.equal(record.toString(), `<model:${record.constructor.modelName}:${guidFor(record)}:1>`, 'reports id in toString');
-    });
-  });
+  assert.equal(
+    person.toString(),
+    `<model:${person.constructor.modelName}:${guidFor(person)}:1>`,
+    'reports id in toString'
+  );
 });
 
 testInDebug('trying to set an `id` attribute should raise', function(assert) {

--- a/tests/unit/store/asserts-test.js
+++ b/tests/unit/store/asserts-test.js
@@ -16,7 +16,7 @@ const MODEL_NAME_METHODS = [
   'findAll',
   'peekAll',
   'modelFor',
-  'modelFactoryFor',
+  '_modelFactoryFor',
   'normalize',
   'adapterFor',
   'serializerFor'

--- a/tests/unit/system/relationships/relationship-payload-manager-test.js
+++ b/tests/unit/system/relationships/relationship-payload-manager-test.js
@@ -36,15 +36,9 @@ module('unit/system/relationships/relationship-payloads-manager', {
 });
 
 test('get throws for invalid models', function(assert) {
-  this.relationshipPayloadsManager._store._modelFor = (name) => {
-    if (name === 'fish') {
-      throw new Error('What is fish?');
-    }
-  };
-
   assert.throws(() => {
     this.relationshipPayloadsManager.get('fish', 9, 'hobbies');
-  }, /What is fish/);
+  }, /No model was found for 'fish'/);
 });
 
 test('get returns null for invalid relationships', function(assert) {


### PR DESCRIPTION
Resolves #4711
Resolves an issue with `createRecord` failing when being called for a non-existent model
Fixes an issue found with `toString` implementation in #5117 

Example Fail case prior to this PR:

```
let person = run(() => store.push({
    data: {
      type: 'person',
      id: '1'
    }
}));

person.constructor.modelName; // will be unset
```

Previously, we had overly complicated the process of looking up a model with a mixture of public and private and public-looking but private methods.  This complexity resulted in there being multiple code-paths by which a `ModelClass` could be looked up without a `modelName` or in which no factory for the `ModelClass` would be found but we would still attempt to `create` an instance from a missing factory.

Much of this complexity stemmed from the desire to check whether a `ModelClass` existed. I have strengthened our private `_hasModelFor` implementation, and trimmed us down to a single public `modelFor` hook and a single private `_modelFactoryFor` hook to eliminate confusion and prevent these sorts of errors from occurring.

Deprecates

- `_modelForMixin`
- `_modelFor`
- `modelFactoryFor`