### PR TITLE
Update 'navigator.connection'

### DIFF
--- a/packages/adapter/addon/adapter.js
+++ b/packages/adapter/addon/adapter.js
@@ -614,13 +614,9 @@ export default EmberObject.extend({
 
     ```javascript
     shouldBackgroundReloadRecord(store, snapshot) {
-      let connection = window.navigator.connection;
+      let { downlink, effectiveType } = navigator.connection;
 
-      if (connection === 'cellular' || connection === 'none') {
-        return false;
-      } else {
-        return true;
-      }
+      return downlink > 0 && effectiveType === '4g';
     }
     ```
 
@@ -654,13 +650,9 @@ export default EmberObject.extend({
 
     ```javascript
     shouldBackgroundReloadAll(store, snapshotArray) {
-      let connection = window.navigator.connection;
+      let { downlink, effectiveType } = navigator.connection;
 
-      if (connection === 'cellular' || connection === 'none') {
-        return false;
-      } else {
-        return true;
-      }
+      return downlink > 0 && effectiveType === '4g';
     }
     ```
 


### PR DESCRIPTION
Chrome supports `navigator.connection` partially but the current example is not according to what's currently implemented or even to specifications: http://wicg.github.io/netinfo

Update the example (to use http://wicg.github.io/netinfo/#dfn-effective-connection-type) to enable reload only when there's connectivity (`downlink > 0`) and when the connection is `4g` (not `slow-2g`, `2g` or `3g`).