### PR TITLE
Fix bower global install command for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ before_install:
 
 install:
   - yarn install
-  - yarn add global bower
+  - yarn global add bower
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup


### PR DESCRIPTION
Fixes the command meant to install bower globally during CI runs.

Currently we are using `yarn add global bower`, which actually installs the packages `global` and `bower` locally rather than installing the `bower` package globally.

> Note: Unlike the `--global` flag in npm, `global` is a command which must
> immediately follow `yarn`. Entering `yarn add global package-name` will add
> the packages named `global` and `package-name` locally instead of adding
> package-name globally.

https://yarnpkg.com/lang/en/docs/cli/global/#toc-yarn-global

---

I noticed this while working on https://github.com/emberjs/data/pull/5919, where the following error was starting to show up in CI after converting to use yarn workspaces:

```
yarn add v1.13.0
error Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```