### PR TITLE
fix(blueprints): remove second string argument from transform tests

### DIFF
--- a/blueprints/transform-test/qunit-files/__root__/__path__/__test__.js
+++ b/blueprints/transform-test/qunit-files/__root__/__path__/__test__.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('transform:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>', function(hooks) {
+module('<%= friendlyTestDescription %>', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/node-tests/fixtures/transform-test/default.js
+++ b/node-tests/fixtures/transform-test/default.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('transform:foo', 'Unit | Transform | foo', function(hooks) {
+module('Unit | Transform | foo', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/node-tests/fixtures/transform-test/rfc232.js
+++ b/node-tests/fixtures/transform-test/rfc232.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('transform:foo', 'Unit | Transform | foo', function(hooks) {
+module('Unit | Transform | foo', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.


### PR DESCRIPTION
fixes #5656