### PR TITLE
Include request/response info with Abort error

### DIFF
--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -1228,7 +1228,7 @@ function ajaxError(adapter, payload, requestData, responseData) {
   } else if (responseData.textStatus === 'timeout') {
     error = new TimeoutError();
   } else if (responseData.textStatus === 'abort' || responseData.status === 0) {
-    error = new AbortError();
+    error = handleAbort(requestData, responseData);
   } else {
     try {
       error = adapter.handleResponse(
@@ -1243,6 +1243,15 @@ function ajaxError(adapter, payload, requestData, responseData) {
   }
 
   return error;
+}
+
+// Adapter abort error to include any relevent info, e.g. request/response:
+function handleAbort(requestData, responseData) {
+  let { method, url, errorThrown } = requestData;
+  let { status } = responseData;
+  let msg = `Request failed: ${method} ${url} ${errorThrown || ''}`;
+  let errors = [{ title: 'Adapter Error', detail: msg.trim(), status }];
+  return new AbortError(errors);
 }
 
 //From http://stackoverflow.com/questions/280634/endswith-in-javascript

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -2551,7 +2551,7 @@ test('gracefully handles exceptions in handleResponse where the ajax request err
 });
 
 test('treats status code 0 as an abort', function(assert) {
-  assert.expect(1);
+  assert.expect(3);
 
   adapter._ajaxRequest = function(hash) {
     hash.error({
@@ -2568,6 +2568,21 @@ test('treats status code 0 as an abort', function(assert) {
   return run(() => {
     return store.findRecord('post', '1').catch(err => {
       assert.ok(err instanceof DS.AbortError, 'reason should be an instance of DS.AbortError');
+      assert.equal(
+        err.errors.length,
+        1,
+        'AbortError includes errors with request/response details'
+      );
+      let expectedError = {
+        title: 'Adapter Error',
+        detail: 'Request failed: GET /posts/1',
+        status: 0,
+      };
+      assert.deepEqual(
+        err.errors[0],
+        expectedError,
+        'method, url and, status are captured as details'
+      );
     });
   });
 });


### PR DESCRIPTION
Currently the `AbortError ` does not have any context about the request/response.

This PR adds the request method, url and error if available...

```
error.message
"The adapter operation was aborted"
error.errors[0].title
"Adapter Error"
error.errors[0].detail
"Request failed: GET http://localhost:4200/api/v1/reports"
error.errors[0].status
0
```

The problem is that when you have this error there is no related info captured to identify why the adapter aborted. For example, using a service like bugsnag or raygun, the error may not have any information to help reproduce the problem in your application.