### PR TITLE
[BUGFIX beta] Use `filter` instead of `find` due to IE11

### DIFF
--- a/addon/-private/system/many-array.js
+++ b/addon/-private/system/many-array.js
@@ -136,7 +136,8 @@ export default EmberObject.extend(MutableArray, Evented, {
 
   // TODO: if(DEBUG)
   anyUnloaded() {
-    let unloaded = this.currentState.find(im => im._isDematerializing || !im.isLoaded());
+    // Use `filter[0]` as opposed to `find` because of IE11
+    let unloaded = this.currentState.filter(im => im._isDematerializing || !im.isLoaded())[0];
     return !!unloaded;
   },
 


### PR DESCRIPTION
Related to #5849.

cc @rwjblue & @runspired 