### PR TITLE
[DOC] Add Reference doc and AdapterError uses

### DIFF
--- a/addon/-private/adapters/errors.js
+++ b/addon/-private/adapters/errors.js
@@ -164,6 +164,7 @@ AdapterError.extend = extendFn(AdapterError);
 
   @class InvalidError
   @namespace DS
+  @extends AdapterError
 */
 export const InvalidError = extend(
   AdapterError,
@@ -201,6 +202,7 @@ export const InvalidError = extend(
 
   @class TimeoutError
   @namespace DS
+  @extends AdapterError
 */
 export const TimeoutError = extend(AdapterError, 'The adapter operation timed out');
 
@@ -212,6 +214,7 @@ export const TimeoutError = extend(AdapterError, 'The adapter operation timed ou
 
   @class AbortError
   @namespace DS
+  @extends AdapterError
 */
 export const AbortError = extend(AdapterError, 'The adapter operation was aborted');
 
@@ -247,6 +250,7 @@ export const AbortError = extend(AdapterError, 'The adapter operation was aborte
 
   @class UnauthorizedError
   @namespace DS
+  @extends AdapterError
 */
 export const UnauthorizedError = extend(AdapterError, 'The adapter operation is unauthorized');
 
@@ -259,6 +263,7 @@ export const UnauthorizedError = extend(AdapterError, 'The adapter operation is 
 
   @class ForbiddenError
   @namespace DS
+  @extends AdapterError
 */
 export const ForbiddenError = extend(AdapterError, 'The adapter operation is forbidden');
 
@@ -297,6 +302,7 @@ export const ForbiddenError = extend(AdapterError, 'The adapter operation is for
 
   @class NotFoundError
   @namespace DS
+  @extends AdapterError
 */
 export const NotFoundError = extend(AdapterError, 'The adapter could not find the resource');
 
@@ -309,6 +315,7 @@ export const NotFoundError = extend(AdapterError, 'The adapter could not find th
 
   @class ConflictError
   @namespace DS
+  @extends AdapterError
 */
 export const ConflictError = extend(AdapterError, 'The adapter operation failed due to a conflict');
 
@@ -319,6 +326,7 @@ export const ConflictError = extend(AdapterError, 'The adapter operation failed 
 
   @class ServerError
   @namespace DS
+  @extends AdapterError
 */
 export const ServerError = extend(
   AdapterError,

--- a/addon/-private/system/references/reference.ts
+++ b/addon/-private/system/references/reference.ts
@@ -15,6 +15,13 @@ function isResourceIdentiferWithRelatedLinks(
   return value && value.links && value.links.related;
 }
 
+/**
+  This is the baseClass for the different References
+  like RecordReference/HasManyReference/BelongsToReference
+
+ @class Reference
+ @namespace DS
+ */
 export default abstract class Reference {
   public recordData: InternalModel['_recordData'];
   constructor(


### PR DESCRIPTION
As mentioned in a previous [PR](https://github.com/emberjs/data/pull/5729) this fixes some missing Docs.

Should the Reference Doc somehow be rewritten?
