### PR TITLE
[CHORE blueprints] Update blueprints to use package imports

### DIFF
--- a/packages/-build-infra/src/utilities/extend-from-application-entity.js
+++ b/packages/-build-infra/src/utilities/extend-from-application-entity.js
@@ -34,7 +34,8 @@ module.exports = function(type, baseClass, options) {
         's cannot extend from themself. To resolve this, remove the `--base-class` option or change to a different base-class.'
     );
   }
-  let importStatement = "import DS from 'ember-data';";
+
+  let importStatement;
 
   if (options.baseClass) {
     let baseClassPath = options.baseClass;
@@ -47,10 +48,22 @@ module.exports = function(type, baseClass, options) {
     }
 
     importStatement = `import ${baseClass} from '${relativePath}${baseClassPath}';`;
+  } else {
+    let baseClassPath = `@ember-data/${type}`;
+
+    if (baseClass.startsWith('JSONAPI')) {
+      baseClassPath += '/json-api';
+    }
+
+    if (baseClass.startsWith('REST')) {
+      baseClassPath += '/rest';
+    }
+
+    importStatement = `import ${baseClass} from '${baseClassPath}';`;
   }
 
   return {
-    importStatement: importStatement,
-    baseClass: baseClass,
+    importStatement,
+    baseClass,
   };
 };

--- a/packages/adapter/blueprints/adapter/index.js
+++ b/packages/adapter/blueprints/adapter/index.js
@@ -28,6 +28,6 @@ module.exports = useEditionDetector({
   },
 
   locals(options) {
-    return extendFromApplicationEntity('adapter', 'DS.JSONAPIAdapter', options);
+    return extendFromApplicationEntity('adapter', 'JSONAPIAdapter', options);
   },
 });

--- a/packages/adapter/node-tests/blueprints/adapter-test.js
+++ b/packages/adapter/node-tests/blueprints/adapter-test.js
@@ -31,8 +31,8 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
 
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/adapters/foo.js'))
-          .to.contain("import DS from 'ember-data';")
-          .to.contain('export default DS.JSONAPIAdapter.extend({');
+          .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
+          .to.contain('export default JSONAPIAdapter.extend({');
 
         expect(_file('tests/unit/adapters/foo-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
       });
