### PR TITLE
[BUGFIX relationships] fix infinite retry bug for failed relationship fetches

### DIFF
--- a/packages/-ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/has-many-test.js
@@ -6,7 +6,7 @@ import { get } from '@ember/object';
 import { run } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { relationshipStateFor, relationshipsFor } from 'ember-data/-private';
 import DS from 'ember-data';
 
@@ -955,8 +955,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function(h
     });
   });
 
-  skip('A hasMany relationship can be reloaded even if it failed at the first time', async function(assert) {
-    assert.expect(6);
+  test('A hasMany relationship can be reloaded even if it failed at the first time', async function(assert) {
+    assert.expect(7);
 
     const { store, adapter } = env;
 
@@ -964,7 +964,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function(h
       comments: DS.hasMany('comment', { async: true }),
     });
 
-    adapter.findRecord = function(store, type, id) {
+    adapter.findRecord = function() {
       return resolve({
         data: {
           id: 1,
@@ -978,10 +978,10 @@ module('integration/relationships/has_many - Has-Many Relationships', function(h
       });
     };
 
-    let loadingCount = -1;
-    adapter.findHasMany = function(store, record, link, relationship) {
+    let loadingCount = 0;
+    adapter.findHasMany = function() {
       loadingCount++;
-      if (loadingCount % 2 === 0) {
+      if (loadingCount % 2 === 1) {
         return reject({ data: null });
       } else {
         return resolve({
@@ -995,16 +995,24 @@ module('integration/relationships/has_many - Has-Many Relationships', function(h
 
     let post = await store.findRecord('post', 1);
     let comments = post.get('comments');
-    let manyArray = await comments.catch(() => {
-      assert.ok(true, 'An error was thrown on the first reload of comments');
-      return comments.reload();
-    });
+    let manyArray;
+
+    try {
+      manyArray = await comments;
+      assert.ok(false, 'Expected exception to be raised');
+    } catch (e) {
+      assert.ok(true, `An error was thrown on the first reload of comments: ${e.message}`);
+      manyArray = await comments.reload();
+    }
 
     assert.equal(manyArray.get('isLoaded'), true, 'the reload worked, comments are now loaded');
 
-    await manyArray.reload().catch(() => {
-      assert.ok(true, 'An error was thrown on the second reload via manyArray');
-    });
+    try {
+      await manyArray.reload();
+      assert.ok(false, 'Expected exception to be raised');
+    } catch (e) {
+      assert.ok(true, `An error was thrown on the second reload via manyArray: ${e.message}`);
+    }
 
     assert.equal(
       manyArray.get('isLoaded'),
@@ -1020,6 +1028,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function(h
       'the third reload worked, comments are loaded again'
     );
     assert.ok(reloadedManyArray === manyArray, 'the many array stays the same');
+    assert.equal(loadingCount, 4, 'We only fired 4 requests');
   });
 
   test('A hasMany relationship can be directly reloaded if it was fetched via links', function(assert) {
@@ -2135,25 +2144,26 @@ module('integration/relationships/has_many - Has-Many Relationships', function(h
     );
   });
 
-  skip('A sync hasMany errors out if there are unloaded records in it', function(assert) {
-    let post = run(() => {
-      env.store.push({
-        data: {
-          type: 'post',
-          id: '1',
-          relationships: {
-            comments: {
-              data: [{ type: 'comment', id: '1' }, { type: 'comment', id: '2' }],
-            },
+  testInDebug('A sync hasMany errors out if there are unloaded records in it', function(assert) {
+    let post = env.store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        relationships: {
+          comments: {
+            data: [{ type: 'comment', id: '1' }, { type: 'comment', id: '2' }],
           },
         },
-      });
-      return env.store.peekRecord('post', 1);
+      },
     });
+    const assertionMessage = /You looked up the 'comments' relationship on a 'post' with id 1 but some of the associated records were not loaded./;
 
-    assert.expectAssertion(() => {
-      run(post, 'get', 'comments');
-    }, /You looked up the 'comments' relationship on a 'post' with id 1 but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async \(`DS.hasMany\({ async: true }\)`\)/);
+    try {
+      post.get('comments');
+      assert.ok(false, 'expected assertion');
+    } catch (e) {
+      assert.ok(assertionMessage.test(e.message), 'correct assertion');
+    }
   });
 
   test('After removing and unloading a record, a hasMany relationship should still be valid', function(assert) {

--- a/packages/-ember-data/tests/integration/relationships/unload-new-record-test.js
+++ b/packages/-ember-data/tests/integration/relationships/unload-new-record-test.js
@@ -1,0 +1,262 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
+import EmberObject, { set } from '@ember/object';
+import { settled } from '@ember/test-helpers';
+
+module('Relationships | unloading new records', function(hooks) {
+  setupTest(hooks);
+  let store;
+  let adapter;
+  let entryNode;
+  let newNode;
+
+  class NeverAdapter extends EmberObject {
+    _assert(msg) {
+      if (!this.assert) {
+        throw new Error(
+          `Failed to configure NeverAdapter with "assert" for this test.\n\n\t${msg}`
+        );
+      }
+      this.assert.ok(false, msg);
+    }
+    shouldBackgroundReloadRecord() {
+      return false;
+    }
+    shouldBackgroundReloadAll() {
+      return false;
+    }
+    shouldReloadAll() {
+      return false;
+    }
+    shouldReloadRecord() {
+      return false;
+    }
+    findRecord() {
+      this._assert(`Unexpected Adapter findRecord call`);
+    }
+    findBelongsTo() {
+      this._assert(`Unexpected Adapter findBelongsTo call`);
+    }
+    findHasMany() {
+      this._assert(`Unexpected Adapter findhasMany call`);
+    }
+    findMany() {
+      this._assert(`Unexpected Adapter findMany call`);
+    }
+    findAll() {
+      this._assert(`Unexpected Adapter findAll call`);
+    }
+    query() {
+      this._assert(`Unexpected Adapter query call`);
+    }
+  }
+
+  class Node extends Model {
+    @attr() name;
+    @belongsTo('node', { inverse: 'children', async: false }) parent;
+    @belongsTo('node', { inverse: 'asyncEdges', async: true }) relatedGraph;
+    @hasMany('node', { inverse: 'parent', async: false }) children;
+    @hasMany('node', { inverse: 'relatedGraph', async: true }) asyncEdges;
+  }
+
+  hooks.beforeEach(function(assert) {
+    const { owner } = this;
+    owner.register('model:node', Node);
+    owner.register('adapter:application', NeverAdapter);
+    store = owner.lookup('service:store');
+    adapter = store.adapterFor('application');
+    adapter.assert = assert;
+
+    entryNode = store.push({
+      data: {
+        type: 'node',
+        id: '2',
+        attributes: { name: 'entry-node' },
+        relationships: {
+          parent: { data: { type: 'node', id: '1' } },
+          children: {
+            data: [{ type: 'node', id: '3' }],
+          },
+          relatedGraph: { data: { type: 'node', id: '4' } },
+          asyncEdges: { data: [{ type: 'node', id: '5' }] },
+        },
+      },
+      included: [
+        {
+          type: 'node',
+          id: '1',
+          attributes: { name: 'root' },
+          relationships: {
+            children: {
+              data: [{ type: 'node', id: '2' }],
+            },
+          },
+        },
+        {
+          type: 'node',
+          id: '3',
+          attributes: { name: 'a child node' },
+          relationships: {
+            parent: {
+              data: { type: 'node', id: '2' },
+            },
+          },
+        },
+        {
+          type: 'node',
+          id: '4',
+          attributes: { name: 'an async relatedGraph entry' },
+          relationships: {
+            asyncEdges: {
+              data: [{ type: 'node', id: '2' }],
+            },
+          },
+        },
+        {
+          type: 'node',
+          id: '5',
+          attributes: { name: 'an async edge' },
+          relationships: {
+            relatedGraph: {
+              data: { type: 'node', id: '2' },
+            },
+          },
+        },
+      ],
+    });
+    newNode = store.createRecord('node', {
+      name: 'our newly created node',
+    });
+  });
+
+  test('Unloading a sync belongsTo does not force the relationship state to reload', async function(assert) {
+    const originalRootNode = entryNode.parent;
+
+    assert.ok(originalRootNode.name === 'root', 'PreCond: We have rootNode set');
+    assert.deepEqual(
+      originalRootNode.children.map(c => c.id),
+      ['2'],
+      'Precond: Root Node has the correct children'
+    );
+
+    set(entryNode, 'parent', newNode);
+    const value = entryNode.parent;
+
+    assert.ok(value === newNode, 'PreCond: We properly set the sync belongsTo to the new value');
+    assert.deepEqual(
+      originalRootNode.children.map(c => c.id),
+      [],
+      'Precond: Root Node has the correct children'
+    );
+
+    newNode.unloadRecord();
+    await settled();
+
+    assert.ok(entryNode.parent === null, 'Our relationship state is now null');
+    assert.deepEqual(
+      originalRootNode.children.map(c => c.id),
+      [],
+      'Root Node still has the correct children'
+    );
+  });
+
+  test('Unloading an entry in a sync hasMany does not force the relationship state to reload', async function(assert) {
+    assert.deepEqual(
+      entryNode.children.map(c => c.id),
+      ['3'],
+      'Precond: EntryNode has the correct children'
+    );
+    assert.ok(newNode.parent === null, 'PreCond: The new node does not have a parent');
+
+    set(newNode, 'parent', entryNode);
+
+    assert.ok(
+      newNode.parent === entryNode,
+      'PreCond: We properly set the sync belongsTo to the new value'
+    );
+    assert.deepEqual(
+      entryNode.children.map(c => c.name),
+      ['a child node', 'our newly created node'],
+      'Precond: EntryNode has the correct children'
+    );
+
+    newNode.unloadRecord();
+    await settled();
+
+    assert.deepEqual(
+      entryNode.children.map(c => c.id),
+      ['3'],
+      'entryNode has the correct children'
+    );
+  });
+
+  test('Unloading an async belongsTo does not force the relationship state to reload', async function(assert) {
+    const originalRelatedNode = await entryNode.relatedGraph;
+
+    assert.strictEqual(
+      originalRelatedNode.name,
+      'an async relatedGraph entry',
+      'PreCond: We have rootNode set'
+    );
+
+    let originalNodeAsyncEdges = await originalRelatedNode.asyncEdges;
+
+    assert.deepEqual(
+      originalNodeAsyncEdges.map(c => c.id),
+      ['2'],
+      'Precond: Related Node has the correct asyncEdges'
+    );
+
+    set(entryNode, 'relatedGraph', newNode);
+
+    let value = await entryNode.relatedGraph;
+    originalNodeAsyncEdges = await originalRelatedNode.asyncEdges;
+
+    assert.ok(value === newNode, 'PreCond: We properly set the async belongsTo to the new value');
+    assert.deepEqual(
+      originalNodeAsyncEdges.map(c => c.id),
+      [],
+      'Precond: Original Related Node has the correct asyncEdges'
+    );
+
+    newNode.unloadRecord();
+    await settled();
+
+    value = await entryNode.relatedGraph;
+    assert.strictEqual(value, null, 'Our relationship state is now null');
+  });
+
+  test('Unloading an entry in an async hasMany does not force the relationship state to reload', async function(assert) {
+    let asyncEdges = await entryNode.asyncEdges;
+    assert.deepEqual(
+      asyncEdges.map(c => c.id),
+      ['5'],
+      'Precond: entryNode has the correct asyncEdges'
+    );
+    let originalRelatedNode = await newNode.relatedGraph;
+    assert.strictEqual(originalRelatedNode, null, 'PreCond: newNode has no relatedGraph yet');
+
+    set(newNode, 'relatedGraph', entryNode);
+
+    let value = await newNode.relatedGraph;
+    asyncEdges = await entryNode.asyncEdges;
+
+    assert.ok(value === entryNode, 'PreCond: We properly set the async belongsTo to the new value');
+    assert.deepEqual(
+      asyncEdges.map(c => c.name),
+      ['an async edge', 'our newly created node'],
+      'Precond: entryNode has the correct asyncEdges'
+    );
+
+    newNode.unloadRecord();
+    await settled();
+
+    asyncEdges = await entryNode.asyncEdges;
+    assert.deepEqual(
+      asyncEdges.map(c => c.name),
+      ['an async edge'],
+      'Precond: entryNode has the correct asyncEdges'
+    );
+  });
+});

--- a/packages/store/addon/-private/system/many-array.js
+++ b/packages/store/addon/-private/system/many-array.js
@@ -56,6 +56,10 @@ import recordDataFor from './record-data-for';
   @uses Ember.MutableArray, Ember.Evented
 */
 export default EmberObject.extend(MutableArray, Evented, {
+  // here to make TS happy
+  _inverseIsAsync: false,
+  isLoaded: false,
+
   init() {
     this._super(...arguments);
 
@@ -64,7 +68,7 @@ export default EmberObject.extend(MutableArray, Evented, {
 
     @property {Boolean} isLoaded
     */
-    this.isLoaded = false;
+    this.isLoaded = this.isLoaded || false;
     this.length = 0;
 
     /**

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -4,7 +4,7 @@ import { default as EmberArray, A } from '@ember/array';
 import { setOwner, getOwner } from '@ember/application';
 import { run } from '@ember/runloop';
 import { assign } from '@ember/polyfills';
-import RSVP, { Promise } from 'rsvp';
+import RSVP, { Promise, resolve } from 'rsvp';
 import Ember from 'ember';
 import { DEBUG } from '@glimmer/env';
 import { assert, inspect } from '@ember/debug';
@@ -13,12 +13,22 @@ import Snapshot from '../snapshot';
 import OrderedSet from '../ordered-set';
 import ManyArray from '../many-array';
 import { PromiseBelongsTo, PromiseManyArray } from '../promise-proxies';
+import Store from '../store';
 
 import { RecordReference, BelongsToReference, HasManyReference } from '../references';
 import { default as recordDataFor, relationshipStateFor } from '../record-data-for';
 import RecordDataDefault from './record-data';
 import RecordData from '../../ts-interfaces/record-data';
 import { JsonApiResource } from '../../ts-interfaces/record-data-json-api';
+import { Dict } from '../../types';
+import BelongsToRelationship from '../relationships/state/belongs-to';
+
+interface BelongsToMetaWrapper {
+  key: string;
+  store: InstanceType<typeof Store>;
+  originatingInternalModel: InternalModel;
+  modelName: string;
+}
 
 /*
   The TransitionChainMap caches the `state.enters`, `state.setups`, and final state reached
@@ -63,7 +73,7 @@ let InternalModelReferenceId = 1;
 */
 export default class InternalModel {
   id: string | null;
-  store: any;
+  store: InstanceType<typeof Store>;
   modelName: string;
   clientId: string | null;
   __recordData: RecordData | null;
@@ -84,9 +94,17 @@ export default class InternalModel {
   __recordArrays: any;
   _references: any;
   _recordReference: any;
-  _manyArrayCache: any;
-  _retainedManyArrayCache: any;
-  _relationshipPromisesCache: any;
+  _manyArrayCache: Dict<string, InstanceType<typeof ManyArray>> = Object.create(null);
+
+  // The previous ManyArrays for this relationship which will be destroyed when
+  // we create a new ManyArray, but in the interim the retained version will be
+  // updated if inverse internal models are unloaded.
+  _retainedManyArrayCache: Dict<string, InstanceType<typeof ManyArray>> = Object.create(null);
+  _relationshipPromisesCache: Dict<string, RSVP.Promise<unknown>> = Object.create(null);
+  _relationshipProxyCache: Dict<
+    string,
+    InstanceType<typeof PromiseManyArray> | InstanceType<typeof PromiseBelongsTo>
+  > = Object.create(null);
   currentState: any;
   error: any;
 
@@ -123,13 +141,6 @@ export default class InternalModel {
     this.__recordArrays = null;
     this._references = null;
     this._recordReference = null;
-
-    this._manyArrayCache = Object.create(null);
-    // The previous ManyArrays for this relationship which will be destroyed when
-    // we create a new ManyArray, but in the interim the retained version will be
-    // updated if inverse internal models are unloaded.
-    this._retainedManyArrayCache = Object.create(null);
-    this._relationshipPromisesCache = Object.create(null);
   }
 
   get modelClass() {
@@ -293,12 +304,8 @@ export default class InternalModel {
       let additionalCreateOptions = this._recordData._initRecordCreateOptions(properties);
       assign(createOptions, additionalCreateOptions);
 
-      if (setOwner) {
-        // ensure that `getOwner(this)` works inside a model instance
-        setOwner(createOptions, getOwner(store));
-      } else {
-        createOptions.container = store.container;
-      }
+      // ensure that `getOwner(this)` works inside a model instance
+      setOwner(createOptions, getOwner(store));
 
       this._record = store._modelFactoryFor(this.modelName).create(createOptions);
 
@@ -325,12 +332,11 @@ export default class InternalModel {
     if (this._record) {
       this._record.destroy();
 
-      Object.keys(this._relationshipPromisesCache).forEach(key => {
-        // TODO Igor cleanup the guard
-        if (this._relationshipPromisesCache[key].destroy) {
-          this._relationshipPromisesCache[key].destroy();
+      Object.keys(this._relationshipProxyCache).forEach(key => {
+        if (this._relationshipProxyCache[key].destroy) {
+          this._relationshipProxyCache[key].destroy();
         }
-        delete this._relationshipPromisesCache[key];
+        delete this._relationshipProxyCache[key];
       });
       Object.keys(this._manyArrayCache).forEach(key => {
         let manyArray = (this._retainedManyArrayCache[key] = this._manyArrayCache[key]);
@@ -496,6 +502,23 @@ export default class InternalModel {
     return this.modelClass.eachRelationship(callback, binding);
   }
 
+  _findBelongsTo(key, resource, relationshipMeta, options) {
+    // TODO @runspired follow up if parent isNew then we should not be attempting load here
+    return this.store
+      ._findBelongsToByJsonApiResource(resource, this, relationshipMeta, options)
+      .then(
+        internalModel =>
+          handleCompletedRelationshipRequest(
+            this,
+            key,
+            resource._relationship,
+            internalModel,
+            null
+          ),
+        e => handleCompletedRelationshipRequest(this, key, resource._relationship, null, e)
+      );
+  }
+
   getBelongsTo(key, options) {
     let resource = this._recordData.getBelongsTo(key);
     let relationshipMeta = this.store._relationshipMetaFor(this.modelName, null, key);
@@ -503,25 +526,27 @@ export default class InternalModel {
     let parentInternalModel = this;
     let async = relationshipMeta.options.async;
     let isAsync = typeof async === 'undefined' ? true : async;
-    let _belongsToState = { 
-      key, 
-      store, 
+    let _belongsToState: BelongsToMetaWrapper = {
+      key,
+      store,
       originatingInternalModel: this,
-      modelName: relationshipMeta.type
-    }
+      modelName: relationshipMeta.type,
+    };
 
     if (isAsync) {
       let internalModel =
         resource && resource.data ? store._internalModelForResource(resource.data) : null;
-      return PromiseBelongsTo.create({
-        _belongsToState,
-        promise: store._findBelongsToByJsonApiResource(
-          resource,
-          parentInternalModel,
-          relationshipMeta,
-          options
-        ),
+
+      if (resource!._relationship!.hasFailedLoadAttempt) {
+        return this._relationshipProxyCache[key];
+      }
+
+      let promise = this._findBelongsTo(key, resource, relationshipMeta, options);
+
+      return this._updatePromiseProxyFor('belongsTo', key, {
+        promise,
         content: internalModel ? internalModel.getRecord() : null,
+        _belongsToState,
       });
     } else {
       if (!resource || !resource.data) {
@@ -545,7 +570,7 @@ export default class InternalModel {
   }
 
   // TODO Igor consider getting rid of initial state
-  getManyArray(key) {
+  getManyArray(key, isAsync = false) {
     let relationshipMeta = this.store._relationshipMetaFor(this.modelName, null, key);
     let jsonApi = this._recordData.getHasMany(key);
     let manyArray = this._manyArrayCache[key];
@@ -569,6 +594,7 @@ export default class InternalModel {
         initialState: initialState.slice(),
         _inverseIsAsync: inverseIsAsync,
         internalModel: this,
+        isLoaded: !isAsync,
       });
       this._manyArrayCache[key] = manyArray;
     }
@@ -581,21 +607,29 @@ export default class InternalModel {
     return manyArray;
   }
 
-  fetchAsyncHasMany(relationshipMeta, jsonApi, manyArray, options) {
-    let promise = this.store._findHasManyByJsonApiResource(
-      jsonApi,
-      this,
-      relationshipMeta,
-      options
-    );
-    promise = promise.then(initialState => {
-      // TODO why don't we do this in the store method
-      manyArray.retrieveLatest();
-      manyArray.set('isLoaded', true);
+  fetchAsyncHasMany(key, relationshipMeta, jsonApi, manyArray, options): RSVP.Promise<unknown> {
+    // TODO @runspired follow up if parent isNew then we should not be attempting load here
+    let loadingPromise = this._relationshipPromisesCache[key];
+    if (loadingPromise) {
+      return loadingPromise;
+    }
 
-      return manyArray;
-    });
-    return promise;
+    loadingPromise = this.store
+      ._findHasManyByJsonApiResource(jsonApi, this, relationshipMeta, options)
+      .then(initialState => {
+        // TODO why don't we do this in the store method
+        manyArray.retrieveLatest();
+        manyArray.set('isLoaded', true);
+
+        return manyArray;
+      })
+      .then(
+        manyArray =>
+          handleCompletedRelationshipRequest(this, key, jsonApi._relationship, manyArray, null),
+        e => handleCompletedRelationshipRequest(this, key, jsonApi._relationship, null, e)
+      );
+    this._relationshipPromisesCache[key] = loadingPromise;
+    return loadingPromise;
   }
 
   getHasMany(key, options) {
@@ -603,22 +637,17 @@ export default class InternalModel {
     let relationshipMeta = this.store._relationshipMetaFor(this.modelName, null, key);
     let async = relationshipMeta.options.async;
     let isAsync = typeof async === 'undefined' ? true : async;
-    let manyArray = this.getManyArray(key);
+    let manyArray = this.getManyArray(key, isAsync);
 
     if (isAsync) {
-      let promiseArray = this._relationshipPromisesCache[key];
-
-      if (!promiseArray) {
-        promiseArray = PromiseManyArray.create({
-          promise: this.fetchAsyncHasMany(relationshipMeta, jsonApi, manyArray, options),
-          content: manyArray,
-        });
-        this._relationshipPromisesCache[key] = promiseArray;
+      if (jsonApi!._relationship!.hasFailedLoadAttempt) {
+        return this._relationshipProxyCache[key];
       }
 
-      return promiseArray;
+      let promise = this.fetchAsyncHasMany(key, relationshipMeta, jsonApi, manyArray, options);
+
+      return this._updatePromiseProxyFor('hasMany', key, { promise, content: manyArray });
     } else {
-      manyArray.set('isLoaded', true);
       assert(
         `You looked up the '${key}' relationship on a '${this.type.modelName}' with id ${
           this.id
@@ -630,59 +659,83 @@ export default class InternalModel {
     }
   }
 
-  _updateLoadingPromiseForHasMany(key, promise, content?) {
-    let loadingPromise = this._relationshipPromisesCache[key];
-    if (loadingPromise) {
-      if (content) {
-        loadingPromise.set('content', content);
+  _updatePromiseProxyFor(
+    kind: 'hasMany' | 'belongsTo',
+    key: string,
+    args: {
+      promise: RSVP.Promise<unknown>;
+      // TODO @runspired
+      // follow up with @mikenorth about what to do here as
+      // we don't have a clear way to type instances of records
+      // it can only be
+      //
+      // * ManyArray
+      // * null
+      // * a record instance (where record may be user defined. instanceof DS.Model is not accurate)
+      // * possibly? undefined when the initial promise has not resolved (I suspect null in this case in reality)
+      //
+      // unknown seems better as this is something we can "know" later and it is one of a finite set of things,
+      // but instance types do not seem to accept `unknown` when we do
+      // `promiseProxy.set('content', args.content);` whereas they do accept `any`
+      content?: any;
+      _belongsToState?: BelongsToMetaWrapper;
+    }
+  ) {
+    let promiseProxy = this._relationshipProxyCache[key];
+    if (promiseProxy) {
+      if (args.content !== undefined) {
+        promiseProxy.set('content', args.content);
       }
-      loadingPromise.set('promise', promise);
+      promiseProxy.set('promise', args.promise);
     } else {
-      this._relationshipPromisesCache[key] = PromiseManyArray.create({
-        promise,
-        content,
-      });
+      const klass = kind === 'hasMany' ? PromiseManyArray : PromiseBelongsTo;
+      this._relationshipProxyCache[key] = klass.create(args);
     }
 
-    return this._relationshipPromisesCache[key];
+    return this._relationshipProxyCache[key];
   }
 
   reloadHasMany(key, options) {
     let loadingPromise = this._relationshipPromisesCache[key];
     if (loadingPromise) {
-      if (loadingPromise.get('isPending')) {
-        return loadingPromise;
-      }
-      /* TODO Igor check wtf this is about
-      if (loadingPromise.get('isRejected')) {
-        manyArray.set('isLoaded', manyArrayLoadedState);
-      }
-      */
+      return loadingPromise;
     }
 
     let jsonApi = this._recordData.getHasMany(key);
     // TODO move this to a public api
     if (jsonApi._relationship) {
-      jsonApi._relationship.setRelationshipIsStale(true);
+      jsonApi._relationship.setHasFailedLoadAttempt(false);
+      jsonApi._relationship.setShouldForceReload(true);
     }
     let relationshipMeta = this.store._relationshipMetaFor(this.modelName, null, key);
     let manyArray = this.getManyArray(key);
-    let promise = this.fetchAsyncHasMany(relationshipMeta, jsonApi, manyArray, options);
+    let promise = this.fetchAsyncHasMany(key, relationshipMeta, jsonApi, manyArray, options);
 
-    // TODO igor Seems like this would mess with promiseArray wrapping, investigate
-    this._updateLoadingPromiseForHasMany(key, promise);
+    if (this._relationshipProxyCache[key]) {
+      return this._updatePromiseProxyFor('hasMany', key, { promise });
+    }
+
     return promise;
   }
 
   reloadBelongsTo(key, options) {
+    let loadingPromise = this._relationshipPromisesCache[key];
+    if (loadingPromise) {
+      return loadingPromise;
+    }
+
     let resource = this._recordData.getBelongsTo(key);
     // TODO move this to a public api
     if (resource._relationship) {
-      resource._relationship.setRelationshipIsStale(true);
+      resource._relationship.setHasFailedLoadAttempt(false);
+      resource._relationship.setShouldForceReload(true);
     }
     let relationshipMeta = this.store._relationshipMetaFor(this.modelName, null, key);
-
-    return this.store._findBelongsToByJsonApiResource(resource, this, relationshipMeta, options);
+    let promise = this._findBelongsTo(key, resource, relationshipMeta, options);
+    if (this._relationshipProxyCache[key]) {
+      return this._updatePromiseProxyFor('belongsTo', key, { promise });
+    }
+    return promise;
   }
 
   destroyFromRecordData() {
@@ -879,11 +932,6 @@ export default class InternalModel {
         //
         //  that said, also not clear why we haven't moved this to retainedmanyarray so maybe that's the bit that's just not workign
         manyArray.retrieveLatest();
-        // TODO Igor be rigorous about when to delete this
-        // TODO: igor check for case where we later unload again
-        if (this._relationshipPromisesCache[key] && manyArray.anyUnloaded()) {
-          delete this._relationshipPromisesCache[key];
-        }
       }
       this.updateRecordArrays();
     }
@@ -904,14 +952,11 @@ export default class InternalModel {
     let manyArray = this._manyArrayCache[key] || this._retainedManyArrayCache[key];
     if (manyArray) {
       let didRemoveUnloadedModel = manyArray.removeUnloadedInternalModel();
+
       if (this._manyArrayCache[key] && didRemoveUnloadedModel) {
         this._retainedManyArrayCache[key] = this._manyArrayCache[key];
         delete this._manyArrayCache[key];
       }
-    }
-    if (this._relationshipPromisesCache[key]) {
-      this._relationshipPromisesCache[key].destroy();
-      delete this._relationshipPromisesCache[key];
     }
   }
 
@@ -1112,6 +1157,7 @@ export default class InternalModel {
     @private
   */
   updateRecordArrays() {
+    // @ts-ignore: Store is untyped and typescript does not detect instance props set in `init`
     this.store.recordArrayManager.recordDidChange(this);
   }
 
@@ -1264,6 +1310,39 @@ export default class InternalModel {
 
     return reference;
   }
+}
+
+function handleCompletedRelationshipRequest(internalModel, key, relationship, value, error) {
+  delete internalModel._relationshipPromisesCache[key];
+  relationship.setShouldForceReload(false);
+
+  if (error) {
+    relationship.setHasFailedLoadAttempt(true);
+    let proxy = internalModel._relationshipProxyCache[key];
+    // belongsTo relationships are sometimes unloaded
+    // when a load fails, in this case we need
+    // to make sure that we aren't proxying
+    // to destroyed content
+    if (relationship.kind === 'belongsTo') {
+      if (proxy.content.isDestroying) {
+        proxy.set('content', null);
+      }
+
+      // clear the promise to make re-access safe
+      // e.g. after initial rejection, don't replay
+      // rejection on subsequent access, otherwise
+      // templates cause lots of rejected promise blow-ups
+      proxy.set('promise', resolve(null));
+    }
+
+    throw error;
+  }
+
+  relationship.setHasFailedLoadAttempt(false);
+  // only set to not stale if no error is thrown
+  relationship.setRelationshipIsStale(false);
+
+  return value;
 }
 
 function assertRecordsPassedToHasMany(records) {

--- a/packages/store/addon/-private/system/promise-proxies.js
+++ b/packages/store/addon/-private/system/promise-proxies.js
@@ -106,6 +106,12 @@ export const PromiseBelongsTo = PromiseObject.extend({
   },
 });
 
+export function proxyToContent(method) {
+  return function() {
+    return get(this, 'content')[method](...arguments);
+  };
+}
+
 /*
   A PromiseManyArray is a PromiseArray that also proxies certain method calls
   to the underlying manyArray.
@@ -122,13 +128,6 @@ export const PromiseBelongsTo = PromiseObject.extend({
   @class PromiseManyArray
   @extends Ember.ArrayProxy
 */
-
-export function proxyToContent(method) {
-  return function() {
-    return get(this, 'content')[method](...arguments);
-  };
-}
-
 export const PromiseManyArray = PromiseArray.extend({
   reload(options) {
     assert(

--- a/packages/store/addon/-private/system/references/belongs-to.js
+++ b/packages/store/addon/-private/system/references/belongs-to.js
@@ -318,31 +318,9 @@ export default class BelongsToReference extends Reference {
    @param {Object} options the options to pass in.
    @return {Promise} a promise that resolves with the record in this belongs-to relationship after the reload has completed.
    */
-  // TODO IGOR CHECK FOR OBJECT PROXIES
   reload(options) {
-    let resource = this._resource();
-    if (resource && resource.links && resource.links.related) {
-      return this.store._fetchBelongsToLinkFromResource(
-        resource,
-        this.parentInternalModel,
-        this.belongsToRelationship.relationshipMeta,
-        options
-      );
-    }
-    if (resource && resource.data) {
-      if (resource.data && (resource.data.id || resource.data.clientId)) {
-        let internalModel = this.store._internalModelForResource(resource.data);
-        if (internalModel.isLoaded()) {
-          return internalModel.reload(options).then(internalModel => {
-            if (internalModel) {
-              return internalModel.getRecord();
-            }
-            return null;
-          });
-        } else {
-          return this.store._findByInternalModel(internalModel, options);
-        }
-      }
-    }
+    return this.parentInternalModel.reloadBelongsTo(this.key, options).then(internalModel => {
+      return this.value();
+    });
   }
 }

--- a/packages/store/addon/-private/system/relationships/state/relationship.ts
+++ b/packages/store/addon/-private/system/relationships/state/relationship.ts
@@ -270,10 +270,12 @@ export default class Relationship {
   }
 
   inverseDidDematerialize(inverseRecordData: RelationshipRecordData | null) {
-    if (!this.isAsync) {
+    if (!this.isAsync || (inverseRecordData && inverseRecordData.isNew())) {
       // unloading inverse of a sync relationship is treated as a client-side
       // delete, so actually remove the models don't merely invalidate the cp
       // cache.
+      // if the record being unloaded only exists on the client, we similarly
+      // treat it as a client side delete
       this.removeRecordDataFromOwn(inverseRecordData);
       this.removeCanonicalRecordDataFromOwn(inverseRecordData);
       this.setRelationshipIsEmpty(true);

--- a/packages/store/addon/-private/system/store.js
+++ b/packages/store/addon/-private/system/store.js
@@ -1339,12 +1339,14 @@ const Store = Service.extend({
       hasDematerializedInverse,
       hasAnyRelationshipData,
       relationshipIsEmpty,
+      shouldForceReload,
     } = resource._relationship;
 
     let shouldFindViaLink =
       resource.links &&
       resource.links.related &&
-      (hasDematerializedInverse ||
+      (shouldForceReload ||
+        hasDematerializedInverse ||
         relationshipIsStale ||
         (!allInverseRecordsAreLoaded && !relationshipIsEmpty));
 
@@ -1372,7 +1374,7 @@ const Store = Service.extend({
       (relationshipIsEmpty && Array.isArray(resource.data) && resource.data.length > 0);
 
     // fetch using data, pulling from local cache if possible
-    if (!relationshipIsStale && (preferLocalCache || hasLocalPartialData)) {
+    if (!shouldForceReload && !relationshipIsStale && (preferLocalCache || hasLocalPartialData)) {
       let internalModels = resource.data.map(json => this._internalModelForResource(json));
 
       return this.findMany(internalModels, options);
@@ -1461,12 +1463,14 @@ const Store = Service.extend({
       hasDematerializedInverse,
       hasAnyRelationshipData,
       relationshipIsEmpty,
+      shouldForceReload,
     } = resource._relationship;
 
     let shouldFindViaLink =
       resource.links &&
       resource.links.related &&
-      (hasDematerializedInverse ||
+      (shouldForceReload ||
+        hasDematerializedInverse ||
         relationshipIsStale ||
         (!allInverseRecordsAreLoaded && !relationshipIsEmpty));
 
@@ -1494,7 +1498,7 @@ const Store = Service.extend({
     let localDataIsEmpty = resource.data === undefined || resource.data === null;
 
     // fetch using data, pulling from local cache if possible
-    if (!relationshipIsStale && (preferLocalCache || hasLocalPartialData)) {
+    if (!shouldForceReload && !relationshipIsStale && (preferLocalCache || hasLocalPartialData)) {
       /*
         We have canonical data, but our local state is empty
        */

--- a/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
+++ b/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
@@ -1,10 +1,10 @@
-import { RecordDataStoreWrapper as IRecordDataStoreWrapper } from "../../ts-interfaces/record-data-store-wrapper";
+import { RecordDataStoreWrapper as IRecordDataStoreWrapper } from '../../ts-interfaces/record-data-store-wrapper';
 
 export default class RecordDataStoreWrapper implements IRecordDataStoreWrapper {
   store: any;
-  _willUpdateManyArrays: boolean; 
+  _willUpdateManyArrays: boolean;
   _pendingManyArrayUpdates: string[];
-   
+
   constructor(store) {
     this.store = store;
     this._willUpdateManyArrays = false;

--- a/packages/store/addon/-private/ts-interfaces/record.ts
+++ b/packages/store/addon/-private/ts-interfaces/record.ts
@@ -1,0 +1,19 @@
+/*
+  A `Record` is the result of the store instantiating a class to present data for a resource to the UI.
+
+  Historically in `ember-data` this meant that it was the result of calling `_modelFactoryFor.create()` to
+  gain instance to a class built upon `@ember-data/model`. However, as we go forward into a future in which
+  model instances (aka `Records`) are completely user supplied and opaque to the internals, we need a type
+  through which to communicate what is valid.
+
+  The type belows allows for either a class instance, or an object, but not primitive values or functions.
+*/
+type Primitive = string | number | boolean | null;
+interface Object {
+  [member: string]: Value | undefined | ((...args: any[]) => any);
+}
+interface Arr extends Array<Object | Arr | undefined> {}
+
+type Value = Primitive | Object | Arr;
+
+export type Record = Object;


### PR DESCRIPTION
This PR unskips tests skipped for landing RecordData and fixes regressions introduced around relationship fetching in 3.5

cc @code0100fun please confirm this resolves #5814 et al.