### PR TITLE
[CHORE cleanup] Cleanup package dependencies

### DIFF
--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -50,7 +50,6 @@
     "broccoli-string-replace": "^0.1.2",
     "broccoli-test-helper": "^2.0.0",
     "broccoli-uglify-sourcemap": "^3.0.0",
-    "ember-compatibility-helpers": "^1.2.0",
     "ember-cli": "^3.12.0",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -24,11 +24,11 @@
     "@ember-data/-build-infra": "3.14.0-alpha.1",
     "@ember-data/canary-features": "3.14.0-alpha.1",
     "@ember-data/store": "3.14.0-alpha.1",
-    "ember-compatibility-helpers": "^1.2.0",
     "ember-cli-babel": "^7.11.0",
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^2.0.2",
+    "ember-compatibility-helpers": "^1.2.0",
     "inflection": "1.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Removes duplicate `ember-compatibility-helpers` entry from `packages/-ember-data/package.json`
- Fixes order of `ember-compatibility-helpers` entry in `packages/model/package.json`
