### PR TITLE
Do not publish yarn.lock to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,6 +20,7 @@
 bower.json
 ember-cli-build.js
 testem.js
+yarn.lock
 
 *.gem
 *.gemspec


### PR DESCRIPTION
`yarn.lock` is the largest file we publish to npm but it isn't used by any consumers of ember-data. This patch prevents us from publishing it to npm so trim our published bundle a bit.

```
npm notice 283.9kB yarn.lock                                                                  
```