### PR TITLE
[BUGFIX deprecation] stop calling A as constructor - partial fix for #5817

### DIFF
--- a/addon/-private/system/model/errors.js
+++ b/addon/-private/system/model/errors.js
@@ -125,7 +125,7 @@ export default ArrayProxy.extend(Evented, {
     let map = get(this, 'errorsByAttributeName');
 
     if (!map.has(attribute)) {
-      map.set(attribute, new A());
+      map.set(attribute, A());
     }
 
     return map.get(attribute);


### PR DESCRIPTION
Issue  #5817 mentions two cases of deprecation warnings, changing usage of merge is being fixed in #5812, but the second case needs fixing, so here is a quick fix for it 