### PR TITLE
[BUGFIX RELEASE] Fix generating from blueprints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,9 @@ jobs:
       env: TARGET_IE11=true
       script: yarn test
 
-    # See https://github.com/emberjs/data/pull/6241
-    # - name: 'Node Tests'
-    #   install: yarn install
-    #   script: yarn test:node
+    - name: 'Node Tests'
+      install: yarn install
+      script: yarn test:node
 
     # runs tests against each supported Ember version
     - stage: ember version tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,10 +84,9 @@ jobs:
           TARGET_IE11=true yarn test
         displayName: 'Max transpilation Tests'
 
-      # See https://github.com/emberjs/data/pull/6241
-      # - script: |
-      #     yarn test:node
-      #   displayName: 'Node Tests'
+      - script: |
+          yarn test:node
+        displayName: 'Node Tests'
 
       - script: |
           yarn test:try-one with-ember-fetch

--- a/packages/-build-infra/src/utilities/edition-detector.js
+++ b/packages/-build-infra/src/utilities/edition-detector.js
@@ -5,7 +5,7 @@ const path = require('path');
 module.exports = function(blueprint) {
   blueprint.filesPath = function() {
     let rootPath = process.env.EMBER_VERSION === 'OCTANE' ? 'native-files' : 'files';
-    return path.join(blueprint.blueprintPath, rootPath);
+    return path.join(blueprint.root, rootPath);
   };
 
   return blueprint;

--- a/packages/-build-infra/src/utilities/edition-detector.js
+++ b/packages/-build-infra/src/utilities/edition-detector.js
@@ -5,7 +5,7 @@ const path = require('path');
 module.exports = function(blueprint) {
   blueprint.filesPath = function() {
     let rootPath = process.env.EMBER_VERSION === 'OCTANE' ? 'native-files' : 'files';
-    return path.join(this.path, rootPath);
+    return path.join(blueprint.blueprintPath, rootPath);
   };
 
   return blueprint;

--- a/packages/-build-infra/src/utilities/test-framework-detector.js
+++ b/packages/-build-infra/src/utilities/test-framework-detector.js
@@ -15,7 +15,7 @@ module.exports = function(blueprint) {
     let dependencies = this.project.dependencies();
 
     if ('ember-qunit' in dependencies) {
-      if (fs.existsSync(blueprint.blueprintPath + '/qunit-rfc-232-files')) {
+      if (fs.existsSync(blueprint.root + '/qunit-rfc-232-files')) {
         type = 'qunit-rfc-232';
       } else {
         type = 'qunit';
@@ -23,7 +23,7 @@ module.exports = function(blueprint) {
     } else if ('ember-cli-qunit' in dependencies) {
       let checker = new VersionChecker(this.project);
       if (
-        fs.existsSync(blueprint.blueprintPath + '/qunit-rfc-232-files') &&
+        fs.existsSync(blueprint.root + '/qunit-rfc-232-files') &&
         checker.for('ember-cli-qunit', 'npm').gte('4.2.0')
       ) {
         type = 'qunit-rfc-232';
@@ -33,7 +33,7 @@ module.exports = function(blueprint) {
     } else if ('ember-mocha' in dependencies) {
       let checker = new VersionChecker(this.project);
       if (
-        fs.existsSync(blueprint.blueprintPath + '/mocha-rfc-232-files') &&
+        fs.existsSync(blueprint.root + '/mocha-rfc-232-files') &&
         checker.for('ember-mocha', 'npm').gte('0.14.0')
       ) {
         type = 'mocha-rfc-232';
@@ -47,7 +47,7 @@ module.exports = function(blueprint) {
       type = 'qunit';
     }
 
-    return path.join(blueprint.blueprintPath, type + '-files');
+    return path.join(blueprint.root, type + '-files');
   };
 
   return blueprint;

--- a/packages/-build-infra/src/utilities/test-framework-detector.js
+++ b/packages/-build-infra/src/utilities/test-framework-detector.js
@@ -41,7 +41,7 @@ module.exports = function(blueprint) {
       type = 'qunit';
     }
 
-    return path.join(this.path, type + '-files');
+    return path.join(blueprint.blueprintPath, type + '-files');
   };
 
   return blueprint;

--- a/packages/-build-infra/src/utilities/test-framework-detector.js
+++ b/packages/-build-infra/src/utilities/test-framework-detector.js
@@ -22,14 +22,20 @@ module.exports = function(blueprint) {
       }
     } else if ('ember-cli-qunit' in dependencies) {
       let checker = new VersionChecker(this.project);
-      if (fs.existsSync(blueprint.blueprintPath + '/qunit-rfc-232-files') && checker.for('ember-cli-qunit', 'npm').gte('4.2.0')) {
+      if (
+        fs.existsSync(blueprint.blueprintPath + '/qunit-rfc-232-files') &&
+        checker.for('ember-cli-qunit', 'npm').gte('4.2.0')
+      ) {
         type = 'qunit-rfc-232';
       } else {
         type = 'qunit';
       }
     } else if ('ember-mocha' in dependencies) {
       let checker = new VersionChecker(this.project);
-      if (fs.existsSync(blueprint.blueprintPath + '/mocha-rfc-232-files') && checker.for('ember-mocha', 'npm').gte('0.14.0')) {
+      if (
+        fs.existsSync(blueprint.blueprintPath + '/mocha-rfc-232-files') &&
+        checker.for('ember-mocha', 'npm').gte('0.14.0')
+      ) {
         type = 'mocha-rfc-232';
       } else {
         type = 'mocha';

--- a/packages/-build-infra/src/utilities/test-framework-detector.js
+++ b/packages/-build-infra/src/utilities/test-framework-detector.js
@@ -32,10 +32,7 @@ module.exports = function(blueprint) {
       }
     } else if ('ember-mocha' in dependencies) {
       let checker = new VersionChecker(this.project);
-      if (
-        fs.existsSync(blueprint.root + '/mocha-rfc-232-files') &&
-        checker.for('ember-mocha', 'npm').gte('0.14.0')
-      ) {
+      if (fs.existsSync(blueprint.root + '/mocha-rfc-232-files') && checker.for('ember-mocha', 'npm').gte('0.14.0')) {
         type = 'mocha-rfc-232';
       } else {
         type = 'mocha';

--- a/packages/-build-infra/src/utilities/test-framework-detector.js
+++ b/packages/-build-infra/src/utilities/test-framework-detector.js
@@ -15,21 +15,21 @@ module.exports = function(blueprint) {
     let dependencies = this.project.dependencies();
 
     if ('ember-qunit' in dependencies) {
-      if (fs.existsSync(this.path + '/qunit-rfc-232-files')) {
+      if (fs.existsSync(blueprint.blueprintPath + '/qunit-rfc-232-files')) {
         type = 'qunit-rfc-232';
       } else {
         type = 'qunit';
       }
     } else if ('ember-cli-qunit' in dependencies) {
       let checker = new VersionChecker(this.project);
-      if (fs.existsSync(this.path + '/qunit-rfc-232-files') && checker.for('ember-cli-qunit', 'npm').gte('4.2.0')) {
+      if (fs.existsSync(blueprint.blueprintPath + '/qunit-rfc-232-files') && checker.for('ember-cli-qunit', 'npm').gte('4.2.0')) {
         type = 'qunit-rfc-232';
       } else {
         type = 'qunit';
       }
     } else if ('ember-mocha' in dependencies) {
       let checker = new VersionChecker(this.project);
-      if (fs.existsSync(this.path + '/mocha-rfc-232-files') && checker.for('ember-mocha', 'npm').gte('0.14.0')) {
+      if (fs.existsSync(blueprint.blueprintPath + '/mocha-rfc-232-files') && checker.for('ember-mocha', 'npm').gte('0.14.0')) {
         type = 'mocha-rfc-232';
       } else {
         type = 'mocha';

--- a/packages/adapter/blueprints/adapter-test/index.js
+++ b/packages/adapter/blueprints/adapter-test/index.js
@@ -7,6 +7,8 @@ const path = require('path');
 module.exports = useTestFrameworkDetector({
   description: 'Generates an ember-data adapter unit test',
 
+  blueprintPath: __dirname,
+
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {
       return {

--- a/packages/adapter/blueprints/adapter-test/index.js
+++ b/packages/adapter/blueprints/adapter-test/index.js
@@ -7,7 +7,7 @@ const path = require('path');
 module.exports = useTestFrameworkDetector({
   description: 'Generates an ember-data adapter unit test',
 
-  blueprintPath: __dirname,
+  root: __dirname,
 
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {

--- a/packages/adapter/blueprints/adapter/index.js
+++ b/packages/adapter/blueprints/adapter/index.js
@@ -9,6 +9,8 @@ module.exports = useEditionDetector({
 
   availableOptions: [{ name: 'base-class', type: String }],
 
+  blueprintPath: __dirname,
+
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {
       return {

--- a/packages/adapter/blueprints/adapter/index.js
+++ b/packages/adapter/blueprints/adapter/index.js
@@ -9,7 +9,7 @@ module.exports = useEditionDetector({
 
   availableOptions: [{ name: 'base-class', type: String }],
 
-  blueprintPath: __dirname,
+  root: __dirname,
 
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {

--- a/packages/model/blueprints/model-test/index.js
+++ b/packages/model/blueprints/model-test/index.js
@@ -8,7 +8,7 @@ const path = require('path');
 module.exports = useTestFrameworkDetector({
   description: 'Generates a model unit test.',
 
-  blueprintPath: __dirname,
+  root: __dirname,
 
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {

--- a/packages/model/blueprints/model-test/index.js
+++ b/packages/model/blueprints/model-test/index.js
@@ -8,6 +8,8 @@ const path = require('path');
 module.exports = useTestFrameworkDetector({
   description: 'Generates a model unit test.',
 
+  blueprintPath: __dirname,
+
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {
       return {

--- a/packages/model/blueprints/model/index.js
+++ b/packages/model/blueprints/model/index.js
@@ -11,6 +11,8 @@ module.exports = useEditionDetector({
 
   anonymousOptions: ['name', 'attr:type'],
 
+  blueprintPath: __dirname,
+
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {
       return {

--- a/packages/model/blueprints/model/index.js
+++ b/packages/model/blueprints/model/index.js
@@ -11,7 +11,7 @@ module.exports = useEditionDetector({
 
   anonymousOptions: ['name', 'attr:type'],
 
-  blueprintPath: __dirname,
+  root: __dirname,
 
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {

--- a/packages/serializer/blueprints/serializer-test/index.js
+++ b/packages/serializer/blueprints/serializer-test/index.js
@@ -7,7 +7,7 @@ const path = require('path');
 module.exports = useTestFrameworkDetector({
   description: 'Generates a serializer unit test.',
 
-  blueprintPath: __dirname,
+  root: __dirname,
 
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {

--- a/packages/serializer/blueprints/serializer-test/index.js
+++ b/packages/serializer/blueprints/serializer-test/index.js
@@ -7,6 +7,8 @@ const path = require('path');
 module.exports = useTestFrameworkDetector({
   description: 'Generates a serializer unit test.',
 
+  blueprintPath: __dirname,
+
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {
       return {

--- a/packages/serializer/blueprints/serializer/index.js
+++ b/packages/serializer/blueprints/serializer/index.js
@@ -9,6 +9,8 @@ module.exports = useEditionDetector({
 
   availableOptions: [{ name: 'base-class', type: String }],
 
+  blueprintPath: __dirname,
+
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {
       return {

--- a/packages/serializer/blueprints/serializer/index.js
+++ b/packages/serializer/blueprints/serializer/index.js
@@ -9,7 +9,7 @@ module.exports = useEditionDetector({
 
   availableOptions: [{ name: 'base-class', type: String }],
 
-  blueprintPath: __dirname,
+  root: __dirname,
 
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {

--- a/packages/serializer/blueprints/transform-test/index.js
+++ b/packages/serializer/blueprints/transform-test/index.js
@@ -7,6 +7,8 @@ const path = require('path');
 module.exports = useTestFrameworkDetector({
   description: 'Generates a transform unit test.',
 
+  blueprintPath: __dirname,
+
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {
       return {

--- a/packages/serializer/blueprints/transform-test/index.js
+++ b/packages/serializer/blueprints/transform-test/index.js
@@ -7,7 +7,7 @@ const path = require('path');
 module.exports = useTestFrameworkDetector({
   description: 'Generates a transform unit test.',
 
-  blueprintPath: __dirname,
+  root: __dirname,
 
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {

--- a/packages/serializer/blueprints/transform/index.js
+++ b/packages/serializer/blueprints/transform/index.js
@@ -6,6 +6,8 @@ const useEditionDetector = require('@ember-data/-build-infra/src/utilities/editi
 module.exports = useEditionDetector({
   description: 'Generates an ember-data value transform.',
 
+  blueprintPath: __dirname,
+
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {
       return {

--- a/packages/serializer/blueprints/transform/index.js
+++ b/packages/serializer/blueprints/transform/index.js
@@ -6,7 +6,7 @@ const useEditionDetector = require('@ember-data/-build-infra/src/utilities/editi
 module.exports = useEditionDetector({
   description: 'Generates an ember-data value transform.',
 
-  blueprintPath: __dirname,
+  root: __dirname,
 
   fileMapTokens(options) {
     if (isModuleUnificationProject(this.project)) {


### PR DESCRIPTION
This fixes unable to generate models, adapters, serializers, and transforms.

Note: This is my first attempt to commit to ember-data.

Also fixes #6263 

Please note that we could not just override `path` or `filesPath` because `path` gets overwritten on `init` and `filesPath` is patched from outside the blueprints object.

Update: Rebased against master