### PR TITLE
fix(Blueprint): remove left over from old testing styles

### DIFF
--- a/blueprints/transform-test/qunit-files/tests/unit/__path__/__test__.js
+++ b/blueprints/transform-test/qunit-files/tests/unit/__path__/__test__.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('transform:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', function(hooks) {
+module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.


### PR DESCRIPTION
This has been missed in 763c5daa2db7f8405aeaf4e9dc0d76e91fa7b3a7 and 530ef1f31e58d9c4f789c6117bb8b462c547bf38.