### PR TITLE
Set group name to relationship.kind

### DIFF
--- a/packages/-ember-data/tests/unit/debug-test.js
+++ b/packages/-ember-data/tests/unit/debug-test.js
@@ -37,8 +37,11 @@ test('_debugInfo groups the attributes and relationships correctly', function(as
   let propertyInfo = record._debugInfo().propertyInfo;
 
   assert.equal(propertyInfo.groups.length, 4);
+  assert.equal(propertyInfo.groups[0].name, 'Attributes');
   assert.deepEqual(propertyInfo.groups[0].properties, ['id', 'name', 'isDrugAddict']);
+  assert.equal(propertyInfo.groups[1].name, 'belongsTo');
   assert.deepEqual(propertyInfo.groups[1].properties, ['maritalStatus']);
+  assert.equal(propertyInfo.groups[2].name, 'hasMany');
   assert.deepEqual(propertyInfo.groups[2].properties, ['posts']);
 });
 
@@ -86,12 +89,12 @@ test('_debugInfo supports arbitray relationship types', function(assert) {
         expand: true,
       },
       {
-        name: 'maritalStatus',
+        name: 'belongsTo',
         properties: ['maritalStatus'],
         expand: true,
       },
       {
-        name: 'posts',
+        name: 'customRelationship',
         properties: ['posts'],
         expand: true,
       },

--- a/packages/store/addon/-private/system/model/model.js
+++ b/packages/store/addon/-private/system/model/model.js
@@ -1195,7 +1195,7 @@ const Model = EmberObject.extend(DeprecatedEvented, {
       if (properties === undefined) {
         properties = relationships[relationship.kind] = [];
         groups.push({
-          name: relationship.name,
+          name: relationship.kind,
           properties,
           expand: true,
         });


### PR DESCRIPTION
This fixes a bug in inspector where the groups are named the model name instead of the relationship type.