### PR TITLE
Stop resurecting internalModels while fetching

### DIFF
--- a/addon/-private/system/store.js
+++ b/addon/-private/system/store.js
@@ -965,18 +965,6 @@ const Store = Service.extend({
       seeking[internalModel.id] = pendingItem;
     }
 
-    for (let i = 0; i < totalItems; i++) {
-      let internalModel = internalModels[i];
-      // We may have unloaded the record after scheduling this fetch, in which
-      // case we must cancel the destroy.  This is because we require a record
-      // to build a snapshot.  This is not fundamental: this cancelation code
-      // can be removed when snapshots can be created for internal models that
-      // have no records.
-      if (internalModel.hasScheduledDestroy()) {
-        internalModels[i].cancelDestroy();
-      }
-    }
-
     function _fetchRecord(recordResolverPair) {
       let recordFetch = store._fetchRecord(
         recordResolverPair.internalModel,


### PR DESCRIPTION
After fixes in snapshots, we no longer need to do this