@@ -75,8 +75,8 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
 
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/adapters/application.js'))
-          .to.contain("import DS from 'ember-data';")
-          .to.contain('export default DS.JSONAPIAdapter.extend({');
+          .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
+          .to.contain('export default JSONAPIAdapter.extend({');
 
         expect(_file('tests/unit/adapters/application-test.js')).to.equal(
           fixture(__dirname, 'adapter-test/application-default.js')
@@ -148,8 +148,8 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/foo/adapter.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('export default DS.JSONAPIAdapter.extend({');
+            .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
+            .to.contain('export default JSONAPIAdapter.extend({');
 
           expect(_file('src/data/models/foo/adapter-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
         },
@@ -198,8 +198,8 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/application/adapter.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('export default DS.JSONAPIAdapter.extend({');
+            .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
+            .to.contain('export default JSONAPIAdapter.extend({');
 
           expect(_file('src/data/models/application/adapter-test.js')).to.equal(
             fixture(__dirname, 'adapter-test/application-default.js')
@@ -297,8 +297,8 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/foo/adapter.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('export default class FooAdapter extends DS.JSONAPIAdapter {');
+            .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
+            .to.contain('export default class FooAdapter extends JSONAPIAdapter {');
 
           expect(_file('src/data/models/foo/adapter-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
         },
@@ -347,8 +347,8 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/application/adapter.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('export default class ApplicationAdapter extends DS.JSONAPIAdapter {');
+            .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
+            .to.contain('export default class ApplicationAdapter extends JSONAPIAdapter {');
 
           expect(_file('src/data/models/application/adapter-test.js')).to.equal(
             fixture(__dirname, 'adapter-test/application-default.js')

--- a/packages/model/blueprints/model/files/__root__/__path__/__name__.js
+++ b/packages/model/blueprints/model/files/__root__/__path__/__name__.js
@@ -1,5 +1,4 @@
-import DS from 'ember-data';
-const { <%= importedModules %> } = DS;
+import Model<%= importedModules.length ? `, { ${importedModules} }` : '' %> from '@ember-data/model';
 
 export default Model.extend({
 <%= attrs.length ? attrs : '' %>

--- a/packages/model/blueprints/model/index.js
+++ b/packages/model/blueprints/model/index.js
@@ -105,7 +105,7 @@ module.exports = useEditionDetector({
     });
     needs = '  needs: [' + needsDeduplicated.join(', ') + ']';
 
-    let importedModules = ['Model'];
+    let importedModules = [];
     if (includeAttr) {
       importedModules.push('attr');
     }
@@ -118,9 +118,9 @@ module.exports = useEditionDetector({
     importedModules = importedModules.join(', ');
 
     return {
-      importedModules: importedModules,
-      attrs: attrs,
-      needs: needs,
+      importedModules,
+      attrs,
+      needs,
     };
   },
 });

--- a/packages/model/blueprints/model/native-files/__root__/__path__/__name__.js
+++ b/packages/model/blueprints/model/native-files/__root__/__path__/__name__.js
@@ -1,5 +1,4 @@
-import DS from 'ember-data';
-const { <%= importedModules %> } = DS;
+import Model<%= importedModules.length ? `, { ${importedModules} }` : '' %> from '@ember-data/model';
 
 export default class <%= classifiedModuleName %>Model extends Model {
 <%= attrs.length ? attrs : '' %>

--- a/packages/model/node-tests/blueprints/model-test.js
+++ b/packages/model/node-tests/blueprints/model-test.js
@@ -28,8 +28,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
 
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/models/foo.js'))
-          .to.contain("import DS from 'ember-data';")
-          .to.contain('const { Model } = DS;')
+          .to.contain(`import Model from '@ember-data/model';`)
           .to.contain('export default Model.extend(');
 
         expect(_file('tests/unit/models/foo-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
@@ -52,8 +51,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
 
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/models/foo.js'))
-          .to.contain("import DS from 'ember-data';")
-          .to.contain('const { Model, attr } = DS;')
+          .to.contain(`import Model, { attr } from '@ember-data/model';`)
           .to.contain('export default Model.extend(')
           .to.contain('  misc: attr(),')
           .to.contain("  skills: attr('array'),")
@@ -73,8 +71,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
 
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/models/comment.js'))
-          .to.contain("import DS from 'ember-data';")
-          .to.contain('const { Model, belongsTo } = DS;')
+          .to.contain(`import Model, { belongsTo } from '@ember-data/model';`)
           .to.contain('export default Model.extend(')
           .to.contain("  post: belongsTo('post'),")
           .to.contain("  author: belongsTo('user')");
@@ -90,8 +87,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
 
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/models/post.js'))
-          .to.contain("import DS from 'ember-data';")
-          .to.contain('const { Model, hasMany } = DS;')
+          .to.contain(`import Model, { hasMany } from '@ember-data/model';`)
           .to.contain('export default Model.extend(')
           .to.contain("  comments: hasMany('comment')")
           .to.contain("  otherComments: hasMany('comment')");
@@ -164,8 +160,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/foo/model.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('const { Model } = DS;')
+            .to.contain(`import Model from '@ember-data/model';`)
             .to.contain('export default Model.extend(');
 
           expect(_file('src/data/models/foo/model-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
@@ -192,8 +187,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/foo/model.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('const { Model, attr } = DS;')
+            .to.contain(`import Model, { attr } from '@ember-data/model';`)
             .to.contain('export default Model.extend(')
             .to.contain('  misc: attr(),')
             .to.contain("  skills: attr('array'),")
@@ -217,8 +211,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/comment/model.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('const { Model, belongsTo } = DS;')
+            .to.contain(`import Model, { belongsTo } from '@ember-data/model';`)
             .to.contain('export default Model.extend(')
             .to.contain("  post: belongsTo('post'),")
             .to.contain("  author: belongsTo('user')");
@@ -238,8 +231,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/post/model.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('const { Model, hasMany } = DS;')
+            .to.contain(`import Model, { hasMany } from '@ember-data/model';`)
             .to.contain('export default Model.extend(')
             .to.contain("  comments: hasMany('comment'),")
             .to.contain("  otherComments: hasMany('comment')");
@@ -339,7 +331,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/foo/model.js'))
-            .to.contain("import DS from 'ember-data';")
+            .to.contain(`import Model from '@ember-data/model';`)
             .to.contain('export default class FooModel extends Model {');
 
           expect(_file('src/data/models/foo/model-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
@@ -366,8 +358,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/foo/model.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('const { Model, attr } = DS;')
+            .to.contain(`import Model, { attr } from '@ember-data/model';`)
             .to.contain('export default class FooModel extends Model {')
             .to.contain('  @attr() misc;')
             .to.contain("  @attr('array') skills;")
@@ -391,8 +382,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/comment/model.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('const { Model, belongsTo } = DS;')
+            .to.contain(`import Model, { belongsTo } from '@ember-data/model';`)
             .to.contain('export default class CommentModel extends Model {')
             .to.contain('  @belongsTo post;')
             .to.contain("  @belongsTo('user') author;");
@@ -412,8 +402,7 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/post/model.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('const { Model, hasMany } = DS;')
+            .to.contain(`import Model, { hasMany } from '@ember-data/model';`)
             .to.contain('export default class PostModel extends Model {')
             .to.contain('  @hasMany comments;')
             .to.contain("  @hasMany('comment') otherComments;");

--- a/packages/serializer/blueprints/serializer/index.js
+++ b/packages/serializer/blueprints/serializer/index.js
@@ -28,6 +28,6 @@ module.exports = useEditionDetector({
   },
 
   locals(options) {
-    return extendFromApplicationEntity('serializer', 'DS.JSONAPISerializer', options);
+    return extendFromApplicationEntity('serializer', 'JSONAPISerializer', options);
   },
 });

--- a/packages/serializer/blueprints/transform/files/__root__/__path__/__name__.js
+++ b/packages/serializer/blueprints/transform/files/__root__/__path__/__name__.js
@@ -1,6 +1,6 @@
-import DS from 'ember-data';
+import Transform from '@ember-data/serializer/transform';
 
-export default DS.Transform.extend({
+export default Transform.extend({
   deserialize(serialized) {
     return serialized;
   },

--- a/packages/serializer/blueprints/transform/native-files/__root__/__path__/__name__.js
+++ b/packages/serializer/blueprints/transform/native-files/__root__/__path__/__name__.js
@@ -1,5 +1,4 @@
-import DS from 'ember-data';
-const { Transform } = DS;
+import Transform from '@ember-data/serializer/transform';
 
 export default class <%= classifiedModuleName %>Transform extends Transform {
   deserialize(serialized) {

--- a/packages/serializer/node-tests/blueprints/serializer-test.js
+++ b/packages/serializer/node-tests/blueprints/serializer-test.js
@@ -31,8 +31,8 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
 
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/serializers/foo.js'))
-          .to.contain("import DS from 'ember-data';")
-          .to.contain('export default DS.JSONAPISerializer.extend(');
+          .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
+          .to.contain('export default JSONAPISerializer.extend(');
 
         expect(_file('tests/unit/serializers/foo-test.js')).to.equal(fixture(__dirname, 'serializer-test/rfc232.js'));
       });
@@ -75,8 +75,8 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
 
       return emberGenerateDestroy(args, _file => {
         expect(_file('app/serializers/application.js'))
-          .to.contain("import DS from 'ember-data';")
-          .to.contain('export default DS.JSONAPISerializer.extend({');
+          .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
+          .to.contain('export default JSONAPISerializer.extend({');
 
         expect(_file('tests/unit/serializers/application-test.js')).to.equal(
           fixture(__dirname, 'serializer-test/application-default.js')
@@ -154,8 +154,8 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/foo/serializer.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('export default DS.JSONAPISerializer.extend(');
+            .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
+            .to.contain('export default JSONAPISerializer.extend(');
 
           expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
             fixture(__dirname, 'serializer-test/rfc232.js')
@@ -219,8 +219,8 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/application/serializer.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('export default DS.JSONAPISerializer.extend({');
+            .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
+            .to.contain('export default JSONAPISerializer.extend(');
 
           expect(_file('src/data/models/application/serializer-test.js')).to.equal(
             fixture(__dirname, 'serializer-test/application-default.js')
@@ -320,8 +320,8 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/foo/serializer.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('export default class FooSerializer extends DS.JSONAPISerializer {');
+            .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
+            .to.contain('export default class FooSerializer extends JSONAPISerializer {');
 
           expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
             fixture(__dirname, 'serializer-test/rfc232.js')
@@ -385,8 +385,8 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
         args,
         _file => {
           expect(_file('src/data/models/application/serializer.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('export default class ApplicationSerializer extends DS.JSONAPISerializer {');
+            .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
+            .to.contain('export default class ApplicationSerializer extends JSONAPISerializer {');
 
           expect(_file('src/data/models/application/serializer-test.js')).to.equal(
             fixture(__dirname, 'serializer-test/application-default.js')

--- a/packages/serializer/node-tests/blueprints/transform-test.js
+++ b/packages/serializer/node-tests/blueprints/transform-test.js
@@ -29,8 +29,8 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
 
         return emberGenerateDestroy(args, _file => {
           expect(_file('app/transforms/foo.js'))
-            .to.contain("import DS from 'ember-data';")
-            .to.contain('export default DS.Transform.extend(')
+            .to.contain(`import Transform from '@ember-data/serializer/transform';`)
+            .to.contain('export default Transform.extend(')
             .to.contain('deserialize(serialized) {')
             .to.contain('serialize(deserialized) {');
 
@@ -110,8 +110,8 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
           args,
           _file => {
             expect(_file('src/data/transforms/foo.js'))
-              .to.contain("import DS from 'ember-data';")
-              .to.contain('export default DS.Transform.extend(')
+              .to.contain(`import Transform from '@ember-data/serializer/transform';`)
+              .to.contain('export default Transform.extend(')
               .to.contain('deserialize(serialized) {')
               .to.contain('serialize(deserialized) {');
 
@@ -211,7 +211,7 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
           args,
           _file => {
             expect(_file('src/data/transforms/foo.js'))
-              .to.contain("import DS from 'ember-data';")
+              .to.contain(`import Transform from '@ember-data/serializer/transform';`)
               .to.contain('export default class FooTransform extends Transform {')
               .to.contain('deserialize(serialized) {')
               .to.contain('serialize(deserialized) {');


### PR DESCRIPTION
This updates all the blueprints to use the namespaced package imports from https://github.com/emberjs/rfcs/blob/master/text/0395-ember-data-packages.md

Blueprints updated for:

- adapters
- serializers
- models
- transforms