### PR TITLE
[BETA] Add environment variable to opt-out of rolling up `-private`

### DIFF
--- a/packages/-build-infra/src/addon-build-config-for-data-package.js
+++ b/packages/-build-infra/src/addon-build-config-for-data-package.js
@@ -111,7 +111,7 @@ function addonBuildConfigForDataPackage(PackageName) {
     },
 
     treeForAddon(tree) {
-      if (this.shouldRollupPrivate !== true) {
+      if (process.env.EMBER_DATA_ROLLUP_PRIVATE !== 'false' && this.shouldRollupPrivate !== true) {
         return this._super.treeForAddon.call(this, tree);
       }
 


### PR DESCRIPTION
This allows us to:

* Gather data about size per `-private` module
* Gather usage details about each `-private` module (via Chrome's coverage stats)
* Test the overall application performance impact of doing the `rollup` stages (do we still need them? how much impact does it have?)