### PR TITLE
Change order of transform usage

### DIFF
--- a/addon/transforms/transform.js
+++ b/addon/transforms/transform.js
@@ -24,6 +24,17 @@ import EmberObject from '@ember/object';
   });
   ```
 
+  Usage
+
+  ```app/models/requirement.js
+  import DS from 'ember-data';
+
+  export default DS.Model.extend({
+    name: DS.attr('string'),
+    temperature: DS.attr('temperature')
+  });
+  ```
+
   The options passed into the `DS.attr` function when the attribute is
   declared on the model is also available in the transform.
 
@@ -50,17 +61,6 @@ import EmberObject from '@ember/object';
 
       return marked(serialized, markdownOptions);
     }
-  });
-  ```
-
-  Usage
-
-  ```app/models/requirement.js
-  import DS from 'ember-data';
-
-  export default DS.Model.extend({
-    name: DS.attr('string'),
-    temperature: DS.attr('temperature')
   });
   ```
 


### PR DESCRIPTION
Reading the [API information about transforms](https://api.emberjs.com/ember-data/release/classes/DS.Transform), the order seemed a little off. First, we indicate a basic example for transforms, and the usage that makes reference (`app/transforms/temperature`) is at the end of this section, after an option slightly more advanced.

This change moves the usage snippet right after the example.