### PR TITLE
Remove module-unification blueprints

### DIFF
--- a/packages/-build-infra/src/utilities/extend-from-application-entity.js
+++ b/packages/-build-infra/src/utilities/extend-from-application-entity.js
@@ -3,11 +3,9 @@ const SilentError = require('silent-error');
 const pathUtil = require('ember-cli-path-utils');
 const fs = require('fs');
 const path = require('path');
-const isModuleUnificationProject = require('./module-unification').isModuleUnificationProject;
 
 module.exports = function(type, baseClass, options) {
   let isAddon = options.inRepoAddon || options.project.isEmberCLIAddon();
-  let isModuleUnification = isModuleUnificationProject(options.project);
 
   let entityName = options.entity.name;
   let relativePath = pathUtil.getRelativePath(options.entity.name);
@@ -16,12 +14,7 @@ module.exports = function(type, baseClass, options) {
     relativePath = pathUtil.getRelativePath(options.podPath + options.entity.name);
   }
 
-  let applicationEntityPath;
-  if (isModuleUnification) {
-    applicationEntityPath = path.join(options.project.root, 'src', 'data', 'models', 'application', `${type}.js`);
-  } else {
-    applicationEntityPath = path.join(options.project.root, 'app', `${type}s`, 'application.js');
-  }
+  let applicationEntityPath = path.join(options.project.root, 'app', `${type}s`, 'application.js');
 
   let hasApplicationEntity = fs.existsSync(applicationEntityPath);
   if (!isAddon && !options.baseClass && entityName !== 'application' && hasApplicationEntity) {
@@ -41,11 +34,6 @@ module.exports = function(type, baseClass, options) {
     let baseClassPath = options.baseClass;
     baseClass = stringUtil.classify(baseClassPath.replace('/', '-'));
     baseClass = baseClass + stringUtil.classify(type);
-
-    if (isModuleUnification) {
-      relativePath = `../${options.baseClass}/`;
-      baseClassPath = type;
-    }
 
     importStatement = `import ${baseClass} from '${relativePath}${baseClassPath}';`;
   } else {

--- a/packages/-build-infra/src/utilities/module-unification.js
+++ b/packages/-build-infra/src/utilities/module-unification.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = {
-  isModuleUnificationProject(project) {
-    return project && project.isModuleUnification && project.isModuleUnification();
-  },
-};

--- a/packages/-test-infra/src/node-test-helpers/setup-test-environment.js
+++ b/packages/-test-infra/src/node-test-helpers/setup-test-environment.js
@@ -1,11 +1,9 @@
 function enableOctane() {
   beforeEach(function() {
-    process.env.EMBER_CLI_MODULE_UNIFICATION = true;
     process.env.EMBER_VERSION = 'OCTANE';
   });
 
   afterEach(function() {
-    delete process.env.EMBER_CLI_MODULE_UNIFICATION;
     delete process.env.EMBER_VERSION;
   });
 }

--- a/packages/adapter/blueprints/adapter-test/index.js
+++ b/packages/adapter/blueprints/adapter-test/index.js
@@ -1,7 +1,5 @@
 const testInfo = require('ember-cli-test-info');
 const useTestFrameworkDetector = require('@ember-data/-build-infra/src/utilities/test-framework-detector');
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification')
-  .isModuleUnificationProject;
 const path = require('path');
 
 module.exports = useTestFrameworkDetector({
@@ -10,28 +8,14 @@ module.exports = useTestFrameworkDetector({
   root: __dirname,
 
   fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'models', options.dasherizedModuleName);
-        },
-        __test__() {
-          return 'adapter-test';
-        },
-      };
-    } else {
-      return {
-        __root__() {
-          return 'tests';
-        },
-        __path__() {
-          return path.join('unit', 'adapters');
-        },
-      };
-    }
+    return {
+      __root__() {
+        return 'tests';
+      },
+      __path__() {
+        return path.join('unit', 'adapters');
+      },
+    };
   },
 
   locals(options) {

--- a/packages/adapter/blueprints/adapter/index.js
+++ b/packages/adapter/blueprints/adapter/index.js
@@ -1,7 +1,4 @@
 const extendFromApplicationEntity = require('@ember-data/-build-infra/src/utilities/extend-from-application-entity');
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification')
-  .isModuleUnificationProject;
-const path = require('path');
 const useEditionDetector = require('@ember-data/-build-infra/src/utilities/edition-detector');
 
 module.exports = useEditionDetector({
@@ -10,22 +7,6 @@ module.exports = useEditionDetector({
   availableOptions: [{ name: 'base-class', type: String }],
 
   root: __dirname,
-
-  fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'models', options.dasherizedModuleName);
-        },
-        __name__() {
-          return 'adapter';
-        },
-      };
-    }
-  },
 
   locals(options) {
     return extendFromApplicationEntity('adapter', 'JSONAPIAdapter', options);

--- a/packages/adapter/node-tests/blueprints/adapter-test.js
+++ b/packages/adapter/node-tests/blueprints/adapter-test.js
@@ -136,238 +136,71 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
     });
   });
 
