### PR TITLE
[CHORE tests] Replace setupStore for adapter integration tests

### DIFF
--- a/packages/-ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -1,18 +1,20 @@
 import RSVP from 'rsvp';
 import { run } from '@ember/runloop';
-import setupStore from 'dummy/tests/helpers/store';
+import { setupTest } from 'ember-qunit';
 
 import { module, test } from 'qunit';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 
 import DS from 'ember-data';
 
-let env, store, adapter;
+let store, adapter;
 let passedUrl, passedVerb, passedHash;
 
 let User, Post, Comment, Handle, GithubHandle, TwitterHandle, Company, DevelopmentShop, DesignStudio;
 
 module('integration/adapter/json-api-adapter - JSONAPIAdapter', function(hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function() {
     User = DS.Model.extend({
       firstName: DS.attr('string'),
@@ -58,26 +60,20 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function(hooks) 
       hipsters: DS.attr('number'),
     });
 
-    env = setupStore({
-      adapter: DS.JSONAPIAdapter.extend(),
+    this.owner.register('adapter:application', DS.JSONAPIAdapter.extend());
 
-      user: User,
-      post: Post,
-      comment: Comment,
-      handle: Handle,
-      'github-handle': GithubHandle,
-      'twitter-handle': TwitterHandle,
-      company: Company,
-      'development-shop': DevelopmentShop,
-      'design-studio': DesignStudio,
-    });
+    this.owner.register('model:user', User);
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('model:handle', Handle);
+    this.owner.register('model:github-handle', GithubHandle);
+    this.owner.register('model:twitter-handle', TwitterHandle);
+    this.owner.register('model:company', Company);
+    this.owner.register('model:development-shop', DevelopmentShop);
+    this.owner.register('model:design-studio', DesignStudio);
 
-    store = env.store;
-    adapter = env.adapter;
-  });
-
-  hooks.afterEach(function() {
-    run(env.store, 'destroy');
+    store = this.owner.lookup('service:store');
+    adapter = store.adapterFor('application');
   });
 
   function ajaxResponse(responses) {
@@ -925,7 +921,7 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function(hooks) 
       },
     ]);
 
