### PR TITLE
[CHORE tests] eliminates usage of -rest serializer fallback in tests

### DIFF
--- a/packages/-ember-data/tests/helpers/store.js
+++ b/packages/-ember-data/tests/helpers/store.js
@@ -5,7 +5,6 @@ import Ember from 'ember';
 import Store from 'ember-data/store';
 import Adapter from '@ember-data/adapter';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
-import RESTSerializer from '@ember-data/serializer/rest';
 import config from '../../config/environment';
 import Resolver from '../../resolver';
 import { StringTransform, DateTransform, NumberTransform, BooleanTransform } from '@ember-data/serializer/-private';
@@ -50,6 +49,8 @@ export default function setupStore(options) {
   };
 
   let adapter = (env.adapter = options.adapter || '-default');
+  let serializer = options.serializer;
+  delete options.serializer;
   delete options.adapter;
 
   if (typeof adapter !== 'string') {
@@ -89,8 +90,8 @@ export default function setupStore(options) {
   // this allows for more incremental migration off of setupStore
   // by supplying the serializer vs forcing an immediate full refactor
   // to modern syntax
-  if (options.serializer) {
-    env.registry.register('serializer:application', options.serializer);
+  if (serializer) {
+    env.registry.register('serializer:application', serializer);
     env.serializer = store.serializerFor('application');
   } else {
     // avoid deprecations for -json-api serializer in our tests
@@ -101,11 +102,6 @@ export default function setupStore(options) {
     // they should refactor to register this as the application serializer
     owner.register('serializer:-default', JSONAPISerializer);
 
-    // RESTAdapter specifies a defaultSerializer of -rest
-    // Tests using this should refactor to register this as the application serializer
-    owner.register('serializer:-rest', RESTSerializer);
-
-    env.restSerializer = store.serializerFor('-rest');
     env.serializer = store.serializerFor('-default');
   }
 

--- a/packages/-ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/-ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -5,6 +5,7 @@ import { resolve } from 'rsvp';
 import deepCopy from 'dummy/tests/helpers/deep-copy';
 import { pluralize } from 'ember-inflector';
 import RESTAdapter from '@ember-data/adapter/rest';
+import RESTSerializer from '@ember-data/serializer/rest';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', function(hooks) {
@@ -30,7 +31,8 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     });
     const SuperUser = Model.extend({});
 
-    owner.register('adapter:application', RESTAdapter);
+    owner.register('adapter:application', RESTAdapter.extend());
+    owner.register('serializer:application', RESTSerializer.extend());
     owner.register('model:comment', CommentModel);
     owner.register('model:post', PostModel);
     owner.register('model:super-user', SuperUser);

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -9,6 +9,8 @@ import { singularize } from 'ember-inflector';
 import deepCopy from 'dummy/tests/helpers/deep-copy';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { module, test } from 'qunit';
+import RESTAdapter from '@ember-data/adapter/rest';
+import RESTSerializer from '@ember-data/serializer/rest';
 
 import Pretender from 'pretender';
 
@@ -38,7 +40,8 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
     this.owner.register('model:comment', Comment);
     this.owner.register('model:super-user', SuperUser);
 
-    this.owner.register('adapter:application', DS.RESTAdapter.extend());
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
 
     server = new Pretender();
     store = this.owner.lookup('service:store');

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -5,6 +5,8 @@ import Ember from 'ember';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import deepCopy from 'dummy/tests/helpers/deep-copy';
 import { module, test } from 'qunit';
+import RESTAdapter from '@ember-data/adapter/rest';
+import RESTSerializer from '@ember-data/serializer/rest';
 
 import DS from 'ember-data';
 
@@ -33,9 +35,10 @@ Car.reopenClass({
   },
 });
 
-function initializeStore(adapter) {
+function initializeStore(adapter, serializer) {
   env = setupStore({
-    adapter: adapter,
+    adapter,
+    serializer,
   });
   store = env.store;
 
@@ -243,9 +246,8 @@ module('integration/store - findRecord', function() {
   test('store#findRecord fetches record from server when cached record is not present', function(assert) {
     assert.expect(2);
 
-    initializeStore(DS.RESTAdapter.extend());
+    initializeStore(RESTAdapter.extend(), RESTSerializer.extend());
 
-    env.owner.register('serializer:application', DS.RESTSerializer);
     ajaxResponse({
       cars: [
         {
@@ -269,7 +271,7 @@ module('integration/store - findRecord', function() {
   test('store#findRecord returns cached record immediately and reloads record in the background', function(assert) {
     assert.expect(2);
 
-    initializeStore(DS.RESTAdapter.extend());
+    initializeStore(RESTAdapter.extend(), RESTSerializer.extend());
 
     run(() => {
       store.push({
@@ -315,7 +317,7 @@ module('integration/store - findRecord', function() {
       },
     });
 
-    initializeStore(testAdapter);
+    initializeStore(testAdapter, RESTSerializer.extend());
 
     run(() => {
       store.push({
@@ -403,7 +405,7 @@ module('integration/store - findRecord', function() {
       },
     });
 
-    initializeStore(testAdapter);
+    initializeStore(testAdapter, RESTSerializer.extend());
 
     run(() => {
       store.push({
@@ -439,7 +441,7 @@ module('integration/store - findRecord', function() {
       },
     });
 
-    initializeStore(testAdapter);
+    initializeStore(testAdapter, RESTSerializer.extend());
 
     run(() => {
       store.push({
@@ -489,7 +491,7 @@ module('integration/store - findRecord', function() {
       },
     });
 
-    initializeStore(testAdapter);
+    initializeStore(testAdapter, RESTSerializer.extend());
 
     run(() => {
       store.push({
@@ -532,7 +534,7 @@ module('integration/store - findRecord', function() {
       const badValues = ['', undefined, null, NaN, false];
       assert.expect(badValues.length);
 
-      initializeStore(DS.RESTAdapter.extend());
+      initializeStore(RESTAdapter.extend(), RESTSerializer.extend());
 
       run(() => {
         badValues.map(item => {
@@ -547,7 +549,7 @@ module('integration/store - findRecord', function() {
 
 module('integration/store - findAll', function(hooks) {
   hooks.beforeEach(function() {
-    initializeStore(DS.RESTAdapter.extend());
+    initializeStore(RESTAdapter.extend(), RESTSerializer.extend());
   });
 
   test('Using store#findAll with no records triggers a query', function(assert) {
@@ -641,7 +643,7 @@ module('integration/store - findAll', function(hooks) {
       },
     });
 
-    initializeStore(testAdapter);
+    initializeStore(testAdapter, RESTSerializer.extend());
 
     run(() => {
       store.push({
@@ -679,7 +681,7 @@ module('integration/store - findAll', function(hooks) {
       },
     });
 
-    initializeStore(testAdapter);
+    initializeStore(testAdapter, RESTSerializer.extend());
 
     run(() => {
       store.push({
@@ -737,7 +739,7 @@ module('integration/store - findAll', function(hooks) {
       },
     });
 
-    initializeStore(testAdapter);
+    initializeStore(testAdapter, RESTSerializer.extend());
 
     run(() => {
       store.push({
@@ -903,7 +905,7 @@ module('integration/store - findAll', function(hooks) {
 
 module('integration/store - deleteRecord', function(hooks) {
   hooks.beforeEach(function() {
-    initializeStore(DS.RESTAdapter.extend());
+    initializeStore(RESTAdapter.extend(), RESTSerializer.extend());
   });
 
   test('Using store#deleteRecord should mark the model for removal', function(assert) {

--- a/packages/-ember-data/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
+++ b/packages/-ember-data/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
@@ -6,6 +6,7 @@ import { module, test } from 'qunit';
 
 import Model from '@ember-data/model';
 import RESTAdapter from '@ember-data/adapter/rest';
+import RESTSerializer from '@ember-data/serializer/rest';
 
 let store, requests;
 let maxLength;
@@ -50,6 +51,7 @@ module('unit/adapters/rest_adapter/group_records_for_find_many_test - DS.RESTAda
     });
 
     this.owner.register('adapter:application', ApplicationAdapter);
+    this.owner.register('serializer:application', RESTSerializer.extend());
     this.owner.register('model:test-record', Model.extend());
 
     store = this.owner.lookup('service:store');

--- a/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
+++ b/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
@@ -5,6 +5,7 @@ import { run, later } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
 import Model, { attr } from '@ember-data/model';
 import RESTAdapter from '@ember-data/adapter/rest';
+import RESTSerializer from '@ember-data/serializer/rest';
 import { InvalidError } from '@ember-data/adapter/error';
 
 import { module, test } from 'qunit';
@@ -267,7 +268,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function(ho
       },
     });
 
-    env = setupStore({ person: Person, adapter: adapter });
+    env = setupStore({ person: Person, adapter: adapter, serializer: RESTSerializer.extend() });
 
     let person = env.store.createRecord('person', { id: 1 });
 
@@ -297,7 +298,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function(ho
       },
     });
 
-    env = setupStore({ person: Person, adapter: adapter });
+    env = setupStore({ person: Person, adapter: adapter, serializer: RESTSerializer.extend() });
 
     let person;
     run(() => {
@@ -391,6 +392,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function(ho
     const { owner } = this;
     owner.register(`model:dog`, Dog);
     owner.register(`adapter:application`, TestAdapter);
+    owner.register(`serializer:application`, RESTSerializer.extend());
     const store = owner.lookup(`service:store`);
 
     const dog = store.push({
@@ -458,6 +460,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function(ho
     const { owner } = this;
     owner.register(`model:dog`, Dog);
     owner.register(`adapter:application`, TestAdapter);
+    owner.register(`serializer:application`, RESTSerializer.extend());
     const store = owner.lookup(`service:store`);
 
     const dog = store.push({
@@ -522,7 +525,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function(ho
       },
     });
 
-    env = setupStore({ dog: Dog, adapter: adapter });
+    env = setupStore({ dog: Dog, adapter: adapter, serializer: RESTSerializer.extend() });
     let dog = run(() => {
       env.store.push({
         data: {


### PR DESCRIPTION
[RFC-522](https://github.com/emberjs/rfcs/pull/522) will deprecate the `-rest` serializer and usage of the `adapter.defaultSerializer` fallback which for the RESTAdapter is set to `-rest`. This PR entirely removes our reliance on this fallback from our own test suite.

cc @pete-the-pete for RFC-522
cc @HeroicEric towards efforts on eliminating setupStore