### PR TITLE
[CHORE] Refactor away from `createStore` test helper

### DIFF
--- a/packages/-ember-data/tests/helpers/store.js
+++ b/packages/-ember-data/tests/helpers/store.js
@@ -130,7 +130,3 @@ export default function setupStore(options) {
 }
 
 export { setupStore };
-
-export function createStore(options) {
-  return setupStore(options).store;
-}

--- a/packages/-ember-data/tests/integration/record-arrays/peeked-records-test.js
+++ b/packages/-ember-data/tests/integration/record-arrays/peeked-records-test.js
@@ -1,24 +1,25 @@
+import Model, { attr } from '@ember-data/model';
 import { run } from '@ember/runloop';
-import { createStore } from 'dummy/tests/helpers/store';
+import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import DS from 'ember-data';
 import { get } from '@ember/object';
 import { watchProperties } from '../../helpers/watch-property';
 
 let store;
 
-const Person = DS.Model.extend({
-  name: DS.attr('string'),
+const Person = Model.extend({
+  name: attr('string'),
   toString() {
     return `<Person#${this.get('id')}>`;
   },
 });
 
 module('integration/peeked-records', function(hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function() {
-    store = createStore({
-      person: Person,
-    });
+    this.owner.register('model:person', Person);
+    store = this.owner.lookup('service:store');
   });
 
   test('repeated calls to peekAll in separate run-loops works as expected', function(assert) {

--- a/packages/-ember-data/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
+++ b/packages/-ember-data/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
@@ -1,32 +1,33 @@
 import { run } from '@ember/runloop';
 import { Promise as EmberPromise } from 'rsvp';
-import { createStore } from 'dummy/tests/helpers/store';
+import { setupTest } from 'ember-qunit';
 
 import { module, test } from 'qunit';
 
-import DS from 'ember-data';
+import Model from '@ember-data/model';
+import RESTAdapter from '@ember-data/adapter/rest';
 
-let GroupsAdapter, store, requests;
+let store, requests;
 let maxLength;
 let lengths;
 
 module('unit/adapters/rest_adapter/group_records_for_find_many_test - DS.RESTAdapter#groupRecordsForFindMany', function(
   hooks
 ) {
+  setupTest(hooks);
+
   hooks.beforeEach(function() {
     maxLength = -1;
     requests = [];
     lengths = [];
 
-    GroupsAdapter = DS.RESTAdapter.extend({
+    const ApplicationAdapter = RESTAdapter.extend({
       coalesceFindRequests: true,
 
       findRecord(store, type, id, snapshot) {
         return { id };
       },
-    });
 
-    GroupsAdapter.reopen({
       ajax(url, type, options) {
         requests.push({
           url,
@@ -48,14 +49,10 @@ module('unit/adapters/rest_adapter/group_records_for_find_many_test - DS.RESTAda
       },
     });
 
-    store = createStore({
-      adapter: GroupsAdapter,
-      testRecord: DS.Model.extend(),
-    });
-  });
+    this.owner.register('adapter:application', ApplicationAdapter);
+    this.owner.register('model:test-record', Model.extend());
 
-  hooks.afterEach(function() {
-    run(store, 'destroy');
+    store = this.owner.lookup('service:store');
   });
 
   test('groupRecordsForFindMany - findMany', function(assert) {

--- a/packages/-ember-data/tests/unit/debug-test.js
+++ b/packages/-ember-data/tests/unit/debug-test.js
@@ -1,37 +1,33 @@
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { computed } from '@ember/object';
-import { createStore } from 'dummy/tests/helpers/store';
+import { setupTest } from 'ember-qunit';
 
 import { module, test } from 'qunit';
 
-import DS from 'ember-data';
+module('Debug', function(hooks) {
+  setupTest(hooks);
 
-const TestAdapter = DS.Adapter.extend();
-
-module('Debug', function() {
   test('_debugInfo groups the attributes and relationships correctly', function(assert) {
-    const MaritalStatus = DS.Model.extend({
-      name: DS.attr('string'),
+    const MaritalStatus = Model.extend({
+      name: attr('string'),
     });
 
-    const Post = DS.Model.extend({
-      title: DS.attr('string'),
+    const Post = Model.extend({
+      title: attr('string'),
     });
 
-    const User = DS.Model.extend({
-      name: DS.attr('string'),
-      isDrugAddict: DS.attr('boolean'),
-      maritalStatus: DS.belongsTo('marital-status', { async: false }),
-      posts: DS.hasMany('post', { async: false }),
+    const User = Model.extend({
+      name: attr('string'),
+      isDrugAddict: attr('boolean'),
+      maritalStatus: belongsTo('marital-status', { async: false }),
+      posts: hasMany('post', { async: false }),
     });
 
-    let store = createStore({
-      adapter: TestAdapter.extend(),
-      maritalStatus: MaritalStatus,
-      post: Post,
-      user: User,
-    });
+    this.owner.register('model:marital-status', MaritalStatus);
+    this.owner.register('model:post', Post);
+    this.owner.register('model:user', User);
 
-    let record = store.createRecord('user');
+    let record = this.owner.lookup('service:store').createRecord('user');
 
     let propertyInfo = record._debugInfo().propertyInfo;
 
@@ -45,18 +41,18 @@ module('Debug', function() {
   });
 
   test('_debugInfo supports arbitray relationship types', function(assert) {
-    const MaritalStatus = DS.Model.extend({
-      name: DS.attr('string'),
+    const MaritalStatus = Model.extend({
+      name: attr('string'),
     });
 
-    const Post = DS.Model.extend({
-      title: DS.attr('string'),
+    const Post = Model.extend({
+      title: attr('string'),
     });
 
-    const User = DS.Model.extend({
-      name: DS.attr('string'),
-      isDrugAddict: DS.attr('boolean'),
-      maritalStatus: DS.belongsTo('marital-status', { async: false }),
+    const User = Model.extend({
+      name: attr('string'),
+      isDrugAddict: attr('boolean'),
+      maritalStatus: belongsTo('marital-status', { async: false }),
       posts: computed(() => [1, 2, 3])
         .readOnly()
         .meta({
@@ -68,14 +64,11 @@ module('Debug', function() {
         }),
     });
 
-    let store = createStore({
-      adapter: TestAdapter.extend(),
-      maritalStatus: MaritalStatus,
-      post: Post,
-      user: User,
-    });
+    this.owner.register('model:marital-status', MaritalStatus);
+    this.owner.register('model:post', Post);
+    this.owner.register('model:user', User);
 
-    let record = store.createRecord('user');
+    let record = this.owner.lookup('service:store').createRecord('user');
 
     let propertyInfo = record._debugInfo().propertyInfo;
 

--- a/packages/-ember-data/tests/unit/store/has-model-for-test.js
+++ b/packages/-ember-data/tests/unit/store/has-model-for-test.js
@@ -1,20 +1,17 @@
-import { createStore } from 'dummy/tests/helpers/store';
+import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import DS from 'ember-data';
-
-let store;
+import Model from '@ember-data/model';
 
 module('unit/store/has-model-For', function(hooks) {
-  hooks.beforeEach(function() {
-    store = createStore({
-      adapter: DS.Adapter.extend(),
-      'one-foo': DS.Model.extend({}),
-      'two-foo': DS.Model.extend({}),
-    });
-  });
+  setupTest(hooks);
 
   test(`hasModelFor correctly normalizes`, function(assert) {
+    this.owner.register('model:one-foo', Model.extend({}));
+    this.owner.register('model:two-foo', Model.extend({}));
+
+    let store = this.owner.lookup('service:store');
+
     assert.equal(store._hasModelFor('oneFoo'), true);
-    assert.equal(store._hasModelFor('twoFoo').true);
+    assert.equal(store._hasModelFor('twoFoo'), true);
   });
 });


### PR DESCRIPTION
From https://github.com/emberjs/data/issues/6166

This refactors some tests so that they don't rely on the `createStore` test helper.

`createStore` was helpful in the past but is less so now that we have [nice APIs for dependency injection](https://guides.emberjs.com/release/applications/dependency-injection/).

---

One test was removed from `unit/store/adapter-interop - Store working with a Adapter` because I don't think it was correct.

Here was the test:

https://github.com/emberjs/data/blob/39182f324d5777e4a75c4a582f0791631e37d8de/packages/-ember-data/tests/unit/store/adapter-interop-test.js#L28-L32

This test was, at one time, testing that it was possible to pass a factory as the `adapter` property to `Store`. This feature was removed in https://github.com/emberjs/data/pull/3191 but the test continued passing because of the way the `createStore` works.

https://github.com/emberjs/data/blob/39182f324d5777e4a75c4a582f0791631e37d8de/packages/-ember-data/tests/helpers/store.js#L57-L60