### PR TITLE
Drop ember-source 2.18 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,6 @@ jobs:
       script: yarn test:node
 
     # runs tests against each supported Ember version
-    - stage: ember version tests
-      name: 'Ember LTS 2.18'
-      env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - name: 'Ember LTS 3.4'
       env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - name: 'Ember Release'

--- a/packages/-ember-data/config/ember-try.js
+++ b/packages/-ember-data/config/ember-try.js
@@ -16,33 +16,13 @@ module.exports = function() {
           npm: {},
         },
         {
-          name: 'ember-lts-2.18',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-2.18',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.18.0',
-            },
-          },
-        },
-        {
           name: 'ember-lts-3.4',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
           },
           npm: {
             devDependencies: {
-              '@ember/jquery': '^0.5.1',
+              '@ember/jquery': '^0.6.0',
               'ember-source': '~3.4.0',
             },
           },

--- a/packages/-ember-data/tests/integration/record-array-test.js
+++ b/packages/-ember-data/tests/integration/record-array-test.js
@@ -1,5 +1,4 @@
 import { get } from '@ember/object';
-import { run } from '@ember/runloop';
 import { resolve } from 'rsvp';
 import { setupTest } from 'ember-qunit';
 import { settled } from '@ember/test-helpers';
@@ -185,9 +184,7 @@ module('unit/record-array - RecordArray', function(hooks) {
 
     await settled();
 
-    // Ember 2.18 requires wrapping destroy in a run. Once we drop support with 3.8 LTS
-    //  we can remove this.
-    run(() => recordArray.destroy());
+    recordArray.destroy();
 
     await settled();
 

--- a/packages/-ember-data/tests/integration/store/adapter-for-test.js
+++ b/packages/-ember-data/tests/integration/store/adapter-for-test.js
@@ -1,7 +1,6 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import Store from 'ember-data/store';
-import { run } from '@ember/runloop';
 
 class TestAdapter {
   constructor(args) {
@@ -95,8 +94,7 @@ module('integration/store - adapterFor', function(hooks) {
     assert.ok(didInstantiate, 'We instantiated the other adapter');
     assert.ok(otherAdapter !== adapter, 'We have a different adapter instance');
 
-    // Ember 2.18 requires us to wrap destroy in a run. Use `await settled()` for newer versions.
-    run(() => otherStore.destroy());
+    otherStore.destroy();
   });
 
   test('we can find and instantiate per-type adapters', async function(assert) {

--- a/packages/-ember-data/tests/integration/store/serializer-for-test.js
+++ b/packages/-ember-data/tests/integration/store/serializer-for-test.js
@@ -1,7 +1,6 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import Store from 'ember-data/store';
-import { run } from '@ember/runloop';
 
 class TestAdapter {
   constructor(args) {
@@ -129,8 +128,7 @@ module('integration/store - serializerFor', function(hooks) {
     assert.ok(didInstantiate, 'We instantiated the other serializer');
     assert.ok(otherSerializer !== serializer, 'We have a different serializer instance');
 
-    // Ember 2.18 requires us to wrap destroy in a run. Use `await settled()` for newer versions.
-    run(() => otherStore.destroy());
+    otherStore.destroy();
   });
 
   test('we can find and instantiate per-type serializers', async function(assert) {

--- a/packages/adapter/README.md
+++ b/packages/adapter/README.md
@@ -7,7 +7,7 @@
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v2.18 or above
+* Ember.js v3.4 or above
 * Ember CLI v2.13 or above
 
 

--- a/packages/model/README.md
+++ b/packages/model/README.md
@@ -7,7 +7,7 @@
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v2.18 or above
+* Ember.js v3.4 or above
 * Ember CLI v2.13 or above
 
 

--- a/packages/serializer/README.md
+++ b/packages/serializer/README.md
@@ -7,7 +7,7 @@
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v2.18 or above
+* Ember.js v3.4 or above
 * Ember CLI v2.13 or above
 
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -7,7 +7,7 @@
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v2.18 or above
+* Ember.js v3.4 or above
 * Ember CLI v2.13 or above
 
 

--- a/packages/store/addon/-private/system/model/model.js
+++ b/packages/store/addon/-private/system/model/model.js
@@ -71,11 +71,6 @@ const retrieveFromCurrentState = computed('currentState', function(key) {
   @uses Ember.Evented
 */
 const Model = EmberObject.extend(Evented, {
-  // until: "3.9" as we need to support 2.18
-  __defineNonEnumerable(property) {
-    this[property.name] = property.descriptor.value;
-  },
-
   /**
     If this property is `true` the record is in the `empty`
     state. Empty is the first state all records enter after they have


### PR DESCRIPTION
This will allow some modernizations in the test suite.

LTS support has ended last February for ember-source@2.18 (https://emberjs.com/releases/).