### PR TITLE
[CHORE] Replace Travis CI badge with GitHub CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ember-data
 ==============================================================================
 
-[![Build Status](https://secure.travis-ci.org/emberjs/data.svg?branch=master)](http://travis-ci.org/emberjs/data)
+[![Build Status](https://github.com/emberjs/data/workflows/CI/badge.svg)](https://github.com/emberjs/data/actions?workflow=CI)
 [![Code Climate](https://codeclimate.com/github/emberjs/data/badges/gpa.svg)](https://codeclimate.com/github/emberjs/data)
 [![Discord Community Server](https://img.shields.io/discord/480462759797063690.svg?logo=discord)](https://discord.gg/zT3asNS)
 


### PR DESCRIPTION
Part of https://github.com/emberjs/data/issues/6282

Replaces the Travis CI build status badge in the README with the one for GitHub Actions.

[Preview README with new badge](https://github.com/emberjs/data/blob/411db0bbee6149dbe1acabe40f9f7eba42297c6d/README.md)