### PR TITLE
[BUGFIX release] Fix rollup warnings for require as an external module.

### DIFF
--- a/packages/-ember-data/index.js
+++ b/packages/-ember-data/index.js
@@ -126,6 +126,7 @@ module.exports = Object.assign(addonBaseConfig, {
           'ember-data/-debug',
           'ember-data/adapters/errors',
           '@ember/ordered-set',
+          'require',
         ],
         onwarn: this._suppressCircularDependencyWarnings,
         // cache: true|false Defaults to true


### PR DESCRIPTION
Fixes issue mentioned by @turbo87 in https://github.com/emberjs/data/pull/6077#issuecomment-490006581