### PR TITLE
Guard against this.options.babel.plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ stages:
 
 jobs:
   fail_fast: true
-  allow_failures:
-    - name: "emberaddons.com"
 
   include:
     # runs tests with current locked deps and linting

--- a/packages/-ember-data/index.js
+++ b/packages/-ember-data/index.js
@@ -143,9 +143,10 @@ module.exports = {
   },
 
   buildBabelOptions() {
-    let existing = this.options.babel;
+    let babelOptions = this.options.babel || {};
+    let existingPlugins = babelOptions.plugins || [];
     let customPlugins = require('./lib/stripped-build-plugins')(process.env.EMBER_ENV);
-    let plugins = existing.plugins.map(plugin => {
+    let plugins = existingPlugins.map(plugin => {
       return Array.isArray(plugin) ? plugin : [plugin];
     });
     plugins = plugins.concat(customPlugins.plugins);

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -21,7 +21,7 @@
     "test:try-one": "ember try:one",
     "test-external:ember-m3": "node ./lib/scripts/test-external ember-m3 https://github.com/hjdivad/ember-m3.git",
     "test-external:ember-data-change-tracker": "node ./lib/scripts/test-external ember-data-change-tracker https://github.com/danielspaniel/ember-data-change-tracker.git",
-    "test-external:emberaddons.com": "node ./lib/scripts/test-external ember-cli-addon-search https://github.com/gcollazo/ember-cli-addon-search.git",
+    "test-external:emberaddons.com": "node ./lib/scripts/test-external ember-cli-addon-search https://github.com/dcyriller/ember-cli-addon-search.git",
     "test-external:model-fragments": "node ./lib/scripts/test-external ember-data-model-fragments https://github.com/lytics/ember-data-model-fragments.git",
     "test-external:ember-observer": "node ./lib/scripts/test-external ember-observer https://github.com/emberobserver/client.git",
     "test-external:travis-web": "node ./lib/scripts/test-external travis-web https://github.com/travis-ci/travis-web.git",


### PR DESCRIPTION
This would fix the emberaddons.com job. 

I've not been able to precisely track down the root cause of the failure. My hypothesis is that a slight change in the dependencies resolution has occured (with ember-cli-babel?).