### PR TITLE
Fix 2.18 tests for Travis/CI

### DIFF
--- a/tests/integration/adapter/client-side-delete-test.js
+++ b/tests/integration/adapter/client-side-delete-test.js
@@ -75,7 +75,7 @@ test('client-side deleted records can be added back from an inverse', async func
 
   await book2.destroyRecord({ adapterOptions: { clientSideDelete: true } });
 
-  book2.unloadRecord();
+  run(() => book2.unloadRecord());
 
   await settled();
 

--- a/tests/integration/application-test.js
+++ b/tests/integration/application-test.js
@@ -133,7 +133,7 @@ module('integration/application - Attaching initializer', function(hooks) {
 
     this.application = this.TestApplication.create({ autoboot: false });
 
-    await this.application.boot();
+    await run(() => this.application.boot());
 
     assert.ok(ran, 'ember-data initializer was found');
   });
@@ -153,7 +153,9 @@ module('integration/application - Attaching initializer', function(hooks) {
 
     this.application = this.TestApplication.create({ autoboot: false });
 
-    await this.application.boot().then(() => (this.owner = this.application.buildInstance()));
+    await run(() =>
+      this.application.boot().then(() => (this.owner = this.application.buildInstance()))
+    );
 
     let store = this.owner.lookup('service:store');
     assert.ok(

--- a/tests/integration/debug-adapter-test.js
+++ b/tests/integration/debug-adapter-test.js
@@ -1,6 +1,7 @@
 import { setupTest } from 'ember-qunit';
 import { A } from '@ember/array';
 import { get } from '@ember/object';
+import { run } from '@ember/runloop';
 import Model from 'ember-data/model';
 import { attr } from '@ember-decorators/data';
 import Adapter from 'ember-data/adapter';
@@ -122,7 +123,7 @@ module('integration/debug-adapter - DS.DebugAdapter', function(hooks) {
     assert.deepEqual(record.searchKeywords, ['2', 'New Post']);
     assert.deepEqual(record.color, 'green');
 
-    post.unloadRecord();
+    run(() => post.unloadRecord());
 
     await settled();
 

--- a/tests/unit/store/push-test.js
+++ b/tests/unit/store/push-test.js
@@ -636,8 +636,8 @@ testInDebug(
 
     let person = store.peekRecord('person', 1);
 
-    assert.equal(person.phoneNumbers.length, 1);
-    assert.equal(person.phoneNumbers.firstObject.number, '1-800-DATA');
+    assert.equal(person.get('phoneNumbers.length'), 1);
+    assert.equal(person.get('phoneNumbers.firstObject.number'), '1-800-DATA');
 
     // GET /persons/1
     assert.expectNoWarning(() => {
@@ -656,8 +656,8 @@ testInDebug(
       });
     });
 
-    assert.equal(person.phoneNumbers.length, 1);
-    assert.equal(person.phoneNumbers.firstObject.number, '1-800-DATA');
+    assert.equal(person.get('phoneNumbers.length'), 1);
+    assert.equal(person.get('phoneNumbers.firstObject.number'), '1-800-DATA');
   }
 );
 


### PR DESCRIPTION
I noticed there were a handful of tests, one written by me!, that were failing in 2.18. This is causing the travis badge to say "build failing".

This PR updates those tests to pass in 2.18, which should get the travis to green.

Here's what I did:

* Wrapped `application.boot` in `run` for initializer tests.
* Wrapped `unloadRecord` in `run`
* Used `.get` instead of ES getter for computeds 
