### PR TITLE
[BUGFIX 5720] - assert that replacing has-many with non-array throws assertion

### DIFF
--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -10,6 +10,7 @@ import { assert } from '@ember/debug';
 import { PromiseArray } from './promise-proxies';
 import { _objectIsAlive } from './store/common';
 import diffArray from './diff-array';
+import isArrayLike from './is-array-like';
 
 /**
   A `ManyArray` is a `MutableArray` that represents the contents of a has-many
@@ -201,12 +202,12 @@ export default EmberObject.extend(MutableArray, Evented, {
       );
     }
     if (objects) {
+      assert('The third argument to replace needs to be an array.', isArrayLike(objects));
       this.get('recordData').addToHasMany(
         this.get('key'),
         objects.map(obj => obj._internalModel._recordData),
         idx
       );
-      //this.get('relationship').addInternalModels(objects.map(obj => obj._internalModel), idx);
     }
     this.retrieveLatest();
   },

--- a/tests/unit/model/lifecycle-callbacks-test.js
+++ b/tests/unit/model/lifecycle-callbacks-test.js
@@ -296,4 +296,3 @@ test('a record receives a becameInvalid callback when it became invalid', functi
     });
   });
 });
-

--- a/tests/unit/model/relationships/has-many-test.js
+++ b/tests/unit/model/relationships/has-many-test.js
@@ -2152,6 +2152,65 @@ test('possible to replace items in a relationship using setObjects w/ Ember Enum
   assert.equal(tom.get('tags.firstObject'), store.peekRecord('tag', 2));
 });
 
+test('Replacing `has-many` with non-array will throw assertion', function(assert) {
+  assert.expect(1);
+
+  const Tag = DS.Model.extend({
+    name: DS.attr('string'),
+    person: DS.belongsTo('person', { async: false }),
+  });
+
+  const Person = DS.Model.extend({
+    name: DS.attr('string'),
+    tags: DS.hasMany('tag', { async: false }),
+  });
+
+  let env = setupStore({ tag: Tag, person: Person });
+  let { store } = env;
+
+  run(() => {
+    store.push({
+      data: [
+        {
+          type: 'person',
+          id: '1',
+          attributes: {
+            name: 'Tom Dale',
+          },
+          relationships: {
+            tags: {
+              data: [{ type: 'tag', id: '1' }],
+            },
+          },
+        },
+        {
+          type: 'tag',
+          id: '1',
+          attributes: {
+            name: 'ember',
+          },
+        },
+        {
+          type: 'tag',
+          id: '2',
+          attributes: {
+            name: 'ember-data',
+          },
+        },
+      ],
+    });
+  });
+
+  let tom;
+
+  run(() => {
+    tom = store.peekRecord('person', '1');
+    assert.expectAssertion(() => {
+      tom.get('tags').setObjects(store.peekRecord('tag', '2'));
+    }, /The third argument to replace needs to be an array./);
+  });
+});
+
 test('it is possible to remove an item from a relationship', function(assert) {
   assert.expect(2);
 


### PR DESCRIPTION
Fixes: https://github.com/emberjs/data/issues/5720

Assert that `objects` is an array or has array-like methods and return a more meaningful message when that condition is not met.