### PR TITLE
[BUGFIX build] suppress circular dependency warning from rollup

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,12 @@ module.exports = {
     }
   },
 
+  _suppressCircularDependencyWarnings(message, next) {
+    if (message.code !== 'CIRCULAR_DEPENDENCY') {
+      next(message);
+    }
+  },
+
   getOutputDirForVersion() {
     let VersionChecker = require('ember-cli-version-checker');
     let checker = new VersionChecker(this);
@@ -120,6 +126,7 @@ module.exports = {
           'ember-data/adapters/errors',
           '@ember/ordered-set',
         ],
+        onwarn: this._suppressCircularDependencyWarnings,
         // cache: true|false Defaults to true
       },
     });


### PR DESCRIPTION
Fixes #5799 

This PR suppresses those benign-but-annoying circular dependency warnings from rollup. It's a sledgehammer-style fix where a scalpel is probably more appropriate, but I figure it's worth the PR anyway so it's a button press away if y'all decide to go this route. If not, no worries.

No tests (yet?) 'cause I'm frankly not sure how to go about writing a test for this kind of build-time thing.