### PR TITLE
[BUGFIX BETA] Fix warning on build

### DIFF
--- a/packages/store/addon/-private/system/model/model.js
+++ b/packages/store/addon/-private/system/model/model.js
@@ -19,7 +19,7 @@ import InternalModel from './internal-model';
 import RootState from './states';
 import { RECORD_DATA_ERRORS, RECORD_DATA_STATE, REQUEST_SERVICE } from '@ember-data/canary-features';
 import coerceId from '../coerce-id';
-import { recordIdentifierFor } from '@ember-data/store';
+import { recordIdentifierFor } from '../store/internal-model-factory';
 import { InvalidError } from '@ember-data/adapter/error';
 
 const { changeProperties } = Ember;


### PR DESCRIPTION
For #6407 

Fixes "@ember-data/store' is imported by -private/system/model/model.js, but could not be resolved – treating it as an external dependency" warning on building application or addon including ember-data beta as a dependency.

Note: This is not an issue on master.