### PR TITLE
fix ts package resolution

### DIFF
--- a/packages/-ember-data/tsconfig.json
+++ b/packages/-ember-data/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "allowJs": true,
+    "allowJs": false,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": false,
@@ -21,6 +21,12 @@
       "ember-data/*": ["addon/*"],
       "@ember-data/store": ["../store/addon"],
       "@ember-data/store/*": ["../store/addon/*"],
+      "@ember-data/model": ["../model/addon"],
+      "@ember-data/model/*": ["../model/addon/*"],
+      "@ember-data/adapter": ["../adapter/addon"],
+      "@ember-data/adapter/*": ["../adapter/addon/*"],
+      "@ember-data/serializer": ["../serializer/addon"],
+      "@ember-data/serializer/*": ["../serializer/addon/*"],
       "ember-data/test-support": ["addon-test-support"],
       "ember-data/test-support/*": ["addon-test-support/*"],
       "@ember-data/adapter/error": ["../adapter/addon/error"],


### PR DESCRIPTION
Need to set `allowJs` to false becuase of codedoc comments which conflict with typescript usage.

discussed this over slack with @mike-north Eventually we might want to redo the jsdoc comments, but I think in practice we will end up typing the remaining js files before that.