### PR TITLE
Update appveyor config for release branch 3.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "4"
+    - nodejs_version: "6"
 
 cache:
   - '%LOCALAPPDATA%\Yarn'


### PR DESCRIPTION
Set the node version to be inline with `package.json`

This would fix the CI pipeline build.

I don't know why travis build is not triggered.