### PR TITLE
[CHORE partner-tests] remove emberaddons.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,8 +105,6 @@ jobs:
       script: yarn test-external:ember-data-relationship-tracker
     - name: 'Ember Data Model Fragments' # ~3.5min job
       script: yarn test-external:model-fragments
-    - name: 'emberaddons.com' # ~3.5min job
-      script: yarn test-external:emberaddons.com
     - name: 'Ember Data Change Tracker' # ~3.5min job
       script: yarn test-external:ember-data-change-tracker
     - name: 'ember-m3' # ~3.5min job

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -284,10 +284,6 @@ jobs:
         displayName: 'External: model-fragments'
 
       - script: |
-          yarn test-external:emberaddons.com
-        displayName: 'External: emberaddons.com'
-
-      - script: |
           yarn test-external:ember-data-change-tracker
         displayName: 'External: ember-data-change-tracker'
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "test:enabled-in-progress-features": "yarn workspace ember-data test --enable-in-progress",
     "test-external:ember-m3": "./bin/test-external-partner-project.js ember-m3 https://github.com/hjdivad/ember-m3.git",
     "test-external:ember-data-change-tracker": "./bin/test-external-partner-project.js ember-data-change-tracker https://github.com/danielspaniel/ember-data-change-tracker.git",
-    "test-external:emberaddons.com": "./bin/test-external-partner-project.js ember-cli-addon-search https://github.com/gcollazo/ember-cli-addon-search.git",
     "test-external:model-fragments": "./bin/test-external-partner-project.js ember-data-model-fragments https://github.com/lytics/ember-data-model-fragments.git",
     "test-external:ember-observer": "./bin/test-external-partner-project.js ember-observer https://github.com/emberobserver/client.git",
     "test-external:travis-web": "./bin/test-external-partner-project.js travis-web https://github.com/travis-ci/travis-web.git",


### PR DESCRIPTION
emberaddons.com is no longer maintained and the website has been taken down: https://github.com/gcollazo/ember-cli-addon-search/issues/109