### PR TITLE
[BUGFIX query] Remove arity check for adapter.query

### DIFF
--- a/packages/-ember-data/tests/integration/record-arrays/adapter-populated-record-array-test.js
+++ b/packages/-ember-data/tests/integration/record-arrays/adapter-populated-record-array-test.js
@@ -163,7 +163,7 @@ module('integration/record-arrays/adapter_populated_record_array - DS.AdapterPop
     );
   });
 
-  test('pass record array to adapter.query based on arity', function(assert) {
+  test('pass record array to adapter.query regardless of arity', function(assert) {
     let env = setupStore({ person: Person });
     let store = env.store;
 
@@ -175,7 +175,8 @@ module('integration/record-arrays/adapter_populated_record_array - DS.AdapterPop
     };
 
     env.adapter.query = function(store, type, query) {
-      assert.equal(arguments.length, 3);
+      // Due to #6232, we now expect 5 arguments regardless of arity
+      assert.equal(arguments.length, 5);
       return payload;
     };
 
@@ -188,7 +189,7 @@ module('integration/record-arrays/adapter_populated_record_array - DS.AdapterPop
     });
   });
 
-  test('pass record array to adapter.query based on arity', function(assert) {
+  test('pass record array to adapter.query regardless of arity', function(assert) {
     let env = setupStore({ person: Person });
     let store = env.store;
 
@@ -214,7 +215,8 @@ module('integration/record-arrays/adapter_populated_record_array - DS.AdapterPop
     };
 
     env.adapter.query = function(store, type, query) {
-      assert.equal(arguments.length, 3);
+      // Due to #6232, we now expect 5 arguments regardless of arity
+      assert.equal(arguments.length, 5);
       return payload;
     };
 

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -337,16 +337,8 @@ export function _findAll(adapter, store, modelName, options) {
 export function _query(adapter, store, modelName, query, recordArray, options) {
   let modelClass = store.modelFor(modelName); // adapter.query needs the class
 
-  let promise;
-  let createRecordArray =
-    adapter.query.length > 3 || (adapter.query.wrappedFunction && adapter.query.wrappedFunction.length > 3);
-
-  if (createRecordArray) {
-    recordArray = recordArray || store.recordArrayManager.createAdapterPopulatedRecordArray(modelName, query);
-    promise = Promise.resolve().then(() => adapter.query(store, modelClass, query, recordArray, options));
-  } else {
-    promise = Promise.resolve().then(() => adapter.query(store, modelClass, query));
-  }
+  recordArray = recordArray || store.recordArrayManager.createAdapterPopulatedRecordArray(modelName, query);
+  let promise = Promise.resolve().then(() => adapter.query(store, modelClass, query, recordArray, options));
 
   let label = `DS: Handle Adapter#query of ${modelName}`;
   promise = guardDestroyedStore(promise, store, label);


### PR DESCRIPTION
This addresses the issue described in #6232. The arity check that decides whether to create a record array and pass options to adapter.query when the adapter extends `EmberObject`.

The solution suggested by @runspired is to remove the arity check completely, so I took a stab at doing that.