### PR TITLE
[BUGFIX] destroyRecord should also unload

### DIFF
--- a/addon/-legacy-private/system/model/internal-model.js
+++ b/addon/-legacy-private/system/model/internal-model.js
@@ -133,6 +133,7 @@ export default class InternalModel {
     this._promiseProxy = null;
     this._record = null;
     this._isDestroyed = false;
+    this.isDestroying = false;
     this.isError = false;
     this._pendingRecordArrayManagerFlush = false; // used by the recordArrayManager
 
@@ -1197,12 +1198,13 @@ export default class InternalModel {
     @method adapterDidCommit
   */
   adapterDidCommit(data) {
+    let store = this.store;
+
     if (data) {
-      this.store._internalModelDidReceiveRelationshipData(
-        this.modelName,
-        this.id,
-        data.relationships
-      );
+      // normalize relationship IDs into records
+      store.updateId(this, data);
+      store._setupRelationshipsForModel(this, data);
+      store._internalModelDidReceiveRelationshipData(this.modelName, this.id, data.relationships);
 
       data = data.attributes;
     }

--- a/addon/-legacy-private/system/model/internal-model.js
+++ b/addon/-legacy-private/system/model/internal-model.js
@@ -5,7 +5,7 @@ import EmberError from '@ember/error';
 import { isEqual } from '@ember/utils';
 import { setOwner } from '@ember/application';
 import { run } from '@ember/runloop';
-import RSVP, { Promise } from 'rsvp';
+import { resolve, Promise, defer } from 'rsvp';
 import Ember from 'ember';
 import { DEBUG } from '@glimmer/env';
 import { assert, inspect } from '@ember/debug';
@@ -427,12 +427,31 @@ export default class InternalModel {
   }
 
   deleteRecord() {
-    this.send('deleteRecord');
+    if (this.isNew()) {
+      // deleteRecord will mark us as `root.deleted.saved` which is not new
+      // this could be replaced by updating the state machine to transition
+      //   records that persist their deletion and are then unloaded into
+      //   root.deleted.saved.empty or root.deleted.empty
+      //   since we know these records no longer exist remotely and should not
+      //   be fetched again.
+      this._deletedRecordWasNew = true;
+      run(() => {
+        this.send('deleteRecord');
+        this._triggerDeferredTriggers();
+        this.unloadRecord();
+      });
+    } else {
+      this.send('deleteRecord');
+    }
   }
 
   save(options) {
+    if (this._deletedRecordWasNew) {
+      return resolve();
+    }
+
     let promiseLabel = 'DS: Model#save ' + this;
-    let resolver = RSVP.defer(promiseLabel);
+    let resolver = defer(promiseLabel);
 
     this.store.scheduleSave(this, resolver, options);
     return resolver.promise;

--- a/addon/-legacy-private/system/model/internal-model.js
+++ b/addon/-legacy-private/system/model/internal-model.js
@@ -447,7 +447,7 @@ export default class InternalModel {
 
   save(options) {
     if (this._deletedRecordWasNew) {
-      return resolve();
+      return resolve(null);
     }
 
     let promiseLabel = 'DS: Model#save ' + this;

--- a/addon/-legacy-private/system/model/model.js
+++ b/addon/-legacy-private/system/model/model.js
@@ -1,6 +1,7 @@
 import ComputedProperty from '@ember/object/computed';
 import { isNone } from '@ember/utils';
 import EmberError from '@ember/error';
+import { run } from '@ember/runloop';
 import Evented from '@ember/object/evented';
 import EmberObject, { computed, get } from '@ember/object';
 import Map from '../map';
@@ -614,7 +615,12 @@ const Model = EmberObject.extend(Evented, {
   */
   destroyRecord(options) {
     this.deleteRecord();
-    return this.save(options);
+    return this.save(options).then(() => {
+      // the nested runloop here is necessary to ensure that the record is fully
+      //   destroyed prior to the promise resolving.
+      //   run.join is inadequate as the destroy queue would still be flushed after the resolve
+      run(() => this.unloadRecord());
+    });
   },
 
   /**

--- a/addon/-legacy-private/system/model/model.js
+++ b/addon/-legacy-private/system/model/model.js
@@ -67,11 +67,7 @@ function intersection(array1, array2) {
 const RESERVED_MODEL_PROPS = ['currentState', 'data', 'store'];
 
 const retrieveFromCurrentState = computed('currentState', function(key) {
-  let ret = this._internalModel.currentState[key];
-  if (key === 'isDeleted') {
-    debugger;
-  }
-  return ret;
+  return this._internalModel.currentState[key];
 }).readOnly();
 
 /**

--- a/addon/-legacy-private/system/model/model.js
+++ b/addon/-legacy-private/system/model/model.js
@@ -67,7 +67,11 @@ function intersection(array1, array2) {
 const RESERVED_MODEL_PROPS = ['currentState', 'data', 'store'];
 
 const retrieveFromCurrentState = computed('currentState', function(key) {
-  return get(this._internalModel.currentState, key);
+  let ret = this._internalModel.currentState[key];
+  if (key === 'isDeleted') {
+    debugger;
+  }
+  return ret;
 }).readOnly();
 
 /**

--- a/addon/-legacy-private/system/model/states.js
+++ b/addon/-legacy-private/system/model/states.js
@@ -699,6 +699,8 @@ const RootState = {
         internalModel.triggerLater('didCommit', internalModel);
       },
 
+      // TODO @runspired should we special case unloadRecord for root.deleted.saved ?
+
       willCommit() {},
       didCommit() {},
       pushedData() {},

--- a/addon/-legacy-private/system/relationships/state/belongs-to.js
+++ b/addon/-legacy-private/system/relationships/state/belongs-to.js
@@ -233,6 +233,7 @@ export default class BelongsToRelationship extends Relationship {
    */
   getData(isForcedReload = false) {
     //TODO(Igor) flushCanonical here once our syncing is not stupid
+    // TODO @runspired I suspect our syncing is now "good enough"™
     let record = this.inverseInternalModel ? this.inverseInternalModel.getRecord() : null;
 
     if (this.shouldMakeRequest()) {

--- a/addon/-legacy-private/system/relationships/state/has-many.js
+++ b/addon/-legacy-private/system/relationships/state/has-many.js
@@ -346,6 +346,7 @@ export default class ManyRelationship extends Relationship {
 
   getData(isForcedReload = false) {
     //TODO(Igor) sync server here, once our syncing is not stupid
+    // TODO @runspired I suspect our syncing is now "good enough"™
     let manyArray = this.manyArray;
 
     if (this.shouldMakeRequest()) {

--- a/addon/-legacy-private/system/store.js
+++ b/addon/-legacy-private/system/store.js
@@ -2046,20 +2046,14 @@ Store = Service.extend({
     if (dataArg) {
       data = dataArg.data;
     }
-    if (data) {
-      // normalize relationship IDs into records
-      this.updateId(internalModel, data);
-      this._setupRelationshipsForModel(internalModel, data);
-    } else {
-      assert(
-        `Your ${
-          internalModel.modelName
-        } record was saved to the server, but the response does not have an id and no id has been set client side. Records must have ids. Please update the server response to provide an id in the response or generate the id on the client side either before saving the record or while normalizing the response.`,
-        internalModel.id
-      );
-    }
 
-    //We first make sure the primary data has been updated
+    assert(
+      `Your ${
+        internalModel.modelName
+      } record was saved to the server, but the response does not have an id and no id has been set client side. Records must have ids. Please update the server response to provide an id in the response or generate the id on the client side either before saving the record or while normalizing the response.`,
+      internalModel.id || (data && data.id)
+    );
+
     //TODO try to move notification to the user to the end of the runloop
     internalModel.adapterDidCommit(data);
   },

--- a/addon/-record-data-private/system/model/model.js
+++ b/addon/-record-data-private/system/model/model.js
@@ -796,9 +796,12 @@ const Model = EmberObject.extend(Evented, {
     successfully or rejected if the adapter returns with an error.
   */
   save(options) {
+    return this._internalModel.save(options).then(() => this);
+    /*
     return PromiseObject.create({
       promise: this._internalModel.save(options).then(() => this),
     });
+    */
   },
 
   /**

--- a/addon/-record-data-private/system/model/states.js
+++ b/addon/-record-data-private/system/model/states.js
@@ -697,6 +697,8 @@ const RootState = {
         internalModel.triggerLater('didCommit', internalModel);
       },
 
+      // TODO @runspired should we special case unloadRecord for root.deleted.saved ?
+
       willCommit() {},
       didCommit() {},
       pushedData() {},

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "ember-qunit": "^3.4.1",
     "ember-qunit-assert-helpers": "^0.2.1",
     "ember-resolver": "^5.0.1",
-    "ember-source": "~3.3.0",
+    "ember-source": "2.18",
     "ember-source-channel-url": "^1.1.0",
     "ember-try": "^1.0.0-beta.3",
     "eslint": "^5.3.0",

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -1099,6 +1099,7 @@ test('deleteRecord - a payload with sidloaded updates pushes the updates when th
 
 test('deleteRecord - deleting a newly created record should not throw an error', async function(assert) {
   let post = store.createRecord('post');
+  let internalModel = post._internalModel;
 
   post.deleteRecord();
 
@@ -1120,9 +1121,12 @@ test('deleteRecord - deleting a newly created record should not throw an error',
     'There is no ajax call to delete a record that has never been saved.'
   );
 
-  debugger;
-  assert.equal(post.get('isDeleted'), true, 'the post is now deleted');
-  assert.equal(post.get('isError'), false, 'the post is not an error');
+  // destroyed objects do not allow computed properties to be accessed
+  //   so to check this state we need to go through the internalModel.
+  assert.equal(internalModel.currentState.isEmpty, true, 'the post is now deleted');
+  // TODO ideally we would transition to some sort of `root.deleted.empty` or `root.deleted.unloaded` form of state
+  // assert.equal(internalModel.currentState.isDeleted, true, 'the post is now deleted');
+  // assert.equal(internalModel.currentState.isError, false, 'the post is not an error');
 });
 
 test('findAll - returning an array populates the array', function(assert) {

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -1097,32 +1097,32 @@ test('deleteRecord - a payload with sidloaded updates pushes the updates when th
     });
 });
 
-test('deleteRecord - deleting a newly created record should not throw an error', function(assert) {
+test('deleteRecord - deleting a newly created record should not throw an error', async function(assert) {
   let post = store.createRecord('post');
 
-  return run(() => {
-    post.deleteRecord();
-    return post.save().then(post => {
-      assert.equal(
-        passedUrl,
-        null,
-        'There is no ajax call to delete a record that has never been saved.'
-      );
-      assert.equal(
-        passedVerb,
-        null,
-        'There is no ajax call to delete a record that has never been saved.'
-      );
-      assert.equal(
-        passedHash,
-        null,
-        'There is no ajax call to delete a record that has never been saved.'
-      );
+  post.deleteRecord();
 
-      assert.equal(post.get('isDeleted'), true, 'the post is now deleted');
-      assert.equal(post.get('isError'), false, 'the post is not an error');
-    });
-  });
+  await post.save();
+
+  assert.equal(
+    passedUrl,
+    null,
+    'There is no ajax call to delete a record that has never been saved.'
+  );
+  assert.equal(
+    passedVerb,
+    null,
+    'There is no ajax call to delete a record that has never been saved.'
+  );
+  assert.equal(
+    passedHash,
+    null,
+    'There is no ajax call to delete a record that has never been saved.'
+  );
+
+  debugger;
+  assert.equal(post.get('isDeleted'), true, 'the post is now deleted');
+  assert.equal(post.get('isError'), false, 'the post is not an error');
 });
 
 test('findAll - returning an array populates the array', function(assert) {

--- a/tests/integration/records/delete-record-test.js
+++ b/tests/integration/records/delete-record-test.js
@@ -15,7 +15,8 @@ import { attr, hasMany } from '@ember-decorators/data';
 import todo from '../../helpers/todo';
 
 class Person extends Model {
-  @attr name;
+  @attr
+  name;
 
   static toString() {
     return 'Person';
@@ -151,7 +152,8 @@ module('integration/deletedRecord - Deleting Records', function(hooks) {
 
   test('We properly unload a record when destroyRecord is called', async function(assert) {
     class Group extends Model {
-      @attr name;
+      @attr
+      name;
 
       static toString() {
         return 'Group';
@@ -237,9 +239,7 @@ module('integration/deletedRecord - Deleting Records', function(hooks) {
     assert.equal(allPeople.objectAt(0), null, "can't get any records");
   });
 
-  test('Deleting an invalid newly created record should remove it from the store', async function(
-    assert
-  ) {
+  test('Deleting an invalid newly created record should remove it from the store', async function(assert) {
     adapter.createRecord = function() {
       return reject(
         new InvalidError([
@@ -354,9 +354,7 @@ module('integration/deletedRecord - Deleting Records', function(hooks) {
     assert.equal(internalModel.isDestroyed, true, 'The internal model is destroyed');
   });
 
-  test('Calling save on a newly created then deleted record should not error', async function(
-    assert
-  ) {
+  test('Calling save on a newly created then deleted record should not error', async function(assert) {
     adapter.createRecord = function() {
       assert.ok(false, 'We should not call adapter.createRecord on save');
       return resolve({ data: null });
@@ -404,9 +402,7 @@ module('integration/deletedRecord - Deleting Records', function(hooks) {
     await record.save();
   });
 
-  test('Calling unloadRecord on a newly created then deleted record should not error', async function(
-    assert
-  ) {
+  test('Calling unloadRecord on a newly created then deleted record should not error', async function(assert) {
     adapter.createRecord = function() {
       assert.ok(false, 'We should not call adapter.createRecord on save');
       return resolve({ data: null });

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -3626,30 +3626,15 @@ test('deleteRecord + unloadRecord fun', function(assert) {
     ]);
 
     return run(() => {
-      return env.store
-        .peekRecord('post', 'post-2')
-        .destroyRecord()
-        .then(record => {
-          return env.store.unloadRecord(record);
-        });
+      return env.store.peekRecord('post', 'post-2').destroyRecord();
     })
       .then(() => {
         assert.deepEqual(posts.map(x => x.get('id')), ['post-1', 'post-3', 'post-4', 'post-5']);
-        return env.store
-          .peekRecord('post', 'post-3')
-          .destroyRecord()
-          .then(record => {
-            return env.store.unloadRecord(record);
-          });
+        return env.store.peekRecord('post', 'post-3').destroyRecord();
       })
       .then(() => {
         assert.deepEqual(posts.map(x => x.get('id')), ['post-1', 'post-4', 'post-5']);
-        return env.store
-          .peekRecord('post', 'post-4')
-          .destroyRecord()
-          .then(record => {
-            return env.store.unloadRecord(record);
-          });
+        return env.store.peekRecord('post', 'post-4').destroyRecord();
       })
       .then(() => {
         assert.deepEqual(posts.map(x => x.get('id')), ['post-1', 'post-5']);

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -688,7 +688,8 @@ test('supports canonical updates via pushedData in root.deleted.saved', function
   );
 
   run(() => {
-    record.destroyRecord().then(() => {
+    record.deleteRecord();
+    record.save().then(() => {
       let currentState = record._internalModel.currentState;
 
       assert.ok(
@@ -749,7 +750,8 @@ test('Does not support dirtying in root.deleted.saved', function(assert) {
   );
 
   run(() => {
-    record.destroyRecord().then(() => {
+    record.deleteRecord();
+    record.save().then(() => {
       let currentState = record._internalModel.currentState;
 
       assert.ok(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2759,24 +2759,24 @@ ember-source-channel-url@^1.0.1, ember-source-channel-url@^1.1.0:
   dependencies:
     got "^8.0.1"
 
-ember-source@~3.3.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.3.1.tgz#bcac785b32d5e99867e236979c3fb34536659ecd"
+ember-source@2.18:
+  version "2.18.2"
+  resolved "https://registry.npmjs.org/ember-source/-/ember-source-2.18.2.tgz#75d00eef5488bfe504044b025c752ba924eaf87f"
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
-    chalk "^2.3.0"
     ember-cli-get-component-path-option "^1.0.0"
     ember-cli-is-package-missing "^1.0.0"
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
+    ember-cli-test-info "^1.0.0"
     ember-cli-valid-component-name "^1.0.0"
     ember-cli-version-checker "^2.1.0"
     ember-router-generator "^1.2.3"
     inflection "^1.12.0"
-    jquery "^3.3.1"
-    resolve "^1.6.0"
+    jquery "^3.2.1"
+    resolve "^1.3.3"
 
 ember-try-config@^3.0.0:
   version "3.0.0"
@@ -4501,9 +4501,9 @@ jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
-jquery@^3.3.1:
+jquery@^3.2.1:
   version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+  resolved "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
 js-reporters@1.2.1:
   version "1.2.1"
@@ -6213,7 +6213,7 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6, resolve@^1.2.0, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.7.1, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.2.0, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:


### PR DESCRIPTION
It seems common for APIs to return a paylaod when deleting a record.
Although there is a test for when `undefined` is returned from
`deleteRecord` in the adapter here: https://github.com/emberjs/data/blob/master/tests/integration/records/delete-record-test.js#L87

There are currently no tests showing what happens when you return a
payload. It seems like the correct behavior for destroyRecord should be
`deleteRecord` + `save` + `unloadRecord`.