### PR TITLE
[CHORE] Cleanup ESLint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,26 +1,26 @@
 # unconventional js
-packages/*/blueprints/*/*files/
-vendor/
+**/blueprints/*/*files/
+**/vendor/
 
 # compiled output
+**/dist/
+**/tmp/
 /packages/-ember-data/docs/
-dist
-tmp
 
 # dependencies
-bower_components
-node_modules
+**/bower_components/
+**/node_modules/
 
 # misc
-/coverage/
+**/coverage/
 !.*
 /.yarn/
-.git
+/.git/
 
 # ember-try
-.node_modules.ember-try
-bower.json.ember-try
-package.json.ember-try
+**/.node_modules.ember-try/
+**/bower.json.ember-try
+**/package.json.ember-try
 
 # ember-data
-packages/*/node-tests/fixtures
+**/node-tests/fixtures/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,26 +10,12 @@ module.exports = {
   rules: {
     'mocha/no-exclusive-tests': 'error',
     'prettier/prettier': 'error',
-
-    'no-unused-vars': [
-      'error',
-      {
-        args: 'none',
-      },
-    ],
-
+    'no-unused-vars': ['error', { args: 'none' }],
     'no-cond-assign': ['error', 'except-parens'],
     eqeqeq: 'error',
     'no-eval': 'error',
-    'new-cap': [
-      'error',
-      {
-        capIsNew: false,
-      },
-    ],
+    'new-cap': ['error', { capIsNew: false }],
     'no-caller': 'error',
-    'no-irregular-whitespace': 'error',
-    'no-undef': 'error',
     'no-eq-null': 'error',
     'no-console': 'error', // no longer recommended in eslint v6, this restores it
 
@@ -54,22 +40,26 @@ module.exports = {
         '.mocharc.js',
         '.eslintrc.js',
         '.prettierrc.js',
-        '.template-lintrc.js',
         'bin/*',
         'packages/-build-infra/src/**/*.js',
         'packages/-test-infra/src/**/*.js',
+        'packages/*/.ember-cli.js',
+        'packages/*/.eslintrc.js',
+        'packages/*/.template-lintrc.js',
         'packages/*/ember-cli-build.js',
         'packages/*/index.js',
         'packages/*/testem.js',
-        'packages/*/bin/**',
         'packages/*/blueprints/*/index.js',
-        'packages/*/blueprints/*.js',
         'packages/*/config/**/*.js',
-        'packages/*/lib/**/*.js',
-        'packages/*/node-tests/**',
         'packages/*/tests/dummy/config/**/*.js',
+        'packages/*/node-tests/**/*.js',
       ],
-      excludedFiles: ['packages/*/addon/**/index.js'],
+      excludedFiles: [
+        'packages/*/addon/**',
+        'packages/*/addon-test-support/**',
+        'packages/*/app/**',
+        'packages/*/tests/dummy/app/**',
+      ],
       parserOptions: {
         sourceType: 'script',
         ecmaVersion: 2015,
@@ -85,15 +75,15 @@ module.exports = {
 
     // node tests
     {
-      files: ['packages/*/node-tests/**', 'node-tests/**', 'packages/-test-infra/src/node-test-helpers/**/*'],
-
+      files: ['packages/*/node-tests/**', 'packages/-test-infra/src/node-test-helpers/**/*'],
       env: {
         mocha: true,
       },
     },
+
+    // docs
     {
       files: ['packages/-ember-data/node-tests/docs/*.js'],
-
       env: {
         qunit: true,
         es6: false,
@@ -107,9 +97,7 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         'no-console': 'off',
         'no-process-exit': 'off',
-        'node/no-extraneous-require': 'off',
         'node/no-unpublished-require': 'off',
-        'node/shebang': 'off',
       }),
     },
   ],


### PR DESCRIPTION
Cleans up our ESLint config to be more close to the ember-cli addon blueprints.

- Uses more consistent ignore pattern style
- Removes some unnecessary ESLint rule declarations that are already set via the latest `eslint:recommended` in 6.x.x
- Re-enables some rules for linting bin scripts that no longer need to be disabled