### PR TITLE
[CHORE release] backport fixes from release branch for releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,11 @@ jobs:
       script: yarn test:node
 
     # runs tests against each supported Ember version
-    - name: 'Ember LTS 3.4'
+    - stage: ember version tests
+      name: 'Ember LTS 3.4'
       env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - name: 'Ember LTS 3.8'
+      env: EMBER_TRY_SCENARIO=ember-lts-3.8
     - name: 'Ember Release'
       if: NOT (branch ~= /^(release|lts).*/)
       env: EMBER_TRY_SCENARIO=ember-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ### Master
 
+### Release 3.9.0 (April 8, 2019)
+
+- [1ebff8cb](https://github.com/emberjs/data/commit/1ebff8cb4bcd848e797a056f8cab9a80405772d8) [DOCS] [BUGFIX] Get model relationships by string
+- [a095bebf](https://github.com/emberjs/data/commit/a095bebf1ac94a116dcfd1919fd454c962b0bb13) [DOCS] [BUGFIX] Adding type to forEach app serializer
+- [d13e7840](https://github.com/emberjs/data/commit/d13e7840e6dead927842f095c3c8f2a4537abf50) [DOC serializeHasMany ] Update ember-data imports
+- [2858c32d](https://github.com/emberjs/data/commit/2858c32dbc9458bb28f95c31a5afdeb7a499ea35) [DOCS] [BUGFIX] recordRef push param must be with type
+- [328e1b4f](https://github.com/emberjs/data/commit/328e1b4ff81ac3beb5688bed60717b049f7aa671) [DOCS] [BUGFIX] Added attributes wrapper object
+- [4fdde1ed](https://github.com/emberjs/data/commit/4fdde1edb36372913f8e5271180e95cc5d47ccac) [BUGFIX #5918] Fix promise not being returned
+- [1dbe1015](https://github.com/emberjs/data/commit/1dbe10158fc3b5e36bdf3fb202b744a82a8a1756) [DOCS] [BUGFIX] generateIdForRecord api doc #5803
+- [739f78e3](https://github.com/emberjs/data/commit/739f78e381762525b90bbf91c96578b2ca418e62) [BUGFIX canary] eliminate recordData prop restriction
+- [a61651df](https://github.com/emberjs/data/commit/a61651df4b6c1e759cf308212b9272055cf4e9a9) [BUGFIX canary] Fix options assignment in json-api adapter
+- [f26d07b6](https://github.com/emberjs/data/commit/f26d07b62e4240f723a822b73d5a196ebee8de22) [BUGFIX fetch] Don't set json:api content-type for DELETE requests
+- [75c77a74](https://github.com/emberjs/data/commit/75c77a7427d397e49e835d00c9c7b7403ef99c26) [FIX transforms] don't instantiate via `new`
+- [081432ce](https://github.com/emberjs/data/commit/081432cec3d3a11388046ffc7ea1dd661172ed27) [FIX ManyArray] Evented.off requires a reference to the original callback
+- [1df83339](https://github.com/emberjs/data/commit/1df833396855d956b817540923dd89338463fec2) [BUGFIX model] assertions around create need to account for Ember's own
+
 ### Release 3.8.0 (February 20, 2019)
 
 - [#5671](https://github.com/emberjs/data/pull/5671) Use _scheduleFetch instead of _fetchRecord for belongsTo relationship (#5671)

--- a/bin/changelog
+++ b/bin/changelog
@@ -57,22 +57,92 @@ function getCommitMessage(commitInfo) {
   return message;
 }
 
+var label_cache = Object.create(null);
+function getLabels(str) {
+  if (typeof str !== 'string') {
+    return [];
+  }
+  if (label_cache[str] !== undefined) {
+    return label_cache[str];
+  }
+
+  if (str[0] !== '[') {
+    label_cache[str] = [];
+    return label_cache[str];
+  }
+
+  let hasOpen = true;
+  let labels = [];
+  let label = '[';
+  for (let i = 1; i < str.length; i++) {
+    let c = str[i];
+    if (hasOpen === true && c === ']') {
+      label += c;
+      labels.push(label);
+      hasOpen = false;
+      label = '';
+    } else if (hasOpen === false && c === '[') {
+      label = c;
+      hasOpen = true;
+    } else if (c === EOL) {
+      hasOpen = false;
+      label = '';
+      break;
+    } else if (hasOpen === true) {
+      label += c;
+    }
+  }
+
+  label_cache[str] = labels;
+  return labels;
+}
+
+const MEANINGFUL_LABELS = ['FIX', 'BUGFIX', 'FEAT', 'FEATURE', 'DOCS', 'DOC'];
+function hasLabelForChangelog(message) {
+  let labels = getLabels(message);
+
+  for (let i = 0; i < labels.length; i++) {
+    let label = labels[i];
+
+    for (let j = 0; j < MEANINGFUL_LABELS.length; j++) {
+      if (label.indexOf(MEANINGFUL_LABELS[j]) !== -1) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 function processPages(res) {
   var contributions = res.commits
     .filter(function(commitInfo) {
       var message = commitInfo.commit.message;
+      var author = commitInfo.author || commitInfo.commit.author;
+      if (
+        author.type === 'Bot' || 
+        author.login === 'dependabot[bot]' || 
+        author.name === 'dependabot[bot]' ||
+        author.login === 'dependabot-bot' ||
+        author.name === 'dependabot-bot'
+        ) {
+        return false;
+      }
+
       return (
         message.indexOf('Merge pull request #') > -1 ||
         message.indexOf('cherry picked from') > -1 ||
-        message.match(/\(#\d+\)\n/)
+        message.match(/\(#\d+\)\n/) ||
+        hasLabelForChangelog(message)
       );
     })
     .map(function(commitInfo) {
       var message = getCommitMessage(commitInfo);
+      var labels = getLabels(message);
       var match = message.match(/#(\d+) from (.*)\//);
       var squashMatch = message.match(/#(\d+)\)\n/);
       var result = {
         sha: commitInfo.sha,
+        labels,
       };
 
       if (match) {

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,6 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "packages": [
-    "packages/*"
-  ],
-  "version": "0.0.0"
+  "packages": ["packages/*"],
+  "version": "3.11.0-canary"
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ember-qunit": "^4.4.1",
     "ember-qunit-assert-helpers": "^0.2.2",
     "ember-resolver": "^5.0.1",
-    "ember-source": "~3.8.0",
+    "ember-source": "~3.9.0",
     "ember-source-channel-url": "^1.1.0",
     "ember-try": "^1.1.0",
     "eslint": "^5.15.1",

--- a/packages/-ember-data/config/ember-try.js
+++ b/packages/-ember-data/config/ember-try.js
@@ -22,16 +22,20 @@ module.exports = function() {
           },
           npm: {
             devDependencies: {
-              '@ember/jquery': '^0.6.0',
+              '@ember/jquery': '^0.5.1',
               'ember-source': '~3.4.0',
             },
           },
         },
         {
-          name: 'ember-lts-3.4',
+          name: 'ember-lts-3.8',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
           npm: {
             devDependencies: {
-              'ember-source': '~3.4.0',
+              '@ember/jquery': '^0.5.1',
+              'ember-source': '~3.8.0',
             },
           },
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4678,7 +4678,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.1.4, ember-cli-babel@^7.2.0, ember-cli-babel@^7.4.2, ember-cli-babel@^7.4.3, ember-cli-babel@^7.5.0:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.1.4, ember-cli-babel@^7.4.2, ember-cli-babel@^7.4.3, ember-cli-babel@^7.5.0:
   version "7.7.3"
   resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz#f94709f6727583d18685ca6773a995877b87b8a0"
   integrity sha512-/LWwyKIoSlZQ7k52P+6agC7AhcOBqPJ5C2u27qXHVVxKvCtg6ahNuRk/KmfZmV4zkuw4EjTZxfJE1PzpFyHkXg==
@@ -5277,7 +5277,7 @@ ember-source-channel-url@*, ember-source-channel-url@^1.0.1, ember-source-channe
   dependencies:
     got "^8.0.1"
 
-ember-source@*:
+ember-source@*, ember-source@~3.9.0:
   version "3.9.0"
   resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.9.0.tgz#cab72c07c30d8313e1cae3ef9a68c0a3d7d1b7de"
   integrity sha512-VHeovle0+ZBnIbEcuNcIl1+HfActbplkJBMcaXAj/sCp46ayNPHB0zl+0ix74j+MOTiu8GEXZ6GHaqgwGmhvMw==
@@ -5296,26 +5296,6 @@ ember-source@*:
     inflection "^1.12.0"
     jquery "^3.3.1"
     resolve "^1.10.0"
-
-ember-source@~3.8.0:
-  version "3.8.1"
-  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.8.1.tgz#cd4522df4933decdc0b71db7ef6dc13751185838"
-  integrity sha512-dzz2i2XUY+yqxVIoV8V0B6lIGjtWVJLHtsid2MkDfaJl2GRcsioYVmv20Elyhny0oGBRJY8ESbODULkKoY9Urw==
-  dependencies:
-    broccoli-funnel "^2.0.1"
-    broccoli-merge-trees "^3.0.2"
-    chalk "^2.3.0"
-    ember-cli-babel "^7.2.0"
-    ember-cli-get-component-path-option "^1.0.0"
-    ember-cli-is-package-missing "^1.0.0"
-    ember-cli-normalize-entity-name "^1.0.0"
-    ember-cli-path-utils "^1.0.0"
-    ember-cli-string-utils "^1.1.0"
-    ember-cli-version-checker "^2.1.0"
-    ember-router-generator "^1.2.3"
-    inflection "^1.12.0"
-    jquery "^3.3.1"
-    resolve "^1.9.0"
 
 ember-try-config@^3.0.0:
   version "3.0.0"
@@ -10235,7 +10215,7 @@ resolve@1.9.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1, resolve@^1.9.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1:
   version "1.10.0"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==


### PR DESCRIPTION
* prepare for release
* update ember-source
* filter out dependabot
* dependabot has a user and a bot :scream:
* changelog should include labeled commits
* Release Ember Data 3.9.0
* bump version
