### PR TITLE
chore: eliminate store._getInternalModelForRecordData

### DIFF
--- a/packages/store/addon/-private/system/references/has-many.js
+++ b/packages/store/addon/-private/system/references/has-many.js
@@ -200,7 +200,7 @@ export default class HasManyReference extends Reference {
     //TODO Igor cleanup
     return members.every(recordData => {
       let store = this.parentInternalModel.store;
-      let internalModel = store._internalModelForRecordData(recordData);
+      let internalModel = store._internalModelForResource(recordData.getResourceIdentifier());
       return internalModel.isLoaded() === true;
     });
   }

--- a/packages/store/addon/-private/system/store.js
+++ b/packages/store/addon/-private/system/store.js
@@ -2769,10 +2769,6 @@ const Store = Service.extend({
     return recordDataFor(internalModel);
   },
 
-  _internalModelForRecordData(recordData) {
-    let resource = recordData.getResourceIdentifier();
-    return this._internalModelForId(resource.type, resource.id, resource.clientId);
-  },
   /**
     `normalize` converts a json payload into the normalized form that
     [push](#method_push) expects.


### PR DESCRIPTION
eliminates a private method that only had one usage