### PR TITLE
Fix yuidoc setup to support the split packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ benchmarks/results/*.json
 
 .github-upload-token
 *.swp
-docs/build/
+docs/
 .metadata_never_index
 
 DEBUG

--- a/packages/-ember-data/yuidoc.json
+++ b/packages/-ember-data/yuidoc.json
@@ -7,7 +7,11 @@
     "extension": ".js,.ts",
     "paths": [
       "addon",
-      "node_modules/ember-inflector/addon"
+      "node_modules/ember-inflector/addon",
+      "../adapter/addon",
+      "../model/addon",
+      "../serializer/addon",
+      "../store/addon"
     ],
     "exclude": "vendor",
     "outdir": "docs"


### PR DESCRIPTION
<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
When trying to view the latest doc changes on the API docs app, I noticed that the setup is borked.

With these changes, you can view the latest docs from this branch by following the instructions in https://github.com/ember-learn/ember-jsonapi-docs#generating-api-documentation-and-testing-api-docs-locally.

This is for https://github.com/emberjs/data/issues/6016