### PR TITLE
[WIP FEAT RecordIdentifier] provide a stable reference key for client side records

### DIFF
--- a/addon/-private/system/cache/identifier-index.js
+++ b/addon/-private/system/cache/identifier-index.js
@@ -1,0 +1,218 @@
+// TODO kill this evil awful coerce thing
+import coerceId from '../coerce-id';
+import { DEBUG } from '@glimmer/env';
+
+let CLIENT_ID = 0;
+let IDENTIFIER = null;
+
+export function createIdentifierIndex(config) {
+  if (DEBUG) {
+    if (IDENTIFIER !== null) {
+      debugger;
+      throw new Error('createIdentifierIndex called multiple times without a matching call to clearIdentifierIndex.');
+    } else {
+      console.trace('createIdentifierIndex');
+    }
+  }
+
+  IDENTIFIER = new IdentifierIndex(config);
+
+  return IDENTIFIER;
+}
+
+export function clearIdentifierIndex() {
+  if (DEBUG) {
+    if (IDENTIFIER === null) {
+      throw new Error('clearIdentifierIndex called before createIdentifierIndex has setup an index');
+    } else {
+      console.trace('clearIdentifierIndex');
+    }
+  }
+
+  IDENTIFIER.clear();
+  IDENTIFIER = null;
+}
+
+function generateClientId(int) {
+  return `@ember-data:lid-${int}`;
+}
+
+export class RecordIdentifier {
+  constructor({ type, id, lid, meta }) {
+    this.type = type;
+    this.id = coerceId(id);
+    this.lid = lid || generateClientId(CLIENT_ID++);
+    this.meta = meta || null;
+  }
+
+  update({ meta, type, id }) {
+    if (type !== undefined) {
+      this.type = type;
+    }
+
+    if (id !== undefined) {
+      this.id = coerceId(id);
+    }
+
+    if (meta) {
+      Object.assign(this.meta, meta);
+    } else if (meta === null) {
+      this.meta = null;
+    }
+  }
+}
+
+/*
+```ts
+  interface indexer {
+    name: string;
+    match(identity: any): string|undefined {};
+  }
+```
+*/
+const DEFAULT_INDEXERS = [
+  {
+    name: 'json-api-lid',
+    match(identity) {
+      // convenience for passing in `lid` directly
+      if (typeof identity === 'string' && identity.length > 0) {
+        return [identity];
+      }
+
+      if (typeof identity === 'object' && identity !== null) {
+        return identity.lid !== null && identity.lid !== undefined ? [identity.lid] : undefined;
+      }
+    }
+  },
+  {
+    name: 'json-api-type',
+    match(identity) {
+      if (typeof identity === 'object' && identity !== null) {
+        let { type, lid } = identity;
+
+        if (
+          typeof type === 'string' && type.length > 0 &&
+          typeof lid === 'string' && lid.length > 0
+        ) {
+          return [type, lid];
+        }
+      }
+    }
+  },
+  {
+    name: 'json-api-identifier',
+    match(identity) {
+      if (typeof identity === 'object' && identity !== null) {
+        let { type, id: rawId } = identity;
+        let id = coerceId(rawId);
+
+        if (
+          typeof type === 'string' && type.length > 0 &&
+          typeof id === 'string' && id.length > 0
+        ) {
+          return [type, id];
+        }
+      }
+    }
+  }
+];
+
+class IdentifierIndex {
+  constructor(config = {}) {
+    this.cache = Object.create(null);
+    this.indexers = [].concat(DEFAULT_INDEXERS, config.indexers || []);
+  }
+
+  clear() {
+    this.cache = Object.create(null);
+    this.indexers = [];
+  }
+
+  _iterateIndexes(identifier, cb) {
+    let { indexers } = this;
+
+    for (let i = 0; i < indexers.length; i++) {
+      let { name } = indexers[i];
+      let index = indexers[i].match(identifier);
+
+      if (cb(name, index) === true) {
+        break;
+      }
+    }
+  }
+
+  getRecordIdentifier(resourceIdentifier) {
+    let foundValue = false;
+    let value;
+
+    this._iterateIndexes(resourceIdentifier, (name, path) => {
+      if (Array.isArray(path)) {
+        value = this.getFromIndex(name, path);
+      }
+
+      if (value instanceof RecordIdentifier) {
+        foundValue = true;
+        return true;
+      }
+    });
+
+    if (foundValue === false) {
+      value = new RecordIdentifier(resourceIdentifier);
+
+      this._iterateIndexes(value, (name, path) => {
+        if (Array.isArray(path)) {
+          this.addToIndex(name, path, value);
+        }
+      });
+    }
+
+    return value;
+  }
+
+  updateIndexes() {
+    throw new Error('updateIndexes has not been implemented');
+  }
+
+  getFromIndex(name, path) {
+    let { cache } = this;
+    let index = cache[name];
+
+    if (index !== undefined) {
+      for (let i = 0; i < path.length; i++) {
+        index = index[path[i]];
+
+        if (index === undefined) {
+          break;
+        }
+      }
+    }
+
+    return index;
+  }
+
+  addToIndex(name, path, value) {
+    let { cache } = this;
+    let index = cache[name] = cache[name] || Object.create(null);
+    let lastIndex = path.length - 1;
+
+    for (let i = 0; i < path.length; i++) {
+      let key = path[i];
+
+      if (i === lastIndex) {
+        index[key] = value;
+      } else {
+        index = index[key] = index[key] || Object.create(null);
+      }
+    }
+  }
+}
+
+export function recordIdentifierFor(resourceIdentifier) {
+  if (DEBUG) {
+    if (IDENTIFIER === null) {
+      debugger;
+      throw new Error('recordIdentifierFor called before createIdentifierIndex has setup an index');
+    }
+  }
+  return IDENTIFIER.getRecordIdentifier(resourceIdentifier);
+}

