### PR TITLE
[BUGFIX] ensure ManyArray state is in-sync with relationship state

### DIFF
--- a/addon/-legacy-private/system/many-array.js
+++ b/addon/-legacy-private/system/many-array.js
@@ -136,9 +136,7 @@ export default EmberObject.extend(MutableArray, Evented, {
   },
 
   objectAt(index) {
-    if (this.relationship._willUpdateManyArray) {
-      this.relationship._flushPendingManyArrayUpdates();
-    }
+    this.relationship._flushPendingManyArrayUpdates();
     let internalModel = this.currentState[index];
     if (internalModel === undefined) {
       return;
@@ -152,17 +150,8 @@ export default EmberObject.extend(MutableArray, Evented, {
     if (!_objectIsAlive(this)) {
       return;
     }
-    let toSet = this.canonicalState;
 
-    //a hack for not removing new records
-    //TODO remove once we have proper diffing
-    let newInternalModels = this.currentState.filter(
-      // only add new internalModels which are not yet in the canonical state of this
-      // relationship (a new internalModel can be in the canonical state if it has
-      // been 'acknowleged' to be in the relationship via a store.push)
-      internalModel => internalModel.isNew() && toSet.indexOf(internalModel) === -1
-    );
-    toSet = toSet.concat(newInternalModels);
+    let toSet = this.relationship.members.list.slice();
 
     // diff to find changes
     let diff = diffArray(this.currentState, toSet);

--- a/addon/-legacy-private/system/relationships/state/has-many.js
+++ b/addon/-legacy-private/system/relationships/state/has-many.js
@@ -119,11 +119,9 @@ export default class ManyRelationship extends Relationship {
   }
 
   scheduleManyArrayUpdate(internalModel, idx) {
-    // ideally we would early exit here, but some tests
-    //   currently suggest that we cannot.
-    // if (!this._manyArray) {
-    //   return;
-    // }
+    if (!this._manyArray) {
+      return;
+    }
 
     let pending = (this._pendingManyArrayUpdates = this._pendingManyArrayUpdates || []);
     pending.push(internalModel, idx);
@@ -198,10 +196,10 @@ export default class ManyRelationship extends Relationship {
   }
 
   flushCanonical() {
+    super.flushCanonical();
     if (this._manyArray) {
       this._manyArray.flushCanonical();
     }
-    super.flushCanonical();
   }
 
   removeInternalModelFromOwn(internalModel, idx) {

--- a/addon/-legacy-private/system/relationships/state/relationship.js
+++ b/addon/-legacy-private/system/relationships/state/relationship.js
@@ -263,7 +263,7 @@ export default class Relationship {
   addCanonicalInternalModel(internalModel, idx) {
     heimdall.increment(addCanonicalInternalModel);
     if (!this.canonicalMembers.has(internalModel)) {
-      this.canonicalMembers.add(internalModel);
+      this.canonicalMembers.addWithIndex(internalModel, idx);
       this.setupInverseRelationship(internalModel);
     }
     this.flushCanonicalLater();

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-publisher": "0.0.7",
     "ember-qunit": "^3.4.0",
     "ember-qunit-assert-helpers": "^0.2.1",

--- a/tests/helpers/todo.js
+++ b/tests/helpers/todo.js
@@ -1,0 +1,95 @@
+/* global Proxy */
+import QUnit, { test } from 'qunit';
+
+export default function todo(description, callback) {
+  test(`[TODO] ${description}`, async function todoTest(assert) {
+    let todos = [];
+    hijackAssert(assert, todos);
+
+    await callback(assert);
+
+    assertTestStatus(assert, todos);
+  });
+}
+
+function hijackAssert(assert, todos) {
+  const pushResult = assert.pushResult;
+
+  assert.pushResult = function hijackedPushResult(assertion) {
+    let result = assertion.result;
+    if (!assertion.isTodo && result === false) {
+      assertion.message = `[REGRESSION ENCOUNTERED] ${assertion.message}`;
+    }
+
+    return pushResult.call(assert, assertion);
+  };
+  let handler = {
+    get(target, propKey /*, receiver*/) {
+      const origMethod = target[propKey];
+
+      if (typeof origMethod === 'function' && propKey === 'pushResult') {
+        return function captureResult(assertion) {
+          let result = assertion.result;
+          assertion.isTodo = true;
+          assertion.message = `[TODO ${result === true ? 'COMPLETED' : 'INCOMPLETE'}] ${
+            assertion.message
+          }`;
+
+          todos.push(assertion);
+          origMethod.call(target, assertion);
+        };
+      } else {
+        return origMethod;
+      }
+    },
+  };
+
+  assert.todo = new Proxy(assert, handler);
+}
+
+function assertTestStatus(assert, todos) {
+  assert.todo = false;
+  const totalTodoFailures = todos.reduce((c, r) => {
+    return r.result === false ? c + 1 : c;
+  }, 0);
+  const results = QUnit.config.current.assertions;
+  const totalFailures = results.reduce((c, r) => {
+    return r.result === false ? c + 1 : c;
+  }, 0);
+  const hasNonTodoFailures = totalFailures > totalTodoFailures;
+  const hasSomeCompletedTodos = totalTodoFailures < todos.length;
+  const totalWasMet = assert.test.expected === null || assert.test.expected === results.length;
+  const todoIsComplete = totalWasMet && totalTodoFailures === 0;
+
+  if (todoIsComplete) {
+    assert.pushResult({
+      isTodo: true,
+      actual: true,
+      expected: false,
+      message:
+        '[TODO COMPLETED] This TODO is now complete (all "todo" assertions pass) and MUST be converted from todo() to test()',
+      result: false,
+    });
+  } else if (hasNonTodoFailures) {
+    assert.pushResult({
+      isTodo: true,
+      actual: false,
+      expected: true,
+      message:
+        '[REGRESSION MUST-FIX] This TODO is has regressed (a non "todo" assertion has failed) and MUST be fixed',
+      result: false,
+    });
+  } else if (hasSomeCompletedTodos) {
+    assert.pushResult({
+      isTodo: true,
+      actual: false,
+      expected: true,
+      message:
+        '[TODOS COMPLETED] Some assert.todos assertions have been completed and MUST now be converted from assert.todo to assert.',
+      result: false,
+    });
+  } else {
+    assert.test.skip = true;
+    assert.test.testReport.skipped = true;
+  }
+}

--- a/tests/integration/records/relationship-changes-test.js
+++ b/tests/integration/records/relationship-changes-test.js
@@ -643,16 +643,16 @@ test('Calling push with relationship triggers willChange and didChange with deta
   let observer = {
     arrayWillChange(array, start, removing, adding) {
       willChangeCount++;
-      assert.equal(start, 0);
-      assert.equal(removing, 0);
-      assert.equal(adding, 1);
+      assert.equal(start, 0, 'change will start at the beginning');
+      assert.equal(removing, 0, 'we have no removals');
+      assert.equal(adding, 1, 'we have one insertion');
     },
 
     arrayDidChange(array, start, removed, added) {
       didChangeCount++;
-      assert.equal(start, 0);
-      assert.equal(removed, 0);
-      assert.equal(added, 1);
+      assert.equal(start, 0, 'change did start at the beginning');
+      assert.equal(removed, 0, 'change had no removals');
+      assert.equal(added, 1, 'change had one insertion');
     },
   };
 

--- a/tests/unit/model/relationships/has-many-test.js
+++ b/tests/unit/model/relationships/has-many-test.js
@@ -2,11 +2,10 @@ import { hash, Promise as EmberPromise } from 'rsvp';
 import { get, observer } from '@ember/object';
 import { run } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
-
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { module, test } from 'qunit';
-
 import DS from 'ember-data';
+import todo from '../../../helpers/todo';
 
 let env;
 
@@ -1303,6 +1302,242 @@ test('new items added to a hasMany relationship are not cleared by a delete', fu
   );
 });
 
+todo(
+  '[push hasMany] new items added to a hasMany relationship are not cleared by a store.push',
+  function(assert) {
+    assert.expect(5);
+
+    const Person = DS.Model.extend({
+      name: DS.attr('string'),
+      pets: DS.hasMany('pet', { async: false, inverse: null }),
+    });
+
+    const Pet = DS.Model.extend({
+      name: DS.attr('string'),
+      person: DS.belongsTo('person', { async: false, inverse: null }),
+    });
+
+    let env = setupStore({
+      person: Person,
+      pet: Pet,
+    });
+    env.adapter.shouldBackgroundReloadRecord = () => false;
+    env.adapter.deleteRecord = () => {
+      return EmberPromise.resolve({ data: null });
+    };
+
+    let { store } = env;
+
+    run(() => {
+      store.push({
+        data: {
+          type: 'person',
+          id: '1',
+          attributes: {
+            name: 'Chris Thoburn',
+          },
+          relationships: {
+            pets: {
+              data: [{ type: 'pet', id: '1' }],
+            },
+          },
+        },
+        included: [
+          {
+            type: 'pet',
+            id: '1',
+            attributes: {
+              name: 'Shenanigans',
+            },
+          },
+          {
+            type: 'pet',
+            id: '2',
+            attributes: {
+              name: 'Rambunctious',
+            },
+          },
+          {
+            type: 'pet',
+            id: '3',
+            attributes: {
+              name: 'Rebel',
+            },
+          },
+        ],
+      });
+    });
+
+    const person = store.peekRecord('person', '1');
+    const pets = run(() => person.get('pets'));
+
+    const shen = pets.objectAt(0);
+    const rebel = store.peekRecord('pet', '3');
+
+    assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+    assert.deepEqual(
+      pets.map(p => get(p, 'id')),
+      ['1'],
+      'precond - relationship has the correct pets to start'
+    );
+
+    run(() => {
+      pets.pushObjects([rebel]);
+    });
+
+    assert.deepEqual(
+      pets.map(p => get(p, 'id')),
+      ['1', '3'],
+      'precond2 - relationship now has the correct two pets'
+    );
+
+    run(() => {
+      store.push({
+        data: {
+          type: 'person',
+          id: '1',
+          relationships: {
+            pets: {
+              data: [{ type: 'pet', id: '2' }],
+            },
+          },
+        },
+      });
+    });
+
+    let hasManyCanonical = person.hasMany('pets').hasManyRelationship.canonicalMembers.list;
+
+    assert.todo.deepEqual(
+      pets.map(p => get(p, 'id')),
+      ['2', '3'],
+      'relationship now has the correct current pets'
+    );
+    assert.deepEqual(
+      hasManyCanonical.map(p => get(p, 'id')),
+      ['2'],
+      'relationship now has the correct canonical pets'
+    );
+  }
+);
+
+todo(
+  '[push hasMany] items removed from a hasMany relationship are not cleared by a store.push',
+  function(assert) {
+    assert.expect(5);
+
+    const Person = DS.Model.extend({
+      name: DS.attr('string'),
+      pets: DS.hasMany('pet', { async: false, inverse: null }),
+    });
+
+    const Pet = DS.Model.extend({
+      name: DS.attr('string'),
+      person: DS.belongsTo('person', { async: false, inverse: null }),
+    });
+
+    let env = setupStore({
+      person: Person,
+      pet: Pet,
+    });
+    env.adapter.shouldBackgroundReloadRecord = () => false;
+    env.adapter.deleteRecord = () => {
+      return EmberPromise.resolve({ data: null });
+    };
+
+    let { store } = env;
+
+    run(() => {
+      store.push({
+        data: {
+          type: 'person',
+          id: '1',
+          attributes: {
+            name: 'Chris Thoburn',
+          },
+          relationships: {
+            pets: {
+              data: [{ type: 'pet', id: '1' }, { type: 'pet', id: '3' }],
+            },
+          },
+        },
+        included: [
+          {
+            type: 'pet',
+            id: '1',
+            attributes: {
+              name: 'Shenanigans',
+            },
+          },
+          {
+            type: 'pet',
+            id: '2',
+            attributes: {
+              name: 'Rambunctious',
+            },
+          },
+          {
+            type: 'pet',
+            id: '3',
+            attributes: {
+              name: 'Rebel',
+            },
+          },
+        ],
+      });
+    });
+
+    const person = store.peekRecord('person', '1');
+    const pets = run(() => person.get('pets'));
+
+    const shen = pets.objectAt(0);
+    const rebel = store.peekRecord('pet', '3');
+
+    assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+    assert.deepEqual(
+      pets.map(p => get(p, 'id')),
+      ['1', '3'],
+      'precond - relationship has the correct pets to start'
+    );
+
+    run(() => {
+      pets.removeObject(rebel);
+    });
+
+    assert.deepEqual(
+      pets.map(p => get(p, 'id')),
+      ['1'],
+      'precond2 - relationship now has the correct pet'
+    );
+
+    run(() => {
+      store.push({
+        data: {
+          type: 'person',
+          id: '1',
+          relationships: {
+            pets: {
+              data: [{ type: 'pet', id: '2' }, { type: 'pet', id: '3' }],
+            },
+          },
+        },
+      });
+    });
+
+    let hasManyCanonical = person.hasMany('pets').hasManyRelationship.canonicalMembers.list;
+
+    assert.todo.deepEqual(
+      pets.map(p => get(p, 'id')),
+      ['2'],
+      'relationship now has the correct current pets'
+    );
+    assert.deepEqual(
+      hasManyCanonical.map(p => get(p, 'id')),
+      ['2', '3'],
+      'relationship now has the correct canonical pets'
+    );
+  }
+);
+
 test('new items added to an async hasMany relationship are not cleared by a delete', function(assert) {
   assert.expect(7);
 
@@ -1715,6 +1950,7 @@ test('hasMany.firstObject.unloadRecord should not break that hasMany', function(
   assert.equal(cars.get('length'), 1); // unload now..
   assert.equal(person.get('cars.length'), 1); // unload now..
 });
+
 /*
   This test, when passing, affirms that a known limitation of ember-data still exists.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,7 +2520,7 @@ ember-cli-app-version@^3.0.0:
     ember-cli-babel "^6.8.0"
     git-repo-version "^1.0.0"
 
-ember-cli-babel@6.12.0, ember-cli-babel@^6.0.0, ember-cli-babel@^6.10.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
+ember-cli-babel@6.12.0, ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz#3adcdbe1278da1fcd0b9038f1360cb4ac5d4414c"
   dependencies:
@@ -2932,6 +2932,15 @@ ember-load-initializers@^0.6.0:
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-0.6.3.tgz#f47396ad271ba77294068c98f992a5f19705441a"
   dependencies:
     ember-cli-babel "^5.1.6"
+
+ember-maybe-import-regenerator@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz#35d41828afa6d6a59bc0da3ce47f34c573d776ca"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.0.0"
+    ember-cli-babel "^6.0.0-beta.4"
+    regenerator-runtime "^0.9.5"
 
 ember-publisher@0.0.7:
   version "0.0.7"
@@ -6405,6 +6414,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.9.5:
+  version "0.9.6"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
This PR extracts the non-diff changes from #5269. In general this is just a nice cleanup PR.

It ideally would include a test to show the issue with ManyArray losing sync that it addresses; however, because we do not currently correctly diff when flushing canonical state (thereby losing local changes), this out-of-sync issue is very hard to manifest as in most scenarios we would be in the same incorrect state even though we were drawing our state from the incorrect source.  To be out-of-sync required the currentState to be different from canonicalState post flushCanonical for more changes than just `isNew` records.

I've taken the opportunity to port the tests from #5269 and converted them to `todo`. While fixing the ManyArray state won't resolve those tests, it will move our ability to fix "currentState" in ManyArray forward, and this fix was needed for the full solution in that PR.