### PR TITLE
Update parseResponseHeaders to work in fastboot.

### DIFF
--- a/addon/-private/utils/parse-response-headers.js
+++ b/addon/-private/utils/parse-response-headers.js
@@ -1,4 +1,4 @@
-const CLRF = '\u000d\u000a';
+const newline = /\r?\n/;
 
 export default function parseResponseHeaders(headersString) {
   let headers = Object.create(null);
@@ -7,7 +7,8 @@ export default function parseResponseHeaders(headersString) {
     return headers;
   }
 
-  let headerPairs = headersString.split(CLRF);
+  let headerPairs = headersString.split(newline);
+
   for (let i = 0; i < headerPairs.length; i++) {
     let header = headerPairs[i];
     let j = 0;

--- a/tests/unit/utils/parse-response-headers-test.js
+++ b/tests/unit/utils/parse-response-headers-test.js
@@ -109,12 +109,16 @@ test('works with only line feeds', function(assert) {
   let headersString = [
     'Content-Encoding: gzip',
     'content-type: application/json; charset=utf-8',
-    'date: Fri, 05 Feb 2016 21:47:56 GMT'
+    'date: Fri, 05 Feb 2016 21:47:56 GMT',
   ].join(LF);
 
   let headers = parseResponseHeaders(headersString);
 
   assert.equal(headers['Content-Encoding'], 'gzip', 'parses basic header pair');
-  assert.equal(headers['content-type'], 'application/json; charset=utf-8', 'parses header with complex value');
+  assert.equal(
+    headers['content-type'],
+    'application/json; charset=utf-8',
+    'parses header with complex value'
+  );
   assert.equal(headers['date'], 'Fri, 05 Feb 2016 21:47:56 GMT', 'parses header with date value');
 });

--- a/tests/unit/utils/parse-response-headers-test.js
+++ b/tests/unit/utils/parse-response-headers-test.js
@@ -2,6 +2,7 @@ import { parseResponseHeaders } from 'ember-data/-private';
 import { module, test } from 'qunit';
 
 const CRLF = '\u000d\u000a';
+const LF = '\u000a';
 
 module('unit/adapters/parse-response-headers');
 
@@ -102,4 +103,18 @@ test('tollerate extra new-lines', function(assert) {
 
   assert.deepEqual(headers['foo'], 'bar', 'parses basic header pair');
   assert.equal(Object.keys(headers).length, 1, 'only has the one valid header');
+});
+
+test('works with only line feeds', function(assert) {
+  let headersString = [
+    'Content-Encoding: gzip',
+    'content-type: application/json; charset=utf-8',
+    'date: Fri, 05 Feb 2016 21:47:56 GMT'
+  ].join(LF);
+
+  let headers = parseResponseHeaders(headersString);
+
+  assert.equal(headers['Content-Encoding'], 'gzip', 'parses basic header pair');
+  assert.equal(headers['content-type'], 'application/json; charset=utf-8', 'parses header with complex value');
+  assert.equal(headers['date'], 'Fri, 05 Feb 2016 21:47:56 GMT', 'parses header with date value');
 });


### PR DESCRIPTION
On nix systems the headers will be delimited with only a newline (`\n`) character.

This PR changes the split to `\r?\n`, which will work for all fastboot environments as well as browsers.