### PR TITLE
[BUGFIX beta] Fix Rollup warning about unresolved dependency

### DIFF
--- a/packages/store/addon/-private/system/model/model.js
+++ b/packages/store/addon/-private/system/model/model.js
@@ -19,7 +19,7 @@ import InternalModel from './internal-model';
 import RootState from './states';
 import { RECORD_DATA_ERRORS, RECORD_DATA_STATE, REQUEST_SERVICE } from '@ember-data/canary-features';
 import coerceId from '../coerce-id';
-import { recordIdentifierFor } from '@ember-data/store';
+import { recordIdentifierFor } from '../store/internal-model-factory';
 import { InvalidError } from '@ember-data/adapter/error';
 
 const { changeProperties } = Ember;


### PR DESCRIPTION
Extracted from https://github.com/emberjs/data/pull/6098

Fixes the following warning:

```
'@ember-data/store' is imported by -private/system/model/model.js, but could not be resolved – treating it as an external dependency
```

I'm not sure I understand why but it seems like Rollup does not like the other style of import.

This also resolves an issue with the external partner tests for ember-observer. You can see an example of what happens without this at https://dev.azure.com/ember-data/emberjs/_build/results?buildId=962