### PR TITLE
chore: remove dead sinceToken code

### DIFF
--- a/packages/store/addon/-private/system/store.js
+++ b/packages/store/addon/-private/system/store.js
@@ -1970,7 +1970,6 @@ const Store = Service.extend({
   */
   _fetchAll(modelName, array, options = {}) {
     let adapter = this.adapterFor(modelName);
-    let sinceToken = this._internalModelsFor(modelName).metadata.since;
 
     assert(`You tried to load all records but you have no adapter (for ${modelName})`, adapter);
     assert(
@@ -1980,14 +1979,14 @@ const Store = Service.extend({
 
     if (options.reload) {
       set(array, 'isUpdating', true);
-      return promiseArray(_findAll(adapter, this, modelName, sinceToken, options));
+      return promiseArray(_findAll(adapter, this, modelName, options));
     }
 
     let snapshotArray = array._createSnapshot(options);
 
     if (adapter.shouldReloadAll(this, snapshotArray)) {
       set(array, 'isUpdating', true);
-      return promiseArray(_findAll(adapter, this, modelName, sinceToken, options));
+      return promiseArray(_findAll(adapter, this, modelName, options));
     }
 
     if (options.backgroundReload === false) {
@@ -1996,7 +1995,7 @@ const Store = Service.extend({
 
     if (options.backgroundReload || adapter.shouldBackgroundReloadAll(this, snapshotArray)) {
       set(array, 'isUpdating', true);
-      _findAll(adapter, this, modelName, sinceToken, options);
+      _findAll(adapter, this, modelName, options);
     }
 
     return promiseArray(Promise.resolve(array));

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -366,12 +366,12 @@ export function _findBelongsTo(adapter, store, internalModel, link, relationship
   );
 }
 
-export function _findAll(adapter, store, modelName, sinceToken, options) {
+export function _findAll(adapter, store, modelName, options) {
   let modelClass = store.modelFor(modelName); // adapter.findAll depends on the class
   let recordArray = store.peekAll(modelName);
   let snapshotArray = recordArray._createSnapshot(options);
   let promise = Promise.resolve().then(() =>
-    adapter.findAll(store, modelClass, sinceToken, snapshotArray)
+    adapter.findAll(store, modelClass, null, snapshotArray)
   );
   let label = 'DS: Handle Adapter#findAll of ' + modelClass;
 


### PR DESCRIPTION
Since an unknown time many many (many) years ago, `findAll` has not supported use of a `sinceToken`, even though the adapter API still has a slot for it in the arguments passed to `Adapter.findAll`.

This PR removes a bit of infra that attempted to pull an always missing sinceToken from an always empty cache attached to the InternalModel cache where we were never stashing one to begin with.

If this is a feature we wish to support, we should design a mechanism through which consuming applications can retrieve and update the sinceToken.
