### PR TITLE
scaffold mocha unit testing for feature flags

### DIFF
--- a/packages/canary-features/node-tests/unit/feature-merging-test.js
+++ b/packages/canary-features/node-tests/unit/feature-merging-test.js
@@ -1,0 +1,5 @@
+/* eslint-env mocha */
+describe('Unit: canary-features', function() {
+  it('features.js is the single source of truth for flags');
+  it('provides correct default values for feature flags');
+});

--- a/packages/canary-features/package.json
+++ b/packages/canary-features/package.json
@@ -12,7 +12,9 @@
     "doc": "doc",
     "test": "tests"
   },
-  "scripts": {},
+  "scripts": {
+    "test:node": "mocha"
+  },
   "dependencies": {
     "babel-plugin-debug-macros": "^0.3.2",
     "babel-plugin-feature-flags": "^0.3.1",


### PR DESCRIPTION
I setup some mocha tests. I think once we migrate the `features.js` logic into this package, we could fill out those tests. Until then, this just sets up running it like the other packages.