### PR TITLE
[FEAT] - add a public Typescript interface for the minimal required serializer interface

### DIFF
--- a/packages/store/addon/-private/ts-interfaces/serializer.ts
+++ b/packages/store/addon/-private/ts-interfaces/serializer.ts
@@ -1,0 +1,8 @@
+import {
+  JsonApiResource
+} from './record-data-json-api';
+export default interface Serializer {
+  store: any;
+  normalizeResponse(store: any, primaryModelClass: any, payload: JsonApiResource, id: string | number, requestType: string): any;
+  serialize(typeClass: any, hash: object): object;
+}


### PR DESCRIPTION
@runspired is this even close? Looking at some other TS interface definitions, is seems like there are a few layers of definitions, in this case DS.Store, DS.Model. Should those be defined as well? 

How should this be tested?