### PR TITLE
[CHORE] Use env variables instead of command flags

### DIFF
--- a/packages/-build-infra/src/cli-flags.js
+++ b/packages/-build-infra/src/cli-flags.js
@@ -9,19 +9,14 @@ function wantsEnabledFeatures() {
 }
 
 function getManuallyEnabledFeatures() {
-  let args = process.argv;
   let enabled = {};
-  let ARG = '--enable-in-progress-flag';
+  let ARGS = process.env.ENABLE_IN_PROGRESS;
 
-  for (let i = 0; i < args.length; i++) {
-    if (args[i].indexOf(ARG) === 0) {
-      let toEnable = args[i].substr(ARG.length + 1).split(',');
-      toEnable.forEach(function(flag) {
-        enabled[flag] = true;
-      });
-      break;
+  ARGS.split(',').forEach(function(flag) {
+    if (flag.length > 0) {
+      enabled[flag] = true;
     }
-  }
+  });
 
   return enabled;
 }

--- a/packages/-build-infra/src/cli-flags.js
+++ b/packages/-build-infra/src/cli-flags.js
@@ -12,11 +12,11 @@ function getManuallyEnabledFeatures() {
   let enabled = {};
   let ARGS = process.env.ENABLE_IN_PROGRESS;
 
-  ARGS.split(',').forEach(function(flag) {
-    if (flag.length > 0) {
+  if (ARGS) {
+    ARGS.split(',').forEach(function(flag) {
       enabled[flag] = true;
-    }
-  });
+    });
+  }
 
   return enabled;
 }

--- a/packages/-build-infra/src/cli-flags.js
+++ b/packages/-build-infra/src/cli-flags.js
@@ -1,11 +1,11 @@
 'use strict';
 
 function isInstrumentedBuild() {
-  return process.argv.includes('--instrument');
+  return process.env.INSTRUMENT;
 }
 
 function wantsEnabledFeatures() {
-  return process.argv.includes('--enable-in-progress');
+  return process.env.ENABLE_IN_PROGRESS;
 }
 
 function getManuallyEnabledFeatures() {


### PR DESCRIPTION
Works on https://github.com/emberjs/data/issues/6009

Moves away from using command flags when building eg

`yarn build --instrument` to `INSTRUMENT=true yarn build` and `ENABLE_IN_PROGRESS=true yarn build`
