### PR TITLE
Use _scheduleFetch instead of _fetchRecord for belongsTo relationship

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -1560,7 +1560,7 @@ Store = Service.extend({
 
     // fetch by data
     if (!localDataIsEmpty) {
-      return this._fetchRecord(internalModel, options).then(() => {
+      return this._scheduleFetch(internalModel, options).then(() => {
         return internalModel.getRecord();
       });
     }


### PR DESCRIPTION
In order to ensure coalesceFindRequests works for this case.

Without this, it would trigger one find-request per belongsTo relationship, instead of correctly coalescing them together.

I have stumbled over this while trying to debug something else, and was pretty puzzled as to why it wasn't working as expected. Changing this fixed the issue for me - not sure if there is something I'm not seeing there, though.