### PR TITLE
[chore] Drop references to Bower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,6 @@ before_install:
 
 install:
   - yarn install
-  - yarn global add bower
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
 
 cache:
   - '%LOCALAPPDATA%\Yarn'
-  - '%APPDATA%\Roaming\bower'
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -13,7 +13,6 @@ module.exports = function() {
       scenarios: [
         {
           name: 'default',
-          bower: {},
           npm: {},
         },
         {

--- a/lib/scripts/test-external.js
+++ b/lib/scripts/test-external.js
@@ -60,12 +60,11 @@ try {
 }
 
 const useYarn = fs.existsSync(path.join(projectTempDir, 'yarn.lock'));
-const useBower = fs.existsSync(path.join(projectTempDir, 'bower.json'));
 
 // install project dependencies and link our local version of ember-data
 try {
   execWithLog(`${useYarn ? 'yarn link' : 'npm link'}`);
-  execExternal(`${useYarn ? 'yarn' : 'npm install'}${useBower ? ' && bower install' : ''}`);
+  execExternal(`${useYarn ? 'yarn' : 'npm install'}`);
 } catch (e) {
   debug(e);
   throw new Error(

--- a/node-tests/nodetest-runner.js
+++ b/node-tests/nodetest-runner.js
@@ -14,7 +14,6 @@ var rimraf = require('rimraf');
 var mochaOnlyDetector = require('mocha-only-detector');
 
 rimraf.sync('.node_modules-tmp');
-rimraf.sync('.bower_components-tmp');
 
 var root = 'node-tests/{blueprints,acceptance,unit}';
 var _checkOnlyInTests = RSVP.denodeify(


### PR DESCRIPTION
Bower is still referenced in the test suite (for the external partners tests). But all the projects against which ember-data is tested have dropped Bower. 🎉 