### PR TITLE
[BUGFIX Canary] Wrap `currentState` in `A()`. Fixes IE11.

### DIFF
--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -12,6 +12,7 @@ import { PromiseArray } from './promise-proxies';
 import { _objectIsAlive } from './store/common';
 import diffArray from './diff-array';
 import recordDataFor from './record-data-for';
+import { A } from '@ember/array';
 
 /**
   A `ManyArray` is a `MutableArray` that represents the contents of a has-many
@@ -132,7 +133,7 @@ export default EmberObject.extend(MutableArray, Evented, {
     @property {ManyRelationship} relationship
     @private
     */
-    this.currentState = [];
+    this.currentState = A();
     this.flushCanonical(this.initialState, false);
   },
 
@@ -183,7 +184,7 @@ export default EmberObject.extend(MutableArray, Evented, {
       // we found a change
       this.arrayContentWillChange(diff.firstChangeIndex, diff.removedCount, diff.addedCount);
       this.set('length', toSet.length);
-      this.currentState = toSet.slice();
+      this.currentState = A(toSet.slice());
       this.arrayContentDidChange(diff.firstChangeIndex, diff.removedCount, diff.addedCount);
       if (isInitialized && diff.addedCount > 0) {
         //notify only on additions


### PR DESCRIPTION
See #5849.

Thanks @rwjblue & @runspired.