### PR TITLE
[CHORE] Fix the computed-property.override deprecation

### DIFF
--- a/packages/store/addon/-private/system/model/errors.js
+++ b/packages/store/addon/-private/system/model/errors.js
@@ -1,7 +1,7 @@
 import { mapBy, not } from '@ember/object/computed';
 import Evented from '@ember/object/evented';
 import ArrayProxy from '@ember/array/proxy';
-import { set, get, computed } from '@ember/object';
+import { get, computed } from '@ember/object';
 import { makeArray, A } from '@ember/array';
 
 /**
@@ -320,7 +320,7 @@ export default ArrayProxy.extend(Evented, {
     }
 
     let content = this.rejectBy('attribute', attribute);
-    set(this, 'content', content);
+    get(this, 'content').setObjects(content);
     get(this, 'errorsByAttributeName').delete(attribute);
 
     this.notifyPropertyChange(attribute);


### PR DESCRIPTION
Deprecation id: computed-property.override
https://deprecations.emberjs.com/v3.x/#toc_computed-property-override

This PR doesn't change [the actual computed property](https://github.com/CvX/data/blob/713d640e6d5395da7ff654f246b0969595e98f4a/packages/store/addon/-private/system/model/errors.js#L151-L158), but maybe it would be a good idea to modify that instead, since it is effectively used just as a kind of a lazy initialized property?

A possible alternative to this PR:

```diff
  /**
    @property content
    @type {Array}
    @private
  */
-  content: computed(function() {
-    return A();
-  }),
+  get content() {
+    let _content = get(this, '_content');
+
+    if (_content) {
+      return _content;
+    }
+
+    return set(this, '_content', A());
+  },
+
+  set content(value) {
+    return set(this, '_content', value);
+  },
```