### PR TITLE
[BUGFIX release] Add @ember-data/canary-features dependency where used.

### DIFF
--- a/packages/-build-infra/package.json
+++ b/packages/-build-infra/package.json
@@ -14,6 +14,7 @@
     "test:node": "mocha"
   },
   "dependencies": {
+    "@ember-data/canary-features": "3.14.0-alpha.1",
     "babel-plugin-debug-macros": "^0.3.2",
     "babel-plugin-feature-flags": "^0.3.1",
     "babel-plugin-filter-imports": "^3.0.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@ember-data/-build-infra": "3.14.0-alpha.1",
+    "@ember-data/canary-features": "3.14.0-alpha.1",
     "@ember-data/store": "3.14.0-alpha.1",
     "ember-cli-babel": "^7.8.0",
     "ember-cli-string-utils": "^1.1.0",


### PR DESCRIPTION
@ember-data/-build-infra directly requires `@ember-data/canary-features` (in `packages/-build-infra/src/features.js`), but without a dependency on it directly we can't ensure that it is present.


<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->