### PR TITLE
[CHORE] Fail CI build if `yarn.lock` is out of date

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 10.x
       - name: Yarn install
-        run: yarn
+        run: yarn --frozen-lockfile
       - name: Lint features
         run: yarn lint:features
       - name: Lint prettier

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - yarn install
+  - yarn install --frozen-lockfile
   - node ./bin/packages-for-commit.js
 
 script:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
         inputs:
           versionSpec: '10.x' # The version we're installing
       - script: |
-          yarn
+          yarn --frozen-lockfile
           yarn lint:features
       - script: |
           yarn lint:prettier


### PR DESCRIPTION
This adds the [`--frozen-lockfile`](https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install) flag to our CI scripts where we are `yarn install`ing dependencies.

This flag will cause the script to exit with an error if the committed `yarn.lock` is not up to date.

This makes sure we our `yarn.lock` file is always up to date.