### PR TITLE
[BUGFIX canary] turn off identifiers until we explicitly PR the flag on

### DIFF
--- a/packages/canary-features/addon/default-features.js
+++ b/packages/canary-features/addon/default-features.js
@@ -15,6 +15,6 @@
 export default {
   SAMPLE_FEATURE_FLAG: null,
   RECORD_DATA_ERRORS: null,
-  RECORD_DATA_STATE: true,
-  IDENTIFIERS: true,
+  RECORD_DATA_STATE: null,
+  IDENTIFIERS: null,
 };


### PR DESCRIPTION
#6272 accidentally left these two flags on while debugging a test failure. This turns them back off until we explicitly turn them on later.