### PR TITLE
[BUGFIX] update content of proxy for async belongs-to relationships when null data received

### DIFF
--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -188,7 +188,7 @@ export default class BelongsToRelationship extends Relationship {
 
   _updateLoadingPromise(promise, content) {
     if (this._loadingPromise) {
-      if (content) {
+      if (content !== undefined) {
         this._loadingPromise.set('content', content)
       }
       this._loadingPromise.set('promise', promise)

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -95,7 +95,7 @@ module("integration/relationship/belongs_to Belongs-To Relationships", {
 test("returning a null relationship from payload sets the relationship to null on both sides", function(assert) {
   env.registry.register('model:app', DS.Model.extend({
     name: attr('string'),
-    team: belongsTo('team', { async: true }),
+    team: belongsTo('team', { async: true })
   }));
   env.registry.register('model:team', DS.Model.extend({
     apps: hasMany('app', {async: true})


### PR DESCRIPTION
resolves #5452 
replaces #5457 

This adds a failing test that a relationship should disassociate records
on both sides of the relationship when a payload explicitly returns null
for the data of that relationship.

`'book removed from author'` is the assertion that fails here. e.g. the record is not removed on the hasMany side.