### PR TITLE
 add mocha rfc232 blueprints

### DIFF
--- a/blueprints/adapter-test/mocha-rfc-232-files/__root__/__path__/__test__.js
+++ b/blueprints/adapter-test/mocha-rfc-232-files/__root__/__path__/__test__.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('<%= friendlyTestDescription %>', function() {
+  setupTest();
+
+  // Replace this with your real tests.
+  it('exists', function() {
+    let adapter = this.owner.lookup('adapter:<%= dasherizedModuleName %>');
+    expect(adapter).to.be.ok;
+  });
+});

--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -25,6 +25,16 @@ module.exports = function(blueprint) {
       } else {
         type = 'qunit';
       }
+    } else if ('ember-mocha' in dependencies) {
+      let checker = new VersionChecker(this.project);
+      if (
+        fs.existsSync(this.path + '/mocha-rfc-232-files') &&
+        checker.for('ember-mocha', 'npm').gte('0.14.0')
+      ) {
+        type = 'mocha-rfc-232';
+      } else {
+        type = 'mocha';
+      }
     } else if ('ember-cli-mocha' in dependencies) {
       type = 'mocha';
     } else {

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -133,6 +133,24 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
         });
       });
     });
+
+    describe.only('with ember-mocha v0.14+', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('adapter-test for mocha v0.14+', function() {
+        return emberGenerateDestroy(['adapter-test', 'foo'], _file => {
+          expect(_file('tests/unit/adapters/foo-test.js')).to.equal(
+            fixture('adapter-test/mocha-rfc232.js')
+          );
+        });
+      });
+    });
   });
 
   describe('module unification', function() {

--- a/node-tests/fixtures/adapter-test/mocha-rfc232.js
+++ b/node-tests/fixtures/adapter-test/mocha-rfc232.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Adapter | foo', function() {
+  setupTest();
+
+  // Replace this with your real tests.
+  it('exists', function() {
+    let adapter = this.owner.lookup('adapter:foo');
+    expect(adapter).to.be.ok;
+  });
+});


### PR DESCRIPTION
https://github.com/emberjs/data/issues/5292 added blueprints for RFC232 qunit tests, this PR is a starting point for adding them for Mocha.  If the direction of this PR seems satisfactory I could pretty quickly follow on with the necessary model/serializer/transform tests.