### PR TITLE
[DOC] Added documentation URL to evented deprecation warnings

### DIFF
--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -608,7 +608,9 @@ module('unit/model - Model', function(hooks) {
 
         record.on('event!', F);
 
-        assert.expectDeprecation(/Called event! on person/);
+        if (DEBUG) {
+          assert.expectDeprecation(/Called event! on person/);
+        }
 
         record.trigger('event!');
 

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -607,11 +607,15 @@ module('unit/model - Model', function(hooks) {
         let record = store.createRecord('person');
 
         record.on('event!', F);
+
+        assert.expectDeprecation(/Called event! on person/);
+
         record.trigger('event!');
 
         await settled();
 
         assert.equal(count, 1, 'the event was triggered');
+
         record.trigger('event!');
 
         await settled();

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -1,3 +1,4 @@
+import { DEBUG } from '@glimmer/env';
 import { guidFor } from '@ember/object/internals';
 import { resolve, reject } from 'rsvp';
 import { set, get, observer, computed } from '@ember/object';

--- a/packages/store/addon/-private/system/deprecated-evented.js
+++ b/packages/store/addon/-private/system/deprecated-evented.js
@@ -45,6 +45,7 @@ if (DEBUG) {
       deprecate(deprecationMessage, deprecations[eventName], {
         id: 'ember-data:evented-api-usage',
         until: '4.0',
+        url: 'https://deprecations.emberjs.com/ember-data/v3.x/#deprecatingrecordlifecycleeventmethods',
       });
       deprecations[eventName] = true;
     },


### PR DESCRIPTION
In #6059 deprecation warnings for Evented usage we added. This PR adds a URL to the deprecation documentation for the console warnings.

**before**

<img width="735" alt="image" src="https://user-images.githubusercontent.com/7291324/64046412-cf1efe00-cb39-11e9-9f10-4c8a96cb7f0a.png">

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).
-->

**after**

<img width="732" alt="image" src="https://user-images.githubusercontent.com/7291324/64046301-9bdc6f00-cb39-11e9-9a19-878df7d82ce8.png">
