### PR TITLE
Serialize empty hasMany relationships

### DIFF
--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -516,31 +516,29 @@ const JSONAPISerializer = JSONSerializer.extend({
     if (this.shouldSerializeHasMany(snapshot, key, relationship)) {
       let hasMany = snapshot.hasMany(key);
       if (hasMany !== undefined) {
+
+        json.relationships = json.relationships || {};
+
+        let payloadKey = this._getMappedKey(key, snapshot.type);
+        if (payloadKey === key && this.keyForRelationship) {
+          payloadKey = this.keyForRelationship(key, 'hasMany', 'serialize');
+        }
+
         // only serialize has many relationships that are not new
         let nonNewHasMany = hasMany.filter(item => item.record && !item.record.get('isNew'));
+        let data = new Array(nonNewHasMany.length);
 
-        if (nonNewHasMany.length > 0) {
-          json.relationships = json.relationships || {};
+        for (let i = 0; i < nonNewHasMany.length; i++) {
+          let item = hasMany[i];
+          let payloadType = this.payloadKeyFromModelName(item.modelName);
 
-          let payloadKey = this._getMappedKey(key, snapshot.type);
-          if (payloadKey === key && this.keyForRelationship) {
-            payloadKey = this.keyForRelationship(key, 'hasMany', 'serialize');
-          }
-
-          let data = new Array(nonNewHasMany.length);
-
-          for (let i = 0; i < nonNewHasMany.length; i++) {
-            let item = hasMany[i];
-            let payloadType = this.payloadKeyFromModelName(item.modelName);
-
-            data[i] = {
-              type: payloadType,
-              id: item.id
-            };
-
-            json.relationships[payloadKey] = { data };
-          }
+          data[i] = {
+            type: payloadType,
+            id: item.id
+          };
         }
+
+        json.relationships[payloadKey] = { data };
       }
     }
   }

--- a/tests/integration/serializers/json-api-serializer-test.js
+++ b/tests/integration/serializers/json-api-serializer-test.js
@@ -556,6 +556,65 @@ test('it should not include any records when serializing a hasMany relationship 
           'first-name': null,
           'last-name': null,
           title: null
+        },
+        relationships: {
+          handles: {
+            data: []
+          }
+        }
+      }
+    });
+  });
+});
+
+test('it should include an empty list when serializing an empty hasMany relationship', function(assert) {
+  env.registry.register("serializer:user", DS.JSONAPISerializer.extend({
+    attrs: {
+      handles: { serialize: true }
+    }
+  }));
+
+  run(function() {
+    serializer.pushPayload(store, {
+      data: {
+        type: 'users',
+        id: 1,
+        relationships: {
+          handles: {
+            data: [
+              { type: 'handles', id: 1 },
+              { type: 'handles', id: 2 }
+            ]
+          }
+        }
+      },
+      included: [
+        { type: 'handles', id: 1 },
+        { type: 'handles', id: 2 }
+      ]
+    });
+
+    let user = store.peekRecord('user', 1);
+    let handle1 = store.peekRecord('handle', 1);
+    let handle2 = store.peekRecord('handle', 2);
+    user.get('handles').removeObject(handle1);
+    user.get('handles').removeObject(handle2);
+
+    let serialized = user.serialize({ includeId: true });
+
+    assert.deepEqual(serialized, {
+      data: {
+        type: 'users',
+        id: '1',
+        attributes: {
+          'first-name': null,
+          'last-name': null,
+          title: null
+        },
+        relationships: {
+          handles: {
+            data: []
+          }
         }
       }
     });


### PR DESCRIPTION
This is a fix for the issue [reported here](https://github.com/emberjs/data/pull/5324#issuecomment-386028562). We will now serialize an empty list when the relationship has no records.

This PR removes the `if (nonNewHasMany.length > 0) {` guard and restructures some of the code.

