### PR TITLE
[WIP DEPRECATION events] Implements RFC 329 evented deprecation

### DIFF
--- a/addon/-private/deprecated-evented.js
+++ b/addon/-private/deprecated-evented.js
@@ -1,0 +1,45 @@
+import Mixin from '@ember/object/mixin';
+import Evented from '@ember/object/evented';
+import { deprecate } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+
+let DeprecatedEvented = Evented;
+
+if (DEBUG) {
+  const printDeprecation = function(ctx) {
+    deprecate(
+      `Use of event functionality provided by Ember.Evented with ${
+        ctx._debugContainerKey
+        } has been deprecated.`,
+      {
+        id: 'ember-data:no-longer-evented',
+        until: '3.8',
+      }
+    );
+  };
+
+  DeprecatedEvented = Mixin.create(Evented, {
+    has() {
+      printDeprecation(this);
+      return this._super(...arguments);
+    },
+    off() {
+      printDeprecation(this);
+      return this._super(...arguments);
+    },
+    on() {
+      printDeprecation(this);
+      return this._super(...arguments);
+    },
+    one() {
+      printDeprecation(this);
+      return this._super(...arguments);
+    },
+    trigger() {
+      printDeprecation(this);
+      return this._super(...arguments);
+    },
+  });
+}
+
+export default DeprecatedEvented;

--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -3,7 +3,7 @@
 */
 import { all } from 'rsvp';
 
-import Evented from '@ember/object/evented';
+import Evented from '../deprecated-evented';
 import MutableArray from '@ember/array/mutable';
 import EmberObject, { get } from '@ember/object';
 import { assert } from '@ember/debug';

--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -1,5 +1,5 @@
 import { mapBy, not } from '@ember/object/computed';
-import Evented from '@ember/object/evented';
+import Evented from '../../deprecated-evented';
 import ArrayProxy from '@ember/array/proxy';
 import { set, get, computed } from '@ember/object';
 import { makeArray, A } from '@ember/array';

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1,6 +1,6 @@
 import { isNone } from '@ember/utils';
 import EmberError from '@ember/error';
-import DeprecatedEvented from '../../deprecated-evented';
+import Evented from '../../deprecated-evented';
 import EmberObject, { computed, get } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
 import { assert, warn, deprecate } from '@ember/debug';
