### PR TITLE
[BUGFIX links] relationship setup for link fetch should batch

### DIFF
--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -1716,15 +1716,15 @@ abstract class CoreStore extends Service {
     return this.findBelongsTo(parentInternalModel, resource.links.related, relationshipMeta, options).then(
       internalModel => {
         return this._backburner.join(() => {
-          let response = internalModel && (recordDataFor(internalModel) as RelationshipRecordData).getResourceIdentifier();
+          let response =
+            internalModel && (recordDataFor(internalModel) as RelationshipRecordData).getResourceIdentifier();
           parentInternalModel.linkWasLoadedForRelationship(relationshipMeta.key, { data: response });
           if (internalModel === null) {
             return null;
           }
           // TODO Igor this doesn't seem like the right boundary, probably the caller method should extract the record out
           return internalModel.getRecord();
-          }
-        );
+        });
       }
     );
   }

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -1632,20 +1632,7 @@ abstract class CoreStore extends Service {
 
     // fetch via link
     if (shouldFindViaLink) {
-      return this.findHasMany(parentInternalModel, resource.links.related, relationshipMeta, options).then(
-        internalModels => {
-          this._backburner.join(() => {
-            let payload: { data: any[]; meta?: any } = {
-              data: internalModels.map(im => (recordDataFor(im) as RelationshipRecordData).getResourceIdentifier()),
-            };
-            if (internalModels.meta !== undefined) {
-              payload.meta = internalModels.meta;
-            }
-            parentInternalModel.linkWasLoadedForRelationship(relationshipMeta.key, payload);
-            return internalModels;
-          });
-        }
-      );
+      return this.findHasMany(parentInternalModel, resource.links.related, relationshipMeta, options);
     }
 
     let preferLocalCache = hasAnyRelationshipData && !relationshipIsEmpty;
@@ -1715,16 +1702,7 @@ abstract class CoreStore extends Service {
     }
     return this.findBelongsTo(parentInternalModel, resource.links.related, relationshipMeta, options).then(
       internalModel => {
-        return this._backburner.join(() => {
-          let response =
-            internalModel && (recordDataFor(internalModel) as RelationshipRecordData).getResourceIdentifier();
-          parentInternalModel.linkWasLoadedForRelationship(relationshipMeta.key, { data: response });
-          if (internalModel === null) {
-            return null;
-          }
-          // TODO Igor this doesn't seem like the right boundary, probably the caller method should extract the record out
-          return internalModel.getRecord();
-        });
+        return internalModel ? internalModel.getRecord() : null;
       }
     );
   }

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -515,16 +515,6 @@ export default class InternalModel {
     }
   }
 
-  linkWasLoadedForRelationship(key, data) {
-    let relationships = {};
-    relationships[key] = data;
-    this._recordData.pushData({
-      id: this.id,
-      type: this.modelName,
-      relationships,
-    });
-  }
-
   finishedReloading() {
     this.isReloading = false;
     if (this.hasRecord) {

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -130,12 +130,14 @@ function syncRelationshipDataFromLink(store, payload, parentInternalModel, relat
 
   // now, push the left hand side (the parent record) to ensure things are in sync, since
   // the payload will be pushed with store._push
-  store.push({
+  store._push({
     data: {
       id: parentInternalModel.id,
       type: parentInternalModel.modelName,
       relationships: {
         [relationship.key]: {
+          meta: payload.meta,
+          links: payload.links,
           data: relationshipData,
         },
       },
@@ -285,7 +287,6 @@ export function _findHasMany(adapter, store, internalModel, link, relationship, 
       syncRelationshipDataFromLink(store, payload, internalModel, relationship);
 
       let internalModelArray = store._push(payload);
-      internalModelArray.meta = payload.meta;
       return internalModelArray;
     },
     null,

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -130,19 +130,24 @@ function syncRelationshipDataFromLink(store, payload, parentInternalModel, relat
 
   // now, push the left hand side (the parent record) to ensure things are in sync, since
   // the payload will be pushed with store._push
-  store._push({
-    data: {
-      id: parentInternalModel.id,
-      type: parentInternalModel.modelName,
-      relationships: {
-        [relationship.key]: {
-          meta: payload.meta,
-          links: payload.links,
-          data: relationshipData,
-        },
+  const parentPayload = {
+    id: parentInternalModel.id,
+    type: parentInternalModel.modelName,
+    relationships: {
+      [relationship.key]: {
+        meta: payload.meta,
+        links: payload.links,
+        data: relationshipData,
       },
     },
-  });
+  };
+
+  if (!Array.isArray(payload.included)) {
+    payload.included = [];
+  }
+  payload.included.push(parentPayload);
+
+  return payload;
 }
 
 function ensureRelationshipIsSetToParent(payload, parentInternalModel, store, parentRelationship, index) {
@@ -284,7 +289,7 @@ export function _findHasMany(adapter, store, internalModel, link, relationship, 
       let serializer = store.serializerFor(relationship.type);
       let payload = normalizeResponseHelper(serializer, store, modelClass, adapterPayload, null, 'findHasMany');
 
-      syncRelationshipDataFromLink(store, payload, internalModel, relationship);
+      payload = syncRelationshipDataFromLink(store, payload, internalModel, relationship);
 
       let internalModelArray = store._push(payload);
       return internalModelArray;
@@ -312,7 +317,7 @@ export function _findBelongsTo(adapter, store, internalModel, link, relationship
         return null;
       }
 
-      syncRelationshipDataFromLink(store, payload, internalModel, relationship);
+      payload = syncRelationshipDataFromLink(store, payload, internalModel, relationship);
 
       return store._push(payload);
     },


### PR DESCRIPTION
**Description By @runspired **

Most new data enters the cache via `store._push` which ensures that all operations on state internally occur within one ED runloop. An exception is when fetching relationships via links, where in addition to calling `_push` we make a call to `internalModel.linkWasLoadedForRelationship`. Since this call is not within the call to `_push` we were accidentally spinning up thousands of run loops for hasMany relationships.

Here we ensure that this loading always has an outer run loop so that scheduled work is appropriately batched internally.

**EDIT**

After reflection, @runspired realized that the call to `linkWasLoadedForRelationship` was especially odd. After digging it, it became apparent that this was only necessary to forward links and meta to the relationship, for which we already have a codepath in `_push` when we syncRelationshipDataForLinks to fix the payload. We are able to remove this secondary "push" codepath entirely, which also means we further improve the performance of this codepath by not pushing twice.

The application that @sly7-7 demo'd this perf issue with went from ~12s to <600ms with the original batching change. I suspect if he re-profiles we will now be <250ms.

**Edit 2**

After making the previous change to eliminate `linkWasLoadedForRelationship`, @runspired realized that while we eliminated one relationship flush, we are still calling `store._push` twice meaning we still flush relationship changes twice when we only need one flush. A new commit has been added that changes our relationship sync logic in away to allow us to only flush once. He looks forward to seeing what the new performance number is :)