### PR TITLE
[CHORE tests] simplify setupStore registrations

### DIFF
--- a/packages/-ember-data/addon/setup-container.js
+++ b/packages/-ember-data/addon/setup-container.js
@@ -31,7 +31,6 @@ function initializeStore(registry) {
   registerOptionsForType.call(registry, 'adapter', { singleton: false });
   registry.register('serializer:-default', JSONSerializer);
   registry.register('serializer:-rest', RESTSerializer);
-  registry.register('adapter:-rest', RESTAdapter);
 
   registry.register('adapter:-json-api', JSONAPIAdapter);
   registry.register('serializer:-json-api', JSONAPISerializer);

--- a/packages/-ember-data/addon/setup-container.js
+++ b/packages/-ember-data/addon/setup-container.js
@@ -4,7 +4,6 @@ import JSONAPISerializer from '@ember-data/serializer/json-api';
 import JSONSerializer from '@ember-data/serializer/json';
 import RESTSerializer from '@ember-data/serializer/rest';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import RESTAdapter from '@ember-data/adapter/rest';
 
 import { BooleanTransform, DateTransform, NumberTransform, StringTransform } from '@ember-data/serializer/-private';
 

--- a/packages/-ember-data/tests/helpers/store.js
+++ b/packages/-ember-data/tests/helpers/store.js
@@ -20,7 +20,7 @@ const resolver = Resolver.create({
 });
 
 // TODO get us to a setApplication world instead
-//   seems to require killing off createStore
+//   seems to require killing off setupStore
 setResolver(resolver);
 
 export default function setupStore(options) {
@@ -56,11 +56,11 @@ export default function setupStore(options) {
     adapter = 'application';
   } else if (adapter === '-default') {
     // Tests using this should refactor.
-    // this allows for more incremental migration off of createStore
+    // this allows for more incremental migration off of setupStore
     // by supplying the adapter vs forcing an immediate full refactor
     // to modern syntax
     // The minimal refactor is to set `adapter: Adapter` on usage of
-    // `createStore` that does not currently supply Adapter.
+    // `setupStore` that does not currently supply Adapter.
     owner.register('adapter:-default', Adapter);
   }
 
@@ -79,7 +79,7 @@ export default function setupStore(options) {
 
   const store = (env.store = container.lookup('service:store'));
 
-  // this allows for more incremental migration off of createStore
+  // this allows for more incremental migration off of setupStore
   // by supplying the serializer vs forcing an immediate full refactor
   // to modern syntax
   if (options.serializer) {

--- a/packages/-ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/-ember-data/tests/integration/serializers/json-serializer-test.js
@@ -3,6 +3,7 @@ import { run } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
 
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
+import JSONSerializer from '@ember-data/serializer/json';
 import { module, test } from 'qunit';
 
 import DS from 'ember-data';
@@ -30,7 +31,8 @@ module('integration/serializer/json - JSONSerializer', function(hooks) {
     env.store.modelFor('post');
     env.store.modelFor('comment');
     env.store.modelFor('favorite');
-    serializer = env.store.serializerFor('-json');
+    env.owner.register('serializer:json', JSONSerializer);
+    serializer = env.store.serializerFor('json');
   });
 
   hooks.afterEach(function() {

--- a/packages/-ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/-ember-data/tests/unit/store/adapter-interop-test.js
@@ -32,9 +32,12 @@ module('unit/store/adapter-interop - DS.Store working with a DS.Adapter', functi
   });
 
   test('Adapter can be set as a name', function(assert) {
-    store = createStore({ adapter: 'application' });
+    const env = setupStore({ adapter: 'custom-adapter' });
+    const { store, owner } = env;
+    const CustomAdapter = DS.Adapter.extend({ isCustomAdapter: true });
+    owner.register('adapter:custom-adapter', CustomAdapter);
 
-    assert.ok(store.get('defaultAdapter') instanceof DS.RESTAdapter);
+    assert.ok(store.get('defaultAdapter') instanceof CustomAdapter);
   });
 
   testInDebug('Adapter can not be set as an instance', function(assert) {

--- a/packages/-ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/-ember-data/tests/unit/store/adapter-interop-test.js
@@ -34,7 +34,7 @@ module('unit/store/adapter-interop - DS.Store working with a DS.Adapter', functi
   test('Adapter can be set as a name', function(assert) {
     const env = setupStore({ adapter: 'custom-adapter' });
     const { store, owner } = env;
-    const CustomAdapter = DS.Adapter.extend({ isCustomAdapter: true });
+    const CustomAdapter = DS.Adapter.extend({ aCustomProp: 'Soo hot right now' });
     owner.register('adapter:custom-adapter', CustomAdapter);
 
     assert.ok(store.get('defaultAdapter') instanceof CustomAdapter);


### PR DESCRIPTION
This PR allows for more incremental migration away from `createStore` and `setupStore` to modern test syntax.

Specifically it

- ensures that we aren't registering anything unneeded for tests currently
- provides a path for registering a serializer for use with the test
- encourages use of "application" adapter/serializer

cc @pete-the-pete @snewcomer 