### PR TITLE
[BUGFIX] backport use internalModel promise if already loading

### DIFF
--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -276,7 +276,11 @@ export default class BelongsToRelationship extends Relationship {
 }
 
 function proxyRecord(internalModel) {
-  return resolve(internalModel).then(resolvedInternalModel => {
+  let promise = internalModel;
+  if (internalModel && internalModel.isLoading()) {
+    promise = internalModel._promiseProxy;
+  }
+  return resolve(promise).then(resolvedInternalModel => {
     return resolvedInternalModel ? resolvedInternalModel.getRecord() : null;
   });
 }


### PR DESCRIPTION
Changes from #5562
Refs #5579

As requested by @runspired in https://github.com/emberjs/data/pull/5583#issuecomment-416371215 this is the backport of #5562 into release-3-2.