### PR TITLE
chore(eslint): Add override for bin files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,7 @@ module.exports = {
         '.mocharc.js',
         '.eslintrc.js',
         '.prettierrc.js',
-        'bin/*.js',
+        'bin/*',
         'packages/-build-infra/src/**/*.js',
         'packages/-test-infra/src/**/*.js',
         'packages/*/ember-cli-build.js',
@@ -86,6 +86,19 @@ module.exports = {
       env: {
         mocha: true,
       },
+    },
+
+    // bin files
+    {
+      files: ['bin/*'],
+      // eslint-disable-next-line node/no-unpublished-require
+      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+        'no-console': 'off',
+        'no-process-exit': 'off',
+        'node/no-extraneous-require': 'off',
+        'node/no-unpublished-require': 'off',
+        'node/shebang': 'off',
+      }),
     },
   ],
 };

--- a/bin/-tarball-info.js
+++ b/bin/-tarball-info.js
@@ -9,7 +9,7 @@
   that can be used to insert the locations of our tarballs
   into any package.json
 
-  Example Package Meta: 
+  Example Package Meta:
 
   Given a project named `data` located in the folder `projects`
    containing a package named `@ember-data/-example`
@@ -29,19 +29,19 @@
   {
     // the path to the directory for the package
     location: "/path/to/projects/data/packages/-example",
-    
+
     // the location of the package.json file for the package
     fileLocation: "/path/to/projects/data/packages/some-package-directory/package.json",
-    
+
     // the directory name of the package
     localName: "-example",
-    
+
     // the file location a generated tarball for this package would be placed
     tarballLocation: "/path/to/projects/__tarball-cache/ember-data--example-3.0.0.tgz",
-    
+
     // useful for making edits to add tarball paths to the contents
     packageInfo: <package.json contents as a json object>,
-    
+
     // useful for restoring original state of a package.json after edits
     originalPackageInfo: <package.json contents as a string>,
   }
@@ -52,7 +52,7 @@
 
   This util will discover any dependencies or devDependencies of the given
   package.json that match the package names of the packges in PackageInfos
-  and rewrite the file replacing their version with the file path of the 
+  and rewrite the file replacing their version with the file path of the
   tarball we would generate.
 
   E.g.
@@ -71,7 +71,6 @@
   }
 */
 
-/* eslint-disable no-console, node/no-extraneous-require, node/no-unpublished-require */
 const fs = require('fs');
 const path = require('path');
 const url = require('url');

--- a/bin/add-dev-dependency
+++ b/bin/add-dev-dependency
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * Adds or updates a dev dependency in root
  * and ensures that all packages that have this
@@ -10,7 +11,7 @@
  * yarn run add-dev <package@version>
  * ```
  */
-/* eslint-disable no-console, node/no-extraneous-require, node/no-unpublished-require */
+
 const { shellSync } = require('execa');
 const cliArgs = require('command-line-args');
 const path = require('path');

--- a/bin/packages-for-commit.js
+++ b/bin/packages-for-commit.js
@@ -14,7 +14,7 @@
 */
 
 'use strict';
-/* eslint-disable no-console, node/no-extraneous-require, node/no-unpublished-require */
+
 const fs = require('fs');
 const { shellSync } = require('execa');
 // apparently violates no-extraneous require? /shrug

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 'use strict';
-/* eslint-disable node/no-unsupported-features/es-syntax, no-console, no-process-exit, node/no-extraneous-require, node/no-unpublished-require */
+/* eslint-disable node/no-unsupported-features/es-syntax */
 
 /*
 Usage
@@ -15,7 +15,7 @@ Flags
 --bumpMinor
 --skipVersion
 --skipPack
---skipPublish 
+--skipPublish
 --skipSmokeTest
 
 Inspiration from https://github.com/glimmerjs/glimmer-vm/commit/01e68d7dddf28ac3200f183bffb7d520a3c71249#diff-19fef6f3236e72e3b5af7c884eef67a0
@@ -177,10 +177,10 @@ function assertGitIsClean() {
 }
 
 function retrieveNextVersion() {
-  /* 
+  /*
 
   A brief rundown of how version updates flow through the branches.
-  
+
   - We only ever bump the major or minor version on master
   - All other branches pick it up as those changes flow through the release cycle.
 

--- a/bin/sync-dev-dependency
+++ b/bin/sync-dev-dependency
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * Ensures that the version of a devDependency in root
  * is reflected in individual packages. Hoists any
@@ -10,7 +11,7 @@
  * yarn run sync-dev
  * ```
  */
-/* eslint-disable no-console, node/no-extraneous-require, node/no-unpublished-require */
+
 const { shellSync } = require('execa');
 const path = require('path');
 const fs = require('fs');

--- a/bin/test-external-partner-project.js
+++ b/bin/test-external-partner-project.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 'use strict';
-/* eslint-disable no-console, node/no-extraneous-require, node/no-unpublished-require */
+
 const fs = require('fs');
 const path = require('path');
 const { shellSync } = require('execa');


### PR DESCRIPTION
Add an override for bin-specific lint rules in .eslintrc config file.

Sorry for the whitespaces noise, but it's probably better to trim them down.

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
