### PR TITLE
[BUGFIX release] Fix fetch detection in FastBoot.

### DIFF
--- a/addon/adapters/rest.js
+++ b/addon/adapters/rest.js
@@ -31,7 +31,8 @@ import { warn } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 
 const Promise = EmberPromise;
-const jQ = typeof jQuery !== 'undefined' ? jQuery : undefined;
+const hasJQuery = typeof jQuery !== 'undefined';
+const hasNajax = typeof najax !== 'undefined';
 
 /**
   The REST adapter allows your store to communicate with an HTTP server by
@@ -303,9 +304,17 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
 
   useFetch: computed(function() {
     let ENV = getOwner(this).resolveRegistration('config:environment');
-    let shouldUseFetch = (ENV && ENV._JQUERY_INTEGRATION) === false || jQ === undefined;
+    // TODO: migrate to static build time detection ala https://github.com/embroider-build/embroider/issues/162
+    let jQueryIntegrationDisabled =
+      ENV && ENV.EmberENV && ENV.EmberENV._JQUERY_INTEGRATION === false;
 
-    return shouldUseFetch;
+    if (jQueryIntegrationDisabled) {
+      return true;
+    } else if (hasNajax || hasJQuery) {
+      return false;
+    } else {
+      return true;
+    }
   }),
 
   /**
@@ -1041,7 +1050,7 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
     @param {Object} options jQuery ajax options to be used for the ajax request
   */
   _ajaxRequest(options) {
-    jQ.ajax(options);
+    jQuery.ajax(options);
   },
 
   /**
@@ -1050,7 +1059,7 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
     @param {Object} options jQuery ajax options to be used for the najax request
   */
   _najaxRequest(options) {
-    if (typeof najax !== 'undefined') {
+    if (hasNajax) {
       najax(options);
     } else {
       throw new Error(


### PR DESCRIPTION
The prior detection of when to use fetch vs when to use jQuery was not properly accounting for the `fastboot` case when `ember-fetch` is not present and a `fetch` global is not present. In that scenario, `najax` would be present (provided by `fastboot` itself).

We already had the correct logic in `_ajax`, however the `useFetch` computed was returning `true` which prevented the `najax` supported branch from being used.