### PR TITLE
lock prettier version

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "loader.js": "^4.7.0",
     "mocha": "^6.1.2",
     "pre-commit": "^1.2.2",
-    "prettier": "^1.17.1",
+    "prettier": "~1.18.2",
     "rimraf": "^2.6.2",
     "rsvp": "^4.8.5",
     "semver": "^6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9414,7 +9414,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.17.1:
+prettier@~1.18.2:
   version "1.18.2"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==


### PR DESCRIPTION
We seem to be getting lots of churn with prettier changes, so we should be deliberate about when and how we upgrade. I set the value to what is currently in the lock file
@runspired @rwjblue 