### PR TITLE
Pass options in finders#_query even if createRecordArray is falsy

### DIFF
--- a/addon/-private/system/store/finders.js
+++ b/addon/-private/system/store/finders.js
@@ -225,12 +225,11 @@ export function _query(adapter, store, modelName, query, recordArray, options) {
   if (createRecordArray) {
     recordArray =
       recordArray || store.recordArrayManager.createAdapterPopulatedRecordArray(modelName, query);
-    promise = Promise.resolve().then(() =>
-      adapter.query(store, modelClass, query, recordArray, options)
-    );
-  } else {
-    promise = Promise.resolve().then(() => adapter.query(store, modelClass, query));
   }
+
+  promise = Promise.resolve().then(() =>
+    adapter.query(store, modelClass, query, recordArray, options)
+  );
 
   let label = `DS: Handle Adapter#query of ${modelName}`;
   promise = guardDestroyedStore(promise, store, label);


### PR DESCRIPTION
Currently if `adapterOptions` are passed to store.query they are ignored if `createRecordArray` is falsy.
    
To prevent this we also pass the options to `adapter.query` if `createRecordArray` is falsy.