### PR TITLE
Enable qunit/no-ok-equality eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     sourceType: 'module',
   },
   plugins: ['prettier', 'qunit', 'mocha'],
-  extends: ['eslint:recommended', 'prettier'],
+  extends: ['eslint:recommended', 'prettier', 'plugin:qunit/recommended'],
   rules: {
     'mocha/no-exclusive-tests': 'error',
     'prettier/prettier': 'error',
@@ -37,6 +37,14 @@ module.exports = {
     // Tracked in issue https://github.com/emberjs/data/issues/6405
     'no-prototype-builtins': 'off',
     'require-atomic-updates': 'off',
+
+    // eslint-plugin-qunit
+    'qunit/assert-args': 'off',
+    'qunit/literal-compare-order': 'off',
+    'qunit/no-identical-names': 'off',
+    'qunit/no-ok-equality': 'off',
+    'qunit/require-expect': 'off',
+    'qunit/resolve-async': 'off',
   },
   globals: {
     heimdall: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,6 @@ module.exports = {
     'qunit/assert-args': 'off',
     'qunit/literal-compare-order': 'off',
     'qunit/no-identical-names': 'off',
-    'qunit/no-ok-equality': 'off',
     'qunit/require-expect': 'off',
     'qunit/resolve-async': 'off',
   },

--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -340,36 +340,36 @@ module('async belongs-to rendering tests', function(hooks) {
       await settled();
 
       assert.equal(this.element.textContent.trim(), '');
-      assert.ok(shen.get('bestHuman') === null, 'precond - Shen has no best human');
-      assert.ok(pirate.get('bestHuman') === null, 'precond - pirate has no best human');
-      assert.ok(bestDog === null, 'precond - Chris has no best dog');
+      assert.strictEqual(shen.get('bestHuman'), null, 'precond - Shen has no best human');
+      assert.strictEqual(pirate.get('bestHuman'), null, 'precond - pirate has no best human');
+      assert.strictEqual(bestDog, null, 'precond - Chris has no best dog');
 
       chris.set('bestDog', shen);
       bestDog = await chris.get('bestDog');
       await settled();
 
       assert.equal(this.element.textContent.trim(), 'Shen');
-      assert.ok(shen.get('bestHuman') === chris, "scene 1 - Chris is Shen's best human");
-      assert.ok(pirate.get('bestHuman') === null, 'scene 1 - pirate has no best human');
-      assert.ok(bestDog === shen, "scene 1 - Shen is Chris's best dog");
+      assert.strictEqual(shen.get('bestHuman'), chris, "scene 1 - Chris is Shen's best human");
+      assert.strictEqual(pirate.get('bestHuman'), null, 'scene 1 - pirate has no best human');
+      assert.strictEqual(bestDog, shen, "scene 1 - Shen is Chris's best dog");
 
       chris.set('bestDog', pirate);
       bestDog = await chris.get('bestDog');
       await settled();
 
       assert.equal(this.element.textContent.trim(), 'Pirate');
-      assert.ok(shen.get('bestHuman') === null, "scene 2 - Chris is no longer Shen's best human");
-      assert.ok(pirate.get('bestHuman') === chris, 'scene 2 - pirate now has Chris as best human');
-      assert.ok(bestDog === pirate, "scene 2 - Pirate is now Chris's best dog");
+      assert.strictEqual(shen.get('bestHuman'), null, "scene 2 - Chris is no longer Shen's best human");
+      assert.strictEqual(pirate.get('bestHuman'), chris, 'scene 2 - pirate now has Chris as best human');
+      assert.strictEqual(bestDog, pirate, "scene 2 - Pirate is now Chris's best dog");
 
       chris.set('bestDog', null);
       bestDog = await chris.get('bestDog');
       await settled();
 
       assert.equal(this.element.textContent.trim(), '');
-      assert.ok(shen.get('bestHuman') === null, "scene 3 - Chris remains no longer Shen's best human");
-      assert.ok(pirate.get('bestHuman') === null, 'scene 3 - pirate no longer has Chris as best human');
-      assert.ok(bestDog === null, 'scene 3 - Chris has no best dog');
+      assert.strictEqual(shen.get('bestHuman'), null, "scene 3 - Chris remains no longer Shen's best human");
+      assert.strictEqual(pirate.get('bestHuman'), null, 'scene 3 - pirate no longer has Chris as best human');
+      assert.strictEqual(bestDog, null, 'scene 3 - Chris has no best dog');
     });
   });
 
