### PR TITLE
[CHORE] Use `ember-data` without `@ember-data/debug`

### DIFF
--- a/packages/-ember-data/addon/-private/system/debug/debug-adapter.js
+++ b/packages/-ember-data/addon/-private/system/debug/debug-adapter.js
@@ -1,7 +1,6 @@
 /**
   @module ember-data
 */
-import { getOwner } from '@ember/application';
 import { addObserver, removeObserver } from '@ember/object/observers';
 import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
@@ -20,14 +19,6 @@ import Model from '@ember-data/model';
 */
 export default DataAdapter.extend({
   store: service('store'),
-
-  init() {
-    this._super(...arguments);
-    let owner = getOwner(this.get('store'));
-    if (!owner.hasRegistration('data-adapter:main')) {
-      owner.register('data-adapter:main', this);
-    }
-  },
 
   /**
     Specifies how records can be filtered based on the state of the record

--- a/packages/-ember-data/addon/-private/system/debug/debug-adapter.js
+++ b/packages/-ember-data/addon/-private/system/debug/debug-adapter.js
@@ -1,8 +1,9 @@
 /**
   @module ember-data
 */
+import { getOwner } from '@ember/application';
 import { addObserver, removeObserver } from '@ember/object/observers';
-
+import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
 import DataAdapter from '@ember/debug/data-adapter';
 import { capitalize, underscore } from '@ember/string';
@@ -18,6 +19,16 @@ import Model from '@ember-data/model';
   @private
 */
 export default DataAdapter.extend({
+  store: service('store'),
+
+  init() {
+    this._super(...arguments);
+    let owner = getOwner(this.get('store'));
+    if (!owner.hasRegistration('data-adapter:main')) {
+      owner.register('data-adapter:main', this);
+    }
+  },
+
   /**
     Specifies how records can be filtered based on the state of the record
     Records returned will need to have a `filterValues`

--- a/packages/-ember-data/addon/setup-container.js
+++ b/packages/-ember-data/addon/setup-container.js
@@ -1,4 +1,3 @@
-import { DebugAdapter } from './-private';
 import { deprecate } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import Store from '@ember-data/store';
@@ -41,19 +40,13 @@ function initializeStore(application) {
   }
 }
 
-function initializeDataAdapter(application) {
-  application.register('data-adapter:main', DebugAdapter);
-}
-
 function initializeStoreInjections(application) {
   let inject = application.inject || application.injection;
   inject.call(application, 'controller', 'store', 'service:store');
   inject.call(application, 'route', 'store', 'service:store');
-  inject.call(application, 'data-adapter', 'store', 'service:store');
 }
 
 export default function setupContainer(application) {
-  initializeDataAdapter(application);
   initializeStoreInjections(application);
   initializeStore(application);
 }

--- a/packages/-ember-data/app/debug-adapter.js
+++ b/packages/-ember-data/app/debug-adapter.js
@@ -1,0 +1,1 @@
+export { default as DebugAdapter } from 'ember-data/system/debug/debug-adapter';

--- a/packages/debug/README.md
+++ b/packages/debug/README.md
@@ -1,6 +1,6 @@
 # @ember-data/debug
 
-Provides developer ergonomics and dev-mode enhancements for apps built with EmberData
+Provides developer ergonomics and dev-mode enhancements for apps built with EmberData including a DataAdapter for ember-inspector support
 
 ## Compatibility
 


### PR DESCRIPTION
Provides the DataAdapter for the ember-inspector

- [x] refactor to use service injection, kill initializer injection
- [x] refactor to manage own registration
- [ ] `detect` should not require `Model`
- [ ] stop automatically shipping to production (ship by config only)
- [ ] Add Encapsulation Test

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
