### PR TITLE
[FEAT] deprecate instead of assert method calls on a destroyed store instance

### DIFF
--- a/addon/-legacy-private/system/store.js
+++ b/addon/-legacy-private/system/store.js
@@ -220,6 +220,7 @@ Store = Service.extend({
     this._serializerCache = Object.create(null);
 
     if (DEBUG) {
+      this.shouldAssertMethodCallsOnDestroyedStore = this.shouldAssertMethodCallsOnDestroyedStore || false;
       if (this.shouldTrackAsyncRequests === undefined) {
         this.shouldTrackAsyncRequests = false;
       }
@@ -3414,16 +3415,34 @@ if (DEBUG) {
     );
   };
   assertDestroyingStore = function assertDestroyedStore(store, method) {
-    assert(
-      `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
-      !(store.isDestroying || store.isDestroyed)
-    );
+    if (!store.shouldAssertMethodCallsOnDestroyedStore) {
+      deprecate(`Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        false,
+        {
+          id: 'ember-data:method-calls-on-destroyed-store',
+          until: '3.8',
+        });
+    } else {
+      assert(
+        `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        !(store.isDestroying || store.isDestroyed)
+      );
+    }
   };
   assertDestroyedStoreOnly = function assertDestroyedStoreOnly(store, method) {
-    assert(
-      `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
-      !store.isDestroyed
-    );
+    if (!store.shouldAssertMethodCallsOnDestroyedStore) {
+      deprecate(`Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        false,
+        {
+          id: 'ember-data:method-calls-on-destroyed-store',
+          until: '3.8',
+        });
+    } else {
+      assert(
+        `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        !store.isDestroyed
+      );
+    }
   };
 }
 

--- a/addon/-legacy-private/system/store.js
+++ b/addon/-legacy-private/system/store.js
@@ -220,7 +220,8 @@ Store = Service.extend({
     this._serializerCache = Object.create(null);
 
     if (DEBUG) {
-      this.shouldAssertMethodCallsOnDestroyedStore = this.shouldAssertMethodCallsOnDestroyedStore || false;
+      this.shouldAssertMethodCallsOnDestroyedStore =
+        this.shouldAssertMethodCallsOnDestroyedStore || false;
       if (this.shouldTrackAsyncRequests === undefined) {
         this.shouldTrackAsyncRequests = false;
       }
@@ -3416,12 +3417,14 @@ if (DEBUG) {
   };
   assertDestroyingStore = function assertDestroyedStore(store, method) {
     if (!store.shouldAssertMethodCallsOnDestroyedStore) {
-      deprecate(`Attempted to call store.${method}(), but the store instance has already been destroyed.`,
-        false,
+      deprecate(
+        `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        !(store.isDestroying || store.isDestroyed),
         {
           id: 'ember-data:method-calls-on-destroyed-store',
           until: '3.8',
-        });
+        }
+      );
     } else {
       assert(
         `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
@@ -3431,12 +3434,14 @@ if (DEBUG) {
   };
   assertDestroyedStoreOnly = function assertDestroyedStoreOnly(store, method) {
     if (!store.shouldAssertMethodCallsOnDestroyedStore) {
-      deprecate(`Attempted to call store.${method}(), but the store instance has already been destroyed.`,
-        false,
+      deprecate(
+        `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        !(store.isDestroying || store.isDestroyed),
         {
           id: 'ember-data:method-calls-on-destroyed-store',
           until: '3.8',
-        });
+        }
+      );
     } else {
       assert(
         `Attempted to call store.${method}(), but the store instance has already been destroyed.`,

--- a/addon/-record-data-private/system/store.js
+++ b/addon/-record-data-private/system/store.js
@@ -226,7 +226,8 @@ Store = Service.extend({
     this.modelDataWrapper = new ModelDataWrapper(this);
 
     if (DEBUG) {
-      this.shouldAssertMethodCallsOnDestroyedStore = this.shouldAssertMethodCallsOnDestroyedStore || false;
+      this.shouldAssertMethodCallsOnDestroyedStore =
+        this.shouldAssertMethodCallsOnDestroyedStore || false;
       if (this.shouldTrackAsyncRequests === undefined) {
         this.shouldTrackAsyncRequests = false;
       }
@@ -3501,12 +3502,14 @@ let assertDestroyedStoreOnly;
 if (DEBUG) {
   assertDestroyingStore = function assertDestroyedStore(store, method) {
     if (!store.shouldAssertMethodCallsOnDestroyedStore) {
-      deprecate(`Attempted to call store.${method}(), but the store instance has already been destroyed.`,
-        false,
+      deprecate(
+        `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        !(store.isDestroying || store.isDestroyed),
         {
           id: 'ember-data:method-calls-on-destroyed-store',
           until: '3.8',
-        });
+        }
+      );
     } else {
       assert(
         `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
@@ -3516,12 +3519,14 @@ if (DEBUG) {
   };
   assertDestroyedStoreOnly = function assertDestroyedStoreOnly(store, method) {
     if (!store.shouldAssertMethodCallsOnDestroyedStore) {
-      deprecate(`Attempted to call store.${method}(), but the store instance has already been destroyed.`,
-        false,
+      deprecate(
+        `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        !(store.isDestroying || store.isDestroyed),
         {
           id: 'ember-data:method-calls-on-destroyed-store',
           until: '3.8',
-        });
+        }
+      );
     } else {
       assert(
         `Attempted to call store.${method}(), but the store instance has already been destroyed.`,

--- a/addon/-record-data-private/system/store.js
+++ b/addon/-record-data-private/system/store.js
@@ -226,6 +226,7 @@ Store = Service.extend({
     this.modelDataWrapper = new ModelDataWrapper(this);
 
     if (DEBUG) {
+      this.shouldAssertMethodCallsOnDestroyedStore = this.shouldAssertMethodCallsOnDestroyedStore || false;
       if (this.shouldTrackAsyncRequests === undefined) {
         this.shouldTrackAsyncRequests = false;
       }
@@ -3499,16 +3500,34 @@ let assertDestroyedStoreOnly;
 
 if (DEBUG) {
   assertDestroyingStore = function assertDestroyedStore(store, method) {
-    assert(
-      `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
-      !(store.isDestroying || store.isDestroyed)
-    );
+    if (!store.shouldAssertMethodCallsOnDestroyedStore) {
+      deprecate(`Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        false,
+        {
+          id: 'ember-data:method-calls-on-destroyed-store',
+          until: '3.8',
+        });
+    } else {
+      assert(
+        `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        !(store.isDestroying || store.isDestroyed)
+      );
+    }
   };
   assertDestroyedStoreOnly = function assertDestroyedStoreOnly(store, method) {
-    assert(
-      `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
-      !store.isDestroyed
-    );
+    if (!store.shouldAssertMethodCallsOnDestroyedStore) {
+      deprecate(`Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        false,
+        {
+          id: 'ember-data:method-calls-on-destroyed-store',
+          until: '3.8',
+        });
+    } else {
+      assert(
+        `Attempted to call store.${method}(), but the store instance has already been destroyed.`,
+        !store.isDestroyed
+      );
+    }
   };
 }
 

--- a/tests/unit/store/asserts-test.js
+++ b/tests/unit/store/asserts-test.js
@@ -80,6 +80,7 @@ module('unit/store/asserts - DS.Store methods produce useful assertion messages'
   ];
 
   test('Calling Store methods after the store has been destroyed asserts', function(assert) {
+    store.shouldAssertMethodCallsOnDestroyedStore = true;
     assert.expect(STORE_ENTRY_METHODS.length);
     run(() => store.destroy());
 
@@ -93,6 +94,7 @@ module('unit/store/asserts - DS.Store methods produce useful assertion messages'
   const STORE_TEARDOWN_METHODS = ['unloadAll', 'modelFor', '_modelFactoryFor'];
 
   test('Calling Store teardown methods during destroy does not assert, but calling other methods does', function(assert) {
+    store.shouldAssertMethodCallsOnDestroyedStore = true;
     assert.expect(STORE_ENTRY_METHODS.length - STORE_TEARDOWN_METHODS.length);
 
     run(() => {


### PR DESCRIPTION
Toggle `store.shouldAssertMethodCallsOnDestroyedStore = true;` To turn these deprecations into assertions.