### PR TITLE
[BUGFIX] Lowercase header names in parseResponseHeaders

### DIFF
--- a/addon/-private/utils/parse-response-headers.js
+++ b/addon/-private/utils/parse-response-headers.js
@@ -29,6 +29,9 @@ export default function parseResponseHeaders(headersString) {
     let value = header.substring(j + 1, header.length).trim();
 
     if (value) {
+      let lowerCasedField = field.toLowerCase();
+
+      headers[lowerCasedField] = value;
       headers[field] = value;
     }
   }

--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -1156,7 +1156,7 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
   */
   generatedDetailedMessage: function(status, headers, payload, requestData) {
     let shortenedPayload;
-    let payloadContentType = headers['Content-Type'] || 'Empty Content-Type';
+    let payloadContentType = headers['content-type'] || 'Empty Content-Type';
 
     if (payloadContentType === 'text/html' && payload.length > 250) {
       shortenedPayload = '[Omitted Lengthy HTML]';

--- a/tests/unit/adapters/rest-adapter/detailed-message-test.js
+++ b/tests/unit/adapters/rest-adapter/detailed-message-test.js
@@ -21,7 +21,7 @@ test('generating a wonderfully friendly error message should work', function(ass
 
   let friendlyMessage = adapter.generatedDetailedMessage(
     418,
-    { 'Content-Type': 'text/plain' },
+    { 'content-type': 'text/plain' },
     "I'm a little teapot, short and stout",
     {
       url: '/teapots/testing',

--- a/tests/unit/utils/parse-response-headers-test.js
+++ b/tests/unit/utils/parse-response-headers-test.js
@@ -21,7 +21,7 @@ test('header parsing', function(assert) {
 
   let headers = parseResponseHeaders(headersString);
 
-  assert.equal(headers['Content-Encoding'], 'gzip', 'parses basic header pair');
+  assert.equal(headers['content-encoding'], 'gzip', 'parses basic header pair');
   assert.equal(
     headers['content-type'],
     'application/json; charset=utf-8',
@@ -34,6 +34,7 @@ test('field-name parsing', function(assert) {
   let headersString = [
     '  name-with-leading-whitespace: some value',
     'name-with-whitespace-before-colon : another value',
+    'Uppercase-Name: yet another value',
   ].join(CRLF);
 
   let headers = parseResponseHeaders(headersString);
@@ -48,6 +49,7 @@ test('field-name parsing', function(assert) {
     'another value',
     'strips whitespace before colon from field-name'
   );
+  assert.equal(headers['uppercase-name'], 'yet another value', 'lowercases the field-name');
 });
 
 test('field-value parsing', function(assert) {
@@ -92,9 +94,9 @@ test('ignores headers that do not contain a colon', function(assert) {
 
   let headers = parseResponseHeaders(headersString);
 
-  assert.deepEqual(headers['Content-Encoding'], 'gzip', 'parses basic header pair');
+  assert.deepEqual(headers['content-encoding'], 'gzip', 'parses basic header pair');
   assert.deepEqual(headers['apple'], 'pie', 'parses basic header pair');
-  assert.equal(Object.keys(headers).length, 2, 'only has the one valid header');
+  assert.equal(Object.keys(headers).length, 3, 'only has the three valid headers');
 });
 
 test('tollerate extra new-lines', function(assert) {


### PR DESCRIPTION
Closes #4952.

Pretty sure I got all the places we rely on uppercased header names, like in `generatedDetailedMessage` 🤞 