### PR TITLE
[DOCS has-many]: clarify load/reload behavior

### DIFF
--- a/addon/-private/system/references/has-many.js
+++ b/addon/-private/system/references/has-many.js
@@ -256,7 +256,8 @@ export default class HasManyReference extends Reference {
   /**
    Loads the relationship if it is not already loaded.  If the
    relationship is already loaded this method does not trigger a new
-   load.
+   load. This causes a request to the specified
+   relationship link or reloads all items currently in the relationship.
 
    Example
 
@@ -318,7 +319,8 @@ export default class HasManyReference extends Reference {
   }
 
   /**
-   Reloads this has-many relationship.
+   Reloads this has-many relationship. This causes a request to the specified
+   relationship link or reloads all items currently in the relationship.
 
    Example
 


### PR DESCRIPTION
I was bit hard by this. I expected that calling either of these methods would re-query the relationship through the adapter. This isn't the case. I further understood what was going on reading the source while implementing my own adapters. This commit hopefully clarifies the behavior. If the relationship has a "link", then `findHasMany` is called to re-query the relationship. Otherwise, all existing records are reload.
