### PR TITLE
[BUGFIX] normalize model name for belongs to relationships

### DIFF
--- a/addon/-private/system/relationship-meta.js
+++ b/addon/-private/system/relationship-meta.js
@@ -6,9 +6,12 @@ export function typeForRelationshipMeta(meta) {
   let modelName;
 
   modelName = meta.type || meta.key;
+  modelName = normalizeModelName(modelName);
+
   if (meta.kind === 'hasMany') {
-    modelName = singularize(normalizeModelName(modelName));
+    modelName = singularize(modelName);
   }
+
   return modelName;
 }
 

--- a/tests/unit/model/relationships-test.js
+++ b/tests/unit/model/relationships-test.js
@@ -66,3 +66,53 @@ test('eachRelatedType() iterates over relations without duplication', function(a
 
   assert.deepEqual(relations, ['occupation', 'person']);
 });
+
+test('normalizing belongsTo relationship names', function(assert) {
+  const UserProfile = DS.Model.extend({
+    user: DS.belongsTo(),
+  });
+
+  let User = DS.Model.extend({
+    userProfile: DS.belongsTo(),
+  });
+
+  store = createStore({
+    user: User,
+    userProfile: UserProfile,
+  });
+
+  User = store.modelFor('user');
+
+  const relationships = get(User, 'relationships');
+
+  assert.ok(relationships.has('user-profile'), 'relationship key has been normalized');
+
+  const relationship = relationships.get('user-profile')[0];
+
+  assert.equal(relationship.meta.name, 'userProfile', 'relationship name has not been changed');
+});
+
+test('normalizing hasMany relationship names', function(assert) {
+  const StreamItem = DS.Model.extend({
+    user: DS.belongsTo(),
+  });
+
+  let User = DS.Model.extend({
+    streamItems: DS.hasMany(),
+  });
+
+  store = createStore({
+    user: User,
+    streamItem: StreamItem,
+  });
+
+  User = store.modelFor('user');
+
+  const relationships = get(User, 'relationships');
+
+  assert.ok(relationships.has('stream-item'), 'relationship key has been normalized');
+
+  const relationship = relationships.get('stream-item')[0];
+
+  assert.equal(relationship.meta.name, 'streamItems', 'relationship name has not been changed');
+});


### PR DESCRIPTION
Given these models:

```ruby
const User = DS.Model.extend({
  userProfile: DS.belongsTo(),

  streamItems: DS.hasMany()
});

const UserProfile = DS.Model.extend({
  user: DS.belongsTo()
});

const StreamItem = DS.Model.extend({
  user: DS.belongsTo()
});
```

The inferred model type of `User.streamItems` will be `stream-item` while the type of `User.userProfile` will be `userProfile`.

This goes against the concept of all model types being dasherized.

With this change, `User.userProfile` will be converted into `user-profile`.

I'm not exactly sure where this kind of thing should be tested. It seems like it belongs in same place that the `hasMany` model type normalization tests reside, but I'm having trouble finding that place!