--- a/addon/-private/system/cache/internal-model-for.js
+++ b/addon/-private/system/cache/internal-model-for.js
@@ -1,0 +1,61 @@
+import { recordIdentifierFor } from './identifier-index';
+
+// stores back references for records, recordIdentifiers and internalModels
+const INTERNAL_MODEL_CACHE = new WeakMap();
+
+// TODO this is horrible for perf, perhaps we can make out index store
+//   this info alongside for now until we kill the need for "all-of-type"
+export function internalModelsFor(index, type) {
+  let dict = type ?
+    index.getFromIndex('json-api-type', [type]) :
+    index.getFromIndex('json-api-lid', []);
+  let internalModels = [];
+  if (dict === undefined) {
+    return internalModels;
+  }
+  let lids = Object.keys(dict);
+
+  for (let i = 0; i < lids.length; i++) {
+    let internalModel = internalModelFor(dict[lids[i]]);
+
+    if (internalModel !== undefined) {
+      internalModels.push(internalModel);
+    }
+  }
+
+  return internalModels;
+}
+
+export function clearInternalModels(index, modelName) {
+  let all = internalModelsFor(index, modelName);
+
+  for (let i = 0; i < all.length; i++) {
+    let internalModel = all[i];
+    // TODO the store or some such should initiate this not the internalModel
+    //  so that we can properly handle encapsulation with RecordData
+    internalModel.unloadRecord();
+    // TODO do we need to remove mapping here ourselves?
+    // TODO ^ RE we probably should vs relying on unloadRecord doing it later
+  }
+}
+
+export function setInternalModelFor(obj, internalModel) {
+  if (internalModel === null) {
+    INTERNAL_MODEL_CACHE.delete(obj);
+  } else {
+    INTERNAL_MODEL_CACHE.set(obj, internalModel);
+  }
+}
+
+export function internalModelFor(identifier) {
+  let internalModel = INTERNAL_MODEL_CACHE.get(identifier);
+
+  // TODO don't allow this fallback
+  if (internalModel === undefined) {
+    let recordIdentifier = recordIdentifierFor(identifier);
+
+    internalModel = INTERNAL_MODEL_CACHE.get(recordIdentifier)
+  }
+
+  return internalModel;
+}

--- a/addon/-private/system/cache/record-data-for.js
+++ b/addon/-private/system/cache/record-data-for.js
@@ -1,0 +1,21 @@
+import { recordIdentifierFor } from './identifier-index';
+
+// stores back references for records, recordI and internalModels
+export const RECORD_DATA_CACHE = new WeakMap();
+
+export function setRecordDataFor(obj, recordData) {
+  RECORD_DATA_CACHE.set(obj, recordData);
+}
+
+export function recordDataFor(identifier) {
+  let recordData = RECORD_DATA_CACHE.get(identifier);
+
+  // TODO don't allow this fallback
+  if (recordData === undefined) {
+    let recordIdentifier = recordIdentifierFor(identifier);
+
+    recordData = RECORD_DATA_CACHE.get(recordIdentifier)
+  }
+
+  return recordData;
+}

--- a/addon/-private/system/identity-map.js
+++ b/addon/-private/system/identity-map.js
@@ -4,11 +4,14 @@ import InternalModelMap from './internal-model-map';
  `IdentityMap` is a custom storage map for records by modelName
  used by `DS.Store`.
 
