### PR TITLE
Update Azure Pipelines config to match Travis config

### DIFF
--- a/.azure/basic-tests.yml
+++ b/.azure/basic-tests.yml
@@ -1,0 +1,39 @@
+parameters:
+  nodeVersion: '10.x'
+  useLockfile: true
+
+steps:
+  - template: 'setup-environment.yml'
+
+  - ${{ if not(eq(parameters.useLockfile, 'false')) }}:
+    - script: yarn install --non-interactive
+      displayName: 'Yarn install'
+
+  - ${{ if eq(parameters.useLockfile, 'false') }}:
+    - script: yarn install --no-lockfile --non-interactive
+      displayName: 'Yarn install --no-lockfile'
+
+  - script: yarn test
+    displayName: 'Basic tests'
+
+  - script: yarn test:production
+    displayName: 'Production'
+
+  - script: yarn test:encapsulation
+    displayName: 'Encapsulation Tests'
+
+  - script: yarn test:node
+    displayName: 'Node tests'
+
+  - script: yarn test:docs
+    displayName: 'Docs Tests'
+
+  - script: yarn test:enabled-in-progress-features
+    displayName: 'In progress features'
+    env:
+      EMBER_DATA_FEATURE_OVERRIDE: ENABLE_ALL_OPTIONAL
+    condition: |
+      or(
+        in(variables['Build.SourceBranchName'], 'master', 'beta'),
+        in(variables['System.PullRequest.TargetBranch'], 'master', 'beta')
+      )

--- a/.azure/external-partner-test.yml
+++ b/.azure/external-partner-test.yml
@@ -1,0 +1,23 @@
+parameters:
+  nodeVersion: '10.x'
+  partner: ''
+  allowedToFail: false
+
+steps:
+  - template: 'setup-environment.yml'
+
+  - script: yarn
+    displayName: 'Yarn install'
+
+  - script: node ./bin/packages-for-commit.js
+    displayName: 'Generate package tarballs'
+
+  - ${{ if eq(parameters.allowedToFail, 'true') }}:
+    - script: |
+        CI=true yarn test-external:${{ parameters.partner }}
+        exit 0
+      displayName: 'External: ${{ parameters.partner }} allowed-to-fail'
+
+  - ${{ if not(eq(parameters.allowedToFail, 'true')) }}:
+    - script: CI=true yarn test-external:${{ parameters.partner }}
+      displayName: 'External: ${{ parameters.partner }}'

--- a/.azure/setup-environment.yml
+++ b/.azure/setup-environment.yml
@@ -1,0 +1,12 @@
+parameters:
+  nodeVersion: '10.x'
+
+steps:
+  - script: brew update && brew cask install google-chrome
+    displayName: 'Install Google Chrome'
+    condition: eq(variables['Agent.OS'], 'Darwin')
+
+  - task: NodeTool@0
+    displayName: 'Install Node'
+    inputs:
+      versionSpec: ${{ parameters.nodeVersion }}

--- a/.azure/try-scenario.yml
+++ b/.azure/try-scenario.yml
@@ -1,0 +1,12 @@
+parameters:
+  installCommand: 'yarn install --non-interactive'
+  scenario: ''
+
+steps:
+  - template: 'setup-environment.yml'
+
+  - script: ${{ parameters.installCommand }}
+    displayName: 'Yarn install'
+
+  - script: yarn test:try-one ${{ parameters.scenario }}
+    displayName: 'Basic Tests with ${{ parameters.scenario }}'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,337 +2,181 @@
 # Start with a minimal pipeline that you can customize to build and deploy your code.
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
+#
+# | Type               | Master | Beta | Release | LTS  | Tags |
+# | ---                | ---    | ---  | ---     | ---  | ---  |
+# | Lint               | yes    | yes  | no      | no   | no   |
+# | Basic Tests        | yes    | yes  | yes     | yes  | no   |
+# | Build  Tests       | yes    | yes  | yes*    | yes* | no   |
+# | Windows Tests      | yes    | yes  | yes*    | yes* | no   |
+# | Floating Deps      | yes    | yes  | yes     | yes  | no   |
+# | Ember LTS Branches | yes    | yes  | yes     | yes  | no   |
+# | Release Channels   | yes    | yes  | no      | no   | no   |
+# | External Partners  | yes    | yes  | no      | no   | no   |
+#
+# * Runs but skips tests for in-progress-features
 
 trigger:
   - master
   - beta
   - release
+  - release-*
+  - lts-*
 
 jobs:
   - job: Lint
