### PR TITLE
[CHORE tests] modernize integration/store/adapter-for-test

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -3065,7 +3065,9 @@ Store = Service.extend({
     // no model specific adapter or application adapter, check for an `adapter`
     // property defined on the store
     let adapterName = this.get('adapter');
-    adapter = _adapterCache[adapterName] || owner.lookup(`adapter:${adapterName}`);
+    adapter = adapterName
+      ? _adapterCache[adapterName] || owner.lookup(`adapter:${adapterName}`)
+      : undefined;
     if (adapter !== undefined) {
       set(adapter, 'store', this);
       _adapterCache[normalizedModelName] = adapter;
@@ -3076,6 +3078,10 @@ Store = Service.extend({
     // final fallback, no model specific adapter, no application adapter, no
     // `adapter` property on store: use json-api adapter
     adapter = _adapterCache['-json-api'] || owner.lookup('adapter:-json-api');
+    assert(
+      `No adapter was found for '${modelName}' and no 'application', store.adapter = 'adapter-fallback-name', or '-json-api' adapter were found as fallbacks.`,
+      adapter !== undefined
+    );
     set(adapter, 'store', this);
     _adapterCache[normalizedModelName] = adapter;
     _adapterCache['-json-api'] = adapter;

--- a/tests/integration/records/load-test.js
+++ b/tests/integration/records/load-test.js
@@ -12,6 +12,7 @@ import todo from '../../helpers/todo';
 class Person extends Model {
   @attr
   name;
+
   @belongsTo('person', { async: true, inverse: 'bestFriend' })
   bestFriend;
 }

--- a/tests/integration/store/adapter-for-test.js
+++ b/tests/integration/store/adapter-for-test.js
@@ -1,0 +1,329 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import Store from 'ember-data/store';
+import { run } from '@ember/runloop';
+
+class TestAdapter {
+  constructor(args) {
+    Object.assign(this, args);
+    this.didInit();
+  }
+
+  didInit() {}
+
+  static create(args) {
+    return new this(args);
+  }
+}
+
+module('integration/store - adapterFor', function(hooks) {
+  setupTest(hooks);
+  let store;
+
+  hooks.beforeEach(function() {
+    let { owner } = this;
+    store = owner.lookup('service:store');
+  });
+
+  test('when no adapter is available we throw an error', async function(assert) {
+    let { owner } = this;
+    /*
+      ensure our store instance does not specify a fallback
+      we use an empty string as that would cause `owner.lookup` to blow up if not guarded properly
+      whereas `null` `undefined` `false` would not.
+     */
+    store.adapter = '';
+    /*
+      adapter:-json-api is the "last chance" fallback and is
+      registered automatically.
+      unregistering it will cause adapterFor to return `undefined`.
+     */
+    owner.unregister('adapter:-json-api');
+
+    assert.expectAssertion(() => {
+      store.adapterFor('person');
+    }, /No adapter was found for 'person' and no 'application', store\.adapter = 'adapter-fallback-name', or '-json-api' adapter were found as fallbacks\./);
+  });
+
+  test('we find and instantiate the application adapter', async function(assert) {
+    let { owner } = this;
+    let didInstantiate = false;
+
+    class AppAdapter extends TestAdapter {
+      didInit() {
+        didInstantiate = true;
+      }
+    }
+
+    owner.register('adapter:application', AppAdapter);
+
+    let adapter = store.adapterFor('application');
+
+    assert.ok(adapter instanceof AppAdapter, 'We found the correct adapter');
+    assert.ok(didInstantiate, 'We instantiated the adapter');
+    didInstantiate = false;
+
+    let adapterAgain = store.adapterFor('application');
+
+    assert.ok(adapterAgain instanceof AppAdapter, 'We found the correct adapter');
+    assert.ok(!didInstantiate, 'We did not instantiate the adapter again');
+    assert.ok(adapter === adapterAgain, 'Repeated calls to adapterFor return the same instance');
+  });
+
+  test('multiple stores do not share adapters', async function(assert) {
+    let { owner } = this;
+    let didInstantiate = false;
+
+    class AppAdapter extends TestAdapter {
+      didInit() {
+        didInstantiate = true;
+      }
+    }
+
+    owner.register('adapter:application', AppAdapter);
+    owner.register('service:other-store', Store);
+
+    let otherStore = owner.lookup('service:other-store');
+    let adapter = store.adapterFor('application');
+
+    assert.ok(adapter instanceof AppAdapter, 'We found the correct adapter');
+    assert.ok(didInstantiate, 'We instantiated the adapter');
+    didInstantiate = false;
+
+    let otherAdapter = otherStore.adapterFor('application');
+    assert.ok(otherAdapter instanceof AppAdapter, 'We found the correct adapter again');
+    assert.ok(didInstantiate, 'We instantiated the other adapter');
+    assert.ok(otherAdapter !== adapter, 'We have a different adapter instance');
+
+    // Ember 2.18 requires us to wrap destroy in a run. Use `await settled()` for newer versions.
+    run(() => otherStore.destroy());
+  });
+
+  test('we can find and instantiate per-type adapters', async function(assert) {
+    let { owner } = this;
+    let didInstantiateAppAdapter = false;
+    let didInstantiatePersonAdapter = false;
+
+    class AppAdapter extends TestAdapter {
+      didInit() {
+        didInstantiateAppAdapter = true;
+      }
+    }
+
+    class PersonAdapter extends TestAdapter {
+      didInit() {
+        didInstantiatePersonAdapter = true;
+      }
+    }
+
+    owner.register('adapter:application', AppAdapter);
+    owner.register('adapter:person', PersonAdapter);
+
+    let adapter = store.adapterFor('person');
+
+    assert.ok(adapter instanceof PersonAdapter, 'We found the correct adapter');
+    assert.ok(didInstantiatePersonAdapter, 'We instantiated the person adapter');
+    assert.ok(!didInstantiateAppAdapter, 'We did not instantiate the application adapter');
+
+    let appAdapter = store.adapterFor('application');
+    assert.ok(appAdapter instanceof AppAdapter, 'We found the correct adapter');
+    assert.ok(didInstantiateAppAdapter, 'We instantiated the application adapter');
+    assert.ok(appAdapter !== adapter, 'We have separate adapters');
+  });
+
+  test('we fallback to the application adapter when a per-type adapter is not found', async function(assert) {
+    let { owner } = this;
+    let didInstantiateAppAdapter = false;
+
+    class AppAdapter extends TestAdapter {
+      didInit() {
+        didInstantiateAppAdapter = true;
+      }
+    }
+
+    owner.register('adapter:application', AppAdapter);
+
+    let adapter = store.adapterFor('person');
+
+    assert.ok(adapter instanceof AppAdapter, 'We found the adapter');
+    assert.ok(didInstantiateAppAdapter, 'We instantiated the adapter');
+    didInstantiateAppAdapter = false;
+
+    let appAdapter = store.adapterFor('application');
+    assert.ok(appAdapter instanceof AppAdapter, 'We found the correct adapter');
+    assert.ok(!didInstantiateAppAdapter, 'We did not instantiate the adapter again');
+    assert.ok(appAdapter === adapter, 'We fell back to the application adapter instance');
+  });
+
+  test('we can specify a fallback adapter by name in place of the application adapter', async function(assert) {
+    store.adapter = '-rest';
+    let { owner } = this;
+
+    let didInstantiateRestAdapter = false;
+
+    class RestAdapter extends TestAdapter {
+      didInit() {
+        didInstantiateRestAdapter = true;
+      }
+    }
+    owner.register('adapter:-rest', RestAdapter);
+
+    let adapter = store.adapterFor('person');
+
+    assert.ok(adapter instanceof RestAdapter, 'We found the fallback -rest adapter for person');
+    assert.ok(didInstantiateRestAdapter, 'We instantiated the adapter');
+    didInstantiateRestAdapter = false;
+
+    let appAdapter = store.adapterFor('application');
+
+    assert.ok(
+      appAdapter instanceof RestAdapter,
+      'We found the fallback -rest adapter for application'
+    );
+    assert.ok(!didInstantiateRestAdapter, 'We did not instantiate the adapter again');
+    didInstantiateRestAdapter = false;
+
+    let restAdapter = store.adapterFor('-rest');
+    assert.ok(restAdapter instanceof RestAdapter, 'We found the correct adapter');
+    assert.ok(!didInstantiateRestAdapter, 'We did not instantiate the adapter again');
+    assert.ok(
+      restAdapter === adapter,
+      'We fell back to the -rest adapter instance for the person adapters'
+    );
+    assert.ok(
+      restAdapter === appAdapter,
+      'We fell back to the -rest adapter instance for the application adapter'
+    );
+  });
+
+  test('the application adapter has higher precedence than a fallback adapter defined via store.adapter', async function(assert) {
+    store.adapter = '-rest';
+    let { owner } = this;
+
+    let didInstantiateAppAdapter = false;
+    let didInstantiateRestAdapter = false;
+
+    class AppAdapter extends TestAdapter {
+      didInit() {
+        didInstantiateAppAdapter = true;
+      }
+    }
+
+    class RestAdapter extends TestAdapter {
+      didInit() {
+        didInstantiateRestAdapter = true;
+      }
+    }
+
+    owner.register('adapter:application', AppAdapter);
+    owner.register('adapter:-rest', RestAdapter);
+
+    let adapter = store.adapterFor('person');
+
+    assert.ok(adapter instanceof AppAdapter, 'We found the store specified fallback adapter');
+    assert.ok(
+      !didInstantiateRestAdapter,
+      'We did not instantiate the store.adapter (-rest) adapter'
+    );
+    assert.ok(didInstantiateAppAdapter, 'We instantiated the application adapter');
+    didInstantiateRestAdapter = false;
+    didInstantiateAppAdapter = false;
+
+    let appAdapter = store.adapterFor('application');
+    assert.ok(appAdapter instanceof AppAdapter, 'We found the correct adapter for application');
+    assert.ok(!didInstantiateRestAdapter, 'We did not instantiate the store fallback adapter');
+    assert.ok(!didInstantiateAppAdapter, 'We did not instantiate the application adapter again');
+    assert.ok(appAdapter === adapter, 'We used the application adapter as the person adapter');
+    didInstantiateRestAdapter = false;
+    didInstantiateAppAdapter = false;
+
+    let restAdapter = store.adapterFor('-rest');
+    assert.ok(restAdapter instanceof RestAdapter, 'We found the correct adapter for -rest');
+    assert.ok(!didInstantiateAppAdapter, 'We did not instantiate the application adapter again');
+    assert.ok(didInstantiateRestAdapter, 'We instantiated the fallback adapter');
+    assert.ok(restAdapter !== appAdapter, `We did not use the application adapter instance`);
+  });
+
+  test('we can specify a fallback adapter by name in place of the application adapter', async function(assert) {
+    store.adapter = '-rest';
+    let { owner } = this;
+
+    let didInstantiateRestAdapter = false;
+
+    class RestAdapter extends TestAdapter {
+      didInit() {
+        didInstantiateRestAdapter = true;
+      }
+    }
+    owner.register('adapter:-rest', RestAdapter);
+
+    let adapter = store.adapterFor('application');
+
+    assert.ok(adapter instanceof RestAdapter, 'We found the adapter');
+    assert.ok(didInstantiateRestAdapter, 'We instantiated the adapter');
+    didInstantiateRestAdapter = false;
+
+    let restAdapter = store.adapterFor('-rest');
+    assert.ok(restAdapter instanceof RestAdapter, 'We found the correct adapter');
+    assert.ok(!didInstantiateRestAdapter, 'We did not instantiate the adapter again');
+    assert.ok(
+      restAdapter === adapter,
+      'We fell back to the -rest adapter instance for the application adapter'
+    );
+  });
+
+  test('When the per-type, application and specified fallback adapters do not exist, we fallback to the -json-api adapter', async function(assert) {
+    store.adapter = '-not-a-real-adapter';
+    let { owner } = this;
+
+    let didInstantiateAdapter = false;
+
+    class JsonApiAdapter extends TestAdapter {
+      didInit() {
+        didInstantiateAdapter = true;
+      }
+    }
+    owner.unregister('adapter:-json-api');
+    owner.register('adapter:-json-api', JsonApiAdapter);
+
+    let adapter = store.adapterFor('person');
+
+    assert.ok(adapter instanceof JsonApiAdapter, 'We found the adapter');
+    assert.ok(didInstantiateAdapter, 'We instantiated the adapter');
+    didInstantiateAdapter = false;
+
+    let appAdapter = store.adapterFor('application');
+
+    assert.ok(
+      appAdapter instanceof JsonApiAdapter,
+      'We found the fallback -json-api adapter for application'
+    );
+    assert.ok(!didInstantiateAdapter, 'We did not instantiate the adapter again');
+    didInstantiateAdapter = false;
+
+    let fallbackAdapter = store.adapterFor('-not-a-real-adapter');
+
+    assert.ok(
+      fallbackAdapter instanceof JsonApiAdapter,
+      'We found the fallback -json-api adapter for application'
+    );
+    assert.ok(!didInstantiateAdapter, 'We did not instantiate the adapter again');
+    didInstantiateAdapter = false;
+
+    let jsonApiAdapter = store.adapterFor('-json-api');
+    assert.ok(jsonApiAdapter instanceof JsonApiAdapter, 'We found the correct adapter');
+    assert.ok(!didInstantiateAdapter, 'We did not instantiate the adapter again');
+    assert.ok(
+      jsonApiAdapter === appAdapter,
+      'We fell back to the -json-api adapter instance for application'
+    );
+    assert.ok(
+      jsonApiAdapter === fallbackAdapter,
+      'We fell back to the -json-api adapter instance for the fallback -not-a-real-adapter'
+    );
+    assert.ok(
+      jsonApiAdapter === adapter,
+      'We fell back to the -json-api adapter instance for the per-type adapter'
+    );
+  });
+});

--- a/tests/unit/store/lookup-test.js
+++ b/tests/unit/store/lookup-test.js
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 
 import DS from 'ember-data';
 
-let store, env, applicationAdapter, applicationSerializer, Person;
+let store, env, applicationSerializer, Person;
 
 function resetStore() {
   if (store) {
@@ -23,10 +23,6 @@ function resetStore() {
   env.registry.optionsForType('adapter', { singleton: true });
 
   store = env.store;
-}
-
-function lookupAdapter(adapterName) {
-  return run(store, 'adapterFor', adapterName);
 }
 
 function lookupSerializer(serializerName) {
@@ -48,26 +44,12 @@ module('unit/store/lookup - Managed Instance lookups', {
     env.registry.register('adapter:application', DS.Adapter.extend());
     env.registry.register('adapter:serializer', DS.Adapter.extend());
 
-    applicationAdapter = run(store, 'adapterFor', 'application');
     applicationSerializer = run(store, 'serializerFor', 'application');
   },
 
   afterEach() {
     run(store, 'destroy');
   },
-});
-
-test('when the adapter does not exist for a type, the fallback is returned', assert => {
-  let personAdapter = lookupAdapter('person');
-
-  assert.strictEqual(personAdapter, applicationAdapter);
-});
-
-test('when the adapter for a type exists, returns that instead of the fallback', assert => {
-  registerAdapter('person', DS.Adapter.extend());
-  let personAdapter = lookupAdapter('person');
-
-  assert.ok(personAdapter !== applicationAdapter);
 });
 
 test('when the serializer does not exist for a type, the fallback is returned', assert => {
@@ -82,36 +64,6 @@ test('when the serializer does exist for a type, the serializer is returned', as
   let personSerializer = lookupSerializer('person');
 
   assert.ok(personSerializer !== applicationSerializer);
-});
-
-test('adapter lookup order', assert => {
-  assert.expect(3);
-
-  resetStore();
-
-  let personAdapter = lookupAdapter('person');
-
-  assert.strictEqual(personAdapter, lookupAdapter('-rest'), 'looks up the RESTAdapter first');
-  resetStore();
-
-  registerAdapter('application', DS.RESTSerializer.extend());
-  personAdapter = lookupAdapter('person');
-
-  assert.strictEqual(
-    personAdapter,
-    lookupAdapter('application'),
-    'looks up application adapter before RESTAdapter if it exists'
-  );
-
-  resetStore();
-
-  registerAdapter('application', DS.RESTSerializer.extend());
-  registerAdapter('person', DS.RESTSerializer.extend({ customThingy: true }));
-
-  assert.ok(
-    lookupAdapter('person').get('customThingy'),
-    'looks up type serializer before application'
-  );
 });
 
 test('serializer lookup order', assert => {


### PR DESCRIPTION
Also fixes a bug with `adapterFor` that the expanded test coverage caught.

This was split out from #5708 