### PR TITLE
[BUGFIX BETA RELEASE] ensure commit based versioning passes semver

### DIFF
--- a/bin/-tarball-info.js
+++ b/bin/-tarball-info.js
@@ -136,7 +136,7 @@ packages.forEach(localName => {
   } catch (e) {
     return;
   }
-  const version = `${pkgInfo.version}.${CurrentSha}`;
+  const version = `${pkgInfo.version}-sha.${CurrentSha}`;
   const tarballName = `${convertPackageNameToTarballName(pkgInfo.name)}-${version}.tgz`;
   OurPackages[pkgInfo.name] = {
     location: pkgDir,
@@ -166,7 +166,7 @@ function generatePackageReference(version, tarballName) {
 function insertTarballsToPackageJson(fileLocation, options = {}) {
   const pkgInfo = require(fileLocation);
   if (options.isRelativeTarball) {
-    pkgInfo.version = `${pkgInfo.version}.${CurrentSha}`;
+    pkgInfo.version = `${pkgInfo.version}-sha.${CurrentSha}`;
   }
 
   AllPackages.forEach(packageName => {

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -33,6 +33,7 @@ const projectRoot = path.resolve(__dirname, '../');
 const packagesDir = path.join(projectRoot, './packages');
 const packages = fs.readdirSync(packagesDir);
 const PreviousReleasePattern = /^release-(\d)-(\d+)$/;
+
 let isBugfixRelease = false;
 
 function cleanProject() {


### PR DESCRIPTION
At some point recently `npm` installs began semver validating package versions. The versions we were producing for builds for individual commits failed validation because we required a `-` or ` +` before the sha.

Based on the precedence rules outlined here: https://github.com/semver/semver/blob/master/semver.md

I've updated our versioning from `x.x.x.<SHA>` to `x.x.x+sha.<SHA>`

for beta/canary branches the `-beta` and `-alpha` pre-release identifier will already be present