@@ -82,7 +82,7 @@ const retrieveFromCurrentState = computed('currentState', function(key) {
   @extends Ember.Object
   @uses Ember.Evented
 */
-const Model = EmberObject.extend(DeprecatedEvented, {
+const Model = EmberObject.extend(Evented, {
   _internalModel: null,
   store: null,
   __defineNonEnumerable(property) {

--- a/addon/-private/system/record-arrays/adapter-populated-record-array.js
+++ b/addon/-private/system/record-arrays/adapter-populated-record-array.js
@@ -87,6 +87,7 @@ export default RecordArray.extend({
     this.manager._associateWithRecordArray(internalModels, this);
 
     // TODO: should triggering didLoad event be the last action of the runLoop?
+    // TODO detect if this is listened to and deprecate
     once(this, 'trigger', 'didLoad');
     heimdall.stop(token);
   },

--- a/addon/-private/system/record-arrays/record-array.js
+++ b/addon/-private/system/record-arrays/record-array.js
@@ -2,8 +2,7 @@
   @module ember-data
 */
 
-import Evented from '@ember/object/evented';
-
+import Evented from '../../deprecated-evented';
 import ArrayProxy from '@ember/array/proxy';
 import { set, get, computed } from '@ember/object';
 import { Promise } from 'rsvp';

--- a/addon/-private/system/relationship-meta.js
+++ b/addon/-private/system/relationship-meta.js
@@ -26,8 +26,7 @@ class RelationshipDefinition {
     this._type = '';
     this.__inverseKey = '';
     this.__inverseIsAsync = null;
-    this.modelClass = meta.parentType;
-    this.store = null;
+    this.parentModelName = meta.parentModelName;
   }
 
   get key() {
@@ -48,9 +47,6 @@ class RelationshipDefinition {
   }
   get name() {
     return this.meta.name;
-  }
-  get parentType() {
-    return this.meta.parentType;
   }
 
   _inverseKey(store, modelClass) {

--- a/addon/-private/system/relationships/ext.js
+++ b/addon/-private/system/relationships/ext.js
@@ -22,7 +22,7 @@ export const relationshipsDescriptor = computed(function() {
 }).readOnly();
 
 export const relatedTypesDescriptor = computed(function() {
-  let modelName;
+  let parentModelName = this.modelName;
   let types = A();
 
   // Loop through each computed property on the class,
@@ -31,10 +31,10 @@ export const relatedTypesDescriptor = computed(function() {
   this.eachComputedProperty((name, meta) => {
     if (meta.isRelationship) {
       meta.key = name;
-      modelName = typeForRelationshipMeta(meta);
+      let modelName = typeForRelationshipMeta(meta);
 
       assert(
-        `You specified a hasMany (${meta.type}) on ${meta.parentType} but ${
+        `You specified a hasMany (${meta.type}) on ${parentModelName} but ${
           meta.type
         } was not found.`,
         modelName
@@ -55,10 +55,12 @@ export const relatedTypesDescriptor = computed(function() {
 
 export const relationshipsObjectDescriptor = computed(function() {
   let relationships = Object.create(null);
+  let modelName = this.modelName;
   this.eachComputedProperty((name, meta) => {
     if (meta.isRelationship) {
       meta.key = name;
       meta.name = name;
+      meta.parentModelName = modelName;
       relationships[name] = relationshipFromMeta(meta);
     }
   });

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1347,35 +1347,9 @@ test('A DS.Model can be JSONified', function(assert) {
   assert.deepEqual(record.toJSON(), { data: { type: 'people', attributes: { name: 'TomHuda' } } });
 });
 
-testInDebug('A subclass of DS.Model can not use the `data` property', function(assert) {
-  const Person = DS.Model.extend({
-    data: DS.attr('string'),
-    name: DS.attr('string'),
-  });
-
-  let store = createStore({ person: Person });
-
-  assert.expectAssertion(() => {
-    store.createRecord('person', { name: 'TomHuda' });
-  }, /`data` is a reserved property name on DS.Model objects/);
-});
-
-testInDebug('A subclass of DS.Model can not use the `store` property', function(assert) {
-  const Retailer = DS.Model.extend({
-    store: DS.attr(),
-    name: DS.attr(),
-  });
-
-  let store = createStore({ retailer: Retailer });
-
-  assert.expectAssertion(() => {
-    store.createRecord('retailer', { name: 'Buy n Large' });
-  }, /`store` is a reserved property name on DS.Model objects/);
-});
-
 testInDebug('A subclass of DS.Model can not use reserved properties', function(assert) {
   assert.expect(3);
-  ['currentState', 'data', 'store'].forEach(reservedProperty => {
+  ['recordData', '_internalModel', 'currentState'].forEach(reservedProperty => {
     let invalidExtendObject = {};
     invalidExtendObject[reservedProperty] = DS.attr();
     const Post = DS.Model.extend(invalidExtendObject);


### PR DESCRIPTION
[RFC #329](https://github.com/emberjs/rfcs/blob/5a1e8cddd3c1a210c2d60c7a9ac021dbfbedc370/text/1234-deprecated-ember-evented-in-ember-data.md)

Remaining Tasks

1) Revisit with @hjdivad plan to make `DeprecatedEvented` not be unnecessarily noisy on models and ensure end users may extend `Model` with `Evented` on their own.

2) Figure out if `AdapterPopulatedRecordArray` event `didLoad` is listened to and only fire deprecation then vs every time.