+ // TODO eliminate this and provide iterators for internalModels and recordData
+
  @class IdentityMap
  @private
  */
 export default class IdentityMap {
-  constructor() {
+  constructor(index) {
+    this.index = index;
     this._map = Object.create(null);
   }
 
@@ -25,7 +28,7 @@ export default class IdentityMap {
     let map = this._map[modelName];
 
     if (map === undefined) {
-      map = this._map[modelName] = new InternalModelMap(modelName);
+      map = this._map[modelName] = new InternalModelMap(modelName, this.index);
     }
 
     return map;

--- a/addon/-private/system/promise-proxies.js
+++ b/addon/-private/system/promise-proxies.js
@@ -5,6 +5,7 @@ import { get, computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import { Promise } from 'rsvp';
 import { assert } from '@ember/debug';
+import {recordIdentifierFor} from "./cache/identifier-index";
 
 /**
   A `PromiseArray` is an object that acts like both an `Ember.Array`
@@ -106,7 +107,8 @@ export const PromiseBelongsTo = PromiseObject.extend({
     let key = state.key;
     let store = state.store;
     let resource = state.recordData.getResourceIdentifier();
-    let internalModel = store._internalModelForResource(resource);
+    let recordIdentifier = recordIdentifierFor(resource);
+    let internalModel = store._internalModelForIdentifier(recordIdentifier);
 
     return store.reloadBelongsTo(this, internalModel, key, options).then(() => this);
   },

--- a/addon/-private/system/record-array-manager.js
+++ b/addon/-private/system/record-array-manager.js
@@ -130,8 +130,10 @@ export default class RecordArrayManager {
     let pending = this._pending[modelName];
     let hasPendingChanges = Array.isArray(pending);
     let hasNoPotentialDeletions = !hasPendingChanges || pending.length === 0;
-    let map = this.store._internalModelsFor(modelName);
-    let hasNoInsertionsOrRemovals = get(map, 'length') === get(array, 'length');
+
+    // TODO This is preventing us from removing internalModelsFor
+    let allInternalModels = this.store._internalModelsFor(modelName);
+    let hasNoInsertionsOrRemovals = allInternalModels.length === get(array, 'length');
 
     /*
       Ideally the recordArrayManager has knowledge of the changes to be applied to
@@ -204,7 +206,8 @@ export default class RecordArrayManager {
   }
 
   _visibleInternalModelsByType(modelName) {
-    let all = this.store._internalModelsFor(modelName)._models;
+    // TODO This is preventing us from removing internalModelsFor
+    let all = this.store._internalModelsFor(modelName);
     let visible = [];
     for (let i = 0; i < all.length; i++) {
       let model = all[i];

--- a/addon/-private/system/references/belongs-to.js
+++ b/addon/-private/system/references/belongs-to.js
@@ -206,7 +206,7 @@ export default class BelongsToReference extends Reference {
     let store = this.parentInternalModel.store;
     let resource = this._resource();
     if (resource && resource.data) {
-      let inverseInternalModel = store._internalModelForResource(resource.data);
+      let inverseInternalModel = store._internalModelForIdentifier(resource.data);
       if (inverseInternalModel && inverseInternalModel.isLoaded()) {
         return inverseInternalModel.getRecord();
       }
@@ -337,7 +337,7 @@ export default class BelongsToReference extends Reference {
     }
     if (resource && resource.data) {
       if (resource.data && (resource.data.id || resource.data.clientId)) {
-        let internalModel = this.store._internalModelForResource(resource.data);
+        let internalModel = this.store._internalModelForIdentifier(resource.data);
         if (internalModel.isLoaded()) {
           return internalModel.reload(options).then(internalModel => {
             if (internalModel) {

--- a/addon/-private/system/references/has-many.js
+++ b/addon/-private/system/references/has-many.js
@@ -3,6 +3,7 @@ import { get } from '@ember/object';
 import Reference from './reference';
 import { DEBUG } from '@glimmer/env';
 import { assertPolymorphicType } from 'ember-data/-debug';
+import {internalModelFor} from "../cache/internal-model-for";
 
 /**
  A HasManyReference is a low-level API that allows users and addon
@@ -201,8 +202,7 @@ export default class HasManyReference extends Reference {
 
     //TODO Igor cleanup
     return members.every(recordData => {
-      let store = this.parentInternalModel.store;
-      let internalModel = store._internalModelForRecordData(recordData);
+      let internalModel = internalModelFor(recordData);
       return internalModel.isLoaded() === true;
     });
   }

--- a/addon/-private/system/snapshot.js
+++ b/addon/-private/system/snapshot.js
@@ -5,6 +5,7 @@ import { inspect } from '@ember/debug';
 import EmberError from '@ember/error';
 import { get } from '@ember/object';
 import { assign } from '@ember/polyfills';
+import {recordIdentifierFor} from "./cache/identifier-index";
 
 /**
   @class Snapshot
@@ -245,7 +246,10 @@ export default class Snapshot {
     let value = relationship.getData();
     let data = value && value.data;
 
-    inverseInternalModel = data && store._internalModelForResource(data);
+    if (data) {
+      let recordIdentifier = recordIdentifierFor(data);
+      inverseInternalModel = data && store._internalModelForIdentifier(recordIdentifier);
+    }
 
     if (value && value.data !== undefined) {
       if (inverseInternalModel && !inverseInternalModel.isDeleted()) {
@@ -329,7 +333,9 @@ export default class Snapshot {
     if (value.data) {
       results = [];
       value.data.forEach(member => {
-        let internalModel = store._internalModelForResource(member);
+        let recordIdentifier = recordIdentifierFor(member);
+        let internalModel = store._internalModelForIdentifier(recordIdentifier);
+
         if (!internalModel.isDeleted()) {
           if (ids) {
             results.push(member.id);

--- a/tests/integration/adapter/build-url-mixin-test.js
+++ b/tests/integration/adapter/build-url-mixin-test.js
@@ -40,6 +40,10 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', {
 
     passedUrl = null;
   },
+  afterEach() {
+    run(env.container, 'destroy');
+    run(env.store, 'destroy');
+  },
 });
 
 function ajaxResponse(value) {

--- a/tests/integration/adapter/find-all-test.js
+++ b/tests/integration/adapter/find-all-test.js
@@ -1,19 +1,23 @@
 import { reject, resolve, defer } from 'rsvp';
 import { get } from '@ember/object';
 import { run } from '@ember/runloop';
-import { createStore } from 'dummy/tests/helpers/store';
-import setupStore from 'dummy/tests/helpers/store';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { module, test } from 'qunit';
 import DS from 'ember-data';
+import { setupTest } from 'ember-qunit';
+import Model from 'ember-data/model';
 
 const { attr } = DS;
 
-let Person, store, allRecords, env;
+module('integration/adapter/find-all - Finding All Records of a Type', function(hooks) {
+  setupTest(hooks);
 
-module('integration/adapter/find-all - Finding All Records of a Type', {
-  beforeEach() {
-    Person = DS.Model.extend({
+  let Person, store;
+
+  hooks.beforeEach(function() {
+    let { owner } = this;
+    owner.register('serializer:application', DS.JSONAPISerializer.extend());
+    Person = Model.extend({
       updatedAt: attr('string'),
       name: attr('string'),
       firstName: attr('string'),
@@ -24,90 +28,20 @@ module('integration/adapter/find-all - Finding All Records of a Type', {
         return 'Person';
       },
     });
-
-    allRecords = null;
-
-    env = setupStore({
-      person: Person,
-    });
-    store = env.store;
-  },
-
-  afterEach() {
-    run(() => {
-      if (allRecords) {
-        allRecords.destroy();
-      }
-      store.destroy();
-    });
-  },
-});
-
-test("When all records for a type are requested, the store should call the adapter's `findAll` method.", assert => {
-  assert.expect(5);
-
-  env.registry.register(
-    'adapter:person',
-    DS.Adapter.extend({
-      findAll() {
-        // this will get called twice
-        assert.ok(true, "the adapter's findAll method should be invoked");
-
-        return resolve({
-          data: [
-            {
-              id: 1,
-              type: 'person',
-              attributes: {
-                name: 'Braaaahm Dale',
-              },
-            },
-          ],
-        });
-      },
-    })
-  );
-
-  return run(() => {
-    return store.findAll('person').then(all => {
-      let allRecords = all;
-      assert.equal(
-        get(all, 'length'),
-        1,
-        "the record array's length is 1 after a record is loaded into it"
-      );
-      assert.equal(
-        all.objectAt(0).get('name'),
-        'Braaaahm Dale',
-        'the first item in the record array is Braaaahm Dale'
-      );
-
-      return store.findAll('person').then(all => {
-        // Only one record array per type should ever be created (identity map)
-        assert.strictEqual(
-          allRecords,
-          all,
-          'the same record array is returned every time all records of a type are requested'
-        );
-      });
-    });
+    owner.register('model:person', Person);
+    store = owner.lookup('service:store');
   });
-});
 
-test('When all records for a type are requested, a rejection should reject the promise', assert => {
-  assert.expect(5);
+  test("When all records for a type are requested, the store should call the adapter's `findAll` method.", function(assert) {
+    assert.expect(5);
 
-  let count = 0;
-  env.registry.register(
-    'adapter:person',
-    DS.Adapter.extend({
-      findAll() {
-        // this will get called twice
-        assert.ok(true, "the adapter's findAll method should be invoked");
+    this.owner.register(
+      'adapter:person',
+      DS.Adapter.extend({
+        findAll() {
+          // this will get called twice
+          assert.ok(true, "the adapter's findAll method should be invoked");
 
-        if (count++ === 0) {
-          return reject();
-        } else {
           return resolve({
             data: [
               {
@@ -119,19 +53,13 @@ test('When all records for a type are requested, a rejection should reject the p
               },
             ],
           });
-        }
-      },
-    })
-  );
-
-  return run(() => {
-    return store
-      .findAll('person')
-      .catch(() => {
-        assert.ok(true, 'The rejection should get here');
-        return store.findAll('person');
+        },
       })
-      .then(all => {
+    );
+
+    return run(() => {
+      return store.findAll('person').then(all => {
+        let allRecords = all;
         assert.equal(
           get(all, 'length'),
           1,
@@ -142,212 +70,267 @@ test('When all records for a type are requested, a rejection should reject the p
           'Braaaahm Dale',
           'the first item in the record array is Braaaahm Dale'
         );
+
+        return store.findAll('person').then(all => {
+          // Only one record array per type should ever be created (identity map)
+          assert.strictEqual(
+            allRecords,
+            all,
+            'the same record array is returned every time all records of a type are requested'
+          );
+        });
       });
-  });
-});
-
-test('When all records for a type are requested, records that are already loaded should be returned immediately.', assert => {
-  assert.expect(3);
-  store = createStore({
-    adapter: DS.Adapter.extend(),
-    person: Person,
+    });
   });
 
-  run(() => {
-    // Load a record from the server
-    store.push({
-      data: {
-        type: 'person',
-        id: '1',
-        attributes: {
-          name: 'Jeremy Ashkenas',
+  test('When all records for a type are requested, a rejection should reject the promise', function(assert) {
+    assert.expect(5);
+
+    let count = 0;
+    this.owner.register(
+      'adapter:person',
+      DS.Adapter.extend({
+        findAll() {
+          // this will get called twice
+          assert.ok(true, "the adapter's findAll method should be invoked");
+
+          if (count++ === 0) {
+            return reject();
+          } else {
+            return resolve({
+              data: [
+                {
+                  id: 1,
+                  type: 'person',
+                  attributes: {
+                    name: 'Braaaahm Dale',
+                  },
+                },
+              ],
+            });
+          }
         },
-      },
-    });
-    // Create a new, unsaved record in the store
-    store.createRecord('person', { name: 'Alex MacCaw' });
-  });
-
-  allRecords = store.peekAll('person');
-
-  assert.equal(get(allRecords, 'length'), 2, "the record array's length is 2");
-  assert.equal(
-    allRecords.objectAt(0).get('name'),
-    'Jeremy Ashkenas',
-    'the first item in the record array is Jeremy Ashkenas'
-  );
-  assert.equal(
-    allRecords.objectAt(1).get('name'),
-    'Alex MacCaw',
-    'the second item in the record array is Alex MacCaw'
-  );
-});
-
-test('When all records for a type are requested, records that are created on the client should be added to the record array.', assert => {
-  assert.expect(3);
-
-  store = createStore({
-    adapter: DS.Adapter.extend(),
-    person: Person,
-  });
-
-  allRecords = store.peekAll('person');
-
-  assert.equal(
-    get(allRecords, 'length'),
-    0,
-    "precond - the record array's length is zero before any records are loaded"
-  );
-
-  store.createRecord('person', { name: 'Carsten Nielsen' });
-
-  assert.equal(get(allRecords, 'length'), 1, "the record array's length is 1");
-  assert.equal(
-    allRecords.objectAt(0).get('name'),
-    'Carsten Nielsen',
-    'the first item in the record array is Carsten Nielsen'
-  );
-});
-
-testInDebug('When all records are requested, assert the payload is not blank', assert => {
-  env.registry.register(
-    'adapter:person',
-    DS.Adapter.extend({
-      findAll: () => resolve({}),
-    })
-  );
-
-  assert.expectAssertion(() => {
-    run(() => store.findAll('person'));
-  }, /You made a 'findAll' request for 'person' records, but the adapter's response did not have any data/);
-});
-
-test('isUpdating is true while records are fetched', function(assert) {
-  let findAllDeferred = defer();
-  env.registry.register(
-    'adapter:person',
-    DS.Adapter.extend({
-      findAll() {
-        return findAllDeferred.promise;
-      },
-
-      shouldReloadAll: () => true,
-    })
-  );
-
-  run(() => {
-    store.push({
-      data: [
-        {
-          type: 'person',
-          id: 1,
-        },
-      ],
-    });
-  });
-
-  let persons = store.peekAll('person');
-  assert.equal(persons.get('length'), 1);
-
-  let wait = run(() => {
-    return store.findAll('person').then(persons => {
-      assert.equal(persons.get('isUpdating'), false);
-      assert.equal(persons.get('length'), 2);
-    });
-  });
-
-  assert.equal(persons.get('isUpdating'), true);
-
-  findAllDeferred.resolve({ data: [{ id: 2, type: 'person' }] });
-
-  return wait;
-});
-
-test('isUpdating is true while records are fetched in the background', function(assert) {
-  let findAllDeferred = defer();
-  env.registry.register(
-    'adapter:person',
-    DS.Adapter.extend({
-      findAll() {
-        return findAllDeferred.promise;
-      },
-
-      shouldReloadAll() {
-        return false;
-      },
-      shouldBackgroundReloadAll() {
-        return true;
-      },
-    })
-  );
-
-  run(() => {
-    store.push({
-      data: [
-        {
-          type: 'person',
-          id: 1,
-        },
-      ],
-    });
-  });
-
-  let persons = store.peekAll('person');
-  assert.equal(persons.get('length'), 1);
-
-  return run(() => {
-    return store.findAll('person').then(persons => {
-      assert.equal(persons.get('isUpdating'), true);
-      assert.equal(persons.get('length'), 1, 'persons are updated in the background');
-    });
-  }).then(() => {
-    assert.equal(persons.get('isUpdating'), true);
-
-    run(() => {
-      findAllDeferred.resolve({ data: [{ id: 2, type: 'person' }] });
-    });
+      })
+    );
 
     return run(() => {
-      return findAllDeferred.promise.then(() => {
+      return store
+        .findAll('person')
+        .catch(() => {
+          assert.ok(true, 'The rejection should get here');
+          return store.findAll('person');
+        })
+        .then(all => {
+          assert.equal(
+            get(all, 'length'),
+            1,
+            "the record array's length is 1 after a record is loaded into it"
+          );
+          assert.equal(
+            all.objectAt(0).get('name'),
+            'Braaaahm Dale',
+            'the first item in the record array is Braaaahm Dale'
+          );
+        });
+    });
+  });
+
+  test('When all records for a type are requested, records that are already loaded should be returned immediately.', function(assert) {
+    assert.expect(3);
+    this.owner.register('adapter:application', DS.Adapter.extend());
+
+    run(() => {
+      // Load a record from the server
+      store.push({
+        data: {
+          type: 'person',
+          id: '1',
+          attributes: {
+            name: 'Jeremy Ashkenas',
+          },
+        },
+      });
+      // Create a new, unsaved record in the store
+      store.createRecord('person', { name: 'Alex MacCaw' });
+    });
+
+    let allRecords = store.peekAll('person');
+
+    assert.equal(get(allRecords, 'length'), 2, "the record array's length is 2");
+    assert.equal(
+      allRecords.objectAt(0).get('name'),
+      'Jeremy Ashkenas',
+      'the first item in the record array is Jeremy Ashkenas'
+    );
+    assert.equal(
+      allRecords.objectAt(1).get('name'),
+      'Alex MacCaw',
+      'the second item in the record array is Alex MacCaw'
+    );
+  });
+
+  test('When all records for a type are requested, records that are created on the client should be added to the record array.', function(assert) {
+    assert.expect(3);
+    this.owner.register('adapter:application', DS.Adapter.extend());
+
+    let allRecords = store.peekAll('person');
+
+    assert.equal(
+      get(allRecords, 'length'),
+      0,
+      "precond - the record array's length is zero before any records are loaded"
+    );
+
+    store.createRecord('person', { name: 'Carsten Nielsen' });
+
+    assert.equal(get(allRecords, 'length'), 1, "the record array's length is 1");
+    assert.equal(
+      allRecords.objectAt(0).get('name'),
+      'Carsten Nielsen',
+      'the first item in the record array is Carsten Nielsen'
+    );
+  });
+
+  testInDebug('When all records are requested, assert the payload is not blank', function(assert) {
+    this.owner.register(
+      'adapter:person',
+      DS.Adapter.extend({
+        findAll: () => resolve({}),
+      })
+    );
+
+    assert.expectAssertion(() => {
+      run(() => store.findAll('person'));
+    }, /You made a 'findAll' request for 'person' records, but the adapter's response did not have any data/);
+  });
+
+  test('isUpdating is true while records are fetched', function(assert) {
+    let findAllDeferred = defer();
+    this.owner.register(
+      'adapter:person',
+      DS.Adapter.extend({
+        findAll() {
+          return findAllDeferred.promise;
+        },
+
+        shouldReloadAll: () => true,
+      })
+    );
+
+    run(() => {
+      store.push({
+        data: [
+          {
+            type: 'person',
+            id: 1,
+          },
+        ],
+      });
+    });
+
+    let persons = store.peekAll('person');
+    assert.equal(persons.get('length'), 1);
+
+    let wait = run(() => {
+      return store.findAll('person').then(persons => {
         assert.equal(persons.get('isUpdating'), false);
         assert.equal(persons.get('length'), 2);
       });
     });
+
+    assert.equal(persons.get('isUpdating'), true);
+
+    findAllDeferred.resolve({ data: [{ id: 2, type: 'person' }] });
+
+    return wait;
   });
-});
 
-test('isUpdating is false if records are not fetched in the background', function(assert) {
-  let findAllDeferred = defer();
-  env.registry.register(
-    'adapter:person',
-    DS.Adapter.extend({
-      findAll() {
-        return findAllDeferred.promise;
-      },
-      shouldReloadAll: () => false,
-      shouldBackgroundReloadAll: () => false,
-    })
-  );
-
-  run(() => {
-    store.push({
-      data: [
-        {
-          type: 'person',
-          id: 1,
+  test('isUpdating is true while records are fetched in the background', function(assert) {
+    let findAllDeferred = defer();
+    this.owner.register(
+      'adapter:person',
+      DS.Adapter.extend({
+        findAll() {
+          return findAllDeferred.promise;
         },
-      ],
+
+        shouldReloadAll() {
+          return false;
+        },
+        shouldBackgroundReloadAll() {
+          return true;
+        },
+      })
+    );
+
+    run(() => {
+      store.push({
+        data: [
+          {
+            type: 'person',
+            id: 1,
+          },
+        ],
+      });
+    });
+
+    let persons = store.peekAll('person');
+    assert.equal(persons.get('length'), 1);
+
+    return run(() => {
+      return store.findAll('person').then(persons => {
+        assert.equal(persons.get('isUpdating'), true);
+        assert.equal(persons.get('length'), 1, 'persons are updated in the background');
+      });
+    }).then(() => {
+      assert.equal(persons.get('isUpdating'), true);
+
+      run(() => {
+        findAllDeferred.resolve({ data: [{ id: 2, type: 'person' }] });
+      });
+
+      return run(() => {
+        return findAllDeferred.promise.then(() => {
+          assert.equal(persons.get('isUpdating'), false);
+          assert.equal(persons.get('length'), 2);
+        });
+      });
     });
   });
 
-  let persons = store.peekAll('person');
-  assert.equal(persons.get('length'), 1);
+  test('isUpdating is false if records are not fetched in the background', function(assert) {
+    let findAllDeferred = defer();
+    this.owner.register(
+      'adapter:person',
+      DS.Adapter.extend({
+        findAll() {
+          return findAllDeferred.promise;
+        },
+        shouldReloadAll: () => false,
+        shouldBackgroundReloadAll: () => false,
+      })
+    );
 
-  return run(() => {
-    return store.findAll('person').then(persons => {
+    run(() => {
+      store.push({
+        data: [
+          {
+            type: 'person',
+            id: 1,
+          },
+        ],
+      });
+    });
+
+    let persons = store.peekAll('person');
+    assert.equal(persons.get('length'), 1);
+
+    return run(() => {
+      return store.findAll('person').then(persons => {
+        assert.equal(persons.get('isUpdating'), false);
+      });
+    }).then(() => {
       assert.equal(persons.get('isUpdating'), false);
     });
-  }).then(() => {
-    assert.equal(persons.get('isUpdating'), false);
   });
 });

--- a/tests/integration/adapter/queries-test.js
+++ b/tests/integration/adapter/queries-test.js
@@ -2,142 +2,143 @@ import { Promise as EmberPromise, resolve } from 'rsvp';
 import { get } from '@ember/object';
 import { run } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
+import { setupTest } from 'ember-qunit';
 
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { module, test } from 'qunit';
 
 import DS from 'ember-data';
 
-let Person, env, store, adapter;
+module('integration/adapter/queries - Queries', function(hooks) {
+  setupTest(hooks);
 
-module('integration/adapter/queries - Queries', {
-  beforeEach() {
-    Person = DS.Model.extend({
+  let store, adapter;
+
+  hooks.beforeEach(function() {
+    const Person = DS.Model.extend({
       updatedAt: DS.attr('string'),
       name: DS.attr('string'),
       firstName: DS.attr('string'),
       lastName: DS.attr('string'),
     });
+    let { owner } = this;
 
-    env = setupStore({ person: Person });
-    store = env.store;
-    adapter = env.adapter;
-  },
-
-  afterEach() {
-    run(env.container, 'destroy');
-  },
-});
-
-testInDebug('It raises an assertion when no type is passed', function(assert) {
-  assert.expectAssertion(() => {
-    store.query();
-  }, "You need to pass a model name to the store's query method");
-});
-
-testInDebug('It raises an assertion when no query hash is passed', function(assert) {
-  assert.expectAssertion(() => {
-    store.query('person');
-  }, "You need to pass a query hash to the store's query method");
-});
-
-test('When a query is made, the adapter should receive a record array it can populate with the results of the query.', function(assert) {
-  adapter.query = function(store, type, query, recordArray) {
-    assert.equal(type, Person, 'the query method is called with the correct type');
-
-    return EmberPromise.resolve({
-      data: [
-        {
-          id: 1,
-          type: 'person',
-          attributes: {
-            name: 'Peter Wagenet',
-          },
-        },
-        {
-          id: 2,
-          type: 'person',
-          attributes: {
-            name: 'Brohuda Katz',
-          },
-        },
-      ],
-    });
-  };
-
-  return store.query('person', { page: 1 }).then(queryResults => {
-    assert.equal(
-      get(queryResults, 'length'),
-      2,
-      'the record array has a length of 2 after the results are loaded'
-    );
-    assert.equal(
-      get(queryResults, 'isLoaded'),
-      true,
-      "the record array's `isLoaded` property should be true"
-    );
-
-    assert.equal(
-      queryResults.objectAt(0).get('name'),
-      'Peter Wagenet',
-      "the first record is 'Peter Wagenet'"
-    );
-    assert.equal(
-      queryResults.objectAt(1).get('name'),
-      'Brohuda Katz',
-      "the second record is 'Brohuda Katz'"
-    );
+    owner.register('model:person', Person);
+    store = owner.lookup('service:store');
+    adapter = store.adapterFor('application');
   });
-});
 
-test('a query can be updated via `update()`', function(assert) {
-  adapter.query = function() {
-    return resolve({ data: [{ id: 'first', type: 'person' }] });
-  };
-
-  return run(() => {
-    return store
-      .query('person', {})
-      .then(query => {
-        assert.equal(query.get('length'), 1);
-        assert.equal(query.get('firstObject.id'), 'first');
-        assert.equal(query.get('isUpdating'), false);
-
-        adapter.query = function() {
-          assert.ok('query is called a second time');
-          return resolve({ data: [{ id: 'second', type: 'person' }] });
-        };
-
-        let updateQuery = query.update();
-
-        assert.equal(query.get('isUpdating'), true);
-
-        return updateQuery;
-      })
-      .then(query => {
-        assert.equal(query.get('length'), 1);
-        assert.equal(query.get('firstObject.id'), 'second');
-
-        assert.equal(query.get('isUpdating'), false);
-      });
+  testInDebug('It raises an assertion when no type is passed', function(assert) {
+    assert.expectAssertion(() => {
+      store.query();
+    }, "You need to pass a model name to the store's query method");
   });
-});
 
-testInDebug(
-  'The store asserts when query is made and the adapter responses with a single record.',
-  function(assert) {
-    env = setupStore({ person: Person, adapter: DS.RESTAdapter });
-    store = env.store;
-    adapter = env.adapter;
+  testInDebug('It raises an assertion when no query hash is passed', function(assert) {
+    assert.expectAssertion(() => {
+      store.query('person');
+    }, "You need to pass a query hash to the store's query method");
+  });
 
+  test('When a query is made, the adapter should receive a record array it can populate with the results of the query.', function(assert) {
     adapter.query = function(store, type, query, recordArray) {
+      const Person = store.modelFor('person');
       assert.equal(type, Person, 'the query method is called with the correct type');
 
-      return resolve({ data: [{ id: 1, type: 'person', attributes: { name: 'Peter Wagenet' } }] });
+      return EmberPromise.resolve({
+        data: [
+          {
+            id: 1,
+            type: 'person',
+            attributes: {
+              name: 'Peter Wagenet',
+            },
+          },
+          {
+            id: 2,
+            type: 'person',
+            attributes: {
+              name: 'Brohuda Katz',
+            },
+          },
+        ],
+      });
     };
 
-    assert.expectAssertion(() => {
-      run(() => store.query('person', { page: 1 }));
-    }, /The response to store.query is expected to be an array but it was a single record/);
-  }
-);
+    return store.query('person', { page: 1 }).then(queryResults => {
+      assert.equal(
+        get(queryResults, 'length'),
+        2,
+        'the record array has a length of 2 after the results are loaded'
+      );
+      assert.equal(
+        get(queryResults, 'isLoaded'),
+        true,
+        "the record array's `isLoaded` property should be true"
+      );
+
+      assert.equal(
+        queryResults.objectAt(0).get('name'),
+        'Peter Wagenet',
+        "the first record is 'Peter Wagenet'"
+      );
+      assert.equal(
+        queryResults.objectAt(1).get('name'),
+        'Brohuda Katz',
+        "the second record is 'Brohuda Katz'"
+      );
+    });
+  });
+
+  test('a query can be updated via `update()`', function(assert) {
+    adapter.query = function() {
+      return resolve({ data: [{ id: 'first', type: 'person' }] });
+    };
+
+    return run(() => {
+      return store
+        .query('person', {})
+        .then(query => {
+          assert.equal(query.get('length'), 1);
+          assert.equal(query.get('firstObject.id'), 'first');
+          assert.equal(query.get('isUpdating'), false);
+
+          adapter.query = function() {
+            assert.ok('query is called a second time');
+            return resolve({ data: [{ id: 'second', type: 'person' }] });
+          };
+
+          let updateQuery = query.update();
+
+          assert.equal(query.get('isUpdating'), true);
+
+          return updateQuery;
+        })
+        .then(query => {
+          assert.equal(query.get('length'), 1);
+          assert.equal(query.get('firstObject.id'), 'second');
+
+          assert.equal(query.get('isUpdating'), false);
+        });
+    });
+  });
+
+  testInDebug(
+    'The store asserts when query is made and the adapter responses with a single record.',
+    function(assert) {
+      this.owner.register('adapter:person', DS.RESTAdapter.extend());
+      adapter = store.adapterFor('person');
+      adapter.query = function(store, type, query, recordArray) {
+        const Person = store.modelFor('person');
+        assert.equal(type, Person, 'the query method is called with the correct type');
+
+        return resolve({ data: [{ id: 1, type: 'person', attributes: { name: 'Peter Wagenet' } }] });
+      };
+
+      assert.expectAssertion(() => {
+        run(() => store.query('person', { page: 1 }));
+      }, /The response to store.query is expected to be an array but it was a single record/);
+    }
+  );
+
+});

--- a/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/integration/adapter/rest-adapter-test.js
@@ -626,12 +626,12 @@ test("createRecord - response can contain relationships the client doesn't yet k
         'the comments are related to the correct post model'
       );
       assert.equal(
-        store._internalModelsFor('post').models.length,
+        store._internalModelsFor('post').length,
         1,
         'There should only be one post record in the store'
       );
 
-      let postRecords = store._internalModelsFor('post').models;
+      let postRecords = store._internalModelsFor('post');
       for (var i = 0; i < postRecords.length; i++) {
         assert.equal(
           post,

--- a/tests/integration/records/unload-test.js
+++ b/tests/integration/records/unload-test.js
@@ -484,8 +484,8 @@ test('unloadAll(type) does not leave stranded internalModels in relationships (r
   let knownBoats = store._internalModelsFor('boat');
 
   // ensure we loaded the people and boats
-  assert.equal(knownPeople.models.length, 1, 'one person record is loaded');
-  assert.equal(knownBoats.models.length, 1, 'one boat record is loaded');
+  assert.equal(knownPeople.length, 1, 'one person record is loaded');
+  assert.equal(knownBoats.length, 1, 'one boat record is loaded');
   assert.equal(env.store.hasRecordForId('person', '1'), true);
   assert.equal(env.store.hasRecordForId('boat', '1'), true);
 
@@ -504,8 +504,8 @@ test('unloadAll(type) does not leave stranded internalModels in relationships (r
   });
 
   // ensure that our new state is correct
-  assert.equal(knownPeople.models.length, 1, 'one person record is loaded');
-  assert.equal(knownBoats.models.length, 0, 'no boat records are loaded');
+  assert.equal(knownPeople.length, 1, 'one person record is loaded');
+  assert.equal(knownBoats.length, 0, 'no boat records are loaded');
   assert.equal(
     relationshipState.canonicalMembers.size,
     1,
@@ -567,8 +567,8 @@ test('unloadAll(type) does not leave stranded internalModels in relationships (r
   let knownBoats = store._internalModelsFor('boat');
 
   // ensure we loaded the people and boats
-  assert.equal(knownPeople.models.length, 1, 'one person record is loaded');
-  assert.equal(knownBoats.models.length, 1, 'one boat record is loaded');
+  assert.equal(knownPeople.length, 1, 'one person record is loaded');
+  assert.equal(knownBoats.length, 1, 'one boat record is loaded');
   assert.equal(env.store.hasRecordForId('person', '1'), true);
   assert.equal(env.store.hasRecordForId('boat', '1'), true);
 
@@ -775,12 +775,12 @@ test('unloading a disconnected subgraph clears the relevant internal models', fu
   });
 
   assert.equal(
-    env.store._internalModelsFor('person').models.length,
+    env.store._internalModelsFor('person').length,
     1,
     'one person record is loaded'
   );
   assert.equal(
-    env.store._internalModelsFor('boat').models.length,
+    env.store._internalModelsFor('boat').length,
     2,
     'two boat records are loaded'
   );
@@ -823,8 +823,8 @@ test('unloading a disconnected subgraph clears the relevant internal models', fu
         env.store.peekRecord('boat', 2).unloadRecord();
       });
 
-      assert.equal(env.store._internalModelsFor('person').models.length, 0);
-      assert.equal(env.store._internalModelsFor('boat').models.length, 0);
+      assert.equal(env.store._internalModelsFor('person').length, 0);
+      assert.equal(env.store._internalModelsFor('boat').length, 0);
 
       assert.equal(checkOrphanCalls, 3, 'each internalModel checks for cleanup');
       assert.equal(cleanupOrphanCalls, 3, 'each model data tries to cleanup');

--- a/tests/unit/adapters/build-url-mixin/build-url-test.js
+++ b/tests/unit/adapters/build-url-mixin/build-url-test.js
@@ -1,5 +1,6 @@
 import setupStore from 'dummy/tests/helpers/store';
 import DS from 'ember-data';
+import { run } from '@ember/runloop';
 
 import { module, test } from 'qunit';
 
@@ -23,6 +24,10 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', {
     });
 
     adapter = env.adapter;
+  },
+  afterEach() {
+    run(env.container, 'destroy');
+    run(env.store, 'destroy');
   },
 });
 


### PR DESCRIPTION
Now that `RecordData` has landed we find ourselves looking for the path to:

- eliminate dependence on `InternalModel` by `store`, `Model`, and `record-data-wrapper` methods
- eliminate `InternalModel`
- clean up the relationship graph
- add the ability to provide multiple indexes for records

Much of our internals currently use `internalModel` as a "stable reference" due to the potential lack of an `id`. `RecordData` introduced `clientId` but only makes use of it for newly created records, leading to brittle contracts and redundant code checks and infra to handle the `clientId` vs `id` cases.  

Our relationship layer is now entangled with `RecordData` (which is responsible for membership), `InternalModel` (which is responsible for ui presentation), and `store` (which is responsible for converting the membership to records and which may or may not require network requests).

`unloadAll`, `unloadRecord`, and `peekAll` depend on `InternalModelMap`, which we now have two of and which doesn't fit properly in the post-InternalModel world.

This PR is a first step to addressing these problems and achieving our goals by moving to a system in which all records are uniformly referred to by a `recordIdentifier`, which will always have a `clientId`, now called `lid` in keeping with the `json-api` proposal.  This reduces method signatures, reduces risk of data misalignment, eliminates conversion into-out-of other ways of referencing records by unifying on a single standard, and improves our ability to better isolate our various primitives by providing a standard through which they can communicate.