### PR TITLE
[BUGFIX tsc] ts:precompile needs RSVP Promise not native promise to be documented

### DIFF
--- a/addon/-private/system/references/record.ts
+++ b/addon/-private/system/references/record.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'rsvp';
+import RSVP, { resolve } from 'rsvp';
 import Reference from './reference';
 
 /**
@@ -81,9 +81,9 @@ export default class RecordReference extends Reference {
 
     @method push
     @param objectOrPromise {Promise|Object}
-    @return Promise<record> a promise for the value (record or relationship)
+    @return RSVP.Promise<record> a promise for the value (record or relationship)
   */
-  push(objectOrPromise) {
+  push(objectOrPromise): RSVP.Promise<object> {
     return resolve(objectOrPromise).then(data => {
       return this.store.push(data);
     });


### PR DESCRIPTION
this is what was erroring during `ts:precompile` preventing `npm publish`, seems `tsc` runs with slightly different (and more aggressive) settings during precompile.