### PR TITLE
Add tests for destroyRecord in hasMany/belongsTo relationships

### DIFF
--- a/addon/-legacy-private/system/model/internal-model.js
+++ b/addon/-legacy-private/system/model/internal-model.js
@@ -1197,12 +1197,13 @@ export default class InternalModel {
     @method adapterDidCommit
   */
   adapterDidCommit(data) {
+    let store = this.store;
+
     if (data) {
-      this.store._internalModelDidReceiveRelationshipData(
-        this.modelName,
-        this.id,
-        data.relationships
-      );
+      // normalize relationship IDs into records
+      store.updateId(this, data);
+      store._setupRelationshipsForModel(this, data);
+      store._internalModelDidReceiveRelationshipData(this.modelName, this.id, data.relationships);
 
       data = data.attributes;
     }

--- a/addon/-legacy-private/system/model/model.js
+++ b/addon/-legacy-private/system/model/model.js
@@ -615,7 +615,8 @@ const Model = EmberObject.extend(Evented, {
   destroyRecord(options) {
     this.deleteRecord();
     return this.save(options).then(() => {
-      this.unloadRecord();
+      Ember.run(() => this.unloadRecord());
+      return this;
     });
   },
 

--- a/addon/-legacy-private/system/model/model.js
+++ b/addon/-legacy-private/system/model/model.js
@@ -614,7 +614,9 @@ const Model = EmberObject.extend(Evented, {
   */
   destroyRecord(options) {
     this.deleteRecord();
-    return this.save(options);
+    return this.save(options).then(() => {
+      this.unloadRecord();
+    });
   },
 
   /**

--- a/addon/-legacy-private/system/model/model.js
+++ b/addon/-legacy-private/system/model/model.js
@@ -9,6 +9,7 @@ import { assert, warn } from '@ember/debug';
 import { PromiseObject } from '../promise-proxies';
 import Errors from '../model/errors';
 import RootState from '../model/states';
+import { run } from '@ember/runloop';
 import {
   relationshipsByNameDescriptor,
   relatedTypesDescriptor,
@@ -615,7 +616,7 @@ const Model = EmberObject.extend(Evented, {
   destroyRecord(options) {
     this.deleteRecord();
     return this.save(options).then(() => {
-      Ember.run(() => this.unloadRecord());
+      run(() => this.unloadRecord());
       return this;
     });
   },

--- a/addon/-legacy-private/system/store.js
+++ b/addon/-legacy-private/system/store.js
@@ -1989,20 +1989,14 @@ Store = Service.extend({
     if (dataArg) {
       data = dataArg.data;
     }
-    if (data) {
-      // normalize relationship IDs into records
-      this.updateId(internalModel, data);
-      this._setupRelationshipsForModel(internalModel, data);
-    } else {
-      assert(
-        `Your ${
-          internalModel.modelName
-        } record was saved to the server, but the response does not have an id and no id has been set client side. Records must have ids. Please update the server response to provide an id in the response or generate the id on the client side either before saving the record or while normalizing the response.`,
-        internalModel.id
-      );
-    }
 
-    //We first make sure the primary data has been updated
+    assert(
+      `Your ${
+        internalModel.modelName
+      } record was saved to the server, but the response does not have an id and no id has been set client side. Records must have ids. Please update the server response to provide an id in the response or generate the id on the client side either before saving the record or while normalizing the response.`,
+      internalModel.id || (data && data.id)
+    );
+
     //TODO try to move notification to the user to the end of the runloop
     internalModel.adapterDidCommit(data);
   },

--- a/addon/-record-data-private/system/model/model.js
+++ b/addon/-record-data-private/system/model/model.js
@@ -615,7 +615,9 @@ const Model = EmberObject.extend(Evented, {
   */
   destroyRecord(options) {
     this.deleteRecord();
-    return this.save(options);
+    return this.save(options).then(() => {
+      this.unloadRecord();
+    });
   },
 
   /**

--- a/addon/-record-data-private/system/model/model.js
+++ b/addon/-record-data-private/system/model/model.js
@@ -616,7 +616,8 @@ const Model = EmberObject.extend(Evented, {
   destroyRecord(options) {
     this.deleteRecord();
     return this.save(options).then(() => {
-      this.unloadRecord();
+      Ember.run(() => this.unloadRecord());
+      return this;
     });
   },
 

--- a/addon/-record-data-private/system/model/model.js
+++ b/addon/-record-data-private/system/model/model.js
@@ -9,6 +9,7 @@ import { assert, warn } from '@ember/debug';
 import { PromiseObject } from '../promise-proxies';
 import Errors from '../model/errors';
 import RootState from '../model/states';
+import { run } from '@ember/runloop';
 import {
   relationshipsByNameDescriptor,
   relationshipsObjectDescriptor,
@@ -616,7 +617,7 @@ const Model = EmberObject.extend(Evented, {
   destroyRecord(options) {
     this.deleteRecord();
     return this.save(options).then(() => {
-      Ember.run(() => this.unloadRecord());
+      run(() => this.unloadRecord());
       return this;
     });
   },

--- a/tests/integration/relationships/belongs-to-test.js
+++ b/tests/integration/relationships/belongs-to-test.js
@@ -1,5 +1,6 @@
 import { get } from '@ember/object';
 import { run } from '@ember/runloop';
+import { A } from '@ember/array';
 import RSVP, { resolve } from 'rsvp';
 import setupStore from 'dummy/tests/helpers/store';
 import { module, test } from 'qunit';
@@ -1044,7 +1045,7 @@ test('destroying records in a belongsTo relationship that loaded via links', fun
 
     return posts
       .then(posts => {
-        assert.deepEqual(Ember.A(posts).mapBy('id'), ['1', '1', '1']);
+        assert.deepEqual(A(posts).mapBy('id'), ['1', '1', '1']);
         let post = env.store.peekRecord('post', '1');
         return post.destroyRecord();
       })
@@ -1150,7 +1151,7 @@ test('destroying records in a belongsTo relationship that loaded via sideloading
     return posts
       .then(posts => {
         console.log('posts', posts);
-        assert.deepEqual(Ember.A(posts).mapBy('id'), ['1', '1', '1']);
+        assert.deepEqual(A(posts).mapBy('id'), ['1', '1', '1']);
         let post = env.store.peekRecord('post', '1');
         return post.destroyRecord();
       })

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -3786,30 +3786,15 @@ test('deleteRecord + unloadRecord fun', function(assert) {
     ]);
 
     return run(() => {
-      return env.store
-        .peekRecord('post', 'post-2')
-        .destroyRecord()
-        .then(record => {
-          return env.store.unloadRecord(record);
-        });
+      return env.store.peekRecord('post', 'post-2').destroyRecord();
     })
       .then(() => {
         assert.deepEqual(posts.map(x => x.get('id')), ['post-1', 'post-3', 'post-4', 'post-5']);
-        return env.store
-          .peekRecord('post', 'post-3')
-          .destroyRecord()
-          .then(record => {
-            return env.store.unloadRecord(record);
-          });
+        return env.store.peekRecord('post', 'post-3').destroyRecord();
       })
       .then(() => {
         assert.deepEqual(posts.map(x => x.get('id')), ['post-1', 'post-4', 'post-5']);
-        return env.store
-          .peekRecord('post', 'post-4')
-          .destroyRecord()
-          .then(record => {
-            return env.store.unloadRecord(record);
-          });
+        return env.store.peekRecord('post', 'post-4').destroyRecord();
       })
       .then(() => {
         assert.deepEqual(posts.map(x => x.get('id')), ['post-1', 'post-5']);

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -2915,25 +2915,25 @@ test('destroying records in a hasMany relationship that loaded via links', funct
     comment: Comment,
     adapter: DS.RESTAdapter.extend({
       shouldBackgroundReloadRecord: () => false,
-      findHasMany: () =>  {
+      findHasMany: () => {
         return {
           comments: [
             {
               type: 'comment',
-              id: '1'
+              id: '1',
             },
             {
               type: 'comment',
-              id: '2'
+              id: '2',
             },
             {
               type: 'comment',
-              id: '3'
-            }
-          ]
+              id: '3',
+            },
+          ],
         };
-      }
-    })
+      },
+    }),
   });
 
   env.registry.register(
@@ -2941,7 +2941,7 @@ test('destroying records in a hasMany relationship that loaded via links', funct
     DS.RESTAdapter.extend({
       deleteRecord(record) {
         return resolve();
-      }
+      },
     })
   );
 
@@ -2954,27 +2954,29 @@ test('destroying records in a hasMany relationship that loaded via links', funct
           relationships: {
             comments: {
               links: {
-                related: '/comments'
-              }
-            }
-          }
-        }
-      ]
+                related: '/comments',
+              },
+            },
+          },
+        },
+      ],
     });
   });
 
   return run(() => {
     return env.store.findRecord('post', 1).then(post => {
-      return post.get('comments').then((comments) => {
+      return post.get('comments').then(comments => {
         assert.equal(comments.get('length'), 3, 'Initial comments count');
 
-        return comments.get('lastObject').destroyRecord()
-        .then(() => {
-          let comments = post.get('comments');
-          let length = comments.get('length');
+        return comments
+          .get('lastObject')
+          .destroyRecord()
+          .then(() => {
+            let comments = post.get('comments');
+            let length = comments.get('length');
 
-          assert.equal(length, 2, 'Comments count after destroy');
-        });
+            assert.equal(length, 2, 'Comments count after destroy');
+          });
       });
     });
   });
@@ -2996,8 +2998,8 @@ test('destroying records in a hasMany relationship that loaded via sideloading',
     post: Post,
     comment: Comment,
     adapter: DS.RESTAdapter.extend({
-      shouldBackgroundReloadRecord: () => false
-    })
+      shouldBackgroundReloadRecord: () => false,
+    }),
   });
 
   env.registry.register(
@@ -3005,7 +3007,7 @@ test('destroying records in a hasMany relationship that loaded via sideloading',
     DS.RESTAdapter.extend({
       deleteRecord(record) {
         return resolve();
-      }
+      },
     })
   );
 
@@ -3043,16 +3045,18 @@ test('destroying records in a hasMany relationship that loaded via sideloading',
 
   return run(() => {
     return env.store.findRecord('post', 1).then(post => {
-      return post.get('comments').then((comments) => {
+      return post.get('comments').then(comments => {
         assert.equal(comments.get('length'), 3, 'Initial comments count');
 
-        return comments.get('lastObject').destroyRecord()
-        .then(() => {
-          let comments = post.get('comments');
-          let length = comments.get('length');
+        return comments
+          .get('lastObject')
+          .destroyRecord()
+          .then(() => {
+            let comments = post.get('comments');
+            let length = comments.get('length');
 
-          assert.equal(length, 2, 'Comments count after destroy');
-        });
+            assert.equal(length, 2, 'Comments count after destroy');
+          });
       });
     });
   });

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -688,7 +688,8 @@ test('supports canonical updates via pushedData in root.deleted.saved', function
   );
 
   run(() => {
-    record.destroyRecord().then(() => {
+    record.deleteRecord();
+    record.save().then(() => {
       let currentState = record._internalModel.currentState;
 
       assert.ok(
@@ -749,7 +750,8 @@ test('Does not support dirtying in root.deleted.saved', function(assert) {
   );
 
   run(() => {
-    record.destroyRecord().then(() => {
+    record.deleteRecord();
+    record.save().then(() => {
       let currentState = record._internalModel.currentState;
 
       assert.ok(


### PR DESCRIPTION
Added tests for using `destroyRecord` in relationships. We found that in a hasMany relationship that uses `links` to load the relationships, when calling `destroyRecord`, it does not remove the record in the hasMany array. See failing test. 

Related #5472