### PR TITLE
[FEAT] TrackableRequests for when async leakage is detected

### DIFF
--- a/addon/-legacy-private/system/relationships/state/belongs-to.js
+++ b/addon/-legacy-private/system/relationships/state/belongs-to.js
@@ -19,7 +19,8 @@ export default class BelongsToRelationship extends Relationship {
    * true if there is no inverse
    * false if the inverse exists and is not loaded (empty)
    *
-   * @returns {boolean}
+   * @property
+   * @return {boolean}
    */
   get allInverseRecordsAreLoaded() {
     let internalModel = this.inverseInternalModel;

--- a/addon/-legacy-private/system/relationships/state/has-many.js
+++ b/addon/-legacy-private/system/relationships/state/has-many.js
@@ -33,7 +33,8 @@ export default class ManyRelationship extends Relationship {
    * true if there are no inverse records
    * false if the inverse records exist and any are not loaded (any empty)
    *
-   * @returns {boolean}
+   * @property
+   * @return {boolean}
    */
   get allInverseRecordsAreLoaded() {
     // check currentState for unloaded records

--- a/addon/-private/system/store/common.js
+++ b/addon/-private/system/store/common.js
@@ -34,14 +34,15 @@ export function _objectIsAlive(object) {
 }
 
 export function guardDestroyedStore(promise, store, label) {
+  let token;
   if (DEBUG) {
-    store.__asyncRequestCount++;
+    token = store._trackAsyncRequestStart(label);
   }
   let wrapperPromise = resolve(promise, label).then(v => promise);
 
   return _guard(wrapperPromise, () => {
     if (DEBUG) {
-      store.__asyncRequestCount--;
+      store._trackAsyncRequestEnd(token);
     }
     return _objectIsAlive(store);
   });

--- a/addon/-record-data-private/system/relationships/state/belongs-to.js
+++ b/addon/-record-data-private/system/relationships/state/belongs-to.js
@@ -199,7 +199,7 @@ export default class BelongsToRelationship extends Relationship {
    * true if there is no inverse
    * false if the inverse exists and is not loaded (empty)
    *
-   * @returns {boolean}
+   * @return {boolean}
    */
   get allInverseRecordsAreLoaded() {
     let modelData = this.inverseModelData;

--- a/addon/-record-data-private/system/relationships/state/has-many.js
+++ b/addon/-record-data-private/system/relationships/state/has-many.js
@@ -256,7 +256,7 @@ export default class ManyRelationship extends Relationship {
    * true if there are no inverse records
    * false if the inverse records exist and any are not loaded (any empty)
    *
-   * @returns {boolean}
+   * @return {boolean}
    */
   get allInverseRecordsAreLoaded() {
     // check currentState for unloaded records

--- a/addon/-record-data-private/system/store.js
+++ b/addon/-record-data-private/system/store.js
@@ -226,9 +226,52 @@ Store = Service.extend({
     this.modelDataWrapper = new ModelDataWrapper(this);
 
     if (DEBUG) {
-      this.__asyncRequestCount = 0;
+      if (this.shouldTrackAsyncRequests === undefined) {
+        this.shouldTrackAsyncRequests = false;
+      }
+      if (this.generateStackTracesForTrackedRequests === undefined) {
+        this.generateStackTracesForTrackedRequests = false;
+      }
+
+      this._trackedAsyncRequests = [];
+      this._trackAsyncRequestStart = label => {
+        let trace =
+          'set `store.generateStackTracesForTrackedRequests = true;` to get a detailed trace for where this request originated';
+
+        if (this.generateStackTracesForTrackedRequests) {
+          try {
+            throw new Error(`EmberData TrackedRequest: ${label}`);
+          } catch (e) {
+            trace = e;
+          }
+        }
+
+        let token = Object.freeze({
+          label,
+          trace,
+        });
+
+        this._trackedAsyncRequests.push(token);
+        return token;
+      };
+      this._trackAsyncRequestEnd = token => {
+        let index = this._trackedAsyncRequests.indexOf(token);
+
+        if (index === -1) {
+          throw new Error(
+            `Attempted to end tracking for the following request but it was not being tracked:\n${token}`
+          );
+        }
+
+        this._trackedAsyncRequests.splice(index, 1);
+      };
+
       this.__asyncWaiter = () => {
-        return this.__asyncRequestCount === 0;
+        let shouldTrack = this.shouldTrackAsyncRequests;
+        let tracked = this._trackedAsyncRequests;
+        let isSettled = tracked.length === 0;
+
+        return shouldTrack !== true || isSettled;
       };
 
       Ember.Test.registerWaiter(this.__asyncWaiter);
@@ -841,6 +884,24 @@ Store = Service.extend({
       resolver,
       options,
     };
+
+    if (DEBUG) {
+      if (this.generateStackTracesForTrackedRequests === true) {
+        let trace;
+
+        try {
+          throw new Error(`Trace Origin for scheduled fetch for ${modelName}:${id}.`);
+        } catch (e) {
+          trace = e;
+        }
+
+        // enable folks to discover the origin of this findRecord call when
+        // debugging. Ideally we would have a tracked queue for requests with
+        // labels or local IDs that could be used to merge this trace with
+        // the trace made available when we detect an async leak
+        pendingFetchItem.trace = trace;
+      }
+    }
 
     let promise = resolver.promise;
 
@@ -3062,6 +3123,27 @@ Store = Service.extend({
 
     if (DEBUG) {
       Ember.Test.unregisterWaiter(this.__asyncWaiter);
+      let shouldTrack = this.shouldTrackAsyncRequests;
+      let tracked = this._trackedAsyncRequests;
+      let isSettled = tracked.length === 0;
+
+      if (!isSettled) {
+        if (shouldTrack) {
+          throw new Error(
+            'Async Request leaks detected. Add a breakpoint here and set `store.generateStackTracesForTrackedRequests = true;`to inspect traces for leak origins:\n\t - ' +
+              tracked.map(o => o.label).join('\n\t - ')
+          );
+        } else {
+          warn(
+            'Async Request leaks detected. Add a breakpoint here and set `store.generateStackTracesForTrackedRequests = true;`to inspect traces for leak origins:\n\t - ' +
+              tracked.map(o => o.label).join('\n\t - '),
+            false,
+            {
+              id: 'ds.async.leak.detected',
+            }
+          );
+        }
+      }
     }
   },
 
@@ -3231,7 +3313,7 @@ function _commit(adapter, store, operation, snapshot) {
  * @param store
  * @param cache modelFactoryCache
  * @param normalizedModelName already normalized modelName
- * @returns {*}
+ * @return {*}
  */
 function getModelFactory(store, cache, normalizedModelName) {
   let factory = cache[normalizedModelName];

--- a/tests/unit/store/async-leak-test.js
+++ b/tests/unit/store/async-leak-test.js
@@ -1,0 +1,361 @@
+import { module } from 'qunit';
+import JSONAPIAdapter from 'ember-data/adapters/json-api';
+import JSONAPISerializer from 'ember-data/serializers/json-api';
+import { setupTest } from 'ember-qunit';
+import Store from 'ember-data/store';
+import Model from 'ember-data/model';
+import { Promise } from 'rsvp';
+import { attr } from '@ember-decorators/data';
+import { run } from '@ember/runloop';
+import Ember from 'ember';
+import { testInDebug as test } from '../../helpers/test-in-debug';
+
+class Person extends Model {
+  @attr
+  name;
+}
+
+module('unit/store async-waiter and leak detection', function(hooks) {
+  let store;
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    let { owner } = this;
+    owner.register('service:store', Store);
+    owner.register('model:person', Person);
+    owner.register(
+      'serializer:application',
+      JSONAPISerializer.extend({
+        normalizeResponse(_, __, jsonApiPayload) {
+          return jsonApiPayload;
+        },
+      })
+    );
+    store = owner.lookup('service:store');
+    store.shouldTrackAsyncRequests = true;
+  });
+
+  test('the waiter properly waits for pending requests', async function(assert) {
+    let findRecordWasInvoked;
+    let findRecordWasInvokedPromise = new Promise(resolveStep => {
+      findRecordWasInvoked = resolveStep;
+    });
+    this.owner.register(
+      'adapter:application',
+      JSONAPIAdapter.extend({
+        findRecord() {
+          return new Promise(resolve => {
+            findRecordWasInvoked();
+
+            setTimeout(() => {
+              resolve({ data: { type: 'person', id: '1' } });
+            }, 50); // intentionally longer than the 10ms polling interval of `wait()`
+          });
+        },
+      })
+    );
+
+    let request = store.findRecord('person', '1');
+    let waiter = store.__asyncWaiter;
+
+    assert.equal(
+      waiter(),
+      true,
+      'We return true when no requests have been initiated yet (pending queue flush is async)'
+    );
+
+    await findRecordWasInvokedPromise;
+
+    assert.equal(waiter(), false, 'We return false to keep waiting while requests are pending');
+
+    await request;
+
+    assert.equal(waiter(), true, 'We return true to end waiting when no requests are pending');
+  });
+
+  test('waiter can be turned off', async function(assert) {
+    let findRecordWasInvoked;
+    let findRecordWasInvokedPromise = new Promise(resolveStep => {
+      findRecordWasInvoked = resolveStep;
+    });
+    this.owner.register(
+      'adapter:application',
+      JSONAPIAdapter.extend({
+        findRecord() {
+          return new Promise(resolve => {
+            findRecordWasInvoked();
+
+            setTimeout(() => {
+              resolve({ data: { type: 'person', id: '1' } });
+            }, 50); // intentionally longer than the 10ms polling interval of `wait()`
+          });
+        },
+      })
+    );
+
+    // turn off the waiter
+    store.shouldTrackAsyncRequests = false;
+
+    let request = store.findRecord('person', '1');
+    let waiter = store.__asyncWaiter;
+
+    assert.equal(
+      waiter(),
+      true,
+      'We return true when no requests have been initiated yet (pending queue flush is async)'
+    );
+
+    await findRecordWasInvokedPromise;
+
+    assert.equal(
+      store._trackedAsyncRequests.length,
+      1,
+      'We return true even though a request is pending'
+    );
+    assert.equal(waiter(), true, 'We return true even though a request is pending');
+
+    await request;
+
+    assert.equal(waiter(), true, 'We return true to end waiting when no requests are pending');
+  });
+
+  test('waiter works even when the adapter rejects', async function(assert) {
+    assert.expect(4);
+    let findRecordWasInvoked;
+    let findRecordWasInvokedPromise = new Promise(resolveStep => {
+      findRecordWasInvoked = resolveStep;
+    });
+    this.owner.register(
+      'adapter:application',
+      JSONAPIAdapter.extend({
+        findRecord() {
+          return new Promise((resolve, reject) => {
+            findRecordWasInvoked();
+
+            setTimeout(() => {
+              reject({ errors: [] });
+            }, 50); // intentionally longer than the 10ms polling interval of `wait()`
+          });
+        },
+      })
+    );
+
+    let request = store.findRecord('person', '1');
+    let waiter = store.__asyncWaiter;
+
+    assert.equal(
+      waiter(),
+      true,
+      'We return true when no requests have been initiated yet (pending queue flush is async)'
+    );
+
+    await findRecordWasInvokedPromise;
+
+    assert.equal(waiter(), false, 'We return false to keep waiting while requests are pending');
+
+    await assert.rejects(request);
+
+    assert.equal(waiter(), true, 'We return true to end waiting when no requests are pending');
+  });
+
+  test('waiter works even when the adapter throws', async function(assert) {
+    assert.expect(4);
+    let waiter = store.__asyncWaiter;
+    this.owner.register(
+      'adapter:application',
+      JSONAPIAdapter.extend({
+        findRecord() {
+          assert.equal(
+            waiter(),
+            false,
+            'We return false to keep waiting while requests are pending'
+          );
+          throw new Error('Invalid Request!');
+        },
+      })
+    );
+
+    let request = store.findRecord('person', '1');
+
+    assert.equal(
+      waiter(),
+      true,
+      'We return true when no requests have been initiated yet (pending queue flush is async)'
+    );
+
+    await assert.rejects(request);
+
+    assert.equal(waiter(), true, 'We return true to end waiting when no requests are pending');
+  });
+
+  test('when the store is torn down too early, we throw an error', async function(assert) {
+    let next;
+    let stepPromise = new Promise(resolveStep => {
+      next = resolveStep;
+    });
+    this.owner.register(
+      'adapter:application',
+      JSONAPIAdapter.extend({
+        findRecord() {
+          next();
+          stepPromise = new Promise(resolveStep => {
+            next = resolveStep;
+          }).then(() => {
+            return { data: { type: 'person', id: '1' } };
+          });
+          return stepPromise;
+        },
+      })
+    );
+
+    store.findRecord('person', '1');
+    let waiter = store.__asyncWaiter;
+
+    assert.equal(
+      waiter(),
+      true,
+      'We return true when no requests have been initiated yet (pending queue flush is async)'
+    );
+
+    await stepPromise;
+
+    assert.equal(waiter(), false, 'We return false to keep waiting while requests are pending');
+
+    // needed for LTS 2.16
+    Ember.Test.adapter.exception = e => {
+      throw e;
+    };
+
+    assert.throws(() => {
+      run(() => store.destroy());
+    }, /Async Request leaks detected/);
+
+    assert.equal(waiter(), false, 'We return false because we still have a pending request');
+
+    // make the waiter complete
+    run(() => next());
+    assert.equal(store._trackedAsyncRequests.length, 0, 'Our pending request is cleaned up');
+    assert.equal(waiter(), true, 'We return true because the waiter is cleared');
+  });
+
+  test('when the store is torn down too early, but the waiter behavior is turned off, we emit a warning', async function(assert) {
+    let next;
+    let stepPromise = new Promise(resolveStep => {
+      next = resolveStep;
+    });
+    this.owner.register(
+      'adapter:application',
+      JSONAPIAdapter.extend({
+        findRecord() {
+          next();
+          stepPromise = new Promise(resolveStep => {
+            next = resolveStep;
+          }).then(() => {
+            return { data: { type: 'person', id: '1' } };
+          });
+          return stepPromise;
+        },
+      })
+    );
+
+    // turn off the waiter
+    store.shouldTrackAsyncRequests = false;
+
+    store.findRecord('person', '1');
+    let waiter = store.__asyncWaiter;
+
+    assert.equal(store._trackedAsyncRequests.length, 0, 'We have no requests yet');
+    assert.equal(
+      waiter(),
+      true,
+      'We return true when no requests have been initiated yet (pending queue flush is async)'
+    );
+
+    await stepPromise;
+
+    assert.equal(store._trackedAsyncRequests.length, 1, 'We have a pending request');
+    assert.equal(waiter(), true, 'We return true because the waiter is turned off');
+    assert.expectWarning(() => {
+      run(() => {
+        store.destroy();
+      });
+    }, /Async Request leaks detected/);
+
+    assert.equal(waiter(), true, 'We return true because the waiter is turned off');
+
+    // make the waiter complete
+    run(() => next());
+    assert.equal(store._trackedAsyncRequests.length, 0, 'Our pending request is cleaned up');
+    assert.equal(waiter(), true, 'We return true because the waiter is cleared');
+  });
+
+  test('when configured, pending requests have useful stack traces', async function(assert) {
+    let stepResolve;
+    let stepPromise = new Promise(resolveStep => {
+      stepResolve = resolveStep;
+    });
+    let fakeId = 1;
+    this.owner.register(
+      'adapter:application',
+      JSONAPIAdapter.extend({
+        findRecord() {
+          return new Promise(resolve => {
+            stepResolve();
+
+            setTimeout(() => {
+              resolve({ data: { type: 'person', id: `${fakeId++}` } });
+            }, 50); // intentionally longer than the 10ms polling interval of `wait()`
+          });
+        },
+      })
+    );
+    let request = store.findRecord('person', '1');
+    let waiter = store.__asyncWaiter;
+
+    assert.equal(
+      waiter(),
+      true,
+      'We return true when no requests have been initiated yet (pending queue flush is async)'
+    );
+
+    await stepPromise;
+
+    assert.equal(waiter(), false, 'We return false to keep waiting while requests are pending');
+    assert.equal(
+      store._trackedAsyncRequests[0].trace,
+      'set `store.generateStackTracesForTrackedRequests = true;` to get a detailed trace for where this request originated',
+      'We provide a useful default message in place of a trace'
+    );
+
+    await request;
+
+    assert.equal(waiter(), true, 'We return true to end waiting when no requests are pending');
+
+    store.generateStackTracesForTrackedRequests = true;
+    request = store.findRecord('person', '2');
+
+    assert.equal(
+      waiter(),
+      true,
+      'We return true when no requests have been initiated yet (pending queue flush is async)'
+    );
+
+    await stepPromise;
+
+    assert.equal(waiter(), false, 'We return false to keep waiting while requests are pending');
+    /*
+      TODO this just traces back to the `flushPendingFetches`,
+      we should do something similar to capture where the fetch was scheduled
+      from.
+     */
+    assert.equal(
+      store._trackedAsyncRequests[0].trace.message,
+      "EmberData TrackedRequest: DS: Handle Adapter#findRecord of 'person' with id: '2'",
+      'We captured a trace'
+    );
+
+    await request;
+
+    assert.equal(waiter(), true, 'We return true to end waiting when no requests are pending');
+  });
+});


### PR DESCRIPTION
This feature enables app developers to better use `async ... await` while simultaneously detecting asynchronous test leaks in their data layer.  It is best paired with [ember-qunit's `setupTestIsolationValidation` feature](https://github.com/emberjs/ember-qunit/blob/master/addon-test-support/ember-qunit/index.js#L276).

When running an `ember-cli` application in non-production environments, this feature adds a test-waiter per-store instance that works with the [`settled()` test-helper](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#settled). This test-waiter does not cause waiting by default, in order to prevent immediately breaking any apps that upgrade to this version of ember-data that do have test leaks without warning.

This feature comes with two feature flags, only configurable in `non-production` environments, that live on the `store` instance.  Both of these flags are currently `false` by default.

1. **`store.shouldTrackAsyncRequests`**

When `true`, requests initiated via the store will be assigned a token, and while any tokens have not resolved the test-waiter (and thus `await settled()`) will wait.

When `true`, any detected leaks will throw an error when the store is destroyed after a test, causing the test to fail. The leaks will be logged, with a descriptive `label` for the request that was initiated, and potentially a `trace` (see below) for where the request initiated from.

When `false`, any detected leaks will be emitted as warnings when the store is destroyed after a test.

2. **`store.generateStackTracesForTrackedRequests`**

When `true`, a stack trace will be captured at the point that a request is initiated and saved onto the token used to track the request. For requests other than `findRecord`, these traces will include the point in `app` code that caused this request to be initiated. For `findRecord` these traces currently point back to `flushPendingFetches`; however, we also capture a trace at the point that we schedule these fetches, and will soon thread those traces through so that where the request initiated in `app` code is clear.