### PR TITLE
[RFC] Return promise in _fetchRequest

### DIFF
--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -992,9 +992,6 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
 
     if (get(this, 'useFetch')) {
       return this._fetchRequest(hash)
-        .catch(() => {
-          heimdall.stop(token);
-        })
         .then(response => {
           heimdall.stop(token);
 
@@ -1009,6 +1006,9 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
           } else {
             throw fetchErrorHandler(adapter, payload, response, null, requestData);
           }
+        })
+        .catch(() => {
+          heimdall.stop(token);
         });
     }
 
@@ -1054,7 +1054,7 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
   },
 
   _fetchRequest(options) {
-    fetch(options.url, options)
+    return fetch(options.url, options)
       .then(response => {
         if (response.ok) {
           options.success(response);

--- a/tests/unit/adapters/rest-adapter/fetch-test.js
+++ b/tests/unit/adapters/rest-adapter/fetch-test.js
@@ -133,3 +133,24 @@ test('ajaxOptions() empty data', function(assert) {
     url: 'example.com',
   });
 });
+
+test('_fetchRequest() returns a promise', function(assert) {
+  console.log('DS.RESTAdapter', adapter);
+  let noop = function(){};
+
+  return run(() => {
+    let fetchPlacePromise = adapter._fetchRequest({
+      url: '/places/1',
+      success: noop,
+      error: noop,
+    });
+
+    assert.equal(
+      typeof fetchPlacePromise.then,
+      'function',
+      '_fetchRequest does not return a promise'
+    );
+
+    return fetchPlacePromise;
+  });
+});

--- a/tests/unit/adapters/rest-adapter/fetch-test.js
+++ b/tests/unit/adapters/rest-adapter/fetch-test.js
@@ -135,8 +135,7 @@ test('ajaxOptions() empty data', function(assert) {
 });
 
 test('_fetchRequest() returns a promise', function(assert) {
-  console.log('DS.RESTAdapter', adapter);
-  let noop = function(){};
+  let noop = function() {};
 
   return run(() => {
     let fetchPlacePromise = adapter._fetchRequest({


### PR DESCRIPTION
**Description**
This PR fixes https://github.com/emberjs/data/issues/5918. 

Appears that:
1. The fetch promise was not being returned
2. Premature error handling using `.catch` meant that the success `.then` handlers would also fire.