### PR TITLE
[CHORE/TESTS] Use strictEqual for identifiers/cache test

### DIFF
--- a/packages/-ember-data/tests/integration/identifiers/cache-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/cache-test.ts
@@ -44,7 +44,7 @@ if (IDENTIFIERS) {
         const cache = identifierCacheFor(store);
         const identifier = cache.getOrCreateRecordIdentifier(houseHash);
 
-        assert.equal(
+        assert.strictEqual(
           identifier,
           cache.getOrCreateRecordIdentifier(identifier),
           'getOrCreateRecordIdentifier() return identifier'


### PR DESCRIPTION
Instead of the more permissive `assert.equal`.

This is a follow-up of https://github.com/emberjs/data/pull/6428