### PR TITLE
[CHORE ci] Remove 3.4 LTS scenario for 3.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,7 @@ jobs:
 
     # runs tests against each supported Ember version
     - stage: ember version tests
-      name: 'Ember LTS 3.4'
-      env: EMBER_TRY_SCENARIO=ember-lts-3.4
-    - name: 'Ember LTS 3.8'
+      name: 'Ember LTS 3.8'
       env: EMBER_TRY_SCENARIO=ember-lts-3.8
     - name: 'Ember Release'
       if: NOT tag IS present AND NOT (branch ~= /^(emberjs:release|emberjs:lts|release|lts).*/)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,18 +184,22 @@ jobs:
           yarn
 
       - script: |
+          yarn install
           yarn test:try-one ember-lts-3.8
         displayName: 'Ember LTS test 3.8'
 
       - script: |
+          yarn install
           yarn test:try-one ember-release
         displayName: 'Ember Release'
 
       - script: |
+          yarn install
           yarn test:try-one ember-beta
         displayName: 'Ember Beta'
 
       - script: |
+          yarn install
           yarn test:try-one ember-canary
         displayName: 'Ember Canary'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,7 +245,7 @@ jobs:
           node ./bin/packages-for-commit.js
 
       - script: |
-          yarn test-external:travis-web
+          CI=true yarn test-external:travis-web
         displayName: 'External: travis-web'
 
   - job: External_Partner_tests_ember_observer

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,11 +138,11 @@ jobs:
           yarn install --no-lockfile --non-interactive
 
       - script: |
-           yarn test:try-one default-with-jquery
+          yarn test:try-one default-with-jquery
         displayName: 'Basic Tests with jQuery'
 
       - script: |
-           yarn test:try-one ember-release-with-jquery
+          yarn test:try-one ember-release-with-jquery
         displayName: 'Ember Release Channel Tests with jQuery'
 
   - job: Floating_dependencies
@@ -182,10 +182,6 @@ jobs:
           brew update
           brew cask install google-chrome
           yarn
-
-      - script: |
-          yarn test:try-one ember-lts-3.4
-        displayName: 'Ember LTS test 3.4'
 
       - script: |
           yarn test:try-one ember-lts-3.8

--- a/packages/-ember-data/config/ember-try.js
+++ b/packages/-ember-data/config/ember-try.js
@@ -27,18 +27,6 @@ module.exports = function() {
           npm: {},
         },
         {
-          name: 'ember-lts-3.4',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.6.0',
-              'ember-source': '~3.4.0',
-            },
-          },
-        },
-        {
           name: 'ember-lts-3.8',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),


### PR DESCRIPTION
EmberData's LTS support policy is for two previous LTS releases of Ember. Since master is currently targeting 3.13 and since 3.12 will be an LTS release, this means that on master we no longer need to support 3.4.

Once 3.12 LTS is released we will need to add that into the test configuration.