### PR TITLE
[CHORE] Allow skipping of smoke tests in long running partner tests

### DIFF
--- a/lib/scripts/test-external.js
+++ b/lib/scripts/test-external.js
@@ -10,6 +10,7 @@ const rimraf = require('rimraf');
 const projectRoot = path.resolve(__dirname, '../../');
 const externalProjectName = process.argv[2];
 const gitUrl = process.argv[3];
+const skipSmokeTest = process.argv[4] && process.argv[4] === '--skip-smoke-test';
 const tempDir = path.join(projectRoot, '../__external-test-cache');
 const projectTempDir = path.join(tempDir, externalProjectName);
 
@@ -79,8 +80,12 @@ let smokeTestPassed = true;
 let commitTestPassed = true;
 
 try {
-  debug('Running Smoke Test');
-  execExternal(`ember test`, true);
+  if (skipSmokeTest) {
+    debug('Skipping Smoke Test');
+  } else {
+    debug('Running Smoke Test');
+    execExternal(`ember test`, true);
+  }
 } catch (e) {
   smokeTestPassed = false;
 }
@@ -95,13 +100,15 @@ try {
 }
 
 try {
-  debug('Re-running tests against EmberData commit');
+  debug('Running tests against EmberData commit');
   execExternal(`ember test`, true);
 } catch (e) {
   commitTestPassed = false;
 }
 
-if (!smokeTestPassed && !commitTestPassed) {
+if (skipSmokeTest && !commitTestPassed) {
+  throw new Error('Commit may result in a regression, but the smoke test was skipped.');
+} else if (!smokeTestPassed && !commitTestPassed) {
   throw new Error(
     `Commit may result in a regression, but the smoke test for ${externalProjectName} also failed.`
   );

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test-external:travis-web": "node ./lib/scripts/test-external travis-web https://github.com/travis-ci/travis-web.git",
     "test-external:storefront": "node ./lib/scripts/test-external storefront https://github.com/embermap/ember-data-storefront.git",
     "test-external:factory-guy": "node ./lib/scripts/test-external factory-guy https://github.com/danielspaniel/ember-data-factory-guy.git",
-    "test-external:ilios-frontend": "node ./lib/scripts/test-external ilios-frontend https://github.com/ilios/frontend.git",
+    "test-external:ilios-frontend": "node ./lib/scripts/test-external ilios-frontend https://github.com/ilios/frontend.git --skip-smoke-test",
     "test-external:ember-resource-metadata": "node ./lib/scripts/test-external ember-resource-metadata https://github.com/ef4/ember-resource-metadata.git",
     "test-external:ember-data-relationship-tracker": "node ./lib/scripts/test-external ember-data-relationship-tracker https://github.com/ef4/ember-data-relationship-tracker.git"
   },


### PR DESCRIPTION
The Ilios-frontend tests run very long and often fail to finish before
the Travis 50 minutes timeout. Skipping the smoke tests at least ensures
that passing builds pass. Failing builds will need to be investigated
separately to ensure that smoke tests are not failing as well.