### PR TITLE
[BUGFIX release] Enable `store.createRecord` in FastBoot

### DIFF
--- a/packages/-fastboot-test-app/app/router.ts
+++ b/packages/-fastboot-test-app/app/router.ts
@@ -6,6 +6,10 @@ const Router = EmberRouter.extend({
   rootURL: config.rootURL,
 });
 
-Router.map(function() {});
+Router.map(function() {
+  this.route('person', function() {
+    this.route('new');
+  });
+});
 
 export default Router;

--- a/packages/-fastboot-test-app/app/routes/person/new.js
+++ b/packages/-fastboot-test-app/app/routes/person/new.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default Route.extend({
+  store: service(),
+
+  model() {
+    return this.store.createRecord('person');
+  },
+});

--- a/packages/-fastboot-test-app/app/templates/person/new.hbs
+++ b/packages/-fastboot-test-app/app/templates/person/new.hbs
@@ -1,0 +1,6 @@
+<form>
+  <label>
+    Name
+    {{input class="person-name" value=this.model.name}}
+  </label>
+</form>

--- a/packages/-fastboot-test-app/package.json
+++ b/packages/-fastboot-test-app/package.json
@@ -56,6 +56,9 @@
     "qunit-dom": "^0.9.0",
     "typescript": "~3.6.4"
   },
+  "fastbootDependencies": [
+    "crypto"
+  ],
   "engines": {
     "node": "8.* || >= 10.*"
   }

--- a/packages/-fastboot-test-app/tests/fastboot/person/new-test.js
+++ b/packages/-fastboot-test-app/tests/fastboot/person/new-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setup, visit } from 'ember-cli-fastboot-testing/test-support';
+
+module('FastBoot | /person/new', function(hooks) {
+  setup(hooks);
+
+  test('it does not error in SSR (GH#6563)', async function(assert) {
+    await visit('/person/new');
+
+    // from application.hbs
+    assert.dom('h1').hasText('Ember Data');
+    assert.dom('a').hasAttribute('href', '/tests');
+
+    assert.dom('.person-name').exists();
+  });
+});

--- a/packages/store/addon/-private/identifiers/utils/uuid-v4.ts
+++ b/packages/store/addon/-private/identifiers/utils/uuid-v4.ts
@@ -16,7 +16,7 @@ const CRYPTO = (() => {
   if (isFastBoot) {
     return {
       getRandomValues(buffer: Uint8Array) {
-        return FastBoot.require('crypto').randomFillSync(buffer);
+        return (FastBoot as FastBoot).require('crypto').randomFillSync(buffer);
       },
     };
   } else if (hasWindow && typeof window.crypto !== 'undefined') {

--- a/packages/store/addon/-private/identifiers/utils/uuid-v4.ts
+++ b/packages/store/addon/-private/identifiers/utils/uuid-v4.ts
@@ -9,10 +9,28 @@ declare global {
   }
 }
 
-const CRYPTO =
-  typeof window !== 'undefined' && window.msCrypto && typeof window.msCrypto.getRandomValues === 'function'
-    ? window.msCrypto
-    : window.crypto;
+const CRYPTO = (() => {
+  const hasWindow = typeof window !== 'undefined';
+  const isFastBoot = typeof FastBoot !== 'undefined';
+
+  if (isFastBoot) {
+    return {
+      getRandomValues(buffer: Uint8Array) {
+        return FastBoot.require('crypto').randomFillSync(buffer);
+      },
+    };
+  } else if (hasWindow && typeof window.crypto !== 'undefined') {
+    return window.crypto;
+  } else if (
+    hasWindow &&
+    typeof window.msCrypto !== 'undefined' &&
+    typeof window.msCrypto.getRandomValues === 'function'
+  ) {
+    return window.msCrypto;
+  } else {
+    throw new Error('ember-data: Cannot find a valid way to generate local identifiers');
+  }
+})();
 
 // we might be able to optimize this by requesting more bytes than we need at a time
 function rng() {

--- a/packages/store/types/fastboot/index.d.ts
+++ b/packages/store/types/fastboot/index.d.ts
@@ -1,0 +1,4 @@
+interface FastBoot {
+  require(moduleName: string): any;
+}
+const FastBoot: undefined | FastBoot;


### PR DESCRIPTION
Changes the V4 UUID generation to leverage `FastBoot.require` when possible.

This currently requires that the host application add the following to their `package.json`:

```json
{
  "fastbootDependencies": [
   "crypto"
  ]
}
```

Fixes #6563