### PR TITLE
fix: Strip Symbol from production builds

### DIFF
--- a/packages/store/addon/-private/system/fetch-manager.ts
+++ b/packages/store/addon/-private/system/fetch-manager.ts
@@ -15,6 +15,7 @@ import RequestCache from './request-cache';
 import { CollectionResourceDocument, SingleResourceDocument } from '../ts-interfaces/ember-data-json-api';
 import { RecordIdentifier } from '../ts-interfaces/identifier';
 import { FindRecordQuery, SaveRecordMutation, Request } from '../ts-interfaces/fetch-manager';
+import { symbol } from '../ts-interfaces/utils/symbol';
 import Store from './ds-model-store';
 import recordDataFor from './record-data-for';
 import CoreStore from './core-store';
@@ -28,7 +29,7 @@ function payloadIsNotBlank(adapterPayload): boolean {
 }
 
 const emberRun = emberRunLoop.backburner;
-export const SaveOp = Symbol('SaveOp');
+export const SaveOp: unique symbol = symbol('SaveOp');
 
 interface PendingFetchItem {
   identifier: RecordIdentifier;

--- a/packages/store/addon/-private/system/request-cache.ts
+++ b/packages/store/addon/-private/system/request-cache.ts
@@ -7,11 +7,12 @@ import {
   Operation,
   RequestStateEnum,
 } from '../ts-interfaces/fetch-manager';
+import { symbol } from '../ts-interfaces/utils/symbol';
 
 import { _findHasMany, _findBelongsTo, _findAll, _query, _queryRecord } from './store/finders';
 
-const Touching = Symbol('touching');
-export const RequestPromise = Symbol('promise');
+export const Touching: unique symbol = symbol('touching');
+export const RequestPromise: unique symbol = symbol('promise');
 
 interface InternalRequest extends RequestState {
   [Touching]: RecordIdentifier[];

--- a/packages/store/addon/-private/ts-interfaces/utils/brand.ts
+++ b/packages/store/addon/-private/ts-interfaces/utils/brand.ts
@@ -1,3 +1,5 @@
+import { symbol } from './symbol';
+
 /**
   @module @ember-data/store
 */
@@ -14,4 +16,5 @@
  *
  * @internal
  */
-export const BRAND_SYMBOL = Symbol(`DEBUG-ts-brand`);
+
+export const BRAND_SYMBOL: unique symbol = symbol('DEBUG-ts-brand');

--- a/packages/store/addon/-private/ts-interfaces/utils/symbol.ts
+++ b/packages/store/addon/-private/ts-interfaces/utils/symbol.ts
@@ -1,0 +1,19 @@
+/**
+  @module @ember-data/store
+*/
+
+/**
+ * This symbol provides a Symbol replacement for browsers that do not have it
+ * (eg. IE 11).
+ *
+ * The replacement is different from the native Symbol in some ways. It is a
+ * function that produces an output:
+ * - iterable;
+ * - that is a string, not a symbol.
+ *
+ * @internal
+ */
+export const symbol =
+  typeof Symbol !== 'undefined'
+    ? Symbol
+    : (key: string) => `__${key}${Math.floor(Math.random() * Date.now())}__` as any;


### PR DESCRIPTION
To ensure compatibility with IE11.

This should close https://github.com/emberjs/data/issues/6380.

This implementation is not non-enumerable (as opposed to Symbol). But making it enumerable would come with a cost. And it will only be required for [`identifiers`-related Symbols](https://github.com/emberjs/data/blob/69542df2df7cd0f57404f61f8d7ef0d2e3bae280/packages/store/addon/-private/ts-interfaces/identifier.ts#L4-L8).

These remaining Symbols are still unpublished or behind a feature flag (not sure but they are not part of the build outputs). They are not included in this PR. As they'll require a more sophisticated approach to be specifically non-enumerable. As we said, I'll leave it to you @runspired.