### PR TITLE
[DEPRECATION errors] deprecates use of Ember.Evented with DS.Errors

### DIFF
--- a/addon/-legacy-private/system/model/model.js
+++ b/addon/-legacy-private/system/model/model.js
@@ -396,18 +396,7 @@ const Model = EmberObject.extend(Evented, {
     @type {DS.Errors}
   */
   errors: computed(function() {
-    let errors = Errors.create();
-
-    errors._registerHandlers(
-      this._internalModel,
-      function() {
-        this.send('becameInvalid');
-      },
-      function() {
-        this.send('becameValid');
-      }
-    );
-    return errors;
+    return Errors.create();
   }).readOnly(),
 
   /**

--- a/addon/-private/deprecated-evented.js
+++ b/addon/-private/deprecated-evented.js
@@ -1,0 +1,40 @@
+import Mixin from '@ember/object/mixin';
+import Evented from '@ember/object/evented';
+import { deprecate } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+
+let DeprecatedEvented = Evented;
+
+if (DEBUG) {
+  function printDeprecation(ctx) {
+    deprecate(`Use of event functionality provided by Ember.Evented with ${ctx._debugContainerKey} has been deprecated.`, {
+      id: 'ember-data:no-longer-evented',
+      until: '3.8',
+    });
+  }
+
+  DeprecatedEvented = Mixin.create(Evented, {
+    has() {
+      printDeprecation(this);
+      return this._super(...arguments);
+    },
+    off() {
+      printDeprecation(this);
+      return this._super(...arguments);
+    },
+    on() {
+      printDeprecation(this);
+      return this._super(...arguments);
+    },
+    one() {
+      printDeprecation(this);
+      return this._super(...arguments);
+    },
+    trigger() {
+      printDeprecation(this);
+      return this._super(...arguments);
+    }
+  });
+}
+
+export default DeprecatedEvented;

--- a/addon/-record-data-private/system/model/model.js
+++ b/addon/-record-data-private/system/model/model.js
@@ -397,18 +397,7 @@ const Model = EmberObject.extend(Evented, {
     @type {DS.Errors}
   */
   errors: computed(function() {
-    let errors = Errors.create();
-
-    errors._registerHandlers(
-      this._internalModel,
-      function() {
-        this.send('becameInvalid');
-      },
-      function() {
-        this.send('becameValid');
-      }
-    );
-    return errors;
+    return Errors.create();
   }).readOnly(),
 
   /**


### PR DESCRIPTION
This one is tricky. We inserted warnings that we would eliminate mutating record-state from DS.Errors a very long time ago, but due to the mechanics of it all could not truly "deprecate". This "finalizes" that deprecation.

It also introduces the `Evented` deprecation from https://github.com/emberjs/rfcs/pull/329 for `DS.Errors` in a way that other classes that will need to deprecate events can also utilize.