### PR TITLE
[CHORE tests] Convert non-nested QUnit modules to nested

### DIFF
--- a/packages/-ember-data/tests/unit/adapter-errors-test.js
+++ b/packages/-ember-data/tests/unit/adapter-errors-test.js
@@ -5,178 +5,178 @@ import { module, test } from 'qunit';
 
 import DS from 'ember-data';
 
-module('unit/adapter-errors - DS.AdapterError');
+module('unit/adapter-errors - DS.AdapterError', function() {
+  test('DS.AdapterError', function(assert) {
+    let error = new DS.AdapterError();
 
-test('DS.AdapterError', function(assert) {
-  let error = new DS.AdapterError();
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof EmberError);
+    assert.ok(error.isAdapterError);
+    assert.equal(error.message, 'Adapter operation failed');
+  });
 
-  assert.ok(error instanceof Error);
-  assert.ok(error instanceof EmberError);
-  assert.ok(error.isAdapterError);
-  assert.equal(error.message, 'Adapter operation failed');
-});
+  test('DS.InvalidError', function(assert) {
+    let error = new DS.InvalidError();
 
-test('DS.InvalidError', function(assert) {
-  let error = new DS.InvalidError();
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof DS.AdapterError);
+    assert.ok(error.isAdapterError);
+    assert.equal(error.message, 'The adapter rejected the commit because it was invalid');
+  });
 
-  assert.ok(error instanceof Error);
-  assert.ok(error instanceof DS.AdapterError);
-  assert.ok(error.isAdapterError);
-  assert.equal(error.message, 'The adapter rejected the commit because it was invalid');
-});
+  test('DS.TimeoutError', function(assert) {
+    let error = new DS.TimeoutError();
 
-test('DS.TimeoutError', function(assert) {
-  let error = new DS.TimeoutError();
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof DS.AdapterError);
+    assert.ok(error.isAdapterError);
+    assert.equal(error.message, 'The adapter operation timed out');
+  });
 
-  assert.ok(error instanceof Error);
-  assert.ok(error instanceof DS.AdapterError);
-  assert.ok(error.isAdapterError);
-  assert.equal(error.message, 'The adapter operation timed out');
-});
+  test('DS.AbortError', function(assert) {
+    let error = new DS.AbortError();
 
-test('DS.AbortError', function(assert) {
-  let error = new DS.AbortError();
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof DS.AdapterError);
+    assert.ok(error.isAdapterError);
+    assert.equal(error.message, 'The adapter operation was aborted');
+  });
 
-  assert.ok(error instanceof Error);
-  assert.ok(error instanceof DS.AdapterError);
-  assert.ok(error.isAdapterError);
-  assert.equal(error.message, 'The adapter operation was aborted');
-});
+  test('DS.UnauthorizedError', function(assert) {
+    let error = new DS.UnauthorizedError();
 
-test('DS.UnauthorizedError', function(assert) {
-  let error = new DS.UnauthorizedError();
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof DS.AdapterError);
+    assert.ok(error.isAdapterError);
+    assert.equal(error.message, 'The adapter operation is unauthorized');
+  });
 
-  assert.ok(error instanceof Error);
-  assert.ok(error instanceof DS.AdapterError);
-  assert.ok(error.isAdapterError);
-  assert.equal(error.message, 'The adapter operation is unauthorized');
-});
+  test('DS.ForbiddenError', function(assert) {
+    let error = new DS.ForbiddenError();
 
-test('DS.ForbiddenError', function(assert) {
-  let error = new DS.ForbiddenError();
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof DS.AdapterError);
+    assert.ok(error.isAdapterError);
+    assert.equal(error.message, 'The adapter operation is forbidden');
+  });
 
-  assert.ok(error instanceof Error);
-  assert.ok(error instanceof DS.AdapterError);
-  assert.ok(error.isAdapterError);
-  assert.equal(error.message, 'The adapter operation is forbidden');
-});
+  test('DS.NotFoundError', function(assert) {
+    let error = new DS.NotFoundError();
 
-test('DS.NotFoundError', function(assert) {
-  let error = new DS.NotFoundError();
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof DS.AdapterError);
+    assert.ok(error.isAdapterError);
+    assert.equal(error.message, 'The adapter could not find the resource');
+  });
 
-  assert.ok(error instanceof Error);
-  assert.ok(error instanceof DS.AdapterError);
-  assert.ok(error.isAdapterError);
-  assert.equal(error.message, 'The adapter could not find the resource');
-});
+  test('DS.ConflictError', function(assert) {
+    let error = new DS.ConflictError();
 
-test('DS.ConflictError', function(assert) {
-  let error = new DS.ConflictError();
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof DS.AdapterError);
+    assert.ok(error.isAdapterError);
+    assert.equal(error.message, 'The adapter operation failed due to a conflict');
+  });
 
-  assert.ok(error instanceof Error);
-  assert.ok(error instanceof DS.AdapterError);
-  assert.ok(error.isAdapterError);
-  assert.equal(error.message, 'The adapter operation failed due to a conflict');
-});
+  test('DS.ServerError', function(assert) {
+    let error = new DS.ServerError();
 
-test('DS.ServerError', function(assert) {
-  let error = new DS.ServerError();
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof DS.AdapterError);
+    assert.ok(error.isAdapterError);
+    assert.equal(error.message, 'The adapter operation failed due to a server error');
+  });
 
-  assert.ok(error instanceof Error);
-  assert.ok(error instanceof DS.AdapterError);
-  assert.ok(error.isAdapterError);
-  assert.equal(error.message, 'The adapter operation failed due to a server error');
-});
+  test('CustomAdapterError', function(assert) {
+    let CustomAdapterError = DS.AdapterError.extend();
+    let error = new CustomAdapterError();
 
-test('CustomAdapterError', function(assert) {
-  let CustomAdapterError = DS.AdapterError.extend();
-  let error = new CustomAdapterError();
+    assert.ok(error instanceof Error);
+    assert.ok(error instanceof DS.AdapterError);
+    assert.ok(error.isAdapterError);
+    assert.equal(error.message, 'Adapter operation failed');
+  });
 
-  assert.ok(error instanceof Error);
-  assert.ok(error instanceof DS.AdapterError);
-  assert.ok(error.isAdapterError);
-  assert.equal(error.message, 'Adapter operation failed');
-});
+  test('CustomAdapterError with default message', function(assert) {
+    let CustomAdapterError = DS.AdapterError.extend({ message: 'custom error!' });
+    let error = new CustomAdapterError();
 
-test('CustomAdapterError with default message', function(assert) {
-  let CustomAdapterError = DS.AdapterError.extend({ message: 'custom error!' });
-  let error = new CustomAdapterError();
+    assert.equal(error.message, 'custom error!');
+  });
 
-  assert.equal(error.message, 'custom error!');
-});
+  const errorsHash = {
+    name: ['is invalid', 'must be a string'],
+    age: ['must be a number'],
+  };
 
-const errorsHash = {
-  name: ['is invalid', 'must be a string'],
-  age: ['must be a number'],
-};
-
-const errorsArray = [
-  {
-    title: 'Invalid Attribute',
-    detail: 'is invalid',
-    source: { pointer: '/data/attributes/name' },
-  },
-  {
-    title: 'Invalid Attribute',
-    detail: 'must be a string',
-    source: { pointer: '/data/attributes/name' },
-  },
-  {
-    title: 'Invalid Attribute',
-    detail: 'must be a number',
-    source: { pointer: '/data/attributes/age' },
-  },
-];
-
-const errorsPrimaryHash = {
-  base: ['is invalid', 'error message'],
-};
-
-const errorsPrimaryArray = [
-  {
-    title: 'Invalid Document',
-    detail: 'is invalid',
-    source: { pointer: '/data' },
-  },
-  {
-    title: 'Invalid Document',
-    detail: 'error message',
-    source: { pointer: '/data' },
-  },
-];
-
-test('errorsHashToArray', function(assert) {
-  let result = DS.errorsHashToArray(errorsHash);
-  assert.deepEqual(result, errorsArray);
-});
-
-test('errorsHashToArray for primary data object', function(assert) {
-  let result = DS.errorsHashToArray(errorsPrimaryHash);
-  assert.deepEqual(result, errorsPrimaryArray);
-});
-
-test('errorsArrayToHash', function(assert) {
-  let result = DS.errorsArrayToHash(errorsArray);
-  assert.deepEqual(result, errorsHash);
-});
-
-test('errorsArrayToHash without trailing slash', function(assert) {
-  let result = DS.errorsArrayToHash([
+  const errorsArray = [
     {
-      detail: 'error message',
-      source: { pointer: 'data/attributes/name' },
+      title: 'Invalid Attribute',
+      detail: 'is invalid',
+      source: { pointer: '/data/attributes/name' },
     },
-  ]);
-  assert.deepEqual(result, { name: ['error message'] });
-});
+    {
+      title: 'Invalid Attribute',
+      detail: 'must be a string',
+      source: { pointer: '/data/attributes/name' },
+    },
+    {
+      title: 'Invalid Attribute',
+      detail: 'must be a number',
+      source: { pointer: '/data/attributes/age' },
+    },
+  ];
 
-test('errorsArrayToHash for primary data object', function(assert) {
-  let result = DS.errorsArrayToHash(errorsPrimaryArray);
-  assert.deepEqual(result, errorsPrimaryHash);
-});
+  const errorsPrimaryHash = {
+    base: ['is invalid', 'error message'],
+  };
 
-testInDebug('DS.InvalidError will normalize errors hash will assert', function(assert) {
-  assert.expectAssertion(function() {
-    new DS.InvalidError({ name: ['is invalid'] });
-  }, /expects json-api formatted errors/);
+  const errorsPrimaryArray = [
+    {
+      title: 'Invalid Document',
+      detail: 'is invalid',
+      source: { pointer: '/data' },
+    },
+    {
+      title: 'Invalid Document',
+      detail: 'error message',
+      source: { pointer: '/data' },
+    },
+  ];
+
+  test('errorsHashToArray', function(assert) {
+    let result = DS.errorsHashToArray(errorsHash);
+    assert.deepEqual(result, errorsArray);
+  });
+
+  test('errorsHashToArray for primary data object', function(assert) {
+    let result = DS.errorsHashToArray(errorsPrimaryHash);
+    assert.deepEqual(result, errorsPrimaryArray);
+  });
+
+  test('errorsArrayToHash', function(assert) {
+    let result = DS.errorsArrayToHash(errorsArray);
+    assert.deepEqual(result, errorsHash);
+  });
+
+  test('errorsArrayToHash without trailing slash', function(assert) {
+    let result = DS.errorsArrayToHash([
+      {
+        detail: 'error message',
+        source: { pointer: 'data/attributes/name' },
+      },
+    ]);
+    assert.deepEqual(result, { name: ['error message'] });
+  });
+
+  test('errorsArrayToHash for primary data object', function(assert) {
+    let result = DS.errorsArrayToHash(errorsPrimaryArray);
+    assert.deepEqual(result, errorsPrimaryHash);
+  });
+
+  testInDebug('DS.InvalidError will normalize errors hash will assert', function(assert) {
+    assert.expectAssertion(function() {
+      new DS.InvalidError({ name: ['is invalid'] });
+    }, /expects json-api formatted errors/);
+  });
 });

--- a/packages/-ember-data/tests/unit/debug-test.js
+++ b/packages/-ember-data/tests/unit/debug-test.js
@@ -7,102 +7,102 @@ import DS from 'ember-data';
 
 const TestAdapter = DS.Adapter.extend();
 
