### PR TITLE
[BUGFIX] backport use internalModel promise if already loading

### DIFF
--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -276,7 +276,11 @@ export default class BelongsToRelationship extends Relationship {
 }
 
 function proxyRecord(internalModel) {
-  return resolve(internalModel).then(resolvedInternalModel => {
+  let promise = internalModel;
+  if (internalModel && internalModel.isLoading()) {
+    promise = internalModel._promiseProxy;
+  }
+  return resolve(promise).then(resolvedInternalModel => {
     return resolvedInternalModel ? resolvedInternalModel.getRecord() : null;
   });
 }


### PR DESCRIPTION
Changes from #5562
Fixes #5579

This is super lazy, I couldn't get the new tests in that PR working. The testing model seems to have changed a bit between `release` and `master`. There were also changes in ` addon/-record-data-private/system/store.js`, but I think that is new code that is only in `master`.  If tests are required to merge this let me know and I will keep digging, but I thought maybe the fix was enough for a backport given the relatively small change.