### PR TITLE
[FEAT serializers] clean up packages organization

### DIFF
--- a/packages/-ember-data/addon/setup-container.js
+++ b/packages/-ember-data/addon/setup-container.js
@@ -22,6 +22,8 @@ function hasRegistration(application, registrationName) {
  @param {Ember.Registry} registry
  */
 function initializeStore(application) {
+  // we can just use registerOptionsForType when setupStore is killed
+  // see https://github.com/emberjs/data/issues/6357
   let registerOptionsForType = application.registerOptionsForType || application.optionsForType;
   registerOptionsForType.call(application, 'serializer', { singleton: false });
   registerOptionsForType.call(application, 'adapter', { singleton: false });

--- a/packages/-ember-data/addon/setup-container.js
+++ b/packages/-ember-data/addon/setup-container.js
@@ -4,7 +4,8 @@ import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
 function hasRegistration(application, registrationName) {
   // fallback our ember-data tests necessary
-  // until we kill-off createStore/setupStore
+  // until we kill-off setupStore
+  // see https://github.com/emberjs/data/issues/6357
   // or @ember/test-helpers kills off it's
   // legacy support that calls our initializer with registry
   // instead of application

--- a/packages/-ember-data/addon/setup-container.js
+++ b/packages/-ember-data/addon/setup-container.js
@@ -8,7 +8,7 @@ function hasRegistration(application, registrationName) {
   // or @ember/test-helpers kills off it's
   // legacy support that calls our initializer with registry
   // instead of application
-  if (!application.hasRegistration) {
+  if (typeof application.hasRegistration !== 'function') {
     return application.has(registrationName);
   }
   return application.hasRegistration(registrationName);

--- a/packages/-ember-data/app/serializers/-default.ts
+++ b/packages/-ember-data/app/serializers/-default.ts
@@ -1,0 +1,1 @@
+export { default } from '@ember-data/serializer/json';

--- a/packages/-ember-data/app/serializers/-json-api.ts
+++ b/packages/-ember-data/app/serializers/-json-api.ts
@@ -1,0 +1,1 @@
+export { default } from '@ember-data/serializer/json-api';

--- a/packages/-ember-data/app/serializers/-rest.ts
+++ b/packages/-ember-data/app/serializers/-rest.ts
@@ -1,0 +1,1 @@
+export { default } from '@ember-data/serializer/rest';

--- a/packages/-ember-data/app/transforms/boolean.ts
+++ b/packages/-ember-data/app/transforms/boolean.ts
@@ -1,0 +1,1 @@
+export { BooleanTransform as default } from '@ember-data/serializer/-private';

--- a/packages/-ember-data/app/transforms/date.ts
+++ b/packages/-ember-data/app/transforms/date.ts
@@ -1,0 +1,1 @@
+export { DateTransform as default } from '@ember-data/serializer/-private';

--- a/packages/-ember-data/app/transforms/number.ts
+++ b/packages/-ember-data/app/transforms/number.ts
@@ -1,0 +1,1 @@
+export { NumberTransform as default } from '@ember-data/serializer/-private';

--- a/packages/-ember-data/app/transforms/string.ts
+++ b/packages/-ember-data/app/transforms/string.ts
@@ -1,0 +1,1 @@
+export { StringTransform as default } from '@ember-data/serializer/-private';

--- a/packages/-ember-data/tests/helpers/store.js
+++ b/packages/-ember-data/tests/helpers/store.js
@@ -8,6 +8,7 @@ import JSONAPISerializer from '@ember-data/serializer/json-api';
 import RESTSerializer from '@ember-data/serializer/rest';
 import config from '../../config/environment';
 import Resolver from '../../resolver';
+import { StringTransform, DateTransform, NumberTransform, BooleanTransform } from '@ember-data/serializer/-private';
 
 const { _RegistryProxyMixin, _ContainerProxyMixin, Registry } = Ember;
 
@@ -68,6 +69,12 @@ export default function setupStore(options) {
     registry.register('model:' + dasherize(prop), options[prop]);
   }
 
+  // avoid the deprecation for auto-registration of transforms for our helper
+  registry.register('transform:string', StringTransform);
+  registry.register('transform:date', DateTransform);
+  registry.register('transform:number', NumberTransform);
+  registry.register('transform:boolean', BooleanTransform);
+
   registry.optionsForType('serializer', { singleton: false });
   registry.optionsForType('adapter', { singleton: false });
 
@@ -86,6 +93,10 @@ export default function setupStore(options) {
     env.registry.register('serializer:application', options.serializer);
     env.serializer = store.serializerFor('application');
   } else {
+    // avoid deprecations for -json-api serializer in our tests
+    // uncomment to find locations to refactor to explicit registration
+    owner.register('serializer:-json-api', JSONAPISerializer);
+
     // Many tests rely on falling back to this serializer
     // they should refactor to register this as the application serializer
     owner.register('serializer:-default', JSONAPISerializer);

--- a/packages/-ember-data/tests/integration/store/serializer-for-test.js
+++ b/packages/-ember-data/tests/integration/store/serializer-for-test.js
@@ -42,10 +42,16 @@ module('integration/store - serializerFor', function(hooks) {
     let { owner } = this;
     /*
       serializer:-default is the "last chance" fallback and is
-      registered automatically as the json-api serializer.
-      unregistering it will cause serializerFor to return `undefined`.
+      the json-api serializer which is re-exported as app/serializers/-default.
+      here we override to ensure serializerFor will return `undefined`.
      */
-    owner.unregister('serializer:-default');
+    const lookup = owner.lookup;
+    owner.lookup = registrationName => {
+      if (registrationName === 'serializer:-default') {
+        return undefined;
+      }
+      return lookup.call(owner, registrationName);
+    };
     /*
       we fallback to -json-api adapter by default when no other adapter is present.
       This adapter specifies a defaultSerializer. We register our own to ensure
@@ -64,7 +70,7 @@ module('integration/store - serializerFor', function(hooks) {
 
     assert.expectAssertion(() => {
       store.serializerFor('person');
-    }, /No serializer was found for 'person' and no 'application', Adapter\.defaultSerializer, or '-default' serializer were found as fallbacks\./);
+    }, /Assertion Failed: No serializer was found for 'person' and no 'application' serializer was found as a fallback/);
   });
 
   test('we find and instantiate the application serializer', async function(assert) {

--- a/packages/-ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/-ember-data/tests/unit/store/adapter-interop-test.js
@@ -7,12 +7,14 @@ import setupStore from 'dummy/tests/helpers/store';
 
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { module, test } from 'qunit';
-
 import DS from 'ember-data';
+import { setupTest } from 'ember-qunit';
 
 let TestAdapter, store;
 
 module('unit/store/adapter-interop - DS.Store working with a DS.Adapter', function(hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function() {
     TestAdapter = DS.Adapter.extend();
   });
@@ -43,9 +45,14 @@ module('unit/store/adapter-interop - DS.Store working with a DS.Adapter', functi
   testInDebug('Adapter can not be set as an instance', function(assert) {
     assert.expect(1);
 
-    store = DS.Store.create({
+    const BadStore = DS.Store.extend({
       adapter: DS.Adapter.create(),
     });
+    const { owner } = this;
+
+    owner.unregister('service:store');
+    owner.register('service:store', BadStore);
+    const store = owner.lookup('service:store');
     assert.expectAssertion(() => store.get('defaultAdapter'));
   });
 

--- a/packages/adapter/types/require/index.d.ts
+++ b/packages/adapter/types/require/index.d.ts
@@ -1,0 +1,1 @@
+export default function(moduleName: string): any;

--- a/packages/serializer/tsconfig.json
+++ b/packages/serializer/tsconfig.json
@@ -19,20 +19,16 @@
       "dummy/*": ["tests/dummy/app/*", "app/*"],
       "@ember-data/serializer": ["addon"],
       "@ember-data/serializer/*": ["addon/*"],
+      "@ember-data/store": ["../store/addon"],
+      "@ember-data/store/*": ["../store/addon/*"],
+      "@ember-data/canary-features": ["../canary-features/addon"],
+      "@ember-data/adapter": ["../adapter/addon"],
+      "@ember-data/adapter/*": ["../adapter/addon/*"],
       "@ember-data/serializer/test-support": ["addon-test-support"],
       "@ember-data/serializer/test-support/*": ["addon-test-support/*"],
-      "ember-data": ["../-ember-data/addon"],
-      "ember-data/*": ["../-ember-data/addon/*"],
       "*": ["types/*"]
     }
   },
-  "include": [
-    "app/**/*",
-    "addon/**/*",
-    "tests/**/*",
-    "types/**/*",
-    "test-support/**/*",
-    "addon-test-support/**/*"
-  ],
+  "include": ["app/**/*", "addon/**/*", "tests/**/*", "types/**/*", "test-support/**/*", "addon-test-support/**/*"],
   "exclude": ["node_modules"]
 }

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -3321,10 +3321,6 @@ abstract class CoreStore extends Service {
       `No serializer was found for '${modelName}' and no 'application' serializer was found as a fallback`,
       serializer !== undefined
     );
-    deprecate(`Usage of the '-default' serializer is deprecated.`, false, {
-      id: 'ember-data:default-serializer-fallback',
-      until: '3.12.0',
-    });
 
     set(serializer, 'store', this);
     _serializerCache[normalizedModelName] = serializer;

--- a/packages/store/addon/-private/system/store/serializers.js
+++ b/packages/store/addon/-private/system/store/serializers.js
@@ -9,13 +9,5 @@ export function serializerForAdapter(store, adapter, modelName) {
     serializer = store.serializerFor(modelName);
   }
 
-  if (serializer === null || serializer === undefined) {
-    serializer = {
-      extract(store, type, payload) {
-        return payload;
-      },
-    };
-  }
-
   return serializer;
 }

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -13,6 +13,7 @@ module.exports = Object.assign(addonBaseConfig, {
       'ember-inflector',
       '@ember/ordered-set',
       'ember-data/-debug',
+      'require',
     ];
   },
 });

--- a/packages/store/types/require/index.d.ts
+++ b/packages/store/types/require/index.d.ts
@@ -1,1 +1,3 @@
 export default function(moduleName: string): any;
+
+export function has(moduleName: string): boolean;

--- a/packages/store/types/require/index.d.ts
+++ b/packages/store/types/require/index.d.ts
@@ -1,0 +1,1 @@
+export default function(moduleName: string): any;


### PR DESCRIPTION
**Default Serializers**

Previously several `-json` and `-defaults` serializers corresponding to the `JSONSerializer` and `JSONAPISerializer` were added to applications via `inject`. These are now added via a re-export in the `app/` directory, making them overrideable and easier to drop.

**Transforms**

The RFC for packages intentionally did not provide import paths for the transforms we provide (`date`, `number` `boolean` `string`). A more ideal location for these transforms would be for them to exist in the `app/transforms` directory as overridable defaults; however, in order to continue supporting the legacy import locations in the `ember-data` package they continue to live in`@ember-data/serializer/-private` from whence they are re-exported.

Once the deprecation lifecycle is complete for pre-package import locations this code could be moved into the `app/` directory.