-module('Debug');
+module('Debug', function() {
+  test('_debugInfo groups the attributes and relationships correctly', function(assert) {
+    const MaritalStatus = DS.Model.extend({
+      name: DS.attr('string'),
+    });
 
-test('_debugInfo groups the attributes and relationships correctly', function(assert) {
-  const MaritalStatus = DS.Model.extend({
-    name: DS.attr('string'),
+    const Post = DS.Model.extend({
+      title: DS.attr('string'),
+    });
+
+    const User = DS.Model.extend({
+      name: DS.attr('string'),
+      isDrugAddict: DS.attr('boolean'),
+      maritalStatus: DS.belongsTo('marital-status', { async: false }),
+      posts: DS.hasMany('post', { async: false }),
+    });
+
+    let store = createStore({
+      adapter: TestAdapter.extend(),
+      maritalStatus: MaritalStatus,
+      post: Post,
+      user: User,
+    });
+
+    let record = store.createRecord('user');
+
+    let propertyInfo = record._debugInfo().propertyInfo;
+
+    assert.equal(propertyInfo.groups.length, 4);
+    assert.equal(propertyInfo.groups[0].name, 'Attributes');
+    assert.deepEqual(propertyInfo.groups[0].properties, ['id', 'name', 'isDrugAddict']);
+    assert.equal(propertyInfo.groups[1].name, 'belongsTo');
+    assert.deepEqual(propertyInfo.groups[1].properties, ['maritalStatus']);
+    assert.equal(propertyInfo.groups[2].name, 'hasMany');
+    assert.deepEqual(propertyInfo.groups[2].properties, ['posts']);
   });
 
-  const Post = DS.Model.extend({
-    title: DS.attr('string'),
-  });
+  test('_debugInfo supports arbitray relationship types', function(assert) {
+    const MaritalStatus = DS.Model.extend({
+      name: DS.attr('string'),
+    });
 
-  const User = DS.Model.extend({
-    name: DS.attr('string'),
-    isDrugAddict: DS.attr('boolean'),
-    maritalStatus: DS.belongsTo('marital-status', { async: false }),
-    posts: DS.hasMany('post', { async: false }),
-  });
+    const Post = DS.Model.extend({
+      title: DS.attr('string'),
+    });
 
-  let store = createStore({
-    adapter: TestAdapter.extend(),
-    maritalStatus: MaritalStatus,
-    post: Post,
-    user: User,
-  });
+    const User = DS.Model.extend({
+      name: DS.attr('string'),
+      isDrugAddict: DS.attr('boolean'),
+      maritalStatus: DS.belongsTo('marital-status', { async: false }),
+      posts: computed(() => [1, 2, 3])
+        .readOnly()
+        .meta({
+          options: { inverse: null },
+          isRelationship: true,
+          kind: 'customRelationship',
+          name: 'posts',
+          type: 'post',
+        }),
+    });
 
-  let record = store.createRecord('user');
+    let store = createStore({
+      adapter: TestAdapter.extend(),
+      maritalStatus: MaritalStatus,
+      post: Post,
+      user: User,
+    });
 
-  let propertyInfo = record._debugInfo().propertyInfo;
+    let record = store.createRecord('user');
 
-  assert.equal(propertyInfo.groups.length, 4);
-  assert.equal(propertyInfo.groups[0].name, 'Attributes');
-  assert.deepEqual(propertyInfo.groups[0].properties, ['id', 'name', 'isDrugAddict']);
-  assert.equal(propertyInfo.groups[1].name, 'belongsTo');
-  assert.deepEqual(propertyInfo.groups[1].properties, ['maritalStatus']);
-  assert.equal(propertyInfo.groups[2].name, 'hasMany');
-  assert.deepEqual(propertyInfo.groups[2].properties, ['posts']);
-});
+    let propertyInfo = record._debugInfo().propertyInfo;
 
-test('_debugInfo supports arbitray relationship types', function(assert) {
-  const MaritalStatus = DS.Model.extend({
-    name: DS.attr('string'),
-  });
-
-  const Post = DS.Model.extend({
-    title: DS.attr('string'),
-  });
-
-  const User = DS.Model.extend({
-    name: DS.attr('string'),
-    isDrugAddict: DS.attr('boolean'),
-    maritalStatus: DS.belongsTo('marital-status', { async: false }),
-    posts: computed(() => [1, 2, 3])
-      .readOnly()
-      .meta({
-        options: { inverse: null },
-        isRelationship: true,
-        kind: 'customRelationship',
-        name: 'posts',
-        type: 'post',
-      }),
-  });
-
-  let store = createStore({
-    adapter: TestAdapter.extend(),
-    maritalStatus: MaritalStatus,
-    post: Post,
-    user: User,
-  });
-
-  let record = store.createRecord('user');
-
-  let propertyInfo = record._debugInfo().propertyInfo;
-
-  assert.deepEqual(propertyInfo, {
-    includeOtherProperties: true,
-    groups: [
-      {
-        name: 'Attributes',
-        properties: ['id', 'name', 'isDrugAddict'],
-        expand: true,
-      },
-      {
-        name: 'belongsTo',
-        properties: ['maritalStatus'],
-        expand: true,
-      },
-      {
-        name: 'customRelationship',
-        properties: ['posts'],
-        expand: true,
-      },
-      {
-        name: 'Flags',
-        properties: ['isLoaded', 'hasDirtyAttributes', 'isSaving', 'isDeleted', 'isError', 'isNew', 'isValid'],
-      },
-    ],
-    expensiveProperties: ['maritalStatus', 'posts'],
+    assert.deepEqual(propertyInfo, {
+      includeOtherProperties: true,
+      groups: [
+        {
+          name: 'Attributes',
+          properties: ['id', 'name', 'isDrugAddict'],
+          expand: true,
+        },
+        {
+          name: 'belongsTo',
+          properties: ['maritalStatus'],
+          expand: true,
+        },
+        {
+          name: 'customRelationship',
+          properties: ['posts'],
+          expand: true,
+        },
+        {
+          name: 'Flags',
+          properties: ['isLoaded', 'hasDirtyAttributes', 'isSaving', 'isDeleted', 'isError', 'isNew', 'isValid'],
+        },
+      ],
+      expensiveProperties: ['maritalStatus', 'posts'],
+    });
   });
 });

--- a/packages/-ember-data/tests/unit/diff-array-test.js
+++ b/packages/-ember-data/tests/unit/diff-array-test.js
@@ -2,8 +2,6 @@ import { module, test } from 'qunit';
 
 import { diffArray } from '@ember-data/store/-private';
 
-module('unit/diff-array Diff Array tests', {});
-
 const a = 'aaa';
 const b = 'bbb';
 const c = 'ccc';
@@ -17,471 +15,473 @@ const x = 'xxx';
 const y = 'yyy';
 const z = 'zzz';
 
-test('diff array returns no change given two empty arrays', function(assert) {
-  const result = diffArray([], []);
-  assert.strictEqual(result.firstChangeIndex, null);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns no change given two identical arrays length 1', function(assert) {
-  const result = diffArray([a], [a]);
-  assert.strictEqual(result.firstChangeIndex, null);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns no change given two identical arrays length 3', function(assert) {
-  const result = diffArray([a, b, c], [a, b, c]);
-  assert.strictEqual(result.firstChangeIndex, null);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given one appended item with old length 0', function(assert) {
-  const result = diffArray([], [a]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given one appended item with old length 1', function(assert) {
-  const result = diffArray([a], [a, b]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given one appended item with old length 2', function(assert) {
-  const result = diffArray([a, b], [a, b, c]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given 3 appended items with old length 0', function(assert) {
-  const result = diffArray([], [a, b, c]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given 3 appended items with old length 1', function(assert) {
-  const result = diffArray([a], [a, b, c, d]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given 3 appended items with old length 2', function(assert) {
-  const result = diffArray([a, b], [a, b, c, d, e]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given one item removed from end with old length 1', function(assert) {
-  const result = diffArray([a], []);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given one item removed from end with old length 2', function(assert) {
-  const result = diffArray([a, b], [a]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given one item removed from end with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [a, b]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given 3 items removed from end with old length 3', function(assert) {
-  const result = diffArray([a, b, c], []);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given 3 items removed from end with old length 4', function(assert) {
-  const result = diffArray([a, b, c, d], [a]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given 3 items removed from end with old length 5', function(assert) {
-  const result = diffArray([a, b, c, d, e], [a, b]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given one item removed from beginning with old length 2', function(assert) {
-  const result = diffArray([a, b], [b]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given one item removed from beginning with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [b, c]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given 3 items removed from beginning with old length 4', function(assert) {
-  const result = diffArray([a, b, c, d], [d]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given 3 items removed from beginning with old length 5', function(assert) {
-  const result = diffArray([a, b, c, d, e], [d, e]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given one item removed from middle with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [a, c]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given one item removed from middle with old length 5', function(assert) {
-  const result = diffArray([a, b, c, d, e], [a, b, d, e]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given 3 items removed from middle with old length 5', function(assert) {
-  const result = diffArray([a, b, c, d, e], [a, e]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given 3 items removed from middle with old length 7', function(assert) {
-  const result = diffArray([a, b, c, d, e, f, g], [a, b, f, g]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 0);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given one item added to middle with old length 2', function(assert) {
-  const result = diffArray([a, c], [a, b, c]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given one item added to middle with old length 4', function(assert) {
-  const result = diffArray([a, b, d, e], [a, b, c, d, e]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given 3 items added to middle with old length 2', function(assert) {
-  const result = diffArray([a, e], [a, b, c, d, e]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given 3 items added to middle with old length 4', function(assert) {
-  const result = diffArray([a, b, f, g], [a, b, c, d, e, f, g]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 0);
-});
-
-test('diff array returns correctly given complete replacement with length 1', function(assert) {
-  const result = diffArray([a], [b]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given complete replacement with length 3', function(assert) {
-  const result = diffArray([a, b, c], [x, y, z]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given complete replacement with longer length', function(assert) {
-  const result = diffArray([a, b], [x, y, z]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 2);
-});
-
-test('diff array returns correctly given one item replaced in middle with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [a, x, c]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given one item replaced in middle with old length 5', function(assert) {
-  const result = diffArray([a, b, c, d, e], [a, b, x, d, e]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given 3 items replaced in middle with old length 5', function(assert) {
-  const result = diffArray([a, b, c, d, e], [a, x, y, z, e]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given 3 items replaced in middle with old length 7', function(assert) {
-  const result = diffArray([a, b, c, d, e, f, g], [a, b, x, y, z, f, g]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given one item replaced at beginning with old length 2', function(assert) {
-  const result = diffArray([a, b], [x, b]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given one item replaced at beginning with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [x, b, c]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given 3 items replaced at beginning with old length 4', function(assert) {
-  const result = diffArray([a, b, c, d], [x, y, z, d]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given 3 items replaced at beginning with old length 6', function(assert) {
-  const result = diffArray([a, b, c, d, e, f], [x, y, z, d, e, f]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given one item replaced at end with old length 2', function(assert) {
-  const result = diffArray([a, b], [a, x]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given one item replaced at end with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [a, b, x]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given 3 items replaced at end with old length 4', function(assert) {
-  const result = diffArray([a, b, c, d], [a, x, y, z]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given 3 items replaced at end with old length 6', function(assert) {
-  const result = diffArray([a, b, c, d, e, f], [a, b, c, x, y, z]);
-  assert.equal(result.firstChangeIndex, 3);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given one item replaced with two in middle with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [a, x, y, c]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 2);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given one item replaced with two in middle with old length 5', function(assert) {
-  const result = diffArray([a, b, c, d, e], [a, b, x, y, d, e]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 2);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given 3 items replaced with 4 in middle with old length 5', function(assert) {
-  const result = diffArray([a, b, c, d, e], [a, w, x, y, z, e]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 4);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given 3 items replaced with 4 in middle with old length 7', function(assert) {
-  const result = diffArray([a, b, c, d, e, f, g], [a, b, w, x, y, z, f, g]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 4);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given one item replaced with two at beginning with old length 2', function(assert) {
-  const result = diffArray([a, b], [x, y, b]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 2);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given one item replaced with two at beginning with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [x, y, b, c]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 2);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given 3 items replaced with 4 at beginning with old length 4', function(assert) {
-  const result = diffArray([a, b, c, d], [w, x, y, z, d]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 4);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given 3 items replaced with 4 at beginning with old length 6', function(assert) {
-  const result = diffArray([a, b, c, d, e, f], [w, x, y, z, d, e, f]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 4);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given one item replaced with two at end with old length 2', function(assert) {
-  const result = diffArray([a, b], [a, x, y]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 2);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given one item replaced with two at end with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [a, b, x, y]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 2);
-  assert.equal(result.removedCount, 1);
-});
-
-test('diff array returns correctly given 3 items replaced with 4 at end with old length 4', function(assert) {
-  const result = diffArray([a, b, c, d], [a, w, x, y, z]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 4);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given 3 items replaced with 4 at end with old length 6', function(assert) {
-  const result = diffArray([a, b, c, d, e, f], [a, b, c, w, x, y, z]);
-  assert.equal(result.firstChangeIndex, 3);
-  assert.equal(result.addedCount, 4);
-  assert.equal(result.removedCount, 3);
-});
-
-test('diff array returns correctly given two items replaced with one in middle with old length 4', function(assert) {
-  const result = diffArray([a, b, c, d], [a, x, d]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 2);
-});
-
-test('diff array returns correctly given two items replaced with one in middle with old length 6', function(assert) {
-  const result = diffArray([a, b, c, d, e, f], [a, b, x, e, f]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 2);
-});
-
-test('diff array returns correctly given 4 items replaced with 3 in middle with old length 6', function(assert) {
-  const result = diffArray([a, b, c, d, e, f], [a, x, y, z, f]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 4);
-});
-
-test('diff array returns correctly given 4 items replaced with 3 in middle with old length 8', function(assert) {
-  const result = diffArray([a, b, c, d, e, f, g, h], [a, b, x, y, z, g, h]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 4);
-});
-
-test('diff array returns correctly given two items replaced with one at beginning with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [x, c]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 2);
-});
-
-test('diff array returns correctly given two items replaced with one at beginning with old length 4', function(assert) {
-  const result = diffArray([a, b, c, d], [x, c, d]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 2);
-});
-
-test('diff array returns correctly given 4 items replaced with 3 at beginning with old length 5', function(assert) {
-  const result = diffArray([a, b, c, d, e], [x, y, z, e]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 4);
-});
-
-test('diff array returns correctly given 4 items replaced with 3 at beginning with old length 6', function(assert) {
-  const result = diffArray([a, b, c, d, e, f], [x, y, z, e, f]);
-  assert.equal(result.firstChangeIndex, 0);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 4);
-});
-
-test('diff array returns correctly given two items replaced with one at end with old length 3', function(assert) {
-  const result = diffArray([a, b, c], [a, x]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 2);
-});
-
-test('diff array returns correctly given two items replaced with one at end with old length 4', function(assert) {
-  const result = diffArray([a, b, c, d], [a, b, x]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 1);
-  assert.equal(result.removedCount, 2);
-});
-
-test('diff array returns correctly given 4 items replaced with 3 at end with old length 5', function(assert) {
-  const result = diffArray([a, b, c, d, e], [a, x, y, z]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 4);
-});
-
-test('diff array returns correctly given 4 items replaced with 3 at end with old length 6', function(assert) {
-  const result = diffArray([a, b, c, d, e, f], [a, b, x, y, z]);
-  assert.equal(result.firstChangeIndex, 2);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 4);
-});
-
-test('diff array returns correctly given non-contiguous insertion', function(assert) {
-  const result = diffArray([a, c, e], [a, b, c, d, e]);
-  assert.equal(result.firstChangeIndex, 1);
-  assert.equal(result.addedCount, 3);
-  assert.equal(result.removedCount, 1);
+module('unit/diff-array Diff Array tests', function() {
+  test('diff array returns no change given two empty arrays', function(assert) {
+    const result = diffArray([], []);
+    assert.strictEqual(result.firstChangeIndex, null);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns no change given two identical arrays length 1', function(assert) {
+    const result = diffArray([a], [a]);
+    assert.strictEqual(result.firstChangeIndex, null);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns no change given two identical arrays length 3', function(assert) {
+    const result = diffArray([a, b, c], [a, b, c]);
+    assert.strictEqual(result.firstChangeIndex, null);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given one appended item with old length 0', function(assert) {
+    const result = diffArray([], [a]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given one appended item with old length 1', function(assert) {
+    const result = diffArray([a], [a, b]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given one appended item with old length 2', function(assert) {
+    const result = diffArray([a, b], [a, b, c]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given 3 appended items with old length 0', function(assert) {
+    const result = diffArray([], [a, b, c]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given 3 appended items with old length 1', function(assert) {
+    const result = diffArray([a], [a, b, c, d]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given 3 appended items with old length 2', function(assert) {
+    const result = diffArray([a, b], [a, b, c, d, e]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given one item removed from end with old length 1', function(assert) {
+    const result = diffArray([a], []);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given one item removed from end with old length 2', function(assert) {
+    const result = diffArray([a, b], [a]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given one item removed from end with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [a, b]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given 3 items removed from end with old length 3', function(assert) {
+    const result = diffArray([a, b, c], []);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given 3 items removed from end with old length 4', function(assert) {
+    const result = diffArray([a, b, c, d], [a]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given 3 items removed from end with old length 5', function(assert) {
+    const result = diffArray([a, b, c, d, e], [a, b]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given one item removed from beginning with old length 2', function(assert) {
+    const result = diffArray([a, b], [b]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given one item removed from beginning with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [b, c]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given 3 items removed from beginning with old length 4', function(assert) {
+    const result = diffArray([a, b, c, d], [d]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given 3 items removed from beginning with old length 5', function(assert) {
+    const result = diffArray([a, b, c, d, e], [d, e]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given one item removed from middle with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [a, c]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given one item removed from middle with old length 5', function(assert) {
+    const result = diffArray([a, b, c, d, e], [a, b, d, e]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given 3 items removed from middle with old length 5', function(assert) {
+    const result = diffArray([a, b, c, d, e], [a, e]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given 3 items removed from middle with old length 7', function(assert) {
+    const result = diffArray([a, b, c, d, e, f, g], [a, b, f, g]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 0);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given one item added to middle with old length 2', function(assert) {
+    const result = diffArray([a, c], [a, b, c]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given one item added to middle with old length 4', function(assert) {
+    const result = diffArray([a, b, d, e], [a, b, c, d, e]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given 3 items added to middle with old length 2', function(assert) {
+    const result = diffArray([a, e], [a, b, c, d, e]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given 3 items added to middle with old length 4', function(assert) {
+    const result = diffArray([a, b, f, g], [a, b, c, d, e, f, g]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 0);
+  });
+
+  test('diff array returns correctly given complete replacement with length 1', function(assert) {
+    const result = diffArray([a], [b]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given complete replacement with length 3', function(assert) {
+    const result = diffArray([a, b, c], [x, y, z]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given complete replacement with longer length', function(assert) {
+    const result = diffArray([a, b], [x, y, z]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 2);
+  });
+
+  test('diff array returns correctly given one item replaced in middle with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [a, x, c]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given one item replaced in middle with old length 5', function(assert) {
+    const result = diffArray([a, b, c, d, e], [a, b, x, d, e]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given 3 items replaced in middle with old length 5', function(assert) {
+    const result = diffArray([a, b, c, d, e], [a, x, y, z, e]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given 3 items replaced in middle with old length 7', function(assert) {
+    const result = diffArray([a, b, c, d, e, f, g], [a, b, x, y, z, f, g]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given one item replaced at beginning with old length 2', function(assert) {
+    const result = diffArray([a, b], [x, b]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given one item replaced at beginning with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [x, b, c]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given 3 items replaced at beginning with old length 4', function(assert) {
+    const result = diffArray([a, b, c, d], [x, y, z, d]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given 3 items replaced at beginning with old length 6', function(assert) {
+    const result = diffArray([a, b, c, d, e, f], [x, y, z, d, e, f]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given one item replaced at end with old length 2', function(assert) {
+    const result = diffArray([a, b], [a, x]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given one item replaced at end with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [a, b, x]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given 3 items replaced at end with old length 4', function(assert) {
+    const result = diffArray([a, b, c, d], [a, x, y, z]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given 3 items replaced at end with old length 6', function(assert) {
+    const result = diffArray([a, b, c, d, e, f], [a, b, c, x, y, z]);
+    assert.equal(result.firstChangeIndex, 3);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given one item replaced with two in middle with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [a, x, y, c]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 2);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given one item replaced with two in middle with old length 5', function(assert) {
+    const result = diffArray([a, b, c, d, e], [a, b, x, y, d, e]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 2);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given 3 items replaced with 4 in middle with old length 5', function(assert) {
+    const result = diffArray([a, b, c, d, e], [a, w, x, y, z, e]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 4);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given 3 items replaced with 4 in middle with old length 7', function(assert) {
+    const result = diffArray([a, b, c, d, e, f, g], [a, b, w, x, y, z, f, g]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 4);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given one item replaced with two at beginning with old length 2', function(assert) {
+    const result = diffArray([a, b], [x, y, b]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 2);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given one item replaced with two at beginning with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [x, y, b, c]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 2);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given 3 items replaced with 4 at beginning with old length 4', function(assert) {
+    const result = diffArray([a, b, c, d], [w, x, y, z, d]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 4);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given 3 items replaced with 4 at beginning with old length 6', function(assert) {
+    const result = diffArray([a, b, c, d, e, f], [w, x, y, z, d, e, f]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 4);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given one item replaced with two at end with old length 2', function(assert) {
+    const result = diffArray([a, b], [a, x, y]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 2);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given one item replaced with two at end with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [a, b, x, y]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 2);
+    assert.equal(result.removedCount, 1);
+  });
+
+  test('diff array returns correctly given 3 items replaced with 4 at end with old length 4', function(assert) {
+    const result = diffArray([a, b, c, d], [a, w, x, y, z]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 4);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given 3 items replaced with 4 at end with old length 6', function(assert) {
+    const result = diffArray([a, b, c, d, e, f], [a, b, c, w, x, y, z]);
+    assert.equal(result.firstChangeIndex, 3);
+    assert.equal(result.addedCount, 4);
+    assert.equal(result.removedCount, 3);
+  });
+
+  test('diff array returns correctly given two items replaced with one in middle with old length 4', function(assert) {
+    const result = diffArray([a, b, c, d], [a, x, d]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 2);
+  });
+
+  test('diff array returns correctly given two items replaced with one in middle with old length 6', function(assert) {
+    const result = diffArray([a, b, c, d, e, f], [a, b, x, e, f]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 2);
+  });
+
+  test('diff array returns correctly given 4 items replaced with 3 in middle with old length 6', function(assert) {
+    const result = diffArray([a, b, c, d, e, f], [a, x, y, z, f]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 4);
+  });
+
+  test('diff array returns correctly given 4 items replaced with 3 in middle with old length 8', function(assert) {
+    const result = diffArray([a, b, c, d, e, f, g, h], [a, b, x, y, z, g, h]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 4);
+  });
+
+  test('diff array returns correctly given two items replaced with one at beginning with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [x, c]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 2);
+  });
+
+  test('diff array returns correctly given two items replaced with one at beginning with old length 4', function(assert) {
+    const result = diffArray([a, b, c, d], [x, c, d]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 2);
+  });
+
+  test('diff array returns correctly given 4 items replaced with 3 at beginning with old length 5', function(assert) {
+    const result = diffArray([a, b, c, d, e], [x, y, z, e]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 4);
+  });
+
+  test('diff array returns correctly given 4 items replaced with 3 at beginning with old length 6', function(assert) {
+    const result = diffArray([a, b, c, d, e, f], [x, y, z, e, f]);
+    assert.equal(result.firstChangeIndex, 0);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 4);
+  });
+
+  test('diff array returns correctly given two items replaced with one at end with old length 3', function(assert) {
+    const result = diffArray([a, b, c], [a, x]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 2);
+  });
+
+  test('diff array returns correctly given two items replaced with one at end with old length 4', function(assert) {
+    const result = diffArray([a, b, c, d], [a, b, x]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 1);
+    assert.equal(result.removedCount, 2);
+  });
+
+  test('diff array returns correctly given 4 items replaced with 3 at end with old length 5', function(assert) {
+    const result = diffArray([a, b, c, d, e], [a, x, y, z]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 4);
+  });
+
+  test('diff array returns correctly given 4 items replaced with 3 at end with old length 6', function(assert) {
+    const result = diffArray([a, b, c, d, e, f], [a, b, x, y, z]);
+    assert.equal(result.firstChangeIndex, 2);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 4);
+  });
+
+  test('diff array returns correctly given non-contiguous insertion', function(assert) {
+    const result = diffArray([a, c, e], [a, b, c, d, e]);
+    assert.equal(result.firstChangeIndex, 1);
+    assert.equal(result.addedCount, 3);
+    assert.equal(result.removedCount, 1);
+  });
 });

--- a/packages/-ember-data/tests/unit/modules-test.js
+++ b/packages/-ember-data/tests/unit/modules-test.js
@@ -17,64 +17,64 @@ import RESTSerializer, { EmbeddedRecordsMixin } from '@ember-data/serializer/res
 
 import AdapterError, { InvalidError, TimeoutError, AbortError } from '@ember-data/adapter/error';
 
-module('unit/modules - public modules');
+module('unit/modules - public modules', function() {
+  test('ember-data/transform', function(assert) {
+    assert.ok(Transform);
+  });
 
-test('ember-data/transform', function(assert) {
-  assert.ok(Transform);
-});
+  test('ember-data/adapter', function(assert) {
+    assert.ok(Adapter);
+  });
 
-test('ember-data/adapter', function(assert) {
-  assert.ok(Adapter);
-});
+  test('ember-data/adapters/json-api', function(assert) {
+    assert.ok(JSONAPIAdapter);
+  });
 
-test('ember-data/adapters/json-api', function(assert) {
-  assert.ok(JSONAPIAdapter);
-});
+  test('ember-data/adapters/rest', function(assert) {
+    assert.ok(RESTAdapter);
+  });
 
-test('ember-data/adapters/rest', function(assert) {
-  assert.ok(RESTAdapter);
-});
+  test('ember-data/attr', function(assert) {
+    assert.ok(attr);
+  });
 
-test('ember-data/attr', function(assert) {
-  assert.ok(attr);
-});
+  test('ember-data/relationships', function(assert) {
+    assert.ok(belongsTo);
+    assert.ok(hasMany);
+  });
 
-test('ember-data/relationships', function(assert) {
-  assert.ok(belongsTo);
-  assert.ok(hasMany);
-});
+  test('ember-data/store', function(assert) {
+    assert.ok(Store);
+  });
 
-test('ember-data/store', function(assert) {
-  assert.ok(Store);
-});
+  test('ember-data/model', function(assert) {
+    assert.ok(Model);
+  });
 
-test('ember-data/model', function(assert) {
-  assert.ok(Model);
-});
+  test('ember-data/mixins/embedded-records', function(assert) {
+    assert.ok(EmbeddedRecordsMixin);
+  });
 
-test('ember-data/mixins/embedded-records', function(assert) {
-  assert.ok(EmbeddedRecordsMixin);
-});
+  test('ember-data/serializer', function(assert) {
+    assert.ok(Serializer);
+  });
 
-test('ember-data/serializer', function(assert) {
-  assert.ok(Serializer);
-});
+  test('ember-data/serializers/json-api', function(assert) {
+    assert.ok(JSONAPISerializer);
+  });
 
-test('ember-data/serializers/json-api', function(assert) {
-  assert.ok(JSONAPISerializer);
-});
+  test('ember-data/serializers/json', function(assert) {
+    assert.ok(JSONSerializer);
+  });
 
-test('ember-data/serializers/json', function(assert) {
-  assert.ok(JSONSerializer);
-});
+  test('ember-data/serializers/rest', function(assert) {
+    assert.ok(RESTSerializer);
+  });
 
-test('ember-data/serializers/rest', function(assert) {
-  assert.ok(RESTSerializer);
-});
-
-test('ember-data/adapters/errors', function(assert) {
-  assert.ok(AdapterError);
-  assert.ok(InvalidError);
-  assert.ok(TimeoutError);
-  assert.ok(AbortError);
+  test('ember-data/adapters/errors', function(assert) {
+    assert.ok(AdapterError);
+    assert.ok(InvalidError);
+    assert.ok(TimeoutError);
+    assert.ok(AbortError);
+  });
 });

--- a/packages/-ember-data/tests/unit/private-test.js
+++ b/packages/-ember-data/tests/unit/private-test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
 import { InternalModel, RootState } from '@ember-data/store/-private';
 
-module('-private');
+module('-private', function() {
+  test('`InternalModel` is accessible via private import', function(assert) {
+    assert.ok(!!InternalModel);
+  });
 
-test('`InternalModel` is accessible via private import', function(assert) {
-  assert.ok(!!InternalModel);
-});
-
-test('`RootState` is accessible via private import', function(assert) {
-  assert.ok(!!RootState);
+  test('`RootState` is accessible via private import', function(assert) {
+    assert.ok(!!RootState);
+  });
 });

--- a/packages/-ember-data/tests/unit/promise-proxies-test.js
+++ b/packages/-ember-data/tests/unit/promise-proxies-test.js
@@ -5,108 +5,108 @@ import { module, test } from 'qunit';
 
 import DS from 'ember-data';
 
-module('PromiseManyArray');
+module('PromiseManyArray', function() {
+  test('.reload should NOT leak the internal promise, rather return another promiseArray', function(assert) {
+    assert.expect(2);
 
-test('.reload should NOT leak the internal promise, rather return another promiseArray', function(assert) {
-  assert.expect(2);
+    let content = A();
 
-  let content = A();
+    content.reload = () => EmberPromise.resolve(content);
 
-  content.reload = () => EmberPromise.resolve(content);
-
-  let array = DS.PromiseManyArray.create({
-    content,
-  });
-
-  let reloaded = array.reload();
-
-  assert.ok(reloaded instanceof DS.PromiseManyArray);
-
-  return reloaded.then(value => assert.equal(content, value));
-});
-
-test('.reload should be stable', function(assert) {
-  assert.expect(19);
-
-  let content = A();
-
-  content.reload = () => EmberPromise.resolve(content);
-  let promise = EmberPromise.resolve(content);
-
-  let array = DS.PromiseManyArray.create({
-    promise,
-  });
-
-  assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
-  assert.equal(array.get('isPending'), true, 'should be pending');
-  assert.equal(array.get('isSettled'), false, 'should NOT be settled');
-  assert.equal(array.get('isFulfilled'), false, 'should NOT be fulfilled');
-
-  return array.then(() => {
-    assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
-    assert.equal(array.get('isPending'), false, 'should NOT be pending');
-    assert.equal(array.get('isSettled'), true, 'should be settled');
-    assert.equal(array.get('isFulfilled'), true, 'should be fulfilled');
+    let array = DS.PromiseManyArray.create({
+      content,
+    });
 
     let reloaded = array.reload();
 
+    assert.ok(reloaded instanceof DS.PromiseManyArray);
+
+    return reloaded.then(value => assert.equal(content, value));
+  });
+
+  test('.reload should be stable', function(assert) {
+    assert.expect(19);
+
+    let content = A();
+
+    content.reload = () => EmberPromise.resolve(content);
+    let promise = EmberPromise.resolve(content);
+
+    let array = DS.PromiseManyArray.create({
+      promise,
+    });
+
     assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
     assert.equal(array.get('isPending'), true, 'should be pending');
     assert.equal(array.get('isSettled'), false, 'should NOT be settled');
     assert.equal(array.get('isFulfilled'), false, 'should NOT be fulfilled');
 
-    assert.ok(reloaded instanceof DS.PromiseManyArray);
-    assert.equal(reloaded, array);
-
-    return reloaded.then(value => {
+    return array.then(() => {
       assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
       assert.equal(array.get('isPending'), false, 'should NOT be pending');
       assert.equal(array.get('isSettled'), true, 'should be settled');
       assert.equal(array.get('isFulfilled'), true, 'should be fulfilled');
 
-      assert.equal(content, value);
+      let reloaded = array.reload();
+
+      assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+      assert.equal(array.get('isPending'), true, 'should be pending');
+      assert.equal(array.get('isSettled'), false, 'should NOT be settled');
+      assert.equal(array.get('isFulfilled'), false, 'should NOT be fulfilled');
+
+      assert.ok(reloaded instanceof DS.PromiseManyArray);
+      assert.equal(reloaded, array);
+
+      return reloaded.then(value => {
+        assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+        assert.equal(array.get('isPending'), false, 'should NOT be pending');
+        assert.equal(array.get('isSettled'), true, 'should be settled');
+        assert.equal(array.get('isFulfilled'), true, 'should be fulfilled');
+
+        assert.equal(content, value);
+      });
     });
   });
-});
 
-test('.set to new promise should be like reload', function(assert) {
-  assert.expect(18);
+  test('.set to new promise should be like reload', function(assert) {
+    assert.expect(18);
 
-  let content = A([1, 2, 3]);
+    let content = A([1, 2, 3]);
 
-  let promise = EmberPromise.resolve(content);
+    let promise = EmberPromise.resolve(content);
 
-  let array = DS.PromiseManyArray.create({
-    promise,
-  });
-
-  assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
-  assert.equal(array.get('isPending'), true, 'should be pending');
-  assert.equal(array.get('isSettled'), false, 'should NOT be settled');
-  assert.equal(array.get('isFulfilled'), false, 'should NOT be fulfilled');
-
-  return array.then(() => {
-    assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
-    assert.equal(array.get('isPending'), false, 'should NOT be pending');
-    assert.equal(array.get('isSettled'), true, 'should be settled');
-    assert.equal(array.get('isFulfilled'), true, 'should be fulfilled');
-
-    array.set('promise', EmberPromise.resolve(content));
+    let array = DS.PromiseManyArray.create({
+      promise,
+    });
 
     assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
     assert.equal(array.get('isPending'), true, 'should be pending');
     assert.equal(array.get('isSettled'), false, 'should NOT be settled');
     assert.equal(array.get('isFulfilled'), false, 'should NOT be fulfilled');
 
-    assert.ok(array instanceof DS.PromiseManyArray);
-
-    return array.then(value => {
+    return array.then(() => {
       assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
       assert.equal(array.get('isPending'), false, 'should NOT be pending');
       assert.equal(array.get('isSettled'), true, 'should be settled');
       assert.equal(array.get('isFulfilled'), true, 'should be fulfilled');
 
-      assert.equal(content, value);
+      array.set('promise', EmberPromise.resolve(content));
+
+      assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+      assert.equal(array.get('isPending'), true, 'should be pending');
+      assert.equal(array.get('isSettled'), false, 'should NOT be settled');
+      assert.equal(array.get('isFulfilled'), false, 'should NOT be fulfilled');
+
+      assert.ok(array instanceof DS.PromiseManyArray);
+
+      return array.then(value => {
+        assert.equal(array.get('isRejected'), false, 'should NOT be rejected');
+        assert.equal(array.get('isPending'), false, 'should NOT be pending');
+        assert.equal(array.get('isSettled'), true, 'should be settled');
+        assert.equal(array.get('isFulfilled'), true, 'should be fulfilled');
+
+        assert.equal(content, value);
+      });
     });
   });
 });

--- a/packages/-ember-data/tests/unit/states-test.js
+++ b/packages/-ember-data/tests/unit/states-test.js
@@ -4,14 +4,6 @@ import DS from 'ember-data';
 
 const { assert } = QUnit;
 
-let rootState, stateName;
-
-module('unit/states - Flags for record states', {
-  beforeEach() {
-    rootState = DS.RootState;
-  },
-});
-
 assert.flagIsTrue = function flagIsTrue(flag) {
   this.equal(get(rootState, stateName + '.' + flag), true, stateName + '.' + flag + ' should be true');
 };
@@ -20,74 +12,82 @@ assert.flagIsFalse = function flagIsFalse(flag) {
   this.equal(get(rootState, stateName + '.' + flag), false, stateName + '.' + flag + ' should be false');
 };
 
-test('the empty state', function(assert) {
-  stateName = 'empty';
-  assert.flagIsFalse('isLoading');
-  assert.flagIsFalse('isLoaded');
-  assert.flagIsFalse('isDirty');
-  assert.flagIsFalse('isSaving');
-  assert.flagIsFalse('isDeleted');
-});
+let rootState, stateName;
 
-test('the loading state', function(assert) {
-  stateName = 'loading';
-  assert.flagIsTrue('isLoading');
-  assert.flagIsFalse('isLoaded');
-  assert.flagIsFalse('isDirty');
-  assert.flagIsFalse('isSaving');
-  assert.flagIsFalse('isDeleted');
-});
+module('unit/states - Flags for record states', function(hooks) {
+  hooks.beforeEach(function() {
+    rootState = DS.RootState;
+  });
 
-test('the loaded state', function(assert) {
-  stateName = 'loaded';
-  assert.flagIsFalse('isLoading');
-  assert.flagIsTrue('isLoaded');
-  assert.flagIsFalse('isDirty');
-  assert.flagIsFalse('isSaving');
-  assert.flagIsFalse('isDeleted');
-});
+  test('the empty state', function(assert) {
+    stateName = 'empty';
+    assert.flagIsFalse('isLoading');
+    assert.flagIsFalse('isLoaded');
+    assert.flagIsFalse('isDirty');
+    assert.flagIsFalse('isSaving');
+    assert.flagIsFalse('isDeleted');
+  });
 
-test('the updated state', function(assert) {
-  stateName = 'loaded.updated';
-  assert.flagIsFalse('isLoading');
-  assert.flagIsTrue('isLoaded');
-  assert.flagIsTrue('isDirty');
-  assert.flagIsFalse('isSaving');
-  assert.flagIsFalse('isDeleted');
-});
+  test('the loading state', function(assert) {
+    stateName = 'loading';
+    assert.flagIsTrue('isLoading');
+    assert.flagIsFalse('isLoaded');
+    assert.flagIsFalse('isDirty');
+    assert.flagIsFalse('isSaving');
+    assert.flagIsFalse('isDeleted');
+  });
 
-test('the saving state', function(assert) {
-  stateName = 'loaded.updated.inFlight';
-  assert.flagIsFalse('isLoading');
-  assert.flagIsTrue('isLoaded');
-  assert.flagIsTrue('isDirty');
-  assert.flagIsTrue('isSaving');
-  assert.flagIsFalse('isDeleted');
-});
+  test('the loaded state', function(assert) {
+    stateName = 'loaded';
+    assert.flagIsFalse('isLoading');
+    assert.flagIsTrue('isLoaded');
+    assert.flagIsFalse('isDirty');
+    assert.flagIsFalse('isSaving');
+    assert.flagIsFalse('isDeleted');
+  });
 
-test('the deleted state', function(assert) {
-  stateName = 'deleted';
-  assert.flagIsFalse('isLoading');
-  assert.flagIsTrue('isLoaded');
-  assert.flagIsTrue('isDirty');
-  assert.flagIsFalse('isSaving');
-  assert.flagIsTrue('isDeleted');
-});
+  test('the updated state', function(assert) {
+    stateName = 'loaded.updated';
+    assert.flagIsFalse('isLoading');
+    assert.flagIsTrue('isLoaded');
+    assert.flagIsTrue('isDirty');
+    assert.flagIsFalse('isSaving');
+    assert.flagIsFalse('isDeleted');
+  });
 
-test('the deleted.saving state', function(assert) {
-  stateName = 'deleted.inFlight';
-  assert.flagIsFalse('isLoading');
-  assert.flagIsTrue('isLoaded');
-  assert.flagIsTrue('isDirty');
-  assert.flagIsTrue('isSaving');
-  assert.flagIsTrue('isDeleted');
-});
+  test('the saving state', function(assert) {
+    stateName = 'loaded.updated.inFlight';
+    assert.flagIsFalse('isLoading');
+    assert.flagIsTrue('isLoaded');
+    assert.flagIsTrue('isDirty');
+    assert.flagIsTrue('isSaving');
+    assert.flagIsFalse('isDeleted');
+  });
 
-test('the deleted.saved state', function(assert) {
-  stateName = 'deleted.saved';
-  assert.flagIsFalse('isLoading');
-  assert.flagIsTrue('isLoaded');
-  assert.flagIsFalse('isDirty');
-  assert.flagIsFalse('isSaving');
-  assert.flagIsTrue('isDeleted');
+  test('the deleted state', function(assert) {
+    stateName = 'deleted';
+    assert.flagIsFalse('isLoading');
+    assert.flagIsTrue('isLoaded');
+    assert.flagIsTrue('isDirty');
+    assert.flagIsFalse('isSaving');
+    assert.flagIsTrue('isDeleted');
+  });
+
+  test('the deleted.saving state', function(assert) {
+    stateName = 'deleted.inFlight';
+    assert.flagIsFalse('isLoading');
+    assert.flagIsTrue('isLoaded');
+    assert.flagIsTrue('isDirty');
+    assert.flagIsTrue('isSaving');
+    assert.flagIsTrue('isDeleted');
+  });
+
+  test('the deleted.saved state', function(assert) {
+    stateName = 'deleted.saved';
+    assert.flagIsFalse('isLoading');
+    assert.flagIsTrue('isLoaded');
+    assert.flagIsFalse('isDirty');
+    assert.flagIsFalse('isSaving');
+    assert.flagIsTrue('isDeleted');
+  });
 });

--- a/packages/-ember-data/tests/unit/system/relationships/polymorphic-relationship-payloads-test.js
+++ b/packages/-ember-data/tests/unit/system/relationships/polymorphic-relationship-payloads-test.js
@@ -7,8 +7,8 @@ import testInDebug from '../../../helpers/test-in-debug';
 
 const { Model, hasMany, belongsTo, attr } = DS;
 
-module('unit/system/relationships/relationship-payloads-manager (polymorphic)', {
-  beforeEach() {
+module('unit/system/relationships/relationship-payloads-manager (polymorphic)', function(hooks) {
+  hooks.beforeEach(function() {
     const User = DS.Model.extend({
       hats: hasMany('hat', { async: false, polymorphic: true, inverse: 'user' }),
       sharedHats: hasMany('hat', { async: false, polymorphic: true, inverse: 'sharingUsers' }),
@@ -35,771 +35,771 @@ module('unit/system/relationships/relationship-payloads-manager (polymorphic)', 
       'big-hat': BigHat,
       'small-hat': SmallHat,
     });
-  },
-});
+  });
 
-test('push one side is polymorphic, baseType then subTypes', function(assert) {
-  let id = 1;
+  test('push one side is polymorphic, baseType then subTypes', function(assert) {
+    let id = 1;
 
-  function makeHat(type, props) {
-    const resource = deepCopy(props);
-    resource.id = `${id++}`;
-    resource.type = type;
-    resource.attributes.type = type;
-    return resource;
-  }
+    function makeHat(type, props) {
+      const resource = deepCopy(props);
+      resource.id = `${id++}`;
+      resource.type = type;
+      resource.attributes.type = type;
+      return resource;
+    }
 
-  const hatData = {
-    attributes: {},
-    relationships: {
-      user: {
-        data: { id: '1', type: 'user' },
-      },
-    },
-  };
-
-  const hatData1 = makeHat('hat', hatData),
-    bigHatData1 = makeHat('big-hat', hatData),
-    smallHatData1 = makeHat('small-hat', hatData);
-
-  const userData = {
-    data: {
-      id: '1',
-      type: 'user',
+    const hatData = {
       attributes: {},
-    },
-    included: [hatData1, bigHatData1, smallHatData1],
-  };
-
-  const user = run(() => this.store.push(userData));
-
-  const finalResult = user.get('hats').mapBy('type');
-
-  assert.deepEqual(finalResult, ['hat', 'big-hat', 'small-hat'], 'We got all our hats!');
-});
-
-test('push one side is polymorphic, subType then baseType', function(assert) {
-  let id = 1;
-
-  function makeHat(type, props) {
-    const resource = deepCopy(props);
-    resource.id = `${id++}`;
-    resource.type = type;
-    resource.attributes.type = type;
-    return resource;
-  }
-
-  const hatData = {
-    attributes: {},
-    relationships: {
-      user: {
-        data: { id: '1', type: 'user' },
-      },
-    },
-  };
-
-  const bigHatData1 = makeHat('hat', hatData),
-    smallHatData1 = makeHat('small-hat', hatData),
-    hatData1 = makeHat('big-hat', hatData),
-    included = [bigHatData1, smallHatData1, hatData1];
-
-  const userData = {
-    data: {
-      id: '1',
-      type: 'user',
-      attributes: {},
-    },
-    included,
-  };
-
-  const user = run(() => this.store.push(userData)),
-    finalResult = user.get('hats').mapBy('type'),
-    expectedResults = included.map(m => m.type);
-
-  assert.deepEqual(finalResult, expectedResults, 'We got all our hats!');
-});
-
-test('push one side is polymorphic, different subtypes', function(assert) {
-  let id = 1;
-
-  function makeHat(type, props) {
-    const resource = deepCopy(props);
-    resource.id = `${id++}`;
-    resource.type = type;
-    resource.attributes.type = type;
-    return resource;
-  }
-
-  const hatData = {
-    attributes: {},
-    relationships: {
-      user: {
-        data: { id: '1', type: 'user' },
-      },
-    },
-  };
-
-  const bigHatData1 = makeHat('big-hat', hatData),
-    smallHatData1 = makeHat('small-hat', hatData),
-    bigHatData2 = makeHat('big-hat', hatData),
-    smallHatData2 = makeHat('small-hat', hatData),
-    included = [bigHatData1, smallHatData1, bigHatData2, smallHatData2];
-
-  const userData = {
-    data: {
-      id: '1',
-      type: 'user',
-      attributes: {},
-    },
-    included,
-  };
-
-  const user = run(() => this.store.push(userData)),
-    finalResult = user.get('hats').mapBy('type'),
-    expectedResults = included.map(m => m.type);
-
-  assert.deepEqual(finalResult, expectedResults, 'We got all our hats!');
-});
-
-test('push both sides are polymorphic', function(assert) {
-  let id = 1;
-
-  function makeHat(type, props) {
-    const resource = deepCopy(props);
-    resource.id = `${id++}`;
-    resource.type = type;
-    resource.attributes.type = type;
-    return resource;
-  }
-
-  const alienHatData = {
-    attributes: {},
-    relationships: {
-      user: {
-        data: { id: '1', type: 'alien' },
-      },
-    },
-  };
-
-  const bigHatData1 = makeHat('hat', alienHatData),
-    hatData1 = makeHat('big-hat', alienHatData),
-    alienIncluded = [bigHatData1, hatData1];
-
-  const alienData = {
-    data: {
-      id: '1',
-      type: 'alien',
-      attributes: {},
-    },
-    included: alienIncluded,
-  };
-
-  const expectedAlienResults = alienIncluded.map(m => m.type),
-    alien = run(() => this.store.push(alienData)),
-    alienFinalHats = alien.get('hats').mapBy('type');
-
-  assert.deepEqual(alienFinalHats, expectedAlienResults, 'We got all alien hats!');
-});
-
-test('handles relationships where both sides are polymorphic', function(assert) {
-  let id = 1;
-  function makePolymorphicHatForPolymorphicPerson(type, isForBigPerson = true) {
-    return {
-      id: `${id++}`,
-      type,
       relationships: {
-        person: {
-          data: {
-            id: isForBigPerson ? '1' : '2',
-            type: isForBigPerson ? 'big-person' : 'small-person',
-          },
+        user: {
+          data: { id: '1', type: 'user' },
         },
       },
     };
-  }
 
-  const bigHatData1 = makePolymorphicHatForPolymorphicPerson('big-hat');
-  const bigHatData2 = makePolymorphicHatForPolymorphicPerson('big-hat');
-  const bigHatData3 = makePolymorphicHatForPolymorphicPerson('big-hat', false);
-  const smallHatData1 = makePolymorphicHatForPolymorphicPerson('small-hat');
-  const smallHatData2 = makePolymorphicHatForPolymorphicPerson('small-hat');
-  const smallHatData3 = makePolymorphicHatForPolymorphicPerson('small-hat', false);
+    const hatData1 = makeHat('hat', hatData),
+      bigHatData1 = makeHat('big-hat', hatData),
+      smallHatData1 = makeHat('small-hat', hatData);
 
-  const bigPersonData = {
-    data: {
-      id: '1',
-      type: 'big-person',
-      attributes: {},
-    },
-    included: [bigHatData1, smallHatData1, bigHatData2, smallHatData2],
-  };
-
-  const smallPersonData = {
-    data: {
-      id: '2',
-      type: 'small-person',
-      attributes: {},
-    },
-    included: [bigHatData3, smallHatData3],
-  };
-
-  const PersonModel = Model.extend({
-    hats: hasMany('hat', {
-      async: false,
-      polymorphic: true,
-      inverse: 'person',
-    }),
-  });
-  const HatModel = Model.extend({
-    type: attr('string'),
-    person: belongsTo('person', {
-      async: false,
-      inverse: 'hats',
-      polymorphic: true,
-    }),
-  });
-  const BigHatModel = HatModel.extend({});
-  const SmallHatModel = HatModel.extend({});
-
-  const BigPersonModel = PersonModel.extend({});
-  const SmallPersonModel = PersonModel.extend({});
-
-  const store = (this.store = createStore({
-    person: PersonModel,
-    bigPerson: BigPersonModel,
-    smallPerson: SmallPersonModel,
-    hat: HatModel,
-    bigHat: BigHatModel,
-    smallHat: SmallHatModel,
-  }));
-
-  const bigPerson = run(() => {
-    return store.push(bigPersonData);
-  });
-
-  const smallPerson = run(() => {
-    return store.push(smallPersonData);
-  });
-
-  const finalBigResult = bigPerson.get('hats').toArray();
-  const finalSmallResult = smallPerson.get('hats').toArray();
-
-  assert.equal(finalBigResult.length, 4, 'We got all our hats!');
-  assert.equal(finalSmallResult.length, 2, 'We got all our hats!');
-});
-
-test('handles relationships where both sides are polymorphic reflexive', function(assert) {
-  function link(a, b, relationshipName, recurse = true) {
-    a.relationships = a.relationships || {};
-    const rel = (a.relationships[relationshipName] = a.relationships[relationshipName] || {});
-
-    if (Array.isArray(b)) {
-      rel.data = b.map(i => {
-        let { type, id } = i;
-
-        if (recurse === true) {
-          link(i, [a], relationshipName, false);
-        }
-
-        return { type, id };
-      });
-    } else {
-      rel.data = {
-        type: b.type,
-        id: b.id,
-      };
-
-      if (recurse === true) {
-        link(b, a, relationshipName, false);
-      }
-    }
-  }
-
-  let id = 1;
-  const Person = Model.extend({
-    name: attr(),
-    family: hasMany('person', { async: false, polymorphic: true, inverse: 'family' }),
-    twin: belongsTo('person', { async: false, polymorphic: true, inverse: 'twin' }),
-  });
-  const Girl = Person.extend({});
-  const Boy = Person.extend({});
-  const Grownup = Person.extend({});
-
-  const brotherPayload = {
-    type: 'boy',
-    id: `${id++}`,
-    attributes: {
-      name: 'Gavin',
-    },
-  };
-  const sisterPayload = {
-    type: 'girl',
-    id: `${id++}`,
-    attributes: {
-      name: 'Rose',
-    },
-  };
-  const fatherPayload = {
-    type: 'grownup',
-    id: `${id++}`,
-    attributes: {
-      name: 'Garak',
-    },
-  };
-  const motherPayload = {
-    type: 'grownup',
-    id: `${id++}`,
-    attributes: {
-      name: 'Kira',
-    },
-  };
-
-  link(brotherPayload, sisterPayload, 'twin');
-  link(brotherPayload, [sisterPayload, fatherPayload, motherPayload], 'family');
-
-  const payload = {
-    data: brotherPayload,
-    included: [sisterPayload, fatherPayload, motherPayload],
-  };
-  const expectedFamilyReferences = [
-    { type: 'girl', id: sisterPayload.id },
-    { type: 'grownup', id: fatherPayload.id },
-    { type: 'grownup', id: motherPayload.id },
-  ];
-  const expectedTwinReference = { type: 'girl', id: sisterPayload.id };
-
-  const store = (this.store = createStore({
-    person: Person,
-    grownup: Grownup,
-    boy: Boy,
-    girl: Girl,
-  }));
-
-  const boyInstance = run(() => {
-    return store.push(payload);
-  });
-
-  const familyResultReferences = boyInstance
-    .get('family')
-    .toArray()
-    .map(i => {
-      return { type: i.constructor.modelName, id: i.id };
-    });
-  const twinResult = boyInstance.get('twin');
-  const twinResultReference = { type: twinResult.constructor.modelName, id: twinResult.id };
-
-  assert.deepEqual(familyResultReferences, expectedFamilyReferences, 'We linked family correctly');
-  assert.deepEqual(twinResultReference, expectedTwinReference, 'We linked twin correctly');
-});
-
-test('handles relationships where both sides are polymorphic reflexive but the primary payload does not include linkage', function(assert) {
-  function link(a, b, relationshipName, recurse = true) {
-    a.relationships = a.relationships || {};
-    const rel = (a.relationships[relationshipName] = a.relationships[relationshipName] || {});
-
-    if (Array.isArray(b)) {
-      rel.data = b.map(i => {
-        let { type, id } = i;
-
-        if (recurse === true) {
-          link(i, [a], relationshipName, false);
-        }
-
-        return { type, id };
-      });
-    } else {
-      rel.data = {
-        type: b.type,
-        id: b.id,
-      };
-
-      if (recurse === true) {
-        link(b, a, relationshipName, false);
-      }
-    }
-  }
-
-  let id = 1;
-  const Person = Model.extend({
-    name: attr(),
-    family: hasMany('person', { async: false, polymorphic: true, inverse: 'family' }),
-    twin: belongsTo('person', { async: false, polymorphic: true, inverse: 'twin' }),
-  });
-  const Girl = Person.extend({});
-  const Boy = Person.extend({});
-  const Grownup = Person.extend({});
-
-  const brotherPayload = {
-    type: 'boy',
-    id: `${id++}`,
-    attributes: {
-      name: 'Gavin',
-    },
-  };
-  const sisterPayload = {
-    type: 'girl',
-    id: `${id++}`,
-    attributes: {
-      name: 'Rose',
-    },
-  };
-  const fatherPayload = {
-    type: 'grownup',
-    id: `${id++}`,
-    attributes: {
-      name: 'Garak',
-    },
-  };
-  const motherPayload = {
-    type: 'grownup',
-    id: `${id++}`,
-    attributes: {
-      name: 'Kira',
-    },
-  };
-
-  link(brotherPayload, sisterPayload, 'twin');
-  link(brotherPayload, [sisterPayload, fatherPayload, motherPayload], 'family');
-
-  // unlink all relationships from the primary payload
-  delete brotherPayload.relationships;
-
-  const payload = {
-    data: brotherPayload,
-    included: [sisterPayload, fatherPayload, motherPayload],
-  };
-  const expectedFamilyReferences = [
-    { type: 'girl', id: sisterPayload.id },
-    { type: 'grownup', id: fatherPayload.id },
-    { type: 'grownup', id: motherPayload.id },
-  ];
-  const expectedTwinReference = { type: 'girl', id: sisterPayload.id };
-
-  const store = (this.store = createStore({
-    person: Person,
-    grownup: Grownup,
-    boy: Boy,
-    girl: Girl,
-  }));
-
-  const boyInstance = run(() => {
-    return store.push(payload);
-  });
-
-  const familyResultReferences = boyInstance
-    .get('family')
-    .toArray()
-    .map(i => {
-      return { type: i.constructor.modelName, id: i.id };
-    });
-  const twinResult = boyInstance.get('twin');
-  const twinResultReference = twinResult && {
-    type: twinResult.constructor.modelName,
-    id: twinResult.id,
-  };
-
-  assert.deepEqual(familyResultReferences, expectedFamilyReferences, 'We linked family correctly');
-  assert.deepEqual(twinResultReference, expectedTwinReference, 'We linked twin correctly');
-});
-
-test('push polymorphic self-referential non-reflexive relationship', function(assert) {
-  const store = this.store;
-  const hat1Data = {
-    data: {
-      id: '1',
-      type: 'big-hat',
-      attributes: {},
-    },
-  };
-  const hat2Data = {
-    data: {
-      id: '2',
-      type: 'big-hat',
-      attributes: {},
-      relationships: {
-        hats: {
-          data: [{ id: '1', type: 'big-hat' }],
-        },
-      },
-    },
-  };
-
-  const hat1 = run(() => store.push(hat1Data));
-  const hat2 = run(() => store.push(hat2Data));
-
-  const expectedHatReference = { id: '2', type: 'big-hat' };
-  const expectedHatsReferences = [{ id: '1', type: 'big-hat' }];
-
-  const finalHatsReferences = hat2
-    .get('hats')
-    .toArray()
-    .map(i => {
-      return { type: i.constructor.modelName, id: i.id };
-    });
-  const hatResult = hat1.get('hat');
-  const finalHatReference = hatResult && {
-    type: hatResult.constructor.modelName,
-    id: hatResult.id,
-  };
-
-  assert.deepEqual(finalHatReference, expectedHatReference, 'we set hat on hat:1');
-  assert.deepEqual(finalHatsReferences, expectedHatsReferences, 'We have hats on hat:2');
-});
-
-test('push polymorphic self-referential circular non-reflexive relationship', function(assert) {
-  const store = this.store;
-  const hatData = {
-    data: {
-      id: '1',
-      type: 'big-hat',
-      attributes: {},
-      relationships: {
-        hat: {
-          data: { id: '1', type: 'big-hat' },
-        },
-        hats: {
-          data: [{ id: '1', type: 'big-hat' }],
-        },
-      },
-    },
-  };
-
-  const hat = run(() => store.push(hatData));
-
-  const expectedHatReference = { id: '1', type: 'big-hat' };
-  const expectedHatsReferences = [{ id: '1', type: 'big-hat' }];
-
-  const finalHatsReferences = hat
-    .get('hats')
-    .toArray()
-    .map(i => {
-      return { type: i.constructor.modelName, id: i.id };
-    });
-  const hatResult = hat.get('hat');
-  const finalHatReference = hatResult && {
-    type: hatResult.constructor.modelName,
-    id: hatResult.id,
-  };
-
-  assert.deepEqual(finalHatReference, expectedHatReference, 'we set hat on hat:1');
-  assert.deepEqual(finalHatsReferences, expectedHatsReferences, 'We have hats on hat:2');
-});
-
-test('polymorphic hasMany to types with separate id-spaces', function(assert) {
-  const user = run(() =>
-    this.store.push({
+    const userData = {
       data: {
         id: '1',
         type: 'user',
+        attributes: {},
+      },
+      included: [hatData1, bigHatData1, smallHatData1],
+    };
+
+    const user = run(() => this.store.push(userData));
+
+    const finalResult = user.get('hats').mapBy('type');
+
+    assert.deepEqual(finalResult, ['hat', 'big-hat', 'small-hat'], 'We got all our hats!');
+  });
+
+  test('push one side is polymorphic, subType then baseType', function(assert) {
+    let id = 1;
+
+    function makeHat(type, props) {
+      const resource = deepCopy(props);
+      resource.id = `${id++}`;
+      resource.type = type;
+      resource.attributes.type = type;
+      return resource;
+    }
+
+    const hatData = {
+      attributes: {},
+      relationships: {
+        user: {
+          data: { id: '1', type: 'user' },
+        },
+      },
+    };
+
+    const bigHatData1 = makeHat('hat', hatData),
+      smallHatData1 = makeHat('small-hat', hatData),
+      hatData1 = makeHat('big-hat', hatData),
+      included = [bigHatData1, smallHatData1, hatData1];
+
+    const userData = {
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {},
+      },
+      included,
+    };
+
+    const user = run(() => this.store.push(userData)),
+      finalResult = user.get('hats').mapBy('type'),
+      expectedResults = included.map(m => m.type);
+
+    assert.deepEqual(finalResult, expectedResults, 'We got all our hats!');
+  });
+
+  test('push one side is polymorphic, different subtypes', function(assert) {
+    let id = 1;
+
+    function makeHat(type, props) {
+      const resource = deepCopy(props);
+      resource.id = `${id++}`;
+      resource.type = type;
+      resource.attributes.type = type;
+      return resource;
+    }
+
+    const hatData = {
+      attributes: {},
+      relationships: {
+        user: {
+          data: { id: '1', type: 'user' },
+        },
+      },
+    };
+
+    const bigHatData1 = makeHat('big-hat', hatData),
+      smallHatData1 = makeHat('small-hat', hatData),
+      bigHatData2 = makeHat('big-hat', hatData),
+      smallHatData2 = makeHat('small-hat', hatData),
+      included = [bigHatData1, smallHatData1, bigHatData2, smallHatData2];
+
+    const userData = {
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {},
+      },
+      included,
+    };
+
+    const user = run(() => this.store.push(userData)),
+      finalResult = user.get('hats').mapBy('type'),
+      expectedResults = included.map(m => m.type);
+
+    assert.deepEqual(finalResult, expectedResults, 'We got all our hats!');
+  });
+
+  test('push both sides are polymorphic', function(assert) {
+    let id = 1;
+
+    function makeHat(type, props) {
+      const resource = deepCopy(props);
+      resource.id = `${id++}`;
+      resource.type = type;
+      resource.attributes.type = type;
+      return resource;
+    }
+
+    const alienHatData = {
+      attributes: {},
+      relationships: {
+        user: {
+          data: { id: '1', type: 'alien' },
+        },
+      },
+    };
+
+    const bigHatData1 = makeHat('hat', alienHatData),
+      hatData1 = makeHat('big-hat', alienHatData),
+      alienIncluded = [bigHatData1, hatData1];
+
+    const alienData = {
+      data: {
+        id: '1',
+        type: 'alien',
+        attributes: {},
+      },
+      included: alienIncluded,
+    };
+
+    const expectedAlienResults = alienIncluded.map(m => m.type),
+      alien = run(() => this.store.push(alienData)),
+      alienFinalHats = alien.get('hats').mapBy('type');
+
+    assert.deepEqual(alienFinalHats, expectedAlienResults, 'We got all alien hats!');
+  });
+
+  test('handles relationships where both sides are polymorphic', function(assert) {
+    let id = 1;
+    function makePolymorphicHatForPolymorphicPerson(type, isForBigPerson = true) {
+      return {
+        id: `${id++}`,
+        type,
+        relationships: {
+          person: {
+            data: {
+              id: isForBigPerson ? '1' : '2',
+              type: isForBigPerson ? 'big-person' : 'small-person',
+            },
+          },
+        },
+      };
+    }
+
+    const bigHatData1 = makePolymorphicHatForPolymorphicPerson('big-hat');
+    const bigHatData2 = makePolymorphicHatForPolymorphicPerson('big-hat');
+    const bigHatData3 = makePolymorphicHatForPolymorphicPerson('big-hat', false);
+    const smallHatData1 = makePolymorphicHatForPolymorphicPerson('small-hat');
+    const smallHatData2 = makePolymorphicHatForPolymorphicPerson('small-hat');
+    const smallHatData3 = makePolymorphicHatForPolymorphicPerson('small-hat', false);
+
+    const bigPersonData = {
+      data: {
+        id: '1',
+        type: 'big-person',
+        attributes: {},
+      },
+      included: [bigHatData1, smallHatData1, bigHatData2, smallHatData2],
+    };
+
+    const smallPersonData = {
+      data: {
+        id: '2',
+        type: 'small-person',
+        attributes: {},
+      },
+      included: [bigHatData3, smallHatData3],
+    };
+
+    const PersonModel = Model.extend({
+      hats: hasMany('hat', {
+        async: false,
+        polymorphic: true,
+        inverse: 'person',
+      }),
+    });
+    const HatModel = Model.extend({
+      type: attr('string'),
+      person: belongsTo('person', {
+        async: false,
+        inverse: 'hats',
+        polymorphic: true,
+      }),
+    });
+    const BigHatModel = HatModel.extend({});
+    const SmallHatModel = HatModel.extend({});
+
+    const BigPersonModel = PersonModel.extend({});
+    const SmallPersonModel = PersonModel.extend({});
+
+    const store = (this.store = createStore({
+      person: PersonModel,
+      bigPerson: BigPersonModel,
+      smallPerson: SmallPersonModel,
+      hat: HatModel,
+      bigHat: BigHatModel,
+      smallHat: SmallHatModel,
+    }));
+
+    const bigPerson = run(() => {
+      return store.push(bigPersonData);
+    });
+
+    const smallPerson = run(() => {
+      return store.push(smallPersonData);
+    });
+
+    const finalBigResult = bigPerson.get('hats').toArray();
+    const finalSmallResult = smallPerson.get('hats').toArray();
+
+    assert.equal(finalBigResult.length, 4, 'We got all our hats!');
+    assert.equal(finalSmallResult.length, 2, 'We got all our hats!');
+  });
+
+  test('handles relationships where both sides are polymorphic reflexive', function(assert) {
+    function link(a, b, relationshipName, recurse = true) {
+      a.relationships = a.relationships || {};
+      const rel = (a.relationships[relationshipName] = a.relationships[relationshipName] || {});
+
+      if (Array.isArray(b)) {
+        rel.data = b.map(i => {
+          let { type, id } = i;
+
+          if (recurse === true) {
+            link(i, [a], relationshipName, false);
+          }
+
+          return { type, id };
+        });
+      } else {
+        rel.data = {
+          type: b.type,
+          id: b.id,
+        };
+
+        if (recurse === true) {
+          link(b, a, relationshipName, false);
+        }
+      }
+    }
+
+    let id = 1;
+    const Person = Model.extend({
+      name: attr(),
+      family: hasMany('person', { async: false, polymorphic: true, inverse: 'family' }),
+      twin: belongsTo('person', { async: false, polymorphic: true, inverse: 'twin' }),
+    });
+    const Girl = Person.extend({});
+    const Boy = Person.extend({});
+    const Grownup = Person.extend({});
+
+    const brotherPayload = {
+      type: 'boy',
+      id: `${id++}`,
+      attributes: {
+        name: 'Gavin',
+      },
+    };
+    const sisterPayload = {
+      type: 'girl',
+      id: `${id++}`,
+      attributes: {
+        name: 'Rose',
+      },
+    };
+    const fatherPayload = {
+      type: 'grownup',
+      id: `${id++}`,
+      attributes: {
+        name: 'Garak',
+      },
+    };
+    const motherPayload = {
+      type: 'grownup',
+      id: `${id++}`,
+      attributes: {
+        name: 'Kira',
+      },
+    };
+
+    link(brotherPayload, sisterPayload, 'twin');
+    link(brotherPayload, [sisterPayload, fatherPayload, motherPayload], 'family');
+
+    const payload = {
+      data: brotherPayload,
+      included: [sisterPayload, fatherPayload, motherPayload],
+    };
+    const expectedFamilyReferences = [
+      { type: 'girl', id: sisterPayload.id },
+      { type: 'grownup', id: fatherPayload.id },
+      { type: 'grownup', id: motherPayload.id },
+    ];
+    const expectedTwinReference = { type: 'girl', id: sisterPayload.id };
+
+    const store = (this.store = createStore({
+      person: Person,
+      grownup: Grownup,
+      boy: Boy,
+      girl: Girl,
+    }));
+
+    const boyInstance = run(() => {
+      return store.push(payload);
+    });
+
+    const familyResultReferences = boyInstance
+      .get('family')
+      .toArray()
+      .map(i => {
+        return { type: i.constructor.modelName, id: i.id };
+      });
+    const twinResult = boyInstance.get('twin');
+    const twinResultReference = { type: twinResult.constructor.modelName, id: twinResult.id };
+
+    assert.deepEqual(familyResultReferences, expectedFamilyReferences, 'We linked family correctly');
+    assert.deepEqual(twinResultReference, expectedTwinReference, 'We linked twin correctly');
+  });
+
+  test('handles relationships where both sides are polymorphic reflexive but the primary payload does not include linkage', function(assert) {
+    function link(a, b, relationshipName, recurse = true) {
+      a.relationships = a.relationships || {};
+      const rel = (a.relationships[relationshipName] = a.relationships[relationshipName] || {});
+
+      if (Array.isArray(b)) {
+        rel.data = b.map(i => {
+          let { type, id } = i;
+
+          if (recurse === true) {
+            link(i, [a], relationshipName, false);
+          }
+
+          return { type, id };
+        });
+      } else {
+        rel.data = {
+          type: b.type,
+          id: b.id,
+        };
+
+        if (recurse === true) {
+          link(b, a, relationshipName, false);
+        }
+      }
+    }
+
+    let id = 1;
+    const Person = Model.extend({
+      name: attr(),
+      family: hasMany('person', { async: false, polymorphic: true, inverse: 'family' }),
+      twin: belongsTo('person', { async: false, polymorphic: true, inverse: 'twin' }),
+    });
+    const Girl = Person.extend({});
+    const Boy = Person.extend({});
+    const Grownup = Person.extend({});
+
+    const brotherPayload = {
+      type: 'boy',
+      id: `${id++}`,
+      attributes: {
+        name: 'Gavin',
+      },
+    };
+    const sisterPayload = {
+      type: 'girl',
+      id: `${id++}`,
+      attributes: {
+        name: 'Rose',
+      },
+    };
+    const fatherPayload = {
+      type: 'grownup',
+      id: `${id++}`,
+      attributes: {
+        name: 'Garak',
+      },
+    };
+    const motherPayload = {
+      type: 'grownup',
+      id: `${id++}`,
+      attributes: {
+        name: 'Kira',
+      },
+    };
+
+    link(brotherPayload, sisterPayload, 'twin');
+    link(brotherPayload, [sisterPayload, fatherPayload, motherPayload], 'family');
+
+    // unlink all relationships from the primary payload
+    delete brotherPayload.relationships;
+
+    const payload = {
+      data: brotherPayload,
+      included: [sisterPayload, fatherPayload, motherPayload],
+    };
+    const expectedFamilyReferences = [
+      { type: 'girl', id: sisterPayload.id },
+      { type: 'grownup', id: fatherPayload.id },
+      { type: 'grownup', id: motherPayload.id },
+    ];
+    const expectedTwinReference = { type: 'girl', id: sisterPayload.id };
+
+    const store = (this.store = createStore({
+      person: Person,
+      grownup: Grownup,
+      boy: Boy,
+      girl: Girl,
+    }));
+
+    const boyInstance = run(() => {
+      return store.push(payload);
+    });
+
+    const familyResultReferences = boyInstance
+      .get('family')
+      .toArray()
+      .map(i => {
+        return { type: i.constructor.modelName, id: i.id };
+      });
+    const twinResult = boyInstance.get('twin');
+    const twinResultReference = twinResult && {
+      type: twinResult.constructor.modelName,
+      id: twinResult.id,
+    };
+
+    assert.deepEqual(familyResultReferences, expectedFamilyReferences, 'We linked family correctly');
+    assert.deepEqual(twinResultReference, expectedTwinReference, 'We linked twin correctly');
+  });
+
+  test('push polymorphic self-referential non-reflexive relationship', function(assert) {
+    const store = this.store;
+    const hat1Data = {
+      data: {
+        id: '1',
+        type: 'big-hat',
+        attributes: {},
+      },
+    };
+    const hat2Data = {
+      data: {
+        id: '2',
+        type: 'big-hat',
+        attributes: {},
         relationships: {
           hats: {
-            data: [{ id: '1', type: 'big-hat' }, { id: '1', type: 'small-hat' }],
-          },
-        },
-      },
-      included: [
-        {
-          id: '1',
-          type: 'big-hat',
-        },
-        {
-          id: '1',
-          type: 'small-hat',
-        },
-      ],
-    })
-  );
-
-  const hats = user.get('hats');
-
-  assert.deepEqual(hats.map(h => h.constructor.modelName), ['big-hat', 'small-hat']);
-  assert.deepEqual(hats.map(h => h.id), ['1', '1']);
-});
-
-test('polymorphic hasMany to types with separate id-spaces, from inverse payload', function(assert) {
-  const user = run(() =>
-    this.store.push({
-      data: {
-        id: '1',
-        type: 'user',
-      },
-      included: [
-        {
-          id: '1',
-          type: 'big-hat',
-          relationships: {
-            user: {
-              data: { id: '1', type: 'user' },
-            },
-          },
-        },
-        {
-          id: '1',
-          type: 'small-hat',
-          relationships: {
-            user: {
-              data: { id: '1', type: 'user' },
-            },
-          },
-        },
-      ],
-    })
-  );
-
-  const hats = user.get('hats');
-
-  assert.deepEqual(hats.map(h => h.constructor.modelName), ['big-hat', 'small-hat']);
-  assert.deepEqual(hats.map(h => h.id), ['1', '1']);
-});
-
-test('polymorphic hasMany to polymorphic hasMany types with separate id-spaces', function(assert) {
-  let bigHatId = 1;
-  let smallHatId = 1;
-  function makePolymorphicHatForPolymorphicPerson(type, isForBigPerson = true) {
-    const isSmallHat = type === 'small-hat';
-    return {
-      id: `${isSmallHat ? smallHatId++ : bigHatId++}`,
-      type,
-      relationships: {
-        person: {
-          data: {
-            id: '1',
-            type: isForBigPerson ? 'big-person' : 'small-person',
+            data: [{ id: '1', type: 'big-hat' }],
           },
         },
       },
     };
-  }
 
-  const bigHatData1 = makePolymorphicHatForPolymorphicPerson('big-hat');
-  const bigHatData2 = makePolymorphicHatForPolymorphicPerson('big-hat');
-  const bigHatData3 = makePolymorphicHatForPolymorphicPerson('big-hat', false);
-  const smallHatData1 = makePolymorphicHatForPolymorphicPerson('small-hat');
-  const smallHatData2 = makePolymorphicHatForPolymorphicPerson('small-hat');
-  const smallHatData3 = makePolymorphicHatForPolymorphicPerson('small-hat', false);
+    const hat1 = run(() => store.push(hat1Data));
+    const hat2 = run(() => store.push(hat2Data));
 
-  const bigPersonData = {
-    data: {
-      id: '1',
-      type: 'big-person',
-      attributes: {},
-    },
-    included: [bigHatData1, smallHatData1, bigHatData2, smallHatData2],
-  };
+    const expectedHatReference = { id: '2', type: 'big-hat' };
+    const expectedHatsReferences = [{ id: '1', type: 'big-hat' }];
 
-  const smallPersonData = {
-    data: {
-      id: '1',
-      type: 'small-person',
-      attributes: {},
-    },
-    included: [bigHatData3, smallHatData3],
-  };
+    const finalHatsReferences = hat2
+      .get('hats')
+      .toArray()
+      .map(i => {
+        return { type: i.constructor.modelName, id: i.id };
+      });
+    const hatResult = hat1.get('hat');
+    const finalHatReference = hatResult && {
+      type: hatResult.constructor.modelName,
+      id: hatResult.id,
+    };
 
-  const PersonModel = Model.extend({
-    hats: hasMany('hat', {
-      async: false,
-      polymorphic: true,
-      inverse: 'person',
-    }),
-  });
-  const HatModel = Model.extend({
-    type: attr('string'),
-    person: belongsTo('person', {
-      async: false,
-      inverse: 'hats',
-      polymorphic: true,
-    }),
-  });
-  const BigHatModel = HatModel.extend({});
-  const SmallHatModel = HatModel.extend({});
-
-  const BigPersonModel = PersonModel.extend({});
-  const SmallPersonModel = PersonModel.extend({});
-
-  const store = (this.store = createStore({
-    person: PersonModel,
-    bigPerson: BigPersonModel,
-    smallPerson: SmallPersonModel,
-    hat: HatModel,
-    bigHat: BigHatModel,
-    smallHat: SmallHatModel,
-  }));
-
-  const bigPerson = run(() => {
-    return store.push(bigPersonData);
+    assert.deepEqual(finalHatReference, expectedHatReference, 'we set hat on hat:1');
+    assert.deepEqual(finalHatsReferences, expectedHatsReferences, 'We have hats on hat:2');
   });
 
-  const smallPerson = run(() => {
-    return store.push(smallPersonData);
+  test('push polymorphic self-referential circular non-reflexive relationship', function(assert) {
+    const store = this.store;
+    const hatData = {
+      data: {
+        id: '1',
+        type: 'big-hat',
+        attributes: {},
+        relationships: {
+          hat: {
+            data: { id: '1', type: 'big-hat' },
+          },
+          hats: {
+            data: [{ id: '1', type: 'big-hat' }],
+          },
+        },
+      },
+    };
+
+    const hat = run(() => store.push(hatData));
+
+    const expectedHatReference = { id: '1', type: 'big-hat' };
+    const expectedHatsReferences = [{ id: '1', type: 'big-hat' }];
+
+    const finalHatsReferences = hat
+      .get('hats')
+      .toArray()
+      .map(i => {
+        return { type: i.constructor.modelName, id: i.id };
+      });
+    const hatResult = hat.get('hat');
+    const finalHatReference = hatResult && {
+      type: hatResult.constructor.modelName,
+      id: hatResult.id,
+    };
+
+    assert.deepEqual(finalHatReference, expectedHatReference, 'we set hat on hat:1');
+    assert.deepEqual(finalHatsReferences, expectedHatsReferences, 'We have hats on hat:2');
   });
 
-  const finalBigResult = bigPerson.get('hats').toArray();
-  const finalSmallResult = smallPerson.get('hats').toArray();
-
-  assert.deepEqual(
-    finalBigResult.map(h => ({ type: h.constructor.modelName, id: h.get('id') })),
-    [
-      { type: 'big-hat', id: '1' },
-      { type: 'small-hat', id: '1' },
-      { type: 'big-hat', id: '2' },
-      { type: 'small-hat', id: '2' },
-    ],
-    'big-person hats is all good'
-  );
-
-  assert.deepEqual(
-    finalSmallResult.map(h => ({ type: h.constructor.modelName, id: h.get('id') })),
-    [{ type: 'big-hat', id: '3' }, { type: 'small-hat', id: '3' }],
-    'small-person hats is all good'
-  );
-});
-
-testInDebug('Invalid inverses throw errors', function(assert) {
-  let PostModel = Model.extend({
-    comments: hasMany('comment', { async: false, inverse: 'post' }),
-  });
-  let CommentModel = Model.extend({
-    post: belongsTo('post', { async: false, inverse: null }),
-  });
-  let store = createStore({
-    post: PostModel,
-    comment: CommentModel,
-  });
-
-  function runInvalidPush() {
-    return run(() => {
-      return store.push({
+  test('polymorphic hasMany to types with separate id-spaces', function(assert) {
+    const user = run(() =>
+      this.store.push({
         data: {
-          type: 'post',
           id: '1',
+          type: 'user',
           relationships: {
-            comments: {
-              data: [{ type: 'comment', id: '1' }],
+            hats: {
+              data: [{ id: '1', type: 'big-hat' }, { id: '1', type: 'small-hat' }],
             },
           },
         },
         included: [
           {
-            type: 'comment',
             id: '1',
+            type: 'big-hat',
+          },
+          {
+            id: '1',
+            type: 'small-hat',
+          },
+        ],
+      })
+    );
+
+    const hats = user.get('hats');
+
+    assert.deepEqual(hats.map(h => h.constructor.modelName), ['big-hat', 'small-hat']);
+    assert.deepEqual(hats.map(h => h.id), ['1', '1']);
+  });
+
+  test('polymorphic hasMany to types with separate id-spaces, from inverse payload', function(assert) {
+    const user = run(() =>
+      this.store.push({
+        data: {
+          id: '1',
+          type: 'user',
+        },
+        included: [
+          {
+            id: '1',
+            type: 'big-hat',
             relationships: {
-              post: {
-                data: {
-                  type: 'post',
-                  id: '1',
-                },
+              user: {
+                data: { id: '1', type: 'user' },
+              },
+            },
+          },
+          {
+            id: '1',
+            type: 'small-hat',
+            relationships: {
+              user: {
+                data: { id: '1', type: 'user' },
               },
             },
           },
         ],
-      });
-    });
-  }
+      })
+    );
 
-  assert.expectAssertion(
-    runInvalidPush,
-    /The comment:post relationship declares 'inverse: null', but it was resolved as the inverse for post:comments/,
-    'We detected the invalid inverse'
-  );
+    const hats = user.get('hats');
+
+    assert.deepEqual(hats.map(h => h.constructor.modelName), ['big-hat', 'small-hat']);
+    assert.deepEqual(hats.map(h => h.id), ['1', '1']);
+  });
+
+  test('polymorphic hasMany to polymorphic hasMany types with separate id-spaces', function(assert) {
+    let bigHatId = 1;
+    let smallHatId = 1;
+    function makePolymorphicHatForPolymorphicPerson(type, isForBigPerson = true) {
+      const isSmallHat = type === 'small-hat';
+      return {
+        id: `${isSmallHat ? smallHatId++ : bigHatId++}`,
+        type,
+        relationships: {
+          person: {
+            data: {
+              id: '1',
+              type: isForBigPerson ? 'big-person' : 'small-person',
+            },
+          },
+        },
+      };
+    }
+
+    const bigHatData1 = makePolymorphicHatForPolymorphicPerson('big-hat');
+    const bigHatData2 = makePolymorphicHatForPolymorphicPerson('big-hat');
+    const bigHatData3 = makePolymorphicHatForPolymorphicPerson('big-hat', false);
+    const smallHatData1 = makePolymorphicHatForPolymorphicPerson('small-hat');
+    const smallHatData2 = makePolymorphicHatForPolymorphicPerson('small-hat');
+    const smallHatData3 = makePolymorphicHatForPolymorphicPerson('small-hat', false);
+
+    const bigPersonData = {
+      data: {
+        id: '1',
+        type: 'big-person',
+        attributes: {},
+      },
+      included: [bigHatData1, smallHatData1, bigHatData2, smallHatData2],
+    };
+
+    const smallPersonData = {
+      data: {
+        id: '1',
+        type: 'small-person',
+        attributes: {},
+      },
+      included: [bigHatData3, smallHatData3],
+    };
+
+    const PersonModel = Model.extend({
+      hats: hasMany('hat', {
+        async: false,
+        polymorphic: true,
+        inverse: 'person',
+      }),
+    });
+    const HatModel = Model.extend({
+      type: attr('string'),
+      person: belongsTo('person', {
+        async: false,
+        inverse: 'hats',
+        polymorphic: true,
+      }),
+    });
+    const BigHatModel = HatModel.extend({});
+    const SmallHatModel = HatModel.extend({});
+
+    const BigPersonModel = PersonModel.extend({});
+    const SmallPersonModel = PersonModel.extend({});
+
+    const store = (this.store = createStore({
+      person: PersonModel,
+      bigPerson: BigPersonModel,
+      smallPerson: SmallPersonModel,
+      hat: HatModel,
+      bigHat: BigHatModel,
+      smallHat: SmallHatModel,
+    }));
+
+    const bigPerson = run(() => {
+      return store.push(bigPersonData);
+    });
+
+    const smallPerson = run(() => {
+      return store.push(smallPersonData);
+    });
+
+    const finalBigResult = bigPerson.get('hats').toArray();
+    const finalSmallResult = smallPerson.get('hats').toArray();
+
+    assert.deepEqual(
+      finalBigResult.map(h => ({ type: h.constructor.modelName, id: h.get('id') })),
+      [
+        { type: 'big-hat', id: '1' },
+        { type: 'small-hat', id: '1' },
+        { type: 'big-hat', id: '2' },
+        { type: 'small-hat', id: '2' },
+      ],
+      'big-person hats is all good'
+    );
+
+    assert.deepEqual(
+      finalSmallResult.map(h => ({ type: h.constructor.modelName, id: h.get('id') })),
+      [{ type: 'big-hat', id: '3' }, { type: 'small-hat', id: '3' }],
+      'small-person hats is all good'
+    );
+  });
+
+  testInDebug('Invalid inverses throw errors', function(assert) {
+    let PostModel = Model.extend({
+      comments: hasMany('comment', { async: false, inverse: 'post' }),
+    });
+    let CommentModel = Model.extend({
+      post: belongsTo('post', { async: false, inverse: null }),
+    });
+    let store = createStore({
+      post: PostModel,
+      comment: CommentModel,
+    });
+
+    function runInvalidPush() {
+      return run(() => {
+        return store.push({
+          data: {
+            type: 'post',
+            id: '1',
+            relationships: {
+              comments: {
+                data: [{ type: 'comment', id: '1' }],
+              },
+            },
+          },
+          included: [
+            {
+              type: 'comment',
+              id: '1',
+              relationships: {
+                post: {
+                  data: {
+                    type: 'post',
+                    id: '1',
+                  },
+                },
+              },
+            },
+          ],
+        });
+      });
+    }
+
+    assert.expectAssertion(
+      runInvalidPush,
+      /The comment:post relationship declares 'inverse: null', but it was resolved as the inverse for post:comments/,
+      'We detected the invalid inverse'
+    );
+  });
 });


### PR DESCRIPTION
Converts the remaining QUnit modules that are using the non-nested syntax to the nested syntax.

This will help reduce noise in diffs for further work to modernize the test suite to use things like the `setupTest` helper from `ember-qunit`.

**Highly recommend hiding whitespace changes while reviewing**