### PR TITLE
ember-fetch fastboot passthrough

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const version = require('./lib/version');
 const { isInstrumentedBuild } = require('./lib/cli-flags');
 const BroccoliDebug = require('broccoli-debug');
 const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
+const resolve = require('resolve');
 
 function isProductionEnv() {
   let isProd = /production/.test(process.env.EMBER_ENV);
@@ -67,6 +68,19 @@ module.exports = {
 
   blueprintsPath() {
     return path.join(__dirname, 'blueprints');
+  },
+
+  updateFastBootManifest(manifest) {
+    manifest.vendorFiles.push('ember-data/fetch-fastboot.js');
+    return manifest;
+  },
+
+  treeForPublic() {
+    let fetchPath = resolve.sync('ember-fetch');
+
+    return new Funnel(path.join(path.dirname(fetchPath), 'public'), {
+      destDir: 'ember-data',
+    });
   },
 
   treeForAddon(tree) {

--- a/package.json
+++ b/package.json
@@ -133,6 +133,11 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "fastbootDependencies": [
+      "node-fetch",
+      "abortcontroller-polyfill",
+      "abortcontroller-polyfill/dist/cjs-ponyfill"
+    ]
   }
 }


### PR DESCRIPTION
This is an attempt to fix the issue with fastboot on newly generated ember apps on version 3.9.0

We have discussed this solution at length in the #fastboot channel on the Ember Community Discord and this was one of the quicker ways to fix the issue and the one that required the least amount of up-front work.

Essentially the problem arises from the fact that ember-cli-fastboot should be walking the tree of addons and finding all addons that add things to the manifest using `updateFastBootManifest()` but it currently does not 😞 

As ember-data has now added ember-fetch as a dependency, we need to include the manifest information from ember-fetch for any app that uses ember-data to be able to use fastboot.

If my explanation of this doesn't seem right please feel free to correct me 😂 

Fixes https://github.com/emberjs/data/issues/5998
Fixes https://github.com/ember-fastboot/ember-cli-fastboot/issues/682