+    displayName: 'Lint'
     condition: |
       or(
         in(variables['Build.SourceBranchName'], 'master', 'beta'),
         in(variables['System.PullRequest.TargetBranch'], 'master', 'beta')
       )
-
     pool:
       vmImage: 'macOS-10.14'
-
     steps:
       - task: NodeTool@0
-        displayName: Node install
+        displayName: 'Node install'
         inputs:
           versionSpec: '10.x' # The version we're installing
-      - script: |
-          yarn
-          yarn lint:features
-      - script: |
-          yarn lint:prettier
-      - script: |
-          yarn problems
-        displayName: 'Lint'
-
-  - job: Basic_Ember_Data_tests
-    dependsOn: Lint
-    condition: or(succeeded(), eq(dependencies.Lint.result, 'Skipped'))
-
-    pool:
-      vmImage: 'macOS-10.14'
-
-    steps:
-      - task: NodeTool@0
-        displayName: Node install
-        inputs:
-          versionSpec: '10.x' # The version we're installing
-
-      - script: |
-          yarn
-          brew update
-          brew cask install google-chrome
-
-      - script: |
-          yarn test
-        displayName: 'Basic Tests'
-
-      - script: |
-          yarn test:encapsulation
-        displayName: 'Encapsulation Tests'
-
-  - job: Ember_Data_builds_tests
-    dependsOn: Basic_Ember_Data_tests
-
-    pool:
-      vmImage: 'macOS-10.14'
-
-    steps:
-      - task: NodeTool@0
-        displayName: Node install
-        inputs:
-          versionSpec: '10.x' # The version we're installing
-
-      - script: |
-          brew update
-          brew cask install google-chrome
-          yarn
-
-      - script: |
-          yarn test:enabled-in-progress-features
-        env:
-          EMBER_DATA_FEATURE_OVERRIDE: ENABLE_ALL_OPTIONAL
-          displayName: 'In progress features'
-
-      - script: |
-          yarn test:production
-        displayName: 'Production'
-
-      - script: |
-          TARGET_IE11=true yarn test
-        displayName: 'Max transpilation Tests'
-
-      - script: |
-          yarn test:node
-        displayName: 'Node Tests'
-
-      - script: |
-          yarn test:docs
-        displayName: 'Docs Tests'
-
-      - script: |
-          yarn test:try-one with-ember-fetch
-        displayName: 'Basic Tests with ember-fetch'
-
-  - job: Windows_tests
-    dependsOn: Basic_Ember_Data_tests
-
-    pool:
-      vmImage: 'windows-2019'
-
-    steps:
-      - task: NodeTool@0
-        displayName: Node install
-        inputs:
-          versionSpec: '10.x' # The version we're installing
-
-      - script: |
-          yarn
+      - script: yarn --frozen-lockfile
         displayName: 'Yarn install'
+      - script: yarn lint:features
+        displayName: 'Lint features'
+      - script: yarn lint:features
+        displayName: 'Lint prettier'
+      - script: yarn problems
+        displayName: 'Check for TypeScript problems'
 
-      - script: |
-          yarn test
-        displayName: 'Basic Tests'
-
-      - script: |
-          yarn test:enabled-in-progress-features
-        displayName: 'In progress features'
-
-      - script: |
-          yarn test:production
-        displayName: 'Production'
-
-  - job: jQuery_Tests
-    dependsOn: Basic_Ember_Data_tests
-
+  - job: BasicTests
+    dependsOn: Lint
+    condition: in(dependencies.Lint.result, 'Succeeded', 'Skipped')
+    strategy:
+      matrix:
+        linux:
+          vmImage: 'ubuntu-16.04'
+        mac:
+          vmImage: 'macOS-10.14'
+        windows:
+          vmImage: 'windows-2019'
     pool:
-      vmImage: 'macOS-10.14'
-
+      vmImage: $(vmImage)
     steps:
-      - task: NodeTool@0
-        displayName: Node install
-        inputs:
-          versionSpec: '10.x' # The version we're installing
+      - template: '.azure/basic-tests.yml'
 
-      - script: |
-          brew update
-          brew cask install google-chrome
-          yarn install --no-lockfile --non-interactive
-
-      - script: |
-          yarn test:try-one default-with-jquery
-        displayName: 'Basic Tests with jQuery'
-
-      - script: |
-          yarn test:try-one ember-release-with-jquery
-        displayName: 'Ember Release Channel Tests with jQuery'
-
-  - job: Floating_dependencies
-    dependsOn: Basic_Ember_Data_tests
-
+  - job: FloatingDependencies
+    dependsOn: Lint
+    condition: in(dependencies.Lint.result, 'Succeeded', 'Skipped')
     pool:
