### PR TITLE
[CHORE tests] Added explicit -json-api serializer registration in tests

### DIFF
--- a/packages/-ember-data/tests/helpers/store.js
+++ b/packages/-ember-data/tests/helpers/store.js
@@ -94,10 +94,6 @@ export default function setupStore(options) {
     env.registry.register('serializer:application', serializer);
     env.serializer = store.serializerFor('application');
   } else {
-    // avoid deprecations for -json-api serializer in our tests
-    // uncomment to find locations to refactor to explicit registration
-    owner.register('serializer:-json-api', JSONAPISerializer);
-
     // Many tests rely on falling back to this serializer
     // they should refactor to register this as the application serializer
     owner.register('serializer:-default', JSONAPISerializer);

--- a/packages/-ember-data/tests/integration/adapter/find-all-test.js
+++ b/packages/-ember-data/tests/integration/adapter/find-all-test.js
@@ -7,6 +7,7 @@ import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import Model from '@ember-data/model';
 import { settled } from '@ember/test-helpers';
 import { attr } from '@ember-data/model';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 class Person extends Model {
   @attr()
@@ -34,6 +35,8 @@ module('integration/adapter/find-all - Finding All Records of a Type', function(
     let { owner } = this;
 
     owner.register('model:person', Person);
+    owner.register('serializer:application', JSONAPISerializer.extend());
+
     store = owner.lookup('service:store');
   });
 

--- a/packages/-ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -61,6 +61,7 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function(hooks) 
     });
 
     this.owner.register('adapter:application', DS.JSONAPIAdapter.extend());
+    this.owner.register('serializer:application', DS.JSONAPISerializer.extend());
 
     this.owner.register('model:user', User);
     this.owner.register('model:post', Post);

