### PR TITLE
[BUGFIX relationships] fix proxy isDestroying error

### DIFF
--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -520,7 +520,7 @@ module('async belongs-to rendering tests', function(hooks) {
       }
 
       try {
-        let result = await sedona.get('parent');
+        await sedona.get('parent');
         assert.ok(false, 're-access should throw original rejection');
       } catch (e) {
         assert.ok(true, `Accessing resulted in rejected promise error: ${e.message}`);
@@ -553,7 +553,7 @@ module('async belongs-to rendering tests', function(hooks) {
       assert.equal(this.element.textContent.trim(), '', 'we have no parent');
 
       try {
-        let result = await sedona.get('parent');
+        await sedona.get('parent');
         assert.ok(false, `should have rejected`);
       } catch (e) {
         assert.equal(e.message, error, `should have rejected with '${error}'`);

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -1582,12 +1582,6 @@ function handleCompletedRelationshipRequest(internalModel, key, relationship, va
       if (proxy.content && proxy.content.isDestroying) {
         proxy.set('content', null);
       }
-
-      // clear the promise to make re-access safe
-      // e.g. after initial rejection, don't replay
-      // rejection on subsequent access, otherwise
-      // templates cause lots of rejected promise blow-ups
-      proxy.set('promise', resolve(null));
     }
 
     throw error;

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -1579,7 +1579,7 @@ function handleCompletedRelationshipRequest(internalModel, key, relationship, va
     // for the async reload case there will be no proxy if the ui
     // has never been accessed
     if (proxy && relationship.kind === 'belongsTo') {
-      if (proxy.content.isDestroying) {
+      if (proxy.content && proxy.content.isDestroying) {
         proxy.set('content', null);
       }
 


### PR DESCRIPTION
This fixes an error with async `belongsTo` relationships throwing an error like:
```
Cannot read property 'isDestroying' of null
```
This happens when the relationship fetch fails the first time and is then accessed again later.