### PR TITLE
Add `yarn lint:features` script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       name: "Linting"
       if: NOT (branch ~= /^(release|lts).*/)
       script:
-        - ./bin/lint-features
+        - yarn lint:features
         - yarn lint:js
     - name: "Basic Tests"
       script: yarn test

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "ember build",
     "build:production": "ember build --environment=production",
     "lint:js": "eslint .",
+    "lint:features": "./bin/lint-features",
     "start": "ember server",
     "test": "ember test",
     "test:all": "ember try:each",


### PR DESCRIPTION
This adds a script to `package.json` to run our feature linting script via `yarn lint:features` rather than using `./bin/lint-features` directly.

This makes it easier to run the script from the root package after converting to a monorepo like in https://github.com/emberjs/data/pull/5919