### PR TITLE
[FEAT] Adding eslint-plugin-qunit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module',
   },
-  plugins: ['prettier'],
+  plugins: ['prettier', 'qunit'],
   extends: ['eslint:recommended', 'prettier'],
   rules: {
     'prettier/prettier': 'error',

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
       if: NOT tag IS present AND NOT (branch ~= /^(emberjs:release|emberjs:lts|release|lts).*/)
       script:
         - yarn lint:features
-        - yarn lint:js
+        - yarn lint:prettier
     - name: 'Basic Tests'
       script: yarn test
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       - script: |
           yarn
           yarn lint:features
-          yarn lint:js
+          yarn lint:prettier
     displayName: 'Lint'
 
   - job: Basic_Ember_Data_tests

--- a/bin/lint-js
+++ b/bin/lint-js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+const ESLINT = '.eslintrc.js';
+const fs = require('fs');
+const path = require('path');
+const { shellSync } = require('execa');
+const projectRoot = path.resolve(__dirname, '../');
+const eslintPath = path.join(projectRoot, ESLINT);
+const eslintInfo = require(eslintPath);
+const tmpEslint = path.join(projectRoot, 'tmp', ESLINT);
+
+function unlinkTemp() {
+  if (fs.existsSync(tmpEslint)) {
+    fs.unlinkSync(tmpEslint);
+  }
+}
+
+// grab only the staged files
+let LIST = shellSync('git diff-index --cached --diff-filter=d --name-only HEAD').stdout;
+
+if (LIST) {
+  LIST = LIST.split(/\r?\n/);
+  // filter for javascript
+  LIST = LIST.filter(item => item.match(/^[^.].*\.js$/)).join();
+  console.log("LIST LENGTH", LIST.length)
+  if (LIST) {
+    try {
+      //update eslint config to include qunit
+      eslintInfo.extends.push('plugin:qunit/recommended');
+      fs.writeFileSync(tmpEslint, `module.exports = ${JSON.stringify(eslintInfo)}`);
+      // execut the linter with additional qunit rules
+      shellSync(`yarn eslint --config ${tmpEslint} ${LIST}`, { stdio: 'inherit' });
+    } catch (e) {
+      unlinkTemp();
+      process.exit(1);
+    }
+  }
+}
+unlinkTemp();
+process.exit();

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "workspaces": [
     "packages/*"
   ],
+  "pre-commit": [
+    "lint:js"
+  ],
   "scripts": {
     "build": "yarn workspace ember-data build",
     "build:production": "yarn workspace ember-data build:production",
-    "lint:js": "eslint .",
+    "lint:js": "./bin/lint-js",
+    "lint:prettier": "eslint --plugin prettier .",
     "lint:features": "./bin/lint-features",
     "start": "yarn workspace ember-data start",
     "test": "yarn workspace ember-data test",
@@ -45,8 +49,11 @@
     "broccoli-string-replace": "^0.1.2",
     "broccoli-test-helper": "^2.0.0",
     "broccoli-uglify-sourcemap": "^3.0.0",
+    "chalk": "^2.4.1",
     "co": "^4.6.0",
+    "command-line-args": "^5.1.1",
     "common-tags": "^1.8.0",
+    "debug": "^4.1.1",
     "ember-cli": "^3.9.0",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
@@ -77,6 +84,7 @@
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-qunit": "^4.0.0",
     "execa": "^1.0.0",
     "github": "^1.1.1",
     "glob": "^7.1.4",
@@ -85,18 +93,17 @@
     "loader.js": "^4.7.0",
     "mocha": "^6.1.2",
     "mocha-only-detector": "1.0.1",
+    "pre-commit": "^1.2.2",
     "prettier": "^1.15.3",
     "rimraf": "^2.6.2",
     "rsvp": "^4.8.4",
-    "typescript": "~3.4.3",
-    "chalk": "^2.4.1",
-    "debug": "^4.1.1",
     "semver": "^6.0.0",
-    "command-line-args": "^5.1.1"
+    "typescript": "~3.4.3"
   },
   "bin": {
     "test-partner-project": "./bin/test-external-partner-project.js",
     "prepare-local-packages": "./bin/packages-for-commit.js",
     "publish": "./bin/publish.js"
-  }
+  },
+  "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3951,7 +3951,7 @@ concat-map@0.0.1:
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0:
+concat-stream@^1.4.7, concat-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -4214,6 +4214,15 @@ create-error-class@^3.0.0:
   integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
   dependencies:
     capture-stack-trace "^1.0.0"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -5311,6 +5320,11 @@ eslint-plugin-prettier@^3.1.0:
   integrity sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-qunit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-4.0.0.tgz#5945ba3434bfe8879bea195192e906701051cf01"
+  integrity sha512-+0i2xcYryUoLawi47Lp0iJKzkP931G5GXwIOq1KBKQc2pknV1VPjfE6b4mI2mR2RnL7WRoS30YjwC9SjQgJDXQ==
 
 eslint-scope@3.7.1:
   version "3.7.1"
@@ -8003,7 +8017,7 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-lru-cache@^4.1.2, lru-cache@^4.1.3:
+lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
   version "4.1.5"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -8882,6 +8896,11 @@ os-name@^3.0.0:
     macos-release "^2.2.0"
     windows-release "^3.1.0"
 
+os-shim@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
+  integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
+
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -9259,6 +9278,15 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+pre-commit@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
+  integrity sha1-287g7p3nI15X95xW186UZBpp7sY=
+  dependencies:
+    cross-spawn "^5.0.1"
+    spawn-sync "^1.0.15"
+    which "1.2.x"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -10452,6 +10480,14 @@ spawn-args@^0.2.0:
   resolved "https://registry.npmjs.org/spawn-args/-/spawn-args-0.2.0.tgz#fb7d0bd1d70fd4316bd9e3dec389e65f9d6361bb"
   integrity sha1-+30L0dcP1DFr2ePew4nmX51jYbs=
 
+spawn-sync@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
+  integrity sha1-sAeZVX63+wyDdsKdROih6mfldHY=
+  dependencies:
+    concat-stream "^1.4.7"
+    os-shim "^0.1.2"
+
 spdx-correct@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
@@ -11447,6 +11483,13 @@ which@1, which@1.3.1, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@1.2.x:
+  version "1.2.14"
+  resolved "https://registry.npmjs.org/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  integrity sha1-mofEN48D6CfOyvGs31bHNsAcFOU=
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
This addresses #6090 by adding the eslint plugin. Event though the actual lint rule doesn't enforce having a label for assertions (https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/assert-args.md) I feel like this could still be worthwhile to have.

