### PR TITLE
[DOC] Added URL to `queryRecord` deprecation warning

### DIFF
--- a/packages/serializer/addon/rest.js
+++ b/packages/serializer/addon/rest.js
@@ -286,7 +286,7 @@ const RESTSerializer = JSONSerializer.extend({
           'The adapter returned an array for the primary data of a `queryRecord` response. This is deprecated as `queryRecord` should return a single record.';
 
         deprecate(message, !isQueryRecordAnArray, {
-          id: 'ember-data:store-queryrecord-array-response-with-restserializer',
+          id: 'ds.serializer.rest.queryRecord-array-response',
           until: '3.0',
           url:
             'https://deprecations.emberjs.com/ember-data/v2.x/#toc_store-queryrecord-array-response-with-restserializer',

--- a/packages/serializer/addon/rest.js
+++ b/packages/serializer/addon/rest.js
@@ -286,8 +286,10 @@ const RESTSerializer = JSONSerializer.extend({
           'The adapter returned an array for the primary data of a `queryRecord` response. This is deprecated as `queryRecord` should return a single record.';
 
         deprecate(message, !isQueryRecordAnArray, {
-          id: 'ds.serializer.rest.queryRecord-array-response',
+          id: 'ember-data:store-queryrecord-array-response-with-restserializer',
           until: '3.0',
+          url:
+            'https://deprecations.emberjs.com/ember-data/v2.x/#toc_store-queryrecord-array-response-with-restserializer',
         });
       }
 


### PR DESCRIPTION
<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->

Maybe this deprecation should be removed altogether (and throw some kind of error) since we've passed 3.0?