### PR TITLE
[BUGFIX release] fix type overrides

### DIFF
--- a/packages/-build-infra/.npmignore
+++ b/packages/-build-infra/.npmignore
@@ -1,6 +1,7 @@
 # compiled output
 /dist/
 /tmp/
+/types/
 
 # misc
 /.bowerrc

--- a/packages/-ember-data/.npmignore
+++ b/packages/-ember-data/.npmignore
@@ -1,6 +1,8 @@
 # compiled output
 /dist/
 /tmp/
+/types/
+**/*.d.ts
 
 # dependencies
 /bower_components/

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -16,8 +16,7 @@
     "test:production": "ember test -e production",
     "test:optional-features": "ember test",
     "test:try-one": "ember try:one",
-    "prepublishOnly": "ember build --environment=production && ember ts:precompile",
-    "postpublish": "ember ts:clean"
+    "prepublishOnly": "ember build --environment=production"
   },
   "author": "",
   "license": "MIT",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -87,7 +87,6 @@
   "keywords": [
     "ember-addon"
   ],
-  "types": "./stripped-types.d.ts",
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }

--- a/packages/-ember-data/stripped-types.d.ts
+++ b/packages/-ember-data/stripped-types.d.ts
@@ -1,2 +1,0 @@
-// intentionally empty types to help us preserve semver as we migrate to TS
-declare module 'ember-data';

--- a/packages/adapter/.npmignore
+++ b/packages/adapter/.npmignore
@@ -1,6 +1,8 @@
 # compiled output
 /dist/
 /tmp/
+/types/
+**/*.d.ts
 
 # dependencies
 /bower_components/

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -18,8 +18,7 @@
     "test": "ember test",
     "test:all": "ember try:each",
     "test:node": "mocha",
-    "prepublishOnly": "ember build --environment=production && ember ts:precompile",
-    "postpublish": "ember ts:clean"
+    "prepublishOnly": "ember build --environment=production"
   },
   "dependencies": {
     "@ember-data/-build-infra": "^3.12.0-canary.2",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -53,7 +53,6 @@
   "engines": {
     "node": ">= 8.0.0"
   },
-  "types": "./stripped-types.d.ts",
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }

--- a/packages/adapter/stripped-types.d.ts
+++ b/packages/adapter/stripped-types.d.ts
@@ -1,3 +1,0 @@
-// intentionally empty types to help us preserve semver as we migrate to TS
-declare module 'ember-data';
-declare module '@ember-data/adapter';

--- a/packages/canary-features/.npmignore
+++ b/packages/canary-features/.npmignore
@@ -1,6 +1,8 @@
 # compiled output
 /dist/
 /tmp/
+/types/
+**/*.d.ts
 
 # misc
 /.bowerrc

--- a/packages/model/.npmignore
+++ b/packages/model/.npmignore
@@ -1,6 +1,8 @@
 # compiled output
 /dist/
 /tmp/
+/types/
+**/*.d.ts
 
 # dependencies
 /bower_components/

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -19,8 +19,7 @@
     "test": "ember test",
     "test:all": "ember try:each",
     "test:node": "mocha",
-    "prepublishOnly": "ember build --environment=production && ember ts:precompile",
-    "postpublish": "ember ts:clean"
+    "prepublishOnly": "ember build --environment=production"
   },
   "dependencies": {
     "@ember-data/-build-infra": "^3.12.0-canary.2",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -57,7 +57,6 @@
   "engines": {
     "node": ">= 8.0.0"
   },
-  "types": "./stripped-types.d.ts",
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }

--- a/packages/model/stripped-types.d.ts
+++ b/packages/model/stripped-types.d.ts
@@ -1,3 +1,0 @@
-// intentionally empty types to help us preserve semver as we migrate to TS
-declare module 'ember-data';
-declare module '@ember-data/model';

--- a/packages/serializer/.npmignore
+++ b/packages/serializer/.npmignore
@@ -1,6 +1,8 @@
 # compiled output
 /dist/
 /tmp/
+/types/
+**/*.d.ts
 
 # dependencies
 /bower_components/

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -19,8 +19,7 @@
     "test": "ember test",
     "test:all": "ember try:each",
     "test:node": "mocha",
-    "prepublishOnly": "ember build --environment=production && ember ts:precompile",
-    "postpublish": "ember ts:clean"
+    "prepublishOnly": "ember build --environment=production"
   },
   "dependencies": {
     "@ember-data/-build-infra": "^3.12.0-canary.2",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -55,7 +55,6 @@
   "engines": {
     "node": ">= 8.0.0"
   },
-  "types": "./stripped-types.d.ts",
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }

--- a/packages/serializer/stripped-types.d.ts
+++ b/packages/serializer/stripped-types.d.ts
@@ -1,3 +1,0 @@
-// intentionally empty types to help us preserve semver as we migrate to TS
-declare module 'ember-data';
-declare module '@ember-data/serializer';

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -1,6 +1,8 @@
 # compiled output
 /dist/
 /tmp/
+/types/
+**/*.d.ts
 
 # dependencies
 /bower_components/

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -18,8 +18,7 @@
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each",
-    "prepublishOnly": "ember build --environment=production && ember ts:precompile",
-    "postpublish": "ember ts:clean"
+    "prepublishOnly": "ember build --environment=production && ember ts:clean"
   },
   "dependencies": {
     "@ember-data/-build-infra": "^3.12.0-canary.2",
@@ -56,7 +55,6 @@
   "engines": {
     "node": ">= 8.0.0"
   },
-  "types": "./stripped-types.d.ts",
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -18,7 +18,7 @@
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each",
-    "prepublishOnly": "ember build --environment=production && ember ts:clean"
+    "prepublishOnly": "ember build --environment=production"
   },
   "dependencies": {
     "@ember-data/-build-infra": "^3.12.0-canary.2",

--- a/packages/store/stripped-types.d.ts
+++ b/packages/store/stripped-types.d.ts
@@ -1,3 +1,0 @@
-// intentionally empty types to help us preserve semver as we migrate to TS
-declare module 'ember-data';
-declare module '@ember-data/store';


### PR DESCRIPTION
Updates how we guard against stripping types by:

- not running `ts:precompile`
- ignoring any `.d.ts` files in our `.npmignore`
- ignoring the `/types/` directory in each package where overrides live

See https://typed-ember.github.io/ember-cli-typescript/versions/master/docs/ts-guide/with-addons#publishing