### PR TITLE
[DOC HasManyReference] Indicate that HasManyReference extends Reference

### DIFF
--- a/packages/store/addon/-private/system/references/has-many.js
+++ b/packages/store/addon/-private/system/references/has-many.js
@@ -14,6 +14,7 @@ import recordDataFor from '../record-data-for';
  author to perform meta-operations on a has-many relationship.
 
  @class HasManyReference
+ @extends Reference
  */
 export default class HasManyReference extends Reference {
   constructor(store, parentInternalModel, hasManyRelationship, key) {


### PR DESCRIPTION
I think this was missing. This should also fix: https://github.com/ember-learn/ember-api-docs/issues/630.