### PR TITLE
[BUGFIX] fix timing of ui notification to avoid trolling observers

### DIFF
--- a/addon/-legacy-private/system/relationships/state/relationship.js
+++ b/addon/-legacy-private/system/relationships/state/relationship.js
@@ -522,7 +522,7 @@ export default class Relationship {
     this.store._updateRelationshipState(this);
   }
 
-  updateLink(link, initial) {
+  updateLink(link) {
     heimdall.increment(updateLink);
     warn(
       `You pushed a record of type '${this.internalModel.modelName}' with a relationship '${
@@ -543,10 +543,6 @@ export default class Relationship {
     this.link = link;
     this.fetchPromise = null;
     this.setRelationshipIsStale(true);
-
-    if (!initial) {
-      this.internalModel.notifyPropertyChange(this.key);
-    }
   }
 
   reload() {
@@ -708,7 +704,7 @@ export default class Relationship {
       let relatedLink = _normalizeLink(payload.links.related);
       if (relatedLink && relatedLink.href && relatedLink.href !== this.link) {
         hasLink = true;
-        this.updateLink(relatedLink.href, initial);
+        this.updateLink(relatedLink.href);
       }
     }
 
@@ -736,6 +732,10 @@ export default class Relationship {
       this.setRelationshipIsEmpty(relationshipIsEmpty);
     } else if (hasLink) {
       this.setRelationshipIsStale(true);
+
+      if (!initial) {
+        this.internalModel.notifyPropertyChange(this.key);
+      }
     }
   }
 

--- a/addon/-record-data-private/system/relationships/state/relationship.js
+++ b/addon/-record-data-private/system/relationships/state/relationship.js
@@ -568,7 +568,7 @@ export default class Relationship {
     this.store._updateRelationshipState(this);
   }
 
-  updateLink(link, initial) {
+  updateLink(link) {
     heimdall.increment(updateLink);
     warn(
       `You pushed a record of type '${this.modelData.modelName}' with a relationship '${
@@ -587,18 +587,6 @@ export default class Relationship {
     );
 
     this.link = link;
-    this.setRelationshipIsStale(true);
-
-    if (!initial) {
-      let modelData = this.modelData;
-      let storeWrapper = this.modelData.storeWrapper;
-      storeWrapper.notifyPropertyChange(
-        modelData.modelName,
-        modelData.id,
-        modelData.clientId,
-        this.key
-      );
-    }
   }
 
   updateModelDatasFromAdapter(modelDatas) {
@@ -659,7 +647,7 @@ export default class Relationship {
       let relatedLink = _normalizeLink(payload.links.related);
       if (relatedLink && relatedLink.href && relatedLink.href !== this.link) {
         hasLink = true;
-        this.updateLink(relatedLink.href, initial);
+        this.updateLink(relatedLink.href);
       }
     }
 
@@ -688,6 +676,17 @@ export default class Relationship {
       this.setRelationshipIsEmpty(relationshipIsEmpty);
     } else if (hasLink) {
       this.setRelationshipIsStale(true);
+
+      if (!initial) {
+        let modelData = this.modelData;
+        let storeWrapper = this.modelData.storeWrapper;
+        storeWrapper.notifyPropertyChange(
+          modelData.modelName,
+          modelData.id,
+          modelData.clientId,
+          this.key
+        );
+      }
     }
   }
 


### PR DESCRIPTION
While our `relationship.push` method is sync, we do not wait for the end of the method to `notifyPropertyChange`. This causes issues with observers which then trigger in a broken intermediate state. Here, I've fixed this for notifying that a relationship is stale after receiving a new `link`; however, it is still possible for this to go wrong for folks when new data is pushed in. In a happier future, we ought to have a better setup to ensure we always buffer ui notifications and flush after state is settled.