### PR TITLE
Fix `floating dependencies` test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "loader.js": "^4.5.0",
     "mocha": "^2.4.5",
     "mocha-only-detector": "0.0.2",
-    "prettier": "^1.13.6",
+    "prettier": "^1.14.0",
     "rimraf": "2.5.2",
     "rsvp": "4.8.0",
     "testdouble": "^3.2.6",

--- a/tests/acceptance/relationships/has-many-test.js
+++ b/tests/acceptance/relationships/has-many-test.js
@@ -17,7 +17,8 @@ function domListToArray(domList) {
 }
 
 class Person extends Model {
-  @attr name;
+  @attr
+  name;
   @hasMany('person', { async: true, inverse: 'parent' })
   children;
   @belongsTo('person', { async: true, inverse: 'children' })

--- a/tests/integration/records/create-record-test.js
+++ b/tests/integration/records/create-record-test.js
@@ -12,7 +12,8 @@ class Person extends Model {
   pets;
   @belongsTo('pet', { inverse: 'bestHuman', async: true })
   bestDog;
-  @attr name;
+  @attr
+  name;
 }
 
 class Pet extends Model {
@@ -20,7 +21,8 @@ class Pet extends Model {
   owner;
   @belongsTo('person', { inverse: 'bestDog', async: false })
   bestHuman;
-  @attr name;
+  @attr
+  name;
 }
 
 module('Store.createRecord() coverage', function(hooks) {

--- a/tests/integration/records/edit-record-test.js
+++ b/tests/integration/records/edit-record-test.js
@@ -11,13 +11,15 @@ class Person extends Model {
   friends;
   @belongsTo('person', { inverse: 'bestFriend', async: true })
   bestFriend;
-  @attr name;
+  @attr
+  name;
 }
 
 class Pet extends Model {
   @belongsTo('person', { inverse: 'pets', async: false })
   owner;
-  @attr name;
+  @attr
+  name;
 }
 
 module('Editing a Record', function(hooks) {

--- a/tests/integration/records/load-test.js
+++ b/tests/integration/records/load-test.js
@@ -10,7 +10,8 @@ import { run } from '@ember/runloop';
 import todo from '../../helpers/todo';
 
 class Person extends Model {
-  @attr name;
+  @attr
+  name;
   @belongsTo('person', { async: true, inverse: 'bestFriend' })
   bestFriend;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6292,9 +6292,9 @@ pretender@^1.4.2:
     fake-xml-http-request "^1.6.0"
     route-recognizer "^0.3.3"
 
-prettier@^1.13.6:
-  version "1.13.6"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-1.13.6.tgz#00ae0b777ad92f81a9e7a1df2f0470b6dab0cb44"
+prettier@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.0.tgz#847c235522035fd988100f1f43cf20a7d24f9372"
 
 pretty-ms@^3.1.0:
   version "3.2.0"


### PR DESCRIPTION
With prettier v1.14 release, the way decorators should be formated has changed a bit. Let's update ember-data's Prettier version + apply the new fomatting.

As a result [this kind of failure](https://travis-ci.org/emberjs/data/jobs/410439133) won't happen anymore.

You may want to have a look to this [prettier release note](https://prettier.io/blog/2018/07/29/1.14.0.html#javascript).