### PR TITLE
ensure single source of truth for canary feature flags

### DIFF
--- a/packages/-build-infra/package.json
+++ b/packages/-build-infra/package.json
@@ -14,6 +14,7 @@
     "test:node": "mocha"
   },
   "dependencies": {
+    "@babel/parser": "^7.5.0",
     "babel-plugin-debug-macros": "^0.3.2",
     "babel-plugin-feature-flags": "^0.3.1",
     "babel-plugin-filter-imports": "^3.0.0",

--- a/packages/-build-infra/src/features.js
+++ b/packages/-build-infra/src/features.js
@@ -1,22 +1,61 @@
 'use strict';
 
+function castValue({ type, name, value }) {
+  if (type === 'NullLiteral') {
+    return null;
+  }
+  if (type === 'BooleanLiteral') {
+    return value;
+  }
+  if (type === 'NumericLiteral') {
+    return value;
+  }
+  if (type === 'StringLiteral') {
+    return value;
+  }
+  if (type === 'Identifier' && name === 'undefined') {
+    return undefined;
+  }
+}
 const { parse } = require('@babel/parser');
 const fs = require('fs');
-
 // See ember-source for other implementation to parse typescript file
 function extractFeaturesHash() {
   let fileName = require.resolve('@ember-data/canary-features/addon/index.js');
   let fileContents = fs.readFileSync(fileName, { encoding: 'utf8' }).toString();
-  let parsed = parse(fileContents, { sourceType: 'module' })
-  return parsed.program.body;
+  let parsed = parse(fileContents, {
+    sourceType: 'module',
+    estree: true,
+  });
+  // TODO manual extracting, but should considering using a babel plugin
+  // Passing the plugins configuration option did not seem to work
+  let exportedHashDeclaration = parsed.program.body.find(node => {
+    return (
+      node.type === 'ExportNamedDeclaration' &&
+      node.declaration.type === 'VariableDeclaration' &&
+      node.declaration.declarations.length === 1 &&
+      node.declaration.declarations[0].id &&
+      node.declaration.declarations[0].id.type === 'Identifier' &&
+      node.declaration.declarations[0].id.name === 'DEFAULT_FEATURES'
+    );
+  });
+
+  // grab the fields we need
+  const {
+    declaration: {
+      declarations: [node],
+    },
+  } = exportedHashDeclaration;
+  // populate an object with the values
+  // static values declared in the file
+  const defaults = {};
+  node.init.properties.forEach(prop => {
+    defaults[prop.key.name] = castValue(prop.value);
+  });
+  return defaults;
 }
 function getFeatures() {
-  const features = {
-    SAMPLE_FEATURE_FLAG: null,
-    RECORD_DATA_ERRORS: null,
-    RECORD_DATA_STATE: null,
-  };
-  console.log(extractFeaturesHash());
+  const features = extractFeaturesHash();
 
   const FEATURE_OVERRIDES = process.env.EMBER_DATA_FEATURE_OVERRIDE;
   if (FEATURE_OVERRIDES === 'ENABLE_ALL_OPTIONAL') {

--- a/packages/-build-infra/src/features.js
+++ b/packages/-build-infra/src/features.js
@@ -1,11 +1,22 @@
 'use strict';
 
+const { parse } = require('@babel/parser');
+const fs = require('fs');
+
+// See ember-source for other implementation to parse typescript file
+function extractFeaturesHash() {
+  let fileName = require.resolve('@ember-data/canary-features/addon/index.js');
+  let fileContents = fs.readFileSync(fileName, { encoding: 'utf8' }).toString();
+  let parsed = parse(fileContents, { sourceType: 'module' })
+  return parsed.program.body;
+}
 function getFeatures() {
   const features = {
     SAMPLE_FEATURE_FLAG: null,
     RECORD_DATA_ERRORS: null,
     RECORD_DATA_STATE: null,
   };
+  console.log(extractFeaturesHash());
 
   const FEATURE_OVERRIDES = process.env.EMBER_DATA_FEATURE_OVERRIDE;
   if (FEATURE_OVERRIDES === 'ENABLE_ALL_OPTIONAL') {
@@ -21,7 +32,7 @@ function getFeatures() {
     // enable only the specific features listed in the environment
     // variable (comma separated)
     const forcedFeatures = FEATURE_OVERRIDES.split(',');
-    for (var i = 0; i < forcedFeatures.length; i++) {
+    for (let i = 0; i < forcedFeatures.length; i++) {
       let featureName = forcedFeatures[i];
 
       features[featureName] = true;

--- a/packages/canary-features/addon/index.js
+++ b/packages/canary-features/addon/index.js
@@ -4,8 +4,8 @@ import { assign } from '@ember/polyfills';
 
 const ENV = typeof EmberDataENV === 'object' && EmberDataENV !== null ? EmberDataENV : {};
 
-// TODO: Make this file the source of truth, currently this must match
-//   the contents of `packages/-build-infra/src/features.js`
+// -build-infra/src/features consumes this variable to
+// populate the default features
 export const DEFAULT_FEATURES = {
   SAMPLE_FEATURE_FLAG: null,
   RECORD_DATA_ERRORS: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,6 +230,11 @@
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
   integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
 
+"@babel/parser@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.5.0.tgz#3e0713dff89ad6ae37faec3b29dcfc5c979770b7"
+  integrity sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==
+
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e"


### PR DESCRIPTION
Extract the definitive list of flags from the `DEFAULT_FEATURES` export in canary-features/addon/index.js.
Thanks to @lifeart for the AST extraction tips.
I'll probably close https://github.com/emberjs/data/pull/6212, because the node logic lives mostly in `-build-infra/src/features`, so adding tests there seems more appropriate.
