### PR TITLE
[CHORE tests] Fix QUnit.assert.push() deprecation

### DIFF
--- a/packages/-ember-data/tests/helpers/async.js
+++ b/packages/-ember-data/tests/helpers/async.js
@@ -26,7 +26,11 @@ export function wait(callback, timeout) {
 export function asyncEqual(a, b, message) {
   return all([resolve(a), resolve(b)]).then(
     this.wait(array => {
-      this.push(array[0] === array[1], array[0], array[1], message);
+      let actual = array[0];
+      let expected = array[1];
+      let result = actual === expected;
+
+      this.pushResult({ result, actual, expected, message });
     })
   );
 }


### PR DESCRIPTION
Fixes the following deprecation that is triggered via the `asyncEqual`
custom QUnit assertion:

```
assert.push is deprecated and will be removed in QUnit 3.0. Please use assert.pushResult instead (https://api.qunitjs.com/assert/pushResult).
```

For reference:

- [QUnit.assert.pushResult() docs](https://api.qunitjs.com/assert/pushResult)
- [QUnit.push() docs](https://api.qunitjs.com/config/QUnit.push)