### PR TITLE
[DOC contributing.md] | Clarifying that yarn should be used to run tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ the issue being fixed and test that the solution works.
 
 - PRs will automatically run an extensive set of test scenarios for your work
 - `ember-data` is an `ember-addon` and uses `ember-cli`. To run tests locally
-  use `ember test` or `ember test --serve`. For additional test commands see the list
+  use `yarn test` or `yarn test --serve`. For additional test commands see the list
   of commands in [./package.json](./package.json)
 
 #### Commit Tagging


### PR DESCRIPTION
Contributing currently says to use `ember test`, but that results in `No ember-cli-build.js found.`.
The correct command is `yarn test`.