### PR TITLE
[DOC release] Change misleading documentation for AdapterPopulatedRecordArray

### DIFF
--- a/addon/-private/system/record-arrays/adapter-populated-record-array.js
+++ b/addon/-private/system/record-arrays/adapter-populated-record-array.js
@@ -19,22 +19,23 @@ import cloneNull from '../clone-null';
 
   ```javascript
   // GET /users?isAdmin=true
-  var admins = store.query('user', { isAdmin: true });
+  store.query('user', { isAdmin: true }).then(function(admins) {
 
-  admins.then(function() {
-    console.log(admins.get("length")); // 42
-  });
+    admins.then(function() {
+      console.log(admins.get("length")); // 42
+    });
 
-  // somewhere later in the app code, when new admins have been created
-  // in the meantime
-  //
-  // GET /users?isAdmin=true
-  admins.update().then(function() {
-    admins.get('isUpdating'); // false
-    console.log(admins.get("length")); // 123
-  });
+    // somewhere later in the app code, when new admins have been created
+    // in the meantime
+    //
+    // GET /users?isAdmin=true
+    admins.update().then(function() {
+      admins.get('isUpdating'); // false
+      console.log(admins.get("length")); // 123
+    });
 
-  admins.get('isUpdating'); // true
+    admins.get('isUpdating'); // true
+  }
   ```
 
   @class AdapterPopulatedRecordArray


### PR DESCRIPTION
In my experimentation, I've discovered that though the promise returned from `store.query()` does have array-like methods on it, the actual `AdapterPopulatedRecordArray` is what the promise *resolves to*. The promise does not behave like a proxy (or what I think Ember Proxies do...). The documentation for `store.query` states this plainly, but the documentation here misrepresented that.

For example, the original code actually would behave like this:
```javascript
  // GET /users?isAdmin=true
  var admins = store.query('user', { isAdmin: true });

  admins.then(function() {
    console.log(admins.get("length")); // Throws: "admins.get" is not a function
  });
```