### PR TITLE
[FEAT errors] eliminate the call to warn for add/remove/clear

### DIFF
--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -3,7 +3,6 @@ import Evented from '@ember/object/evented';
 import ArrayProxy from '@ember/array/proxy';
 import { set, get, computed } from '@ember/object';
 import { makeArray, A } from '@ember/array';
-import { warn } from '@ember/debug';
 
 /**
 @module ember-data
@@ -186,27 +185,42 @@ export default ArrayProxy.extend(Evented, {
   isEmpty: not('length').readOnly(),
 
   /**
-    Adds error messages to a given attribute and sends
-    `becameInvalid` event to the record.
+   Manually adds errors to the record. This will triger the `becameInvalid` event/ lifecycle method on
+    the record and transition the record into an `invalid` state.
 
-    Example:
+   Example
+   ```javascript
+    let errors = get(user, 'errors');
+    
+    // add multiple errors
+    errors.addErrors('password', [
+      'Must be at least 12 characters',
+      'Must contain at least one symbol',
+      'Cannot contain your name'
+    ]);
+    
+    errors.errorsFor('password');
+    // =>
+    // [
+    //   { attribute: 'password', message: 'Must be at least 12 characters' },
+    //   { attribute: 'password', message: 'Must contain at least one symbol' },
+    //   { attribute: 'password', message: 'Cannot contain your name' },
+    // ]
+    
+    // add a single error
+    errors.addErrors('username', 'This field is required');
 
-    ```javascript
-    if (!user.get('username') {
-      user.get('errors').add('username', 'This field is required');
-    }
-    ```
-
-    @method add
-    @param {String} attribute
-    @param {(Array|String)} messages
-    @deprecated
-  */
+    errors.errorsFor('password');
+    // =>
+    // [
+    //   { attribute: 'username', message: 'This field is required' },
+    // ]
+   ```
+  @method addErrors
+  @param {string} attribute - the property name of an attribute or relationship
+  @param {string[]|string} messages - an error message or array of error messages for the attribute
+   */
   add(attribute, messages) {
-    warn(`Interacting with a record errors object will no longer change the record state.`, false, {
-      id: 'ds.errors.add',
-    });
-
     let wasEmpty = get(this, 'isEmpty');
 
     this._add(attribute, messages);
@@ -257,45 +271,32 @@ export default ArrayProxy.extend(Evented, {
   },
 
   /**
-    Removes all error messages from the given attribute and sends
-    `becameValid` event to the record if there no more errors left.
+   Manually removes all errors for a given member from the record.
+     This will transition the record into a `valid` state, and
+    triggers the `becameValid` event and lifecycle method.
 
-    Example:
+   Example:
 
-    ```app/models/user.js
-    import DS from 'ember-data';
-
-    export default DS.Model.extend({
-      email: DS.attr('string'),
-      twoFactorAuth: DS.attr('boolean'),
-      phone: DS.attr('string')
-    });
-    ```
-
-    ```app/routes/user/edit.js
-    import Route from '@ember/routing/route';
-
-    export default Route.extend({
-      actions: {
-        save: function(user) {
-          if (!user.get('twoFactorAuth')) {
-            user.get('errors').remove('phone');
-          }
-          user.save();
-        }
-      }
-    });
-    ```
-
-    @method remove
-    @param {String} attribute
-    @deprecated
-  */
+   ```javascript
+    let errors = get('user', errors);
+    errors.addErrors('phone', ['error-1', 'error-2']);
+    
+    errors.errorsFor('phone');
+    // =>
+    // [
+    //   { attribute: 'phone', message: 'error-1' },
+    //   { attribute: 'phone', message: 'error-2' },
+    // ]
+    
+    errors.remove('phone');
+    
+    errors.errorsFor('phone');
+    // => undefined
+   ```
+   @method removeErrors
+   @param {string} member - the property name of an attribute or relationship
+   */
   remove(attribute) {
-    warn(`Interacting with a record errors object will no longer change the record state.`, false, {
-      id: 'ds.errors.remove',
-    });
-
     if (get(this, 'isEmpty')) {
       return;
     }
@@ -327,32 +328,44 @@ export default ArrayProxy.extend(Evented, {
   },
 
   /**
-    Removes all error messages and sends `becameValid` event
-    to the record.
-
-    Example:
-
-    ```app/routes/user/edit.js
-  import Route from '@ember/routing/route';
-
-    export default Route.extend({
-      actions: {
-        retrySave: function(user) {
-          user.get('errors').clear();
-          user.save();
-        }
-      }
-    });
-    ```
-
-    @method clear
-    @deprecated
-  */
+   Manually clears all errors for the record.
+     This will transition the record into a `valid` state, and
+     will trigger the `becameValid` event and lifecycle method.
+   
+  Example:
+   
+   ```javascript
+   let errors = get('user', errors);
+   errors.addErrors('username', ['error-a']);
+   errors.addErrors('phone', ['error-1', 'error-2']);
+   
+   errors.errorsFor('username');
+   // =>
+   // [
+   //   { attribute: 'username', message: 'error-a' },
+   // ]
+   
+   errors.errorsFor('phone');
+   // =>
+   // [
+   //   { attribute: 'phone', message: 'error-1' },
+   //   { attribute: 'phone', message: 'error-2' },
+   // ]
+   
+   errors.clearErrors();
+   
+   errors.errorsFor('username');
+   // => undefined
+   
+   errors.errorsFor('phone');
+   // => undefined
+   
+   errors.get('messages')
+   // => []
+   ```
+   @method removeErrors
+   */
   clear() {
-    warn(`Interacting with a record errors object will no longer change the record state.`, false, {
-      id: 'ds.errors.clear',
-    });
-
     if (get(this, 'isEmpty')) {
       return;
     }

--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -193,7 +193,7 @@ export default ArrayProxy.extend(Evented, {
     let errors = get(user, 'errors');
     
     // add multiple errors
-    errors.addErrors('password', [
+    errors.add('password', [
       'Must be at least 12 characters',
       'Must contain at least one symbol',
       'Cannot contain your name'
@@ -208,7 +208,7 @@ export default ArrayProxy.extend(Evented, {
     // ]
     
     // add a single error
-    errors.addErrors('username', 'This field is required');
+    errors.add('username', 'This field is required');
 
     errors.errorsFor('password');
     // =>
@@ -216,7 +216,7 @@ export default ArrayProxy.extend(Evented, {
     //   { attribute: 'username', message: 'This field is required' },
     // ]
    ```
