### PR TITLE
Fixed small Docs and Code mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1982,7 +1982,7 @@ var Post = DS.Model.extend({
 ```
 
 **no longer works**. Instead, you should just watch each attribute like you
-would with any `Ember.Object`:
+would with any `EmberObject`:
 
 ```javascript
 var Post = DS.Model.extend({

--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -51,7 +51,7 @@ import diffArray from './diff-array';
 
   @class ManyArray
   @namespace DS
-  @extends Ember.Object
+  @extends EmberObject
   @uses Ember.MutableArray, Ember.Evented
 */
 export default EmberObject.extend(MutableArray, Evented, {

--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -81,8 +81,7 @@ import { warn } from '@ember/debug';
 
   @class Errors
   @namespace DS
-  @extends Ember.Object
-  @uses Ember.Enumerable
+  @extends Ember.ArrayProxy
   @uses Ember.Evented
  */
 export default ArrayProxy.extend(Evented, {

--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -80,7 +80,7 @@ const retrieveFromCurrentState = computed('currentState', function(key) {
 
   @class Model
   @namespace DS
-  @extends Ember.Object
+  @extends EmberObject
   @uses Ember.Evented
 */
 const Model = EmberObject.extend(Evented, {

--- a/addon/-private/system/promise-proxies.js
+++ b/addon/-private/system/promise-proxies.js
@@ -40,7 +40,7 @@ export const PromiseArray = ArrayProxy.extend(PromiseProxyMixin, {
 });
 
 /**
-  A `PromiseObject` is an object that acts like both an `Ember.Object`
+  A `PromiseObject` is an object that acts like both an `EmberObject`
   and a promise. When the promise is resolved, then the resulting value
   will be set to the `PromiseObject`'s `content` property. This makes
   it easy to create data bindings with the `PromiseObject` that will

--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -57,7 +57,7 @@ import EmberObject from '@ember/object';
 
   @class Adapter
   @namespace DS
-  @extends Ember.Object
+  @extends EmberObject
 */
 
 export default EmberObject.extend({

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -21,7 +21,7 @@ import EmberObject from '@ember/object';
 
   @class Serializer
   @namespace DS
-  @extends Ember.Object
+  @extends EmberObject
 */
 
 export default EmberObject.extend({


### PR DESCRIPTION
As I was working on ember-api-docs I noticed some small missmatches between ED Api-docs and the actual implementation. Also EmberObject should also be referenced without a dot. I did fix these. 

- [ ] Also I notices that there is no Documentation for DS.Reference.
- [ ] There is no Reference of all the uses of AdapterError in `addon/-private/adapters/errors.js`. Should I add them?