### PR TITLE
[FIX recordArrayManager] removes an extraneous flush

### DIFF
--- a/packages/store/addon/-private/system/record-array-manager.js
+++ b/packages/store/addon/-private/system/record-array-manager.js
@@ -119,7 +119,7 @@ export default class RecordArrayManager {
 
     if (hasPendingChanges) {
       this._flushPendingInternalModelsForModelName(modelName, pending);
-      delete pending[modelName];
+      delete this._pending[modelName];
     }
 
     let internalModels = this._visibleInternalModelsByType(modelName);


### PR DESCRIPTION
Perf 🔥 🔥 🔥 

Previously we were failing to clear the scheduled flush because we were trying to delete the wrong thing, which led to us having a double flush in a large number of common scenarios.