### PR TITLE
Fixed broken link to defining relationships in guides

### DIFF
--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -77,7 +77,7 @@ import { warn } from '@ember/debug';
 
   To successfully extract and serialize embedded records the model relationships
   must be setup correcty. See the
-  [defining relationships](/guides/models/defining-models/#toc_defining-relationships)
+  [defining relationships](/guides/models/relationships)
   section of the **Defining Models** guide page.
 
   Records without an `id` property are not considered embedded records, model


### PR DESCRIPTION
The current link to "defining relationships" returns a 404. This fixes the issue mentioned here: https://github.com/emberjs/website/issues/3504