### PR TITLE
[BUGFIX] Await potentially async operations

### DIFF
--- a/packages/-ember-data/tests/integration/adapter/find-all-test.js
+++ b/packages/-ember-data/tests/integration/adapter/find-all-test.js
@@ -141,7 +141,7 @@ module('integration/adapter/find-all - Finding All Records of a Type', function(
     );
   });
 
-  test('When all records for a type are requested, records that are created on the client should be added to the record array.', assert => {
+  test('When all records for a type are requested, records that are created on the client should be added to the record array.', async assert => {
     assert.expect(3);
 
     let allRecords = store.peekAll('person');
@@ -153,6 +153,8 @@ module('integration/adapter/find-all - Finding All Records of a Type', function(
     );
 
     store.createRecord('person', { name: 'Carsten Nielsen' });
+
+    await settled();
 
     assert.equal(get(allRecords, 'length'), 1, "the record array's length is 1");
     assert.equal(

--- a/packages/-ember-data/tests/integration/record-array-test.js
+++ b/packages/-ember-data/tests/integration/record-array-test.js
@@ -383,11 +383,14 @@ module('unit/record-array - RecordArray', function(hooks) {
       name: 'Scumbag Dale',
     });
 
+    await settled();
     assert.equal(get(recordArray, 'length'), 1, 'precond - record array already has the first created item');
 
     store.createRecord('person', { name: 'p1' });
     store.createRecord('person', { name: 'p2' });
     store.createRecord('person', { name: 'p3' });
+
+    await settled();
 
     assert.equal(get(recordArray, 'length'), 4, 'precond - record array has the created item');
     assert.equal(recordArray.objectAt(0), scumbag, 'item at index 0 is record with id 1');

--- a/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
+++ b/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
@@ -12,6 +12,7 @@ import { module, test } from 'qunit';
 import DS from 'ember-data';
 import { setupTest } from 'ember-qunit';
 import { settled } from '@ember/test-helpers';
+import { gte } from 'ember-compatibility-helpers';
 
 let env, store, Person;
 
@@ -367,7 +368,11 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function(ho
   });
 
   test("invalid record's attributes can be rollbacked", async function(assert) {
-    assert.expect(12);
+    if (gte('3.13.0')) {
+      assert.expect(14);
+    } else {
+      assert.expect(13);
+    }
 
     class Dog extends Model {
       @attr() name;
@@ -438,7 +443,11 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function(ho
   });
 
   test(`invalid record's attributes rolled back to correct state after set`, async function(assert) {
-    assert.expect(14);
+    if (gte('3.13.0')) {
+      assert.expect(15);
+    } else {
+      assert.expect(14);
+    }
 
     class Dog extends Model {
       @attr() name;

--- a/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
+++ b/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
@@ -421,18 +421,19 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function(ho
     );
 
     try {
+      assert.ok(true, 'saving');
       await dog.save();
     } catch (reason) {
-      assert.equal(reason, thrownAdapterError);
+      assert.equal(reason, thrownAdapterError, 'We threw the expected error during save');
 
       dog.rollbackAttributes();
       await settled();
 
       assert.equal(dog.get('hasDirtyAttributes'), false, 'must not be dirty');
-      assert.equal(dog.get('name'), 'Pluto');
-      assert.notOk(dog.get('errors.name'));
-      assert.ok(dog.get('isValid'));
-      assert.equal(dog.get('rolledBackCount'), 1);
+      assert.equal(dog.get('name'), 'Pluto', 'Name is rolled back');
+      assert.notOk(dog.get('errors.name'), 'We have no errors for name anymore');
+      assert.ok(dog.get('isValid'), 'We are now in a valid state');
+      assert.equal(dog.get('rolledBackCount'), 1, 'we only rolled back once');
     }
   });
 


### PR DESCRIPTION
Some operations in Ember Data flush using `run.join`. This will flush
_synchronously_ if no runloop or autorun currently exists, but will
join the existing runloop otherwise, making the scheduled task
effectively asynchronous.

With the tracked properties feature flag enabled, the way we've
scheduled autoruns has changed. A few Data tests were failing because
they were expecting an operation to flush synchronously, but it flushed
asynchronously due to an existing autorun. This PR adds appropriate
`await settled();` statements in these cases.