-  describe('module unification', function() {
-    beforeEach(function() {
-      return emberNew({ isModuleUnification: true });
-    });
-
-    it('adapter', function() {
-      let args = ['adapter', 'foo'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/adapter.js'))
-            .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
-            .to.contain('export default JSONAPIAdapter.extend({');
-
-          expect(_file('src/data/models/foo/adapter-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    it('adapter extends application adapter if it exists', function() {
-      let args = ['adapter', 'foo'];
-
-      return emberGenerate(['adapter', 'application'], { isModuleUnification: true }).then(() =>
-        emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/adapter.js'))
-              .to.contain("import ApplicationAdapter from '../application/adapter';")
-              .to.contain('export default ApplicationAdapter.extend({');
-
-            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
-          },
-          { isModuleUnification: true }
-        )
-      );
-    });
-
-    it('adapter with --base-class', function() {
-      let args = ['adapter', 'foo', '--base-class=bar'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/adapter.js'))
-            .to.contain("import BarAdapter from '../bar/adapter';")
-            .to.contain('export default BarAdapter.extend({');
-
-          expect(_file('src/data/models/foo/adapter-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    it('adapter when is named "application"', function() {
-      let args = ['adapter', 'application'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/application/adapter.js'))
-            .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
-            .to.contain('export default JSONAPIAdapter.extend({');
-
-          expect(_file('src/data/models/application/adapter-test.js')).to.equal(
-            fixture(__dirname, 'adapter-test/application-default.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    it('adapter-test', function() {
-      let args = ['adapter-test', 'foo'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/adapter-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    describe('adapter-test with ember-cli-qunit@4.1.0', function() {
-      beforeEach(function() {
-        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-cli-qunit', delete: true }]);
-        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
-      });
-
-      it('adapter-test-test foo', function() {
-        return emberGenerateDestroy(
-          ['adapter-test', 'foo'],
-          _file => {
-            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
-              fixture(__dirname, 'adapter-test/foo-default.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
-      });
-    });
-
-    describe('with ember-cli-mocha v0.12+', function() {
-      beforeEach(function() {
-        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-cli-mocha', dev: true }]);
-        generateFakePackageManifest('ember-cli-mocha', '0.12.0');
-      });
-
-      it('adapter-test for mocha v0.12+', function() {
-        let args = ['adapter-test', 'foo'];
-
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
-              fixture(__dirname, 'adapter-test/foo-mocha-0.12.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
-      });
-    });
-
-    describe('with ember-mocha v0.14+', function() {
-      beforeEach(function() {
-        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-mocha', dev: true }]);
-        generateFakePackageManifest('ember-mocha', '0.14.0');
-      });
-
-      it('adapter-test for mocha v0.14+', function() {
-        let args = ['adapter-test', 'foo'];
-
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
-              fixture(__dirname, 'adapter-test/mocha-rfc232.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
-      });
-    });
-  });
-
   describe('octane', function() {
     enableOctane();
 
     beforeEach(function() {
-      return emberNew({ isModuleUnification: true });
+      return emberNew();
     });
 
     it('adapter', function() {
       let args = ['adapter', 'foo'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/adapter.js'))
-            .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
-            .to.contain('export default class FooAdapter extends JSONAPIAdapter {');
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('app/adapters/foo.js'))
+          .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
+          .to.contain('export default class FooAdapter extends JSONAPIAdapter {');
 
-          expect(_file('src/data/models/foo/adapter-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
+        expect(_file('tests/unit/adapters/foo-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
+      });
     });
 
     it('adapter extends application adapter if it exists', function() {
       let args = ['adapter', 'foo'];
 
-      return emberGenerate(['adapter', 'application'], { isModuleUnification: true }).then(() =>
-        emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/adapter.js'))
-              .to.contain("import ApplicationAdapter from '../application/adapter';")
-              .to.contain('export default class FooAdapter extends ApplicationAdapter {');
+      return emberGenerate(['adapter', 'application']).then(() =>
+        emberGenerateDestroy(args, _file => {
+          expect(_file('app/adapters/foo.js'))
+            .to.contain("import ApplicationAdapter from './application';")
+            .to.contain('export default class FooAdapter extends ApplicationAdapter {');
 
-            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
-          },
-          { isModuleUnification: true }
-        )
+          expect(_file('tests/unit/adapters/foo-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
+        })
       );
     });
 
     it('adapter with --base-class', function() {
       let args = ['adapter', 'foo', '--base-class=bar'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/adapter.js'))
-            .to.contain("import BarAdapter from '../bar/adapter';")
-            .to.contain('export default class FooAdapter extends BarAdapter {');
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('app/adapters/foo.js'))
+          .to.contain("import BarAdapter from './bar';")
+          .to.contain('export default class FooAdapter extends BarAdapter {');
 
-          expect(_file('src/data/models/foo/adapter-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
+        expect(_file('tests/unit/adapters/foo-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
+      });
     });
 
     it('adapter when is named "application"', function() {
       let args = ['adapter', 'application'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/application/adapter.js'))
-            .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
-            .to.contain('export default class ApplicationAdapter extends JSONAPIAdapter {');
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('app/adapters/application.js'))
+          .to.contain(`import JSONAPIAdapter from '@ember-data/adapter/json-api';`)
+          .to.contain('export default class ApplicationAdapter extends JSONAPIAdapter {');
 
-          expect(_file('src/data/models/application/adapter-test.js')).to.equal(
-            fixture(__dirname, 'adapter-test/application-default.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
+        expect(_file('tests/unit/adapters/application-test.js')).to.equal(
+          fixture(__dirname, 'adapter-test/application-default.js')
+        );
+      });
     });
 
     it('adapter-test', function() {
       let args = ['adapter-test', 'foo'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/adapter-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/adapters/foo-test.js')).to.equal(fixture(__dirname, 'adapter-test/rfc232.js'));
+      });
     });
 
     describe('adapter-test with ember-cli-qunit@4.1.0', function() {
@@ -377,15 +210,9 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
       });
 
       it('adapter-test-test foo', function() {
-        return emberGenerateDestroy(
-          ['adapter-test', 'foo'],
-          _file => {
-            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
-              fixture(__dirname, 'adapter-test/foo-default.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
+        return emberGenerateDestroy(['adapter-test', 'foo'], _file => {
+          expect(_file('tests/unit/adapters/foo-test.js')).to.equal(fixture(__dirname, 'adapter-test/foo-default.js'));
+        });
       });
     });
 
@@ -398,15 +225,11 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
       it('adapter-test for mocha v0.12+', function() {
         let args = ['adapter-test', 'foo'];
 
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
-              fixture(__dirname, 'adapter-test/foo-mocha-0.12.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
+        return emberGenerateDestroy(args, _file => {
+          expect(_file('tests/unit/adapters/foo-test.js')).to.equal(
+            fixture(__dirname, 'adapter-test/foo-mocha-0.12.js')
+          );
+        });
       });
     });
 
@@ -419,15 +242,9 @@ describe('Acceptance: generate and destroy adapter blueprints', function() {
       it('adapter-test for mocha v0.14+', function() {
         let args = ['adapter-test', 'foo'];
 
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/adapter-test.js')).to.equal(
-              fixture(__dirname, 'adapter-test/mocha-rfc232.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
+        return emberGenerateDestroy(args, _file => {
+          expect(_file('tests/unit/adapters/foo-test.js')).to.equal(fixture(__dirname, 'adapter-test/mocha-rfc232.js'));
+        });
       });
     });
   });

--- a/packages/model/blueprints/model-test/index.js
+++ b/packages/model/blueprints/model-test/index.js
@@ -1,8 +1,6 @@
 const ModelBlueprint = require('../model');
 const testInfo = require('ember-cli-test-info');
 const useTestFrameworkDetector = require('@ember-data/-build-infra/src/utilities/test-framework-detector');
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification')
-  .isModuleUnificationProject;
 const path = require('path');
 
 module.exports = useTestFrameworkDetector({
@@ -11,28 +9,14 @@ module.exports = useTestFrameworkDetector({
   root: __dirname,
 
   fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'models', options.dasherizedModuleName);
-        },
-        __test__() {
-          return 'model-test';
-        },
-      };
-    } else {
-      return {
-        __root__() {
-          return 'tests';
-        },
-        __path__() {
-          return path.join('unit', 'models');
-        },
-      };
-    }
+    return {
+      __root__() {
+        return 'tests';
+      },
+      __path__() {
+        return path.join('unit', 'models');
+      },
+    };
   },
 
   locals(options) {

--- a/packages/model/blueprints/model/index.js
+++ b/packages/model/blueprints/model/index.js
@@ -1,9 +1,6 @@
 const inflection = require('inflection');
 const stringUtils = require('ember-cli-string-utils');
 const EOL = require('os').EOL;
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification')
-  .isModuleUnificationProject;
-const path = require('path');
 const useEditionDetector = require('@ember-data/-build-infra/src/utilities/edition-detector');
 
 module.exports = useEditionDetector({
@@ -12,22 +9,6 @@ module.exports = useEditionDetector({
   anonymousOptions: ['name', 'attr:type'],
 
   root: __dirname,
-
-  fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'models', options.dasherizedModuleName);
-        },
-        __name__() {
-          return 'model';
-        },
-      };
-    }
-  },
 
   locals(options) {
     let attrs = [];

--- a/packages/model/node-tests/blueprints/model-test.js
+++ b/packages/model/node-tests/blueprints/model-test.js
@@ -148,196 +148,23 @@ describe('Acceptance: generate and destroy model blueprints', function() {
     });
   });
 
-  describe('module unification', function() {
-    beforeEach(function() {
-      return emberNew({ isModuleUnification: true });
-    });
-
-    it('model', function() {
-      let args = ['model', 'foo'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/model.js'))
-            .to.contain(`import Model from '@ember-data/model';`)
-            .to.contain('export default Model.extend(');
-
-          expect(_file('src/data/models/foo/model-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    it('model with attrs', function() {
-      let args = [
-        'model',
-        'foo',
-        'misc',
-        'skills:array',
-        'isActive:boolean',
-        'birthday:date',
-        'someObject:object',
-        'age:number',
-        'name:string',
-        'customAttr:custom-transform',
-      ];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/model.js'))
-            .to.contain(`import Model, { attr } from '@ember-data/model';`)
-            .to.contain('export default Model.extend(')
-            .to.contain('  misc: attr(),')
-            .to.contain("  skills: attr('array'),")
-            .to.contain("  isActive: attr('boolean'),")
-            .to.contain("  birthday: attr('date'),")
-            .to.contain("  someObject: attr('object'),")
-            .to.contain("  age: attr('number'),")
-            .to.contain("  name: attr('string'),")
-            .to.contain("  customAttr: attr('custom-transform')");
-
-          expect(_file('src/data/models/foo/model-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    it('model with belongsTo', function() {
-      let args = ['model', 'comment', 'post:belongs-to', 'author:belongs-to:user'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/comment/model.js'))
-            .to.contain(`import Model, { belongsTo } from '@ember-data/model';`)
-            .to.contain('export default Model.extend(')
-            .to.contain("  post: belongsTo('post'),")
-            .to.contain("  author: belongsTo('user')");
-
-          expect(_file('src/data/models/comment/model-test.js')).to.equal(
-            fixture(__dirname, 'model-test/comment-default.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    it('model with hasMany', function() {
-      let args = ['model', 'post', 'comments:has-many', 'otherComments:has-many:comment'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/post/model.js'))
-            .to.contain(`import Model, { hasMany } from '@ember-data/model';`)
-            .to.contain('export default Model.extend(')
-            .to.contain("  comments: hasMany('comment'),")
-            .to.contain("  otherComments: hasMany('comment')");
-
-          expect(_file('src/data/models/post/model-test.js')).to.equal(
-            fixture(__dirname, 'model-test/post-default.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    it('model-test', function() {
-      let args = ['model-test', 'foo'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/model-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    describe('model-test with ember-cli-qunit@4.1.0', function() {
-      beforeEach(function() {
-        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-cli-qunit', delete: true }]);
-        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
-      });
-
-      it('model-test-test foo', function() {
-        return emberGenerateDestroy(
-          ['model-test', 'foo'],
-          _file => {
-            expect(_file('src/data/models/foo/model-test.js')).to.equal(
-              fixture(__dirname, 'model-test/foo-default.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
-      });
-    });
-
-    describe('with ember-cli-mocha v0.12+', function() {
-      beforeEach(function() {
-        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-cli-mocha', dev: true }]);
-        generateFakePackageManifest('ember-cli-mocha', '0.12.0');
-      });
-
-      it('model-test for mocha v0.12+', function() {
-        let args = ['model-test', 'foo'];
-
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/model-test.js')).to.equal(
-              fixture(__dirname, 'model-test/foo-mocha-0.12.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
-      });
-    });
-
-    describe('with ember-mocha v0.14+', function() {
-      beforeEach(function() {
-        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-mocha', dev: true }]);
-        generateFakePackageManifest('ember-mocha', '0.14.0');
-      });
-
-      it('model-test for mocha v0.14+', function() {
-        let args = ['model-test', 'foo'];
-
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/model-test.js')).to.equal(
-              fixture(__dirname, 'model-test/mocha-rfc232.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
-      });
-    });
-  });
-
   describe('octane', function() {
     enableOctane();
+
     beforeEach(function() {
-      return emberNew({ isModuleUnification: true });
+      return emberNew();
     });
 
     it('model', function() {
       let args = ['model', 'foo'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/model.js'))
-            .to.contain(`import Model from '@ember-data/model';`)
-            .to.contain('export default class FooModel extends Model {');
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('app/models/foo.js'))
+          .to.contain(`import Model from '@ember-data/model';`)
+          .to.contain('export default class FooModel extends Model {');
 
-          expect(_file('src/data/models/foo/model-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
+        expect(_file('tests/unit/models/foo-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
+      });
     });
 
     it('model with attrs', function() {
@@ -354,77 +181,59 @@ describe('Acceptance: generate and destroy model blueprints', function() {
         'customAttr:custom-transform',
       ];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/model.js'))
-            .to.contain(`import Model, { attr } from '@ember-data/model';`)
-            .to.contain('export default class FooModel extends Model {')
-            .to.contain('  @attr() misc;')
-            .to.contain("  @attr('array') skills;")
-            .to.contain("  @attr('boolean') isActive;")
-            .to.contain("  @attr('date') birthday;")
-            .to.contain("  @attr('object') someObject;")
-            .to.contain("  @attr('number') age;")
-            .to.contain("  @attr('string') name;")
-            .to.contain("  @attr('custom-transform') customAttr;");
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('app/models/foo.js'))
+          .to.contain(`import Model, { attr } from '@ember-data/model';`)
+          .to.contain('export default class FooModel extends Model {')
+          .to.contain('  @attr() misc;')
+          .to.contain("  @attr('array') skills;")
+          .to.contain("  @attr('boolean') isActive;")
+          .to.contain("  @attr('date') birthday;")
+          .to.contain("  @attr('object') someObject;")
+          .to.contain("  @attr('number') age;")
+          .to.contain("  @attr('string') name;")
+          .to.contain("  @attr('custom-transform') customAttr;");
 
-          expect(_file('src/data/models/foo/model-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
+        expect(_file('tests/unit/models/foo-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
+      });
     });
 
     it('model with belongsTo', function() {
       let args = ['model', 'comment', 'post:belongs-to', 'author:belongs-to:user'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/comment/model.js'))
-            .to.contain(`import Model, { belongsTo } from '@ember-data/model';`)
-            .to.contain('export default class CommentModel extends Model {')
-            .to.contain('  @belongsTo post;')
-            .to.contain("  @belongsTo('user') author;");
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('app/models/comment.js'))
+          .to.contain(`import Model, { belongsTo } from '@ember-data/model';`)
+          .to.contain('export default class CommentModel extends Model {')
+          .to.contain('  @belongsTo post;')
+          .to.contain("  @belongsTo('user') author;");
 
-          expect(_file('src/data/models/comment/model-test.js')).to.equal(
-            fixture(__dirname, 'model-test/comment-default.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
+        expect(_file('tests/unit/models/comment-test.js')).to.equal(
+          fixture(__dirname, 'model-test/comment-default.js')
+        );
+      });
     });
 
     it('model with hasMany', function() {
       let args = ['model', 'post', 'comments:has-many', 'otherComments:has-many:comment'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/post/model.js'))
-            .to.contain(`import Model, { hasMany } from '@ember-data/model';`)
-            .to.contain('export default class PostModel extends Model {')
-            .to.contain('  @hasMany comments;')
-            .to.contain("  @hasMany('comment') otherComments;");
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('app/models/post.js'))
+          .to.contain(`import Model, { hasMany } from '@ember-data/model';`)
+          .to.contain('export default class PostModel extends Model {')
+          .to.contain('  @hasMany comments;')
+          .to.contain("  @hasMany('comment') otherComments;");
 
-          expect(_file('src/data/models/post/model-test.js')).to.equal(
-            fixture(__dirname, 'model-test/post-default.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
+        expect(_file('tests/unit/models/post-test.js')).to.equal(fixture(__dirname, 'model-test/post-default.js'));
+      });
     });
 
     it('model-test', function() {
       let args = ['model-test', 'foo'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/model-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
-        },
-        { isModuleUnification: true }
-      );
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/models/foo-test.js')).to.equal(fixture(__dirname, 'model-test/rfc232.js'));
+      });
     });
 
     describe('model-test with ember-cli-qunit@4.1.0', function() {
@@ -434,15 +243,9 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       });
 
       it('model-test-test foo', function() {
-        return emberGenerateDestroy(
-          ['model-test', 'foo'],
-          _file => {
-            expect(_file('src/data/models/foo/model-test.js')).to.equal(
-              fixture(__dirname, 'model-test/foo-default.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
+        return emberGenerateDestroy(['model-test', 'foo'], _file => {
+          expect(_file('tests/unit/models/foo-test.js')).to.equal(fixture(__dirname, 'model-test/foo-default.js'));
+        });
       });
     });
 
@@ -455,15 +258,9 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       it('model-test for mocha v0.12+', function() {
         let args = ['model-test', 'foo'];
 
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/model-test.js')).to.equal(
-              fixture(__dirname, 'model-test/foo-mocha-0.12.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
+        return emberGenerateDestroy(args, _file => {
+          expect(_file('tests/unit/models/foo-test.js')).to.equal(fixture(__dirname, 'model-test/foo-mocha-0.12.js'));
+        });
       });
     });
 
@@ -476,15 +273,9 @@ describe('Acceptance: generate and destroy model blueprints', function() {
       it('model-test for mocha v0.14+', function() {
         let args = ['model-test', 'foo'];
 
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/model-test.js')).to.equal(
-              fixture(__dirname, 'model-test/mocha-rfc232.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
+        return emberGenerateDestroy(args, _file => {
+          expect(_file('tests/unit/models/foo-test.js')).to.equal(fixture(__dirname, 'model-test/mocha-rfc232.js'));
+        });
       });
     });
   });

--- a/packages/serializer/blueprints/serializer-test/index.js
+++ b/packages/serializer/blueprints/serializer-test/index.js
@@ -1,7 +1,5 @@
 const testInfo = require('ember-cli-test-info');
 const useTestFrameworkDetector = require('@ember-data/-build-infra/src/utilities/test-framework-detector');
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification')
-  .isModuleUnificationProject;
 const path = require('path');
 
 module.exports = useTestFrameworkDetector({
@@ -10,28 +8,14 @@ module.exports = useTestFrameworkDetector({
   root: __dirname,
 
   fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'models', options.dasherizedModuleName);
-        },
-        __test__() {
-          return 'serializer-test';
-        },
-      };
-    } else {
-      return {
-        __root__() {
-          return 'tests';
-        },
-        __path__() {
-          return path.join('unit', 'serializers');
-        },
-      };
-    }
+    return {
+      __root__() {
+        return 'tests';
+      },
+      __path__() {
+        return path.join('unit', 'serializers');
+      },
+    };
   },
 
   locals(options) {

--- a/packages/serializer/blueprints/serializer/index.js
+++ b/packages/serializer/blueprints/serializer/index.js
@@ -1,7 +1,4 @@
 const extendFromApplicationEntity = require('@ember-data/-build-infra/src/utilities/extend-from-application-entity');
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification')
-  .isModuleUnificationProject;
-const path = require('path');
 const useEditionDetector = require('@ember-data/-build-infra/src/utilities/edition-detector');
 
 module.exports = useEditionDetector({
@@ -10,22 +7,6 @@ module.exports = useEditionDetector({
   availableOptions: [{ name: 'base-class', type: String }],
 
   root: __dirname,
-
-  fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'models', options.dasherizedModuleName);
-        },
-        __name__() {
-          return 'serializer';
-        },
-      };
-    }
-  },
 
   locals(options) {
     return extendFromApplicationEntity('serializer', 'JSONAPISerializer', options);

--- a/packages/serializer/blueprints/transform-test/index.js
+++ b/packages/serializer/blueprints/transform-test/index.js
@@ -1,7 +1,5 @@
 const testInfo = require('ember-cli-test-info');
 const useTestFrameworkDetector = require('@ember-data/-build-infra/src/utilities/test-framework-detector');
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification')
-  .isModuleUnificationProject;
 const path = require('path');
 
 module.exports = useTestFrameworkDetector({
@@ -10,28 +8,14 @@ module.exports = useTestFrameworkDetector({
   root: __dirname,
 
   fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'transforms');
-        },
-        __test__() {
-          return `${options.dasherizedModuleName}-test`;
-        },
-      };
-    } else {
-      return {
-        __root__() {
-          return 'tests';
-        },
-        __path__() {
-          return path.join('unit', 'transforms');
-        },
-      };
-    }
+    return {
+      __root__() {
+        return 'tests';
+      },
+      __path__() {
+        return path.join('unit', 'transforms');
+      },
+    };
   },
 
   locals(options) {

--- a/packages/serializer/blueprints/transform/index.js
+++ b/packages/serializer/blueprints/transform/index.js
@@ -1,26 +1,7 @@
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification')
-  .isModuleUnificationProject;
-const path = require('path');
 const useEditionDetector = require('@ember-data/-build-infra/src/utilities/edition-detector');
 
 module.exports = useEditionDetector({
   description: 'Generates an ember-data value transform.',
 
   root: __dirname,
-
-  fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'transforms');
-        },
-        __name__() {
-          return options.dasherizedModuleName;
-        },
-      };
-    }
-  },
 });

--- a/packages/serializer/node-tests/blueprints/serializer-test.js
+++ b/packages/serializer/node-tests/blueprints/serializer-test.js
@@ -142,272 +142,77 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
     });
   });
 
-  describe('module unification', function() {
-    beforeEach(function() {
-      return emberNew({ isModuleUnification: true });
-    });
-
-    it('serializer', function() {
-      let args = ['serializer', 'foo'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/serializer.js'))
-            .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
-            .to.contain('export default JSONAPISerializer.extend(');
-
-          expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-            fixture(__dirname, 'serializer-test/rfc232.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    it('serializer extends application serializer if it exists', function() {
-      let args = ['serializer', 'foo'];
-
-      return emberGenerate(['serializer', 'application'], { isModuleUnification: true }).then(() =>
-        emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/serializer.js'))
-              .to.contain("import ApplicationSerializer from '../application/serializer';")
-              .to.contain('export default ApplicationSerializer.extend({');
-
-            expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-              fixture(__dirname, 'serializer-test/rfc232.js')
-            );
-          },
-          { isModuleUnification: true }
-        )
-      );
-    });
-
-    it('serializer with --base-class', function() {
-      let args = ['serializer', 'foo', '--base-class=bar'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/serializer.js'))
-            .to.contain("import BarSerializer from '../bar/serializer';")
-            .to.contain('export default BarSerializer.extend({');
-
-          expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-            fixture(__dirname, 'serializer-test/rfc232.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    xit('serializer throws when --base-class is same as name', function() {
-      let args = ['serializer', 'foo', '--base-class=foo'];
-
-      return expect(emberGenerate(args, { isModuleUnification: true })).to.be.rejectedWith(
-        SilentError,
-        /Serializers cannot extend from themself/
-      );
-    });
-
-    it('serializer when is named "application"', function() {
-      let args = ['serializer', 'application'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/application/serializer.js'))
-            .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
-            .to.contain('export default JSONAPISerializer.extend(');
-
-          expect(_file('src/data/models/application/serializer-test.js')).to.equal(
-            fixture(__dirname, 'serializer-test/application-default.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    it('serializer-test', function() {
-      let args = ['serializer-test', 'foo'];
-
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-            fixture(__dirname, 'serializer-test/rfc232.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
-    });
-
-    describe('serializer-test with ember-cli-qunit@4.1.0', function() {
-      beforeEach(function() {
-        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-cli-qunit', delete: true }]);
-        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
-      });
-
-      it('serializer-test-test foo', function() {
-        return emberGenerateDestroy(
-          ['serializer-test', 'foo'],
-          _file => {
-            expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-              fixture(__dirname, 'serializer-test/foo-default.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
-      });
-    });
-
-    describe('with ember-cli-mocha v0.12+', function() {
-      beforeEach(function() {
-        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-cli-mocha', dev: true }]);
-        generateFakePackageManifest('ember-cli-mocha', '0.12.0');
-      });
-
-      it('serializer-test for mocha v0.12+', function() {
-        let args = ['serializer-test', 'foo'];
-
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-              fixture(__dirname, 'serializer-test/foo-mocha-0.12.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
-      });
-    });
-
-    describe('with ember-mocha v0.14+', function() {
-      beforeEach(function() {
-        modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-mocha', dev: true }]);
-        generateFakePackageManifest('ember-mocha', '0.14.0');
-      });
-
-      it('serializer-test for mocha v0.14+', function() {
-        let args = ['serializer-test', 'foo'];
-
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-              fixture(__dirname, 'serializer-test/mocha-rfc232.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
-      });
-    });
-  });
-
   describe('octane', function() {
     enableOctane();
 
     beforeEach(function() {
-      return emberNew({ isModuleUnification: true });
+      return emberNew();
     });
 
     it('serializer', function() {
       let args = ['serializer', 'foo'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/serializer.js'))
-            .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
-            .to.contain('export default class FooSerializer extends JSONAPISerializer {');
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('app/serializers/foo.js'))
+          .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
+          .to.contain('export default class FooSerializer extends JSONAPISerializer {');
 
-          expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-            fixture(__dirname, 'serializer-test/rfc232.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
+        expect(_file('tests/unit/serializers/foo-test.js')).to.equal(fixture(__dirname, 'serializer-test/rfc232.js'));
+      });
     });
 
     it('serializer extends application serializer if it exists', function() {
       let args = ['serializer', 'foo'];
 
-      return emberGenerate(['serializer', 'application'], { isModuleUnification: true }).then(() =>
-        emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/serializer.js'))
-              .to.contain("import ApplicationSerializer from '../application/serializer';")
-              .to.contain('export default class FooSerializer extends ApplicationSerializer {');
+      return emberGenerate(['serializer', 'application']).then(() =>
+        emberGenerateDestroy(args, _file => {
+          expect(_file('app/serializers/foo.js'))
+            .to.contain("import ApplicationSerializer from './application';")
+            .to.contain('export default class FooSerializer extends ApplicationSerializer {');
 
-            expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-              fixture(__dirname, 'serializer-test/rfc232.js')
-            );
-          },
-          { isModuleUnification: true }
-        )
+          expect(_file('tests/unit/serializers/foo-test.js')).to.equal(fixture(__dirname, 'serializer-test/rfc232.js'));
+        })
       );
     });
 
     it('serializer with --base-class', function() {
       let args = ['serializer', 'foo', '--base-class=bar'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/serializer.js'))
-            .to.contain("import BarSerializer from '../bar/serializer';")
-            .to.contain('export default class FooSerializer extends BarSerializer');
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('app/serializers/foo.js'))
+          .to.contain("import BarSerializer from './bar';")
+          .to.contain('export default class FooSerializer extends BarSerializer');
 
-          expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-            fixture(__dirname, 'serializer-test/rfc232.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
+        expect(_file('tests/unit/serializers/foo-test.js')).to.equal(fixture(__dirname, 'serializer-test/rfc232.js'));
+      });
     });
 
     xit('serializer throws when --base-class is same as name', function() {
       let args = ['serializer', 'foo', '--base-class=foo'];
 
-      return expect(emberGenerate(args, { isModuleUnification: true })).to.be.rejectedWith(
-        SilentError,
-        /Serializers cannot extend from themself/
-      );
+      return expect(emberGenerate(args)).to.be.rejectedWith(SilentError, /Serializers cannot extend from themself/);
     });
 
     it('serializer when is named "application"', function() {
       let args = ['serializer', 'application'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/application/serializer.js'))
-            .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
-            .to.contain('export default class ApplicationSerializer extends JSONAPISerializer {');
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('app/serializers/application.js'))
+          .to.contain(`import JSONAPISerializer from '@ember-data/serializer/json-api';`)
+          .to.contain('export default class ApplicationSerializer extends JSONAPISerializer {');
 
-          expect(_file('src/data/models/application/serializer-test.js')).to.equal(
-            fixture(__dirname, 'serializer-test/application-default.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
+        expect(_file('tests/unit/serializers/application-test.js')).to.equal(
+          fixture(__dirname, 'serializer-test/application-default.js')
+        );
+      });
     });
 
     it('serializer-test', function() {
       let args = ['serializer-test', 'foo'];
 
-      return emberGenerateDestroy(
-        args,
-        _file => {
-          expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-            fixture(__dirname, 'serializer-test/rfc232.js')
-          );
-        },
-        { isModuleUnification: true }
-      );
+      return emberGenerateDestroy(args, _file => {
+        expect(_file('tests/unit/serializers/foo-test.js')).to.equal(fixture(__dirname, 'serializer-test/rfc232.js'));
+      });
     });
 
     describe('serializer-test with ember-cli-qunit@4.1.0', function() {
@@ -417,15 +222,11 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
       });
 
       it('serializer-test-test foo', function() {
-        return emberGenerateDestroy(
-          ['serializer-test', 'foo'],
-          _file => {
-            expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-              fixture(__dirname, 'serializer-test/foo-default.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
+        return emberGenerateDestroy(['serializer-test', 'foo'], _file => {
+          expect(_file('tests/unit/serializers/foo-test.js')).to.equal(
+            fixture(__dirname, 'serializer-test/foo-default.js')
+          );
+        });
       });
     });
 
@@ -438,15 +239,11 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
       it('serializer-test for mocha v0.12+', function() {
         let args = ['serializer-test', 'foo'];
 
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-              fixture(__dirname, 'serializer-test/foo-mocha-0.12.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
+        return emberGenerateDestroy(args, _file => {
+          expect(_file('tests/unit/serializers/foo-test.js')).to.equal(
+            fixture(__dirname, 'serializer-test/foo-mocha-0.12.js')
+          );
+        });
       });
     });
 
@@ -459,15 +256,11 @@ describe('Acceptance: generate and destroy serializer blueprints', function() {
       it('serializer-test for mocha v0.14+', function() {
         let args = ['serializer-test', 'foo'];
 
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/models/foo/serializer-test.js')).to.equal(
-              fixture(__dirname, 'serializer-test/mocha-rfc232.js')
-            );
-          },
-          { isModuleUnification: true }
-        );
+        return emberGenerateDestroy(args, _file => {
+          expect(_file('tests/unit/serializers/foo-test.js')).to.equal(
+            fixture(__dirname, 'serializer-test/mocha-rfc232.js')
+          );
+        });
       });
     });
   });

--- a/packages/serializer/node-tests/blueprints/transform-test.js
+++ b/packages/serializer/node-tests/blueprints/transform-test.js
@@ -97,141 +97,34 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
     });
   });
 
-  describe('module unification', function() {
-    describe('in app', function() {
-      beforeEach(function() {
-        return emberNew({ isModuleUnification: true });
-      });
-
-      it('transform', function() {
-        let args = ['transform', 'foo'];
-
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/transforms/foo.js'))
-              .to.contain(`import Transform from '@ember-data/serializer/transform';`)
-              .to.contain('export default Transform.extend(')
-              .to.contain('deserialize(serialized) {')
-              .to.contain('serialize(deserialized) {');
-
-            expect(_file('src/data/transforms/foo-test.js')).to.equal(fixture(__dirname, 'transform-test/rfc232.js'));
-          },
-          { isModuleUnification: true }
-        );
-      });
-
-      it('transform-test', function() {
-        let args = ['transform-test', 'foo'];
-
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/transforms/foo-test.js')).to.equal(fixture(__dirname, 'transform-test/rfc232.js'));
-          },
-          { isModuleUnification: true }
-        );
-      });
-
-      describe('transform-test with ember-cli-qunit@4.1.0', function() {
-        beforeEach(function() {
-          modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-cli-qunit', delete: true }]);
-          generateFakePackageManifest('ember-cli-qunit', '4.1.0');
-        });
-
-        it('transform-test-test foo', function() {
-          return emberGenerateDestroy(
-            ['transform-test', 'foo'],
-            _file => {
-              expect(_file('src/data/transforms/foo-test.js')).to.equal(
-                fixture(__dirname, 'transform-test/default.js')
-              );
-            },
-            { isModuleUnification: true }
-          );
-        });
-      });
-
-      describe('with ember-cli-mocha v0.12+', function() {
-        beforeEach(function() {
-          modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-cli-mocha', dev: true }]);
-          generateFakePackageManifest('ember-cli-mocha', '0.12.0');
-        });
-
-        it('transform-test for mocha v0.12+', function() {
-          let args = ['transform-test', 'foo'];
-
-          return emberGenerateDestroy(
-            args,
-            _file => {
-              expect(_file('src/data/transforms/foo-test.js')).to.equal(
-                fixture(__dirname, 'transform-test/mocha-0.12.js')
-              );
-            },
-            { isModuleUnification: true }
-          );
-        });
-      });
-
-      describe('with ember-mocha v0.14+', function() {
-        beforeEach(function() {
-          modifyPackages([{ name: 'ember-qunit', delete: true }, { name: 'ember-mocha', dev: true }]);
-          generateFakePackageManifest('ember-mocha', '0.14.0');
-        });
-
-        it('transform-test for mocha v0.14+', function() {
-          let args = ['transform-test', 'foo'];
-
-          return emberGenerateDestroy(
-            args,
-            _file => {
-              expect(_file('src/data/transforms/foo-test.js')).to.equal(
-                fixture(__dirname, 'transform-test/mocha-rfc232.js')
-              );
-            },
-            { isModuleUnification: true }
-          );
-        });
-      });
-    });
-  });
-
   describe('octane', function() {
     describe('in app', function() {
       enableOctane();
 
       beforeEach(function() {
-        return emberNew({ isModuleUnification: true });
+        return emberNew();
       });
 
       it('transform', function() {
         let args = ['transform', 'foo'];
 
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/transforms/foo.js'))
-              .to.contain(`import Transform from '@ember-data/serializer/transform';`)
-              .to.contain('export default class FooTransform extends Transform {')
-              .to.contain('deserialize(serialized) {')
-              .to.contain('serialize(deserialized) {');
+        return emberGenerateDestroy(args, _file => {
+          expect(_file('app/transforms/foo.js'))
+            .to.contain(`import Transform from '@ember-data/serializer/transform';`)
+            .to.contain('export default class FooTransform extends Transform {')
+            .to.contain('deserialize(serialized) {')
+            .to.contain('serialize(deserialized) {');
 
-            expect(_file('src/data/transforms/foo-test.js')).to.equal(fixture(__dirname, 'transform-test/rfc232.js'));
-          },
-          { isModuleUnification: true }
-        );
+          expect(_file('tests/unit/transforms/foo-test.js')).to.equal(fixture(__dirname, 'transform-test/rfc232.js'));
+        });
       });
 
       it('transform-test', function() {
         let args = ['transform-test', 'foo'];
 
-        return emberGenerateDestroy(
-          args,
-          _file => {
-            expect(_file('src/data/transforms/foo-test.js')).to.equal(fixture(__dirname, 'transform-test/rfc232.js'));
-          },
-          { isModuleUnification: true }
-        );
+        return emberGenerateDestroy(args, _file => {
+          expect(_file('tests/unit/transforms/foo-test.js')).to.equal(fixture(__dirname, 'transform-test/rfc232.js'));
+        });
       });
 
       describe('transform-test with ember-cli-qunit@4.1.0', function() {
@@ -241,15 +134,11 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
         });
 
         it('transform-test-test foo', function() {
-          return emberGenerateDestroy(
-            ['transform-test', 'foo'],
-            _file => {
-              expect(_file('src/data/transforms/foo-test.js')).to.equal(
-                fixture(__dirname, 'transform-test/default.js')
-              );
-            },
-            { isModuleUnification: true }
-          );
+          return emberGenerateDestroy(['transform-test', 'foo'], _file => {
+            expect(_file('tests/unit/transforms/foo-test.js')).to.equal(
+              fixture(__dirname, 'transform-test/default.js')
+            );
+          });
         });
       });
 
@@ -262,15 +151,11 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
         it('transform-test for mocha v0.12+', function() {
           let args = ['transform-test', 'foo'];
 
-          return emberGenerateDestroy(
-            args,
-            _file => {
-              expect(_file('src/data/transforms/foo-test.js')).to.equal(
-                fixture(__dirname, 'transform-test/mocha-0.12.js')
-              );
-            },
-            { isModuleUnification: true }
-          );
+          return emberGenerateDestroy(args, _file => {
+            expect(_file('tests/unit/transforms/foo-test.js')).to.equal(
+              fixture(__dirname, 'transform-test/mocha-0.12.js')
+            );
+          });
         });
       });
 
@@ -283,15 +168,11 @@ describe('Acceptance: generate and destroy transform blueprints', function() {
         it('transform-test for mocha v0.14+', function() {
           let args = ['transform-test', 'foo'];
 
-          return emberGenerateDestroy(
-            args,
-            _file => {
-              expect(_file('src/data/transforms/foo-test.js')).to.equal(
-                fixture(__dirname, 'transform-test/mocha-rfc232.js')
-              );
-            },
-            { isModuleUnification: true }
-          );
+          return emberGenerateDestroy(args, _file => {
+            expect(_file('tests/unit/transforms/foo-test.js')).to.equal(
+              fixture(__dirname, 'transform-test/mocha-rfc232.js')
+            );
+          });
         });
       });
     });


### PR DESCRIPTION
This experiement has been disabled in Ember, meaning it can't be used anymore (starting from `ember-source@v3.12.0-beta.1`).