### PR TITLE
[CHORE packaging] enable tarballs to be installed elsewhere

### DIFF
--- a/bin/-tarball-info.js
+++ b/bin/-tarball-info.js
@@ -101,7 +101,7 @@ const optionsDefinitions = [
     defaultValue: false,
   },
 ];
-const options = cliArgs(optionsDefinitions);
+const options = cliArgs(optionsDefinitions, { partial: true });
 
 function execWithLog(command, force) {
   debug(chalk.cyan('Executing: ') + chalk.yellow(command));

--- a/bin/packages-for-commit.js
+++ b/bin/packages-for-commit.js
@@ -82,12 +82,13 @@ console.log(
     chalk.yellow(
       `The tarballs for these packages are available within ${chalk.white(tarballDir)}.\n\r\n\r`
     ) +
-    (TarballConfig.options.hostPath.indexOf('file:') === 0
-      ? chalk.red('⚠️ They may only be used on this machine.')
+    (!TarballConfig.options.referenceViaVersion &&
+    TarballConfig.options.hostPath.indexOf('file:') === 0
+      ? chalk.red('⚠️  They may only be used on this machine.')
       : chalk.yellow(
-          `They can be hosted ${
-            TarballConfig.options.insertTarballLinks
-              ? 'only at ' + TarballConfig.options.hostPath
+          `⚠️  They can be hosted ${
+            !TarballConfig.options.referenceViaVersion
+              ? 'only at ' + chalk.white(TarballConfig.options.hostPath)
               : 'on any registry'
           }`
         ))

--- a/bin/packages-for-commit.js
+++ b/bin/packages-for-commit.js
@@ -63,7 +63,7 @@ AllPackages.forEach(packageName => {
   execWithLog(`
   cd ${tarballDir};
   npm pack ${pkg.location};
-  npm cache add ${pkg.tarballLocation};
+  npm cache add ${pkg.tarballLocation} --global;
     `);
 
   availablePackages.push(`${pkg.packageInfo.name}@${pkg.version}`);

--- a/bin/packages-for-commit.js
+++ b/bin/packages-for-commit.js
@@ -63,10 +63,11 @@ AllPackages.forEach(packageName => {
   execWithLog(`
   cd ${tarballDir};
   npm pack ${pkg.location};
-  npm cache add ${pkg.tarballLocation} --global;
     `);
 
-  availablePackages.push(`${pkg.packageInfo.name}@${pkg.version}`);
+  availablePackages.push(
+    chalk.cyan(`"${pkg.packageInfo.name}"`) + chalk.white(': ') + chalk.grey(`"${pkg.reference}"`)
+  );
 
   // cleanup
   fs.writeFileSync(pkg.fileLocation, pkg.originalPackageInfo);
@@ -75,13 +76,19 @@ AllPackages.forEach(packageName => {
 console.log(
   chalk.cyan(`Successfully packaged commit ${chalk.white(TarballConfig.sha)}!`) +
     '\n\r\n\r' +
-    chalk.yellow(`The following packages have been added to the local npm cache:\n\r\t✅ `) +
+    chalk.yellow(`The following packages have been generated:\n\r\t✅ `) +
     chalk.grey(availablePackages.join('\n\r\t✅ ')) +
     '\n\r\n\r' +
     chalk.yellow(
-      `The tarballs for these packages are also available within ${chalk.white(
-        tarballDir
-      )} and can be installed elsewhere using `
+      `The tarballs for these packages are available within ${chalk.white(tarballDir)}.\n\r\n\r`
     ) +
-    chalk.magenta('`npm cache add <tarball>`')
+    (TarballConfig.options.hostPath.indexOf('file:') === 0
+      ? chalk.red('⚠️ They may only be used on this machine.')
+      : chalk.yellow(
+          `They can be hosted ${
+            TarballConfig.options.insertTarballLinks
+              ? 'only at ' + TarballConfig.options.hostPath
+              : 'on any registry'
+          }`
+        ))
 );


### PR DESCRIPTION
Resolves the "portability" requirements of #6119 

The tarballs now include the commit `SHA` in their version number, and they are placed together in a directory named via that same `SHA` (this both makes it a bit easier to quickly grab them but also helps us avoid accidentally using stale tarballs).

The script also now helpfully outputs information that can be used for quickly grabbing / making use of these tarballs, and comes with two flags that allow configuration of the generated tarballs for `local|hosted|registry` usage. These flags alter how the produced tarballs refer to the other produced tarballs in their `dependencies`.

### Example output:

**Building for Local Usage**

`node ./bin/packages-for-commit.js`

<img width="1070" alt="Screen Shot 2019-05-21 at 5 07 49 PM" src="https://user-images.githubusercontent.com/650309/58138429-eb320b80-7bea-11e9-8e8f-e3ba79ff03ca.png">

**Building for Hosted Tarballs**

`node ./bin/packages-for-commit.js --hostPath="https://example.com/tarball-cache/ember-data/"`

<img width="1070" alt="Screen Shot 2019-05-21 at 5 07 21 PM" src="https://user-images.githubusercontent.com/650309/58138436-f2f1b000-7bea-11e9-87d0-2f5eec41e4d2.png">

**Building for Custom Registry**

` node ./bin/packages-for-commit.js --referenceViaVersion`

<img width="1070" alt="Screen Shot 2019-05-21 at 5 04 34 PM" src="https://user-images.githubusercontent.com/650309/58138446-00a73580-7beb-11e9-91cf-4857fda897e0.png">

**Users wishing to test a specific version of `ember-data` need all of the produced tarballs**