### PR TITLE
Using a config to include ember-data/debug in the build

### DIFF
--- a/packages/debug/index.js
+++ b/packages/debug/index.js
@@ -4,9 +4,51 @@ const name = require('./package').name;
 const addonBuildConfigForDataPackage = require('@ember-data/private-build-infra/src/addon-build-config-for-data-package');
 const addonBaseConfig = addonBuildConfigForDataPackage(name);
 
+function getApp(addon) {
+  while (addon && !addon.app) {
+    addon = addon.parent;
+  }
+  if (!addon) {
+    throw new Error(`Unable to find the parent application`);
+  }
+  return addon.app;
+}
+
 module.exports = Object.assign({}, addonBaseConfig, {
   shouldRollupPrivate: false,
+  __isEnabled: null,
   externalDependenciesForPrivateModule() {
     return [];
+  },
+  treeFor() {
+    // Nested addons don't call isEnabled automatically,
+    // So this ensures that we return empty trees whenever
+    // we are not enabled.
+    if (this.isEnabled()) {
+      return this._super.treeFor.call(this, ...arguments);
+    }
+  },
+  isEnabled() {
+    if (this.__isEnabled !== null) {
+      return this.__isEnabled;
+    }
+    const options = this.setupOptions();
+    const env = getApp(this).env;
+
+    this.__isEnabled = env !== 'production' || options.includeDataAdapterInProduction === true;
+
+    return this.__isEnabled;
+  },
+  setupOptions() {
+    const app = getApp(this);
+    const parentIsEmberDataAddon = this.parent.pkg.name === 'ember-data';
+
+    let options = (app.options = app.options || {});
+    options.emberData = options.emberData || {};
+
+    if (options.emberData.includeDataAdapterInProduction === undefined) {
+      options.emberData.includeDataAdapterInProduction = parentIsEmberDataAddon;
+    }
+    return options.emberData;
   },
 });


### PR DESCRIPTION
Part of #6166 , the debug package is included based on a config setting in `environment.js`.

This relies on the `isEnabled` hook of the debug package's index.js. I manually ran yarn build in the following scenarios with the following outcomes:

1. in debug package -> not included
2. in the main addon -> included
3. in the main added with `ENV.includeDebug = false;` in environment.js -> not included

I used the environment.js settings to hold the potential config value, but this is mostly a POC, please let me know if there is a better location, name, etc.
<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
