### PR TITLE
Fail CI when TypeScript errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
       script:
         - yarn lint:features
         - yarn lint:prettier
+        - yarn problems
     - name: 'Basic Tests'
       script: yarn test
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,12 +24,12 @@ jobs:
         displayName: Node install
         inputs:
           versionSpec: '10.x' # The version we're installing
-
       - script: |
           yarn
           yarn lint:features
           yarn lint:prettier
-    displayName: 'Lint'
+          yarn problems
+        displayName: 'Lint'
 
   - job: Basic_Ember_Data_tests
     dependsOn: Lint

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:js": "./bin/lint-js",
     "lint:prettier": "eslint --plugin prettier .",
     "lint:features": "./bin/lint-features",
+    "problems": "yarn workspace ember-data problems",
     "start": "yarn workspace ember-data start",
     "test": "yarn workspace ember-data test",
     "test:all": "yarn workspace ember-data test:all",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -16,7 +16,8 @@
     "test:production": "ember test -e production",
     "test:optional-features": "ember test",
     "test:try-one": "ember try:one",
-    "prepublishOnly": "ember build --environment=production"
+    "prepublishOnly": "ember build --environment=production",
+    "problems": "tsc -p tsconfig.json --noEmit --pretty false"
   },
   "author": "",
   "license": "MIT",

--- a/packages/store/addon/-private/system/store.ts
+++ b/packages/store/addon/-private/system/store.ts
@@ -16,7 +16,8 @@ import { typeOf, isPresent, isNone } from '@ember/utils';
 
 import Ember from 'ember';
 import { InvalidError } from '@ember-data/adapter/error';
-import { assert, warn, deprecate, inspect } from '@ember/debug';
+import { assert, warn, inspect } from '@ember/debug';
+import { deprecate } from '@ember/application/deprecations';
 import { DEBUG } from '@glimmer/env';
 import Model from './model/model';
 import normalizeModelName from './normalize-model-name';
@@ -2192,7 +2193,7 @@ class Store extends Service {
         Note to future spelunkers hoping to optimize.
         We rely on this `run` to create a run loop if needed
         that `store._push` and `store.didSaveRecord` will both share.
-   
+
         We use `join` because it is often the case that we
         have an outer run loop available still from the first
         call to `store._push`;


### PR DESCRIPTION
This updates the CI config to fail the build if TypeScript compilation
fails.

This also fixes the following existing TypeScript compilation error:

```
../store/addon/-private/system/store.ts:19:24 - error TS2305: Module '"../../../../../../../../../../Users/eric/code/emberjs/data/node_modules/@types/ember__debug"' has no exported member 'deprecate'.
```
