### PR TITLE
Allow to define readOnly attributes and relationships in models definition

### DIFF
--- a/addon/-private/attr.ts
+++ b/addon/-private/attr.ts
@@ -25,6 +25,7 @@ function hasValue(internalModel, key) {
 
 interface AttrOptions {
   defaultValue?: string | null | (() => any);
+  readOnly?: boolean;
 }
 
 /**
@@ -69,6 +70,19 @@ interface AttrOptions {
         return {};
       }
     })
+  });
+  ```
+
+  - `readOnly`: A boolean value that determines if the attribute should be read only and serialized in a payload.
+
+  Example
+
+  ```app/models/user.js
+  import DS from 'ember-data';
+
+  export default DS.Model.extend({
+    username: DS.attr('string'),
+    isAdmin: DS.attr('string', { readOnly: true }),
   });
   ```
 
@@ -150,6 +164,9 @@ export default function attr(type?: string | AttrOptions, options?: AttrOptions)
           );
         }
       }
+
+      assert(`Cannot set read-only attribute "${key}" on instance of model "${this.constructor.modelName}"`, !(options && options.readOnly))
+
       return this._internalModel.setDirtyAttribute(key, value);
     },
   }).meta(meta);

--- a/addon/-private/system/relationships/belongs-to.js
+++ b/addon/-private/system/relationships/belongs-to.js
@@ -14,6 +14,7 @@ import { DEBUG } from '@glimmer/env';
   - `async`: A boolean value used to explicitly declare this to be an async relationship. The default is true.
   - `inverse`: A string used to identify the inverse property on a
     related model in a One-To-Many relationship. See [Explicit Inverses](#explicit-inverses)
+  - `readOnly`: A boolean value that determines if the relationship should be read only and serialized in a payload.
 
   #### One-To-One
   To declare a one-to-one relationship between two models, use
@@ -176,6 +177,14 @@ export default function belongsTo(modelName, options) {
           );
         }
       }
+
+      assert(
+        `Cannot set read-only relationship "${key}" on instance of model "${
+          this.constructor.modelName
+        }"`,
+        !(options && options.readOnly)
+      );
+
       this._internalModel.setDirtyBelongsTo(key, value);
 
       return this._internalModel.getBelongsTo(key);

--- a/addon/-private/system/relationships/has-many.js
+++ b/addon/-private/system/relationships/has-many.js
@@ -15,6 +15,7 @@ import { DEBUG } from '@glimmer/env';
 
   - `async`: A boolean value used to explicitly declare this to be an async relationship. The default is true.
   - `inverse`: A string used to identify the inverse property on a related model.
+  - `readOnly`: A boolean value that determines if the relationship should be read only and serialized in a payload.
 
   #### One-To-Many
   To declare a one-to-many relationship between two models, use
@@ -194,6 +195,14 @@ export default function hasMany(type, options) {
           );
         }
       }
+
+      assert(
+        `Cannot set read-only relationship "${key}" on instance of model "${
+          this.constructor.modelName
+        }"`,
+        !(options && options.readOnly)
+      );
+
       let internalModel = this._internalModel;
       internalModel.setDirtyHasMany(key, records);
 

--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -477,7 +477,7 @@ const JSONAPISerializer = JSONSerializer.extend({
   serializeAttribute(snapshot, json, key, attribute) {
     let type = attribute.type;
 
-    if (this._canSerialize(key)) {
+    if (this._canSerialize(key, attribute.options)) {
       json.attributes = json.attributes || {};
 
       let value = snapshot.attr(key);
@@ -499,7 +499,7 @@ const JSONAPISerializer = JSONSerializer.extend({
   serializeBelongsTo(snapshot, json, relationship) {
     let key = relationship.key;
 
-    if (this._canSerialize(key)) {
+    if (this._canSerialize(key, relationship.options)) {
       let belongsTo = snapshot.belongsTo(key);
       let belongsToIsNotNew = belongsTo && belongsTo.record && !belongsTo.record.get('isNew');
 

--- a/addon/serializers/json.js
+++ b/addon/serializers/json.js
@@ -827,18 +827,19 @@ const JSONSerializer = Serializer.extend({
   },
 
   /**
-    Check attrs.key.serialize property to inform if the `key`
-    can be serialized
+    Check attrs.key.serialize property and readOnly option
+    to inform if the `key` can be serialized
 
     @method _canSerialize
     @private
     @param {String} key
     @return {boolean} true if the key can be serialized
   */
-  _canSerialize(key) {
+  _canSerialize(key, options = {}) {
     let attrs = get(this, 'attrs');
+    let readOnly = get(options, 'readOnly');
 
-    return !attrs || !attrs[key] || attrs[key].serialize !== false;
+    return !readOnly && (!attrs || !attrs[key] || attrs[key].serialize !== false);
   },
 
   /**
@@ -875,7 +876,7 @@ const JSONSerializer = Serializer.extend({
       return true;
     }
     return (
-      this._canSerialize(key) &&
+      this._canSerialize(key, relationship.options) &&
       (relationshipType === 'manyToNone' || relationshipType === 'manyToMany')
     );
   },
@@ -1116,7 +1117,7 @@ const JSONSerializer = Serializer.extend({
     @param {Object} attribute
   */
   serializeAttribute(snapshot, json, key, attribute) {
-    if (this._canSerialize(key)) {
+    if (this._canSerialize(key, attribute.options)) {
       let type = attribute.type;
       let value = snapshot.attr(key);
       if (type) {
@@ -1166,7 +1167,7 @@ const JSONSerializer = Serializer.extend({
   serializeBelongsTo(snapshot, json, relationship) {
     let key = relationship.key;
 
-    if (this._canSerialize(key)) {
+    if (this._canSerialize(key, relationship.options)) {
       let belongsToId = snapshot.belongsTo(key, { id: true });
 
       // if provided, use the mapping provided by `attrs` in


### PR DESCRIPTION
# The Issue
Many times I encounter bugs when developers forgot to mark the model's attributes/relationships in serializer as `serialize: false` (readOnly) during models creation based and schema definition. They even very often put comments like:
```js
name: attr('string') // readOnly
```
but forgot to disable serialization what caused API errors.

Also, it happened that developers were setting such properties eg in a form while they were excluded from serialization, which caused a question "Why this attribute was not sent to API?" or "Why this attribute changed after save?"

# Solution
I found it much simpler and convenient way to mark attrs/rels as `readOnly` in model than creating a new serializer to just mark one property as `serialize: false` in `attrs` definition. What's more, I disabled setters and raise a proper error for all `readOnly` properties, so the user will know that this property is not meant to be changed.

# Usage
## Before
```js
export default Model.extend({
  title: attr('string'), // readOnly
  author: belongsTo('user'), // readOnly
  comments: hasMany('comment') // readOnly
});

export default Serializer.extend({
  attr: {
    title: { serialize: false }
    author: { serialize: false }
    tasks: { serialize: false }
  }
});
```
**However it still didn't prevent the `set` on property**

## After
```js
export default Model.extend({
  title: attr('string', { readOnly: true })
  author: belongsTo('user', { readOnly: true })
  comments: hasMany('comment', { readOnly: true })
});
```

And in case the user will set the `readOnly` attribute, it will raise the following error:
`Assertion Failed: Cannot set read-only attribute "title" on instance of model "post"`

Related issue: https://github.com/emberjs/data/issues/3803