### PR TITLE
[BUGFIX beta] Update edition detection logic.

### DIFF
--- a/packages/-build-infra/package.json
+++ b/packages/-build-infra/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@babel/plugin-transform-block-scoping": "^7.6.0",
     "@ember-data/canary-features": "3.14.0-alpha.3",
+    "@ember/edition-utils": "^1.1.1",
     "babel-plugin-debug-macros": "^0.3.3",
     "babel-plugin-feature-flags": "^0.3.1",
     "babel-plugin-filter-imports": "^3.0.0",

--- a/packages/-build-infra/src/utilities/edition-detector.js
+++ b/packages/-build-infra/src/utilities/edition-detector.js
@@ -1,10 +1,11 @@
 'use strict';
 
+const { has } = require('@ember/edition-utils');
 const path = require('path');
 
 module.exports = function(blueprint) {
   blueprint.filesPath = function() {
-    let rootPath = process.env.EMBER_VERSION === 'OCTANE' ? 'native-files' : 'files';
+    let rootPath = has('octane') ? 'native-files' : 'files';
     return path.join(blueprint.root, rootPath);
   };
 

--- a/packages/-test-infra/package.json
+++ b/packages/-test-infra/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {},
   "dependencies": {
+    "@ember/edition-utils": "^1.1.1",
     "ember-cli-blueprint-test-helpers": "^0.19.1"
   },
   "engines": {

--- a/packages/-test-infra/src/node-test-helpers/setup-test-environment.js
+++ b/packages/-test-infra/src/node-test-helpers/setup-test-environment.js
@@ -1,10 +1,12 @@
+const { setEdition, clearEdition } = require('@ember/edition-utils');
+
 function enableOctane() {
   beforeEach(function() {
-    process.env.EMBER_VERSION = 'OCTANE';
+    setEdition('octane');
   });
 
   afterEach(function() {
-    delete process.env.EMBER_VERSION;
+    clearEdition();
   });
 }
 

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@ember-data/-build-infra": "3.14.0-alpha.3",
+    "@ember/edition-utils": "^1.1.1",
     "ember-cli-babel": "^7.11.0",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^3.0.0"

--- a/packages/model/blueprints/model/index.js
+++ b/packages/model/blueprints/model/index.js
@@ -2,6 +2,7 @@ const inflection = require('inflection');
 const stringUtils = require('ember-cli-string-utils');
 const EOL = require('os').EOL;
 const useEditionDetector = require('@ember-data/-build-infra/src/utilities/edition-detector');
+const { has } = require('@ember/edition-utils');
 
 module.exports = useEditionDetector({
   description: 'Generates an ember-data model.',
@@ -65,7 +66,7 @@ module.exports = useEditionDetector({
     if (attrs.length) {
       let attrTransformer, attrSeparator;
 
-      let isOctane = process.env.EMBER_VERSION === 'OCTANE';
+      let isOctane = has('octane');
       if (isOctane) {
         attrTransformer = nativeAttr;
         attrSeparator = ';';

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -24,6 +24,7 @@
     "@ember-data/-build-infra": "3.14.0-alpha.3",
     "@ember-data/canary-features": "3.14.0-alpha.3",
     "@ember-data/store": "3.14.0-alpha.3",
+    "@ember/edition-utils": "^1.1.1",
     "ember-cli-babel": "^7.11.0",
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-test-info": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -740,6 +740,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@ember/edition-utils@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/@ember/edition-utils/-/edition-utils-1.1.1.tgz#d5732c3da593f202e6e1ac6dbee56a758242403f"
+  integrity sha512-GEhri78jdQp/xxPpM6z08KlB0wrHfnfrJ9dmQk7JeQ4XCiMzXsJci7yooQgg/IcTKCM/PxE/IkGCQAo80adMkw==
+
 "@ember/optional-features@^0.7.0":
   version "0.7.0"
   resolved "https://registry.npmjs.org/@ember/optional-features/-/optional-features-0.7.0.tgz#f65a858007020ddfb8342f586112750c32abd2d9"
@@ -5793,7 +5798,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^2.0.0:
+execa@^2.0.0, execa@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/execa/-/execa-2.0.4.tgz#2f5cc589c81db316628627004ea4e37b93391d8e"
   integrity sha512-VcQfhuGD51vQUQtKIq2fjGDLDbL6N1DTQVpYzxZ7LPIXw3HqTuIz6uxRmpV1qf8i31LHf2kjiaGI+GdHwRgbnQ==


### PR DESCRIPTION
[@ember/edition-utils](https://github.com/emberjs/ember-edition-utils)
was created to make it easier to both set and retrieve the current
edition information.

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->