### PR TITLE
[FIX] only include version in ember-data output

### DIFF
--- a/packages/-build-infra/src/addon-build-config-for-data-package.js
+++ b/packages/-build-infra/src/addon-build-config-for-data-package.js
@@ -2,7 +2,6 @@ const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 const Funnel = require('broccoli-funnel');
 const merge = require('broccoli-merge-trees');
 const BroccoliDebug = require('broccoli-debug');
-const version = require('./create-version-module');
 const { isInstrumentedBuild } = require('./cli-flags');
 const rollupPrivateModule = require('./utilities/rollup-private-module');
 
@@ -111,6 +110,9 @@ function addonBuildConfigForDataPackage(PackageName) {
     },
 
     treeForAddon(tree) {
+      if (typeof this._additionalAddonFiles === 'function') {
+        tree = merge(tree, this._additionalAddonFiles(tree));
+      }
       if (process.env.EMBER_DATA_ROLLUP_PRIVATE !== 'false' && this.shouldRollupPrivate !== true) {
         return this._super.treeForAddon.call(this, tree);
       }
@@ -119,11 +121,6 @@ function addonBuildConfigForDataPackage(PackageName) {
       this._setupBabelOptions();
 
       let babel = this.addons.find(addon => addon.name === 'ember-cli-babel');
-
-      let treeWithVersion = merge([
-        tree,
-        version(), // compile the VERSION into the build
-      ]);
 
       let privateTree = rollupPrivateModule(tree, {
         packageName: PackageName,
@@ -134,7 +131,7 @@ function addonBuildConfigForDataPackage(PackageName) {
         destDir: this.getOutputDirForVersion(),
       });
 
-      let withoutPrivate = new Funnel(treeWithVersion, {
+      let withoutPrivate = new Funnel(tree, {
         exclude: ['-private', isProductionEnv() && !isInstrumentedBuild() ? '-debug' : false].filter(Boolean),
 
         destDir: PackageName,

--- a/packages/-build-infra/src/addon-build-config-for-data-package.js
+++ b/packages/-build-infra/src/addon-build-config-for-data-package.js
@@ -110,9 +110,6 @@ function addonBuildConfigForDataPackage(PackageName) {
     },
 
     treeForAddon(tree) {
-      if (typeof this._additionalAddonFiles === 'function') {
-        tree = merge([tree, this._additionalAddonFiles(tree)]);
-      }
       if (process.env.EMBER_DATA_ROLLUP_PRIVATE !== 'false' && this.shouldRollupPrivate !== true) {
         return this._super.treeForAddon.call(this, tree);
       }

--- a/packages/-build-infra/src/addon-build-config-for-data-package.js
+++ b/packages/-build-infra/src/addon-build-config-for-data-package.js
@@ -111,7 +111,7 @@ function addonBuildConfigForDataPackage(PackageName) {
 
     treeForAddon(tree) {
       if (typeof this._additionalAddonFiles === 'function') {
-        tree = merge(tree, this._additionalAddonFiles(tree));
+        tree = merge([tree, this._additionalAddonFiles(tree)]);
       }
       if (process.env.EMBER_DATA_ROLLUP_PRIVATE !== 'false' && this.shouldRollupPrivate !== true) {
         return this._super.treeForAddon.call(this, tree);

--- a/packages/-ember-data/index.js
+++ b/packages/-ember-data/index.js
@@ -5,7 +5,7 @@ const addonBaseConfig = addonBuildConfigForDataPackage('ember-data');
 const version = require('@ember-data/-build-infra/src/create-version-module');
 const merge = require('broccoli-merge-trees');
 
-module.exports = Object.assign(addonBaseConfig, {
+module.exports = Object.assign({}, addonBaseConfig, {
   shouldRollupPrivate: true,
   externalDependenciesForPrivateModule() {
     return ['ember-data/version', '@ember-data/store/-private', '@ember-data/store', '@ember-data/model'];

--- a/packages/-ember-data/index.js
+++ b/packages/-ember-data/index.js
@@ -3,13 +3,15 @@
 const addonBuildConfigForDataPackage = require('@ember-data/-build-infra/src/addon-build-config-for-data-package');
 const addonBaseConfig = addonBuildConfigForDataPackage('ember-data');
 const version = require('@ember-data/-build-infra/src/create-version-module');
+const merge = require('broccoli-merge-trees');
 
 module.exports = Object.assign(addonBaseConfig, {
   shouldRollupPrivate: true,
   externalDependenciesForPrivateModule() {
     return ['ember-data/version', '@ember-data/store/-private', '@ember-data/store', '@ember-data/model'];
   },
-  _additionalAddonFiles() {
-    return version();
+  treeForAddon(tree) {
+    tree = merge([tree, version()]);
+    return addonBaseConfig.treeForAddon.call(this, tree);
   },
 });

--- a/packages/-ember-data/index.js
+++ b/packages/-ember-data/index.js
@@ -2,10 +2,14 @@
 
 const addonBuildConfigForDataPackage = require('@ember-data/-build-infra/src/addon-build-config-for-data-package');
 const addonBaseConfig = addonBuildConfigForDataPackage('ember-data');
+const version = require('@ember-data/-build-infra/src/create-version-module');
 
 module.exports = Object.assign(addonBaseConfig, {
   shouldRollupPrivate: true,
   externalDependenciesForPrivateModule() {
     return ['ember-data/version', '@ember-data/store/-private', '@ember-data/store', '@ember-data/model'];
+  },
+  _additionalAddonFiles() {
+    return version();
   },
 });

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -33,7 +33,8 @@
     "@glimmer/env": "^0.1.7",
     "ember-cli-babel": "^7.11.1",
     "ember-cli-typescript": "^3.0.0",
-    "ember-inflector": "^3.0.1"
+    "ember-inflector": "^3.0.1",
+    "broccoli-merge-trees": "^3.0.2"
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.6.0",

--- a/packages/adapter/index.js
+++ b/packages/adapter/index.js
@@ -4,7 +4,7 @@ const name = require('./package').name;
 const addonBuildConfigForDataPackage = require('@ember-data/-build-infra/src/addon-build-config-for-data-package');
 const addonBaseConfig = addonBuildConfigForDataPackage(name);
 
-module.exports = Object.assign(addonBaseConfig, {
+module.exports = Object.assign({}, addonBaseConfig, {
   shouldRollupPrivate: true,
   externalDependenciesForPrivateModule() {
     return ['require', 'ember-inflector'];

--- a/packages/debug/index.js
+++ b/packages/debug/index.js
@@ -4,7 +4,7 @@ const name = require('./package').name;
 const addonBuildConfigForDataPackage = require('@ember-data/-build-infra/src/addon-build-config-for-data-package');
 const addonBaseConfig = addonBuildConfigForDataPackage(name);
 
-module.exports = Object.assign(addonBaseConfig, {
+module.exports = Object.assign({}, addonBaseConfig, {
   shouldRollupPrivate: false,
   externalDependenciesForPrivateModule() {
     return [];

--- a/packages/model/index.js
+++ b/packages/model/index.js
@@ -4,7 +4,7 @@ const name = require('./package').name;
 const addonBuildConfigForDataPackage = require('@ember-data/-build-infra/src/addon-build-config-for-data-package');
 const addonBaseConfig = addonBuildConfigForDataPackage(name);
 
-module.exports = Object.assign(addonBaseConfig, {
+module.exports = Object.assign({}, addonBaseConfig, {
   shouldRollupPrivate: true,
   externalDependenciesForPrivateModule() {
     return ['@ember-data/canary-features', '@ember-data/store', '@ember-data/store/-private'];

--- a/packages/record-data/index.js
+++ b/packages/record-data/index.js
@@ -4,7 +4,7 @@ const name = require('./package').name;
 const addonBuildConfigForDataPackage = require('@ember-data/-build-infra/src/addon-build-config-for-data-package');
 const addonBaseConfig = addonBuildConfigForDataPackage(name);
 
-module.exports = Object.assign(addonBaseConfig, {
+module.exports = Object.assign({}, addonBaseConfig, {
   shouldRollupPrivate: false,
   externalDependenciesForPrivateModule() {
     return [];

--- a/packages/serializer/index.js
+++ b/packages/serializer/index.js
@@ -4,7 +4,7 @@ const name = require('./package').name;
 const addonBuildConfigForDataPackage = require('@ember-data/-build-infra/src/addon-build-config-for-data-package');
 const addonBaseConfig = addonBuildConfigForDataPackage(name);
 
-module.exports = Object.assign(addonBaseConfig, {
+module.exports = Object.assign({}, addonBaseConfig, {
   shouldRollupPrivate: true,
   externalDependenciesForPrivateModule() {
     return [];

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -4,7 +4,7 @@ const name = require('./package').name;
 const addonBuildConfigForDataPackage = require('@ember-data/-build-infra/src/addon-build-config-for-data-package');
 const addonBaseConfig = addonBuildConfigForDataPackage(name);
 
-module.exports = Object.assign(addonBaseConfig, {
+module.exports = Object.assign({}, addonBaseConfig, {
   shouldRollupPrivate: true,
   externalDependenciesForPrivateModule() {
     return [


### PR DESCRIPTION
Previously we were adding version to the tree in every package (whoops!)

This also ensures that version is always included in the output regardless of whether shouldRollupPrivate is used.

Resolves #6219 