### PR TITLE
Make rest adapter test pass for fetch

### DIFF
--- a/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -2665,7 +2665,6 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
     });
   });
 
-
   testInDebug('warns when an empty response is returned, though a valid stringified JSON is expected', function(
     assert
   ) {

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -2665,24 +2665,23 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
     });
   });
 
-  if (hasJQuery) {
-    testInDebug('warns when an empty response is returned, though a valid stringified JSON is expected', function(
-      assert
-    ) {
-      server.post('/posts', function() {
-        return [201, { 'Content-Type': 'application/json' }, ''];
-      });
 
-      return run(() => {
-        return store.createRecord('post').save();
-      }).then(
-        () => {
-          assert.equal(true, false, 'should not have fulfilled');
-        },
-        reason => {
-          assert.ok(/JSON/.test(reason.message));
-        }
-      );
+  testInDebug('warns when an empty response is returned, though a valid stringified JSON is expected', function(
+    assert
+  ) {
+    server.post('/posts', function() {
+      return [201, { 'Content-Type': 'application/json' }, ''];
     });
-  }
+
+    return run(() => {
+      return store.createRecord('post').save();
+    }).then(
+      () => {
+        assert.equal(true, false, 'should not have fulfilled');
+      },
+      reason => {
+        assert.ok(/JSON/.test(reason.message));
+      }
+    );
+  });
 });

--- a/packages/adapter/addon/-private/utils/determine-body-promise.ts
+++ b/packages/adapter/addon/-private/utils/determine-body-promise.ts
@@ -1,3 +1,6 @@
+import { warn } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+
 /*
  * Function that always attempts to parse the response as json, and if an error is thrown,
  * returns `undefined` if the response is successful and has a status code of 204 (No Content),
@@ -22,6 +25,16 @@ export function determineBodyPromise(
       ) {
         ret = undefined;
       } else {
+        if (DEBUG) {
+          let message = `The server returned an empty string for ${requestData.method} ${requestData.url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
+          if (payload === '') {
+            warn(message, true, {
+              id: 'ds.adapter.returned-empty-string-as-JSON',
+            });
+            throw error;
+          }
+        }
+
         console.warn('This response was unable to be parsed as json.', payload);
       }
     }

--- a/packages/adapter/addon/rest.js
+++ b/packages/adapter/addon/rest.js
@@ -1246,14 +1246,6 @@ function ajaxSuccess(adapter, payload, requestData, responseData) {
 }
 
 function ajaxError(adapter, payload, requestData, responseData) {
-  if (DEBUG) {
-    let message = `The server returned an empty string for ${requestData.method} ${requestData.url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
-    let validJSONString = !(responseData.textStatus === 'parsererror' && payload === '');
-    warn(message, validJSONString, {
-      id: 'ds.adapter.returned-empty-string-as-JSON',
-    });
-  }
-
   let error;
 
   if (responseData.errorThrown instanceof Error) {
@@ -1316,6 +1308,15 @@ function ajaxErrorHandler(adapter, jqXHR, errorThrown, requestData) {
   let responseData = ajaxResponseData(jqXHR);
   responseData.errorThrown = errorThrown;
   let payload = adapter.parseErrorResponse(jqXHR.responseText);
+
+  if (DEBUG) {
+    let message = `The server returned an empty string for ${requestData.method} ${requestData.url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
+    let validJSONString = !(responseData.textStatus === 'parsererror' && payload === '');
+    warn(message, validJSONString, {
+      id: 'ds.adapter.returned-empty-string-as-JSON',
+    });
+  }
+
   return ajaxError(adapter, payload, requestData, responseData);
 }
 


### PR DESCRIPTION
Fixes #6083 

The issue wasn't pretender after all. ember-fetch overrides ajaxError so we have to move the debugging code.
