### PR TITLE
[BUGFIX defaultValue] return null instead of undefined

### DIFF
--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -483,6 +483,17 @@ module('unit/model - Model', function(hooks) {
         get(tag, 'tagInfo');
       }, /Non primitive defaultValues are not supported/);
     });
+
+    test('return `null` when a defaultValue is not defined', async function(assert) {
+      class Person extends Model {
+        @attr('string')
+        name;
+      }
+      this.owner.register('model:person', Person);
+
+      let person = store.createRecord('person');
+      assert.strictEqual(get(person, 'name'), null, 'the defaultValue is null if not defined');
+    });
   });
 
   module('Attribute Transforms', function() {

--- a/packages/model/addon/-private/attr.js
+++ b/packages/model/addon/-private/attr.js
@@ -12,6 +12,10 @@ function getDefaultValue(record, options, key) {
     return options.defaultValue.apply(null, arguments);
   } else {
     let defaultValue = options.defaultValue;
+    if (defaultValue === undefined) {
+      defaultValue = null;
+    }
+
     assert(
       `Non primitive defaultValues are not supported because they are shared between all instances. If you would like to use a complex object as a default value please provide a function that returns the complex object.`,
       typeof defaultValue !== 'object' || defaultValue === null


### PR DESCRIPTION
I have a model with the following definition:
```
class Person extends DS.Model {
  @DS.attr("string")
  name
}
```

When fetching a record via API, the `name` attribute is set to `null` if it doesn't have any value.
However when creating a new record, `const person = store.createRecord("person")`, the `name` attribute is `undefined` making it inconsistent with type checking.