### PR TITLE
Implicit null inverse test.

### DIFF
--- a/addon/-debug/index.js
+++ b/addon/-debug/index.js
@@ -34,7 +34,7 @@ if (DEBUG) {
       return modelClass.__mixin.detect(addedModelClass.PrototypeMixin);
     }
 
-    return modelClass.detect(addedModelClass);
+    return addedModelClass.prototype instanceof modelClass || modelClass.detect(addedModelClass);
   };
 
   assertPolymorphicType = function assertPolymorphicType(

--- a/tests/integration/relationships/inverse-relationships-test.js
+++ b/tests/integration/relationships/inverse-relationships-test.js
@@ -688,7 +688,7 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     }
   );
 
-  test('No inverse configuration - should default to a null inverse', function(assert) {
+  test('No inverse configuration - should default to a null inverse', async function(assert) {
     class User extends Model {}
 
     class Comment extends Model {

--- a/tests/integration/relationships/inverse-relationships-test.js
+++ b/tests/integration/relationships/inverse-relationships-test.js
@@ -639,3 +639,20 @@ testInDebug(
     env.store.createRecord('user', {});
   }
 );
+
+test('No inverse configuration - should default to a null inverse', function (assert) {  
+  User = DS.Model.extend();
+  
+  Comment = DS.Model.extend({
+    user: belongsTo('user')
+  });
+
+  const env = setupStore({
+    user: User,
+    comment: Comment
+  });
+
+  const comment = env.store.createRecord('comment');
+
+  assert.equal(comment.inverseFor('user'), null, 'Defaults to a null inverse');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "noImplicitAny": false,
     "noEmitOnError": false,
     "strictNullChecks": true,
+    "experimentalDecorators": true,
     "noEmit": true,
     "skipLibCheck": true,
     "inlineSourceMap": true,


### PR DESCRIPTION
This PR adds a test to verify that a missing `inverse` on a one-sided association results in the same situation as having an `inverse: null`. Closes #5538.

Two questions; in the original issue, it was mentioned this behaviour ought to be deprecated. If so, where in the docs would you like to indicate this? Then I'll make that change, too. Finally, is there any reason `"experimentalDecorators": true` isn't set in `tsconfig.json`? The decorators are causing VSCode to report code everywhere. If this is something you'd like to see, I'd be more than willing to add it.