### PR TITLE
Backporting beta fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     heimdall: true,
     Map: false,
     WeakMap: true,
+    Set: true,
   },
   env: {
     browser: true,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -293,6 +293,7 @@ jobs:
       - script: |
           yarn test-external:storefront
         displayName: 'External: storefront'
+        condition: always()
 
       #  - script: |
       #      yarn test-external:factory-guy
@@ -301,19 +302,26 @@ jobs:
       - script: |
           yarn test-external:ember-resource-metadata
         displayName: 'External: ember-resource-metadata'
+        condition: always()
 
       - script: |
           yarn test-external:ember-data-relationship-tracker
         displayName: 'External: ember-data-relationship-tracker'
+        condition: always()
 
       - script: |
           yarn test-external:model-fragments
+          exit 0
         displayName: 'External: model-fragments'
+        condition: always()
 
       - script: |
           yarn test-external:ember-data-change-tracker
+          exit 0
         displayName: 'External: ember-data-change-tracker'
+        condition: always()
 
       - script: |
           yarn test-external:ember-m3
         displayName: 'External: ember-m3'
+        condition: always()

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -142,11 +142,7 @@ function assertGitIsClean() {
   }
 
   let expectedChannelBranch =
-    options.distTag === 'canary'
-      ? 'master'
-      : options.distTag === 'latest'
-      ? 'release'
-      : options.distTag;
+    options.distTag === 'canary' ? 'master' : options.distTag === 'latest' ? 'release' : options.distTag;
 
   if (options.channel === 'lts') {
     expectedChannelBranch = `lts-${semver.major(options.currentVersion)}-${semver.minor(options.currentVersion)}`;

--- a/packages/-build-infra/src/addon-build-config-for-data-package.js
+++ b/packages/-build-infra/src/addon-build-config-for-data-package.js
@@ -111,7 +111,7 @@ function addonBuildConfigForDataPackage(PackageName) {
     },
 
     treeForAddon(tree) {
-      if (this.shouldRollupPrivate !== true) {
+      if (process.env.EMBER_DATA_ROLLUP_PRIVATE !== 'false' && this.shouldRollupPrivate !== true) {
         return this._super.treeForAddon.call(this, tree);
       }
 

--- a/packages/-ember-data/tests/integration/adapter/find-all-test.js
+++ b/packages/-ember-data/tests/integration/adapter/find-all-test.js
@@ -141,7 +141,7 @@ module('integration/adapter/find-all - Finding All Records of a Type', function(
     );
   });
 
-  test('When all records for a type are requested, records that are created on the client should be added to the record array.', assert => {
+  test('When all records for a type are requested, records that are created on the client should be added to the record array.', async assert => {
     assert.expect(3);
 
     let allRecords = store.peekAll('person');
@@ -153,6 +153,8 @@ module('integration/adapter/find-all - Finding All Records of a Type', function(
     );
 
     store.createRecord('person', { name: 'Carsten Nielsen' });
+
+    await settled();
 
     assert.equal(get(allRecords, 'length'), 1, "the record array's length is 1");
     assert.equal(

--- a/packages/-ember-data/tests/integration/record-array-test.js
+++ b/packages/-ember-data/tests/integration/record-array-test.js
@@ -383,11 +383,14 @@ module('unit/record-array - RecordArray', function(hooks) {
       name: 'Scumbag Dale',
     });
 
+    await settled();
     assert.equal(get(recordArray, 'length'), 1, 'precond - record array already has the first created item');
 
     store.createRecord('person', { name: 'p1' });
     store.createRecord('person', { name: 'p2' });
     store.createRecord('person', { name: 'p3' });
+
+    await settled();
 
     assert.equal(get(recordArray, 'length'), 4, 'precond - record array has the created item');
     assert.equal(recordArray.objectAt(0), scumbag, 'item at index 0 is record with id 1');

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -663,6 +663,34 @@ module('unit/model - Model', function(hooks) {
         assert.equal(eventMethodArgs[1], 2);
       }
     );
+
+    testInDebug('defining record lifecycle event methods on a model class is deprecated', async function(assert) {
+      class EngineerModel extends Model {
+        becameError() {}
+        becameInvalid() {}
+        didCreate() {}
+        didDelete() {}
+        didLoad() {}
+        didUpdate() {}
+        ready() {}
+        rolledBack() {}
+      }
+
+      this.owner.register('model:engineer', EngineerModel);
+
+      let store = this.owner.lookup('service:store');
+
+      store.createRecord('engineer');
+
+      assert.expectDeprecation(/You defined a `becameError` method for model:engineer but lifecycle events/);
+      assert.expectDeprecation(/You defined a `becameInvalid` method for model:engineer but lifecycle events/);
+      assert.expectDeprecation(/You defined a `didCreate` method for model:engineer but lifecycle events/);
+      assert.expectDeprecation(/You defined a `didDelete` method for model:engineer but lifecycle events/);
+      assert.expectDeprecation(/You defined a `didLoad` method for model:engineer but lifecycle events/);
+      assert.expectDeprecation(/You defined a `didUpdate` method for model:engineer but lifecycle events/);
+      assert.expectDeprecation(/You defined a `ready` method for model:engineer but lifecycle events/);
+      assert.expectDeprecation(/You defined a `rolledBack` method for model:engineer but lifecycle events/);
+    });
   });
 
   module('Reserved Props', function() {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -46,24 +46,6 @@ interface BelongsToMetaWrapper {
   modelName: string;
 }
 
-let INSTANCE_DEPRECATIONS;
-let lookupDeprecations;
-
-if (DEBUG) {
-  INSTANCE_DEPRECATIONS = new WeakMap();
-
-  lookupDeprecations = function lookupInstanceDrecations(instance) {
-    let deprecations = INSTANCE_DEPRECATIONS.get(instance);
-
-    if (!deprecations) {
-      deprecations = {};
-      INSTANCE_DEPRECATIONS.set(instance, deprecations);
-    }
-
-    return deprecations;
-  };
-}
-
 /*
   The TransitionChainMap caches the `state.enters`, `state.setups`, and final state reached
   when transitioning from one state to another, so that future transitions can replay the
@@ -401,31 +383,6 @@ export default class InternalModel {
       this._record = store._modelFactoryFor(this.modelName).create(createOptions);
       if (IDENTIFIERS) {
         setRecordIdentifier(this._record, this.identifier);
-      }
-      if (DEBUG) {
-        let klass = this._record.constructor;
-        let deprecations = lookupDeprecations(klass);
-        [
-          'becameError',
-          'becameInvalid',
-          'didCreate',
-          'didDelete',
-          'didLoad',
-          'didUpdate',
-          'ready',
-          'rolledBack',
-        ].forEach(methodName => {
-          if (this instanceof Model && typeof this._record[methodName] === 'function') {
-            deprecate(
-              `Attempted to define ${methodName} on ${this._record.modelName}#${this._record.id}`,
-              deprecations[methodName],
-              {
-                id: 'ember-data:record-lifecycle-event-methods',
-                until: '4.0',
-              }
-            );
-          }
-        });
       }
 
       this._triggerDeferredTriggers();

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -159,6 +159,18 @@ export default class InternalModel {
     return this._id;
   }
 
+  set id(value: string | null) {
+    if (IDENTIFIERS) {
+      if (value !== this._id) {
+        let newIdentifier = { type: this.identifier.type, lid: this.identifier.lid, id: value };
+        identifierCacheFor(this.store).updateRecordIdentifier(this.identifier, newIdentifier);
+        // TODO Show deprecation for private api
+      }
+    } else if (!IDENTIFIERS) {
+      this._id = value;
+    }
+  }
+
   get modelClass() {
     return this._modelClass || (this._modelClass = this.store.modelFor(this.modelName));
   }

--- a/packages/store/addon/-private/system/model/model.js
+++ b/packages/store/addon/-private/system/model/model.js
@@ -19,7 +19,7 @@ import InternalModel from './internal-model';
 import RootState from './states';
 import { RECORD_DATA_ERRORS, RECORD_DATA_STATE, REQUEST_SERVICE } from '@ember-data/canary-features';
 import coerceId from '../coerce-id';
-import { recordIdentifierFor } from '@ember-data/store';
+import { recordIdentifierFor } from '../store/internal-model-factory';
 import { InvalidError } from '@ember-data/adapter/error';
 
 const { changeProperties } = Ember;

--- a/packages/store/addon/-private/system/store.ts
+++ b/packages/store/addon/-private/system/store.ts
@@ -7,7 +7,7 @@ import { registerWaiter, unregisterWaiter } from '@ember/test';
 import { A } from '@ember/array';
 import EmberError from '@ember/error';
 import { run as emberRunLoop } from '@ember/runloop';
-import { set, get, computed } from '@ember/object';
+import { set, get, computed, defineProperty } from '@ember/object';
 import { getOwner } from '@ember/application';
 import { assign } from '@ember/polyfills';
 import { default as RSVP, all, resolve, Promise, defer } from 'rsvp';
@@ -236,6 +236,22 @@ class Store extends Service {
   */
 
   /**
+  This property returns the adapter, after resolving a possible
+  string key.
+
+  If the supplied `adapter` was a class, or a String property
+  path resolved to a class, this property will instantiate the
+  class.
+
+  This property is cacheable, so the same instance of a specified
+  adapter class should be used for the lifetime of the store.
+
+  @property defaultAdapter
+  @private
+  @return Adapter
+*/
+
+  /**
     @method init
     @private
   */
@@ -305,33 +321,6 @@ class Store extends Service {
       return this._fetchManager.requestCache;
     }
     throw 'RequestService is not available unless the feature flag is on and running on a canary build';
-  }
-
-  /**
-    This property returns the adapter, after resolving a possible
-    string key.
-
-    If the supplied `adapter` was a class, or a String property
-    path resolved to a class, this property will instantiate the
-    class.
-
-    This property is cacheable, so the same instance of a specified
-    adapter class should be used for the lifetime of the store.
-
-    @property defaultAdapter
-    @private
-    @return Adapter
-  */
-  @computed('adapter')
-  get defaultAdapter() {
-    let adapter = this.adapter || '-json-api';
-
-    assert(
-      'You tried to set `adapter` property to an instance of `Adapter`, where it should be a name',
-      typeof adapter === 'string'
-    );
-
-    return this.adapterFor(adapter);
   }
 
   get identifierCache(): IdentifierCache {
@@ -3238,6 +3227,21 @@ class Store extends Service {
     updated.length = 0;
   }
 }
+
+defineProperty(
+  Store.prototype,
+  'defaultAdapter',
+  computed('adapter', function() {
+    let adapter = this.adapter || '-json-api';
+
+    assert(
+      'You tried to set `adapter` property to an instance of `Adapter`, where it should be a name',
+      typeof adapter === 'string'
+    );
+
+    return this.adapterFor(adapter);
+  })
+);
 
 export default Store;
 


### PR DESCRIPTION
`bc0cb5d`: `id setting` was erroneously not tagged as needing to be backported to beta, and it needs to be because it fixes intimate api breakage for addons
