### PR TITLE
[CHORE] Configure @typescript-eslint for linting TypeScript files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,7 +58,6 @@ module.exports = {
       plugins: ['@typescript-eslint'],
       extends: ['eslint:recommended', 'plugin:@typescript-eslint/eslint-recommended'],
       rules: {
-        'no-console': 'off',
         'no-empty': 'off',
         'no-extra-semi': 'off',
         'no-unused-vars': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,27 @@ module.exports = {
     node: false,
   },
   overrides: [
+    // TypeScript files
+    {
+      files: ['**/*.ts'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        sourceType: 'module',
+      },
+      plugins: ['@typescript-eslint'],
+      extends: ['eslint:recommended', 'plugin:@typescript-eslint/eslint-recommended'],
+      rules: {
+        'no-console': 'off',
+        'no-empty': 'off',
+        'no-empty-pattern': 'off',
+        'no-extra-semi': 'off',
+        'no-prototype-builtins': 'off',
+        'no-unused-vars': 'off',
+        'prettier/prettier': 'off',
+        'require-atomic-updates': 'off',
+      },
+    },
+
     // node files
     {
       files: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,7 @@ module.exports = {
       plugins: ['@typescript-eslint'],
       extends: ['eslint:recommended', 'plugin:@typescript-eslint/eslint-recommended'],
       rules: {
+        '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
         'no-unused-vars': 'off',
         'require-atomic-updates': 'off',
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,9 +58,7 @@ module.exports = {
       plugins: ['@typescript-eslint'],
       extends: ['eslint:recommended', 'plugin:@typescript-eslint/eslint-recommended'],
       rules: {
-        'no-extra-semi': 'off',
         'no-unused-vars': 'off',
-        'prettier/prettier': 'off',
         'require-atomic-updates': 'off',
       },
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,7 +60,6 @@ module.exports = {
       rules: {
         'no-console': 'off',
         'no-empty': 'off',
-        'no-empty-pattern': 'off',
         'no-extra-semi': 'off',
         'no-unused-vars': 'off',
         'prettier/prettier': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,6 @@ module.exports = {
         'no-empty': 'off',
         'no-empty-pattern': 'off',
         'no-extra-semi': 'off',
-        'no-prototype-builtins': 'off',
         'no-unused-vars': 'off',
         'prettier/prettier': 'off',
         'require-atomic-updates': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,7 +58,6 @@ module.exports = {
       plugins: ['@typescript-eslint'],
       extends: ['eslint:recommended', 'plugin:@typescript-eslint/eslint-recommended'],
       rules: {
-        'no-empty': 'off',
         'no-extra-semi': 'off',
         'no-unused-vars': 'off',
         'prettier/prettier': 'off',

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,8 @@ jobs:
         run: yarn --frozen-lockfile
       - name: Lint features
         run: yarn lint:features
-      - name: Lint prettier
-        run: yarn lint:prettier
+      - name: Lint js
+        run: yarn lint:js
       - name: Check for TypeScript problems
         run: yarn problems
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       if: NOT tag IS present AND NOT (branch ~= /^(emberjs:release|emberjs:lts|release|lts).*/)
       script:
         - yarn lint:features
-        - yarn lint:prettier
+        - yarn lint:js
         - yarn problems
     - name: 'Basic Tests'
       script: yarn test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
           yarn --frozen-lockfile
           yarn lint:features
       - script: |
-          yarn lint:prettier
+          yarn lint:js
       - script: |
           yarn problems
         displayName: 'Lint'

--- a/bin/lint-changed-js
+++ b/bin/lint-changed-js
@@ -31,7 +31,10 @@ if (LIST) {
       eslintInfo.extends.push('plugin:qunit/recommended');
       fs.writeFileSync(tmpEslint, `module.exports = ${JSON.stringify(eslintInfo)}`);
       // execut the linter with additional qunit rules
-      execa.sync(`yarn eslint --config ${tmpEslint} ${LIST}`, { stdio: 'inherit', shell: true });
+      execa.sync(`yarn eslint --config ${tmpEslint} --ext=js,ts ${LIST}`, {
+        stdio: 'inherit',
+        shell: true
+      });
     } catch (e) {
       unlinkTemp();
       console.log(e);

--- a/package.json
+++ b/package.json
@@ -5,16 +5,16 @@
     "packages/*"
   ],
   "pre-commit": [
-    "lint:js"
+    "lint:js:changed"
   ],
   "scripts": {
     "add-dev": "./bin/add-dev-dependency",
     "sync-dev": "./bin/sync-dev-dependency",
     "build": "yarn workspace ember-data build",
     "build:production": "yarn workspace ember-data build:production",
-    "lint:js": "./bin/lint-js",
-    "lint:prettier": "eslint --plugin prettier --cache .",
     "lint:features": "./bin/lint-features",
+    "lint:js": "eslint --cache --ext=js,ts .",
+    "lint:js:changed": "./bin/lint-changed-js",
     "problems": "yarn workspace ember-data problems",
     "start": "yarn workspace ember-data start",
     "test": "yarn workspace ember-data test",
@@ -47,6 +47,8 @@
     "@types/ember__test-helpers": "~0.7.8",
     "@types/qunit": "^2.5.3",
     "@types/rsvp": "^4.0.3",
+    "@typescript-eslint/eslint-plugin": "^2.3.1",
+    "@typescript-eslint/parser": "^2.3.1",
     "babel-eslint": "^10.0.3",
     "babel-plugin-debug-macros": "^0.3.3",
     "babel-plugin-feature-flags": "^0.3.1",
@@ -68,6 +70,7 @@
     "debug": "^4.1.1",
     "ember-cli": "~3.13.1",
     "ember-cli-app-version": "^3.2.0",
+    "ember-cli-babel": "^7.12.0",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-htmlbars": "^4.0.2",
@@ -79,6 +82,7 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-string-utils": "^1.1.0",
+    "ember-cli-template-lint": "^1.0.0-beta.1",
     "ember-cli-test-loader": "^2.2.0",
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-cli-uglify": "3.0.0",
@@ -98,6 +102,7 @@
     "ember-try": "^1.2.1",
     "eslint": "^6.5.0",
     "eslint-config-prettier": "^6.3.0",
+    "eslint-plugin-ember": "^7.1.0",
     "eslint-plugin-mocha": "^6.1.1",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.1.1",
@@ -115,15 +120,12 @@
     "pre-commit": "^1.2.2",
     "prettier": "~1.18.2",
     "qunit": "^2.9.2",
+    "qunit-dom": "^0.9.0",
     "rimraf": "^3.0.0",
     "rsvp": "^4.8.5",
     "semver": "^6.2.0",
     "silent-error": "^1.1.1",
-    "typescript": "~3.6.3",
-    "ember-cli-babel": "^7.12.0",
-    "ember-cli-template-lint": "^1.0.0-beta.1",
-    "eslint-plugin-ember": "^7.1.0",
-    "qunit-dom": "^0.9.0"
+    "typescript": "~3.6.3"
   },
   "bin": {
     "test-partner-project": "./bin/test-external-partner-project.js",

--- a/packages/-ember-data/tests/integration/identifiers/cache-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/cache-test.ts
@@ -30,7 +30,11 @@ if (IDENTIFIERS) {
 
         const regeneratedIdentifier = cache.getOrCreateRecordIdentifier(runspiredHash);
 
-        assert.notStrictEqual(identifier, regeneratedIdentifier, 'a record get a new identifier if identifier get forgotten');
+        assert.notStrictEqual(
+          identifier,
+          regeneratedIdentifier,
+          'a record get a new identifier if identifier get forgotten'
+        );
       });
 
       test('returns the existing identifier when called with an identifier', async function(assert) {

--- a/packages/-ember-data/tests/integration/identifiers/new-records-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/new-records-test.ts
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { IDENTIFIERS } from '@ember-data/canary-features';
 import Store, { recordIdentifierFor } from '@ember-data/store';
 import Model, { attr } from '@ember-data/model';
 

--- a/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
@@ -1,12 +1,10 @@
-import { get } from '@ember/object';
 import { setupTest } from 'ember-qunit';
 import Model from 'ember-data/model';
 import Store from 'ember-data/store';
 import { module, test } from 'qunit';
-import { settled } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
-import { attr, hasMany, belongsTo } from '@ember-data/model';
-import { InvalidError, ServerError } from '@ember-data/adapter/error';
+import { attr } from '@ember-data/model';
+import { InvalidError } from '@ember-data/adapter/error';
 import { JsonApiValidationError } from '@ember-data/store/-private/ts-interfaces/record-data-json-api';
 import RecordData from '@ember-data/store/-private/ts-interfaces/record-data';
 import { RecordIdentifier } from '@ember-data/store/-private/ts-interfaces/identifier';
@@ -115,8 +113,7 @@ module('integration/record-data - Custom RecordData Errors', function(hooks) {
 
   test('Record Data invalid errors', async function(assert) {
     assert.expect(2);
-    let called = 0;
-    let createCalled = 0;
+
     const personHash = {
       type: 'person',
       id: '1',
@@ -289,8 +286,7 @@ module('integration/record-data - Custom RecordData Errors', function(hooks) {
 
   test('Record data which does not implement getErrors still works correctly with the default DS.Model', async function(assert) {
     assert.expect(4);
-    let called = 0;
-    let createCalled = 0;
+
     const personHash = {
       type: 'person',
       id: '1',

--- a/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
@@ -1,11 +1,9 @@
-import { get } from '@ember/object';
 import { setupTest } from 'ember-qunit';
 import Model from 'ember-data/model';
 import Store from 'ember-data/store';
 import { module, test } from 'qunit';
-import { settled } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
-import { attr, hasMany, belongsTo } from '@ember-data/model';
+import { attr } from '@ember-data/model';
 import Ember from 'ember';
 import RecordData from '@ember-data/store/-private/ts-interfaces/record-data';
 import { RECORD_DATA_STATE } from '@ember-data/canary-features';
@@ -111,11 +109,11 @@ module('integration/record-data - Record Data State', function(hooks) {
 
   test('Record Data state saving', async function(assert) {
     assert.expect(3);
+
     let isDeleted, isNew, isDeletionCommitted;
     let calledDelete = false;
     let calledUpdate = false;
     let calledCreate = false;
-    let storeWrapper;
 
     const personHash = {
       type: 'person',
@@ -127,11 +125,6 @@ module('integration/record-data - Record Data State', function(hooks) {
     let { owner } = this;
 
     class LifecycleRecordData extends TestRecordData {
-      constructor(sw) {
-        super();
-        storeWrapper = sw;
-      }
-
       isNew(): boolean {
         return isNew;
       }
@@ -149,7 +142,7 @@ module('integration/record-data - Record Data State', function(hooks) {
 
     let TestStore = Store.extend({
       createRecordDataFor(modelName, id, clientId, storeWrapper) {
-        return new LifecycleRecordData(storeWrapper);
+        return new LifecycleRecordData();
       },
     });
 

--- a/packages/-ember-data/tests/integration/record-data/record-data-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-test.ts
@@ -459,11 +459,7 @@ module('integration/record-data - Custom RecordData Implementations', function(h
     assert.equal(house.get('landlord.name'), 'David', 'belongsTo get correctly looked up');
 
     house.set('landlord', runspired);
-    assert.equal(
-      house.get('landlord.name'),
-      'David',
-      'belongsTo does not change if RD did not notify'
-    );
+    assert.equal(house.get('landlord.name'), 'David', 'belongsTo does not change if RD did not notify');
   });
 
   test('Record Data custom belongsTo', async function(assert) {
@@ -604,11 +600,7 @@ module('integration/record-data - Custom RecordData Implementations', function(h
     assert.deepEqual(people.toArray(), [david], 'has many doesnt change if RD did not notify');
 
     people.removeObject(david);
-    assert.deepEqual(
-      people.toArray(),
-      [david],
-      'hasMany removal doesnt apply the change unless notified'
-    );
+    assert.deepEqual(people.toArray(), [david], 'hasMany removal doesnt apply the change unless notified');
 
     house.set('tenants', [igor]);
     assert.deepEqual(people.toArray(), [david], 'setDirtyHasMany doesnt apply unless notified');

--- a/packages/-ember-data/tests/integration/record-data/record-data-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-test.ts
@@ -189,7 +189,6 @@ module('integration/record-data - Custom RecordData Implementations', function(h
   test('Record Data push, create and save lifecycle', async function(assert) {
     assert.expect(17);
     let called = 0;
-    let createCalled = 0;
     const personHash = {
       type: 'person',
       id: '1',
@@ -408,8 +407,6 @@ module('integration/record-data - Custom RecordData Implementations', function(h
 
   test('Record Data controls belongsTo notifications', async function(assert) {
     assert.expect(6);
-    let called = 0;
-    let createCalled = 0;
 
     let { owner } = this;
     let belongsToReturnValue = { data: { id: '1', type: 'person' } };
@@ -519,8 +516,6 @@ module('integration/record-data - Custom RecordData Implementations', function(h
 
   test('Record Data controls hasMany notifications', async function(assert) {
     assert.expect(10);
-    let called = 0;
-    let createCalled = 0;
 
     let { owner } = this;
 
@@ -612,7 +607,6 @@ module('integration/record-data - Custom RecordData Implementations', function(h
 
     let calledAddToHasMany = 0;
     let calledRemoveFromHasMany = 0;
-    let calledSetDirtyHasMany = 0;
     let hasManyReturnValue = { data: [{ id: '1', type: 'person' }] };
 
     class RelationshipRecordData extends TestRecordData {

--- a/packages/-ember-data/tests/integration/record-data/store-wrapper-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/store-wrapper-test.ts
@@ -1,9 +1,7 @@
-import { get } from '@ember/object';
 import { setupTest } from 'ember-qunit';
 import Model from 'ember-data/model';
 import Store from 'ember-data/store';
 import { module, test } from 'qunit';
-import { settled } from '@ember/test-helpers';
 import publicProps from '../../helpers/public-props';
 import { attr, hasMany, belongsTo } from '@ember-data/model';
 
@@ -339,7 +337,6 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function(hoo
     assert.expect(1);
     let { owner } = this;
 
-    let count = 0;
     class RecordDataForTest extends TestRecordData {
       id: string;
 
@@ -377,7 +374,6 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function(hoo
     assert.expect(2);
     let { owner } = this;
 
-    let count = 0;
     class RecordDataForTest extends TestRecordData {
       constructor(storeWrapper, id, clientId) {
         super();
@@ -405,7 +401,7 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function(hoo
     store.push({
       data: [houseHash, houseHash2],
     });
-    let house1 = store.peekRecord('house', 1);
+    store.peekRecord('house', 1);
 
     // TODO isRecordInUse returns true if record has never been instantiated, think through whether thats correct
     let house2 = store.peekRecord('house', 2);
@@ -419,7 +415,6 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function(hoo
     let { owner } = this;
     let wrapper;
 
-    let count = 0;
     class RecordDataForTest extends TestRecordData {
       constructor(storeWrapper, id, clientId) {
         super();

--- a/packages/-ember-data/tests/integration/request-state-service-test.ts
+++ b/packages/-ember-data/tests/integration/request-state-service-test.ts
@@ -193,7 +193,7 @@ if (REQUEST_SERVICE) {
         options: {},
       };
 
-      let unsubToken = requestService.subscribeForRecord(identifier, request => {
+      requestService.subscribeForRecord(identifier, request => {
         if (count === 0) {
           assert.equal(request.state, 'pending', 'request is pending');
           assert.equal(request.type, 'query', 'request is a query');

--- a/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -11,7 +11,7 @@ import { StableRecordIdentifier, RecordIdentifier } from '@ember-data/store/-pri
 import NotificationManager from '@ember-data/store/-private/system/record-notification-manager';
 import RecordDataRecordWrapper from '@ember-data/store/-private/ts-interfaces/record-data-record-wrapper';
 
-let CustomStore, store, adapter, schemaDefinition;
+let CustomStore, store, schemaDefinition;
 if (CUSTOM_MODEL_CLASS) {
   module('unit/model - Custom Class Model', function(hooks) {
     setupTest(hooks);
@@ -102,7 +102,7 @@ if (CUSTOM_MODEL_CLASS) {
       });
       this.owner.register('service:store', CreationStore);
       store = this.owner.lookup('service:store');
-      let person = store.push({ data: { id: '1', type: 'person', name: 'chris' } });
+      store.push({ data: { id: '1', type: 'person', name: 'chris' } });
       recordData.storeWrapper.notifyHasManyChange(identifier.type, identifier.id, identifier.lid, 'key');
       recordData.storeWrapper.notifyBelongsToChange(identifier.type, identifier.id, identifier.lid, 'key');
       recordData.storeWrapper.notifyStateChange(identifier.type, identifier.id, identifier.lid, 'key');
@@ -163,7 +163,7 @@ if (CUSTOM_MODEL_CLASS) {
       };
       store.registerSchemaDefinitionService(schema);
 
-      let person = store.createRecord('person', { name: 'chris' });
+      store.createRecord('person', { name: 'chris' });
     });
 
     test('attribute and relationship with custom schema definition', async function(assert) {
@@ -345,7 +345,7 @@ if (CUSTOM_MODEL_CLASS) {
       let person = store.push({ data: { type: 'person', id: '1', attributes: { name: 'chris' } } });
       store.deleteRecord(person);
       assert.equal(rd!.isDeleted!(), true, 'record has been marked as deleted');
-      let promisePerson = await store.saveRecord(person);
+      await store.saveRecord(person);
       assert.equal(rd!.isDeletionCommitted!(), true, 'deletion has been commited');
     });
 

--- a/packages/adapter/addon/-private/utils/determine-body-promise.ts
+++ b/packages/adapter/addon/-private/utils/determine-body-promise.ts
@@ -19,10 +19,7 @@ export function determineBodyPromise(
         throw error;
       }
       const status = response.status;
-      if (
-        response.ok &&
-        (status === 204 || status === 205 || requestData.method === 'HEAD')
-      ) {
+      if (response.ok && (status === 204 || status === 205 || requestData.method === 'HEAD')) {
         ret = undefined;
       } else {
         if (DEBUG) {

--- a/packages/adapter/addon/-private/utils/determine-body-promise.ts
+++ b/packages/adapter/addon/-private/utils/determine-body-promise.ts
@@ -35,6 +35,7 @@ export function determineBodyPromise(
           }
         }
 
+        // eslint-disable-next-line no-console
         console.warn('This response was unable to be parsed as json.', payload);
       }
     }

--- a/packages/adapter/addon/-private/utils/serialize-query-params.ts
+++ b/packages/adapter/addon/-private/utils/serialize-query-params.ts
@@ -8,9 +8,7 @@ function isPlainObject(obj: any): boolean {
  * Helper function that turns the data/body of a request into a query param string.
  * This is directly copied from jQuery.param.
  */
-export function serializeQueryParams(
-  queryParamsObject: object | string
-): string {
+export function serializeQueryParams(queryParamsObject: object | string): string {
   var s: any[] = [];
 
   function buildParams(prefix: string, obj: any) {
@@ -22,10 +20,7 @@ export function serializeQueryParams(
           if (RBRACKET.test(prefix)) {
             add(s, prefix, obj[i]);
           } else {
-            buildParams(
-              prefix + '[' + (typeof obj[i] === 'object' ? i : '') + ']',
-              obj[i]
-            );
+            buildParams(prefix + '[' + (typeof obj[i] === 'object' ? i : '') + ']', obj[i]);
           }
         }
       } else if (isPlainObject(obj)) {

--- a/packages/model/addon/index.ts
+++ b/packages/model/addon/index.ts
@@ -39,9 +39,4 @@
   @public
  */
 
-export {
-  Model as default,
-  attr,
-  belongsTo,
-  hasMany
-} from './-private';
+export { Model as default, attr, belongsTo, hasMany } from './-private';

--- a/packages/store/addon/-private/identifiers/cache.ts
+++ b/packages/store/addon/-private/identifiers/cache.ts
@@ -17,7 +17,6 @@ import uuidv4 from './utils/uuid-v4';
 import normalizeModelName from '../system/normalize-model-name';
 import isStableIdentifier, { markStableIdentifier, unmarkStableIdentifier } from './is-stable-identifier';
 import isNonEmptyString from '../utils/is-non-empty-string';
-import Store from '../system/ds-model-store';
 import CoreStore from '../system/core-store';
 
 /**

--- a/packages/store/addon/-private/identifiers/utils/uuid-v4.ts
+++ b/packages/store/addon/-private/identifiers/utils/uuid-v4.ts
@@ -10,9 +10,7 @@ declare global {
 }
 
 const CRYPTO =
-  typeof window !== 'undefined' &&
-  window.msCrypto &&
-  typeof window.msCrypto.getRandomValues === 'function'
+  typeof window !== 'undefined' && window.msCrypto && typeof window.msCrypto.getRandomValues === 'function'
     ? window.msCrypto
     : window.crypto;
 

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -4,8 +4,7 @@
 
 import { registerWaiter, unregisterWaiter } from '@ember/test';
 
-import { default as EmberArray, A } from '@ember/array';
-import EmberError from '@ember/error';
+import { A } from '@ember/array';
 import { getOwner } from '@ember/application';
 import { run as emberRunLoop } from '@ember/runloop';
 import { set, get, computed, defineProperty } from '@ember/object';
@@ -70,11 +69,10 @@ import { RequestPromise } from './request-cache';
 import { PromiseProxy } from '../ts-interfaces/promise-proxies';
 import { DSModel } from '../ts-interfaces/ds-model';
 import NotificationManager from './record-notification-manager';
-import { RelationshipsSchema, AttributeSchema, AttributesSchema } from '../ts-interfaces/record-data-schemas';
+import { AttributesSchema } from '../ts-interfaces/record-data-schemas';
 import { SchemaDefinitionService } from '../ts-interfaces/schema-definition-service';
 import ShimModelClass from './model/shim-model-class';
 import RecordDataRecordWrapper from '../ts-interfaces/record-data-record-wrapper';
-import Reference from './references/reference';
 import { Dict } from '../ts-interfaces/utils';
 
 import constructResource from '../utils/construct-resource';
@@ -3618,88 +3616,6 @@ function _commit(adapter, store, operation, snapshot) {
     },
     label
   );
-}
-
-/**
- *
- * @param store
- * @param cache modelFactoryCache
- * @param normalizedModelName already normalized modelName
- * @return {*}
- */
-function getModelFactory(store, cache, normalizedModelName) {
-  let factory = cache[normalizedModelName];
-
-  if (!factory) {
-    factory = _lookupModelFactory(store, normalizedModelName);
-
-    if (!factory) {
-      //Support looking up mixins as base types for polymorphic relationships
-      factory = _modelForMixin(store, normalizedModelName);
-    }
-
-    if (!factory) {
-      // we don't cache misses in case someone wants to register a missing model
-      return null;
-    }
-
-    let klass = factory.class;
-    assert(`'${inspect(klass)}' does not appear to be an ember-data model`, klass.isModel);
-
-    // TODO: deprecate this
-    let hasOwnModelNameSet = klass.modelName && Object.prototype.hasOwnProperty.call(klass, 'modelName');
-    if (!hasOwnModelNameSet) {
-      klass.modelName = normalizedModelName;
-    }
-
-    cache[normalizedModelName] = factory;
-  }
-
-  return factory;
-}
-
-function _lookupModelFactory(store, normalizedModelName) {
-  let owner = getOwner(store);
-
-  return owner.factoryFor(`model:${normalizedModelName}`);
-}
-
-/*
-  In case someone defined a relationship to a mixin, for example:
-  ```
-    import Model, { belongsTo, hasMany } from '@ember-data/model';
-
-    let Comment = Model.extend({
-      owner: belongsTo('commentable'. { polymorphic: true })
-    });
-    let Commentable = Ember.Mixin.create({
-      comments: hasMany('comment')
-    });
-  ```
-  we want to look up a Commentable class which has all the necessary
-  relationship metadata. Thus, we look up the mixin and create a mock
-  Model, so we can access the relationship CPs of the mixin (`comments`)
-  in this case
-*/
-function _modelForMixin(store, normalizedModelName) {
-  if (HAS_MODEL_PACKAGE) {
-    let owner = getOwner(store);
-    let MaybeMixin = owner.factoryFor(`mixin:${normalizedModelName}`);
-    let mixin = MaybeMixin && MaybeMixin.class;
-
-    if (mixin) {
-      let ModelForMixin = getModel().extend(mixin);
-      ModelForMixin.reopenClass({
-        __isMixin: true,
-        __mixin: mixin,
-      });
-
-      //Cache the class as a model
-      owner.register('model:' + normalizedModelName, ModelForMixin);
-    }
-
-    return _lookupModelFactory(store, normalizedModelName);
-  }
 }
 
 let assertDestroyingStore: Function;

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -3647,7 +3647,7 @@ function getModelFactory(store, cache, normalizedModelName) {
     assert(`'${inspect(klass)}' does not appear to be an ember-data model`, klass.isModel);
 
     // TODO: deprecate this
-    let hasOwnModelNameSet = klass.modelName && klass.hasOwnProperty('modelName');
+    let hasOwnModelNameSet = klass.modelName && Object.prototype.hasOwnProperty.call(klass, 'modelName');
     if (!hasOwnModelNameSet) {
       klass.modelName = normalizedModelName;
     }

--- a/packages/store/addon/-private/system/fetch-manager.ts
+++ b/packages/store/addon/-private/system/fetch-manager.ts
@@ -1,20 +1,17 @@
 import { default as RSVP, Promise } from 'rsvp';
 import { DEBUG } from '@glimmer/env';
 import { run as emberRunLoop } from '@ember/runloop';
-import { assert, warn, inspect } from '@ember/debug';
+import { assert, warn } from '@ember/debug';
 import Snapshot from './snapshot';
 import { guardDestroyedStore, _guard, _bind, _objectIsAlive } from './store/common';
 import { normalizeResponseHelper } from './store/serializer-response';
 import coerceId from './coerce-id';
 import { A } from '@ember/array';
-import { _findHasMany, _findBelongsTo, _findAll, _query, _queryRecord } from './store/finders';
 import RequestCache from './request-cache';
 import { CollectionResourceDocument, SingleResourceDocument } from '../ts-interfaces/ember-data-json-api';
 import { RecordIdentifier } from '../ts-interfaces/identifier';
 import { FindRecordQuery, SaveRecordMutation, Request } from '../ts-interfaces/fetch-manager';
 import { symbol } from '../ts-interfaces/utils/symbol';
-import Store from './ds-model-store';
-import recordDataFor from './record-data-for';
 import CoreStore from './core-store';
 import { errorsArrayToHash } from './errors-utils';
 
@@ -99,7 +96,6 @@ export default class FetchManager {
     let { snapshot, resolver, identifier, options } = pending;
     let adapter = this._store.adapterFor(identifier.type);
     let operation = options[SaveOp];
-    let recordData = recordDataFor(this._store._internalModelForResource(identifier));
 
     let internalModel = snapshot._internalModel;
     let modelName = snapshot.modelName;
@@ -126,10 +122,8 @@ export default class FetchManager {
 
     promise = promise.then(
       adapterPayload => {
-        let payload, data, sideloaded;
         if (adapterPayload) {
-          payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, snapshot.id, operation);
-          return payload;
+          return normalizeResponseHelper(serializer, store, modelClass, adapterPayload, snapshot.id, operation);
         }
       },
       function(error) {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -35,6 +35,8 @@ import { internalModelFactoryFor, setRecordIdentifier } from '../store/internal-
 import CoreStore from '../core-store';
 import coerceId from '../coerce-id';
 
+const { hasOwnProperty } = Object.prototype;
+
 /**
   @module @ember-data/store
 */
@@ -1463,7 +1465,7 @@ export default class InternalModel {
       if (error && parsedErrors) {
         if (!this._recordData.getErrors) {
           for (attribute in parsedErrors) {
-            if (parsedErrors.hasOwnProperty(attribute)) {
+            if (hasOwnProperty.call(parsedErrors, attribute)) {
               this.addErrorMessageToAttribute(attribute, parsedErrors[attribute]);
             }
           }
@@ -1483,7 +1485,7 @@ export default class InternalModel {
       let attribute;
 
       for (attribute in parsedErrors) {
-        if (parsedErrors.hasOwnProperty(attribute)) {
+        if (hasOwnProperty.call(parsedErrors, attribute)) {
           this.addErrorMessageToAttribute(attribute, parsedErrors[attribute]);
         }
       }
@@ -1601,7 +1603,7 @@ export function assertRecordsPassedToHasMany(records) {
   assert(
     `All elements of a hasMany relationship must be instances of Model, you passed ${inspect(records)}`,
     (function() {
-      return A(records).every(record => record.hasOwnProperty('_internalModel') === true);
+      return A(records).every(record => hasOwnProperty.call(record, '_internalModel') === true);
     })()
   );
 }

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -4,7 +4,7 @@ import { default as EmberArray, A } from '@ember/array';
 import { setOwner, getOwner } from '@ember/application';
 import { assign } from '@ember/polyfills';
 import { run } from '@ember/runloop';
-import RSVP, { Promise, resolve } from 'rsvp';
+import RSVP, { Promise } from 'rsvp';
 import Ember from 'ember';
 import { DEBUG } from '@glimmer/env';
 import { assert, inspect } from '@ember/debug';
@@ -522,7 +522,6 @@ export default class InternalModel {
       }
       this.startedReloading();
       let internalModel = this;
-      let promiseLabel = 'DS: Model#reload of ' + this;
 
       return internalModel.store
         ._reloadRecord(internalModel, options)
@@ -1177,7 +1176,6 @@ export default class InternalModel {
 
     let pivotName = extractPivotName(name);
     let state = this.currentState;
-    let oldState = state;
     let transitionMapId = `${state.stateName}->${name}`;
 
     do {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -332,8 +332,7 @@ export default class InternalModel {
   }
 
   isValid() {
-    if (RECORD_DATA_ERRORS) {
-    } else {
+    if (!RECORD_DATA_ERRORS) {
       return this.currentState.isValid;
     }
   }

--- a/packages/store/addon/-private/system/relationship-meta.ts
+++ b/packages/store/addon/-private/system/relationship-meta.ts
@@ -3,7 +3,6 @@ import { DEBUG } from '@glimmer/env';
 import normalizeModelName from './normalize-model-name';
 import { RelationshipSchema } from '../ts-interfaces/record-data-schemas';
 import { BRAND_SYMBOL } from '../ts-interfaces/utils/brand';
-import Store from './ds-model-store';
 import CoreStore from './core-store';
 
 /**

--- a/packages/store/addon/-private/system/relationships/state/create.ts
+++ b/packages/store/addon/-private/system/relationships/state/create.ts
@@ -2,7 +2,6 @@ import ManyRelationship from './has-many';
 import BelongsToRelationship from './belongs-to';
 import { RelationshipRecordData } from '../../../ts-interfaces/relationship-record-data';
 import { RelationshipSchema } from '../../../ts-interfaces/record-data-schemas';
-import Store from '../../ds-model-store';
 import RecordDataStoreWrapper from '../../store/record-data-store-wrapper';
 import { upgradeForInternal } from '../../ts-upgrade-map';
 import CoreStore from '../../core-store';

--- a/packages/store/addon/-private/system/relationships/state/relationship.ts
+++ b/packages/store/addon/-private/system/relationships/state/relationship.ts
@@ -509,11 +509,11 @@ export default class Relationship {
         const id = guidFor(inverseRecordData);
 
         if (this._hasSupportForImplicitRelationships(inverseRecordData) && seen[id] === undefined) {
-          const relationship = implicitRelationshipStateFor(inverseRecordData, this.inverseKeyForImplicit)
+          const relationship = implicitRelationshipStateFor(inverseRecordData, this.inverseKeyForImplicit);
           relationship.removeCompletelyFromOwn(recordData);
           seen[id] = true;
         }
-      }
+      };
     }
 
     this.members.forEach(unload);

--- a/packages/store/addon/-private/system/relationships/state/relationship.ts
+++ b/packages/store/addon/-private/system/relationships/state/relationship.ts
@@ -5,7 +5,6 @@ import { assert, warn } from '@ember/debug';
 import OrderedSet from '../../ordered-set';
 import _normalizeLink from '../../normalize-link';
 import { RelationshipRecordData } from '../../..//ts-interfaces/relationship-record-data';
-import RecordData from '../../../ts-interfaces/record-data';
 import { JsonApiRelationship } from '../../../ts-interfaces/record-data-json-api';
 import { RelationshipSchema } from '../../../ts-interfaces/record-data-schemas';
 import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';

--- a/packages/store/addon/-private/system/request-cache.ts
+++ b/packages/store/addon/-private/system/request-cache.ts
@@ -9,8 +9,6 @@ import {
 } from '../ts-interfaces/fetch-manager';
 import { symbol } from '../ts-interfaces/utils/symbol';
 
-import { _findHasMany, _findBelongsTo, _findAll, _query, _queryRecord } from './store/finders';
-
 export const Touching: unique symbol = symbol('touching');
 export const RequestPromise: unique symbol = symbol('promise');
 

--- a/packages/store/addon/-private/system/schema-definition-service.ts
+++ b/packages/store/addon/-private/system/schema-definition-service.ts
@@ -101,7 +101,7 @@ export function getModelFactory(store, cache, normalizedModelName) {
 
     // TODO: deprecate this
     if (klass.isModel) {
-      let hasOwnModelNameSet = klass.modelName && klass.hasOwnProperty('modelName');
+      let hasOwnModelNameSet = klass.modelName && Object.prototype.hasOwnProperty.call(klass, 'modelName');
       if (!hasOwnModelNameSet) {
         klass.modelName = normalizedModelName;
       }

--- a/packages/store/addon/-private/system/store/internal-model-factory.ts
+++ b/packages/store/addon/-private/system/store/internal-model-factory.ts
@@ -1,8 +1,6 @@
-import coerceId from '../coerce-id';
 import { assert, warn } from '@ember/debug';
 import { IdentifierCache, identifierCacheFor } from '../../identifiers/cache';
 import InternalModel from '../model/internal-model';
-import Store from '../ds-model-store';
 import IdentityMap from '../identity-map';
 import { StableRecordIdentifier } from '../../ts-interfaces/identifier';
 import InternalModelMap from '../internal-model-map';

--- a/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
+++ b/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
@@ -1,5 +1,4 @@
 import { RecordDataStoreWrapper as IRecordDataStoreWrapper } from '../../ts-interfaces/record-data-store-wrapper';
-import Store from '../ds-model-store';
 import { AttributesSchema, RelationshipsSchema } from '../../ts-interfaces/record-data-schemas';
 import { BRAND_SYMBOL } from '../../ts-interfaces/utils/brand';
 import { upgradeForInternal } from '../ts-upgrade-map';

--- a/packages/store/addon/-private/ts-interfaces/ds-model.ts
+++ b/packages/store/addon/-private/ts-interfaces/ds-model.ts
@@ -2,8 +2,6 @@ import { Record } from './record';
 import RSVP from 'rsvp';
 import EmberObject from '@ember/object';
 import { JsonApiValidationError } from './record-data-json-api';
-import { Relationship } from '..';
-import { RelationshipRecordData } from './relationship-record-data';
 import { RelationshipSchema } from './record-data-schemas';
 
 // Placeholder until model.js is typed

--- a/packages/store/addon/-private/ts-interfaces/record-data-record-wrapper.ts
+++ b/packages/store/addon/-private/ts-interfaces/record-data-record-wrapper.ts
@@ -39,7 +39,7 @@ export default interface RecordDataRecordWrapper {
   /**
    * @deprecated
    */
-  getErrors?({}): JsonApiValidationError[];
+  getErrors?({}): JsonApiValidationError[]; // eslint-disable-line no-empty-pattern
 
   isNew?(): boolean;
   isDeleted?(): boolean;

--- a/packages/store/addon/-private/ts-interfaces/record-data-record-wrapper.ts
+++ b/packages/store/addon/-private/ts-interfaces/record-data-record-wrapper.ts
@@ -1,5 +1,4 @@
 import {
-  JsonApiResource,
   JsonApiHasManyRelationship,
   JsonApiBelongsToRelationship,
   JsonApiValidationError,

--- a/packages/store/addon/-private/ts-interfaces/record-data.ts
+++ b/packages/store/addon/-private/ts-interfaces/record-data.ts
@@ -57,7 +57,7 @@ export default interface RecordData {
   /**
    * @deprecated
    */
-  getErrors?({}): JsonApiValidationError[];
+  getErrors?({}): JsonApiValidationError[]; // eslint-disable-line no-empty-pattern
 
   isNew?(): boolean;
   isDeleted?(): boolean;

--- a/packages/store/addon/-private/utils/promise-record.ts
+++ b/packages/store/addon/-private/utils/promise-record.ts
@@ -1,6 +1,5 @@
 import InternalModel from '../system/model/internal-model';
 import { promiseObject } from '../system/promise-proxies';
-import { Record } from '../ts-interfaces/record';
 import { PromiseProxy } from '../ts-interfaces/promise-proxies';
 import { DSModel } from '../ts-interfaces/ds-model';
 /**

--- a/packages/store/types/@ember/array/index.d.ts
+++ b/packages/store/types/@ember/array/index.d.ts
@@ -1,6 +1,6 @@
 import EmberArray, { A } from '@ember/array';
 namespace EmberArray {
-    function detect(arr: any): boolean;
+  function detect(arr: any): boolean;
 }
 
 export default EmberArray;

--- a/packages/store/types/@ember/array/index.d.ts
+++ b/packages/store/types/@ember/array/index.d.ts
@@ -1,5 +1,7 @@
 import EmberArray, { A } from '@ember/array';
+
 namespace EmberArray {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function detect(arr: any): boolean;
 }
 

--- a/packages/store/types/@ember/ordered-set/index.d.ts
+++ b/packages/store/types/@ember/ordered-set/index.d.ts
@@ -1,14 +1,14 @@
 // TODO Flesh out this type if it sticks around
 class OrderedSet<T> {
-    presenceSet: any;
-    list: any;
-    size: any;
-    has(T): boolean;
-    add(T);
-    delete(T);
-    toArray(): T[];
-    clear();
-    copy(): this;
-    forEach(f: (elem: T) => void);
-};
+  presenceSet: any;
+  list: any;
+  size: any;
+  has(T): boolean;
+  add(T);
+  delete(T);
+  toArray(): T[];
+  clear();
+  copy(): this;
+  forEach(f: (elem: T) => void);
+}
 export default OrderedSet;

--- a/packages/store/types/@ember/polyfills/index.d.ts
+++ b/packages/store/types/@ember/polyfills/index.d.ts
@@ -3,5 +3,14 @@
  * @deprecated Use Object.assign
  */
 export function assign<T extends object, U extends object | null | undefined>(target: T, source: U): Mix<T, U>;
-export function assign<T extends object, U extends object, V extends object | null | undefined>(target: T, source1: U, source2: V): Mix3<T, U, V>;
-export function assign<T extends object, U extends object, V extends object, W extends object | null | undefined>(target: T, source1: U, source2: V, source3: W): Mix4<T, U, V, W>;
+export function assign<T extends object, U extends object, V extends object | null | undefined>(
+  target: T,
+  source1: U,
+  source2: V
+): Mix3<T, U, V>;
+export function assign<T extends object, U extends object, V extends object, W extends object | null | undefined>(
+  target: T,
+  source1: U,
+  source2: V,
+  source3: W
+): Mix4<T, U, V, W>;

--- a/packages/store/types/@ember/runloop/index.d.ts
+++ b/packages/store/types/@ember/runloop/index.d.ts
@@ -1,2 +1,1 @@
-
 export const run: any;

--- a/packages/store/types/ember/index.d.ts
+++ b/packages/store/types/ember/index.d.ts
@@ -1,5 +1,3 @@
-import Ember from 'ember';
-
 export const GUID_KEY: string;
 export function run(callback: Function);
 export const ENV: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,6 +1952,11 @@
   resolved "https://registry.npmjs.org/@types/ember__utils/-/ember__utils-3.0.2.tgz#d4c32007d0c84c95faa9221a1582b87ac3b1b4f3"
   integrity sha512-d6fswmNDozslgUk+0DfC1oG0vD8R5ivvrEe0t3BuWSnF+TVyYhj24KZINecpBySg/4RODCg2IVV1GeRsimqzkg==
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -1982,6 +1987,11 @@
   integrity sha512-chB+QbLulamShZAFcTJtl8opZwHFBpDOP6nRLrPGkhC6N1aKWrDXg2Nc71tEg6ny6E8SQpRwbWSi9GdstH5VJA==
   dependencies:
     "@types/sizzle" "*"
+
+"@types/json-schema@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
+  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
@@ -2017,6 +2027,46 @@
   version "0.0.33"
   resolved "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
   integrity sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=
+
+"@typescript-eslint/eslint-plugin@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.3.1.tgz#b0b1e6b9b3f84b3e1afbdd338f4194c8ab92db21"
+  integrity sha512-VqVNEsvemviajlaWm03kVMabc6S3xCHGYuY0fReTrIIOZg+3WzB+wfw6fD3KYKerw5lYxmzogmHOZ0i7YKnuwA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.3.1"
+    eslint-utils "^1.4.2"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^2.0.1"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.3.1.tgz#92f2531d3e7c22e64a2cc10cfe89935deaf00f7c"
+  integrity sha512-FaZEj73o4h6Wd0Lg+R4pZiJGdR0ZYbJr+O2+RbQ1aZjX8bZcfkVDtD+qm74Dv77rfSKkDKE64UTziLBo9UYHQA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.3.1"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/parser@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.3.1.tgz#f2b93b614d9b338825c44e75552a433e2ebf8c33"
+  integrity sha512-ZlWdzhCJ2iZnSp/VBAJ/sowFbyHycIux8t0UEH0JsKgQvfSf7949hLYFMwTXdCMeEnpP1zRTHimrR+YHzs8LIw==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.3.1"
+    "@typescript-eslint/typescript-estree" "2.3.1"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/typescript-estree@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.3.1.tgz#62c64f149948473d06a129dc33b4fc76e6c051f9"
+  integrity sha512-9SFhUgFuePJBB6jlLkOPPhMkZNiDCr+S8Ft7yAkkP2c5x5bxPhG3pe/exMiQaF8IGyVMDW6Ul0q4/cZ+uF3uog==
+  dependencies:
+    glob "^7.1.4"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
 
 "@xg-wang/whatwg-fetch@^3.0.0":
   version "3.0.0"
@@ -8342,6 +8392,11 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
 lodash.uniq@^4.2.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -11580,10 +11635,17 @@ trim-right@^1.0.1:
   resolved "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
This updates our ESLint configuration so that it also runs for TypeScript files using [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint).

## If it is preferred, I can break this up into smaller pull requests

Details

- Adds [`@typescript-eslint/parser`](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser)
- Adds [`@typescript-eslint/eslint-plugin`](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin)
- Disables all rules that cause linting TypeScript files to fail
- Renames `bin/lint-js` -> `bin/lint-changed-js` & `yarn lint:js` -> `yarn lint:js:changed` to make it's purpose more obvious
- Updates `bin/lint-changed-js` to include linting TypeScript files
- Replaces `yarn lint:prettier` with `yarn lint:js` which runs ESLint for JavaScript & TypeScript, including enforcing our Prettier config
- Updates all CI scripts to use `yarn lint:js` rather than `yarn lint:prettier`

Since we haven't been running eslint for TypeScript files, some files don't pass with our current eslint config. Any rules that were causing errors have been disabled temporarily so we can make any neccessary code changes enable the rules again separately.

---

The diff here is kind of large so this was broken up into many commits. The first one configures `typescript-eslint` and updates our CI scripts to use include typescript files when linting. Any rules that were failing were disabled.

The following 6 commits each enable a rule and fix any errors.

There are probably more rules that we will want to look into enabling that are provided by `typescript-eslint`. This only attempts to configure the same rules that we already use for regular JS files.