### PR TITLE
Preserve hasmany order when pushing child

### DIFF
--- a/addon/-private/system/relationships/state/belongs-to.js
+++ b/addon/-private/system/relationships/state/belongs-to.js
@@ -24,10 +24,12 @@ export default class BelongsToRelationship extends Relationship {
   }
 
   setCanonicalRecordData(recordData) {
-    if (recordData) {
-      this.addCanonicalRecordData(recordData);
-    } else if (this.canonicalState) {
-      this.removeCanonicalRecordData(this.canonicalState);
+    if (recordData !== this.canonicalState) {
+      if (recordData) {
+        this.addCanonicalRecordData(recordData);
+      } else if (this.canonicalState) {
+        this.removeCanonicalRecordData(this.canonicalState);
+      }
     }
     this.flushCanonicalLater();
   }
@@ -51,14 +53,16 @@ export default class BelongsToRelationship extends Relationship {
       return;
     }
 
-    if (this.canonicalState) {
-      this.removeCanonicalRecordData(this.canonicalState);
-    }
+    if (this.canonicalState !== recordData) {
+      if (this.canonicalState) {
+        this.removeCanonicalRecordData(this.canonicalState);
+      }
 
-    this.canonicalState = recordData;
-    super.addCanonicalRecordData(recordData);
-    this.setHasAnyRelationshipData(true);
-    this.setRelationshipIsEmpty(false);
+      this.canonicalState = recordData;
+      super.addCanonicalRecordData(recordData);
+      this.setHasAnyRelationshipData(true);
+      this.setRelationshipIsEmpty(false);
+    }
   }
 
   inverseDidDematerialize() {
@@ -107,13 +111,15 @@ export default class BelongsToRelationship extends Relationship {
     // TODO Igor cleanup
     assertPolymorphicType(this.recordData, this.relationshipMeta, recordData, this.store);
 
-    if (this.inverseRecordData) {
-      this.removeRecordData(this.inverseRecordData);
-    }
+    if (this.inverseRecordData !== recordData) {
+      if (this.inverseRecordData) {
+        this.removeRecordData(this.inverseRecordData);
+      }
 
-    this.inverseRecordData = recordData;
-    super.addRecordData(recordData);
-    this.notifyBelongsToChange();
+      this.inverseRecordData = recordData;
+      super.addRecordData(recordData);
+      this.notifyBelongsToChange();
+    }
   }
 
   removeRecordDataFromOwn(recordData) {

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -159,7 +159,7 @@ export default class ManyRelationship extends Relationship {
     const membersLength = members.list.length;
     for (let i = 0, l = recordDatas.length; i < l; i++) {
       let recordData = recordDatas[i];
-      if (membersLength <= i || members.list[i] !== recordData) {
+      if ((i >= membersLength) || (members.list[i] !== recordData)) {
         this.removeCanonicalRecordData(recordData);
         this.addCanonicalRecordData(recordData, i);
       }

--- a/addon/-private/system/relationships/state/has-many.js
+++ b/addon/-private/system/relationships/state/has-many.js
@@ -156,10 +156,13 @@ export default class ManyRelationship extends Relationship {
 
     this.removeCanonicalRecordDatas(recordDatasToRemove);
 
+    const membersLength = members.list.length;
     for (let i = 0, l = recordDatas.length; i < l; i++) {
       let recordData = recordDatas[i];
-      this.removeCanonicalRecordData(recordData);
-      this.addCanonicalRecordData(recordData, i);
+      if (membersLength <= i || members.list[i] !== recordData) {
+        this.removeCanonicalRecordData(recordData);
+        this.addCanonicalRecordData(recordData, i);
+      }
     }
   }
 

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -69,7 +69,7 @@ export default class Relationship {
     this.relationshipMeta = relationshipMeta;
     //This probably breaks for polymorphic relationship in complex scenarios, due to
     //multiple possible modelNames
-    this.inverseKeyForImplicit = this._tempModelName + this.key;
+    this.inverseKeyForImplicit = (this._tempModelName ? this._tempModelName : '') + this.key;
     this.meta = null;
     this.__inverseMeta = undefined;
 
@@ -342,7 +342,7 @@ export default class Relationship {
   addCanonicalRecordData(recordData, idx) {
     heimdall.increment(addCanonicalRecordData);
     if (!this.canonicalMembers.has(recordData)) {
-      this.canonicalMembers.add(recordData);
+      this.canonicalMembers.addWithIndex(recordData, idx);
       this.setupInverseRelationship(recordData);
     }
     this.flushCanonicalLater();

--- a/tests/integration/adapter/client-side-delete-test.js
+++ b/tests/integration/adapter/client-side-delete-test.js
@@ -38,68 +38,70 @@ test('client-side deleted records can be added back from an inverse', async func
     assert.ok(false, 'unreachable');
   };
 
-  let bookstore = this.store.push({
-    data: {
-      id: '1',
-      type: 'bookstore',
-      relationships: {
-        books: {
-          data: [
-            {
-              id: '1',
-              type: 'book',
-            },
-            {
-              id: '2',
-              type: 'book',
-            },
-          ],
-        },
-      },
-    },
-    included: [
-      {
+  return await run(async () => {
+    let bookstore = this.store.push({
+      data: {
         id: '1',
-        type: 'book',
-      },
-      {
-        id: '2',
-        type: 'book',
-      },
-    ],
-  });
-
-  assert.deepEqual(bookstore.get('books').mapBy('id'), ['1', '2'], 'initial hasmany loaded');
-
-  let book2 = this.store.peekRecord('book', '2');
-
-  await book2.destroyRecord({ adapterOptions: { clientSideDelete: true } });
-
-  book2.unloadRecord();
-
-  await settled();
-
-  assert.equal(this.store.hasRecordForId('book', '2'), false, 'book 2 unloaded');
-  assert.deepEqual(bookstore.get('books').mapBy('id'), ['1'], 'one book client-side deleted');
-
-  this.store.push({
-    data: {
-      id: '2',
-      type: 'book',
-      relationships: {
-        bookstore: {
-          data: {
-            id: '1',
-            type: 'bookstore',
+        type: 'bookstore',
+        relationships: {
+          books: {
+            data: [
+              {
+                id: '1',
+                type: 'book',
+              },
+              {
+                id: '2',
+                type: 'book',
+              },
+            ],
           },
         },
       },
-    },
-  });
+      included: [
+        {
+          id: '1',
+          type: 'book',
+        },
+        {
+          id: '2',
+          type: 'book',
+        },
+      ],
+    });
 
-  assert.deepEqual(
-    bookstore.get('books').mapBy('id'),
-    ['1', '2'],
-    'the deleted book (with same id) is pushed back into the store'
-  );
+    assert.deepEqual(bookstore.get('books').mapBy('id'), ['1', '2'], 'initial hasmany loaded');
+
+    let book2 = this.store.peekRecord('book', '2');
+
+    await book2.destroyRecord({ adapterOptions: { clientSideDelete: true } });
+
+    book2.unloadRecord();
+
+    await settled();
+
+    assert.equal(this.store.hasRecordForId('book', '2'), false, 'book 2 unloaded');
+    assert.deepEqual(bookstore.get('books').mapBy('id'), ['1'], 'one book client-side deleted');
+
+    this.store.push({
+      data: {
+        id: '2',
+        type: 'book',
+        relationships: {
+          bookstore: {
+            data: {
+              id: '1',
+              type: 'bookstore',
+            },
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(
+      bookstore.get('books').mapBy('id'),
+      ['1', '2'],
+      'the deleted book (with same id) is pushed back into the store'
+    );
+  });
 });

--- a/tests/integration/application-test.js
+++ b/tests/integration/application-test.js
@@ -131,11 +131,13 @@ module('integration/application - Attaching initializer', function(hooks) {
       },
     });
 
-    this.application = this.TestApplication.create({ autoboot: false });
+    return await run(async () => {
+      this.application = this.TestApplication.create({ autoboot: false });
 
-    await this.application.boot();
+      await this.application.boot();
 
-    assert.ok(ran, 'ember-data initializer was found');
+      assert.ok(ran, 'ember-data initializer was found');
+    });
   });
 
   test('ember-data initializer does not register the store service when it was already registered', async function(assert) {
@@ -151,14 +153,16 @@ module('integration/application - Attaching initializer', function(hooks) {
       },
     });
 
-    this.application = this.TestApplication.create({ autoboot: false });
+    return await run(async () => {
+      this.application = this.TestApplication.create({ autoboot: false });
 
-    await this.application.boot().then(() => (this.owner = this.application.buildInstance()));
+      await this.application.boot().then(() => (this.owner = this.application.buildInstance()));
 
-    let store = this.owner.lookup('service:store');
-    assert.ok(
-      store && store.get('isCustomStore'),
-      'ember-data initializer does not overwrite the previous registered service store'
-    );
+      let store = this.owner.lookup('service:store');
+      assert.ok(
+        store && store.get('isCustomStore'),
+        'ember-data initializer does not overwrite the previous registered service store'
+      );
+    });
   });
 });

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -3977,7 +3977,7 @@ test('A hasMany relationship with a link will trigger the link request even if a
       });
     };
 
-    return run(() => 
+    return run(() => {
       let author1 = env.store.createRecord('user', { id: 2 });
       let author2 = env.store.createRecord('user', { id: 3 });
       let post = env.store.createRecord('post', { id: 1, authors: [author1, author2] });

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -3884,4 +3884,138 @@ test('A hasMany relationship with a link will trigger the link request even if a
         });
     });
   });
+   
+  test('A many-one hasMany should not be reordered when a child is posted with the reverse relationship specified', function (assert) {
+    Post.reopen({
+      comments: DS.hasMany('comment', { async: true }),
+    });
+  
+    Comment.reopen({
+      message: DS.belongsTo('post', { async: true }),
+    });
+  
+    env.adapter.findHasMany = function(store, snapshot, link, relationship) {
+      return resolve({ data: [] });
+    };
+  
+    env.adapter.createRecord = function(store, snapshot, link, relationship) {
+      return resolve({
+        data: {
+          id: 1,
+          type: 'post',
+          relationships: {
+            comments: {
+              links: { related: '/some/link' },
+            },
+          },
+        },
+      });
+    };
+  
+    return run(() => {
+      let post = env.store.createRecord('post', {});
+      let comment1 = env.store.createRecord('comment', { message: post });
+      env.store.createRecord('comment', { message: post });
+      return post
+        .save()
+        .then(() => comment1.save())
+        .then(() => post.get('comments'))
+        .then(comments => {
+          assert.equal(comments.toArray()[0], comment1, 'initially in the correct order');
+        })
+        .then(() => {
+          // push the first comment with no changes
+          return env.store.push({
+            data: [
+              {
+                id: comment1.id,
+                type: 'comment',
+                attributes: {},
+                relationships: {
+                  message: {
+                    data: {
+                      id: 1,
+                      type: 'post',
+                    },
+                  },
+                },
+              },
+            ],
+          });
+        })
+        .then(() => post.get('comments'))
+        .then(comments => {
+          assert.equal(comments.toArray()[0], comment1, 'after post the comments are in the correct order');
+        });
+    });
+  });
+  
+  test('A many-many hasMany should not be reordered when a child is posted with the reverse relationship specified', function(assert) {
+    Post.reopen({
+      authors: DS.hasMany('user', { async: true, inverse: 'posts' }),
+    });
+
+    User.reopen({
+      posts: DS.hasMany('post', { async: true, inverse: 'authors' }),
+    });
+
+    env.adapter.findHasMany = function(store, snapshot, link, relationship) {
+      return resolve({ data: [] });
+    };
+
+    env.adapter.createRecord = function(store, snapshot, link, relationship) {
+      return resolve({
+        data: {
+          id: 1,
+          type: 'post',
+          relationships: {
+            comments: {
+              links: { related: '/some/link' },
+            },
+          },
+        },
+      });
+    };
+
+    return run(() => 
+      let author1 = env.store.createRecord('user', { id: 2 });
+      let author2 = env.store.createRecord('user', { id: 3 });
+      let post = env.store.createRecord('post', { id: 1, authors: [author1, author2] });
+      return post
+        .save()
+        .then(() => post.get('authors'))
+        .then(authors => {
+          assert.equal(authors.toArray()[0], author1, 'initially in the correct order (1)');
+          assert.equal(authors.toArray()[1], author2, 'initially in the correct order (2)');
+        })
+        .then(() => {
+          // push the first author with no changes
+          return env.store.push({
+            data: [
+              {
+                id: author1.id,
+                type: 'user',
+                attributes: {},
+                relationships: {
+                  posts: {
+                    data: [
+                      {
+                        id: post.id,
+                        type: 'post',
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          });
+        })
+        .then(() => post.get('authors'))
+        .then(authors => {
+          assert.equal(authors.toArray()[0], author1, 'after post in the correct order (1)');
+          assert.equal(authors.toArray()[1], author2, 'after post in the correct order (2)');
+        });
+    });
+  });
+    
 });

--- a/tests/integration/relationships/has-many-test.js
+++ b/tests/integration/relationships/has-many-test.js
@@ -3886,7 +3886,7 @@ test('A hasMany relationship with a link will trigger the link request even if a
   });
 });
 
-test('A polymorphic hasMany should not be reordered when a child is posted with the reverse relationship specified', function (assert) {
+test('A polymorphic hasMany should not be reordered when a child is posted with the reverse relationship specified', function(assert) {
   Post.reopen({
     messages: DS.hasMany('message', { async: true, polymorphic: true, inverse: 'post' }),
   });

--- a/tests/unit/model/relationships/has-many-test.js
+++ b/tests/unit/model/relationships/has-many-test.js
@@ -1244,21 +1244,21 @@ test('new items added to a hasMany relationship are not cleared by a delete', fu
           type: 'pet',
           id: '1',
           attributes: {
-            name: 'Shenanigans',
+            name: 'Pet1',
           },
         },
         {
           type: 'pet',
           id: '2',
           attributes: {
-            name: 'Rambunctious',
+            name: 'Pet2',
           },
         },
         {
           type: 'pet',
           id: '3',
           attributes: {
-            name: 'Rebel',
+            name: 'Pet3',
           },
         },
       ],
@@ -1268,11 +1268,11 @@ test('new items added to a hasMany relationship are not cleared by a delete', fu
   const person = store.peekRecord('person', '1');
   const pets = run(() => person.get('pets'));
 
-  const shen = pets.objectAt(0);
-  const rambo = store.peekRecord('pet', '2');
-  const rebel = store.peekRecord('pet', '3');
+  const pet1 = pets.objectAt(0);
+  const pet2 = store.peekRecord('pet', '2');
+  const pet3 = store.peekRecord('pet', '3');
 
-  assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+  assert.equal(get(pet1, 'name'), 'Pet1', 'precond - relationships work');
   assert.deepEqual(
     pets.map(p => get(p, 'id')),
     ['1'],
@@ -1280,7 +1280,7 @@ test('new items added to a hasMany relationship are not cleared by a delete', fu
   );
 
   run(() => {
-    pets.pushObjects([rambo, rebel]);
+    pets.pushObjects([pet2, pet3]);
   });
 
   assert.deepEqual(
@@ -1290,8 +1290,8 @@ test('new items added to a hasMany relationship are not cleared by a delete', fu
   );
 
   run(() => {
-    return shen.destroyRecord({}).then(() => {
-      shen.unloadRecord();
+    return pet1.destroyRecord({}).then(() => {
+      pet1.unloadRecord();
     });
   });
 
@@ -1347,21 +1347,21 @@ todo(
             type: 'pet',
             id: '1',
             attributes: {
-              name: 'Shenanigans',
+              name: 'Pet1',
             },
           },
           {
             type: 'pet',
             id: '2',
             attributes: {
-              name: 'Rambunctious',
+              name: 'Pet2',
             },
           },
           {
             type: 'pet',
             id: '3',
             attributes: {
-              name: 'Rebel',
+              name: 'Pet3',
             },
           },
         ],
@@ -1371,10 +1371,10 @@ todo(
     const person = store.peekRecord('person', '1');
     const pets = run(() => person.get('pets'));
 
-    const shen = pets.objectAt(0);
-    const rebel = store.peekRecord('pet', '3');
+    const pet1 = pets.objectAt(0);
+    const pet3 = store.peekRecord('pet', '3');
 
-    assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+    assert.equal(get(pet1, 'name'), 'Pet1', 'precond - relationships work');
     assert.deepEqual(
       pets.map(p => get(p, 'id')),
       ['1'],
@@ -1382,7 +1382,7 @@ todo(
     );
 
     run(() => {
-      pets.pushObjects([rebel]);
+      pets.pushObjects([pet3]);
     });
 
     assert.deepEqual(
@@ -1465,21 +1465,21 @@ todo(
             type: 'pet',
             id: '1',
             attributes: {
-              name: 'Shenanigans',
+              name: 'Pet1',
             },
           },
           {
             type: 'pet',
             id: '2',
             attributes: {
-              name: 'Rambunctious',
+              name: 'Pet2',
             },
           },
           {
             type: 'pet',
             id: '3',
             attributes: {
-              name: 'Rebel',
+              name: 'Pet3',
             },
           },
         ],
@@ -1489,10 +1489,10 @@ todo(
     const person = store.peekRecord('person', '1');
     const pets = run(() => person.get('pets'));
 
-    const shen = pets.objectAt(0);
-    const rebel = store.peekRecord('pet', '3');
+    const pet1 = pets.objectAt(0);
+    const pet3 = store.peekRecord('pet', '3');
 
-    assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+    assert.equal(get(pet1, 'name'), 'Pet1', 'precond - relationships work');
     assert.deepEqual(
       pets.map(p => get(p, 'id')),
       ['1', '3'],
@@ -1500,7 +1500,7 @@ todo(
     );
 
     run(() => {
-      pets.removeObject(rebel);
+      pets.removeObject(pet3);
     });
 
     assert.deepEqual(
@@ -1581,21 +1581,21 @@ test('new items added to an async hasMany relationship are not cleared by a dele
           type: 'pet',
           id: '1',
           attributes: {
-            name: 'Shenanigans',
+            name: 'Pet1',
           },
         },
         {
           type: 'pet',
           id: '2',
           attributes: {
-            name: 'Rambunctious',
+            name: 'Pet2',
           },
         },
         {
           type: 'pet',
           id: '3',
           attributes: {
-            name: 'Rebel',
+            name: 'Pet3',
           },
         },
       ],
@@ -1607,11 +1607,11 @@ test('new items added to an async hasMany relationship are not cleared by a dele
     const petsProxy = run(() => person.get('pets'));
 
     return petsProxy.then(pets => {
-      const shen = pets.objectAt(0);
-      const rambo = store.peekRecord('pet', '2');
-      const rebel = store.peekRecord('pet', '3');
+      const pet1 = pets.objectAt(0);
+      const pet2 = store.peekRecord('pet', '2');
+      const pet3 = store.peekRecord('pet', '3');
 
-      assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+      assert.equal(get(pet1, 'name'), 'Pet1', 'precond - relationships work');
       assert.deepEqual(
         pets.map(p => get(p, 'id')),
         ['1'],
@@ -1619,7 +1619,7 @@ test('new items added to an async hasMany relationship are not cleared by a dele
       );
       assert.equal(get(petsProxy, 'length'), 1, 'precond - proxy has only one pet to start');
 
-      pets.pushObjects([rambo, rebel]);
+      pets.pushObjects([pet2, pet3]);
 
       assert.deepEqual(
         pets.map(p => get(p, 'id')),
@@ -1628,8 +1628,8 @@ test('new items added to an async hasMany relationship are not cleared by a dele
       );
       assert.equal(get(petsProxy, 'length'), 3, 'precond2 - proxy now reflects three pets');
 
-      return shen.destroyRecord({}).then(() => {
-        shen.unloadRecord();
+      return pet1.destroyRecord({}).then(() => {
+        pet1.unloadRecord();
 
         assert.deepEqual(
           pets.map(p => get(p, 'id')),
@@ -1684,14 +1684,14 @@ test('new items added to a belongsTo relationship are not cleared by a delete', 
           type: 'dog',
           id: '1',
           attributes: {
-            name: 'Shenanigans',
+            name: 'Pet1',
           },
         },
         {
           type: 'dog',
           id: '2',
           attributes: {
-            name: 'Rambunctious',
+            name: 'Pet2',
           },
         },
       ],
@@ -1700,25 +1700,25 @@ test('new items added to a belongsTo relationship are not cleared by a delete', 
 
   const person = store.peekRecord('person', '1');
   let dog = run(() => person.get('dog'));
-  const shen = store.peekRecord('dog', '1');
-  const rambo = store.peekRecord('dog', '2');
+  const pet1 = store.peekRecord('dog', '1');
+  const pet2 = store.peekRecord('dog', '2');
 
-  assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
-  assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
+  assert.ok(dog === pet1, 'precond - the belongsTo points to the correct dog');
+  assert.equal(get(dog, 'name'), 'Pet1', 'precond - relationships work');
 
   run(() => {
-    person.set('dog', rambo);
+    person.set('dog', pet2);
   });
 
   dog = person.get('dog');
-  assert.equal(dog, rambo, 'precond2 - relationship was updated');
+  assert.equal(dog, pet2, 'precond2 - relationship was updated');
 
   return run(() => {
-    return shen.destroyRecord({}).then(() => {
-      shen.unloadRecord();
+    return pet1.destroyRecord({}).then(() => {
+      pet1.unloadRecord();
 
       dog = person.get('dog');
-      assert.equal(dog, rambo, 'The currentState of the belongsTo was preserved after the delete');
+      assert.equal(dog, pet2, 'The currentState of the belongsTo was preserved after the delete');
     });
   });
 });
@@ -1765,14 +1765,14 @@ test('new items added to an async belongsTo relationship are not cleared by a de
           type: 'dog',
           id: '1',
           attributes: {
-            name: 'Shenanigans',
+            name: 'Pet1',
           },
         },
         {
           type: 'dog',
           id: '2',
           attributes: {
-            name: 'Rambunctious',
+            name: 'Pet2',
           },
         },
       ],
@@ -1781,27 +1781,24 @@ test('new items added to an async belongsTo relationship are not cleared by a de
 
   return run(() => {
     const person = store.peekRecord('person', '1');
-    const shen = store.peekRecord('dog', '1');
-    const rambo = store.peekRecord('dog', '2');
+    const pet1 = store.peekRecord('dog', '1');
+    const pet2 = store.peekRecord('dog', '2');
 
     return person.get('dog').then(dog => {
-      assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
-      assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
+      assert.ok(dog === pet1, 'precond - the belongsTo points to the correct dog');
+      assert.equal(get(dog, 'name'), 'Pet1', 'precond - relationships work');
 
-      person.set('dog', rambo);
+      person.set('dog', pet2);
 
       dog = person.get('dog.content');
 
-      assert.ok(dog === rambo, 'precond2 - relationship was updated');
+      assert.ok(dog === pet2, 'precond2 - relationship was updated');
 
-      return shen.destroyRecord({}).then(() => {
-        shen.unloadRecord();
+      return pet1.destroyRecord({}).then(() => {
+        pet1.unloadRecord();
 
         dog = person.get('dog.content');
-        assert.ok(
-          dog === rambo,
-          'The currentState of the belongsTo was preserved after the delete'
-        );
+        assert.ok(dog === pet2, 'The currentState of the belongsTo was preserved after the delete');
       });
     });
   });
@@ -1849,14 +1846,14 @@ test('deleting an item that is the current state of a belongsTo clears currentSt
           type: 'dog',
           id: '1',
           attributes: {
-            name: 'Shenanigans',
+            name: 'Pet1',
           },
         },
         {
           type: 'dog',
           id: '2',
           attributes: {
-            name: 'Rambunctious',
+            name: 'Pet2',
           },
         },
       ],
@@ -1865,22 +1862,22 @@ test('deleting an item that is the current state of a belongsTo clears currentSt
 
   const person = store.peekRecord('person', '1');
   let dog = run(() => person.get('dog'));
-  const shen = store.peekRecord('dog', '1');
-  const rambo = store.peekRecord('dog', '2');
+  const pet1 = store.peekRecord('dog', '1');
+  const pet2 = store.peekRecord('dog', '2');
 
-  assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
-  assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
+  assert.ok(dog === pet1, 'precond - the belongsTo points to the correct dog');
+  assert.equal(get(dog, 'name'), 'Pet1', 'precond - relationships work');
 
   run(() => {
-    person.set('dog', rambo);
+    person.set('dog', pet2);
   });
 
   dog = person.get('dog');
-  assert.equal(dog, rambo, 'precond2 - relationship was updated');
+  assert.equal(dog, pet2, 'precond2 - relationship was updated');
 
   return run(() => {
-    return rambo.destroyRecord({}).then(() => {
-      rambo.unloadRecord();
+    return pet2.destroyRecord({}).then(() => {
+      pet2.unloadRecord();
 
       dog = person.get('dog');
       assert.equal(dog, null, 'The current state of the belongsTo was clearer');
@@ -2019,21 +2016,21 @@ test('[ASSERTS KNOWN LIMITATION STILL EXISTS] returning new hasMany relationship
           type: 'pet',
           id: '1',
           attributes: {
-            name: 'Shenanigans',
+            name: 'Pet1',
           },
         },
         {
           type: 'pet',
           id: '2',
           attributes: {
-            name: 'Rambunctious',
+            name: 'Pet2',
           },
         },
         {
           type: 'pet',
           id: '3',
           attributes: {
-            name: 'Rebel',
+            name: 'Pet3',
           },
         },
       ],
@@ -2043,10 +2040,10 @@ test('[ASSERTS KNOWN LIMITATION STILL EXISTS] returning new hasMany relationship
   const person = store.peekRecord('person', '1');
   const pets = run(() => person.get('pets'));
 
-  const shen = store.peekRecord('pet', '1');
-  const rebel = store.peekRecord('pet', '3');
+  const pet1 = store.peekRecord('pet', '1');
+  const pet3 = store.peekRecord('pet', '3');
 
-  assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+  assert.equal(get(pet1, 'name'), 'Pet1', 'precond - relationships work');
   assert.deepEqual(
     pets.map(p => get(p, 'id')),
     ['1', '2'],
@@ -2054,7 +2051,7 @@ test('[ASSERTS KNOWN LIMITATION STILL EXISTS] returning new hasMany relationship
   );
 
   run(() => {
-    pets.pushObjects([rebel]);
+    pets.pushObjects([pet3]);
   });
 
   assert.deepEqual(
@@ -2064,8 +2061,8 @@ test('[ASSERTS KNOWN LIMITATION STILL EXISTS] returning new hasMany relationship
   );
 
   return run(() => {
-    return shen.destroyRecord({}).then(() => {
-      shen.unloadRecord();
+    return pet1.destroyRecord({}).then(() => {
+      pet1.unloadRecord();
 
       // were ember-data to now preserve local edits during a relationship push, this would be '2'
       assert.deepEqual(


### PR DESCRIPTION
In my app I have a websocket receiving jsonapi updates from the server. I use store.push to put these into ember-data.

If I push a model which is part of an ordered hasMany, it gets bumped to the end of the list.

I can't reproduce this in a test, although I've tried to in this PR. My fix, however, works in the app. It is also a nice optimisation when pushing a hasMany with very few changes. Previously every item was removed and then added again. I skip that if the item in the old and new array matches at this index.