### PR TITLE
[DOCS] [BUGFIX] Adding type to forEach app serializer

### DIFF
--- a/addon/serializers/json.js
+++ b/addon/serializers/json.js
@@ -515,7 +515,7 @@ const JSONSerializer = Serializer.extend({
       normalize(typeClass, hash) {
         var fields = get(typeClass, 'fields');
 
-        fields.forEach(function(field) {
+        fields.forEach(function(type, field) {
           var payloadField = underscore(field);
           if (field === payloadField) { return; }
 


### PR DESCRIPTION
Fixes #5819
Adding type in the normalize example of app serializer
fields.forEach should have field as the second param


