### PR TITLE
[BUGFIX RELEASE] Fix missing @babel/plugin-transform-block-scoping dependency (#6432)

### DIFF
--- a/packages/-build-infra/package.json
+++ b/packages/-build-infra/package.json
@@ -14,6 +14,7 @@
     "test:node": "mocha"
   },
   "dependencies": {
+    "@babel/plugin-transform-block-scoping": "^7.5.5",
     "babel-plugin-debug-macros": "^0.3.2",
     "babel-plugin-feature-flags": "^0.3.1",
     "babel-plugin-filter-imports": "^3.0.0",


### PR DESCRIPTION
backports #6432 to release