### PR TITLE
[BUGFIX] ensure external-partner tests correctly symlink

### DIFF
--- a/lib/scripts/test-external.js
+++ b/lib/scripts/test-external.js
@@ -27,6 +27,11 @@ console.log(
   `Preparing to test external project ${externalProjectName} located at ${gitUrl} against this ember-data commit.`
 );
 
+function execExternal(command, force) {
+  command = `cd ../__external-test-cache/${externalProjectName} && ${command}`;
+  return execWithLog(command, force);
+}
+
 function execWithLog(command, force) {
   if (debug.enabled || force) {
     return shellSync(command, { stdio: [0, 1, 2] });
@@ -45,9 +50,7 @@ if (fs.existsSync(projectTempDir)) {
 
 // install the project
 try {
-  execWithLog(
-    `cd ../__external-test-cache && git clone --depth=1 ${gitUrl} ./${externalProjectName}`
-  );
+  execWithLog(`git clone --depth=1 ${gitUrl} ../__external-test-cache/${externalProjectName}`);
 } catch (e) {
   debug(e);
   throw new Error(
@@ -60,13 +63,8 @@ const useBower = fs.existsSync(path.join(projectTempDir, 'bower.json'));
 
 // install project dependencies and link our local version of ember-data
 try {
-  execWithLog(
-    `${
-      useYarn ? 'yarn link' : 'npm link'
-    } && cd ../__external-test-cache/${externalProjectName} && ${useYarn ? 'yarn' : 'npm install'}${
-      useBower ? ' && bower install' : ''
-    }`
-  );
+  execWithLog(`${useYarn ? 'yarn link' : 'npm link'}`);
+  execExternal(`${useYarn ? 'yarn' : 'npm install'}${ useBower ? ' && bower install' : '' }`);
 } catch (e) {
   debug(e);
   throw new Error(
@@ -82,13 +80,13 @@ let commitTestPassed = true;
 
 try {
   debug('Running Smoke Test');
-  execWithLog(`cd ../__external-test-cache/${externalProjectName} && ember test`, true);
+  execExternal(`ember test`, true);
 } catch (e) {
   smokeTestPassed = false;
 }
 
 try {
-  execWithLog(`${useYarn ? 'yarn link ember-data' : 'npm link ember-data'}`);
+  execExternal(`${useYarn ? 'yarn link ember-data' : 'npm link ember-data'}`);
 } catch (e) {
   debug(e);
   throw new Error(
@@ -98,7 +96,7 @@ try {
 
 try {
   debug('Re-running tests against EmberData commit');
-  execWithLog(`cd ../__external-test-cache/${externalProjectName} && ember test`, true);
+  execExternal(`ember test`, true);
 } catch (e) {
   commitTestPassed = false;
 }

--- a/lib/scripts/test-external.js
+++ b/lib/scripts/test-external.js
@@ -64,7 +64,7 @@ const useBower = fs.existsSync(path.join(projectTempDir, 'bower.json'));
 // install project dependencies and link our local version of ember-data
 try {
   execWithLog(`${useYarn ? 'yarn link' : 'npm link'}`);
-  execExternal(`${useYarn ? 'yarn' : 'npm install'}${ useBower ? ' && bower install' : '' }`);
+  execExternal(`${useYarn ? 'yarn' : 'npm install'}${useBower ? ' && bower install' : ''}`);
 } catch (e) {
   debug(e);
   throw new Error(


### PR DESCRIPTION
Turns out we weren't symlink-ing from within the external project directory and so we haven't been testing external partners correctly. We have work to do.