### PR TITLE
[DOC debug-adapter]: Add comments for each method in debug-adapter

### DIFF
--- a/packages/-ember-data/addon/-private/system/debug/debug-adapter.js
+++ b/packages/-ember-data/addon/-private/system/debug/debug-adapter.js
@@ -18,6 +18,15 @@ import Model from '@ember-data/model';
   @private
 */
 export default DataAdapter.extend({
+  /**
+    Specifies how records can be filtered based on the state of the record
+    Records returned will need to have a `filterValues`
+    property with a key for every name in the returned array
+    @public
+    @method getFilters
+    @return {Array} List of objects defining filters
+     The object should have a `name` and `desc` property
+  */
   getFilters() {
     return [
       { name: 'isNew', desc: 'New' },
@@ -26,10 +35,24 @@ export default DataAdapter.extend({
     ];
   },
 
+  /**
+    Detect whether a class is a DS.Model
+    @public
+    @method detect
+    @param {DS.Model} typeClass
+    @return {Boolean} Whether the typeClass is a DS.Model class or not
+  */
   detect(typeClass) {
     return typeClass !== Model && Model.detect(typeClass);
   },
 
+  /**
+    Creates a human readable string used for column headers
+    @public
+    @method columnNameToDesc
+    @param {String} name The attribute name
+    @return {String} Human readable string based on the attribute name
+  */
   columnNameToDesc(name) {
     return capitalize(
       underscore(name)
@@ -38,6 +61,15 @@ export default DataAdapter.extend({
     );
   },
 
+  /**
+    Get the columns for a given model type
+    @public
+    @method columnsForType
+    @param {DS.Model} typeClass
+    @return {Array} An array of columns of the following format:
+     name: {String} The name of the column
+     desc: {String} Humanized description (what would show in a table column name)
+  */
   columnsForType(typeClass) {
     let columns = [
       {
@@ -57,6 +89,16 @@ export default DataAdapter.extend({
     return columns;
   },
 
+  /**
+    Fetches all loaded records for a given type
+    @public
+    @method getRecords
+    @param {DS.Model} modelClass of the record
+    @param {String} modelName of the record
+    @return {Array} An array of DS.Model records
+     This array will be observed for changes,
+     so it should update when new records are added/removed
+  */
   getRecords(modelClass, modelName) {
     if (arguments.length < 2) {
       // Legacy Ember.js < 1.13 support
@@ -72,6 +114,14 @@ export default DataAdapter.extend({
     return this.get('store').peekAll(modelName);
   },
 
+  /**
+    Gets the values for each column
+    This is the attribute values for a given record
+    @public
+    @method getRecordColumnValues
+    @param {DS.Model} record to get values from
+    @return {Object} Keys should match column names defined by the model type
+  */
   getRecordColumnValues(record) {
     let count = 0;
     let columnValues = { id: get(record, 'id') };
@@ -85,6 +135,13 @@ export default DataAdapter.extend({
     return columnValues;
   },
 
+  /**
+    Returns keywords to match when searching records
+    @public
+    @method getRecordKeywords
+    @param {DS.Model} record
+    @return {Array} Relevant keywords for search based on the record's attribute values
+  */
   getRecordKeywords(record) {
     let keywords = [];
     let keys = A(['id']);
@@ -93,6 +150,14 @@ export default DataAdapter.extend({
     return keywords;
   },
 
+  /**
+    Returns the values of filters defined by `getFilters`
+    These reflect the state of the record
+    @public
+    @method getRecordFilterValues
+    @param {DS.Model} record
+    @return {Object} The record state filter values
+  */
   getRecordFilterValues(record) {
     return {
       isNew: record.get('isNew'),
@@ -101,6 +166,14 @@ export default DataAdapter.extend({
     };
   },
 
+  /**
+    Returns a color that represents the record's state
+    @public
+    @method getRecordColor
+    @param {DS.Model} record
+    @return {String} The record color
+      Possible options: black, blue, green
+  */
   getRecordColor(record) {
     let color = 'black';
     if (record.get('isNew')) {
@@ -111,6 +184,15 @@ export default DataAdapter.extend({
     return color;
   },
 
+  /**
+    Observes all relevant properties and re-sends the wrapped record
+    when a change occurs
+    @public
+    @method observerRecord
+    @param {DS.Model} record
+    @param {Function} recordUpdated Callback used to notify changes
+    @return {Function} The function to call to remove all observers
+  */
   observeRecord(record, recordUpdated) {
     let releaseMethods = A();
     let keysToObserve = A(['id', 'isNew', 'hasDirtyAttributes']);


### PR DESCRIPTION
This will be useful for debugging in the future when developers are stepping through both this `debug-adapter` and the `m3` `debug-adapter`.