### PR TITLE
chore(ci): Increase browser start timeout

### DIFF
--- a/packages/-ember-data/testem.js
+++ b/packages/-ember-data/testem.js
@@ -4,6 +4,7 @@ module.exports = {
   reporter: 'dot',
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       ci: [


### PR DESCRIPTION
We're frequently seeing an error about testem failing to connect to the browser (Chrome) within the 30 second default timeout in our CI builds.

This increases the timeout from 30 seconds to 120 seconds in an effort to at least diagnose whether the timeout is just too short or if there is another problem causing these timeouts.

There is a pretty long related issue on the testem repo that suggests that this may help our issue: https://github.com/testem/testem/issues/1021

This is what the error looks like:

```
Built project successfully. Stored in "/tmp/tests-dist-2019911-2914-80vil9.m6t3n".

F

1 tests complete (30770 ms)

1) [Chrome] error
   Error: Browser failed to connect within 30s. testem.js not loaded?
```

Some sample runs that include the browser timing out:

- https://github.com/emberjs/data/runs/256124548
- https://github.com/emberjs/data/runs/256124527
- https://github.com/emberjs/data/runs/255983061

[Testem Config Level Options Docs](https://github.com/testem/testem/blob/master/docs/config_file.md#config-level-options)
