### PR TITLE
Add firefox addon to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 
 addons:
   chrome: stable
+  firefox: latest
 
 cache:
   yarn: true


### PR DESCRIPTION
Needed for external partner ilios-frontend where Firefox is the CI
browser of choice. The alias 'latest' refers to the [most recent released
version](https://docs.travis-ci.com/user/firefox/#version-aliases)

As I mentioned in https://github.com/emberjs/data/pull/5386#issuecomment-420745846 ilios-frontend tests have become flaky recently and the reason seems to be an issue with the shared memory allocation for [Chrome in Travis](https://github.com/testem/testem/issues/1021). New versions if Ilios will use Firefox to run tests and hopefully this will resolve the testing issues here as well.
