### PR TITLE
[BUGFIX canary] eliminate recordData prop restriction

### DIFF
--- a/addon/-private/system/model/model.js
+++ b/addon/-private/system/model/model.js
@@ -1214,16 +1214,6 @@ if (DEBUG) {
       }
 
       if (
-        !isDefaultEmptyDescriptor(this, 'recordData') ||
-        this.recordData !== undefined ||
-        this.recordData !== this._internalModel.recordData
-      ) {
-        throw new Error(
-          `'recordData' is a reserved property name on instances of classes extending Model. Please choose a different property name for ${this.constructor.toString()}`
-        );
-      }
-
-      if (
         !isDefaultEmptyDescriptor(this, 'currentState') ||
         this.get('currentState') !== this._internalModel.currentState
       ) {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -676,12 +676,6 @@ module('unit/model - Model', function(hooks) {
       @attr('string')
       name;
     }
-    class NativePostWithRecordData extends Model {
-      @attr('string', { defaultValue: 'hello' })
-      recordData;
-      @attr('string')
-      name;
-    }
     class NativePostWithCurrentState extends Model {
       @attr('string')
       currentState;
@@ -690,7 +684,6 @@ module('unit/model - Model', function(hooks) {
     }
     const PROP_MAP = {
       _internalModel: NativePostWithInternalModel,
-      recordData: NativePostWithRecordData,
       currentState: NativePostWithCurrentState,
     };
 
@@ -730,7 +723,7 @@ module('unit/model - Model', function(hooks) {
       });
     }
 
-    ['recordData', '_internalModel', 'currentState'].forEach(testReservedProperty);
+    ['_internalModel', 'currentState'].forEach(testReservedProperty);
 
     testInDebug(
       'A subclass of Model throws an error when calling create() directly',


### PR DESCRIPTION
Our check for `recordData` isn't viable in the native class world because we are reserving a prop that we don't actually use yet. This leads to us having no good way to test that the prop isn't what we expect.

This said, with the direction the `custom-class` RFC have taken and the intent to introduce a non reserved-prop based lookup for the `RecordData` of an instance (which we already do internally), there is no reason to reserve this prop at all.

Note: There is still an outstanding question around why the defaultValue for this `attr` was not being returned. That case should be covered by other tests and may have simply been a timing issue with where our check is, but we should follow up with a new test for defaultValue on native classes attrs.