### PR TITLE
[BUGFIX docs] ensure we publish docs

### DIFF
--- a/packages/-ember-data/.npmignore
+++ b/packages/-ember-data/.npmignore
@@ -1,5 +1,6 @@
 # compiled output
 /dist/
+/dist/**/*
 /tmp/
 /types/
 **/*.d.ts

--- a/packages/adapter/.npmignore
+++ b/packages/adapter/.npmignore
@@ -1,5 +1,6 @@
 # compiled output
 /dist/
+/dist/**/*
 /tmp/
 /types/
 **/*.d.ts
@@ -34,3 +35,6 @@
 
 # ember-data
 /node-tests
+
+# whitelist yuidoc's data.json for api docs generation
+!/dist/docs/data.json

--- a/packages/model/.npmignore
+++ b/packages/model/.npmignore
@@ -1,5 +1,6 @@
 # compiled output
 /dist/
+/dist/**/*
 /tmp/
 /types/
 **/*.d.ts
@@ -34,3 +35,6 @@
 
 # ember-data
 /node-tests
+
+# whitelist yuidoc's data.json for api docs generation
+!/dist/docs/data.json

--- a/packages/serializer/.npmignore
+++ b/packages/serializer/.npmignore
@@ -1,5 +1,6 @@
 # compiled output
 /dist/
+/dist/**/*
 /tmp/
 /types/
 **/*.d.ts
@@ -34,3 +35,6 @@
 
 # ember-data
 /node-tests
+
+# whitelist yuidoc's data.json for api docs generation
+!/dist/docs/data.json

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -1,5 +1,6 @@
 # compiled output
 /dist/
+/dist/**/*
 /tmp/
 /types/
 **/*.d.ts
@@ -31,3 +32,6 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# whitelist yuidoc's data.json for api docs generation
+!/dist/docs/data.json


### PR DESCRIPTION
The previous fix in #6252 didn't work properly with `npm` pack which does not run `prepublishOnly`. Incidentally this means we've not been running our `prepublishOnly` script with previous releases, and `ts:precompile` which it contained does not currently work. #6256 removes this command anyway so I've also gone ahead and removed it here to ensure we build properly.

I added the new `.npmignore` rules and made sure we do a production build for each individual package. At a glance, it appears that the `data.json` file produced in the `-ember-data` package is the only such file and contains the docs from the other packages.

cc @sivakumar-kailasam  