### PR TITLE
[CHORE] Use model name instead of store in isPrimaryType

### DIFF
--- a/packages/serializer/addon/rest.js
+++ b/packages/serializer/addon/rest.js
@@ -273,7 +273,7 @@ const RESTSerializer = JSONSerializer.extend({
         continue;
       }
 
-      var isPrimary = !forcedSecondary && this.isPrimaryType(modelName, PrimaryModelClass);
+      var isPrimary = !forcedSecondary && this.isPrimaryType(modelName, primaryModelClass);
       var value = payload[prop];
 
       if (value === null) {
@@ -351,8 +351,8 @@ const RESTSerializer = JSONSerializer.extend({
     return documentHash;
   },
 
-  isPrimaryType(modelName, PrimaryModelClass) {
-    return normalizeModelName(modelName) === PrimaryModelClass.modelName;
+  isPrimaryType(modelName, primaryModelClass) {
+    return normalizeModelName(modelName) === primaryModelClass.modelName;
   },
 
   /**

--- a/packages/serializer/addon/rest.js
+++ b/packages/serializer/addon/rest.js
@@ -273,7 +273,7 @@ const RESTSerializer = JSONSerializer.extend({
         continue;
       }
 
-      var isPrimary = !forcedSecondary && this.isPrimaryType(store, typeName, primaryModelClass);
+      var isPrimary = !forcedSecondary && this.isPrimaryType(modelName, PrimaryModelClass);
       var value = payload[prop];
 
       if (value === null) {
@@ -351,8 +351,8 @@ const RESTSerializer = JSONSerializer.extend({
     return documentHash;
   },
 
-  isPrimaryType(store, typeName, primaryTypeClass) {
-    return store.modelFor(typeName) === primaryTypeClass;
+  isPrimaryType(modelName, PrimaryModelClass) {
+    return normalizeModelName(modelName) === PrimaryModelClass.modelName;
   },
 
   /**


### PR DESCRIPTION
Update rest serializer `isPrimaryType` to not use store anymore. 

Closes #5809 