### PR TITLE
Ensure tags start a CI job.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
       - release
       - 'release-*'
       - 'lts-*'
+    tags:
+      - '*'
 
 jobs:
   lint:


### PR DESCRIPTION
Without this change, all pushed tags will *not* do a CI build (because there must be at least one positive match if any filtering is done).

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
