### PR TITLE
Don't reset sync relationship

### DIFF
--- a/addon/-private/system/model/record-data.js
+++ b/addon/-private/system/model/record-data.js
@@ -92,6 +92,7 @@ export default class RecordData {
 
       // in debug, assert payload validity eagerly
       let relationshipData = data.relationships[relationshipName];
+
       if (DEBUG) {
         let store = this.store;
         let recordData = this;
@@ -102,11 +103,12 @@ export default class RecordData {
 
         if (relationshipData.links) {
           let isAsync = relationshipMeta.options && relationshipMeta.options.async !== false;
+          let relationship = this._relationships.get(relationshipName);
           warn(
             `You pushed a record of type '${
               this.modelName
             }' with a relationship '${relationshipName}' configured as 'async: false'. You've included a link but no primary data, this may be an error in your payload. EmberData will treat this relationship as known-to-be-empty.`,
-            isAsync || relationshipData.data,
+            isAsync || relationshipData.data || relationship.hasAnyRelationshipData,
             {
               id: 'ds.store.push-link-for-sync-relationship',
             }
@@ -144,6 +146,7 @@ export default class RecordData {
           }
         }
       }
+
       let relationship = this._relationships.get(relationshipName);
 
       relationship.push(relationshipData);

--- a/addon/-private/system/relationships/state/relationship.js
+++ b/addon/-private/system/relationships/state/relationship.js
@@ -637,7 +637,7 @@ export default class Relationship {
     if (payload.data !== undefined) {
       hasRelationshipDataProperty = true;
       this.updateData(payload.data, initial);
-    } else if (this.isAsync === false) {
+    } else if (this.isAsync === false && !this.hasAnyRelationshipData) {
       hasRelationshipDataProperty = true;
       let data = this.kind === 'hasMany' ? [] : null;
 

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -606,6 +606,69 @@ testInDebug(
   }
 );
 
+testInDebug(
+  'Calling push with a link for a non async relationship should not reset an existing relationship',
+  function(assert) {
+    Person.reopen({
+      phoneNumbers: hasMany('phone-number', { async: false }),
+    });
+
+    // GET /persons/1?include=phone-numbers
+    run(() => {
+      store.push({
+        data: {
+          type: 'person',
+          id: '1',
+          relationships: {
+            phoneNumbers: {
+              data: [
+                { type: 'phone-number', id: '2' }
+              ],
+              links: {
+                related: '/api/people/1/phone-numbers',
+              },
+            },
+          },
+        },
+        included: [{
+          type: 'phone-number',
+          id: '2',
+          attributes: {
+            number: '1-800-DATA'
+          }
+        }]
+      });
+    });
+
+    let person = store.peekRecord('person', 1);
+
+    assert.equal(person.phoneNumbers.length, 1);
+    assert.equal(person.phoneNumbers.firstObject.number, '1-800-DATA');
+
+    // GET /persons/1
+    assert.expectNoWarning(() => {
+      run(() => {
+        store.push({
+          data: {
+            type: 'person',
+            id: '1',
+            relationships: {
+              phoneNumbers: {
+                links: {
+                  related: '/api/people/1/phone-numbers',
+                },
+              },
+            },
+          },
+        });
+      });
+    });
+
+    assert.equal(person.phoneNumbers.length, 1);
+    assert.equal(person.phoneNumbers.firstObject.number, '1-800-DATA');
+  }
+);
+
 testInDebug('Calling push with an unknown model name throws an assertion error', function(assert) {
   assert.expectAssertion(() => {
     run(() => {

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -621,22 +621,22 @@ testInDebug(
           id: '1',
           relationships: {
             phoneNumbers: {
-              data: [
-                { type: 'phone-number', id: '2' }
-              ],
+              data: [{ type: 'phone-number', id: '2' }],
               links: {
                 related: '/api/people/1/phone-numbers',
               },
             },
           },
         },
-        included: [{
-          type: 'phone-number',
-          id: '2',
-          attributes: {
-            number: '1-800-DATA'
-          }
-        }]
+        included: [
+          {
+            type: 'phone-number',
+            id: '2',
+            attributes: {
+              number: '1-800-DATA',
+            },
+          },
+        ],
       });
     });
 

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -609,35 +609,29 @@ testInDebug(
 testInDebug(
   'Calling push with a link for a non async relationship should not reset an existing relationship',
   function(assert) {
-    Person.reopen({
-      phoneNumbers: hasMany('phone-number', { async: false }),
-    });
-
     // GET /persons/1?include=phone-numbers
-    run(() => {
-      store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            phoneNumbers: {
-              data: [{ type: 'phone-number', id: '2' }],
-              links: {
-                related: '/api/people/1/phone-numbers',
-              },
+    store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          phoneNumbers: {
+            data: [{ type: 'phone-number', id: '2' }],
+            links: {
+              related: '/api/people/1/phone-numbers',
             },
           },
         },
-        included: [
-          {
-            type: 'phone-number',
-            id: '2',
-            attributes: {
-              number: '1-800-DATA',
-            },
+      },
+      included: [
+        {
+          type: 'phone-number',
+          id: '2',
+          attributes: {
+            number: '1-800-DATA',
           },
-        ],
-      });
+        },
+      ],
     });
 
     let person = store.peekRecord('person', 1);
@@ -647,20 +641,18 @@ testInDebug(
 
     // GET /persons/1
     assert.expectNoWarning(() => {
-      run(() => {
-        store.push({
-          data: {
-            type: 'person',
-            id: '1',
-            relationships: {
-              phoneNumbers: {
-                links: {
-                  related: '/api/people/1/phone-numbers',
-                },
+      store.push({
+        data: {
+          type: 'person',
+          id: '1',
+          relationships: {
+            phoneNumbers: {
+              links: {
+                related: '/api/people/1/phone-numbers',
               },
             },
           },
-        });
+        },
       });
     });
 


### PR DESCRIPTION
This PR changes the known to be empty behavior. It allows a second payload push without included data to keep any relationship data that the model knows about.

Related issue: https://github.com/emberjs/data/issues/5866
