### PR TITLE
Show transform usage after example

### DIFF
--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -261,7 +261,7 @@ export default Mixin.create({
     Use a custom (type) serializer for the post model to configure embedded comments
 
     ```app/serializers/post.js
-    import DS from 'ember-data';
+    import DS from 'ember-data;
 
     export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
       attrs: {
@@ -300,7 +300,7 @@ export default Mixin.create({
     To embed the `ids` for a related object (using a hasMany relationship):
 
     ```app/serializers/post.js
-    import DS from 'ember-data';
+    import DS from 'ember-data;
 
     export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
       attrs: {
@@ -348,7 +348,7 @@ export default Mixin.create({
     ```
 
     ```app/serializers/user.js
-    import DS from 'ember-data';
+    import DS from 'ember-data;
 
     export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
       attrs: {

--- a/addon/serializers/embedded-records-mixin.js
+++ b/addon/serializers/embedded-records-mixin.js
@@ -261,7 +261,7 @@ export default Mixin.create({
     Use a custom (type) serializer for the post model to configure embedded comments
 
     ```app/serializers/post.js
-    import DS from 'ember-data;
+    import DS from 'ember-data';
 
     export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
       attrs: {
@@ -300,7 +300,7 @@ export default Mixin.create({
     To embed the `ids` for a related object (using a hasMany relationship):
 
     ```app/serializers/post.js
-    import DS from 'ember-data;
+    import DS from 'ember-data';
 
     export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
       attrs: {
@@ -348,7 +348,7 @@ export default Mixin.create({
     ```
 
     ```app/serializers/user.js
-    import DS from 'ember-data;
+    import DS from 'ember-data';
 
     export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin, {
       attrs: {

--- a/addon/transforms/transform.js
+++ b/addon/transforms/transform.js
@@ -23,6 +23,17 @@ import EmberObject from '@ember/object';
     }
   });
   ```
+  
+  Usage
+
+  ```app/models/requirement.js
+  import DS from 'ember-data';
+
+  export default DS.Model.extend({
+    name: DS.attr('string'),
+    temperature: DS.attr('temperature')
+  });
+  ```
 
   The options passed into the `DS.attr` function when the attribute is
   declared on the model is also available in the transform.
@@ -50,17 +61,6 @@ import EmberObject from '@ember/object';
 
       return marked(serialized, markdownOptions);
     }
-  });
-  ```
-
-  Usage
-
-  ```app/models/requirement.js
-  import DS from 'ember-data';
-
-  export default DS.Model.extend({
-    name: DS.attr('string'),
-    temperature: DS.attr('temperature')
   });
   ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data",
-  "version": "3.9.0-canary",
+  "version": "3.8.0",
   "description": "A data layer for your Ember applications.",
   "repository": "git://github.com/emberjs/data.git",
   "directories": {


### PR DESCRIPTION
Reading the [API information about transforms](https://api.emberjs.com/ember-data/release/classes/DS.Transform), the order seemed a little off. First, we indicate a basic example for transforms, and the usage that makes reference (`app/transforms/temperature`) is at the end of this section, after an option slightly more advanced.

This change moves the usage snippet right after the example.