### PR TITLE
[BUGFIX][DOCS]Fix yuidoc generation across packages

### DIFF
--- a/packages/-ember-data/.npmignore
+++ b/packages/-ember-data/.npmignore
@@ -41,5 +41,4 @@
 lib/scripts
 
 # whitelist yuidoc's data.json for api docs generation
-!/dist/docs/data.json
-
+!dist/docs/data.json

--- a/packages/adapter/.npmignore
+++ b/packages/adapter/.npmignore
@@ -37,4 +37,4 @@
 /node-tests
 
 # whitelist yuidoc's data.json for api docs generation
-!/dist/docs/data.json
+!dist/docs/data.json

--- a/packages/model/.npmignore
+++ b/packages/model/.npmignore
@@ -37,4 +37,4 @@
 /node-tests
 
 # whitelist yuidoc's data.json for api docs generation
-!/dist/docs/data.json
+!dist/docs/data.json

--- a/packages/serializer/.npmignore
+++ b/packages/serializer/.npmignore
@@ -37,4 +37,4 @@
 /node-tests
 
 # whitelist yuidoc's data.json for api docs generation
-!/dist/docs/data.json
+!dist/docs/data.json

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -34,4 +34,4 @@
 /package.json.ember-try
 
 # whitelist yuidoc's data.json for api docs generation
-!/dist/docs/data.json
+!dist/docs/data.json


### PR DESCRIPTION
Last time I made [a PR like this](#6252) I tested the changes with `yarn pack` without realizing that we were using `npm` for publishes 😅. This time I tested the changes by running,

`node bin/publish.js release --skipPublish --skipSmokeTest --skipVersion --force`