### PR TITLE
[BUGFIX] fix AdapterError reexport

### DIFF
--- a/packages/-ember-data/addon/adapters/errors.js
+++ b/packages/-ember-data/addon/adapters/errors.js
@@ -1,6 +1,6 @@
 export {
   AbortError,
-  AdapterError,
+  default as AdapterError,
   ConflictError,
   ForbiddenError,
   InvalidError,


### PR DESCRIPTION
embroider flagged `export 'AdapterError' was not found in '@ember-data/adapter/error'`.
turns out `AdapterError` is the default export, not a named export.