### PR TITLE
Add partner test for the ilios frontend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,8 @@ jobs:
       script: yarn test-external:storefront
     - name: "Ember Data Factory Guy"
       script: yarn test-external:factory-guy
+    - name: "Ilios Frontend"
+      script: yarn test-external:ilios-frontend
 
     - stage: deploy
       name: "Publish"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test-external:ember-observer": "node ./lib/scripts/test-external ember-observer https://github.com/emberobserver/client.git",
     "test-external:travis-web": "node ./lib/scripts/test-external travis-web https://github.com/travis-ci/travis-web.git",
     "test-external:storefront": "node ./lib/scripts/test-external storefront https://github.com/embermap/ember-data-storefront.git",
-    "test-external:factory-guy": "node ./lib/scripts/test-external factory-guy https://github.com/danielspaniel/ember-data-factory-guy.git"
+    "test-external:factory-guy": "node ./lib/scripts/test-external factory-guy https://github.com/danielspaniel/ember-data-factory-guy.git",
+    "test-external:ilios-frontend": "node ./lib/scripts/test-external ilios-frontend https://github.com/ilios/frontend.git"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
[Ilios](https://www.iliosproject.org/) is an open source application built to manage the curriculum of
medical, pharmacy, dental, and nursing health science degrees. It
is sponsored by UCSF and used at universities around the world.

There are a few features that I hope make this a useful partner test:
1) The app is four years old and has been using ember data since 0.x, but is currently using 3.4
2) The models for this app are in an addon which might present unique challenges
3) The regressions in 3.2/3.3 showed up in our tests
4) This is the UCSF app mentioned in @runspired's #5618
5) You would be helping us in our mission to *improve health world wide* ™️  😄 

The biggest potential downside is that our test suite typically takes 20 - 25 minutes to run on travis which is significantly longer than the other partner tests seem to be.