### PR TITLE
fix: Strip Symbol from production builds (#6389)

### DIFF
--- a/packages/store/addon/-private/system/fetch-manager.ts
+++ b/packages/store/addon/-private/system/fetch-manager.ts
@@ -15,6 +15,7 @@ import RequestCache from './request-cache';
 import { CollectionResourceDocument, SingleResourceDocument } from '../ts-interfaces/ember-data-json-api';
 import { RecordIdentifier } from '../ts-interfaces/identifier';
 import { FindRecordQuery, SaveRecordMutation, Request } from '../ts-interfaces/fetch-manager';
+import { symbol } from '../ts-interfaces/utils/symbol';
 import Store from './store';
 import recordDataFor from './record-data-for';
 
@@ -27,7 +28,7 @@ function payloadIsNotBlank(adapterPayload): boolean {
 }
 
 const emberRun = emberRunLoop.backburner;
-export const SaveOp = Symbol('SaveOp');
+export const SaveOp: unique symbol = symbol('SaveOp');
 
 interface PendingFetchItem {
   identifier: RecordIdentifier;

--- a/packages/store/addon/-private/system/request-cache.ts
+++ b/packages/store/addon/-private/system/request-cache.ts
@@ -7,11 +7,12 @@ import {
   Operation,
   RequestStateEnum,
 } from '../ts-interfaces/fetch-manager';
+import { symbol } from '../ts-interfaces/utils/symbol';
 
 import { _findHasMany, _findBelongsTo, _findAll, _query, _queryRecord } from './store/finders';
 
-const Touching = Symbol('touching');
-export const RequestPromise = Symbol('promise');
+export const Touching: unique symbol = symbol('touching');
+export const RequestPromise: unique symbol = symbol('promise');
 
 export interface InternalRequest extends RequestState {
   [Touching]: RecordIdentifier[];

--- a/packages/store/addon/-private/ts-interfaces/utils/brand.ts
+++ b/packages/store/addon/-private/ts-interfaces/utils/brand.ts
@@ -1,3 +1,5 @@
+import { symbol } from './symbol';
+
 /**
   @module @ember-data/store
 */
@@ -14,4 +16,5 @@
  *
  * @internal
  */
-export const BRAND_SYMBOL = Symbol(`DEBUG-ts-brand`);
+
+export const BRAND_SYMBOL: unique symbol = symbol('DEBUG-ts-brand');

--- a/packages/store/addon/-private/ts-interfaces/utils/symbol.ts
+++ b/packages/store/addon/-private/ts-interfaces/utils/symbol.ts
@@ -1,0 +1,19 @@
+/**
+  @module @ember-data/store
+*/
+
+/**
+ * This symbol provides a Symbol replacement for browsers that do not have it
+ * (eg. IE 11).
+ *
+ * The replacement is different from the native Symbol in some ways. It is a
+ * function that produces an output:
+ * - iterable;
+ * - that is a string, not a symbol.
+ *
+ * @internal
+ */
+export const symbol =
+  typeof Symbol !== 'undefined'
+    ? Symbol
+    : (key: string) => `__${key}${Math.floor(Math.random() * Date.now())}__` as any;


### PR DESCRIPTION
Backports #6389 to beta

* Add a Symbol-like symbol (thank you glimmer-vm)

This is similar to what is implemented here:
https://github.com/glimmerjs/glimmer-vm/blob/72718d0d6ebb2614ec984f51435a44830d410e4c/packages/%40glimmer/reference/lib/validators.ts

* Replace `Symbol`s that may be iterable by `symbol`s

These occurences of Symbol might be replaced by this `symbol`, similar
but different in the sense it is iterable.
