### PR TITLE
[BUGFIX] Includes yuidoc's output data.json to published package

### DIFF
--- a/packages/-ember-data/.npmignore
+++ b/packages/-ember-data/.npmignore
@@ -34,6 +34,9 @@
 /bin
 /docs
 /node-tests
-!/dist/docs # ignore all assets except /dist/docs folder
 .appveyor.yml
 lib/scripts
+
+# whitelist yuidoc's data.json for api docs generation
+!/dist/docs/data.json
+


### PR DESCRIPTION
<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
The `.npmignore` file entry that includes the `data.json` file generated by yuidoc doesn't seem to work after the package movement. I used `yarn pack` to verify that this includes the file as a part of the published package.

We need a patch release of 3.11 with this commit.