-    env.owner.register(
+    this.owner.register(
       'serializer:user',
       DS.JSONAPISerializer.extend({
         attrs: {

--- a/packages/-ember-data/tests/integration/adapter/queries-test.js
+++ b/packages/-ember-data/tests/integration/adapter/queries-test.js
@@ -1,46 +1,47 @@
 import { Promise as EmberPromise, resolve } from 'rsvp';
 import { get } from '@ember/object';
 import { run } from '@ember/runloop';
-import setupStore from 'dummy/tests/helpers/store';
-
+import { setupTest } from 'ember-qunit';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { module, test } from 'qunit';
 
-import DS from 'ember-data';
-
-let Person, env, store, adapter;
+import Model, { attr } from '@ember-data/model';
 
 module('integration/adapter/queries - Queries', function(hooks) {
-  hooks.beforeEach(function() {
-    Person = DS.Model.extend({
-      updatedAt: DS.attr('string'),
-      name: DS.attr('string'),
-      firstName: DS.attr('string'),
-      lastName: DS.attr('string'),
-    });
-
-    env = setupStore({ person: Person });
-    store = env.store;
-    adapter = env.adapter;
-  });
-
-  hooks.afterEach(function() {
-    run(env.container, 'destroy');
-  });
+  setupTest(hooks);
 
   testInDebug('It raises an assertion when no type is passed', function(assert) {
+    const Person = Model.extend();
+
+    this.owner.register('model:person', Person);
+
+    let store = this.owner.lookup('service:store');
+
     assert.expectAssertion(() => {
       store.query();
     }, "You need to pass a model name to the store's query method");
   });
 
   testInDebug('It raises an assertion when no query hash is passed', function(assert) {
+    const Person = Model.extend();
+
+    this.owner.register('model:person', Person);
+
+    let store = this.owner.lookup('service:store');
+
     assert.expectAssertion(() => {
       store.query('person');
     }, "You need to pass a query hash to the store's query method");
   });
 
   test('When a query is made, the adapter should receive a record array it can populate with the results of the query.', function(assert) {
+    const Person = Model.extend({ name: attr() });
+
+    this.owner.register('model:person', Person);
+
+    let store = this.owner.lookup('service:store');
+    let adapter = store.adapterFor('application');
+
     adapter.query = function(store, type, query, recordArray) {
       assert.equal(type, Person, 'the query method is called with the correct type');
 
@@ -74,6 +75,13 @@ module('integration/adapter/queries - Queries', function(hooks) {
   });
 
   test('a query can be updated via `update()`', function(assert) {
+    const Person = Model.extend();
+
+    this.owner.register('model:person', Person);
+
+    let store = this.owner.lookup('service:store');
+    let adapter = store.adapterFor('application');
+
     adapter.query = function() {
       return resolve({ data: [{ id: 'first', type: 'person' }] });
     };
@@ -107,12 +115,12 @@ module('integration/adapter/queries - Queries', function(hooks) {
   });
 
   testInDebug('The store asserts when query is made and the adapter responses with a single record.', function(assert) {
-    env = setupStore({
-      person: Person,
-      adapter: DS.RESTAdapter,
-    });
-    store = env.store;
-    adapter = env.adapter;
+    const Person = Model.extend({ name: attr() });
+
+    this.owner.register('model:person', Person);
+
+    let store = this.owner.lookup('service:store');
+    let adapter = store.adapterFor('application');
 
     adapter.query = function(store, type, query, recordArray) {
       assert.equal(type, Person, 'the query method is called with the correct type');

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -4,7 +4,7 @@ import { underscore } from '@ember/string';
 import { resolve, reject } from 'rsvp';
 import { run } from '@ember/runloop';
 import { get } from '@ember/object';
-import setupStore from 'dummy/tests/helpers/store';
+import { setupTest } from 'ember-qunit';
 import { singularize } from 'ember-inflector';
 import deepCopy from 'dummy/tests/helpers/deep-copy';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
@@ -16,11 +16,13 @@ import DS from 'ember-data';
 
 const hasJQuery = typeof jQuery !== 'undefined';
 
-let env, store, adapter, Post, Comment, SuperUser;
+let store, adapter, Post, Comment, SuperUser;
 let passedUrl, passedVerb, passedHash;
 let server;
 
 module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function() {
     Post = DS.Model.extend({
       name: DS.attr('string'),
@@ -32,16 +34,15 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
 
     SuperUser = DS.Model.extend();
 
-    env = setupStore({
-      post: Post,
-      comment: Comment,
-      superUser: SuperUser,
-      adapter: DS.RESTAdapter,
-    });
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('model:super-user', SuperUser);
+
+    this.owner.register('adapter:application', DS.RESTAdapter.extend());
 
     server = new Pretender();
-    store = env.store;
-    adapter = env.adapter;
+    store = this.owner.lookup('service:store');
+    adapter = store.adapterFor('application');
 
     passedUrl = passedVerb = passedHash = null;
   });
@@ -213,7 +214,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
   });
 
   test('findRecord - payload with an serializer-specified primary key', function(assert) {
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         primaryKey: '_ID_',
@@ -235,7 +236,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
   });
 
   test('findRecord - payload with a serializer-specified attribute mapping', function(assert) {
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         attrs: {
@@ -382,7 +383,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
   });
 
   test("createRecord - a serializer's primary key and attributes are consulted when building the payload", function(assert) {
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         primaryKey: '_id_',
@@ -408,7 +409,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
 
   test("createRecord - a serializer's attributes are consulted when building the payload if no id is pre-defined", function(assert) {
     let post;
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         attrs: {
@@ -431,7 +432,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
   });
 
   test("createRecord - a serializer's attribute mapping takes precedence over keyForAttribute when building the payload", function(assert) {
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         attrs: {
@@ -458,7 +459,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
   });
 
   test("createRecord - a serializer's attribute mapping takes precedence over keyForRelationship (belongsTo) when building the payload", function(assert) {
-    env.owner.register(
+    this.owner.register(
       'serializer:comment',
       DS.RESTSerializer.extend({
         attrs: {
@@ -492,7 +493,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
   });
 
   test("createRecord - a serializer's attribute mapping takes precedence over keyForRelationship (hasMany) when building the payload", function(assert) {
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         attrs: {
@@ -892,7 +893,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
 
   test("updateRecord - a serializer's primary key and attributes are consulted when building the payload", function(assert) {
     adapter.shouldBackgroundReloadRecord = () => false;
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         primaryKey: '_id_',
@@ -1202,7 +1203,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
   });
 
   test('findAll - data is normalized through custom serializers', function(assert) {
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         primaryKey: '_ID_',
@@ -1365,7 +1366,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
   });
 
   test('query - data is normalized through custom serializers', function(assert) {
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         primaryKey: '_ID_',
@@ -1482,7 +1483,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
   });
 
   test('queryRecord - data is normalized through custom serializers', function(assert) {
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         primaryKey: '_ID_',
@@ -1709,7 +1710,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
 
   test('findMany - a custom serializer is used if present', function(assert) {
     adapter.shouldBackgroundReloadRecord = () => false;
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         primaryKey: '_ID_',
@@ -1717,7 +1718,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
       })
     );
 
-    env.owner.register(
+    this.owner.register(
       'serializer:comment',
       DS.RESTSerializer.extend({
         primaryKey: '_ID_',
@@ -1923,7 +1924,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
 
   test('findMany - a custom serializer is used if present', function(assert) {
     adapter.shouldBackgroundReloadRecord = () => false;
-    env.owner.register(
+    this.owner.register(
       'serializer:post',
       DS.RESTSerializer.extend({
         primaryKey: '_ID_',
@@ -1931,7 +1932,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
       })
     );
 
-    env.owner.register(
+    this.owner.register(
       'serializer:comment',
       DS.RESTSerializer.extend({
         primaryKey: '_ID_',
@@ -2150,7 +2151,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
   });
 
   test('normalizeKey - to set up _ids and _id', function(assert) {
-    env.owner.register(
+    this.owner.register(
       'serializer:application',
       DS.RESTSerializer.extend({
         keyForAttribute(attr) {
@@ -2171,7 +2172,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
       })
     );
 
-    env.owner.register(
+    this.owner.register(
       'model:post',
       DS.Model.extend({
         name: DS.attr(),
@@ -2181,7 +2182,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
       })
     );
 
-    env.owner.register(
+    this.owner.register(
       'model:user',
       DS.Model.extend({
         createdAt: DS.attr(),
@@ -2189,7 +2190,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
       })
     );
 
-    env.owner.register(
+    this.owner.register(
       'model:comment',
       DS.Model.extend({
         body: DS.attr(),

--- a/packages/-ember-data/tests/integration/adapter/serialize-test.js
+++ b/packages/-ember-data/tests/integration/adapter/serialize-test.js
@@ -1,36 +1,31 @@
-import { run } from '@ember/runloop';
-import setupStore from 'dummy/tests/helpers/store';
-
+import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-
-import DS from 'ember-data';
-
-let env, store, adapter, serializer;
+import Adapter from '@ember-data/adapter';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+import Model from '@ember-data/model';
 
 module('integration/adapter/serialize - DS.Adapter integration test', function(hooks) {
-  hooks.beforeEach(function() {
-    const Person = DS.Model.extend({
-      name: DS.attr('string'),
-    });
-
-    env = setupStore({ person: Person });
-    store = env.store;
-    adapter = env.adapter;
-    serializer = store.serializerFor('person');
-  });
-
-  hooks.afterEach(function() {
-    run(env.container, 'destroy');
-  });
+  setupTest(hooks);
 
   test('serialize() is delegated to the serializer', function(assert) {
     assert.expect(1);
+
+    const Person = Model.extend();
+
+    this.owner.register('model:person', Person);
+    this.owner.register('adapter:application', Adapter.extend());
+    this.owner.register('serializer:application', JSONAPISerializer.extend());
+
+    let store = this.owner.lookup('service:store');
+    let adapter = store.adapterFor('application');
+    let serializer = store.serializerFor('application');
 
     serializer.serialize = function(snapshot, options) {
       assert.deepEqual(options, { foo: 'bar' });
     };
 
     let person = store.createRecord('person');
+
     adapter.serialize(person._createSnapshot(), { foo: 'bar' });
   });
 });


### PR DESCRIPTION
Part of https://github.com/emberjs/data/issues/6166

This replaces usage of the `setupStore` helper for `tests/integration/adapter/*`.

cc @runspired 