-  @method addErrors
+  @method add
   @param {string} attribute - the property name of an attribute or relationship
   @param {string[]|string} messages - an error message or array of error messages for the attribute
    */
@@ -279,7 +279,7 @@ export default ArrayProxy.extend(Evented, {
 
    ```javascript
     let errors = get('user', errors);
-    errors.addErrors('phone', ['error-1', 'error-2']);
+    errors.add('phone', ['error-1', 'error-2']);
     
     errors.errorsFor('phone');
     // =>
@@ -293,7 +293,7 @@ export default ArrayProxy.extend(Evented, {
     errors.errorsFor('phone');
     // => undefined
    ```
-   @method removeErrors
+   @method remove
    @param {string} member - the property name of an attribute or relationship
    */
   remove(attribute) {
@@ -336,8 +336,8 @@ export default ArrayProxy.extend(Evented, {
    
    ```javascript
    let errors = get('user', errors);
-   errors.addErrors('username', ['error-a']);
-   errors.addErrors('phone', ['error-1', 'error-2']);
+   errors.add('username', ['error-a']);
+   errors.add('phone', ['error-1', 'error-2']);
    
    errors.errorsFor('username');
    // =>
@@ -352,7 +352,7 @@ export default ArrayProxy.extend(Evented, {
    //   { attribute: 'phone', message: 'error-2' },
    // ]
    
-   errors.clearErrors();
+   errors.clear();
    
    errors.errorsFor('username');
    // => undefined
@@ -363,7 +363,7 @@ export default ArrayProxy.extend(Evented, {
    errors.get('messages')
    // => []
    ```
-   @method removeErrors
+   @method remove
    */
   clear() {
     if (get(this, 'isEmpty')) {

--- a/tests/integration/records/error-test.js
+++ b/tests/integration/records/error-test.js
@@ -8,12 +8,6 @@ import RSVP from 'rsvp';
 var env, store, Person;
 var attr = DS.attr;
 
-function updateErrors(func, assert) {
-  assert.expectWarning(function() {
-    run(func);
-  }, 'Interacting with a record errors object will no longer change the record state.');
-}
-
 module('integration/records/error', {
   beforeEach: function() {
     Person = DS.Model.extend({
@@ -36,8 +30,6 @@ module('integration/records/error', {
 });
 
 testInDebug('adding errors during root.loaded.created.invalid works', function(assert) {
-  assert.expect(5);
-
   var person = run(() => {
     store.push({
       data: {
@@ -59,11 +51,11 @@ testInDebug('adding errors during root.loaded.created.invalid works', function(a
 
   assert.equal(person._internalModel.currentState.stateName, 'root.loaded.updated.uncommitted');
 
-  updateErrors(() => person.get('errors').add('firstName', 'is invalid'), assert);
+  person.get('errors').add('firstName', 'is invalid');
 
   assert.equal(person._internalModel.currentState.stateName, 'root.loaded.updated.invalid');
 
-  updateErrors(() => person.get('errors').add('lastName', 'is invalid'), assert);
+  person.get('errors').add('lastName', 'is invalid');
 
   assert.deepEqual(person.get('errors').toArray(), [
     { attribute: 'firstName', message: 'is invalid' },
@@ -72,8 +64,6 @@ testInDebug('adding errors during root.loaded.created.invalid works', function(a
 });
 
 testInDebug('adding errors root.loaded.created.invalid works', function(assert) {
-  assert.expect(5);
-
   let person = store.createRecord('person', {
     id: 'wat',
     firstName: 'Yehuda',
@@ -87,11 +77,11 @@ testInDebug('adding errors root.loaded.created.invalid works', function(assert) 
 
   assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.uncommitted');
 
-  updateErrors(() => person.get('errors').add('firstName', 'is invalid'), assert);
+  person.get('errors').add('firstName', 'is invalid');
 
   assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.invalid');
 
-  updateErrors(() => person.get('errors').add('lastName', 'is invalid'), assert);
+  person.get('errors').add('lastName', 'is invalid');
 
   assert.deepEqual(person.get('errors').toArray(), [
     { attribute: 'firstName', message: 'is invalid' },
@@ -100,8 +90,6 @@ testInDebug('adding errors root.loaded.created.invalid works', function(assert) 
 });
 
 testInDebug('adding errors root.loaded.created.invalid works add + remove + add', function(assert) {
-  assert.expect(7);
-
   let person = store.createRecord('person', {
     id: 'wat',
     firstName: 'Yehuda',
@@ -113,15 +101,15 @@ testInDebug('adding errors root.loaded.created.invalid works add + remove + add'
 
   assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.uncommitted');
 
-  updateErrors(() => person.get('errors').add('firstName', 'is invalid'), assert);
+  person.get('errors').add('firstName', 'is invalid');
 
   assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.invalid');
 
-  updateErrors(() => person.get('errors').remove('firstName'), assert);
+  person.get('errors').remove('firstName');
 
   assert.deepEqual(person.get('errors').toArray(), []);
 
-  updateErrors(() => person.get('errors').add('firstName', 'is invalid'), assert);
+  person.get('errors').add('firstName', 'is invalid');
 
   assert.deepEqual(person.get('errors').toArray(), [
     { attribute: 'firstName', message: 'is invalid' },
@@ -131,8 +119,6 @@ testInDebug('adding errors root.loaded.created.invalid works add + remove + add'
 testInDebug('adding errors root.loaded.created.invalid works add + (remove, add)', function(
   assert
 ) {
-  assert.expect(6);
-
   let person = store.createRecord('person', {
     id: 'wat',
     firstName: 'Yehuda',
@@ -144,16 +130,16 @@ testInDebug('adding errors root.loaded.created.invalid works add + (remove, add)
 
   assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.uncommitted');
 
-  updateErrors(() => {
+  {
     person.get('errors').add('firstName', 'is invalid');
-  }, assert);
+  }
 
   assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.invalid');
 
-  updateErrors(() => {
+  {
     person.get('errors').remove('firstName');
     person.get('errors').add('firstName', 'is invalid');
-  }, assert);
+  }
 
   assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.invalid');
 

--- a/tests/unit/model/errors-test.js
+++ b/tests/unit/model/errors-test.js
@@ -12,13 +12,6 @@ module('unit/model/errors', {
   },
 });
 
-function updateErrors(func, assert) {
-  assert.expectWarning(
-    func,
-    'Interacting with a record errors object will no longer change the record state.'
-  );
-}
-
 AssertPrototype.becameInvalid = function becameInvalid(eventName) {
   if (eventName === 'becameInvalid') {
     this.ok(true, 'becameInvalid send');
@@ -40,33 +33,29 @@ AssertPrototype.unexpectedSend = function unexpectedSend(eventName) {
 }.bind(AssertPrototype);
 
 testInDebug('add error', function(assert) {
-  assert.expect(10);
-
   errors.trigger = assert.becameInvalid;
-  updateErrors(() => errors.add('firstName', 'error'), assert);
+  errors.add('firstName', 'error');
   errors.trigger = assert.unexpectedSend;
   assert.ok(errors.has('firstName'), 'it has firstName errors');
   assert.equal(errors.get('length'), 1, 'it has 1 error');
-  updateErrors(() => errors.add('firstName', ['error1', 'error2']), assert);
+  errors.add('firstName', ['error1', 'error2']);
   assert.equal(errors.get('length'), 3, 'it has 3 errors');
   assert.ok(!errors.get('isEmpty'), 'it is not empty');
-  updateErrors(() => errors.add('lastName', 'error'), assert);
-  updateErrors(() => errors.add('lastName', 'error'), assert);
+  errors.add('lastName', 'error');
+  errors.add('lastName', 'error');
   assert.equal(errors.get('length'), 4, 'it has 4 errors');
 });
 
 testInDebug('get error', function(assert) {
-  assert.expect(11);
-
   assert.ok(errors.get('firstObject') === undefined, 'returns undefined');
   errors.trigger = assert.becameInvalid;
-  updateErrors(() => errors.add('firstName', 'error'), assert);
+  errors.add('firstName', 'error');
   errors.trigger = assert.unexpectedSend;
   assert.ok(errors.get('firstName').length === 1, 'returns errors');
   assert.deepEqual(errors.get('firstObject'), { attribute: 'firstName', message: 'error' });
-  updateErrors(() => errors.add('firstName', 'error2'), assert);
+  errors.add('firstName', 'error2');
   assert.ok(errors.get('firstName').length === 2, 'returns errors');
-  updateErrors(() => errors.add('lastName', 'error3'), assert);
+  errors.add('lastName', 'error3');
   assert.deepEqual(errors.toArray(), [
     { attribute: 'firstName', message: 'error' },
     { attribute: 'firstName', message: 'error2' },
@@ -80,44 +69,38 @@ testInDebug('get error', function(assert) {
 });
 
 testInDebug('remove error', function(assert) {
-  assert.expect(8);
-
   errors.trigger = assert.becameInvalid;
-  updateErrors(() => errors.add('firstName', 'error'), assert);
+  errors.add('firstName', 'error');
   errors.trigger = assert.becameValid;
-  updateErrors(() => errors.remove('firstName'), assert);
+  errors.remove('firstName');
   errors.trigger = assert.unexpectedSend;
   assert.ok(!errors.has('firstName'), 'it has no firstName errors');
   assert.equal(errors.get('length'), 0, 'it has 0 error');
   assert.ok(errors.get('isEmpty'), 'it is empty');
-  updateErrors(() => errors.remove('firstName'), assert);
+  errors.remove('firstName');
 });
 
 testInDebug('remove same errors fromm different attributes', function(assert) {
-  assert.expect(9);
-
   errors.trigger = assert.becameInvalid;
-  updateErrors(() => errors.add('firstName', 'error'), assert);
-  updateErrors(() => errors.add('lastName', 'error'), assert);
+  errors.add('firstName', 'error');
+  errors.add('lastName', 'error');
   errors.trigger = assert.unexpectedSend;
   assert.equal(errors.get('length'), 2, 'it has 2 error');
-  updateErrors(() => errors.remove('firstName'), assert);
+  errors.remove('firstName');
   assert.equal(errors.get('length'), 1, 'it has 1 error');
   errors.trigger = assert.becameValid;
-  updateErrors(() => errors.remove('lastName'), assert);
+  errors.remove('lastName');
   assert.ok(errors.get('isEmpty'), 'it is empty');
 });
 
 testInDebug('clear errors', function(assert) {
-  assert.expect(8);
-
   errors.trigger = assert.becameInvalid;
-  updateErrors(() => errors.add('firstName', ['error', 'error1']), assert);
+  errors.add('firstName', ['error', 'error1']);
   assert.equal(errors.get('length'), 2, 'it has 2 errors');
   errors.trigger = assert.becameValid;
-  updateErrors(() => errors.clear(), assert);
+  errors.clear();
   errors.trigger = assert.unexpectedSend;
   assert.ok(!errors.has('firstName'), 'it has no firstName errors');
   assert.equal(errors.get('length'), 0, 'it has 0 error');
-  updateErrors(() => errors.clear(), assert);
+  errors.clear();
 });


### PR DESCRIPTION
Replaces #5705 following discussion on the [RFC](https://github.com/emberjs/rfcs/pull/384) in which we decided to simply eliminate the warning vs proceeding with a deprecation.