### PR TITLE
chore: refactor store to class

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/ember__debug": "^3.0.3",
     "@types/ember__test-helpers": "~0.7.8",
     "@types/qunit": "^2.5.3",
-    "@types/rsvp": "^4.0.2",
+    "@types/rsvp": "^4.0.3",
     "babel-eslint": "^10.0.2",
     "broccoli-babel-transpiler": "^7.2.0",
     "broccoli-concat": "^3.7.3",

--- a/packages/-ember-data/tests/helpers/store.js
+++ b/packages/-ember-data/tests/helpers/store.js
@@ -66,7 +66,8 @@ export default function setupStore(options) {
   registry.optionsForType('serializer', { singleton: false });
   registry.optionsForType('adapter', { singleton: false });
 
-  owner.register('service:store', Store.extend({ adapter }));
+  const TestStore = Store.extend({ adapter });
+  owner.register('service:store', TestStore);
   owner.register('serializer:-default', JSONAPISerializer);
   owner.register('serializer:-json', JSONSerializer);
   owner.register('serializer:-rest', RESTSerializer);

--- a/packages/-ember-data/tests/integration/adapter/queries-test.js
+++ b/packages/-ember-data/tests/integration/adapter/queries-test.js
@@ -107,7 +107,10 @@ module('integration/adapter/queries - Queries', function(hooks) {
   });
 
   testInDebug('The store asserts when query is made and the adapter responses with a single record.', function(assert) {
-    env = setupStore({ person: Person, adapter: DS.RESTAdapter });
+    env = setupStore({
+      person: Person,
+      adapter: DS.RESTAdapter,
+    });
     store = env.store;
     adapter = env.adapter;
 
@@ -115,7 +118,7 @@ module('integration/adapter/queries - Queries', function(hooks) {
       assert.equal(type, Person, 'the query method is called with the correct type');
 
       return resolve({
-        data: [{ id: 1, type: 'person', attributes: { name: 'Peter Wagenet' } }],
+        data: { id: 1, type: 'person', attributes: { name: 'Peter Wagenet' } },
       });
     };
 

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -474,7 +474,7 @@ export default class InternalModel {
 
   save(options) {
     let promiseLabel = 'DS: Model#save ' + this;
-    let resolver = RSVP.defer(promiseLabel);
+    let resolver = RSVP.defer<InternalModel>(promiseLabel);
 
     this.store.scheduleSave(this, resolver, options);
     return resolver.promise;

--- a/packages/store/addon/-private/system/references/record.ts
+++ b/packages/store/addon/-private/system/references/record.ts
@@ -92,7 +92,7 @@ export default class RecordReference extends Reference {
      ```
 
     @method push
-    @param objectOrPromise
+    @param objectOrPromise a JSON:API ResourceDocument or a promise resolving to one
     @return a promise for the value (record or relationship)
   */
   push(objectOrPromise: SingleResourceDocument | Promise<SingleResourceDocument>): RSVP.Promise<Record> {

--- a/packages/store/addon/-private/system/references/record.ts
+++ b/packages/store/addon/-private/system/references/record.ts
@@ -1,5 +1,8 @@
 import RSVP, { resolve } from 'rsvp';
 import Reference from './reference';
+import { Record } from '../../ts-interfaces/record';
+import { JsonApiResource } from '../../ts-interfaces/record-data-json-api';
+import { JsonApiDocument, SingleResourceDocument } from '../../ts-interfaces/ember-data-json-api';
 
 /**
    An RecordReference is a low-level API that allows users and
@@ -89,10 +92,10 @@ export default class RecordReference extends Reference {
      ```
 
     @method push
-    @param objectOrPromise {Promise|Object}
-    @return RSVP.Promise<record> a promise for the value (record or relationship)
+    @param objectOrPromise
+    @return a promise for the value (record or relationship)
   */
-  push(objectOrPromise): RSVP.Promise<object> {
+  push(objectOrPromise: SingleResourceDocument | Promise<SingleResourceDocument>): RSVP.Promise<Record> {
     return resolve(objectOrPromise).then(data => {
       return this.store.push(data);
     });

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -189,15 +189,15 @@ function getInverse(store, parentInternalModel, parentRelationship, type) {
   return recordDataFindInverseRelationshipInfo(store, parentInternalModel, parentRelationship, type);
 }
 
-function recordDataFindInverseRelationshipInfo({ storeWrapper }, parentInternalModel, parentRelationship, type) {
+function recordDataFindInverseRelationshipInfo({ _storeWrapper }, parentInternalModel, parentRelationship, type) {
   let { name: lhs_relationshipName } = parentRelationship;
   let { modelName } = parentInternalModel;
-  let inverseKey = storeWrapper.inverseForRelationship(modelName, lhs_relationshipName);
+  let inverseKey = _storeWrapper.inverseForRelationship(modelName, lhs_relationshipName);
 
   if (inverseKey) {
     let {
       meta: { kind },
-    } = storeWrapper.relationshipsDefinitionFor(type)[inverseKey];
+    } = _storeWrapper.relationshipsDefinitionFor(type)[inverseKey];
     return {
       inverseKey,
       kind,

--- a/packages/store/addon/-private/ts-interfaces/ember-data-json-api.ts
+++ b/packages/store/addon/-private/ts-interfaces/ember-data-json-api.ts
@@ -64,6 +64,34 @@ export interface NewResourceIdentifierObject {
   lid: string;
 }
 
-export type ResourceIdentifierObject =
-  | ExistingResourceIdentifierObject
-  | NewResourceIdentifierObject;
+export type ResourceIdentifierObject = ExistingResourceIdentifierObject | NewResourceIdentifierObject;
+
+/**
+ * Contains the data for an existing resource in JSON:API format
+ */
+export interface ExistingResourceObject extends ExistingResourceIdentifierObject {
+  meta?: Dict<string, JSONValue>;
+  attributes?: Dict<string, JSONValue>;
+  // these are lossy, need improved typing
+  relationships?: Dict<string, JSONValue>;
+  links?: Dict<string, JSONValue>;
+}
+
+interface Document {
+  meta?: Dict<string, JSONValue>;
+  included?: ExistingResourceObject[];
+}
+
+export interface EmptyResourceDocument extends Document {
+  data: null;
+}
+
+export interface SingleResourceDocument extends Document {
+  data: ExistingResourceObject;
+}
+
+export interface CollectionResourceDocument extends Document {
+  data: ExistingResourceObject[];
+}
+
+export type JsonApiDocument = EmptyResourceDocument | SingleResourceDocument | CollectionResourceDocument;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,10 +1791,15 @@
   resolved "https://registry.npmjs.org/@types/qunit/-/qunit-2.9.0.tgz#0b3fcbe2b92f067856adac82ba3afbc66d8835ac"
   integrity sha512-Hx34HZmTJKRay+x3sFdEK62I8Z8YSWYg+rAlNr4M+AbwvNUJYxTTmWEH4a8B9ZN+Fl61awFrw+oRicWLFVugvQ==
 
-"@types/rsvp@*", "@types/rsvp@^4.0.2":
+"@types/rsvp@*":
   version "4.0.2"
   resolved "https://registry.npmjs.org/@types/rsvp/-/rsvp-4.0.2.tgz#bf9f72eaa6771292638a85bb8ce1db97e754b371"
   integrity sha512-48ZwxFD1hdBj8QMOSNGA2kYuo3+SKh8OEYh5cMi7cPRZXBF9jwVPV4yqA7EcJTNlAJL0v99pEUYetl0TsufMQA==
+
+"@types/rsvp@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/@types/rsvp/-/rsvp-4.0.3.tgz#4a1223158453257bce09d42b9eef7cfa6d257482"
+  integrity sha512-OpRwxbgx16nL/0/7ol0WoLLyLaMXBvtPOHjqLljnzAB/E7Qk1wtjytxgBhOTBMZvuLXnJUqfnjb4W/QclNFvSA==
 
 "@types/sizzle@*":
   version "2.3.2"


### PR DESCRIPTION
`Service.extend` forces us to move all properties onto the prototype in order for them to be type checked, the syntax does not allow for method overloads, and TS struggles to flow expected types through the store methods.

This PR refactors the store into a native class, giving us much improved type checking and allowing us to use method overloads.

It surfaced one issue where we expect folks to be able to overwrite `adapter` as a property on the store when extending; however, when using babel+typescript and a class this is transpiled with an automatic initializer to `void 0` that overwrites anything set via `create` or `extend`. We worked around this by not declaring that particular property and using a (nasty) type cast in the two locations we access it. @rwjblue does not believe this issue of interop of `TS` + `babel` + `legacy .extend` syntax is something apps will encounter often.

This PR builds on #6246 and #6247 