-      vmImage: 'macOS-10.14'
-
+      vmImage: 'ubuntu-16.04'
     steps:
-      - task: NodeTool@0
-        displayName: Node install
-        inputs:
-          versionSpec: '10.x' # The version we're installing
+      - template: '.azure/basic-tests.yml'
+        parameters:
+          useLockfile: false
 
-      - script: |
-          brew update
-          brew cask install google-chrome
-          yarn install --no-lockfile --non-interactive
-
-      - script: |
-          yarn test
-        displayName: 'Basic Tests'
-
-  - job: Ember_LTS_tests
-    dependsOn: Basic_Ember_Data_tests
-
+  - job: LTS
+    dependsOn: Lint
+    condition: in(dependencies.Lint.result, 'Succeeded', 'Skipped')
     pool:
-      vmImage: 'macOS-10.14'
-
+      vmImage: 'ubuntu-16.04'
     steps:
-      - task: NodeTool@0
-        displayName: Node install
-        inputs:
-          versionSpec: '10.x' # The version we're installing
+      - template: '.azure/try-scenario.yml'
+        parameters:
+          scenario: ember-lts-3.8
 
-      - script: |
-          brew update
-          brew cask install google-chrome
-          yarn
-
-      - script: |
-          yarn install
-          yarn test:try-one ember-lts-3.8
-        displayName: 'Ember LTS test 3.8'
-
-      - script: |
-          yarn install
-          yarn test:try-one ember-release
-        displayName: 'Ember Release'
-
-      - script: |
-          yarn install
-          yarn test:try-one ember-beta
-        displayName: 'Ember Beta'
-
-      - script: |
-          yarn install
-          yarn test:try-one ember-canary
-        displayName: 'Ember Canary'
-
-  - job: External_Partner_tests_ilios
-    dependsOn: Basic_Ember_Data_tests
-
+  - job: ReleaseChannels
+    condition: |
+      and(
+        in(dependencies.Lint.result, 'Succeeded', 'Skipped'),
+        or(
+          in(variables['Build.SourceBranchName'], 'master', 'beta'),
+          in(variables['System.PullRequest.TargetBranch'], 'master', 'beta')
+        )
+      )
     pool:
-      vmImage: 'macOS-10.14'
-
+      vmImage: 'ubuntu-16.04'
+    strategy:
+      matrix:
+        ember_release:
+          scenario: ember-release
+        ember_beta:
+          scenario: ember-beta
+        ember_canary:
+          scenario: ember-canary
+        ember_release_with_jquery:
+          scenario: ember-release-with-jquery
     steps:
-      - task: NodeTool@0
-        displayName: Node install
-        inputs:
-          versionSpec: '10.x' # The version we're installing
+      - template: '.azure/try-scenario.yml'
+        parameters:
+          scenario: $(scenario)
 
-      - script: |
-          brew update
-          brew cask install firefox
-          yarn
-          node ./bin/packages-for-commit.js
-
-      - script: |
-          yarn test-external:ilios-frontend
-        displayName: 'External: ilios-frontend'
-
-  - job: External_Partner_tests_travis
-    dependsOn: Basic_Ember_Data_tests
-
+  - job: AdditionalScenarios
+    dependsOn: Lint
+    condition: in(dependencies.Lint.result, 'Succeeded', 'Skipped')
     pool:
-      vmImage: 'macOS-10.14'
-
+      vmImage: 'ubuntu-16.04'
+    strategy:
+      matrix:
+        with_ember_fetch:
+          scenario: with-ember-fetch
+        with_jquery:
+          scenario: default-with-jquery
+        with_max_transpilation:
+          scenario: with-max-transpilation
     steps:
-      - task: NodeTool@0
-        displayName: Node install
-        inputs:
-          versionSpec: '10.x' # The version we're installing
+      - template: '.azure/try-scenario.yml'
+        parameters:
+          scenario: $(scenario)
 
-      - script: |
-          brew update
-          brew cask install google-chrome
-          brew cask install firefox
-          yarn
-          node ./bin/packages-for-commit.js
-
-      - script: |
-          CI=true yarn test-external:travis-web
-        displayName: 'External: travis-web'
-
-  - job: External_Partner_tests_ember_observer
-    dependsOn: Basic_Ember_Data_tests
-
+  - job: ExternalPartners
+    dependsOn:
+      - BasicTests
+      - FloatingDependencies
+      - LTS
+      - AdditionalScenarios
+    condition: |
+      and(
+        succeeded(),
+        or(
+          in(variables['Build.SourceBranchName'], 'master', 'beta'),
+          in(variables['System.PullRequest.TargetBranch'], 'master', 'beta')
+        )
+      )
     pool:
-      vmImage: 'macOS-10.14'
-
+      vmImage: 'ubuntu-16.04'
+    strategy:
+      matrix:
+        ilios_frontend:
+          partner: ilios-frontend
+          allowedToFail: false
+        ember_observer:
+          partner: ember-observer
+          allowedToFail: false
+        ember_data_change_tracker:
+          partner: ember-data-change-tracker
+          allowedToFail: true
+        ember_data_relationship_tracker:
+          partner: ember-data-relationship-tracker
+          allowedToFail: false
+        ember_m3:
+          partner: ember-m3
+          allowedToFail: false
+        ember_resource_metadata:
+          partner: ember-resource-metadata
+          allowedToFail: false
+        factory_guy:
+          partner: factory-guy
+          allowedToFail: true
+        model_fragments:
+          partner: model-fragments
+          allowedToFail: true
+        storefront:
+          partner: storefront
+          allowedToFail: false
+        travis_web:
+          partner: travis-web
+          allowedToFail: false
     steps:
-      - task: NodeTool@0
-        displayName: Node install
-        inputs:
-          versionSpec: '10.x' # The version we're installing
-
-      - script: |
-          brew update
-          brew cask install google-chrome
-          brew cask install firefox
-          yarn
-          node ./bin/packages-for-commit.js
-
-      - script: |
-          yarn test-external:ember-observer
-        displayName: 'External: ember-observer'
-
-  - job: External_Partner_tests_other
-    dependsOn: Basic_Ember_Data_tests
-
-    pool:
-      vmImage: 'macOS-10.14'
-
-    steps:
-      - task: NodeTool@0
-        displayName: Node install
-        inputs:
-          versionSpec: '10.x' # The version we're installing
-
-      - script: |
-          brew update
-          brew cask install google-chrome
-          brew cask install firefox
-          yarn
-          node ./bin/packages-for-commit.js
-        condition: always()
-
-      - script: |
-          yarn test-external:storefront
-        displayName: 'External: storefront'
-        condition: always()
-
-      #  - script: |
-      #      yarn test-external:factory-guy
-      #    displayName: 'External: factory-guy'
-
-      - script: |
-          yarn test-external:ember-resource-metadata
-        displayName: 'External: ember-resource-metadata'
-        condition: always()
-
-      - script: |
-          yarn test-external:ember-data-relationship-tracker
-        displayName: 'External: ember-data-relationship-tracker'
-        condition: always()
-
-      - script: |
-          yarn test-external:model-fragments
-          exit 0
-        displayName: 'External: model-fragments'
-        condition: always()
-
-      - script: |
-          yarn test-external:ember-data-change-tracker
-          exit 0
-        displayName: 'External: ember-data-change-tracker'
-        condition: always()
-
-      - script: |
-          yarn test-external:ember-m3
-        displayName: 'External: ember-m3'
-        condition: always()
+      - template: '.azure/external-partner-test.yml'
+        parameters:
+          partner: $(partner)
+          allowedToFail: $(allowedToFail)

--- a/packages/-ember-data/config/ember-try.js
+++ b/packages/-ember-data/config/ember-try.js
@@ -20,6 +20,13 @@ module.exports = function() {
           },
         },
         {
+          name: 'with-max-transpilation',
+          env: {
+            TARGET_IE11: true,
+          },
+          npm: {},
+        },
+        {
           name: 'default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),


### PR DESCRIPTION
Updates the Azure Pipelines config to be more similar to the Travis CI config.

| Type               | Master | Beta | Release | LTS  | Tags |
| ---                | ---    | ---  | ---     | ---  | ---  |
| Lint               | yes    | yes  | no      | no   | no   |
| Basic Tests        | yes    | yes  | yes     | yes  | no   |
| Build  Tests       | yes    | yes  | yes*    | yes* | no   |
| Windows Tests      | yes    | yes  | yes*    | yes* | no   |
| Floating Deps      | yes    | yes  | yes     | yes  | no   |
| Ember LTS Branches | yes    | yes  | yes     | yes  | no   |
| Release Channels   | yes    | yes  | no      | no   | no   |
| External Partners  | yes    | yes  | no      | no   | no   |

* Runs but skips tests for in-progress-features

- Runs Basic Tests for Mac, Linux, and Windows
- Runs the rest of the tests using Linux because it is much faster. Mostly because we get to skip installing Chrome and Firefox, which adds ~= 2 minutes for each job, because they're already available from the Linux VM