--- a/packages/-ember-data/tests/integration/adapter/queries-test.js
+++ b/packages/-ember-data/tests/integration/adapter/queries-test.js
@@ -5,10 +5,17 @@ import { setupTest } from 'ember-qunit';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';
 import { module, test } from 'qunit';
 
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
 import Model, { attr } from '@ember-data/model';
 
 module('integration/adapter/queries - Queries', function(hooks) {
   setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.owner.register('adapter:application', JSONAPIAdapter.extend());
+    this.owner.register('serializer:application', JSONAPISerializer.extend());
+  });
 
   testInDebug('It raises an assertion when no type is passed', function(assert) {
     const Person = Model.extend();

--- a/packages/-ember-data/tests/integration/client-id-generation-test.js
+++ b/packages/-ember-data/tests/integration/client-id-generation-test.js
@@ -4,6 +4,7 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import Model from '@ember-data/model';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { attr, hasMany, belongsTo } from '@ember-data/model';
 
 module('integration - Client Id Generation', function(hooks) {
@@ -34,7 +35,8 @@ module('integration - Client Id Generation', function(hooks) {
     owner.register('model:comment', Comment);
     owner.register('model:post', Post);
     owner.register('model:misc', Misc);
-    owner.register('adapter:application', JSONAPIAdapter);
+    owner.register('adapter:application', JSONAPIAdapter.extend());
+    owner.register('serializer:application', JSONAPISerializer.extend());
 
     store = owner.lookup('service:store');
     adapter = store.adapterFor('application');

--- a/packages/-ember-data/tests/integration/lifecycle-hooks-test.js
+++ b/packages/-ember-data/tests/integration/lifecycle-hooks-test.js
@@ -3,6 +3,8 @@ import { setupTest } from 'ember-qunit';
 import { deprecatedTest } from 'dummy/tests/helpers/deprecated-test';
 import Model from '@ember-data/model';
 import { attr } from '@ember-data/model';
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 import { module } from 'qunit';
 
@@ -18,6 +20,8 @@ module('integration/lifecycle_hooks - Lifecycle Hooks', function(hooks) {
     }
 
     owner.register('model:person', Person);
+    owner.register('adapter:application', JSONAPIAdapter.extend());
+    owner.register('serializer:application', JSONAPISerializer.extend());
     store = owner.lookup('service:store');
     adapter = store.adapterFor('application');
   });

--- a/packages/-ember-data/tests/integration/record-array-test.js
+++ b/packages/-ember-data/tests/integration/record-array-test.js
@@ -5,6 +5,8 @@ import { settled } from '@ember/test-helpers';
 import Model from '@ember-data/model';
 import { module, test } from 'qunit';
 import Adapter from '@ember-data/adapter';
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { attr, hasMany, belongsTo } from '@ember-data/model';
 
 class Person extends Model {
@@ -34,6 +36,8 @@ module('unit/record-array - RecordArray', function(hooks) {
     owner.register('model:person', Person);
     owner.register('model:tag', Tag);
     owner.register('model:tool', Tool);
+    owner.register('adapter:application', JSONAPIAdapter.extend());
+    owner.register('serializer:application', JSONAPISerializer.extend());
 
     store = owner.lookup('service:store');
   });

--- a/packages/-ember-data/tests/integration/record-arrays/adapter-populated-record-array-test.js
+++ b/packages/-ember-data/tests/integration/record-arrays/adapter-populated-record-array-test.js
@@ -6,6 +6,8 @@ import { module, test } from 'qunit';
 
 import Adapter from '@ember-data/adapter';
 import Model, { attr } from '@ember-data/model';
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 const Person = Model.extend({
   name: attr('string'),
@@ -19,6 +21,8 @@ module('integration/record-arrays/adapter_populated_record_array - AdapterPopula
 
   hooks.beforeEach(function() {
     this.owner.register('model:person', Person);
+    this.owner.register('adapter:application', JSONAPIAdapter.extend());
+    this.owner.register('serializer:application', JSONAPISerializer.extend());
   });
 
   test('when a record is deleted in an adapter populated record array, it should be removed', function(assert) {

--- a/packages/-ember-data/tests/integration/records/unload-test.js
+++ b/packages/-ember-data/tests/integration/records/unload-test.js
@@ -7,6 +7,8 @@ import { module, test } from 'qunit';
 import DS from 'ember-data';
 import { setupTest } from 'ember-qunit';
 import { recordDataFor } from 'ember-data/-private';
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 function idsFromOrderedSet(set) {
   return set.list.map(i => i.id);
@@ -138,6 +140,8 @@ module('integration/unload - Unloading Records', function(hooks) {
     owner.register(`model:book`, Book);
     owner.register(`model:spoon`, Spoon);
     owner.register(`model:show`, Show);
+    owner.register('adapter:application', JSONAPIAdapter.extend());
+    owner.register('serializer:application', JSONAPISerializer.extend());
 
     store = owner.lookup('service:store');
     adapter = store.adapterFor('application');

--- a/packages/-ember-data/tests/integration/snapshot-test.js
+++ b/packages/-ember-data/tests/integration/snapshot-test.js
@@ -2,6 +2,8 @@ import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
 import Model from '@ember-data/model';
 import { Snapshot } from 'ember-data/-private';
 import { attr, belongsTo, hasMany } from '@ember-data/model';
@@ -34,6 +36,8 @@ module('integration/snapshot - Snapshot', function(hooks) {
     owner = this.owner;
     owner.register('model:post', Post);
     owner.register('model:comment', Comment);
+    owner.register('adapter:application', JSONAPIAdapter.extend());
+    owner.register('serializer:application', JSONAPISerializer.extend());
     store = owner.lookup('service:store');
   });
 

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -40,6 +40,7 @@ module('unit/model - Model', function(hooks) {
       })
     );
     owner.register('serializer:-default', JSONAPISerializer);
+    owner.register('serializer:application', JSONAPISerializer.extend());
 
     store = owner.lookup('service:store');
     adapter = store.adapterFor('application');


### PR DESCRIPTION
The intent of this PR is to mirror #6368 but for -json-api fallback behavior.

[RFC-522](https://github.com/pete-the-pete/rfcs/blob/master/text/0000-default-serializers-and-adapters.md#deprecate-storedefaultadapter--json-api-and-the--json-api-adapter-fallback-behavior) will deprecate the -json-api serializer and usage of the adapter.defaultSerializer fallback which for the JSONAPIAdapter is set to -json-api. This PR entirely removes our reliance on this fallback from our own test suite.




Part of https://github.com/emberjs/data/issues/6166

Co-Authored-By: Eric Kelly <heroiceric@gmail.com> @HeroicEric 

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
