### PR TITLE
chore: ignore local tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ npm-debug.log*
 testem.log
 yarn-error.log
 
+# Ignore artifacts of publishing
+*.tgz
+
 # ember-try
 .node_modules.ember-try/
 bower.json.ember-try


### PR DESCRIPTION
make sure that the tarballs we produce while publishing aren't checked in