### PR TITLE
[BUGFIX] Destroy proxy object in BelongsTo relation when no longer needed.

### DIFF
--- a/addon/-legacy-private/system/relationships/state/belongs-to.js
+++ b/addon/-legacy-private/system/relationships/state/belongs-to.js
@@ -110,7 +110,11 @@ export default class BelongsToRelationship extends Relationship {
     }
     if (this.inverseInternalModel !== this.canonicalState) {
       this.inverseInternalModel = this.canonicalState;
-      this._promiseProxy = null;
+      const proxy = this._promiseProxy;
+      if (proxy) {
+        proxy.destroy();
+        this._promiseProxy = null;
+      }
       this.notifyBelongsToChange();
     }
 
@@ -151,7 +155,11 @@ export default class BelongsToRelationship extends Relationship {
       return;
     }
     this.inverseInternalModel = null;
-    this._promiseProxy = null;
+    const proxy = this._promiseProxy;
+    if (proxy) {
+      proxy.destroy();
+      this._promiseProxy = null;
+    }
     super.removeInternalModelFromOwn(internalModel);
     this.notifyBelongsToChange();
   }
@@ -159,7 +167,11 @@ export default class BelongsToRelationship extends Relationship {
   removeAllInternalModelsFromOwn() {
     super.removeAllInternalModelsFromOwn();
     this.inverseInternalModel = null;
-    this._promiseProxy = null;
+    const proxy = this._promiseProxy;
+    if (proxy) {
+      proxy.destroy();
+      this._promiseProxy = null;
+    }
     this.notifyBelongsToChange();
   }
 

--- a/addon/-legacy-private/system/relationships/state/belongs-to.js
+++ b/addon/-legacy-private/system/relationships/state/belongs-to.js
@@ -110,11 +110,6 @@ export default class BelongsToRelationship extends Relationship {
     }
     if (this.inverseInternalModel !== this.canonicalState) {
       this.inverseInternalModel = this.canonicalState;
-      const proxy = this._promiseProxy;
-      if (proxy) {
-        proxy.destroy();
-        this._promiseProxy = null;
-      }
       this.notifyBelongsToChange();
     }
 


### PR DESCRIPTION
The `_promiseProxy` object that is used by the belongsTo relationship is not destroyed when no longer needed.

This `_promiseProxy` keeps a reference to the internalModel. This especially a problem if the record is deleted while the other side of the relationship is still alive.

This results for us in a large memory leak: our application has a small set of long living records and during the lifetime it receives a large number of records (those records will be deleted after a while) that has a belongsTo reference to the records in the first set.

There is also a memory leak when proxies are destroyed when the proxied object is still alive. (reported as a separate issue in ember.js)