### PR TITLE
Add failing test when changing parent and unloading original parent

### DIFF
--- a/packages/store/addon/-private/system/model/record-data.ts
+++ b/packages/store/addon/-private/system/model/record-data.ts
@@ -766,7 +766,7 @@ function assertRelationshipData(store, recordData, data, meta) {
 }
 
 // Handle dematerialization for relationship `rel`.  In all cases, notify the
-// relatinoship of the dematerialization: this is done so the relationship can
+// relationship of the dematerialization: this is done so the relationship can
 // notify its inverse which needs to update state
 //
 // If the inverse is sync, unloading this record is treated as a client-side

--- a/packages/store/addon/-private/system/relationships/state/relationship.ts
+++ b/packages/store/addon/-private/system/relationships/state/relationship.ts
@@ -214,7 +214,8 @@ export default class Relationship {
   }
 
   recordDataDidDematerialize() {
-    if (!this.inverseKey) {
+    const inverseKey = this.inverseKey
+    if (!inverseKey) {
       return;
     }
     // TODO @runspired fairly sure we need to become stale here
@@ -226,8 +227,18 @@ export default class Relationship {
       if (!this._hasSupportForRelationships(inverseRecordData)) {
         return;
       }
-      let relationship = relationshipStateFor(inverseRecordData, this.inverseKey);
-      relationship.inverseDidDematerialize(this.recordData);
+      let relationship = relationshipStateFor(inverseRecordData, inverseKey);
+      let belongsToRelationship = inverseRecordData.getBelongsTo(inverseKey)._relationship;
+
+      // For canonical members, it is possible that inverseRecordData has already been associated to
+      // to another record. For such cases, do not dematerialize the inverseRecordData
+      if (
+        !belongsToRelationship ||
+        !belongsToRelationship.inverseRecordData ||
+        this.recordData === belongsToRelationship.inverseRecordData
+      ) {
+        relationship.inverseDidDematerialize(this.recordData);
+      }
     });
   }
 


### PR DESCRIPTION
Bug wherein changing the parent of a child then unloading the original parent sets the child association to `null`.
Setup:
```js
  // This is the association set up
  class Child extends DS.Model {
    @belongsTo('parent')
  }

  class Parent extends DS.Model {
    @hasMany('child')
  }
```

```js
  // Assume here that `child` is already associated to Parent 1
  const parent1 = this.store.peekRecord('parent', 1)
  const child = this.store.peekRecord('child', 1)

  const parent2 = this.store.peekRecord('parent', 2)
  set(child, 'parent', parent2) // We are not commiting to the database yet at this point

  // Delete Parent 1
  parent1.unloadRecord()
  child.parent // Returns null. Parent 2 is expected
```
Current work around:
```js
// Assume here that `child` is already associated to Parent 1
  const parent1 = this.store.peekRecord('parent', 1)
  const child = this.store.peekRecord('child', 1)

  const parent2 = this.store.peekRecord('parent', 2)
  const payload = {
    data: {
      type: 'child',
      id: child.id,
      relationships: {
        parent: {
          data: { type: 'parent', id: parent2.id }
        }
      }
    }
  }
  this.store.pushPayload(payload) // Instead of set(child, 'parent', parent2)

  // Delete Parent 1
  parent1.unloadRecord()
  child.parent // Returns Parent 2
```