### PR TITLE
[BUGFIX release] Fixing adapter "Accept" header overwriting issue.

### DIFF
--- a/packages/-ember-data/tests/unit/adapters/json-api-adapter/ajax-test.js
+++ b/packages/-ember-data/tests/unit/adapters/json-api-adapter/ajax-test.js
@@ -84,3 +84,22 @@ test('ajaxOptions() adds Accept header to existing computed properties headers',
     'headers assigned'
   );
 });
+
+test('ajaxOptions() does not overwrite Accept header if it is provided', function(assert) {
+  let url = 'example.com';
+  let type = 'GET';
+  adapter.headers = { Accept: 'application/json' };
+  let ajaxOptions = adapter.ajaxOptions(url, type, {});
+  let receivedHeaders = [];
+  let fakeXHR = {
+    setRequestHeader(key, value) {
+      receivedHeaders.push([key, value]);
+    },
+  };
+  ajaxOptions.beforeSend(fakeXHR);
+  assert.deepEqual(
+    alphabetize(receivedHeaders),
+    [['Accept', 'application/json']],
+    'Accept header is not overwritten'
+  );
+});

--- a/packages/-ember-data/tests/unit/adapters/json-api-adapter/fetch-test.js
+++ b/packages/-ember-data/tests/unit/adapters/json-api-adapter/fetch-test.js
@@ -73,3 +73,20 @@ test('ajaxOptions() adds Accept header to existing computed properties headers',
     'headers assigned'
   );
 });
+
+test('ajaxOptions() does not overwrite passed value of Accept headers', function(assert) {
+  adapter.headers = { 'Other-Key': 'Other Value', Accept: 'application/json' };
+  let url = 'example.com';
+  let type = 'GET';
+  let ajaxOptions = adapter.ajaxOptions(url, type, {});
+  let receivedHeaders = ajaxOptions.headers;
+
+  assert.deepEqual(
+    receivedHeaders,
+    {
+      Accept: 'application/json',
+      'Other-Key': 'Other Value',
+    },
+    'headers assigned, Accept header not overwritten'
+  );
+});

--- a/packages/adapter/addon/json-api.js
+++ b/packages/adapter/addon/json-api.js
@@ -153,10 +153,11 @@ const JSONAPIAdapter = RESTAdapter.extend({
     @return {Object}
   */
   ajaxOptions(url, type, options = {}) {
-    options.contentType = 'application/vnd.api+json';
+    options.contentType = options.contentType || 'application/vnd.api+json';
 
     let hash = this._super(url, type, options);
-    hash.headers['Accept'] = 'application/vnd.api+json';
+    hash.headers['Accept'] = hash.headers['Accept'] || 'application/vnd.api+json';
+
     return hash;
   },
 


### PR DESCRIPTION
Fixing the bug that caused overwriting of "Accept" header in "ajaxOptions" method of the adapter. This is for addressing the issue #6058 

Change description:

1. Updated the code in "packages\adapter\addon\json-api.js". If the input hash contains value for "Accept" header, it should not be overwritten by the default "application/vnd.api+json" string.

2. Added unit tests for checking this flow.

Fixes https://github.com/emberjs/data/issues/6058