@@ -414,7 +414,7 @@ module('async belongs-to rendering tests', function(hooks) {
 
       await settled();
 
-      assert.ok(newParent === null, 'We no longer have a parent');
+      assert.strictEqual(newParent, null, 'We no longer have a parent');
       assert.equal(
         this.element.textContent.trim(),
         '',
@@ -502,7 +502,7 @@ module('async belongs-to rendering tests', function(hooks) {
 
       try {
         let result = await sedona.get('parent');
-        assert.ok(result === null, 're-access is safe');
+        assert.strictEqual(result, null, 're-access is safe');
       } catch (e) {
         assert.ok(false, `Accessing resulted in rejected promise error: ${e.message}`);
       }

--- a/packages/-ember-data/tests/acceptance/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/has-many-test.js
@@ -265,7 +265,7 @@ module('async has-many rendering tests', function(hooks) {
       this.set('parent', null);
 
       items = this.element.querySelectorAll('li');
-      assert.ok(items.length === 0, 'We have no items');
+      assert.strictEqual(items.length, 0, 'We have no items');
 
       this.set('parent', parent);
 
@@ -388,7 +388,7 @@ module('async has-many rendering tests', function(hooks) {
       this.set('parent', null);
 
       items = this.element.querySelectorAll('li');
-      assert.ok(items.length === 0, 'We have no items');
+      assert.strictEqual(items.length, 0, 'We have no items');
 
       this.set('parent', parent);
 
@@ -543,7 +543,7 @@ module('async has-many rendering tests', function(hooks) {
       this.set('parent', null);
 
       items = this.element.querySelectorAll('li');
-      assert.ok(items.length === 0, 'We have no items');
+      assert.strictEqual(items.length, 0, 'We have no items');
 
       this.set('parent', parent);
 

--- a/packages/-ember-data/tests/integration/adapter/store-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/store-adapter-test.js
@@ -1117,7 +1117,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
 
     let count = 0;
     adapter.findHasMany = function(store, snapshot, link, relationship) {
-      assert.ok(count++ === 0, 'findHasMany is only called once');
+      assert.strictEqual(count++, 0, 'findHasMany is only called once');
 
       return resolve({ data: [{ id: 1, type: 'dog', attributes: { name: 'Scruffy' } }] });
     };

--- a/packages/-ember-data/tests/integration/application-test.js
+++ b/packages/-ember-data/tests/integration/application-test.js
@@ -23,7 +23,7 @@ module('integration/application - Injecting a Custom Store', function(hooks) {
 
   test('If a Store property exists on an Application, it should be instantiated.', async function(assert) {
     let store = this.owner.lookup('service:store');
-    assert.ok(store.isCustom === true, 'the custom store was instantiated');
+    assert.strictEqual(store.isCustom, true, 'the custom store was instantiated');
   });
 
   test('If a store is instantiated, it should be made available to each controller.', async function(assert) {
@@ -90,7 +90,7 @@ module('integration/application - Using the store as a service', function(hooks)
     let secondService = this.owner.lookup('service:second-store');
 
     assert.ok(secondService instanceof Store, 'the store can be used as a service');
-    assert.ok(store !== secondService, 'the store can be used as a service');
+    assert.notStrictEqual(store, secondService, 'the store can be used as a service');
   });
 });
 

--- a/packages/-ember-data/tests/integration/client-id-generation-test.js
+++ b/packages/-ember-data/tests/integration/client-id-generation-test.js
@@ -48,7 +48,7 @@ module('integration - Client Id Generation', function(hooks) {
     let idCount = 1;
 
     adapter.generateIdForRecord = function(passedStore, record) {
-      assert.ok(store === passedStore, 'store is the first parameter');
+      assert.strictEqual(store, passedStore, 'store is the first parameter');
 
       return 'id-' + idCount++;
     };
@@ -94,7 +94,7 @@ module('integration - Client Id Generation', function(hooks) {
     let ids = [undefined, ''];
 
     adapter.generateIdForRecord = function(passedStore, record) {
-      assert.ok(store === passedStore, 'store is the first parameter');
+      assert.strictEqual(store, passedStore, 'store is the first parameter');
 
       return ids[idCount++];
     };

--- a/packages/-ember-data/tests/integration/identifiers/configuration-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/configuration-test.ts
@@ -155,7 +155,7 @@ if (IDENTIFIERS) {
         'Precond: We receive the expected identifier for a new record'
       );
       assert.strictEqual(identifier.id, null, 'Precond: We have no id yet');
-      assert.ok(updateMethodCalls === 0, 'Precond: We have not updated the identifier yet');
+      assert.strictEqual(updateMethodCalls, 0, 'Precond: We have not updated the identifier yet');
       updateCallback = (updatedIdentifier, resource) => {
         assert.strictEqual(identifier, updatedIdentifier, 'We updated the expected identifier');
         assert.strictEqual(resource.attributes!.firstName, 'James', 'We received the expected resource to update with');
@@ -163,7 +163,7 @@ if (IDENTIFIERS) {
 
       await record.save();
 
-      assert.ok(updateMethodCalls === 1, 'We made a single call to our update method');
+      assert.strictEqual(updateMethodCalls, 1, 'We made a single call to our update method');
     });
 
     test(`The configured update method is called when newly created records with an id are committed`, async function(assert) {
@@ -208,7 +208,7 @@ if (IDENTIFIERS) {
         'Precond: We receive the expected identifier for the new record'
       );
       assert.strictEqual(identifier.id, '1', 'Precond: We have an id already');
-      assert.ok(updateMethodCalls === 0, 'Precond: We have not updated the identifier yet');
+      assert.strictEqual(updateMethodCalls, 0, 'Precond: We have not updated the identifier yet');
       updateCallback = (updatedIdentifier, resource) => {
         assert.strictEqual(identifier, updatedIdentifier, 'We updated the expected identifier');
         assert.strictEqual(resource.attributes!.firstName, 'James', 'We received the expected resource to update with');
@@ -216,7 +216,7 @@ if (IDENTIFIERS) {
 
       await record.save();
 
-      assert.ok(updateMethodCalls === 1, 'We made a single call to our update method after save');
+      assert.strictEqual(updateMethodCalls, 1, 'We made a single call to our update method after save');
     });
 
     test(`The configured update method is called when existing records are saved successfully`, async function(assert) {
@@ -271,7 +271,7 @@ if (IDENTIFIERS) {
         'Precond: We receive the expected identifier for the new record'
       );
       assert.strictEqual(identifier.id, '1', 'Precond: We have an id already');
-      assert.ok(updateMethodCalls === 0, 'Precond: We have not updated the identifier yet');
+      assert.strictEqual(updateMethodCalls, 0, 'Precond: We have not updated the identifier yet');
       updateCallback = (updatedIdentifier, resource) => {
         assert.strictEqual(identifier, updatedIdentifier, 'We updated the expected identifier');
         assert.strictEqual(resource.attributes!.firstName, 'Chris', 'We received the expected resource to update with');
@@ -281,7 +281,7 @@ if (IDENTIFIERS) {
 
       await record.save();
 
-      assert.ok(updateMethodCalls === 1, 'We made a single call to our update method after save');
+      assert.strictEqual(updateMethodCalls, 1, 'We made a single call to our update method after save');
     });
 
     test(`The reset method is called when the application is destroyed`, async function(assert) {
@@ -292,7 +292,7 @@ if (IDENTIFIERS) {
       });
 
       run(() => store.destroy());
-      assert.ok(resetMethodCalled, 'We called the reset method when the application was torn down');
+      assert.strictEqual(resetMethodCalled, true, 'called the reset method when the application was torn down');
     });
 
     test(`The forget method called when an identifier is "merged" with another`, async function(assert) {
@@ -329,7 +329,7 @@ if (IDENTIFIERS) {
 
       let testMethod = identifier => {
         forgetMethodCalls++;
-        assert.ok(expectedIdentifier === identifier, `We forgot the expected identifier ${expectedIdentifier}`);
+        assert.strictEqual(expectedIdentifier, identifier, `We forgot the expected identifier ${expectedIdentifier}`);
       };
 
       setIdentifierForgetMethod(identifier => {
@@ -364,8 +364,9 @@ if (IDENTIFIERS) {
       assert.strictEqual(generateLidCalls, 0, 'We generated no new lids when we looked up the final by record');
       assert.strictEqual(forgetMethodCalls, 1, 'We abandoned an identifier');
 
-      assert.ok(
-        finalUserByUsernameIdentifier !== originalUserByUsernameIdentifier,
+      assert.notStrictEqual(
+        finalUserByUsernameIdentifier,
+        originalUserByUsernameIdentifier,
         'We are not using the original identifier by username for the result of findRecord with username'
       );
       assert.strictEqual(
@@ -397,7 +398,7 @@ if (IDENTIFIERS) {
 
       setIdentifierForgetMethod(identifier => {
         forgetMethodCalls++;
-        assert.ok(expectedIdentifier === identifier, `We forgot the expected identifier ${expectedIdentifier}`);
+        assert.strictEqual(expectedIdentifier, identifier, `We forgot the expected identifier ${expectedIdentifier}`);
       });
 
       const user: any = store.push({
@@ -461,7 +462,7 @@ if (IDENTIFIERS) {
       setIdentifierForgetMethod(identifier => {
         forgetMethodCalls++;
         let expectedIdentifier = expectedIdentifiers.shift();
-        assert.ok(expectedIdentifier === identifier, `We forgot the expected identifier ${expectedIdentifier}`);
+        assert.strictEqual(expectedIdentifier, identifier, `We forgot the expected identifier ${expectedIdentifier}`);
       });
 
       // no retainers

--- a/packages/-ember-data/tests/integration/identifiers/lid-reflection-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/lid-reflection-test.ts
@@ -67,7 +67,7 @@ if (IDENTIFIERS) {
         },
       });
 
-      assert.ok(pushedRecord === record, 'We have the same record instance');
+      assert.strictEqual(pushedRecord , record, 'We have the same record instance');
       assert.strictEqual(record.name, 'Chris', 'We use the dirty name');
       assert.strictEqual(record.isNew, false, 'We are no longer in the new state');
 
@@ -125,7 +125,7 @@ if (IDENTIFIERS) {
         },
       });
 
-      assert.ok(pushedRecord === record, 'We have the same record instance');
+      assert.strictEqual(pushedRecord , record, 'We have the same record instance');
       assert.strictEqual(record.name, 'Chris', 'We use the in-flight name');
       assert.strictEqual(record.age, 31, 'We received the pushed data');
       if (RECORD_DATA_STATE) {

--- a/packages/-ember-data/tests/integration/identifiers/new-records-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/new-records-test.ts
@@ -22,7 +22,7 @@ module('Integration | Identifiers - creating new records', function(hooks) {
 
   test(`We can peek before create`, async function(assert) {
     let record = store.peekRecord('user', '1');
-    assert.ok(record === null, 'peekRecord returns null');
+    assert.strictEqual(record, null, 'peekRecord returns null');
 
     try {
       record = store.createRecord('user', { name: 'Chris', id: '1' });
@@ -32,7 +32,8 @@ module('Integration | Identifiers - creating new records', function(hooks) {
 
       assert.strictEqual(identifier.type, 'user', 'We have an identifier with the right type');
       assert.strictEqual(identifier.id, '1', 'We have an identifier with an id');
-      assert.ok(typeof identifier.lid === 'string' && identifier.lid.length > 0, 'We have an identifier with an lid');
+      assert.strictEqual(typeof identifier.lid, 'string', 'lid is a string');
+      assert.ok(identifier.lid.length > 0, 'We have an identifier with an lid');
     } catch (e) {
       assert.ok(false, `Did not expect error: ${e.message}`);
     }

--- a/packages/-ember-data/tests/integration/identifiers/record-identifier-for-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/record-identifier-for-test.ts
@@ -31,7 +31,8 @@ if (IDENTIFIERS) {
 
       assert.strictEqual(identifier.type, 'user', 'We have an identifier with the right type');
       assert.strictEqual(identifier.id, null, 'We have an identifier without an id');
-      assert.ok(typeof identifier.lid === 'string' && identifier.lid.length > 0, 'We have an identifier with an lid');
+      assert.ok(identifier.lid.length > 0, 'We have an identifier with an lid');
+      assert.strictEqual(typeof identifier.lid, 'string', 'lid is a string');
     });
 
     test(`Saving newly created records updates the associated id on the identifier`, async function(assert) {
@@ -61,7 +62,8 @@ if (IDENTIFIERS) {
 
       assert.strictEqual(identifier.type, 'user', 'We have an identifier with the right type');
       assert.strictEqual(identifier.id, null, 'We have an identifier without an id');
-      assert.ok(typeof identifier.lid === 'string' && identifier.lid.length > 0, 'We have an identifier with an lid');
+      assert.ok(identifier.lid.length > 0, 'We have an identifier with an lid');
+      assert.strictEqual(typeof identifier.lid, 'string', 'lid is a string');
 
       await record.save();
 
@@ -69,7 +71,8 @@ if (IDENTIFIERS) {
 
       assert.strictEqual(identifier.type, 'user', 'We have an identifier with the right type');
       assert.strictEqual(identifier.id, '1', 'We updated the identifier with the correct id');
-      assert.ok(typeof identifier.lid === 'string' && identifier.lid.length > 0, 'We have an identifier with an lid');
+      assert.ok(identifier.lid.length > 0, 'We have an identifier with an lid');
+      assert.strictEqual(typeof identifier.lid, 'string', 'lid is a string');
     });
 
     test(`It works for existing records`, async function(assert) {
@@ -87,7 +90,8 @@ if (IDENTIFIERS) {
 
       assert.strictEqual(identifier.type, 'user', 'We have an identifier with the right type');
       assert.strictEqual(identifier.id, '1', 'We have an identifier with the correct id');
-      assert.ok(typeof identifier.lid === 'string' && identifier.lid.length > 0, 'We have an identifier with an lid');
+      assert.ok(identifier.lid.length > 0, 'We have an identifier with an lid');
+      assert.strictEqual(typeof identifier.lid, 'string', 'lid is a string');
     });
 
     // TODO should it also work for promiseRecord and promiseBelongsTo ?

--- a/packages/-ember-data/tests/integration/injection-test.js
+++ b/packages/-ember-data/tests/integration/injection-test.js
@@ -55,7 +55,7 @@ module('integration/injection eager injections', function(hooks) {
     let appleService = this.owner.lookup('service:apple');
 
     assert.ok(apple, `'model:foo' instance should have an 'apple' property`);
-    assert.ok(apple === appleService, `'model:foo.apple' should be the apple service`);
+    assert.strictEqual(apple, appleService, `'model:foo.apple' should be the apple service`);
     assert.ok(apple instanceof Apple, `'model:foo'.apple should be an instance of 'service:apple'`);
   });
 });

--- a/packages/-ember-data/tests/integration/record-array-test.js
+++ b/packages/-ember-data/tests/integration/record-array-test.js
@@ -140,7 +140,7 @@ module('unit/record-array - RecordArray', function(hooks) {
     let recordArray = store.peekAll('Person');
     let otherRecordArray = store.peekAll('person');
 
-    assert.ok(recordArray === otherRecordArray, 'Person and person are the same record-array');
+    assert.strictEqual(recordArray, otherRecordArray, 'Person and person are the same record-array');
 
     store.push({
       data: {
@@ -260,7 +260,7 @@ module('unit/record-array - RecordArray', function(hooks) {
 
     recordArray.addObject(scumbag);
 
-    assert.ok(scumbag.get('tag') === tag, "precond - the scumbag's tag has been set");
+    assert.strictEqual(scumbag.get('tag'), tag, "precond - the scumbag's tag has been set");
     assert.equal(get(recordArray, 'length'), 1, 'precond - record array has one item');
     assert.equal(get(recordArray.objectAt(0), 'name'), 'Scumbag Dale', 'item at index 0 is record with id 1');
 

--- a/packages/-ember-data/tests/integration/records/create-record-test.js
+++ b/packages/-ember-data/tests/integration/records/create-record-test.js
@@ -59,7 +59,7 @@ module('Store.createRecord() coverage', function(hooks) {
     });
 
     // check that we are properly configured
-    assert.ok(pet.get('owner') === chris, 'Precondition: Our owner is Chris');
+    assert.strictEqual(pet.get('owner'), chris, 'Precondition: Our owner is Chris');
 
     let pets = chris
       .get('pets')
@@ -69,7 +69,7 @@ module('Store.createRecord() coverage', function(hooks) {
 
     pet.unloadRecord();
 
-    assert.ok(pet.get('owner') === null, 'Shen no longer has an owner');
+    assert.strictEqual(pet.get('owner'), null, 'Shen no longer has an owner');
 
     // check that the relationship has been dissolved
     pets = chris
@@ -101,7 +101,7 @@ module('Store.createRecord() coverage', function(hooks) {
     });
 
     // check that we are properly configured
-    assert.ok(pet.get('owner') === chris, 'Precondition: Our owner is Chris');
+    assert.strictEqual(pet.get('owner'), chris, 'Precondition: Our owner is Chris');
 
     let pets = chris
       .get('pets')
@@ -111,7 +111,7 @@ module('Store.createRecord() coverage', function(hooks) {
 
     chris.unloadRecord();
 
-    assert.ok(pet.get('owner') === null, 'Shen no longer has an owner');
+    assert.strictEqual(pet.get('owner'), null, 'Shen no longer has an owner');
 
     // check that the relationship has been dissolved
     pets = chris
@@ -185,8 +185,8 @@ module('Store.createRecord() coverage', function(hooks) {
     let bestDog = await chris.get('bestDog');
 
     // check that we are properly configured
-    assert.ok(bestHuman === chris, 'Precondition: Shen has bestHuman as Chris');
-    assert.ok(bestDog === shen, 'Precondition: Chris has Shen as his bestDog');
+    assert.strictEqual(bestHuman, chris, 'Precondition: Shen has bestHuman as Chris');
+    assert.strictEqual(bestDog, shen, 'Precondition: Chris has Shen as his bestDog');
 
     await shen.save();
 
@@ -194,7 +194,7 @@ module('Store.createRecord() coverage', function(hooks) {
     bestDog = await chris.get('bestDog');
 
     // check that the relationship has remained established
-    assert.ok(bestHuman === chris, 'Shen bestHuman is still Chris');
-    assert.ok(bestDog === shen, 'Chris still has Shen as bestDog');
+    assert.strictEqual(bestHuman, chris, 'Shen bestHuman is still Chris');
+    assert.strictEqual(bestDog, shen, 'Chris still has Shen as bestDog');
   });
 });

--- a/packages/-ember-data/tests/integration/records/edit-record-test.js
+++ b/packages/-ember-data/tests/integration/records/edit-record-test.js
@@ -64,7 +64,7 @@ module('Editing a Record', function(hooks) {
         });
 
         // check that we are properly configured
-        assert.ok(pet.get('owner') === null, 'Precondition: Our owner is null');
+        assert.strictEqual(pet.get('owner'), null, 'Precondition: Our owner is null');
 
         let pets = chris
           .get('pets')
@@ -74,7 +74,7 @@ module('Editing a Record', function(hooks) {
 
         pet.set('owner', chris);
 
-        assert.ok(pet.get('owner') === chris, 'Shen has Chris as an owner');
+        assert.strictEqual(pet.get('owner'), chris, 'Shen has Chris as an owner');
 
         // check that the relationship has been established
         pets = chris
@@ -104,7 +104,7 @@ module('Editing a Record', function(hooks) {
         });
 
         // check that we are properly configured
-        assert.ok(pet.get('owner') === null, 'Precondition: Our owner is null');
+        assert.strictEqual(pet.get('owner'), null, 'Precondition: Our owner is null');
 
         let pets = chris
           .get('pets')
@@ -114,7 +114,7 @@ module('Editing a Record', function(hooks) {
 
         pet.set('owner', chris);
 
-        assert.ok(pet.get('owner') === chris, 'Shen has Chris as an owner');
+        assert.strictEqual(pet.get('owner'), chris, 'Shen has Chris as an owner');
 
         // check that the relationship has been established
         pets = chris
@@ -136,7 +136,7 @@ module('Editing a Record', function(hooks) {
         });
 
         // check that we are properly configured
-        assert.ok(pet.get('owner') === null, 'Precondition: Our owner is null');
+        assert.strictEqual(pet.get('owner'), null, 'Precondition: Our owner is null');
 
         let pets = chris
           .get('pets')
@@ -146,7 +146,7 @@ module('Editing a Record', function(hooks) {
 
         pet.set('owner', chris);
 
-        assert.ok(pet.get('owner') === chris, 'Shen has Chris as an owner');
+        assert.strictEqual(pet.get('owner'), chris, 'Shen has Chris as an owner');
 
         // check that the relationship has been established
         pets = chris
@@ -176,7 +176,7 @@ module('Editing a Record', function(hooks) {
         });
 
         // check that we are properly configured
-        assert.ok(pet.get('owner') === null, 'Precondition: Our owner is null');
+        assert.strictEqual(pet.get('owner'), null, 'Precondition: Our owner is null');
 
         let pets = chris
           .get('pets')
@@ -186,7 +186,7 @@ module('Editing a Record', function(hooks) {
 
         pet.set('owner', chris);
 
-        assert.ok(pet.get('owner') === chris, 'Shen has Chris as an owner');
+        assert.strictEqual(pet.get('owner'), chris, 'Shen has Chris as an owner');
 
         // check that the relationship has been established
         pets = chris
@@ -255,14 +255,14 @@ module('Editing a Record', function(hooks) {
           },
         });
 
-        assert.ok(shen.get('owner') === chris, 'Precondition: Chris is the current owner');
-        assert.ok(rocky.get('owner') === chris, 'Precondition: Chris is the current owner');
+        assert.strictEqual(shen.get('owner'), chris, 'Precondition: Chris is the current owner');
+        assert.strictEqual(rocky.get('owner'), chris, 'Precondition: Chris is the current owner');
 
         let pets = chris.pets.toArray().map(pet => pet.name);
         assert.deepEqual(pets, ['Shen', 'Rocky'], 'Precondition: Chris has Shen and Rocky as pets');
 
         shen.set('owner', john);
-        assert.ok(shen.get('owner') === john, 'Precondition: John is the new owner of Shen');
+        assert.strictEqual(shen.get('owner'), john, 'Precondition: John is the new owner of Shen');
 
         pets = chris.pets.toArray().map(pet => pet.name);
         assert.deepEqual(pets, ['Rocky'], 'Precondition: Chris has Rocky as a pet');
@@ -272,8 +272,8 @@ module('Editing a Record', function(hooks) {
 
         chris.unloadRecord();
 
-        assert.ok(rocky.get('owner') === null, 'Rocky has no owner');
-        assert.ok(shen.get('owner') === john, 'John should still be the owner of Shen');
+        assert.strictEqual(rocky.get('owner'), null, 'Rocky has no owner');
+        assert.strictEqual(shen.get('owner'), john, 'John should still be the owner of Shen');
 
         pets = john.pets.toArray().map(pet => pet.name);
         assert.deepEqual(pets, ['Shen'], 'John still has Shen as a pet');
@@ -312,8 +312,8 @@ module('Editing a Record', function(hooks) {
         let chrisBestFriend = await chris.get('bestFriend');
         let jamesBestFriend = await james.get('bestFriend');
 
-        assert.ok(chrisBestFriend === null, 'Precondition: Chris has no best friend');
-        assert.ok(jamesBestFriend === null, 'Precondition: James has no best friend');
+        assert.strictEqual(chrisBestFriend, null, 'Precondition: Chris has no best friend');
+        assert.strictEqual(jamesBestFriend, null, 'Precondition: James has no best friend');
 
         chris.set('bestFriend', james);
 
@@ -321,8 +321,8 @@ module('Editing a Record', function(hooks) {
         chrisBestFriend = await chris.get('bestFriend');
         jamesBestFriend = await james.get('bestFriend');
 
-        assert.ok(chrisBestFriend === james, 'Chris has James as a best friend');
-        assert.ok(jamesBestFriend === chris, 'James has Chris as a best friend');
+        assert.strictEqual(chrisBestFriend, james, 'Chris has James as a best friend');
+        assert.strictEqual(jamesBestFriend, chris, 'James has Chris as a best friend');
       });
 
       test('We can add a new record to a record', async function(assert) {
@@ -348,8 +348,8 @@ module('Editing a Record', function(hooks) {
         let chrisBestFriend = await chris.get('bestFriend');
         let jamesBestFriend = await james.get('bestFriend');
 
-        assert.ok(chrisBestFriend === null, 'Precondition: Chris has no best friend');
-        assert.ok(jamesBestFriend === null, 'Precondition: James has no best friend');
+        assert.strictEqual(chrisBestFriend, null, 'Precondition: Chris has no best friend');
+        assert.strictEqual(jamesBestFriend, null, 'Precondition: James has no best friend');
 
         chris.set('bestFriend', james);
 
@@ -357,8 +357,8 @@ module('Editing a Record', function(hooks) {
         chrisBestFriend = await chris.get('bestFriend');
         jamesBestFriend = await james.get('bestFriend');
 
-        assert.ok(chrisBestFriend === james, 'Chris has James as a best friend');
-        assert.ok(jamesBestFriend === chris, 'James has Chris as a best friend');
+        assert.strictEqual(chrisBestFriend, james, 'Chris has James as a best friend');
+        assert.strictEqual(jamesBestFriend, chris, 'James has Chris as a best friend');
       });
 
       test('We can add a new record to a new record', async function(assert) {
@@ -376,8 +376,8 @@ module('Editing a Record', function(hooks) {
         let chrisBestFriend = await chris.get('bestFriend');
         let jamesBestFriend = await james.get('bestFriend');
 
-        assert.ok(chrisBestFriend === null, 'Precondition: Chris has no best friend');
-        assert.ok(jamesBestFriend === null, 'Precondition: James has no best friend');
+        assert.strictEqual(chrisBestFriend, null, 'Precondition: Chris has no best friend');
+        assert.strictEqual(jamesBestFriend, null, 'Precondition: James has no best friend');
 
         chris.set('bestFriend', james);
 
@@ -385,8 +385,8 @@ module('Editing a Record', function(hooks) {
         chrisBestFriend = await chris.get('bestFriend');
         jamesBestFriend = await james.get('bestFriend');
 
-        assert.ok(chrisBestFriend === james, 'Chris has James as a best friend');
-        assert.ok(jamesBestFriend === chris, 'James has Chris as a best friend');
+        assert.strictEqual(chrisBestFriend, james, 'Chris has James as a best friend');
+        assert.strictEqual(jamesBestFriend, chris, 'James has Chris as a best friend');
       });
 
       test('We can add to a new record', async function(assert) {
@@ -412,8 +412,8 @@ module('Editing a Record', function(hooks) {
         let chrisBestFriend = await chris.get('bestFriend');
         let jamesBestFriend = await james.get('bestFriend');
 
-        assert.ok(chrisBestFriend === null, 'Precondition: Chris has no best friend');
-        assert.ok(jamesBestFriend === null, 'Precondition: James has no best friend');
+        assert.strictEqual(chrisBestFriend, null, 'Precondition: Chris has no best friend');
+        assert.strictEqual(jamesBestFriend, null, 'Precondition: James has no best friend');
 
         chris.set('bestFriend', james);
 
@@ -421,8 +421,8 @@ module('Editing a Record', function(hooks) {
         chrisBestFriend = await chris.get('bestFriend');
         jamesBestFriend = await james.get('bestFriend');
 
-        assert.ok(chrisBestFriend === james, 'Chris has James as a best friend');
-        assert.ok(jamesBestFriend === chris, 'James has Chris as a best friend');
+        assert.strictEqual(chrisBestFriend, james, 'Chris has James as a best friend');
+        assert.strictEqual(jamesBestFriend, chris, 'James has Chris as a best friend');
       });
     });
   });

--- a/packages/-ember-data/tests/integration/records/load-test.js
+++ b/packages/-ember-data/tests/integration/records/load-test.js
@@ -147,8 +147,8 @@ module('integration/load - Loading Records', function(hooks) {
     //  discard the internalModel
     let shen = store.peekRecord('person', '2');
 
-    assert.ok(bestFriend === shen, 'Precond: bestFriend is correct');
-    assert.ok(trueBestFriend === record, 'Precond: bestFriend of bestFriend is correct');
+    assert.strictEqual(bestFriend, shen, 'Precond: bestFriend is correct');
+    assert.strictEqual(trueBestFriend, record, 'Precond: bestFriend of bestFriend is correct');
 
     recordPromise = record.reload();
 

--- a/packages/-ember-data/tests/integration/records/reload-test.js
+++ b/packages/-ember-data/tests/integration/records/reload-test.js
@@ -305,7 +305,7 @@ module('integration/reload - Reloading Records', function(hooks) {
       let owner = shen.get('owner');
       let ownerViaRef = await ownerRef.reload();
 
-      assert.ok(owner === ownerViaRef, 'We received the same reference via reload');
+      assert.strictEqual(owner, ownerViaRef, 'We received the same reference via reload');
     });
 
     test('When a sync belongsTo relationship has not been loaded, it can still be reloaded via the reference', async function(assert) {
@@ -353,7 +353,7 @@ module('integration/reload - Reloading Records', function(hooks) {
       let ownerViaRef = await ownerRef.reload();
       let owner = shen.get('owner');
 
-      assert.ok(owner === ownerViaRef, 'We received the same reference via reload');
+      assert.strictEqual(owner, ownerViaRef, 'We received the same reference via reload');
     });
 
     test('When a sync hasMany relationship has been loaded, it can still be reloaded via the reference', async function(assert) {
@@ -410,7 +410,7 @@ module('integration/reload - Reloading Records', function(hooks) {
       let owners = shen.get('owners');
       let ownersViaRef = await ownersRef.reload();
 
-      assert.ok(owners.objectAt(0) === ownersViaRef.objectAt(0), 'We received the same reference via reload');
+      assert.strictEqual(owners.objectAt(0), ownersViaRef.objectAt(0), 'We received the same reference via reload');
     });
 
     test('When a sync hasMany relationship has not been loaded, it can still be reloaded via the reference', async function(assert) {
@@ -458,7 +458,7 @@ module('integration/reload - Reloading Records', function(hooks) {
       let ownersViaRef = await ownersRef.reload();
       let owners = shen.get('owners');
 
-      assert.ok(owners.objectAt(0) === ownersViaRef.objectAt(0), 'We received the same reference via reload');
+      assert.strictEqual(owners.objectAt(0), ownersViaRef.objectAt(0), 'We received the same reference via reload');
     });
   });
 
@@ -520,7 +520,7 @@ module('integration/reload - Reloading Records', function(hooks) {
       let owner = shen.get('owner');
       let ownerViaRef = await ownerRef.reload();
 
-      assert.ok(owner === ownerViaRef, 'We received the same reference via reload');
+      assert.strictEqual(owner, ownerViaRef, 'We received the same reference via reload');
     });
 
     test('When a sync belongsTo relationship has not been loaded, it can still be reloaded via the reference', async function(assert) {
@@ -571,7 +571,7 @@ module('integration/reload - Reloading Records', function(hooks) {
       let ownerViaRef = await ownerRef.reload();
       let owner = shen.get('owner');
 
-      assert.ok(owner === ownerViaRef, 'We received the same reference via reload');
+      assert.strictEqual(owner, ownerViaRef, 'We received the same reference via reload');
     });
 
     test('When a sync hasMany relationship has been loaded, it can still be reloaded via the reference', async function(assert) {
@@ -633,7 +633,7 @@ module('integration/reload - Reloading Records', function(hooks) {
       let owners = shen.get('owners');
       let ownersViaRef = await ownersRef.reload();
 
-      assert.ok(owners.objectAt(0) === ownersViaRef.objectAt(0), 'We received the same reference via reload');
+      assert.strictEqual(owners.objectAt(0), ownersViaRef.objectAt(0), 'We received the same reference via reload');
     });
 
     test('When a sync hasMany relationship has not been loaded, it can still be reloaded via the reference', async function(assert) {
@@ -686,7 +686,7 @@ module('integration/reload - Reloading Records', function(hooks) {
       let ownersViaRef = await ownersRef.reload();
       let owners = shen.get('owners');
 
-      assert.ok(owners.objectAt(0) === ownersViaRef.objectAt(0), 'We received the same reference via reload');
+      assert.strictEqual(owners.objectAt(0), ownersViaRef.objectAt(0), 'We received the same reference via reload');
     });
   });
 });

--- a/packages/-ember-data/tests/integration/records/rematerialize-test.js
+++ b/packages/-ember-data/tests/integration/records/rematerialize-test.js
@@ -253,7 +253,7 @@ module('integration/unload - Rematerializing Unloaded Records', function(hooks) 
     assert.equal(adam.get('boats.length'), 2, 'boats.length correct after rematerialization');
     assert.equal(rematerializedBoaty.get('id'), '1', 'Rematerialized boat has the right id');
     assert.equal(rematerializedBoaty.get('name'), 'Boaty McBoatface', 'Rematerialized boat has the right name');
-    assert.ok(rematerializedBoaty !== boaty, 'the boat is rematerialized, not recycled');
+    assert.notStrictEqual(rematerializedBoaty, boaty, 'the boat is rematerialized, not recycled');
 
     assert.equal(store.hasRecordForId('boat', '1'), true, 'The boat is loaded');
     assert.equal(

--- a/packages/-ember-data/tests/integration/records/unload-test.js
+++ b/packages/-ember-data/tests/integration/records/unload-test.js
@@ -465,9 +465,9 @@ module('integration/unload - Unloading Records', function(hooks) {
 
     assert.equal(relationshipState.canonicalMembers.size, 1, 'canonical member size should be 1');
     assert.equal(relationshipState.members.size, 1, 'members size should be 1');
-    assert.ok(get(peopleBoats, 'length') === 1, 'Our person has a boat');
-    assert.ok(peopleBoats.objectAt(0) === boat, 'Our person has the right boat');
-    assert.ok(boatPerson === person, 'Our boat has the right person');
+    assert.strictEqual(get(peopleBoats, 'length'), 1, 'Our person has a boat');
+    assert.strictEqual(peopleBoats.objectAt(0), boat, 'Our person has the right boat');
+    assert.strictEqual(boatPerson, person, 'Our boat has the right person');
 
     run(() => {
       store.unloadAll('boat');
@@ -478,7 +478,7 @@ module('integration/unload - Unloading Records', function(hooks) {
     assert.equal(knownBoats.models.length, 0, 'no boat records are loaded');
     assert.equal(relationshipState.canonicalMembers.size, 1, 'canonical member size should still be 1');
     assert.equal(relationshipState.members.size, 1, 'members size should still be 1');
-    assert.ok(get(peopleBoats, 'length') === 0, 'Our person thinks they have no boats');
+    assert.strictEqual(get(peopleBoats, 'length'), 0, 'Our person thinks they have no boats');
 
     run(() =>
       store.push({
@@ -489,8 +489,9 @@ module('integration/unload - Unloading Records', function(hooks) {
     let reloadedBoat = store.peekRecord('boat', '1');
     let reloadedBoatInternalModel = reloadedBoat._internalModel;
 
-    assert.ok(
-      reloadedBoatInternalModel === initialBoatInternalModel,
+    assert.strictEqual(
+      reloadedBoatInternalModel,
+      initialBoatInternalModel,
       'after an unloadAll, subsequent fetch results in the same InternalModel'
     );
   });
@@ -499,8 +500,8 @@ module('integration/unload - Unloading Records', function(hooks) {
     assert.expect(17);
 
     adapter.findRecord = (store, type, id) => {
-      assert.ok(type.modelName === 'boat', 'We refetch the boat');
-      assert.ok(id === '1', 'We refetch the right boat');
+      assert.strictEqual(type.modelName, 'boat', 'We refetch the boat');
+      assert.strictEqual(id, '1', 'We refetch the right boat');
       return resolve({
         data: makeBoatOneForPersonOne(),
       });
@@ -542,9 +543,9 @@ module('integration/unload - Unloading Records', function(hooks) {
 
     assert.equal(relationshipState.canonicalMembers.size, 1, 'canonical member size should be 1');
     assert.equal(relationshipState.members.size, 1, 'members size should be 1');
-    assert.ok(get(peopleBoats, 'length') === 1, 'Our person has a boat');
-    assert.ok(peopleBoats.objectAt(0) === boat, 'Our person has the right boat');
-    assert.ok(boatPerson === person, 'Our boat has the right person');
+    assert.strictEqual(get(peopleBoats, 'length'), 1, 'Our person has a boat');
+    assert.strictEqual(peopleBoats.objectAt(0), boat, 'Our person has the right boat');
+    assert.strictEqual(boatPerson, person, 'Our boat has the right person');
 
     run(() => {
       store.unloadAll('boat');
@@ -555,15 +556,16 @@ module('integration/unload - Unloading Records', function(hooks) {
     assert.equal(knownBoats.models.length, 0, 'no boat records are loaded');
     assert.equal(relationshipState.canonicalMembers.size, 1, 'canonical member size should still be 1');
     assert.equal(relationshipState.members.size, 1, 'members size should still be 1');
-    assert.ok(get(peopleBoats, 'length') === 0, 'Our person thinks they have no boats');
+    assert.strictEqual(get(peopleBoats, 'length'), 0, 'Our person thinks they have no boats');
 
     run(() => person.get('boats'));
 
     let reloadedBoat = store.peekRecord('boat', '1');
     let reloadedBoatInternalModel = reloadedBoat._internalModel;
 
-    assert.ok(
-      reloadedBoatInternalModel === initialBoatInternalModel,
+    assert.strictEqual(
+      reloadedBoatInternalModel,
+      initialBoatInternalModel,
       'after an unloadAll, subsequent fetch results in the same InternalModel'
     );
   });
@@ -605,16 +607,16 @@ module('integration/unload - Unloading Records', function(hooks) {
 
     assert.deepEqual(idsFromOrderedSet(relationshipState.canonicalMembers), ['1'], 'canonical member size should be 1');
     assert.deepEqual(idsFromOrderedSet(relationshipState.members), ['1'], 'members size should be 1');
-    assert.ok(get(peopleBoats, 'length') === 1, 'Our person has a boat');
-    assert.ok(peopleBoats.objectAt(0) === boat, 'Our person has the right boat');
-    assert.ok(boatPerson === person, 'Our boat has the right person');
+    assert.strictEqual(get(peopleBoats, 'length'), 1, 'Our person has a boat');
+    assert.strictEqual(peopleBoats.objectAt(0), boat, 'Our person has the right boat');
+    assert.strictEqual(boatPerson, person, 'Our boat has the right person');
 
     run(() => boat.unloadRecord());
 
     // ensure that our new state is correct
     assert.deepEqual(knownPeople.models.map(m => m.id), ['1'], 'one person record is loaded');
     assert.deepEqual(knownBoats.models.map(m => m.id), ['1'], 'one boat record is known');
-    assert.ok(knownBoats.models[0] === initialBoatInternalModel, 'We still have our boat');
+    assert.strictEqual(knownBoats.models[0], initialBoatInternalModel, 'We still have our boat');
     assert.equal(initialBoatInternalModel.isEmpty(), true, 'Model is in the empty state');
     assert.deepEqual(
       idsFromOrderedSet(relationshipState.canonicalMembers),
@@ -622,7 +624,7 @@ module('integration/unload - Unloading Records', function(hooks) {
       'canonical member size should still be 1'
     );
     assert.deepEqual(idsFromOrderedSet(relationshipState.members), ['1'], 'members size should still be 1');
-    assert.ok(get(peopleBoats, 'length') === 0, 'Our person thinks they have no boats');
+    assert.strictEqual(get(peopleBoats, 'length'), 0, 'Our person thinks they have no boats');
 
     run(() =>
       store.push({
@@ -635,8 +637,9 @@ module('integration/unload - Unloading Records', function(hooks) {
 
     assert.deepEqual(idsFromOrderedSet(relationshipState.canonicalMembers), ['1'], 'canonical member size should be 1');
     assert.deepEqual(idsFromOrderedSet(relationshipState.members), ['1'], 'members size should be 1');
-    assert.ok(
-      reloadedBoatInternalModel === initialBoatInternalModel,
+    assert.strictEqual(
+      reloadedBoatInternalModel,
+      initialBoatInternalModel,
       'after an unloadRecord, subsequent fetch results in the same InternalModel'
     );
 
@@ -656,8 +659,9 @@ module('integration/unload - Unloading Records', function(hooks) {
 
     assert.deepEqual(idsFromOrderedSet(relationshipState.canonicalMembers), ['1'], 'canonical member size should be 1');
     assert.deepEqual(idsFromOrderedSet(relationshipState.members), ['1'], 'members size should be 1');
-    assert.ok(
-      yaBoatInternalModel === initialBoatInternalModel,
+    assert.strictEqual(
+      yaBoatInternalModel,
+      initialBoatInternalModel,
       'after an unloadRecord, subsequent same-loop push results in the same InternalModel'
     );
   });
@@ -880,7 +884,7 @@ module('integration/unload - Unloading Records', function(hooks) {
       assert.equal(record.isDestroying, true, 'the record is destroying');
       assert.equal(internalModel.currentState.stateName, 'root.empty', 'We are unloaded after unloadRecord');
       return store.findRecord('person', '1').then(newRecord => {
-        assert.ok(internalModel === newRecord._internalModel, 'the old internalModel is reused');
+        assert.strictEqual(internalModel, newRecord._internalModel, 'the old internalModel is reused');
         assert.equal(
           newRecord._internalModel.currentState.stateName,
           'root.loaded.saved',
@@ -958,7 +962,7 @@ module('integration/unload - Unloading Records', function(hooks) {
 
       return store.findRecord('person', '1').then(record => {
         assert.equal(record.get('cars.length'), 0, 'Expected relationship to be cleared by the new push');
-        assert.ok(internalModel === record._internalModel, 'the old internalModel is reused');
+        assert.strictEqual(internalModel, record._internalModel, 'the old internalModel is reused');
         assert.equal(
           record._internalModel.currentState.stateName,
           'root.loaded.saved',
@@ -1022,7 +1026,7 @@ module('integration/unload - Unloading Records', function(hooks) {
 
       let wait = store.findRecord('person', '1').then(newRecord => {
         assert.equal(record.isDestroyed, false, 'the record is NOT YET destroyed');
-        assert.ok(newRecord.get('bike') === bike, 'the newRecord should retain knowledge of the bike');
+        assert.strictEqual(newRecord.get('bike'), bike, 'the newRecord should retain knowledge of the bike');
       });
 
       assert.equal(record.isDestroyed, false, 'the record is NOT YET destroyed');

--- a/packages/-ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/integration/relationships/belongs-to-test.js
@@ -113,7 +113,7 @@ module('integration/relationship/belongs-to BelongsTo Relationships (new-style)'
     let personPet = await personPetRequest;
     let pet = await petRequest;
 
-    assert.ok(personPet === pet, 'We ended up in the same state');
+    assert.strictEqual(personPet, pet, 'We ended up in the same state');
   });
 
   test('async belongsTo returns correct new value after a local change', async function(assert) {
@@ -156,30 +156,30 @@ module('integration/relationship/belongs-to BelongsTo Relationships (new-style)'
     let pirate = store.peekRecord('pet', '2');
     let bestDog = await chris.get('bestDog');
 
-    assert.ok(shen.get('bestHuman') === null, 'precond - Shen has no best human');
-    assert.ok(pirate.get('bestHuman') === null, 'precond - pirate has no best human');
-    assert.ok(bestDog === null, 'precond - Chris has no best dog');
+    assert.strictEqual(shen.get('bestHuman'), null, 'precond - Shen has no best human');
+    assert.strictEqual(pirate.get('bestHuman'), null, 'precond - pirate has no best human');
+    assert.strictEqual(bestDog, null, 'precond - Chris has no best dog');
 
     chris.set('bestDog', shen);
     bestDog = await chris.get('bestDog');
 
-    assert.ok(shen.get('bestHuman') === chris, "scene 1 - Chris is Shen's best human");
-    assert.ok(pirate.get('bestHuman') === null, 'scene 1 - pirate has no best human');
-    assert.ok(bestDog === shen, "scene 1 - Shen is Chris's best dog");
+    assert.strictEqual(shen.get('bestHuman'), chris, "scene 1 - Chris is Shen's best human");
+    assert.strictEqual(pirate.get('bestHuman'), null, 'scene 1 - pirate has no best human');
+    assert.strictEqual(bestDog, shen, "scene 1 - Shen is Chris's best dog");
 
     chris.set('bestDog', pirate);
     bestDog = await chris.get('bestDog');
 
-    assert.ok(shen.get('bestHuman') === null, "scene 2 - Chris is no longer Shen's best human");
-    assert.ok(pirate.get('bestHuman') === chris, 'scene 2 - pirate now has Chris as best human');
-    assert.ok(bestDog === pirate, "scene 2 - Pirate is now Chris's best dog");
+    assert.strictEqual(shen.get('bestHuman'), null, "scene 2 - Chris is no longer Shen's best human");
+    assert.strictEqual(pirate.get('bestHuman'), chris, 'scene 2 - pirate now has Chris as best human');
+    assert.strictEqual(bestDog, pirate, "scene 2 - Pirate is now Chris's best dog");
 
     chris.set('bestDog', null);
     bestDog = await chris.get('bestDog');
 
-    assert.ok(shen.get('bestHuman') === null, "scene 3 - Chris remains no longer Shen's best human");
-    assert.ok(pirate.get('bestHuman') === null, 'scene 3 - pirate no longer has Chris as best human');
-    assert.ok(bestDog === null, 'scene 3 - Chris has no best dog');
+    assert.strictEqual(shen.get('bestHuman'), null, "scene 3 - Chris remains no longer Shen's best human");
+    assert.strictEqual(pirate.get('bestHuman'), null, 'scene 3 - pirate no longer has Chris as best human');
+    assert.strictEqual(bestDog, null, 'scene 3 - Chris has no best dog');
   });
 });
 
@@ -702,7 +702,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
         })
         .then(group => {
           assert.ok(group instanceof Group, 'A group object is loaded');
-          assert.ok(group.get('id') === '1', 'It is the group we are expecting');
+          assert.strictEqual(group.get('id'), '1', 'It is the group we are expecting');
         });
     });
   });
@@ -809,7 +809,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
         return person.get('group');
       })
       .then(group => {
-        assert.ok(group === null, 'group should be null');
+        assert.strictEqual(group, null, 'group should be null');
       });
   });
 

--- a/packages/-ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/has-many-test.js
@@ -1045,7 +1045,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function(h
     let reloadedManyArray = await manyArray.reload();
 
     assert.equal(reloadedManyArray.get('isLoaded'), true, 'the third reload worked, comments are loaded again');
-    assert.ok(reloadedManyArray === manyArray, 'the many array stays the same');
+    assert.strictEqual(reloadedManyArray, manyArray, 'the many array stays the same');
     assert.equal(loadingCount, 4, 'We only fired 4 requests');
   });
 

--- a/packages/-ember-data/tests/integration/relationships/json-api-links-test.js
+++ b/packages/-ember-data/tests/integration/relationships/json-api-links-test.js
@@ -164,7 +164,7 @@ module('integration/relationship/json-api-links | Relationship state updates', f
         assert.ok(false, 'adapter findMany called instead of using findRecord');
       },
       findRecord(_, __, id) {
-        assert.ok(id !== '1', `adapter findRecord called for all IDs except "1", called for "${id}"`);
+        assert.notStrictEqual(id, '1', `adapter findRecord called for all IDs except "1", called for "${id}"`);
         return resolve({
           data: {
             type: 'pet',
@@ -230,7 +230,7 @@ module('integration/relationship/json-api-links | Relationship state updates', f
     });
     const Adapter = JSONAPIAdapter.extend({
       findHasMany(_, __, link) {
-        assert.ok(link === './user/1/pets', 'We fetched via the correct link');
+        assert.strictEqual(link, './user/1/pets', 'We fetched via the correct link');
         return resolve({
           data: [
             {
@@ -315,7 +315,7 @@ module('integration/relationship/json-api-links | Relationship state updates', f
     });
     const Adapter = JSONAPIAdapter.extend({
       findHasMany(_, __, link) {
-        assert.ok(link === './user/1/pets', 'We fetched via the correct link');
+        assert.strictEqual(link, './user/1/pets', 'We fetched via the correct link');
         return resolve({
           data: [
             {
@@ -402,7 +402,7 @@ module('integration/relationship/json-api-links | Relationship state updates', f
     });
     const Adapter = JSONAPIAdapter.extend({
       findHasMany(_, __, link) {
-        assert.ok(link === './user/1/pets', 'We fetched via the correct link');
+        assert.strictEqual(link, './user/1/pets', 'We fetched via the correct link');
         return resolve({
           data: [
             {
@@ -491,7 +491,7 @@ module('integration/relationship/json-api-links | Relationship state updates', f
     });
     const Adapter = JSONAPIAdapter.extend({
       findHasMany(_, __, link) {
-        assert.ok(link === './user/1/pets', 'We fetched via the correct link');
+        assert.strictEqual(link, './user/1/pets', 'We fetched via the correct link');
         return resolve({
           data: [
             {
@@ -562,7 +562,7 @@ module('integration/relationship/json-api-links | Relationship state updates', f
     });
     const Adapter = JSONAPIAdapter.extend({
       findHasMany(_, __, link) {
-        assert.ok(link === './user/1/pets', 'We fetched via the correct link');
+        assert.strictEqual(link, './user/1/pets', 'We fetched via the correct link');
         return resolve({
           data: [
             {
@@ -701,7 +701,11 @@ module('integration/relationship/json-api-links | Relationship fetching', functi
         assert.ok(false, 'We should not call findMany');
       };
       adapter.findHasMany = (_, __, link) => {
-        assert.ok(link === payloads.user.data.relationships.pets.links.related, 'We fetched the appropriate link');
+        assert.strictEqual(
+          link,
+          payloads.user.data.relationships.pets.links.related,
+          'We fetched the appropriate link'
+        );
         return resolve(deepCopy(payloads.pets));
       };
 
@@ -732,12 +736,17 @@ module('integration/relationship/json-api-links | Relationship fetching', functi
       };
       adapter.findHasMany = (_, __, link) => {
         if (petRelDataWasEmpty) {
-          assert.ok(
-            link === payloads.user.data.relationships.pets.links.related,
+          assert.strictEqual(
+            link,
+            payloads.user.data.relationships.pets.links.related,
             'We fetched this link even though we really should not have'
           );
         } else {
-          assert.ok(link === payloads.user.data.relationships.pets.links.related, 'We fetched the appropriate link');
+          assert.strictEqual(
+            link,
+            payloads.user.data.relationships.pets.links.related,
+            'We fetched the appropriate link'
+          );
         }
         return resolve(deepCopy(payloads.pets));
       };
@@ -779,7 +788,11 @@ module('integration/relationship/json-api-links | Relationship fetching', functi
           assert.ok(false, 'We should not fetch a relationship we believe is empty');
           didFetchInitially = true;
         } else {
-          assert.ok(link === payloads.user.data.relationships.home.links.related, 'We fetched the appropriate link');
+          assert.strictEqual(
+            link,
+            payloads.user.data.relationships.home.links.related,
+            'We fetched the appropriate link'
+          );
         }
         return resolve(deepCopy(payloads.home));
       };
@@ -815,8 +828,10 @@ module('integration/relationship/json-api-links | Relationship fetching', functi
         assert.ok(false, 'We should not call findMany');
       };
       adapter.findBelongsTo = (_, __, link) => {
-        assert.ok(
-          !homeRelWasEmpty && link === payloads.user.data.relationships.home.links.related,
+        assert.ok(!homeRelWasEmpty, 'home relationship wasnt empty');
+        assert.strictEqual(
+          link,
+          payloads.user.data.relationships.home.links.related,
           'We fetched the appropriate link'
         );
         return resolve(deepCopy(payloads.home));
@@ -985,7 +1000,11 @@ module('integration/relationship/json-api-links | Relationship fetching', functi
         assert.ok(false, 'We should not call findMany');
       };
       adapter.findHasMany = (_, __, link) => {
-        assert.ok(link === payloads.user.data.relationships.pets.links.related, 'We fetched the appropriate link');
+        assert.strictEqual(
+          link,
+          payloads.user.data.relationships.pets.links.related,
+          'We fetched the appropriate link'
+        );
         return resolve(deepCopy(payloads.pets));
       };
 
@@ -1013,7 +1032,11 @@ module('integration/relationship/json-api-links | Relationship fetching', functi
         assert.ok(false, 'We should not call findMany');
       };
       adapter.findHasMany = (_, __, link) => {
-        assert.ok(link === payloads.user.data.relationships.pets.links.related, 'We fetched the appropriate link');
+        assert.strictEqual(
+          link,
+          payloads.user.data.relationships.pets.links.related,
+          'We fetched the appropriate link'
+        );
         return resolve(deepCopy(payloads.pets));
       };
 
@@ -1042,7 +1065,11 @@ module('integration/relationship/json-api-links | Relationship fetching', functi
         assert.ok(false, 'We should not call findMany');
       };
       adapter.findBelongsTo = (_, __, link) => {
-        assert.ok(link === payloads.user.data.relationships.home.links.related, 'We fetched the appropriate link');
+        assert.strictEqual(
+          link,
+          payloads.user.data.relationships.home.links.related,
+          'We fetched the appropriate link'
+        );
         return resolve(deepCopy(payloads.home));
       };
 
@@ -1070,7 +1097,11 @@ module('integration/relationship/json-api-links | Relationship fetching', functi
         assert.ok(false, 'We should not call findMany');
       };
       adapter.findBelongsTo = (_, __, link) => {
-        assert.ok(link === payloads.user.data.relationships.home.links.related, 'We fetched the appropriate link');
+        assert.strictEqual(
+          link,
+          payloads.user.data.relationships.home.links.related,
+          'We fetched the appropriate link'
+        );
         return resolve(deepCopy(payloads.home));
       };
 
@@ -1921,7 +1952,11 @@ module('integration/relationship/json-api-links | Relationship fetching', functi
       if (!requestedUser) {
         assert.ok(false, failureDescription);
       } else {
-        assert.ok(link === requestedUser.data.relationships.pets.links.related, 'We fetched the appropriate link');
+        assert.strictEqual(
+          link,
+          requestedUser.data.relationships.pets.links.related,
+          'We fetched the appropriate link'
+        );
       }
 
       return resolve({

--- a/packages/-ember-data/tests/integration/relationships/one-to-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/one-to-many-test.js
@@ -588,8 +588,8 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
 
     run(function() {
-      assert.ok(account1.get('user') === null, 'User was removed correctly');
-      assert.ok(account2.get('user') === user, 'User was added correctly');
+      assert.strictEqual(account1.get('user'), null, 'User was removed correctly');
+      assert.strictEqual(account2.get('user'), user, 'User was added correctly');
     });
   });
 
@@ -1596,7 +1596,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       assert.equal(user.get('messages.length'), 1, 'The message is added to the record array');
 
       let messageFromArray = user.get('messages.firstObject');
-      assert.ok(message === messageFromArray, 'Only one message record instance should be created');
+      assert.strictEqual(message, messageFromArray, 'Only one message record instance should be created');
     });
   });
 });

--- a/packages/-ember-data/tests/integration/relationships/unload-new-record-test.js
+++ b/packages/-ember-data/tests/integration/relationships/unload-new-record-test.js
@@ -131,29 +131,29 @@ module('Relationships | unloading new records', function(hooks) {
   test('Unloading a sync belongsTo does not force the relationship state to reload', async function(assert) {
     const originalRootNode = entryNode.parent;
 
-    assert.ok(originalRootNode.name === 'root', 'PreCond: We have rootNode set');
+    assert.strictEqual(originalRootNode.name, 'root', 'PreCond: We have rootNode set');
     assert.deepEqual(originalRootNode.children.map(c => c.id), ['2'], 'Precond: Root Node has the correct children');
 
     set(entryNode, 'parent', newNode);
     const value = entryNode.parent;
 
-    assert.ok(value === newNode, 'PreCond: We properly set the sync belongsTo to the new value');
+    assert.strictEqual(value, newNode, 'PreCond: We properly set the sync belongsTo to the new value');
     assert.deepEqual(originalRootNode.children.map(c => c.id), [], 'Precond: Root Node has the correct children');
 
     newNode.unloadRecord();
     await settled();
 
-    assert.ok(entryNode.parent === null, 'Our relationship state is now null');
+    assert.strictEqual(entryNode.parent, null, 'Our relationship state is now null');
     assert.deepEqual(originalRootNode.children.map(c => c.id), [], 'Root Node still has the correct children');
   });
 
   test('Unloading an entry in a sync hasMany does not force the relationship state to reload', async function(assert) {
     assert.deepEqual(entryNode.children.map(c => c.id), ['3'], 'Precond: EntryNode has the correct children');
-    assert.ok(newNode.parent === null, 'PreCond: The new node does not have a parent');
+    assert.strictEqual(newNode.parent, null, 'PreCond: The new node does not have a parent');
 
     set(newNode, 'parent', entryNode);
 
-    assert.ok(newNode.parent === entryNode, 'PreCond: We properly set the sync belongsTo to the new value');
+    assert.strictEqual(newNode.parent, entryNode, 'PreCond: We properly set the sync belongsTo to the new value');
     assert.deepEqual(
       entryNode.children.map(c => c.name),
       ['a child node', 'our newly created node'],
@@ -180,7 +180,7 @@ module('Relationships | unloading new records', function(hooks) {
     let value = await entryNode.relatedGraph;
     originalNodeAsyncEdges = await originalRelatedNode.asyncEdges;
 
-    assert.ok(value === newNode, 'PreCond: We properly set the async belongsTo to the new value');
+    assert.strictEqual(value, newNode, 'PreCond: We properly set the async belongsTo to the new value');
     assert.deepEqual(
       originalNodeAsyncEdges.map(c => c.id),
       [],
@@ -205,7 +205,7 @@ module('Relationships | unloading new records', function(hooks) {
     let value = await newNode.relatedGraph;
     asyncEdges = await entryNode.asyncEdges;
 
-    assert.ok(value === entryNode, 'PreCond: We properly set the async belongsTo to the new value');
+    assert.strictEqual(value, entryNode, 'PreCond: We properly set the async belongsTo to the new value');
     assert.deepEqual(
       asyncEdges.map(c => c.name),
       ['an async edge', 'our newly created node'],

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -398,7 +398,7 @@ module('integration/store - findRecord', function(hooks) {
     run(() => {
       let promiseCar = store.findRecord('car', 1, { reload: true });
 
-      assert.ok(promiseCar.get('model') === undefined, `We don't have early access to local data`);
+      assert.strictEqual(promiseCar.get('model'), undefined, `We don't have early access to local data`);
     });
 
     assert.equal(calls, 2, 'We made a second call to findRecord');

--- a/packages/-ember-data/tests/integration/store/adapter-for-test.js
+++ b/packages/-ember-data/tests/integration/store/adapter-for-test.js
@@ -66,7 +66,7 @@ module('integration/store - adapterFor', function(hooks) {
 
     assert.ok(adapterAgain instanceof AppAdapter, 'We found the correct adapter');
     assert.ok(!didInstantiate, 'We did not instantiate the adapter again');
-    assert.ok(adapter === adapterAgain, 'Repeated calls to adapterFor return the same instance');
+    assert.strictEqual(adapter, adapterAgain, 'Repeated calls to adapterFor return the same instance');
   });
 
   test('multiple stores do not share adapters', async function(assert) {
@@ -92,7 +92,7 @@ module('integration/store - adapterFor', function(hooks) {
     let otherAdapter = otherStore.adapterFor('application');
     assert.ok(otherAdapter instanceof AppAdapter, 'We found the correct adapter again');
     assert.ok(didInstantiate, 'We instantiated the other adapter');
-    assert.ok(otherAdapter !== adapter, 'We have a different adapter instance');
+    assert.notStrictEqual(otherAdapter, adapter, 'We have a different adapter instance');
 
     otherStore.destroy();
   });
@@ -126,7 +126,7 @@ module('integration/store - adapterFor', function(hooks) {
     let appAdapter = store.adapterFor('application');
     assert.ok(appAdapter instanceof AppAdapter, 'We found the correct adapter');
     assert.ok(didInstantiateAppAdapter, 'We instantiated the application adapter');
-    assert.ok(appAdapter !== adapter, 'We have separate adapters');
+    assert.notStrictEqual(appAdapter, adapter, 'We have separate adapters');
   });
 
   test('we fallback to the application adapter when a per-type adapter is not found', async function(assert) {
@@ -150,7 +150,7 @@ module('integration/store - adapterFor', function(hooks) {
     let appAdapter = store.adapterFor('application');
     assert.ok(appAdapter instanceof AppAdapter, 'We found the correct adapter');
     assert.ok(!didInstantiateAppAdapter, 'We did not instantiate the adapter again');
-    assert.ok(appAdapter === adapter, 'We fell back to the application adapter instance');
+    assert.strictEqual(appAdapter, adapter, 'We fell back to the application adapter instance');
   });
 
   test('we can specify a fallback adapter by name in place of the application adapter', async function(assert) {
@@ -181,8 +181,12 @@ module('integration/store - adapterFor', function(hooks) {
     let restAdapter = store.adapterFor('-fallback');
     assert.ok(restAdapter instanceof RestAdapter, 'We found the correct adapter');
     assert.ok(!didInstantiateRestAdapter, 'We did not instantiate the adapter again');
-    assert.ok(restAdapter === adapter, 'We fell back to the -fallback adapter instance for the person adapters');
-    assert.ok(restAdapter === appAdapter, 'We fell back to the -fallback adapter instance for the application adapter');
+    assert.strictEqual(restAdapter, adapter, 'We fell back to the -fallback adapter instance for the person adapters');
+    assert.strictEqual(
+      restAdapter,
+      appAdapter,
+      'We fell back to the -fallback adapter instance for the application adapter'
+    );
   });
 
   test('the application adapter has higher precedence than a fallback adapter defined via store.adapter', async function(assert) {
@@ -219,7 +223,7 @@ module('integration/store - adapterFor', function(hooks) {
     assert.ok(appAdapter instanceof AppAdapter, 'We found the correct adapter for application');
     assert.ok(!didInstantiateRestAdapter, 'We did not instantiate the store fallback adapter');
     assert.ok(!didInstantiateAppAdapter, 'We did not instantiate the application adapter again');
-    assert.ok(appAdapter === adapter, 'We used the application adapter as the person adapter');
+    assert.strictEqual(appAdapter, adapter, 'We used the application adapter as the person adapter');
     didInstantiateRestAdapter = false;
     didInstantiateAppAdapter = false;
 
@@ -227,7 +231,7 @@ module('integration/store - adapterFor', function(hooks) {
     assert.ok(restAdapter instanceof RestAdapter, 'We found the correct adapter for -fallback');
     assert.ok(!didInstantiateAppAdapter, 'We did not instantiate the application adapter again');
     assert.ok(didInstantiateRestAdapter, 'We instantiated the fallback adapter');
-    assert.ok(restAdapter !== appAdapter, `We did not use the application adapter instance`);
+    assert.notStrictEqual(restAdapter, appAdapter, `We did not use the application adapter instance`);
   });
 
   test('When the per-type, application and specified fallback adapters do not exist, we fallback to the -json-api adapter', async function(assert) {
@@ -265,11 +269,16 @@ module('integration/store - adapterFor', function(hooks) {
     let jsonApiAdapter = store.adapterFor('-json-api');
     assert.ok(jsonApiAdapter instanceof JsonApiAdapter, 'We found the correct adapter');
     assert.ok(!didInstantiateAdapter, 'We did not instantiate the adapter again');
-    assert.ok(jsonApiAdapter === appAdapter, 'We fell back to the -json-api adapter instance for application');
-    assert.ok(
-      jsonApiAdapter === fallbackAdapter,
+    assert.strictEqual(jsonApiAdapter, appAdapter, 'We fell back to the -json-api adapter instance for application');
+    assert.strictEqual(
+      jsonApiAdapter,
+      fallbackAdapter,
       'We fell back to the -json-api adapter instance for the fallback -not-a-real-adapter'
     );
-    assert.ok(jsonApiAdapter === adapter, 'We fell back to the -json-api adapter instance for the per-type adapter');
+    assert.strictEqual(
+      jsonApiAdapter,
+      adapter,
+      'We fell back to the -json-api adapter instance for the per-type adapter'
+    );
   });
 });

--- a/packages/-ember-data/tests/integration/store/serializer-for-test.js
+++ b/packages/-ember-data/tests/integration/store/serializer-for-test.js
@@ -95,7 +95,7 @@ module('integration/store - serializerFor', function(hooks) {
 
     assert.ok(serializerAgain instanceof AppSerializer, 'We found the correct serializer');
     assert.ok(!didInstantiate, 'We did not instantiate the serializer again');
-    assert.ok(serializer === serializerAgain, 'Repeated calls to serializerFor return the same instance');
+    assert.strictEqual(serializer, serializerAgain, 'Repeated calls to serializerFor return the same instance');
   });
 
   test('multiple stores do not share serializers', async function(assert) {
@@ -121,7 +121,7 @@ module('integration/store - serializerFor', function(hooks) {
     let otherSerializer = otherStore.serializerFor('application');
     assert.ok(otherSerializer instanceof AppSerializer, 'We found the correct serializer again');
     assert.ok(didInstantiate, 'We instantiated the other serializer');
-    assert.ok(otherSerializer !== serializer, 'We have a different serializer instance');
+    assert.notStrictEqual(otherSerializer, serializer, 'We have a different serializer instance');
 
     otherStore.destroy();
   });
@@ -155,7 +155,7 @@ module('integration/store - serializerFor', function(hooks) {
     let appSerializer = store.serializerFor('application');
     assert.ok(appSerializer instanceof AppSerializer, 'We found the correct serializer');
     assert.ok(didInstantiateAppSerializer, 'We instantiated the application serializer');
-    assert.ok(appSerializer !== serializer, 'We have separate serializers');
+    assert.notStrictEqual(appSerializer, serializer, 'We have separate serializers');
   });
 
   test('we fallback to the application serializer when a per-type serializer is not found', async function(assert) {
@@ -179,7 +179,7 @@ module('integration/store - serializerFor', function(hooks) {
     let appSerializer = store.serializerFor('application');
     assert.ok(appSerializer instanceof AppSerializer, 'We found the correct serializer');
     assert.ok(!didInstantiateAppSerializer, 'We did not instantiate the serializer again');
-    assert.ok(appSerializer === serializer, 'We fell back to the application serializer instance');
+    assert.strictEqual(appSerializer, serializer, 'We fell back to the application serializer instance');
   });
 
   module('Adapter Fallback', function() {
@@ -219,7 +219,7 @@ module('integration/store - serializerFor', function(hooks) {
       assert.ok(fallbackSerializer instanceof FallbackSerializer, 'We found the correct serializer');
       assert.ok(!fallbackSerializerDidInit, 'We did not instantiate the serializer again');
       assert.ok(!personAdapterDidInit, 'We did not instantiate the adapter again');
-      assert.ok(fallbackSerializer === serializer, 'We fell back to the fallback-serializer instance');
+      assert.strictEqual(fallbackSerializer, serializer, 'We fell back to the fallback-serializer instance');
     });
 
     test('specifying defaultSerializer on application serializer when there is a per-type serializer does not work', async function(assert) {
@@ -288,7 +288,7 @@ module('integration/store - serializerFor', function(hooks) {
       assert.ok(!appAdapterDidInit, 'We did not instantiate the application adapter');
       assert.ok(!fallbackSerializerDidInit, 'We did not instantiate the application adapter fallback serializer');
       assert.ok(!personAdapterDidInit, 'We did not instantiate the adapter again');
-      assert.ok(defaultSerializer === serializer, 'We fell back to the fallback-serializer instance');
+      assert.strictEqual(defaultSerializer, serializer, 'We fell back to the fallback-serializer instance');
     });
 
     test('specifying defaultSerializer on a fallback serializer when there is no per-type serializer does work', async function(assert) {
@@ -342,7 +342,7 @@ module('integration/store - serializerFor', function(hooks) {
       assert.ok(!defaultSerializerDidInit, 'We did not instantiate the default serializer');
       assert.ok(!appAdapterDidInit, 'We did not instantiate the application adapter again');
       assert.ok(!fallbackSerializerDidInit, 'We did not instantiate the application adapter fallback serializer again');
-      assert.ok(fallbackSerializer === serializer, 'We fell back to the fallback-serializer instance');
+      assert.strictEqual(fallbackSerializer, serializer, 'We fell back to the fallback-serializer instance');
     });
   });
 
@@ -403,16 +403,19 @@ module('integration/store - serializerFor', function(hooks) {
     assert.ok(defaultSerializer instanceof DefaultSerializer, 'We found the correct serializer');
     assert.ok(!defaultSerializerDidInit, 'We did not instantiate the default serializer again');
     assert.ok(!appAdapterDidInit, 'We did not instantiate the application adapter again');
-    assert.ok(
-      defaultSerializer === serializer,
+    assert.strictEqual(
+      defaultSerializer,
+      serializer,
       'We fell back to the -default serializer instance for the per-type serializer'
     );
-    assert.ok(
-      defaultSerializer === appSerializer,
+    assert.strictEqual(
+      defaultSerializer,
+      appSerializer,
       'We fell back to the -default serializer instance for the application serializer'
     );
-    assert.ok(
-      defaultSerializer === fallbackSerializer,
+    assert.strictEqual(
+      defaultSerializer,
+      fallbackSerializer,
       'We fell back to the -default serializer instance for the adapter defaultSerializer'
     );
   });

--- a/packages/-ember-data/tests/test-helper.js
+++ b/packages/-ember-data/tests/test-helper.js
@@ -51,11 +51,11 @@ assert.assertClean = function(promise) {
 };
 
 assert.contains = function(array, item) {
-  this.ok(array.indexOf(item) !== -1, `array contains ${item}`);
+  this.notStrictEqual(array.indexOf(item), -1, `array contains ${item}`);
 };
 
 assert.without = function(array, item) {
-  this.ok(array.indexOf(item) === -1, `array doesn't contain ${item}`);
+  this.strictEqual(array.indexOf(item), -1, `array doesn't contain ${item}`);
 };
 
 QUnit.config.testTimeout = 2000;

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -90,10 +90,11 @@ module('unit/model - Model', function(hooks) {
 
       let currentState = record._internalModel.currentState;
 
-      assert.ok(currentState.stateName === 'root.deleted.saved', 'record is in a persisted deleted state');
+      assert.strictEqual(currentState.stateName, 'root.deleted.saved', 'record is in a persisted deleted state');
       assert.equal(get(record, 'isDeleted'), true);
-      assert.ok(
-        store.peekRecord('person', '1') !== null,
+      assert.notStrictEqual(
+        store.peekRecord('person', '1'),
+        null,
         'the deleted person is not removed from store (no unload called)'
       );
 
@@ -109,9 +110,9 @@ module('unit/model - Model', function(hooks) {
 
       currentState = record._internalModel.currentState;
 
-      assert.ok(currentState.stateName === 'root.deleted.saved', 'record is still in a persisted deleted state');
-      assert.ok(get(record, 'isDeleted') === true, 'The record is still deleted');
-      assert.ok(get(record, 'isArchived') === true, 'The record reflects the update to canonical state');
+      assert.strictEqual(currentState.stateName, 'root.deleted.saved', 'record is still in a persisted deleted state');
+      assert.strictEqual(get(record, 'isDeleted'), true, 'The record is still deleted');
+      assert.strictEqual(get(record, 'isArchived'), true, 'The record reflects the update to canonical state');
     });
 
     test('Does not support dirtying in root.deleted.saved', async function(assert) {
@@ -133,10 +134,11 @@ module('unit/model - Model', function(hooks) {
 
       let currentState = record._internalModel.currentState;
 
-      assert.ok(currentState.stateName === 'root.deleted.saved', 'record is in a persisted deleted state');
+      assert.strictEqual(currentState.stateName, 'root.deleted.saved', 'record is in a persisted deleted state');
       assert.equal(get(record, 'isDeleted'), true);
-      assert.ok(
-        store.peekRecord('person', '1') !== null,
+      assert.notStrictEqual(
+        store.peekRecord('person', '1'),
+        null,
         'the deleted person is not removed from store (no unload called)'
       );
 
@@ -146,9 +148,9 @@ module('unit/model - Model', function(hooks) {
 
       currentState = record._internalModel.currentState;
 
-      assert.ok(currentState.stateName === 'root.deleted.saved', 'record is still in a persisted deleted state');
-      assert.ok(get(record, 'isDeleted') === true, 'The record is still deleted');
-      assert.ok(get(record, 'isArchived') === false, 'The record reflects canonical state');
+      assert.strictEqual(currentState.stateName, 'root.deleted.saved', 'record is still in a persisted deleted state');
+      assert.strictEqual(get(record, 'isDeleted'), true, 'The record is still deleted');
+      assert.strictEqual(get(record, 'isArchived'), false, 'The record reflects canonical state');
     });
 
     test('currentState is accessible when the record is created', async function(assert) {
@@ -295,7 +297,7 @@ module('unit/model - Model', function(hooks) {
 
       let record = store.peekRecord('person', 'john');
 
-      assert.ok(person === record, 'The cache has an entry for john');
+      assert.strictEqual(person, record, 'The cache has an entry for john');
     });
 
     test('setting the id after createRecord should correctly update the id', async function(assert) {
@@ -309,7 +311,7 @@ module('unit/model - Model', function(hooks) {
 
       let record = store.peekRecord('person', 'john');
 
-      assert.ok(person === record, 'The cache has an entry for john');
+      assert.strictEqual(person, record, 'The cache has an entry for john');
     });
 
     testInDebug('mutating the id after createRecord but before save works', async function(assert) {
@@ -327,8 +329,8 @@ module('unit/model - Model', function(hooks) {
       let chris = store.peekRecord('person', 'chris');
       let john = store.peekRecord('person', 'john');
 
-      assert.ok(chris === person, 'The cache still has an entry for chris');
-      assert.ok(john === null, 'The cache has no entry for john');
+      assert.strictEqual(chris, person, 'The cache still has an entry for chris');
+      assert.strictEqual(john, null, 'The cache has no entry for john');
     });
 
     test('updating the id with store.setRecordId should work correctly when the id property is watched', async function(assert) {
@@ -898,7 +900,7 @@ module('unit/model - Model', function(hooks) {
 
         init() {
           this._super(...arguments);
-          assert.ok(this.get('name') === 'bam!', 'We all good here');
+          assert.strictEqual(this.get('name'), 'bam!', 'We all good here');
         },
       });
       this.owner.register('model:odd-person', Person);

--- a/packages/-ember-data/tests/unit/model/init-properties-test.js
+++ b/packages/-ember-data/tests/unit/model/init-properties-test.js
@@ -59,8 +59,8 @@ module('unit/model - init properties', function(hooks) {
     let author;
 
     function testState(types, record) {
-      assert.ok(get(record, 'title') === 'My Post', 'Attrs are available as expected');
-      assert.ok(get(record, 'randomProp') === 'An unknown prop', 'Unknown properties are available as expected');
+      assert.strictEqual(get(record, 'title'), 'My Post', 'Attrs are available as expected');
+      assert.strictEqual(get(record, 'randomProp'), 'An unknown prop', 'Unknown properties are available as expected');
       assert.ok(get(record, 'author') instanceof types.Author, 'belongsTo relationships are available as expected');
       assert.ok(
         get(record, 'comments.firstObject') instanceof types.Comment,
@@ -105,7 +105,7 @@ module('unit/model - init properties', function(hooks) {
     assert.expect(3);
 
     function testState(types, record) {
-      assert.ok(get(record, 'title') === 'My Post', 'Attrs are available as expected');
+      assert.strictEqual(get(record, 'title'), 'My Post', 'Attrs are available as expected');
       assert.ok(get(record, 'author') instanceof types.Author, 'belongsTo relationships are available as expected');
       assert.ok(
         get(record, 'comments.firstObject') instanceof types.Comment,
@@ -156,7 +156,7 @@ module('unit/model - init properties', function(hooks) {
     assert.expect(3);
 
     function testState(types, record) {
-      assert.ok(get(record, 'title') === 'My Post', 'Attrs are available as expected');
+      assert.strictEqual(get(record, 'title'), 'My Post', 'Attrs are available as expected');
       assert.ok(get(record, 'author') instanceof types.Author, 'belongsTo relationships are available as expected');
       assert.ok(
         get(record, 'comments.firstObject') instanceof types.Comment,
@@ -209,7 +209,7 @@ module('unit/model - init properties', function(hooks) {
     assert.expect(3);
 
     function testState(types, record) {
-      assert.ok(get(record, 'title') === 'My Post', 'Attrs are available as expected');
+      assert.strictEqual(get(record, 'title'), 'My Post', 'Attrs are available as expected');
       assert.ok(get(record, 'author') instanceof types.Author, 'belongsTo relationships are available as expected');
       assert.ok(
         get(record, 'comments.firstObject') instanceof types.Comment,

--- a/packages/-ember-data/tests/unit/model/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/unit/model/relationships/has-many-test.js
@@ -1629,7 +1629,7 @@ module('unit/model/relationships - DS.hasMany', function(hooks) {
     const shen = store.peekRecord('dog', '1');
     const rambo = store.peekRecord('dog', '2');
 
-    assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
+    assert.strictEqual(dog, shen, 'precond - the belongsTo points to the correct dog');
     assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
 
     run(() => {
@@ -1711,20 +1711,20 @@ module('unit/model/relationships - DS.hasMany', function(hooks) {
       const rambo = store.peekRecord('dog', '2');
 
       return person.get('dog').then(dog => {
-        assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
+        assert.strictEqual(dog, shen, 'precond - the belongsTo points to the correct dog');
         assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
 
         person.set('dog', rambo);
 
         dog = person.get('dog.content');
 
-        assert.ok(dog === rambo, 'precond2 - relationship was updated');
+        assert.strictEqual(dog, rambo, 'precond2 - relationship was updated');
 
         return shen.destroyRecord({}).then(() => {
           shen.unloadRecord();
 
           dog = person.get('dog.content');
-          assert.ok(dog === rambo, 'The currentState of the belongsTo was preserved after the delete');
+          assert.strictEqual(dog, rambo, 'The currentState of the belongsTo was preserved after the delete');
         });
       });
     });
@@ -1791,7 +1791,7 @@ module('unit/model/relationships - DS.hasMany', function(hooks) {
     const shen = store.peekRecord('dog', '1');
     const rambo = store.peekRecord('dog', '2');
 
-    assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
+    assert.strictEqual(dog, shen, 'precond - the belongsTo points to the correct dog');
     assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
 
     run(() => {

--- a/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
+++ b/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
@@ -578,7 +578,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function(ho
         assert.equal(dog.get('isError'), false, 'must not be error after `rollbackAttributes`');
         assert.equal(dog.get('isDeleted'), false, 'must not be deleted after `rollbackAttributes`');
         assert.equal(dog.get('isValid'), true, 'must be valid after `rollbackAttributes`');
-        assert.ok(dog.get('errors.length') === 0, 'must not have errors');
+        assert.strictEqual(dog.get('errors.length'), 0, 'must not have errors');
       });
     });
   });

--- a/packages/-ember-data/tests/unit/store/unload-test.js
+++ b/packages/-ember-data/tests/unit/store/unload-test.js
@@ -112,12 +112,12 @@ module('unit/store/unload - Store unloading records', function(hooks) {
   test('unload followed by create of the same type + id', function(assert) {
     let record = store.createRecord('record', { id: 1 });
 
-    assert.ok(store.recordForId('record', 1) === record, 'record should exactly equal');
+    assert.strictEqual(store.recordForId('record', 1), record, 'record should exactly equal');
 
     return run(() => {
       record.unloadRecord();
       let createdRecord = store.createRecord('record', { id: 1 });
-      assert.ok(record !== createdRecord, 'newly created record is fresh (and was created)');
+      assert.notStrictEqual(record, createdRecord, 'newly created record is fresh (and was created)');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5793,7 +5793,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^2.0.0:
+execa@^2.0.0, execa@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/execa/-/execa-2.0.4.tgz#2f5cc589c81db316628627004ea4e37b93391d8e"
   integrity sha512-VcQfhuGD51vQUQtKIq2fjGDLDbL6N1DTQVpYzxZ7LPIXw3HqTuIz6uxRmpV1qf8i31LHf2kjiaGI+GdHwRgbnQ==


### PR DESCRIPTION

Needs #6476 

https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-ok-equality.md

> Equality comparisons in assert.ok or assert.notOk calls are not valuable because if the assertion fails, QUnit cannot reveal any comparison information. Instead, developers should use assert.equal, assert.strictEqual, assert.notEqual, or assert.notStrictEqual to allow QUnit to track the expected and actual values and show a useful diff. This makes test output much easier to read.

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
