### PR TITLE
[FIX transforms] don't instantiate via `new`

### DIFF
--- a/tests/unit/transform/boolean-test.js
+++ b/tests/unit/transform/boolean-test.js
@@ -1,54 +1,87 @@
-import DS from 'ember-data';
-
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-module('unit/transform - DS.BooleanTransform');
+module('unit/transform - BooleanTransform', function(hooks) {
+  setupTest(hooks);
 
-test('#serialize', function(assert) {
-  let transform = new DS.BooleanTransform();
+  test('#serialize', async function(assert) {
+    const transform = this.owner.lookup('transform:boolean');
 
-  assert.strictEqual(transform.serialize(null, { allowNull: true }), null);
-  assert.strictEqual(transform.serialize(undefined, { allowNull: true }), null);
+    assert.strictEqual(
+      transform.serialize(null, { allowNull: true }),
+      null,
+      '{ allowNull: true } - we serialize null to null'
+    );
+    assert.strictEqual(
+      transform.serialize(undefined, { allowNull: true }),
+      null,
+      '{ allowNull: true } - we serialize undefined to null'
+    );
 
-  assert.equal(transform.serialize(null, { allowNull: false }), false);
-  assert.equal(transform.serialize(undefined, { allowNull: false }), false);
+    assert.equal(
+      transform.serialize(null, { allowNull: false }),
+      false,
+      '{ allowNull: false } - we serialize null to false'
+    );
+    assert.equal(
+      transform.serialize(undefined, { allowNull: false }),
+      false,
+      '{ allowNull: false } - we serialize null to false'
+    );
 
-  assert.equal(transform.serialize(null, {}), false);
-  assert.equal(transform.serialize(undefined, {}), false);
+    assert.equal(transform.serialize(null, {}), false, 'we serialize null to false');
+    assert.equal(transform.serialize(undefined, {}), false, 'we serialize undefined to false');
 
-  assert.equal(transform.serialize(true), true);
-  assert.equal(transform.serialize(false), false);
-});
+    assert.equal(transform.serialize(true), true, 'we serialize true to true');
+    assert.equal(transform.serialize(false), false, 'we serialize false to false');
+  });
 
-test('#deserialize', function(assert) {
-  let transform = new DS.BooleanTransform();
+  test('#deserialize', async function(assert) {
+    const transform = this.owner.lookup('transform:boolean');
 
-  assert.strictEqual(transform.deserialize(null, { allowNull: true }), null);
-  assert.strictEqual(transform.deserialize(undefined, { allowNull: true }), null);
+    assert.strictEqual(
+      transform.deserialize(null, { allowNull: true }),
+      null,
+      '{ allowNull: true } - we deserialize null to null'
+    );
+    assert.strictEqual(
+      transform.deserialize(undefined, { allowNull: true }),
+      null,
+      '{ allowNull: true } - we deserialize undefined to null'
+    );
 
-  assert.equal(transform.deserialize(null, { allowNull: false }), false);
-  assert.equal(transform.deserialize(undefined, { allowNull: false }), false);
+    assert.equal(
+      transform.deserialize(null, { allowNull: false }),
+      false,
+      '{ allowNull: false } - we deserialize null to false'
+    );
+    assert.equal(
+      transform.deserialize(undefined, { allowNull: false }),
+      false,
+      '{ allowNull: true } - we deserialize undefined to false'
+    );
 
-  assert.equal(transform.deserialize(null, {}), false);
-  assert.equal(transform.deserialize(undefined, {}), false);
+    assert.equal(transform.deserialize(null, {}), false, 'we deserialize null to false');
+    assert.equal(transform.deserialize(undefined, {}), false, 'we deserialize undefined to false');
 
-  assert.equal(transform.deserialize(true), true);
-  assert.equal(transform.deserialize(false), false);
+    assert.equal(transform.deserialize(true), true, 'we deserialize true to true');
+    assert.equal(transform.deserialize(false), false, 'we deserialize false to false');
 
-  assert.equal(transform.deserialize('true'), true);
-  assert.equal(transform.deserialize('TRUE'), true);
-  assert.equal(transform.deserialize('false'), false);
-  assert.equal(transform.deserialize('FALSE'), false);
+    assert.equal(transform.deserialize('true'), true, 'we deserialize string "true" to true');
+    assert.equal(transform.deserialize('TRUE'), true, 'we deserialize string "TRUE" to true');
+    assert.equal(transform.deserialize('false'), false, 'we deserialize string "false" to false');
+    assert.equal(transform.deserialize('FALSE'), false, 'we deserialize string "FALSE" to false');
 
-  assert.equal(transform.deserialize('t'), true);
-  assert.equal(transform.deserialize('T'), true);
-  assert.equal(transform.deserialize('f'), false);
-  assert.equal(transform.deserialize('F'), false);
+    assert.equal(transform.deserialize('t'), true, 'we deserialize string "t" to true');
+    assert.equal(transform.deserialize('T'), true, 'we deserialize string "T" to true');
+    assert.equal(transform.deserialize('f'), false, 'we deserialize string "f" to false');
+    assert.equal(transform.deserialize('F'), false, 'we deserialize string "F" to false');
 
-  assert.equal(transform.deserialize('1'), true);
-  assert.equal(transform.deserialize('0'), false);
+    assert.equal(transform.deserialize('1'), true, 'we deserialize string "1" to true');
+    assert.equal(transform.deserialize('0'), false, 'we deserialize string "0" to false');
 
-  assert.equal(transform.deserialize(1), true);
-  assert.equal(transform.deserialize(2), false);
-  assert.equal(transform.deserialize(0), false);
+    assert.equal(transform.deserialize(1), true, 'we deserialize number 1 to true');
+    assert.equal(transform.deserialize(2), false, 'we deserialize numbers greater than 1 to false');
+    assert.equal(transform.deserialize(0), false, 'we deserialize number 0 to false');
+  });
 });

--- a/tests/unit/transform/date-test.js
+++ b/tests/unit/transform/date-test.js
@@ -1,36 +1,36 @@
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-import DS from 'ember-data';
+module('unit/transform - DateTransform', function(hooks) {
+  setupTest(hooks);
+  const dateString = '2015-01-01T00:00:00.000Z';
+  const dateInMillis = Date.parse(dateString);
+  const date = new Date(dateString);
 
-module('unit/transform - DS.DateTransform');
+  test('#serialize', async function(assert) {
+    const transform = this.owner.lookup('transform:date');
 
-let dateString = '2015-01-01T00:00:00.000Z';
-let dateInMillis = Date.parse(dateString);
-let date = new Date(dateString);
+    assert.strictEqual(transform.serialize(null), null);
+    assert.strictEqual(transform.serialize(undefined), null);
+    assert.strictEqual(transform.serialize(new Date('invalid')), null);
 
-test('#serialize', function(assert) {
-  let transform = new DS.DateTransform();
+    assert.equal(transform.serialize(date), dateString);
+  });
 
-  assert.strictEqual(transform.serialize(null), null);
-  assert.strictEqual(transform.serialize(undefined), null);
-  assert.strictEqual(transform.serialize(new Date('invalid')), null);
+  test('#deserialize', async function(assert) {
+    const transform = this.owner.lookup('transform:date');
 
-  assert.equal(transform.serialize(date), dateString);
-});
+    // from String
+    assert.equal(transform.deserialize(dateString).toISOString(), dateString);
 
-test('#deserialize', function(assert) {
-  let transform = new DS.DateTransform();
+    // from Number
+    assert.equal(transform.deserialize(dateInMillis).valueOf(), dateInMillis);
 
-  // from String
-  assert.equal(transform.deserialize(dateString).toISOString(), dateString);
+    // from other
+    assert.strictEqual(transform.deserialize({}), null);
 
-  // from Number
-  assert.equal(transform.deserialize(dateInMillis).valueOf(), dateInMillis);
-
-  // from other
-  assert.strictEqual(transform.deserialize({}), null);
-
-  // from none
-  assert.strictEqual(transform.deserialize(null), null);
-  assert.strictEqual(transform.deserialize(undefined), undefined);
+    // from none
+    assert.strictEqual(transform.deserialize(null), null);
+    assert.strictEqual(transform.deserialize(undefined), undefined);
+  });
 });

--- a/tests/unit/transform/number-test.js
+++ b/tests/unit/transform/number-test.js
@@ -1,31 +1,32 @@
-import DS from 'ember-data';
-
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-module('unit/transform - DS.NumberTransform');
+module('unit/transform - NumberTransform', function(hooks) {
+  setupTest(hooks);
 
-test('#serialize', function(assert) {
-  let transform = new DS.NumberTransform();
+  test('#serialize', async function(assert) {
+    const transform = this.owner.lookup('transform:number');
 
-  assert.strictEqual(transform.serialize(null), null);
-  assert.strictEqual(transform.serialize(undefined), null);
-  assert.equal(transform.serialize('1.1'), 1.1);
-  assert.equal(transform.serialize(1.1), 1.1);
-  assert.equal(transform.serialize(new Number(1.1)), 1.1);
-  assert.strictEqual(transform.serialize(NaN), null);
-  assert.strictEqual(transform.serialize(Infinity), null);
-  assert.strictEqual(transform.serialize(-Infinity), null);
-});
+    assert.strictEqual(transform.serialize(null), null);
+    assert.strictEqual(transform.serialize(undefined), null);
+    assert.equal(transform.serialize('1.1'), 1.1);
+    assert.equal(transform.serialize(1.1), 1.1);
+    assert.equal(transform.serialize(new Number(1.1)), 1.1);
+    assert.strictEqual(transform.serialize(NaN), null);
+    assert.strictEqual(transform.serialize(Infinity), null);
+    assert.strictEqual(transform.serialize(-Infinity), null);
+  });
 
-test('#deserialize', function(assert) {
-  let transform = new DS.NumberTransform();
+  test('#deserialize', async function(assert) {
+    const transform = this.owner.lookup('transform:number');
 
-  assert.strictEqual(transform.deserialize(null), null);
-  assert.strictEqual(transform.deserialize(undefined), null);
-  assert.equal(transform.deserialize('1.1'), 1.1);
-  assert.equal(transform.deserialize(1.1), 1.1);
-  assert.equal(transform.deserialize(new Number(1.1)), 1.1);
-  assert.strictEqual(transform.deserialize(NaN), null);
-  assert.strictEqual(transform.deserialize(Infinity), null);
-  assert.strictEqual(transform.deserialize(-Infinity), null);
+    assert.strictEqual(transform.deserialize(null), null);
+    assert.strictEqual(transform.deserialize(undefined), null);
+    assert.equal(transform.deserialize('1.1'), 1.1);
+    assert.equal(transform.deserialize(1.1), 1.1);
+    assert.equal(transform.deserialize(new Number(1.1)), 1.1);
+    assert.strictEqual(transform.deserialize(NaN), null);
+    assert.strictEqual(transform.deserialize(Infinity), null);
+    assert.strictEqual(transform.deserialize(-Infinity), null);
+  });
 });

--- a/tests/unit/transform/string-test.js
+++ b/tests/unit/transform/string-test.js
@@ -1,25 +1,26 @@
-import DS from 'ember-data';
-
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-module('unit/transform - DS.StringTransform');
+module('unit/transform - StringTransform', function(hooks) {
+  setupTest(hooks);
 
-test('#serialize', function(assert) {
-  let transform = new DS.StringTransform();
+  test('#serialize', async function(assert) {
+    const transform = this.owner.lookup('transform:string');
 
-  assert.strictEqual(transform.serialize(null), null);
-  assert.strictEqual(transform.serialize(undefined), null);
+    assert.strictEqual(transform.serialize(null), null);
+    assert.strictEqual(transform.serialize(undefined), null);
 
-  assert.equal(transform.serialize('foo'), 'foo');
-  assert.equal(transform.serialize(1), '1');
-});
+    assert.equal(transform.serialize('foo'), 'foo');
+    assert.equal(transform.serialize(1), '1');
+  });
 
-test('#deserialize', function(assert) {
-  let transform = new DS.StringTransform();
+  test('#deserialize', async function(assert) {
+    const transform = this.owner.lookup('transform:string');
 
-  assert.strictEqual(transform.deserialize(null), null);
-  assert.strictEqual(transform.deserialize(undefined), null);
+    assert.strictEqual(transform.deserialize(null), null);
+    assert.strictEqual(transform.deserialize(undefined), null);
 
-  assert.equal(transform.deserialize('foo'), 'foo');
-  assert.equal(transform.deserialize(1), '1');
+    assert.equal(transform.deserialize('foo'), 'foo');
+    assert.equal(transform.deserialize(1), '1');
+  });
 });


### PR DESCRIPTION
* instantiates the transforms for the tests via container lookup instead of the new keyword
* ports tests to modern test format
* addresses lack of assertion messages in the boolean test (others still require this fix)