### PR TITLE
Refactor argument parsing for --instrument and --record-data-rfc-build

### DIFF
--- a/lib/cli-flags.js
+++ b/lib/cli-flags.js
@@ -1,0 +1,26 @@
+'use strict';
+
+function isInstrumentedBuild() {
+  return process.argv.includes('--instrument');
+}
+
+function useRecordData() {
+  try {
+    let currentProjectName = require(`${process.cwd()}/package`);
+    if (
+      currentProjectName === 'ember-data' &&
+      process.argv.includes('--disable-record-data-rfc-build')
+    ) {
+      return false;
+    }
+  } catch (e) {
+    // swallow any errors for missing package.json in CWD.
+  }
+
+  return true;
+}
+
+module.exports = {
+  isInstrumentedBuild,
+  useRecordData,
+};

--- a/lib/stripped-build-plugins.js
+++ b/lib/stripped-build-plugins.js
@@ -8,6 +8,7 @@ const StripHeimdall = requireBabelPlugin('babel6-plugin-strip-heimdall');
 const StripClassCallCheck = requireBabelPlugin('babel6-plugin-strip-class-callcheck');
 const StripFilteredImports = requireBabelPlugin('./transforms/babel-plugin-remove-imports');
 const TransformBlockScoping = requireBabelPlugin('babel-plugin-transform-es2015-block-scoping');
+const { isInstrumentedBuild } = require('./cli-flags');
 
 function uniqueAdd(obj, key, values) {
   const a = (obj[key] = obj[key] || []);
@@ -52,7 +53,7 @@ module.exports = function(environment) {
     ],
   ];
 
-  if (process.env.INSTRUMENT_HEIMDALL === 'false') {
+  if (!isInstrumentedBuild()) {
     plugins.push([StripHeimdall]);
     uniqueAdd(filteredImports, 'ember-data/-debug', ['instrument']);
   } else {
@@ -60,7 +61,7 @@ module.exports = function(environment) {
     console.warn('NOT STRIPPING HEIMDALL');
   }
 
-  if (/production/.test(environment) || process.env.INSTRUMENT_HEIMDALL === 'true') {
+  if (/production/.test(environment) || isInstrumentedBuild()) {
     postTransformPlugins.push([StripClassCallCheck]);
     uniqueAdd(filteredImports, 'ember-data/-debug', ['assertPolymorphicType']);
   }

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -5,6 +5,7 @@ var path = require('path');
 var featuresJsonPath = path.join(__dirname, '../../../config/features.json');
 var featuresJson = fs.readFileSync(featuresJsonPath, { encoding: 'utf8' });
 var featureFlags = JSON.parse(featuresJson);
+let { useRecordData } = require('../../../lib/cli-flags');
 
 module.exports = function(environment) {
   var ENV = {
@@ -46,6 +47,10 @@ module.exports = function(environment) {
 
     ENV.APP.rootElement = '#ember-testing';
   }
+
+  ENV.emberData = {
+    enableRecordDataRFCBuild: useRecordData(),
+  };
 
   return ENV;
 };


### PR DESCRIPTION
This simplifies and reorganizes the process.argv processing that needs to be done for the two flags that we support.

This commit migrates the instrument flag handling to a single file (`lib/heimdall-utils.js`) and uses that single exported function throughout the rest of the code. It also removes the reliance on `process.env` string coercion (which apparently _can_ be broken when you've reassigned `process.env`).

It also changes around the details of the previous `--record-data-rfc-build` flag. Instead, we add a `--disable-record-data-rfc-build` flag (because as of 3.5 beta's the record data code is enabled by default). During this refactor, the `config` hook was migrated into the dummy app itself, so that ember-data no longer adds that flag to all consuming app's runtime config.