### PR TITLE
Update blueprints to use native JS classes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ node-tests/fixtures/
 blueprints/*/mocha-files/
 blueprints/*/qunit-files/
 blueprints/*/files/
+blueprints/*/native-files/

--- a/blueprints/adapter/index.js
+++ b/blueprints/adapter/index.js
@@ -2,8 +2,9 @@ const extendFromApplicationEntity = require('../../lib/utilities/extend-from-app
 const isModuleUnificationProject = require('../../lib/utilities/module-unification')
   .isModuleUnificationProject;
 const path = require('path');
+const useEditionDetector = require('../edition-detector');
 
-module.exports = {
+module.exports = useEditionDetector({
   description: 'Generates an ember-data adapter.',
 
   availableOptions: [{ name: 'base-class', type: String }],
@@ -27,4 +28,4 @@ module.exports = {
   locals(options) {
     return extendFromApplicationEntity('adapter', 'DS.JSONAPIAdapter', options);
   },
-};
+});

--- a/blueprints/adapter/native-files/__root__/__path__/__name__.js
+++ b/blueprints/adapter/native-files/__root__/__path__/__name__.js
@@ -1,0 +1,4 @@
+<%= importStatement %>
+
+export default class <%= classifiedModuleName %>Adapter extends <%= baseClass %> {
+}

--- a/blueprints/edition-detector.js
+++ b/blueprints/edition-detector.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = function(blueprint) {
+  blueprint.filesPath = function() {
+    let rootPath = process.env.EMBER_VERSION === 'OCTANE' ? 'native-files' : 'files';
+    return path.join(this.path, rootPath);
+  };
+
+  return blueprint;
+};

--- a/blueprints/model/files/__root__/__path__/__name__.js
+++ b/blueprints/model/files/__root__/__path__/__name__.js
@@ -2,5 +2,5 @@ import DS from 'ember-data';
 const { <%= importedModules %> } = DS;
 
 export default Model.extend({
-<%= attrs.length ? '  ' + attrs : '' %>
+<%= attrs.length ? attrs : '' %>
 });

--- a/blueprints/model/files/__root__/__path__/__name__.js
+++ b/blueprints/model/files/__root__/__path__/__name__.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
+const { <%= importedModules %> } = DS;
 
-export default DS.Model.extend({
+export default Model.extend({
 <%= attrs.length ? '  ' + attrs : '' %>
 });

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -73,16 +73,24 @@ module.exports = useEditionDetector({
       }
     }
 
-    let attrTransformer, attrSeparator;
-    if (process.env.EMBER_VERSION === 'OCTANE') {
-      attrTransformer = nativeAttr;
-      attrSeparator = ';';
-    } else {
-      attrTransformer = classicAttr;
-      attrSeparator = ',';
+    if (attrs.length) {
+      let isOctane = process.env.EMBER_VERSION === 'OCTANE';
+
+      let attrTransformer, attrSeparator;
+      if (isOctane) {
+        attrTransformer = nativeAttr;
+        attrSeparator = ';';
+      } else {
+        attrTransformer = classicAttr;
+        attrSeparator = ',';
+      }
+
+      attrs = attrs.map(attrTransformer);
+      attrs = '  ' + attrs.join(attrSeparator + EOL + '  ');
+      if (isOctane) {
+        attrs = attrs + attrSeparator;
+      }
     }
-    attrs = attrs.map(attrTransformer);
-    attrs = attrs.join(attrSeparator + EOL + '  ');
 
     let needsDeduplicated = needs.filter(function(need, i) {
       return needs.indexOf(need) === i;

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -4,8 +4,9 @@ const EOL = require('os').EOL;
 const isModuleUnificationProject = require('../../lib/utilities/module-unification')
   .isModuleUnificationProject;
 const path = require('path');
+const useEditionDetector = require('../edition-detector');
 
-module.exports = {
+module.exports = useEditionDetector({
   description: 'Generates an ember-data model.',
 
   anonymousOptions: ['name', 'attr:type'],
@@ -74,7 +75,7 @@ module.exports = {
       needs: needs,
     };
   },
-};
+});
 
 function dsAttr(name, type) {
   switch (type) {

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -34,7 +34,6 @@ module.exports = useEditionDetector({
     let includeHasMany = false;
     let includeBelongsTo = false;
     let includeAttr = false;
-    let importedModules = null;
 
     for (let name in entityOptions) {
       let type = entityOptions[name] || '';
@@ -80,10 +79,10 @@ module.exports = useEditionDetector({
       }
     }
 
-    let isOctane = process.env.EMBER_VERSION === 'OCTANE';
-
     if (attrs.length) {
       let attrTransformer, attrSeparator;
+
+      let isOctane = process.env.EMBER_VERSION === 'OCTANE';
       if (isOctane) {
         attrTransformer = nativeAttr;
         attrSeparator = ';';
@@ -104,19 +103,17 @@ module.exports = useEditionDetector({
     });
     needs = '  needs: [' + needsDeduplicated.join(', ') + ']';
 
-    if (isOctane) {
-      importedModules = ['Model'];
-      if (includeAttr) {
-        importedModules.push('attr');
-      }
-      if (includeBelongsTo) {
-        importedModules.push('belongsTo');
-      }
-      if (includeHasMany) {
-        importedModules.push('hasMany');
-      }
-      importedModules = importedModules.join(', ');
+    let importedModules = ['Model'];
+    if (includeAttr) {
+      importedModules.push('attr');
     }
+    if (includeBelongsTo) {
+      importedModules.push('belongsTo');
+    }
+    if (includeHasMany) {
+      importedModules.push('hasMany');
+    }
+    importedModules = importedModules.join(', ');
 
     return {
       importedModules: importedModules,
@@ -159,15 +156,15 @@ function classicAttr(attr) {
     result;
 
   if (type === 'belongs-to') {
-    result = "DS.belongsTo('" + name + "')";
+    result = "belongsTo('" + name + "')";
   } else if (type === 'has-many') {
-    result = "DS.hasMany('" + name + "')";
+    result = "hasMany('" + name + "')";
   } else if (type === '') {
     //"If you don't specify the type of the attribute, it will be whatever was provided by the server"
     //https://emberjs.com/guides/models/defining-models/
-    result = 'DS.attr()';
+    result = 'attr()';
   } else {
-    result = "DS.attr('" + type + "')";
+    result = "attr('" + type + "')";
   }
   return propertyName + ': ' + result;
 }

--- a/blueprints/model/index.js
+++ b/blueprints/model/index.js
@@ -48,15 +48,26 @@ module.exports = useEditionDetector({
       let attr;
       if (/has-many/.test(dasherizedType)) {
         let camelizedNamePlural = inflection.pluralize(camelizedName);
-        attr = dsAttr(dasherizedForeignModelSingular, dasherizedType);
-        attrs.push(camelizedNamePlural + ': ' + attr);
+        attr = {
+          name: dasherizedForeignModelSingular,
+          type: dasherizedType,
+          propertyName: camelizedNamePlural
+        };
       } else if (/belongs-to/.test(dasherizedType)) {
-        attr = dsAttr(dasherizedForeignModel, dasherizedType);
-        attrs.push(camelizedName + ': ' + attr);
+        attr = {
+          name: dasherizedForeignModel,
+          type: dasherizedType,
+          propertyName: camelizedName
+        };
       } else {
-        attr = dsAttr(dasherizedName, dasherizedType);
-        attrs.push(camelizedName + ': ' + attr);
+        attr = {
+          name: dasherizedName,
+          type: dasherizedType,
+          propertyName: camelizedName
+        };
       }
+
+      attrs.push(attr);
 
       if (/has-many|belongs-to/.test(dasherizedType)) {
         needs.push("'model:" + dasherizedForeignModelSingular + "'");
@@ -67,7 +78,11 @@ module.exports = useEditionDetector({
       return needs.indexOf(need) === i;
     });
 
+    attrs = attrs.map(function(attr) {
+      return attr.propertyName + ': ' + dsAttr(attr.name, attr.type);
+    });
     attrs = attrs.join(',' + EOL + '  ');
+
     needs = '  needs: [' + needsDeduplicated.join(', ') + ']';
 
     return {

--- a/blueprints/model/native-files/__root__/__path__/__name__.js
+++ b/blueprints/model/native-files/__root__/__path__/__name__.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+const { Model } = DS;
+
+export default class <%= classifiedModuleName %>Model extends Model {
+<%= attrs.length ? attrs : '' %>
+}

--- a/blueprints/model/native-files/__root__/__path__/__name__.js
+++ b/blueprints/model/native-files/__root__/__path__/__name__.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-const { Model } = DS;
+const { <%= importedModules %> } = DS;
 
 export default class <%= classifiedModuleName %>Model extends Model {
 <%= attrs.length ? attrs : '' %>

--- a/blueprints/serializer/index.js
+++ b/blueprints/serializer/index.js
@@ -2,8 +2,9 @@ const extendFromApplicationEntity = require('../../lib/utilities/extend-from-app
 const isModuleUnificationProject = require('../../lib/utilities/module-unification')
   .isModuleUnificationProject;
 const path = require('path');
+const useEditionDetector = require('../edition-detector');
 
-module.exports = {
+module.exports = useEditionDetector({
   description: 'Generates an ember-data serializer.',
 
   availableOptions: [{ name: 'base-class', type: String }],
@@ -27,4 +28,4 @@ module.exports = {
   locals(options) {
     return extendFromApplicationEntity('serializer', 'DS.JSONAPISerializer', options);
   },
-};
+});

--- a/blueprints/serializer/native-files/__root__/__path__/__name__.js
+++ b/blueprints/serializer/native-files/__root__/__path__/__name__.js
@@ -1,0 +1,4 @@
+<%= importStatement %>
+
+export default class <%= classifiedModuleName %>Serializer extends <%= baseClass %> {
+}

--- a/blueprints/transform/index.js
+++ b/blueprints/transform/index.js
@@ -1,8 +1,9 @@
 const isModuleUnificationProject = require('../../lib/utilities/module-unification')
   .isModuleUnificationProject;
 const path = require('path');
+const useEditionDetector = require('../edition-detector');
 
-module.exports = {
+module.exports = useEditionDetector({
   description: 'Generates an ember-data value transform.',
 
   fileMapTokens(options) {
@@ -20,4 +21,4 @@ module.exports = {
       };
     }
   },
-};
+});

--- a/blueprints/transform/native-files/__root__/__path__/__name__.js
+++ b/blueprints/transform/native-files/__root__/__path__/__name__.js
@@ -1,0 +1,12 @@
+import DS from 'ember-data';
+const { Transform } = DS;
+
+export default class <%= classifiedModuleName %>Transform extends Transform {
+  deserialize(serialized) {
+    return serialized;
+  }
+
+  serialize(deserialized) {
+    return deserialized;
+  }
+}

--- a/node-tests/blueprints/adapter-test.js
+++ b/node-tests/blueprints/adapter-test.js
@@ -15,6 +15,9 @@ const SilentError = require('silent-error');
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const fixture = require('../helpers/fixture');
 
+const setupTestEnvironment = require('../helpers/setup-test-environment');
+const enableOctane = setupTestEnvironment.enableOctane;
+
 describe('Acceptance: generate and destroy adapter blueprints', function() {
   setupTestHooks(this);
 
@@ -224,6 +227,169 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
           expect(_file('src/data/models/application/adapter.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default DS.JSONAPIAdapter.extend({');
+
+          expect(_file('src/data/models/application/adapter-test.js')).to.equal(
+            fixture('adapter-test/application-default.js')
+          );
+        },
+        { isModuleUnification: true }
+      );
+    });
+
+    it('adapter-test', function() {
+      let args = ['adapter-test', 'foo'];
+
+      return emberGenerateDestroy(
+        args,
+        _file => {
+          expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
+            fixture('adapter-test/rfc232.js')
+          );
+        },
+        { isModuleUnification: true }
+      );
+    });
+
+    describe('adapter-test with ember-cli-qunit@4.1.0', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-qunit', delete: true },
+        ]);
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
+
+      it('adapter-test-test foo', function() {
+        return emberGenerateDestroy(
+          ['adapter-test', 'foo'],
+          _file => {
+            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
+              fixture('adapter-test/foo-default.js')
+            );
+          },
+          { isModuleUnification: true }
+        );
+      });
+    });
+
+    describe('with ember-cli-mocha v0.12+', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-cli-mocha', '0.12.0');
+      });
+
+      it('adapter-test for mocha v0.12+', function() {
+        let args = ['adapter-test', 'foo'];
+
+        return emberGenerateDestroy(
+          args,
+          _file => {
+            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
+              fixture('adapter-test/foo-mocha-0.12.js')
+            );
+          },
+          { isModuleUnification: true }
+        );
+      });
+    });
+
+    describe('with ember-mocha v0.14+', function() {
+      beforeEach(function() {
+        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-mocha', dev: true }]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('adapter-test for mocha v0.14+', function() {
+        let args = ['adapter-test', 'foo'];
+
+        return emberGenerateDestroy(
+          args,
+          _file => {
+            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
+              fixture('adapter-test/mocha-rfc232.js')
+            );
+          },
+          { isModuleUnification: true }
+        );
+      });
+    });
+  });
+
+  describe('octane', function() {
+    enableOctane();
+
+    beforeEach(function() {
+      return emberNew({ isModuleUnification: true });
+    });
+
+    it('adapter', function() {
+      let args = ['adapter', 'foo'];
+
+      return emberGenerateDestroy(
+        args,
+        _file => {
+          expect(_file('src/data/models/foo/adapter.js'))
+            .to.contain("import DS from 'ember-data';")
+            .to.contain('export default class FooAdapter extends DS.JSONAPIAdapter {');
+
+          expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
+            fixture('adapter-test/rfc232.js')
+          );
+        },
+        { isModuleUnification: true }
+      );
+    });
+
+    it('adapter extends application adapter if it exists', function() {
+      let args = ['adapter', 'foo'];
+
+      return emberGenerate(['adapter', 'application'], { isModuleUnification: true }).then(() =>
+        emberGenerateDestroy(
+          args,
+          _file => {
+            expect(_file('src/data/models/foo/adapter.js'))
+              .to.contain("import ApplicationAdapter from '../application/adapter';")
+              .to.contain('export default class FooAdapter extends ApplicationAdapter {');
+
+            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
+              fixture('adapter-test/rfc232.js')
+            );
+          },
+          { isModuleUnification: true }
+        )
+      );
+    });
+
+    it('adapter with --base-class', function() {
+      let args = ['adapter', 'foo', '--base-class=bar'];
+
+      return emberGenerateDestroy(
+        args,
+        _file => {
+          expect(_file('src/data/models/foo/adapter.js'))
+            .to.contain("import BarAdapter from '../bar/adapter';")
+            .to.contain('export default class FooAdapter extends BarAdapter {');
+
+          expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
+            fixture('adapter-test/rfc232.js')
+          );
+        },
+        { isModuleUnification: true }
+      );
+    });
+
+    it('adapter when is named "application"', function() {
+      let args = ['adapter', 'application'];
+
+      return emberGenerateDestroy(
+        args,
+        _file => {
+          expect(_file('src/data/models/application/adapter.js'))
+            .to.contain("import DS from 'ember-data';")
+            .to.contain('export default class ApplicationAdapter extends DS.JSONAPIAdapter {');
 
           expect(_file('src/data/models/application/adapter-test.js')).to.equal(
             fixture('adapter-test/application-default.js')

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -29,7 +29,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/models/foo.js'))
           .to.contain("import DS from 'ember-data';")
-          .to.contain('export default DS.Model.extend(');
+          .to.contain('const { Model } = DS;')
+          .to.contain('export default Model.extend(');
 
         expect(_file('tests/unit/models/foo-test.js')).to.equal(fixture('model-test/rfc232.js'));
       });
@@ -52,15 +53,16 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/models/foo.js'))
           .to.contain("import DS from 'ember-data';")
-          .to.contain('export default DS.Model.extend(')
-          .to.contain('  misc: DS.attr(),')
-          .to.contain("  skills: DS.attr('array'),")
-          .to.contain("  isActive: DS.attr('boolean'),")
-          .to.contain("  birthday: DS.attr('date'),")
-          .to.contain("  someObject: DS.attr('object'),")
-          .to.contain("  age: DS.attr('number'),")
-          .to.contain("  name: DS.attr('string'),")
-          .to.contain("  customAttr: DS.attr('custom-transform')");
+          .to.contain('const { Model, attr } = DS;')
+          .to.contain('export default Model.extend(')
+          .to.contain('  misc: attr(),')
+          .to.contain("  skills: attr('array'),")
+          .to.contain("  isActive: attr('boolean'),")
+          .to.contain("  birthday: attr('date'),")
+          .to.contain("  someObject: attr('object'),")
+          .to.contain("  age: attr('number'),")
+          .to.contain("  name: attr('string'),")
+          .to.contain("  customAttr: attr('custom-transform')");
 
         expect(_file('tests/unit/models/foo-test.js')).to.equal(fixture('model-test/rfc232.js'));
       });
@@ -72,9 +74,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/models/comment.js'))
           .to.contain("import DS from 'ember-data';")
-          .to.contain('export default DS.Model.extend(')
-          .to.contain("  post: DS.belongsTo('post'),")
-          .to.contain("  author: DS.belongsTo('user')");
+          .to.contain('const { Model, belongsTo } = DS;')
+          .to.contain('export default Model.extend(')
+          .to.contain("  post: belongsTo('post'),")
+          .to.contain("  author: belongsTo('user')");
 
         expect(_file('tests/unit/models/comment-test.js')).to.equal(
           fixture('model-test/comment-default.js')
@@ -88,9 +91,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/models/post.js'))
           .to.contain("import DS from 'ember-data';")
-          .to.contain('export default DS.Model.extend(')
-          .to.contain("  comments: DS.hasMany('comment')")
-          .to.contain("  otherComments: DS.hasMany('comment')");
+          .to.contain('const { Model, hasMany } = DS;')
+          .to.contain('export default Model.extend(')
+          .to.contain("  comments: hasMany('comment')")
+          .to.contain("  otherComments: hasMany('comment')");
 
         expect(_file('tests/unit/models/post-test.js')).to.equal(
           fixture('model-test/post-default.js')
@@ -175,7 +179,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         _file => {
           expect(_file('src/data/models/foo/model.js'))
             .to.contain("import DS from 'ember-data';")
-            .to.contain('export default DS.Model.extend(');
+            .to.contain('const { Model } = DS;')
+            .to.contain('export default Model.extend(');
 
           expect(_file('src/data/models/foo/model-test.js')).to.equal(
             fixture('model-test/rfc232.js')
@@ -204,15 +209,16 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         _file => {
           expect(_file('src/data/models/foo/model.js'))
             .to.contain("import DS from 'ember-data';")
-            .to.contain('export default DS.Model.extend(')
-            .to.contain('  misc: DS.attr(),')
-            .to.contain("  skills: DS.attr('array'),")
-            .to.contain("  isActive: DS.attr('boolean'),")
-            .to.contain("  birthday: DS.attr('date'),")
-            .to.contain("  someObject: DS.attr('object'),")
-            .to.contain("  age: DS.attr('number'),")
-            .to.contain("  name: DS.attr('string'),")
-            .to.contain("  customAttr: DS.attr('custom-transform')");
+            .to.contain('const { Model, attr } = DS;')
+            .to.contain('export default Model.extend(')
+            .to.contain('  misc: attr(),')
+            .to.contain("  skills: attr('array'),")
+            .to.contain("  isActive: attr('boolean'),")
+            .to.contain("  birthday: attr('date'),")
+            .to.contain("  someObject: attr('object'),")
+            .to.contain("  age: attr('number'),")
+            .to.contain("  name: attr('string'),")
+            .to.contain("  customAttr: attr('custom-transform')");
 
           expect(_file('src/data/models/foo/model-test.js')).to.equal(
             fixture('model-test/rfc232.js')
@@ -230,9 +236,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         _file => {
           expect(_file('src/data/models/comment/model.js'))
             .to.contain("import DS from 'ember-data';")
-            .to.contain('export default DS.Model.extend(')
-            .to.contain("  post: DS.belongsTo('post'),")
-            .to.contain("  author: DS.belongsTo('user')");
+            .to.contain('const { Model, belongsTo } = DS;')
+            .to.contain('export default Model.extend(')
+            .to.contain("  post: belongsTo('post'),")
+            .to.contain("  author: belongsTo('user')");
 
           expect(_file('src/data/models/comment/model-test.js')).to.equal(
             fixture('model-test/comment-default.js')
@@ -250,9 +257,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         _file => {
           expect(_file('src/data/models/post/model.js'))
             .to.contain("import DS from 'ember-data';")
-            .to.contain('export default DS.Model.extend(')
-            .to.contain("  comments: DS.hasMany('comment'),")
-            .to.contain("  otherComments: DS.hasMany('comment')");
+            .to.contain('const { Model, hasMany } = DS;')
+            .to.contain('export default Model.extend(')
+            .to.contain("  comments: hasMany('comment'),")
+            .to.contain("  otherComments: hasMany('comment')");
 
           expect(_file('src/data/models/post/model-test.js')).to.equal(
             fixture('model-test/post-default.js')

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -387,15 +387,16 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         _file => {
           expect(_file('src/data/models/foo/model.js'))
             .to.contain("import DS from 'ember-data';")
+            .to.contain('const { Model, attr } = DS;')
             .to.contain('export default class FooModel extends Model {')
-            .to.contain('  @DS.attr misc;')
-            .to.contain("  @DS.attr('array') skills;")
-            .to.contain("  @DS.attr('boolean') isActive;")
-            .to.contain("  @DS.attr('date') birthday;")
-            .to.contain("  @DS.attr('object') someObject;")
-            .to.contain("  @DS.attr('number') age;")
-            .to.contain("  @DS.attr('string') name;")
-            .to.contain("  @DS.attr('custom-transform') customAttr;");
+            .to.contain('  @attr misc;')
+            .to.contain("  @attr('array') skills;")
+            .to.contain("  @attr('boolean') isActive;")
+            .to.contain("  @attr('date') birthday;")
+            .to.contain("  @attr('object') someObject;")
+            .to.contain("  @attr('number') age;")
+            .to.contain("  @attr('string') name;")
+            .to.contain("  @attr('custom-transform') customAttr;");
 
           expect(_file('src/data/models/foo/model-test.js')).to.equal(
             fixture('model-test/rfc232.js')
@@ -413,9 +414,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         _file => {
           expect(_file('src/data/models/comment/model.js'))
             .to.contain("import DS from 'ember-data';")
+            .to.contain('const { Model, belongsTo } = DS;')
             .to.contain('export default class CommentModel extends Model {')
-            .to.contain('  @DS.belongsTo post;')
-            .to.contain("  @DS.belongsTo('user') author;");
+            .to.contain('  @belongsTo post;')
+            .to.contain("  @belongsTo('user') author;");
 
           expect(_file('src/data/models/comment/model-test.js')).to.equal(
             fixture('model-test/comment-default.js')
@@ -433,9 +435,10 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         _file => {
           expect(_file('src/data/models/post/model.js'))
             .to.contain("import DS from 'ember-data';")
+            .to.contain('const { Model, hasMany } = DS;')
             .to.contain('export default class PostModel extends Model {')
-            .to.contain('  @DS.hasMany comments;')
-            .to.contain("  @DS.hasMany('comment') otherComments;");
+            .to.contain('  @hasMany comments;')
+            .to.contain("  @hasMany('comment') otherComments;");
 
           expect(_file('src/data/models/post/model-test.js')).to.equal(
             fixture('model-test/post-default.js')

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -388,14 +388,14 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/foo/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default class FooModel extends Model {')
-            .to.contain('misc: DS.attr()')
-            .to.contain("skills: DS.attr('array')")
-            .to.contain("isActive: DS.attr('boolean')")
-            .to.contain("birthday: DS.attr('date')")
-            .to.contain("someObject: DS.attr('object')")
-            .to.contain("age: DS.attr('number')")
-            .to.contain("name: DS.attr('string')")
-            .to.contain("customAttr: DS.attr('custom-transform')");
+            .to.contain('@DS.attr misc')
+            .to.contain("@DS.attr('array') skills")
+            .to.contain("@DS.attr('boolean') isActive")
+            .to.contain("@DS.attr('date') birthday")
+            .to.contain("@DS.attr('object') someObject")
+            .to.contain("@DS.attr('number') age")
+            .to.contain("@DS.attr('string') name")
+            .to.contain("@DS.attr('custom-transform') customAttr");
 
           expect(_file('src/data/models/foo/model-test.js')).to.equal(
             fixture('model-test/rfc232.js')
@@ -414,8 +414,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/comment/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default class CommentModel extends Model {')
-            .to.contain("post: DS.belongsTo('post')")
-            .to.contain("author: DS.belongsTo('user')");
+            .to.contain('@DS.belongsTo post')
+            .to.contain("@DS.belongsTo('user') author");
 
           expect(_file('src/data/models/comment/model-test.js')).to.equal(
             fixture('model-test/comment-default.js')
@@ -434,8 +434,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/post/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default class PostModel extends Model {')
-            .to.contain("comments: DS.hasMany('comment')")
-            .to.contain("otherComments: DS.hasMany('comment')");
+            .to.contain('@DS.hasMany comments')
+            .to.contain("@DS.hasMany('comment') otherComments");
 
           expect(_file('src/data/models/post/model-test.js')).to.equal(
             fixture('model-test/post-default.js')

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -53,14 +53,14 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         expect(_file('app/models/foo.js'))
           .to.contain("import DS from 'ember-data';")
           .to.contain('export default DS.Model.extend(')
-          .to.contain('misc: DS.attr()')
-          .to.contain("skills: DS.attr('array')")
-          .to.contain("isActive: DS.attr('boolean')")
-          .to.contain("birthday: DS.attr('date')")
-          .to.contain("someObject: DS.attr('object')")
-          .to.contain("age: DS.attr('number')")
-          .to.contain("name: DS.attr('string')")
-          .to.contain("customAttr: DS.attr('custom-transform')");
+          .to.contain('  misc: DS.attr(),')
+          .to.contain("  skills: DS.attr('array'),")
+          .to.contain("  isActive: DS.attr('boolean'),")
+          .to.contain("  birthday: DS.attr('date'),")
+          .to.contain("  someObject: DS.attr('object'),")
+          .to.contain("  age: DS.attr('number'),")
+          .to.contain("  name: DS.attr('string'),")
+          .to.contain("  customAttr: DS.attr('custom-transform')");
 
         expect(_file('tests/unit/models/foo-test.js')).to.equal(fixture('model-test/rfc232.js'));
       });
@@ -73,8 +73,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         expect(_file('app/models/comment.js'))
           .to.contain("import DS from 'ember-data';")
           .to.contain('export default DS.Model.extend(')
-          .to.contain("post: DS.belongsTo('post')")
-          .to.contain("author: DS.belongsTo('user')");
+          .to.contain("  post: DS.belongsTo('post'),")
+          .to.contain("  author: DS.belongsTo('user')");
 
         expect(_file('tests/unit/models/comment-test.js')).to.equal(
           fixture('model-test/comment-default.js')
@@ -89,8 +89,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         expect(_file('app/models/post.js'))
           .to.contain("import DS from 'ember-data';")
           .to.contain('export default DS.Model.extend(')
-          .to.contain("comments: DS.hasMany('comment')")
-          .to.contain("otherComments: DS.hasMany('comment')");
+          .to.contain("  comments: DS.hasMany('comment')")
+          .to.contain("  otherComments: DS.hasMany('comment')");
 
         expect(_file('tests/unit/models/post-test.js')).to.equal(
           fixture('model-test/post-default.js')
@@ -205,14 +205,14 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/foo/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default DS.Model.extend(')
-            .to.contain('misc: DS.attr()')
-            .to.contain("skills: DS.attr('array')")
-            .to.contain("isActive: DS.attr('boolean')")
-            .to.contain("birthday: DS.attr('date')")
-            .to.contain("someObject: DS.attr('object')")
-            .to.contain("age: DS.attr('number')")
-            .to.contain("name: DS.attr('string')")
-            .to.contain("customAttr: DS.attr('custom-transform')");
+            .to.contain('  misc: DS.attr(),')
+            .to.contain("  skills: DS.attr('array'),")
+            .to.contain("  isActive: DS.attr('boolean'),")
+            .to.contain("  birthday: DS.attr('date'),")
+            .to.contain("  someObject: DS.attr('object'),")
+            .to.contain("  age: DS.attr('number'),")
+            .to.contain("  name: DS.attr('string'),")
+            .to.contain("  customAttr: DS.attr('custom-transform')");
 
           expect(_file('src/data/models/foo/model-test.js')).to.equal(
             fixture('model-test/rfc232.js')
@@ -231,8 +231,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/comment/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default DS.Model.extend(')
-            .to.contain("post: DS.belongsTo('post')")
-            .to.contain("author: DS.belongsTo('user')");
+            .to.contain("  post: DS.belongsTo('post'),")
+            .to.contain("  author: DS.belongsTo('user')");
 
           expect(_file('src/data/models/comment/model-test.js')).to.equal(
             fixture('model-test/comment-default.js')
@@ -251,8 +251,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/post/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default DS.Model.extend(')
-            .to.contain("comments: DS.hasMany('comment')")
-            .to.contain("otherComments: DS.hasMany('comment')");
+            .to.contain("  comments: DS.hasMany('comment'),")
+            .to.contain("  otherComments: DS.hasMany('comment')");
 
           expect(_file('src/data/models/post/model-test.js')).to.equal(
             fixture('model-test/post-default.js')
@@ -388,14 +388,14 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/foo/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default class FooModel extends Model {')
-            .to.contain('@DS.attr misc;')
-            .to.contain("@DS.attr('array') skills;")
-            .to.contain("@DS.attr('boolean') isActive;")
-            .to.contain("@DS.attr('date') birthday;")
-            .to.contain("@DS.attr('object') someObject;")
-            .to.contain("@DS.attr('number') age;")
-            .to.contain("@DS.attr('string') name;")
-            .to.contain("@DS.attr('custom-transform') customAttr;");
+            .to.contain('  @DS.attr misc;')
+            .to.contain("  @DS.attr('array') skills;")
+            .to.contain("  @DS.attr('boolean') isActive;")
+            .to.contain("  @DS.attr('date') birthday;")
+            .to.contain("  @DS.attr('object') someObject;")
+            .to.contain("  @DS.attr('number') age;")
+            .to.contain("  @DS.attr('string') name;")
+            .to.contain("  @DS.attr('custom-transform') customAttr;");
 
           expect(_file('src/data/models/foo/model-test.js')).to.equal(
             fixture('model-test/rfc232.js')
@@ -414,8 +414,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/comment/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default class CommentModel extends Model {')
-            .to.contain('@DS.belongsTo post;')
-            .to.contain("@DS.belongsTo('user') author;");
+            .to.contain('  @DS.belongsTo post;')
+            .to.contain("  @DS.belongsTo('user') author;");
 
           expect(_file('src/data/models/comment/model-test.js')).to.equal(
             fixture('model-test/comment-default.js')
@@ -434,8 +434,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/post/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default class PostModel extends Model {')
-            .to.contain('@DS.hasMany comments;')
-            .to.contain("@DS.hasMany('comment') otherComments;");
+            .to.contain('  @DS.hasMany comments;')
+            .to.contain("  @DS.hasMany('comment') otherComments;");
 
           expect(_file('src/data/models/post/model-test.js')).to.equal(
             fixture('model-test/post-default.js')

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -388,14 +388,14 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/foo/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default class FooModel extends Model {')
-            .to.contain('@DS.attr misc')
-            .to.contain("@DS.attr('array') skills")
-            .to.contain("@DS.attr('boolean') isActive")
-            .to.contain("@DS.attr('date') birthday")
-            .to.contain("@DS.attr('object') someObject")
-            .to.contain("@DS.attr('number') age")
-            .to.contain("@DS.attr('string') name")
-            .to.contain("@DS.attr('custom-transform') customAttr");
+            .to.contain('@DS.attr misc;')
+            .to.contain("@DS.attr('array') skills;")
+            .to.contain("@DS.attr('boolean') isActive;")
+            .to.contain("@DS.attr('date') birthday;")
+            .to.contain("@DS.attr('object') someObject;")
+            .to.contain("@DS.attr('number') age;")
+            .to.contain("@DS.attr('string') name;")
+            .to.contain("@DS.attr('custom-transform') customAttr;");
 
           expect(_file('src/data/models/foo/model-test.js')).to.equal(
             fixture('model-test/rfc232.js')
@@ -414,8 +414,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/comment/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default class CommentModel extends Model {')
-            .to.contain('@DS.belongsTo post')
-            .to.contain("@DS.belongsTo('user') author");
+            .to.contain('@DS.belongsTo post;')
+            .to.contain("@DS.belongsTo('user') author;");
 
           expect(_file('src/data/models/comment/model-test.js')).to.equal(
             fixture('model-test/comment-default.js')
@@ -434,8 +434,8 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/post/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default class PostModel extends Model {')
-            .to.contain('@DS.hasMany comments')
-            .to.contain("@DS.hasMany('comment') otherComments");
+            .to.contain('@DS.hasMany comments;')
+            .to.contain("@DS.hasMany('comment') otherComments;");
 
           expect(_file('src/data/models/post/model-test.js')).to.equal(
             fixture('model-test/post-default.js')

--- a/node-tests/blueprints/model-test.js
+++ b/node-tests/blueprints/model-test.js
@@ -12,6 +12,9 @@ const expect = chai.expect;
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const fixture = require('../helpers/fixture');
 
+const setupTestEnvironment = require('../helpers/setup-test-environment');
+const enableOctane = setupTestEnvironment.enableOctane;
+
 describe('Acceptance: generate and destroy model blueprints', function() {
   setupTestHooks(this);
 
@@ -248,6 +251,189 @@ describe('Acceptance: generate and destroy model blueprints', function() {
           expect(_file('src/data/models/post/model.js'))
             .to.contain("import DS from 'ember-data';")
             .to.contain('export default DS.Model.extend(')
+            .to.contain("comments: DS.hasMany('comment')")
+            .to.contain("otherComments: DS.hasMany('comment')");
+
+          expect(_file('src/data/models/post/model-test.js')).to.equal(
+            fixture('model-test/post-default.js')
+          );
+        },
+        { isModuleUnification: true }
+      );
+    });
+
+    it('model-test', function() {
+      let args = ['model-test', 'foo'];
+
+      return emberGenerateDestroy(
+        args,
+        _file => {
+          expect(_file('src/data/models/foo/model-test.js')).to.equal(
+            fixture('model-test/rfc232.js')
+          );
+        },
+        { isModuleUnification: true }
+      );
+    });
+
+    describe('model-test with ember-cli-qunit@4.1.0', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-qunit', delete: true },
+        ]);
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
+
+      it('model-test-test foo', function() {
+        return emberGenerateDestroy(
+          ['model-test', 'foo'],
+          _file => {
+            expect(_file('src/data/models/foo/model-test.js')).to.equal(
+              fixture('model-test/foo-default.js')
+            );
+          },
+          { isModuleUnification: true }
+        );
+      });
+    });
+
+    describe('with ember-cli-mocha v0.12+', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-cli-mocha', '0.12.0');
+      });
+
+      it('model-test for mocha v0.12+', function() {
+        let args = ['model-test', 'foo'];
+
+        return emberGenerateDestroy(
+          args,
+          _file => {
+            expect(_file('src/data/models/foo/model-test.js')).to.equal(
+              fixture('model-test/foo-mocha-0.12.js')
+            );
+          },
+          { isModuleUnification: true }
+        );
+      });
+    });
+
+    describe('with ember-mocha v0.14+', function() {
+      beforeEach(function() {
+        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-mocha', dev: true }]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('model-test for mocha v0.14+', function() {
+        let args = ['model-test', 'foo'];
+
+        return emberGenerateDestroy(
+          args,
+          _file => {
+            expect(_file('src/data/models/foo/model-test.js')).to.equal(
+              fixture('model-test/mocha-rfc232.js')
+            );
+          },
+          { isModuleUnification: true }
+        );
+      });
+    });
+  });
+
+  describe('octane', function() {
+    enableOctane();
+    beforeEach(function() {
+      return emberNew({ isModuleUnification: true });
+    });
+
+    it('model', function() {
+      let args = ['model', 'foo'];
+
+      return emberGenerateDestroy(
+        args,
+        _file => {
+          expect(_file('src/data/models/foo/model.js'))
+            .to.contain("import DS from 'ember-data';")
+            .to.contain('export default class FooModel extends Model {');
+
+          expect(_file('src/data/models/foo/model-test.js')).to.equal(
+            fixture('model-test/rfc232.js')
+          );
+        },
+        { isModuleUnification: true }
+      );
+    });
+
+    it('model with attrs', function() {
+      let args = [
+        'model',
+        'foo',
+        'misc',
+        'skills:array',
+        'isActive:boolean',
+        'birthday:date',
+        'someObject:object',
+        'age:number',
+        'name:string',
+        'customAttr:custom-transform',
+      ];
+
+      return emberGenerateDestroy(
+        args,
+        _file => {
+          expect(_file('src/data/models/foo/model.js'))
+            .to.contain("import DS from 'ember-data';")
+            .to.contain('export default class FooModel extends Model {')
+            .to.contain('misc: DS.attr()')
+            .to.contain("skills: DS.attr('array')")
+            .to.contain("isActive: DS.attr('boolean')")
+            .to.contain("birthday: DS.attr('date')")
+            .to.contain("someObject: DS.attr('object')")
+            .to.contain("age: DS.attr('number')")
+            .to.contain("name: DS.attr('string')")
+            .to.contain("customAttr: DS.attr('custom-transform')");
+
+          expect(_file('src/data/models/foo/model-test.js')).to.equal(
+            fixture('model-test/rfc232.js')
+          );
+        },
+        { isModuleUnification: true }
+      );
+    });
+
+    it('model with belongsTo', function() {
+      let args = ['model', 'comment', 'post:belongs-to', 'author:belongs-to:user'];
+
+      return emberGenerateDestroy(
+        args,
+        _file => {
+          expect(_file('src/data/models/comment/model.js'))
+            .to.contain("import DS from 'ember-data';")
+            .to.contain('export default class CommentModel extends Model {')
+            .to.contain("post: DS.belongsTo('post')")
+            .to.contain("author: DS.belongsTo('user')");
+
+          expect(_file('src/data/models/comment/model-test.js')).to.equal(
+            fixture('model-test/comment-default.js')
+          );
+        },
+        { isModuleUnification: true }
+      );
+    });
+
+    it('model with hasMany', function() {
+      let args = ['model', 'post', 'comments:has-many', 'otherComments:has-many:comment'];
+
+      return emberGenerateDestroy(
+        args,
+        _file => {
+          expect(_file('src/data/models/post/model.js'))
+            .to.contain("import DS from 'ember-data';")
+            .to.contain('export default class PostModel extends Model {')
             .to.contain("comments: DS.hasMany('comment')")
             .to.contain("otherComments: DS.hasMany('comment')");
 

--- a/node-tests/blueprints/transform-test.js
+++ b/node-tests/blueprints/transform-test.js
@@ -12,6 +12,9 @@ const expect = chai.expect;
 const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
 const fixture = require('../helpers/fixture');
 
+const setupTestEnvironment = require('../helpers/setup-test-environment');
+const enableOctane = setupTestEnvironment.enableOctane;
+
 describe('Acceptance: generate and destroy transform blueprints', function() {
   setupTestHooks(this);
 
@@ -122,6 +125,120 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
             expect(_file('src/data/transforms/foo.js'))
               .to.contain("import DS from 'ember-data';")
               .to.contain('export default DS.Transform.extend(')
+              .to.contain('deserialize(serialized) {')
+              .to.contain('serialize(deserialized) {');
+
+            expect(_file('src/data/transforms/foo-test.js')).to.equal(
+              fixture('transform-test/rfc232.js')
+            );
+          },
+          { isModuleUnification: true }
+        );
+      });
+
+      it('transform-test', function() {
+        let args = ['transform-test', 'foo'];
+
+        return emberGenerateDestroy(
+          args,
+          _file => {
+            expect(_file('src/data/transforms/foo-test.js')).to.equal(
+              fixture('transform-test/rfc232.js')
+            );
+          },
+          { isModuleUnification: true }
+        );
+      });
+
+      describe('transform-test with ember-cli-qunit@4.1.0', function() {
+        beforeEach(function() {
+          modifyPackages([
+            { name: 'ember-qunit', delete: true },
+            { name: 'ember-cli-qunit', delete: true },
+          ]);
+          generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+        });
+
+        it('transform-test-test foo', function() {
+          return emberGenerateDestroy(
+            ['transform-test', 'foo'],
+            _file => {
+              expect(_file('src/data/transforms/foo-test.js')).to.equal(
+                fixture('transform-test/default.js')
+              );
+            },
+            { isModuleUnification: true }
+          );
+        });
+      });
+
+      describe('with ember-cli-mocha v0.12+', function() {
+        beforeEach(function() {
+          modifyPackages([
+            { name: 'ember-qunit', delete: true },
+            { name: 'ember-cli-mocha', dev: true },
+          ]);
+          generateFakePackageManifest('ember-cli-mocha', '0.12.0');
+        });
+
+        it('transform-test for mocha v0.12+', function() {
+          let args = ['transform-test', 'foo'];
+
+          return emberGenerateDestroy(
+            args,
+            _file => {
+              expect(_file('src/data/transforms/foo-test.js')).to.equal(
+                fixture('transform-test/mocha-0.12.js')
+              );
+            },
+            { isModuleUnification: true }
+          );
+        });
+      });
+
+      describe('with ember-mocha v0.14+', function() {
+        beforeEach(function() {
+          modifyPackages([
+            { name: 'ember-qunit', delete: true },
+            { name: 'ember-mocha', dev: true },
+          ]);
+          generateFakePackageManifest('ember-mocha', '0.14.0');
+        });
+
+        it('transform-test for mocha v0.14+', function() {
+          let args = ['transform-test', 'foo'];
+
+          return emberGenerateDestroy(
+            args,
+            _file => {
+              expect(_file('src/data/transforms/foo-test.js')).to.equal(
+                fixture('transform-test/mocha-rfc232.js')
+              );
+            },
+            { isModuleUnification: true }
+          );
+        });
+      });
+    });
+  });
+
+  describe('octane', function() {
+    describe('in app', function() {
+      enableOctane();
+
+      beforeEach(function() {
+        return emberNew({ isModuleUnification: true });
+      });
+
+      it('transform', function() {
+        let args = ['transform', 'foo'];
+
+        return emberGenerateDestroy(
+          args,
+          _file => {
+            expect(_file('src/data/transforms/foo.js'))
+              .to.contain("import DS from 'ember-data';")
+              .to.contain('export default class FooTransform extends Transform {')
               .to.contain('deserialize(serialized) {')
               .to.contain('serialize(deserialized) {');
 

--- a/node-tests/helpers/setup-test-environment.js
+++ b/node-tests/helpers/setup-test-environment.js
@@ -1,0 +1,15 @@
+function enableOctane() {
+  beforeEach(function() {
+    process.env.EMBER_CLI_MODULE_UNIFICATION = true;
+    process.env.EMBER_VERSION = 'OCTANE';
+  });
+
+  afterEach(function() {
+    delete process.env.EMBER_CLI_MODULE_UNIFICATION;
+    delete process.env.EMBER_VERSION;
+  });
+}
+
+module.exports = {
+  enableOctane,
+};


### PR DESCRIPTION
Part of the Octane Tracking issue. 

Atm, the blueprints will only generate Native Classes if the env `EMBER_VERSION` is equal to `OCTANE`; the [octane-blueprints](https://github.com/ember-cli/ember-octane-blueprint) will set the variable.

It follows the same implementation than the Ember repo https://github.com/emberjs/ember.js/pull/17621
