### PR TITLE
[BUGFIX] sync-dev-dependency should not hoist @ember-data/-test-infra

### DIFF
--- a/bin/sync-dev-dependency
+++ b/bin/sync-dev-dependency
@@ -27,10 +27,21 @@ function execWithLog(command) {
   return shellSync(command, { stdio: [0, 1, 2] });
 }
 
+// Remove this ponyfill once fromEntries is supported in min version of node.js
+if (!Object.fromEntries) {
+  Object.fromEntries = require('fromentries');
+}
+
 // gather deps not yet in root
 let rootPackage = require(rootJson);
-const rootUpdates = {};
+let rootUpdates = {};
 const packageJsons = {};
+
+// Write a json object to file
+// Add \n to end of file in accordance with .editorconfig
+function writeJsonToFile(path, json) {
+  return fs.writeFileSync(path, JSON.stringify(json, null, 2) + '\n');
+}
 
 // hoist anything needed to root
 packages.forEach(localName => {
@@ -81,9 +92,15 @@ if (Object.keys(rootUpdates).length > 0) {
   // grab latest in case we wrote in the previous step
   delete require.cache[rootJson];
   rootPackage = require(rootJson);
+
+  // Do not hoist devDependencies in @ember-data namespace
+  // This is a single pass, so should be faster than spread operator or filter/reduce,
+  // especially if fromEntries is supported natiely
+  rootUpdates = Object.fromEntries(Object.entries(rootUpdates).filter(([key]) => !key.startsWith('@ember-data/')));
+
   debug(`Adding staged devDependencies to root: ${JSON.stringify(rootUpdates, null, 2)}`);
   Object.assign(rootPackage.devDependencies, rootUpdates);
-  fs.writeFileSync(rootJson, JSON.stringify(rootPackage, null, 2));
+  writeJsonToFile(rootJson, rootPackage);
 }
 
 // assign root versions to sub-packages and write
@@ -96,7 +113,7 @@ Object.keys(packageJsons).forEach(key => {
     }
   });
 
-  fs.writeFileSync(key, JSON.stringify(pkg, null, 2));
+  writeJsonToFile(key, pkg);
 });
 
 execWithLog(`yarn install`);

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-qunit": "^4.0.0",
     "execa": "^1.0.0",
+    "fromentries": "^1.2.0",
     "git-repo-info": "^2.0.0",
     "github": "^1.1.1",
     "glob": "^7.1.4",
@@ -110,7 +111,12 @@
     "rsvp": "^4.8.5",
     "semver": "^6.2.0",
     "silent-error": "^1.1.1",
-    "typescript": "~3.6.3"
+    "typescript": "~3.6.3",
+    "babel-plugin-debug-macros": "^0.3.3",
+    "babel-plugin-feature-flags": "^0.3.1",
+    "babel-plugin-filter-imports": "^3.0.0",
+    "babel6-plugin-strip-class-callcheck": "^6.0.0",
+    "broccoli-file-creator": "^2.1.1"
   },
   "bin": {
     "test-partner-project": "./bin/test-external-partner-project.js",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -40,7 +40,7 @@
     "@types/ember-qunit": "^3.4.6",
     "@types/ember-test-helpers": "~1.0.5",
     "@types/ember-testing-helpers": "~0.0.3",
-    "@types/ember__debug": "^3.0.3",
+    "@types/ember__debug": "3.0.4",
     "@types/ember__test-helpers": "~0.7.8",
     "@types/qunit": "^2.5.3",
     "@types/rsvp": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,7 +1703,7 @@
   dependencies:
     "@types/ember__object" "*"
 
-"@types/ember__debug@*", "@types/ember__debug@3.0.4", "@types/ember__debug@^3.0.3":
+"@types/ember__debug@*", "@types/ember__debug@3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@types/ember__debug/-/ember__debug-3.0.4.tgz#cdf87a580688a0e3053820eff6f390fbb7ba0e80"
   integrity sha512-jTdLdNGvDn3MhktfskhdxOaDHO09QtQqeh+krI7EDePl2+Xom+KnNeveFeCkzxDkYOa+/R7UNSxW4yN/3YTw3w==
@@ -6223,6 +6223,11 @@ from2@^2.1.0, from2@^2.1.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fromentries@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz#e6aa06f240d6267f913cea422075ef88b63e7897"
+  integrity sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==
 
 fs-extra@^0.24.0:
   version "0.24.0"


### PR DESCRIPTION
Noticed thisi issue while working on #6373

Prevents sync-dev-dependency from hoisting @ember-data/-test-infra

Also ensures newline at end of files in accordance with .editorconfig
Also runs sync-dev-dependency script