### PR TITLE
Remaining Module Unification Blueprints

### DIFF
--- a/blueprints/model-test/index.js
+++ b/blueprints/model-test/index.js
@@ -1,6 +1,9 @@
 var ModelBlueprint = require('../model');
 var testInfo = require('ember-cli-test-info');
 var useTestFrameworkDetector = require('../test-framework-detector');
+const isModuleUnificationProject = require('../../lib/utilities/module-unification')
+  .isModuleUnificationProject;
+const path = require('path');
 
 module.exports = useTestFrameworkDetector({
   description: 'Generates a model unit test.',
@@ -11,5 +14,30 @@ module.exports = useTestFrameworkDetector({
     result.friendlyTestDescription = testInfo.description(options.entity.name, 'Unit', 'Model');
 
     return result;
+  },
+
+  fileMapTokens(options) {
+    if (isModuleUnificationProject(this.project)) {
+      return {
+        __root__() {
+          return 'src';
+        },
+        __path__(options) {
+          return path.join('data', 'models', options.dasherizedModuleName);
+        },
+        __test__() {
+          return 'model-test';
+        },
+      };
+    } else {
+      return {
+        __root__() {
+          return 'tests';
+        },
+        __path__() {
+          return path.join('unit', 'models');
+        },
+      };
+    }
   },
 });

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -1,11 +1,30 @@
 var inflection = require('inflection');
 var stringUtils = require('ember-cli-string-utils');
 var EOL = require('os').EOL;
+const isModuleUnificationProject = require('../../lib/utilities/module-unification')
+  .isModuleUnificationProject;
+const path = require('path');
 
 module.exports = {
   description: 'Generates an ember-data model.',
 
   anonymousOptions: ['name', 'attr:type'],
+
+  fileMapTokens(options) {
+    if (isModuleUnificationProject(this.project)) {
+      return {
+        __root__() {
+          return 'src';
+        },
+        __path__(options) {
+          return path.join('data', 'models', options.dasherizedModuleName);
+        },
+        __name__() {
+          return 'adapter';
+        },
+      };
+    }
+  },
 
   locals: function(options) {
     var attrs = [];

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -20,7 +20,7 @@ module.exports = {
           return path.join('data', 'models', options.dasherizedModuleName);
         },
         __name__() {
-          return 'adapter';
+          return 'model';
         },
       };
     }

--- a/blueprints/serializer-test/index.js
+++ b/blueprints/serializer-test/index.js
@@ -1,5 +1,8 @@
 var testInfo = require('ember-cli-test-info');
 var useTestFrameworkDetector = require('../test-framework-detector');
+const isModuleUnificationProject = require('../../lib/utilities/module-unification')
+  .isModuleUnificationProject;
+const path = require('path');
 
 module.exports = useTestFrameworkDetector({
   description: 'Generates a serializer unit test.',
@@ -8,5 +11,30 @@ module.exports = useTestFrameworkDetector({
     return {
       friendlyTestDescription: testInfo.description(options.entity.name, 'Unit', 'Serializer'),
     };
+  },
+
+  fileMapTokens(options) {
+    if (isModuleUnificationProject(this.project)) {
+      return {
+        __root__() {
+          return 'src';
+        },
+        __path__(options) {
+          return path.join('data', 'models', options.dasherizedModuleName);
+        },
+        __test__() {
+          return 'serializer-test';
+        },
+      };
+    } else {
+      return {
+        __root__() {
+          return 'tests';
+        },
+        __path__() {
+          return path.join('unit', 'serializers');
+        },
+      };
+    }
   },
 });

--- a/blueprints/serializer/index.js
+++ b/blueprints/serializer/index.js
@@ -1,4 +1,7 @@
 var extendFromApplicationEntity = require('../../lib/utilities/extend-from-application-entity');
+const isModuleUnificationProject = require('../../lib/utilities/module-unification')
+  .isModuleUnificationProject;
+const path = require('path');
 
 module.exports = {
   description: 'Generates an ember-data serializer.',
@@ -7,5 +10,21 @@ module.exports = {
 
   locals: function(options) {
     return extendFromApplicationEntity('serializer', 'DS.JSONAPISerializer', options);
+  },
+
+  fileMapTokens(options) {
+    if (isModuleUnificationProject(this.project)) {
+      return {
+        __root__() {
+          return 'src';
+        },
+        __path__(options) {
+          return path.join('data', 'models', options.dasherizedModuleName);
+        },
+        __name__() {
+          return 'adapter';
+        },
+      };
+    }
   },
 };

--- a/blueprints/serializer/index.js
+++ b/blueprints/serializer/index.js
@@ -22,7 +22,7 @@ module.exports = {
           return path.join('data', 'models', options.dasherizedModuleName);
         },
         __name__() {
-          return 'adapter';
+          return 'serializer';
         },
       };
     }

--- a/blueprints/transform-test/index.js
+++ b/blueprints/transform-test/index.js
@@ -1,5 +1,8 @@
 var testInfo = require('ember-cli-test-info');
 var useTestFrameworkDetector = require('../test-framework-detector');
+const isModuleUnificationProject = require('../../lib/utilities/module-unification')
+  .isModuleUnificationProject;
+const path = require('path');
 
 module.exports = useTestFrameworkDetector({
   description: 'Generates a transform unit test.',
@@ -8,5 +11,30 @@ module.exports = useTestFrameworkDetector({
     return {
       friendlyTestDescription: testInfo.description(options.entity.name, 'Unit', 'Transform'),
     };
+  },
+
+  fileMapTokens(options) {
+    if (isModuleUnificationProject(this.project)) {
+      return {
+        __root__() {
+          return 'src';
+        },
+        __path__(options) {
+          return path.join('data', 'transforms', options.dasherizedModuleName);
+        },
+        __test__() {
+          return 'transforms-test';
+        },
+      };
+    } else {
+      return {
+        __root__() {
+          return 'tests';
+        },
+        __path__() {
+          return path.join('unit', 'transforms');
+        },
+      };
+    }
   },
 });

--- a/blueprints/transform/index.js
+++ b/blueprints/transform/index.js
@@ -1,3 +1,32 @@
+const isModuleUnificationProject = require('../../lib/utilities/module-unification')
+  .isModuleUnificationProject;
+const path = require('path');
+
 module.exports = {
   description: 'Generates an ember-data value transform.',
+
+  fileMapTokens(options) {
+    if (isModuleUnificationProject(this.project)) {
+      return {
+        __root__() {
+          return 'src';
+        },
+        __path__(options) {
+          return path.join('data', 'transforms', options.dasherizedModuleName);
+        },
+        __test__() {
+          return 'transform-test';
+        },
+      };
+    } else {
+      return {
+        __root__() {
+          return 'tests';
+        },
+        __path__() {
+          return path.join('unit', 'transforms');
+        },
+      };
+    }
+  },
 };


### PR DESCRIPTION
When this is done, this should check off all the ember-data items on https://github.com/ember-cli/ember-cli/issues/7530

 - models
 - serializers
 - transforms

Things left to do:
 - see if there are automated tests to add


Test:
```bash
yarn add ember-cli
mv package.json .package.json
MODULE_UNIFICATION=true EMBER_CLI_MODULE_UNIFICATION=true node_modules/.bin/ember new mu-data-test
cd mu-data-test/node_modules
rm -rf ember-data
ln -s ~/Development/NullVoxPopuli/ember-data ember-data
cd ..
```

## Testing if the blueprints work

in my test project's package.json#scripts, I'll add:

```
    "ember": "EMBER_CLI_MODULE_UNIFICATION=true node_modules/.bin/ember",
```

then, 

```bash
yarn ember g model planet --dry-run
```
```
installing model
  create src/data/models/planet/model.js
installing model-test
  create tests/unit/data/models/my-model/model-test.js
```
```bash
yarn ember g adapter planet --dry-run
```
```
installing adapter
  create src/data/models/planet/adapter.js
installing adapter-test
  create src/data/models/planet/adapter-test.js
```
```bash
yarn ember g serializer planet --dry-run
```
```
installing serializer
  create src/data/models/planet/serializer.js
installing serializer-test
  create tests/unit/data/models/planet/serializer-test.js
```
```bash
 yarn ember g transform my-transform --dry-run
```
```
installing transform
  create src/data/transforms/my-transform/my-transform.js
installing transform-test
  create tests/unit/data/transforms/my-transform/transforms-test.js

# NOTE: dry-run messages omitted
```

# Questions

 - should the tests be co-located?

example:

```
src/
  data/
    models/
      planet/
        model.js
        model-test.js
        adapter.js
        adapter-test.js
        serializer.js
        serializer-test.js
    transforms/
      my-transform/
        transform.js
        transform-test.js
```