### PR TITLE
Add paranthesis to the Octane attr decorator when there is no data type

### DIFF
--- a/packages/-ember-data/blueprints/model/index.js
+++ b/packages/-ember-data/blueprints/model/index.js
@@ -142,7 +142,7 @@ function nativeAttr(attr) {
       result = "@hasMany('" + name + "')";
     }
   } else if (type === '') {
-    result = '@attr';
+    result = '@attr()';
   } else {
     result = "@attr('" + type + "')";
   }

--- a/packages/-ember-data/node-tests/blueprints/model-test.js
+++ b/packages/-ember-data/node-tests/blueprints/model-test.js
@@ -397,7 +397,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
             .to.contain("import DS from 'ember-data';")
             .to.contain('const { Model, attr } = DS;')
             .to.contain('export default class FooModel extends Model {')
-            .to.contain('  @attr misc;')
+            .to.contain('  @attr() misc;')
             .to.contain("  @attr('array') skills;")
             .to.contain("  @attr('boolean') isActive;")
             .to.contain("  @attr('date') birthday;")


### PR DESCRIPTION
Addresses issue https://github.com/emberjs/data/issues/5937

I suspect this may not be how you want to fix this problem - as otherwise you'd have done it by now. However, it just cost me an hour or so stepping through the code wondering what was going on, which not everyone is going to do.  Seems better to 'fix' the blueprint, and then go back to remove the parentheses if ED is updated to detect the `@attr` without them.
