### PR TITLE
[BUGFIX] fix promise labels

### DIFF
--- a/addon/-legacy-private/system/store.js
+++ b/addon/-legacy-private/system/store.js
@@ -1616,15 +1616,17 @@ Store = Service.extend({
     );
 
     return promiseObject(
-      _queryRecord(adapter, this, normalizedModelName, query, adapterOptionsWrapper).then(internalModel => {
-        // the promise returned by store.queryRecord is expected to resolve with
-        // an instance of DS.Model
-        if (internalModel) {
-          return internalModel.getRecord();
-        }
+      _queryRecord(adapter, this, normalizedModelName, query, adapterOptionsWrapper).then(
+        internalModel => {
+          // the promise returned by store.queryRecord is expected to resolve with
+          // an instance of DS.Model
+          if (internalModel) {
+            return internalModel.getRecord();
+          }
 
-        return null;
-      })
+          return null;
+        }
+      )
     );
   },
 

--- a/addon/-record-data-private/system/store.js
+++ b/addon/-record-data-private/system/store.js
@@ -1784,15 +1784,17 @@ Store = Service.extend({
     );
 
     return promiseObject(
-      _queryRecord(adapter, this, normalizedModelName, query, adapterOptionsWrapper).then(internalModel => {
-        // the promise returned by store.queryRecord is expected to resolve with
-        // an instance of DS.Model
-        if (internalModel) {
-          return internalModel.getRecord();
-        }
+      _queryRecord(adapter, this, normalizedModelName, query, adapterOptionsWrapper).then(
+        internalModel => {
+          // the promise returned by store.queryRecord is expected to resolve with
+          // an instance of DS.Model
+          if (internalModel) {
+            return internalModel.getRecord();
+          }
 
-        return null;
-      })
+          return null;
+        }
+      )
     );
   },
 


### PR DESCRIPTION
We were incorrectly passing the non-normalized model-name to `_queryRecord()`.

In addition to being inconsistent, somehow this results in the label printing `camelCase [object Object]` when `camelCase` modelNames are used to call `queryRecord` instead of `dasherized` modelNames. I suspect a transpilation issue is overwriting a variable but I don't spot where.