### PR TITLE
Add *.ts to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -33,3 +33,9 @@ yarn.lock
 **/*.rb
 node-tests/
 lib/version-replace.js
+
+# typescript
+#
+# avoid publishing .d.ts or .ts files
+# until they have become enforced "public" APIs
+*.ts


### PR DESCRIPTION
Don't publish .ts files in order to not make them public api until
we are confident in our typings.
