### PR TITLE
[FEAT links] ensures full links object support for relationships

### DIFF
--- a/packages/-build-infra/src/features.js
+++ b/packages/-build-infra/src/features.js
@@ -2,7 +2,7 @@
 
 const requireEsm = require('esm')(module);
 function getFeatures() {
-  const { default: features } = requireEsm('@ember-data/canary-features/addon/default-features.js');
+  const { default: features } = requireEsm('@ember-data/canary-features/addon/default-features.ts');
 
   const FEATURE_OVERRIDES = process.env.EMBER_DATA_FEATURE_OVERRIDE;
   if (FEATURE_OVERRIDES === 'ENABLE_ALL_OPTIONAL') {

--- a/packages/-ember-data/tests/acceptance/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/has-many-test.js
@@ -457,7 +457,7 @@ module('async has-many rendering tests', function(hooks) {
       assert.equal(!!RelationshipPromiseCache['children'], false, 'The relationship has no fetch promise');
       assert.equal(!!RelationshipProxyCache['children'], true, 'The relationship has a promise proxy');
       assert.equal(relationshipState.hasFailedLoadAttempt === true, true, 'The relationship has attempted a load');
-      assert.equal(!!relationshipState.link, true, 'The relationship has a link');
+      assert.equal(!!(relationshipState.links && relationshipState.links.related), true, 'The relationship has a link');
 
       Ember.onerror = originalOnError;
     });

--- a/packages/-ember-data/tests/integration/adapter/record-persistence-test.js
+++ b/packages/-ember-data/tests/integration/adapter/record-persistence-test.js
@@ -28,7 +28,7 @@ module('integration/adapter/record_persistence - Persisting Records', function(h
     this.owner.register('serializer:application', JSONAPISerializer.extend());
   });
 
-  test("When a store is committed, the adapter's `commit` method should be called with records that have been changed.", function(assert) {
+  test("When a store is committed, the adapter's `updateRecord` method should be called with records that have been changed.", async function(assert) {
     assert.expect(2);
 
     let store = this.owner.lookup('service:store');
@@ -42,27 +42,18 @@ module('integration/adapter/record_persistence - Persisting Records', function(h
       return run(RSVP, 'resolve');
     };
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          attributes: {
-            name: 'Braaaahm Dale',
-          },
+    const tom = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        attributes: {
+          name: 'Braaaahm Dale',
         },
-      });
+      },
     });
 
-    let tom;
-
-    return run(() => {
-      return store.findRecord('person', 1).then(person => {
-        tom = person;
-        set(tom, 'name', 'Tom Dale');
-        return tom.save();
-      });
-    });
+    set(tom, 'name', 'Tom Dale');
+    await tom.save();
   });
 
   test("When a store is committed, the adapter's `commit` method should be called with records that have been created.", function(assert) {

--- a/packages/-ember-data/tests/integration/relationships/relationship-links-test.js
+++ b/packages/-ember-data/tests/integration/relationships/relationship-links-test.js
@@ -4,6 +4,7 @@ import { setupTest } from 'ember-qunit';
 import Store from '@ember-data/store';
 import Model, { attr, hasMany } from '@ember-data/model';
 import { resolve } from 'rsvp';
+import { FULL_LINKS_ON_RELATIONSHIPS } from '@ember-data/canary-features';
 
 module('JSON:API links access on relationships', function(hooks) {
   setupTest(hooks);
@@ -15,339 +16,341 @@ module('JSON:API links access on relationships', function(hooks) {
     store = owner.lookup('service:store');
   });
 
-  test('We can access links from a hasMany', async function(assert) {
-    class ApplicationAdapter extends EmberObject {
-      findRecord() {}
-      findHasMany() {
-        return resolve({
-          data: [],
-        });
+  if (FULL_LINKS_ON_RELATIONSHIPS) {
+    test('We can access links from a hasMany', async function(assert) {
+      class ApplicationAdapter extends EmberObject {
+        findRecord() {}
+        findHasMany() {
+          return resolve({
+            data: [],
+          });
+        }
+        shouldBackgroundReloadRecord() {
+          return false;
+        }
+        shouldReloadRecord() {
+          return false;
+        }
       }
-      shouldBackgroundReloadRecord() {
-        return false;
+      class User extends Model {
+        @attr name;
+        @hasMany('tool', { inverse: null, async: true })
+        tools;
       }
-      shouldReloadRecord() {
-        return false;
+      class Tool extends Model {
+        @attr name;
       }
-    }
-    class User extends Model {
-      @attr name;
-      @hasMany('tool', { inverse: null, async: true })
-      tools;
-    }
-    class Tool extends Model {
-      @attr name;
-    }
-    class ApplicationSerializer extends EmberObject {
-      normalizeResponse(_, __, data) {
-        return data;
+      class ApplicationSerializer extends EmberObject {
+        normalizeResponse(_, __, data) {
+          return data;
+        }
       }
-    }
-    this.owner.register('adapter:application', ApplicationAdapter);
-    this.owner.register('serializer:application', ApplicationSerializer);
-    this.owner.register('model:user', User);
-    this.owner.register('model:tool', Tool);
+      this.owner.register('adapter:application', ApplicationAdapter);
+      this.owner.register('serializer:application', ApplicationSerializer);
+      this.owner.register('model:user', User);
+      this.owner.register('model:tool', Tool);
 
-    const user = store.push({
-      data: {
-        id: '1',
-        type: 'user',
-        attributes: {
-          name: '@runspired',
-        },
-        relationships: {
-          tools: {
-            links: {
-              self: '/the/original/path',
-              related: '/the/related/link',
-              first: '/the/related/link?page=1',
-              prev: null,
-              last: '/the/related/link?page=3',
-              next: '/the/related/link?page=2',
+      const user = store.push({
+        data: {
+          id: '1',
+          type: 'user',
+          attributes: {
+            name: '@runspired',
+          },
+          relationships: {
+            tools: {
+              links: {
+                self: '/the/original/path',
+                related: '/the/related/link',
+                first: '/the/related/link?page=1',
+                prev: null,
+                last: '/the/related/link?page=3',
+                next: '/the/related/link?page=2',
+              },
             },
           },
         },
-      },
+      });
+
+      // Test we have access via the HasManyReference
+      const toolsRef = user.hasMany('tools');
+      let links = toolsRef.links();
+      assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
+      assert.strictEqual(links.related, '/the/related/link', 'The related link is correctly available');
+      assert.strictEqual(links.first, '/the/related/link?page=1', 'The first link is correctly available');
+      assert.strictEqual(links.last, '/the/related/link?page=3', 'The last link is correctly available');
+      assert.strictEqual(links.prev, null, 'The prev link is correctly available');
+      assert.strictEqual(links.next, '/the/related/link?page=2', 'The next link is correctly available');
+      assert.strictEqual(links.self, '/the/original/path', 'The self link is correctly available');
+
+      // Test we have access via the ManyArray
+      const toolsRel = await user.tools;
+      links = toolsRel.links;
+      assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
+      assert.strictEqual(links.related, '/the/related/link', 'The related link is correctly available');
+      assert.strictEqual(links.first, '/the/related/link?page=1', 'The first link is correctly available');
+      assert.strictEqual(links.last, '/the/related/link?page=3', 'The last link is correctly available');
+      assert.strictEqual(links.prev, null, 'The prev link is correctly available');
+      assert.strictEqual(links.next, '/the/related/link?page=2', 'The next link is correctly available');
+      assert.strictEqual(links.self, '/the/original/path', 'The self link is correctly available');
     });
 
-    // Test we have access via the HasManyReference
-    const toolsRef = user.hasMany('tools');
-    let links = toolsRef.links();
-    assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
-    assert.strictEqual(links.related, '/the/related/link', 'The related link is correctly available');
-    assert.strictEqual(links.first, '/the/related/link?page=1', 'The first link is correctly available');
-    assert.strictEqual(links.last, '/the/related/link?page=3', 'The last link is correctly available');
-    assert.strictEqual(links.prev, null, 'The prev link is correctly available');
-    assert.strictEqual(links.next, '/the/related/link?page=2', 'The next link is correctly available');
-    assert.strictEqual(links.self, '/the/original/path', 'The self link is correctly available');
+    test('We preserve { href } link objects', async function(assert) {
+      class ApplicationAdapter extends EmberObject {
+        findRecord() {}
+        findHasMany() {
+          return resolve({
+            data: [],
+          });
+        }
+        shouldBackgroundReloadRecord() {
+          return false;
+        }
+        shouldReloadRecord() {
+          return false;
+        }
+      }
+      class User extends Model {
+        @attr name;
+        @hasMany('tool', { inverse: null, async: true })
+        tools;
+      }
+      class Tool extends Model {
+        @attr name;
+      }
+      class ApplicationSerializer extends EmberObject {
+        normalizeResponse(_, __, data) {
+          return data;
+        }
+      }
+      this.owner.register('adapter:application', ApplicationAdapter);
+      this.owner.register('serializer:application', ApplicationSerializer);
+      this.owner.register('model:user', User);
+      this.owner.register('model:tool', Tool);
 
-    // Test we have access via the ManyArray
-    const toolsRel = await user.tools;
-    links = toolsRel.links;
-    assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
-    assert.strictEqual(links.related, '/the/related/link', 'The related link is correctly available');
-    assert.strictEqual(links.first, '/the/related/link?page=1', 'The first link is correctly available');
-    assert.strictEqual(links.last, '/the/related/link?page=3', 'The last link is correctly available');
-    assert.strictEqual(links.prev, null, 'The prev link is correctly available');
-    assert.strictEqual(links.next, '/the/related/link?page=2', 'The next link is correctly available');
-    assert.strictEqual(links.self, '/the/original/path', 'The self link is correctly available');
-  });
-
-  test('We preserve { href } link objects', async function(assert) {
-    class ApplicationAdapter extends EmberObject {
-      findRecord() {}
-      findHasMany() {
-        return resolve({
-          data: [],
-        });
-      }
-      shouldBackgroundReloadRecord() {
-        return false;
-      }
-      shouldReloadRecord() {
-        return false;
-      }
-    }
-    class User extends Model {
-      @attr name;
-      @hasMany('tool', { inverse: null, async: true })
-      tools;
-    }
-    class Tool extends Model {
-      @attr name;
-    }
-    class ApplicationSerializer extends EmberObject {
-      normalizeResponse(_, __, data) {
-        return data;
-      }
-    }
-    this.owner.register('adapter:application', ApplicationAdapter);
-    this.owner.register('serializer:application', ApplicationSerializer);
-    this.owner.register('model:user', User);
-    this.owner.register('model:tool', Tool);
-
-    const user = store.push({
-      data: {
-        id: '1',
-        type: 'user',
-        attributes: {
-          name: '@runspired',
-        },
-        relationships: {
-          tools: {
-            links: {
-              self: { href: '/the/original/path' },
-              related: { href: '/the/related/link' },
-              first: { href: '/the/related/link?page=1' },
-              prev: null,
-              last: { href: '/the/related/link?page=3' },
-              next: { href: '/the/related/link?page=2' },
+      const user = store.push({
+        data: {
+          id: '1',
+          type: 'user',
+          attributes: {
+            name: '@runspired',
+          },
+          relationships: {
+            tools: {
+              links: {
+                self: { href: '/the/original/path' },
+                related: { href: '/the/related/link' },
+                first: { href: '/the/related/link?page=1' },
+                prev: null,
+                last: { href: '/the/related/link?page=3' },
+                next: { href: '/the/related/link?page=2' },
+              },
             },
           },
         },
-      },
+      });
+
+      // Test we have access via the HasManyReference
+      const toolsRef = user.hasMany('tools');
+      let links = toolsRef.links();
+      assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
+      assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+      assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
+      assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
+      assert.deepEqual(links.prev, null, 'The prev link is correctly available');
+      assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
+      assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
+
+      // Test we have access via the ManyArray
+      const toolsRel = await user.tools;
+      links = toolsRel.links;
+      assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
+      assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+      assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
+      assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
+      assert.deepEqual(links.prev, null, 'The prev link is correctly available');
+      assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
+      assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
     });
 
-    // Test we have access via the HasManyReference
-    const toolsRef = user.hasMany('tools');
-    let links = toolsRef.links();
-    assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
-    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
-    assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
-    assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
-    assert.deepEqual(links.prev, null, 'The prev link is correctly available');
-    assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
-    assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
+    test('We unwrap the { href } link object when related link is accessed directly', async function(assert) {
+      class ApplicationAdapter extends EmberObject {
+        findRecord() {}
+        findHasMany() {
+          return resolve({
+            data: [],
+          });
+        }
+        shouldBackgroundReloadRecord() {
+          return false;
+        }
+        shouldReloadRecord() {
+          return false;
+        }
+      }
+      class User extends Model {
+        @attr name;
+        @hasMany('tool', { inverse: null, async: true })
+        tools;
+      }
+      class Tool extends Model {
+        @attr name;
+      }
+      class ApplicationSerializer extends EmberObject {
+        normalizeResponse(_, __, data) {
+          return data;
+        }
+      }
+      this.owner.register('adapter:application', ApplicationAdapter);
+      this.owner.register('serializer:application', ApplicationSerializer);
+      this.owner.register('model:user', User);
+      this.owner.register('model:tool', Tool);
 
-    // Test we have access via the ManyArray
-    const toolsRel = await user.tools;
-    links = toolsRel.links;
-    assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
-    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
-    assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
-    assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
-    assert.deepEqual(links.prev, null, 'The prev link is correctly available');
-    assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
-    assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
-  });
-
-  test('We unwrap the { href } link object when related link is accessed directly', async function(assert) {
-    class ApplicationAdapter extends EmberObject {
-      findRecord() {}
-      findHasMany() {
-        return resolve({
-          data: [],
-        });
-      }
-      shouldBackgroundReloadRecord() {
-        return false;
-      }
-      shouldReloadRecord() {
-        return false;
-      }
-    }
-    class User extends Model {
-      @attr name;
-      @hasMany('tool', { inverse: null, async: true })
-      tools;
-    }
-    class Tool extends Model {
-      @attr name;
-    }
-    class ApplicationSerializer extends EmberObject {
-      normalizeResponse(_, __, data) {
-        return data;
-      }
-    }
-    this.owner.register('adapter:application', ApplicationAdapter);
-    this.owner.register('serializer:application', ApplicationSerializer);
-    this.owner.register('model:user', User);
-    this.owner.register('model:tool', Tool);
-
-    const user = store.push({
-      data: {
-        id: '1',
-        type: 'user',
-        attributes: {
-          name: '@runspired',
-        },
-        relationships: {
-          tools: {
-            links: {
-              related: { href: '/the/related/link' },
+      const user = store.push({
+        data: {
+          id: '1',
+          type: 'user',
+          attributes: {
+            name: '@runspired',
+          },
+          relationships: {
+            tools: {
+              links: {
+                related: { href: '/the/related/link' },
+              },
             },
           },
         },
-      },
+      });
+
+      // Test we have access via the HasManyReference
+      const toolsRef = user.hasMany('tools');
+      let links = toolsRef.links();
+      assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
+      assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+
+      let link = toolsRef.link();
+      assert.strictEqual(link, '/the/related/link', 'The related link is unwrapped when accessed directly');
+
+      // Test we have access via the ManyArray
+      const toolsRel = await user.tools;
+      links = toolsRel.links;
+      assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
+      assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
     });
 
-    // Test we have access via the HasManyReference
-    const toolsRef = user.hasMany('tools');
-    let links = toolsRef.links();
-    assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
-    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
-
-    let link = toolsRef.link();
-    assert.strictEqual(link, '/the/related/link', 'The related link is unwrapped when accessed directly');
-
-    // Test we have access via the ManyArray
-    const toolsRel = await user.tools;
-    links = toolsRel.links;
-    assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
-    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
-  });
-
-  test('Links in the top-level of a relationship-document update the relationship links', async function(assert) {
-    class ApplicationAdapter extends EmberObject {
-      findRecord() {}
-      findHasMany() {
-        return resolve({
-          data: [],
-          links: {
-            self: { href: '/some/other/path' },
-            related: { href: '/the/new/related/link?page=3' },
-            first: { href: '/the/new/related/link?page=1' },
-            prev: { href: '/the/new/related/link?page=2' },
-            last: { href: '/the/new/related/link?page=5' },
-            next: { href: '/the/new/related/link?page=4' },
-          },
-        });
-      }
-      shouldBackgroundReloadRecord() {
-        return false;
-      }
-      shouldReloadRecord() {
-        return false;
-      }
-    }
-    class User extends Model {
-      @attr name;
-      @hasMany('tool', { inverse: null, async: true })
-      tools;
-    }
-    class Tool extends Model {
-      @attr name;
-    }
-    class ApplicationSerializer extends EmberObject {
-      normalizeResponse(_, __, data) {
-        return data;
-      }
-    }
-    this.owner.register('adapter:application', ApplicationAdapter);
-    this.owner.register('serializer:application', ApplicationSerializer);
-    this.owner.register('model:user', User);
-    this.owner.register('model:tool', Tool);
-
-    const user = store.push({
-      data: {
-        id: '1',
-        type: 'user',
-        attributes: {
-          name: '@runspired',
-        },
-        relationships: {
-          tools: {
+    test('Links in the top-level of a relationship-document update the relationship links', async function(assert) {
+      class ApplicationAdapter extends EmberObject {
+        findRecord() {}
+        findHasMany() {
+          return resolve({
+            data: [],
             links: {
-              self: { href: '/the/original/path' },
-              related: { href: '/the/related/link' },
-              first: { href: '/the/related/link?page=1' },
-              prev: null,
-              last: { href: '/the/related/link?page=3' },
-              next: { href: '/the/related/link?page=2' },
+              self: { href: '/some/other/path' },
+              related: { href: '/the/new/related/link?page=3' },
+              first: { href: '/the/new/related/link?page=1' },
+              prev: { href: '/the/new/related/link?page=2' },
+              last: { href: '/the/new/related/link?page=5' },
+              next: { href: '/the/new/related/link?page=4' },
+            },
+          });
+        }
+        shouldBackgroundReloadRecord() {
+          return false;
+        }
+        shouldReloadRecord() {
+          return false;
+        }
+      }
+      class User extends Model {
+        @attr name;
+        @hasMany('tool', { inverse: null, async: true })
+        tools;
+      }
+      class Tool extends Model {
+        @attr name;
+      }
+      class ApplicationSerializer extends EmberObject {
+        normalizeResponse(_, __, data) {
+          return data;
+        }
+      }
+      this.owner.register('adapter:application', ApplicationAdapter);
+      this.owner.register('serializer:application', ApplicationSerializer);
+      this.owner.register('model:user', User);
+      this.owner.register('model:tool', Tool);
+
+      const user = store.push({
+        data: {
+          id: '1',
+          type: 'user',
+          attributes: {
+            name: '@runspired',
+          },
+          relationships: {
+            tools: {
+              links: {
+                self: { href: '/the/original/path' },
+                related: { href: '/the/related/link' },
+                first: { href: '/the/related/link?page=1' },
+                prev: null,
+                last: { href: '/the/related/link?page=3' },
+                next: { href: '/the/related/link?page=2' },
+              },
             },
           },
         },
-      },
+      });
+
+      // Test we have access via the HasManyReference
+      const toolsRef = user.hasMany('tools');
+      let links = toolsRef.links();
+      assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
+      assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+      assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
+      assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
+      assert.deepEqual(links.prev, null, 'The prev link is correctly available');
+      assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
+      assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
+
+      // Test we have access via the PromiseManyArray
+      links = user.tools.links;
+      assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+      assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
+      assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
+      assert.deepEqual(links.prev, null, 'The prev link is correctly available');
+      assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
+      assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
+
+      // Make a request that returns top-level relationship links
+      const toolsRel = await user.tools;
+
+      links = toolsRef.links();
+      assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
+      assert.deepEqual(
+        links.related,
+        { href: '/the/new/related/link?page=3' },
+        'The related link is correctly available'
+      );
+      assert.deepEqual(links.first, { href: '/the/new/related/link?page=1' }, 'The first link is correctly available');
+      assert.deepEqual(links.last, { href: '/the/new/related/link?page=5' }, 'The last link is correctly available');
+      assert.deepEqual(links.prev, { href: '/the/new/related/link?page=2' }, 'The prev link is correctly available');
+      assert.deepEqual(links.next, { href: '/the/new/related/link?page=4' }, 'The next link is correctly available');
+      assert.deepEqual(links.self, { href: '/some/other/path' }, 'The self link is correctly available');
+
+      // Test we have access via the ManyArray
+      links = toolsRel.links;
+      assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
+      assert.deepEqual(
+        links.related,
+        { href: '/the/new/related/link?page=3' },
+        'The related link is correctly available'
+      );
+      assert.deepEqual(links.first, { href: '/the/new/related/link?page=1' }, 'The first link is correctly available');
+      assert.deepEqual(links.last, { href: '/the/new/related/link?page=5' }, 'The last link is correctly available');
+      assert.deepEqual(links.prev, { href: '/the/new/related/link?page=2' }, 'The prev link is correctly available');
+      assert.deepEqual(links.next, { href: '/the/new/related/link?page=4' }, 'The next link is correctly available');
+      assert.deepEqual(links.self, { href: '/some/other/path' }, 'The self link is correctly available');
     });
-
-    // Test we have access via the HasManyReference
-    const toolsRef = user.hasMany('tools');
-    let links = toolsRef.links();
-    assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
-    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
-    assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
-    assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
-    assert.deepEqual(links.prev, null, 'The prev link is correctly available');
-    assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
-    assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
-
-    // Test we have access via the PromiseManyArray
-    links = user.tools.links;
-    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
-    assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
-    assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
-    assert.deepEqual(links.prev, null, 'The prev link is correctly available');
-    assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
-    assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
-
-    // Make a request that returns top-level relationship links
-    const toolsRel = await user.tools;
-
-    links = toolsRef.links();
-    assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
-    assert.deepEqual(
-      links.related,
-      { href: '/the/new/related/link?page=3' },
-      'The related link is correctly available'
-    );
-    assert.deepEqual(links.first, { href: '/the/new/related/link?page=1' }, 'The first link is correctly available');
-    assert.deepEqual(links.last, { href: '/the/new/related/link?page=5' }, 'The last link is correctly available');
-    assert.deepEqual(links.prev, { href: '/the/new/related/link?page=2' }, 'The prev link is correctly available');
-    assert.deepEqual(links.next, { href: '/the/new/related/link?page=4' }, 'The next link is correctly available');
-    assert.deepEqual(links.self, { href: '/some/other/path' }, 'The self link is correctly available');
-
-    // Test we have access via the ManyArray
-    links = toolsRel.links;
-    assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
-    assert.deepEqual(
-      links.related,
-      { href: '/the/new/related/link?page=3' },
-      'The related link is correctly available'
-    );
-    assert.deepEqual(links.first, { href: '/the/new/related/link?page=1' }, 'The first link is correctly available');
-    assert.deepEqual(links.last, { href: '/the/new/related/link?page=5' }, 'The last link is correctly available');
-    assert.deepEqual(links.prev, { href: '/the/new/related/link?page=2' }, 'The prev link is correctly available');
-    assert.deepEqual(links.next, { href: '/the/new/related/link?page=4' }, 'The next link is correctly available');
-    assert.deepEqual(links.self, { href: '/some/other/path' }, 'The self link is correctly available');
-  });
+  }
 });

--- a/packages/-ember-data/tests/integration/relationships/relationship-links-test.js
+++ b/packages/-ember-data/tests/integration/relationships/relationship-links-test.js
@@ -1,0 +1,352 @@
+import EmberObject from '@ember/object';
+import { test, module } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Store from '@ember-data/store';
+import Model, { attr, hasMany } from '@ember-data/model';
+
+module('JSON:API links access on relationships', function(hooks) {
+  setupTest(hooks);
+  let store;
+
+  hooks.beforeEach(function() {
+    const { owner } = this;
+    owner.register('service:store', Store);
+    store = owner.lookup('service:store');
+  });
+
+  test('We can access links from a hasMany', async function(assert) {
+    class ApplicationAdapter extends EmberObject {
+      findRecord() {}
+      findHasMany() {
+        return Promise.resolve({
+          data: [],
+        });
+      }
+      shouldBackgroundReloadRecord() {
+        return false;
+      }
+      shouldReloadRecord() {
+        return false;
+      }
+    }
+    class User extends Model {
+      @attr name;
+      @hasMany('tool', { inverse: null, async: true })
+      tools;
+    }
+    class Tool extends Model {
+      @attr name;
+    }
+    class ApplicationSerializer extends EmberObject {
+      normalizeResponse(_, __, data) {
+        return data;
+      }
+    }
+    this.owner.register('adapter:application', ApplicationAdapter);
+    this.owner.register('serializer:application', ApplicationSerializer);
+    this.owner.register('model:user', User);
+    this.owner.register('model:tool', Tool);
+
+    const user = store.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          name: '@runspired',
+        },
+        relationships: {
+          tools: {
+            links: {
+              self: '/the/original/path',
+              related: '/the/related/link',
+              first: '/the/related/link?page=1',
+              prev: null,
+              last: '/the/related/link?page=3',
+              next: '/the/related/link?page=2',
+            },
+          },
+        },
+      },
+    });
+
+    // Test we have access via the HasManyReference
+    const toolsRef = user.hasMany('tools');
+    let links = toolsRef.links();
+    assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
+    assert.strictEqual(links.related, '/the/related/link', 'The related link is correctly available');
+    assert.strictEqual(links.first, '/the/related/link?page=1', 'The first link is correctly available');
+    assert.strictEqual(links.last, '/the/related/link?page=3', 'The last link is correctly available');
+    assert.strictEqual(links.prev, null, 'The prev link is correctly available');
+    assert.strictEqual(links.next, '/the/related/link?page=2', 'The next link is correctly available');
+    assert.strictEqual(links.self, '/the/original/path', 'The self link is correctly available');
+
+    // Test we have access via the ManyArray
+    const toolsRel = await user.tools;
+    links = toolsRel.links;
+    assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
+    assert.strictEqual(links.related, '/the/related/link', 'The related link is correctly available');
+    assert.strictEqual(links.first, '/the/related/link?page=1', 'The first link is correctly available');
+    assert.strictEqual(links.last, '/the/related/link?page=3', 'The last link is correctly available');
+    assert.strictEqual(links.prev, null, 'The prev link is correctly available');
+    assert.strictEqual(links.next, '/the/related/link?page=2', 'The next link is correctly available');
+    assert.strictEqual(links.self, '/the/original/path', 'The self link is correctly available');
+  });
+
+  test('We preserve { href } link objects', async function(assert) {
+    class ApplicationAdapter extends EmberObject {
+      findRecord() {}
+      findHasMany() {
+        return Promise.resolve({
+          data: [],
+        });
+      }
+      shouldBackgroundReloadRecord() {
+        return false;
+      }
+      shouldReloadRecord() {
+        return false;
+      }
+    }
+    class User extends Model {
+      @attr name;
+      @hasMany('tool', { inverse: null, async: true })
+      tools;
+    }
+    class Tool extends Model {
+      @attr name;
+    }
+    class ApplicationSerializer extends EmberObject {
+      normalizeResponse(_, __, data) {
+        return data;
+      }
+    }
+    this.owner.register('adapter:application', ApplicationAdapter);
+    this.owner.register('serializer:application', ApplicationSerializer);
+    this.owner.register('model:user', User);
+    this.owner.register('model:tool', Tool);
+
+    const user = store.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          name: '@runspired',
+        },
+        relationships: {
+          tools: {
+            links: {
+              self: { href: '/the/original/path' },
+              related: { href: '/the/related/link' },
+              first: { href: '/the/related/link?page=1' },
+              prev: null,
+              last: { href: '/the/related/link?page=3' },
+              next: { href: '/the/related/link?page=2' },
+            },
+          },
+        },
+      },
+    });
+
+    // Test we have access via the HasManyReference
+    const toolsRef = user.hasMany('tools');
+    let links = toolsRef.links();
+    assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
+    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+    assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
+    assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
+    assert.deepEqual(links.prev, null, 'The prev link is correctly available');
+    assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
+    assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
+
+    // Test we have access via the ManyArray
+    const toolsRel = await user.tools;
+    links = toolsRel.links;
+    assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
+    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+    assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
+    assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
+    assert.deepEqual(links.prev, null, 'The prev link is correctly available');
+    assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
+    assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
+  });
+
+  test('We unwrap the { href } link object when related link is accessed directly', async function(assert) {
+    class ApplicationAdapter extends EmberObject {
+      findRecord() {}
+      findHasMany() {
+        return Promise.resolve({
+          data: [],
+        });
+      }
+      shouldBackgroundReloadRecord() {
+        return false;
+      }
+      shouldReloadRecord() {
+        return false;
+      }
+    }
+    class User extends Model {
+      @attr name;
+      @hasMany('tool', { inverse: null, async: true })
+      tools;
+    }
+    class Tool extends Model {
+      @attr name;
+    }
+    class ApplicationSerializer extends EmberObject {
+      normalizeResponse(_, __, data) {
+        return data;
+      }
+    }
+    this.owner.register('adapter:application', ApplicationAdapter);
+    this.owner.register('serializer:application', ApplicationSerializer);
+    this.owner.register('model:user', User);
+    this.owner.register('model:tool', Tool);
+
+    const user = store.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          name: '@runspired',
+        },
+        relationships: {
+          tools: {
+            links: {
+              related: { href: '/the/related/link' },
+            },
+          },
+        },
+      },
+    });
+
+    // Test we have access via the HasManyReference
+    const toolsRef = user.hasMany('tools');
+    let links = toolsRef.links();
+    assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
+    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+
+    let link = toolsRef.link();
+    assert.strictEqual(link, '/the/related/link', 'The related link is unwrapped when accessed directly');
+
+    // Test we have access via the ManyArray
+    const toolsRel = await user.tools;
+    links = toolsRel.links;
+    assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
+    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+  });
+
+  test('Links in the top-level of a relationship-document update the relationship links', async function(assert) {
+    class ApplicationAdapter extends EmberObject {
+      findRecord() {}
+      findHasMany() {
+        return Promise.resolve({
+          data: [],
+          links: {
+            self: { href: '/some/other/path' },
+            related: { href: '/the/new/related/link?page=3' },
+            first: { href: '/the/new/related/link?page=1' },
+            prev: { href: '/the/new/related/link?page=2' },
+            last: { href: '/the/new/related/link?page=5' },
+            next: { href: '/the/new/related/link?page=4' },
+          },
+        });
+      }
+      shouldBackgroundReloadRecord() {
+        return false;
+      }
+      shouldReloadRecord() {
+        return false;
+      }
+    }
+    class User extends Model {
+      @attr name;
+      @hasMany('tool', { inverse: null, async: true })
+      tools;
+    }
+    class Tool extends Model {
+      @attr name;
+    }
+    class ApplicationSerializer extends EmberObject {
+      normalizeResponse(_, __, data) {
+        return data;
+      }
+    }
+    this.owner.register('adapter:application', ApplicationAdapter);
+    this.owner.register('serializer:application', ApplicationSerializer);
+    this.owner.register('model:user', User);
+    this.owner.register('model:tool', Tool);
+
+    const user = store.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          name: '@runspired',
+        },
+        relationships: {
+          tools: {
+            links: {
+              self: { href: '/the/original/path' },
+              related: { href: '/the/related/link' },
+              first: { href: '/the/related/link?page=1' },
+              prev: null,
+              last: { href: '/the/related/link?page=3' },
+              next: { href: '/the/related/link?page=2' },
+            },
+          },
+        },
+      },
+    });
+
+    // Test we have access via the HasManyReference
+    const toolsRef = user.hasMany('tools');
+    let links = toolsRef.links();
+    assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
+    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+    assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
+    assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
+    assert.deepEqual(links.prev, null, 'The prev link is correctly available');
+    assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
+    assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
+
+    // Test we have access via the PromiseManyArray
+    links = user.tools.links;
+    assert.deepEqual(links.related, { href: '/the/related/link' }, 'The related link is correctly available');
+    assert.deepEqual(links.first, { href: '/the/related/link?page=1' }, 'The first link is correctly available');
+    assert.deepEqual(links.last, { href: '/the/related/link?page=3' }, 'The last link is correctly available');
+    assert.deepEqual(links.prev, null, 'The prev link is correctly available');
+    assert.deepEqual(links.next, { href: '/the/related/link?page=2' }, 'The next link is correctly available');
+    assert.deepEqual(links.self, { href: '/the/original/path' }, 'The self link is correctly available');
+
+    // Make a request that returns top-level relationship links
+    const toolsRel = await user.tools;
+
+    links = toolsRef.links();
+    assert.strictEqual(!!links, true, 'We have a links value on the relationship HasManyReference');
+    assert.deepEqual(
+      links.related,
+      { href: '/the/new/related/link?page=3' },
+      'The related link is correctly available'
+    );
+    assert.deepEqual(links.first, { href: '/the/new/related/link?page=1' }, 'The first link is correctly available');
+    assert.deepEqual(links.last, { href: '/the/new/related/link?page=5' }, 'The last link is correctly available');
+    assert.deepEqual(links.prev, { href: '/the/new/related/link?page=2' }, 'The prev link is correctly available');
+    assert.deepEqual(links.next, { href: '/the/new/related/link?page=4' }, 'The next link is correctly available');
+    assert.deepEqual(links.self, { href: '/some/other/path' }, 'The self link is correctly available');
+
+    // Test we have access via the ManyArray
+    links = toolsRel.links;
+    assert.strictEqual(!!links, true, 'We have a links value on the relationship ManyArray');
+    assert.deepEqual(
+      links.related,
+      { href: '/the/new/related/link?page=3' },
+      'The related link is correctly available'
+    );
+    assert.deepEqual(links.first, { href: '/the/new/related/link?page=1' }, 'The first link is correctly available');
+    assert.deepEqual(links.last, { href: '/the/new/related/link?page=5' }, 'The last link is correctly available');
+    assert.deepEqual(links.prev, { href: '/the/new/related/link?page=2' }, 'The prev link is correctly available');
+    assert.deepEqual(links.next, { href: '/the/new/related/link?page=4' }, 'The next link is correctly available');
+    assert.deepEqual(links.self, { href: '/some/other/path' }, 'The self link is correctly available');
+  });
+});

--- a/packages/-ember-data/tests/integration/relationships/relationship-links-test.js
+++ b/packages/-ember-data/tests/integration/relationships/relationship-links-test.js
@@ -3,6 +3,7 @@ import { test, module } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Store from '@ember-data/store';
 import Model, { attr, hasMany } from '@ember-data/model';
+import { resolve } from 'rsvp';
 
 module('JSON:API links access on relationships', function(hooks) {
   setupTest(hooks);
@@ -18,7 +19,7 @@ module('JSON:API links access on relationships', function(hooks) {
     class ApplicationAdapter extends EmberObject {
       findRecord() {}
       findHasMany() {
-        return Promise.resolve({
+        return resolve({
           data: [],
         });
       }
@@ -96,7 +97,7 @@ module('JSON:API links access on relationships', function(hooks) {
     class ApplicationAdapter extends EmberObject {
       findRecord() {}
       findHasMany() {
-        return Promise.resolve({
+        return resolve({
           data: [],
         });
       }
@@ -174,7 +175,7 @@ module('JSON:API links access on relationships', function(hooks) {
     class ApplicationAdapter extends EmberObject {
       findRecord() {}
       findHasMany() {
-        return Promise.resolve({
+        return resolve({
           data: [],
         });
       }
@@ -240,7 +241,7 @@ module('JSON:API links access on relationships', function(hooks) {
     class ApplicationAdapter extends EmberObject {
       findRecord() {}
       findHasMany() {
-        return Promise.resolve({
+        return resolve({
           data: [],
           links: {
             self: { href: '/some/other/path' },

--- a/packages/canary-features/addon/default-features.ts
+++ b/packages/canary-features/addon/default-features.ts
@@ -19,4 +19,5 @@ export default {
   IDENTIFIERS: true,
   REQUEST_SERVICE: null,
   CUSTOM_MODEL_CLASS: null,
+  FULL_LINKS_ON_RELATIONSHIPS: null,
 };

--- a/packages/canary-features/addon/index.ts
+++ b/packages/canary-features/addon/index.ts
@@ -7,9 +7,19 @@
 import { assign } from '@ember/polyfills';
 import DEFAULT_FEATURES from './default-features';
 
-const ENV = typeof EmberDataENV === 'object' && EmberDataENV !== null ? EmberDataENV : {};
+interface ConfigEnv {
+  ENABLE_OPTIONAL_FEATURES?: boolean;
+  FEATURES?: {
+    [key in keyof typeof DEFAULT_FEATURES]: boolean | null;
+  };
+}
 
-function featureValue(value) {
+declare global {
+  export const EmberDataENV: ConfigEnv | undefined | null;
+}
+const ENV: ConfigEnv = typeof EmberDataENV === 'object' && EmberDataENV !== null ? EmberDataENV : {};
+
+function featureValue(value: boolean | null): boolean | null {
   if (ENV.ENABLE_OPTIONAL_FEATURES && value === null) {
     return true;
   }
@@ -24,3 +34,4 @@ export const RECORD_DATA_STATE = featureValue(FEATURES.RECORD_DATA_STATE);
 export const REQUEST_SERVICE = featureValue(FEATURES.REQUEST_SERVICE);
 export const IDENTIFIERS = featureValue(FEATURES.IDENTIFIERS);
 export const CUSTOM_MODEL_CLASS = featureValue(FEATURES.CUSTOM_MODEL_CLASS);
+export const FULL_LINKS_ON_RELATIONSHIPS = featureValue(FEATURES.FULL_LINKS_ON_RELATIONSHIPS);

--- a/packages/canary-features/package.json
+++ b/packages/canary-features/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {},
   "dependencies": {
-    "ember-cli-babel": "^7.12.0"
+    "ember-cli-babel": "^7.12.0",
+    "ember-cli-typescript": "^3.0.0"
   },
   "devDependencies": {
     "babel-plugin-debug-macros": "^0.3.3",

--- a/packages/record-data/addon/-private/record-data.ts
+++ b/packages/record-data/addon/-private/record-data.ts
@@ -135,7 +135,7 @@ export default class RecordDataDefault implements RelationshipRecordData {
   }
 
   getErrors(): JsonApiValidationError[] {
-    assert('Can not call getErrors unless the RECORD_DATA_ERRORS feature flag is on', RECORD_DATA_ERRORS);
+    assert('Can not call getErrors unless the RECORD_DATA_ERRORS feature flag is on', !!RECORD_DATA_ERRORS);
     if (RECORD_DATA_ERRORS) {
       let errors: JsonApiValidationError[] = this._errors || [];
       return errors;

--- a/packages/record-data/addon/-private/relationships/state/belongs-to.ts
+++ b/packages/record-data/addon/-private/relationships/state/belongs-to.ts
@@ -178,10 +178,8 @@ export default class BelongsToRelationship extends Relationship {
     if (this.inverseRecordData === null && this.hasAnyRelationshipData) {
       data = null;
     }
-    if (this.link) {
-      payload.links = {
-        related: this.link,
-      };
+    if (this.links) {
+      payload.links = this.links;
     }
     if (data !== undefined) {
       payload.data = data;

--- a/packages/record-data/addon/-private/relationships/state/has-many.ts
+++ b/packages/record-data/addon/-private/relationships/state/has-many.ts
@@ -1,7 +1,6 @@
 import { assertPolymorphicType } from '@ember-data/store/-debug';
 import Relationship from './relationship';
 import OrderedSet from '../../ordered-set';
-import { assign } from '@ember/polyfills';
 import { isNone } from '@ember/utils';
 import {
   RelationshipRecordData,

--- a/packages/record-data/addon/-private/relationships/state/has-many.ts
+++ b/packages/record-data/addon/-private/relationships/state/has-many.ts
@@ -1,6 +1,7 @@
 import { assertPolymorphicType } from '@ember-data/store/-debug';
 import Relationship from './relationship';
 import OrderedSet from '../../ordered-set';
+import { assign } from '@ember/polyfills';
 import { isNone } from '@ember/utils';
 import {
   RelationshipRecordData,
@@ -223,10 +224,8 @@ export default class ManyRelationship extends Relationship {
     if (this.hasAnyRelationshipData) {
       payload.data = this.currentState.map(recordData => recordData.getResourceIdentifier());
     }
-    if (this.link) {
-      payload.links = {
-        related: this.link,
-      };
+    if (this.links) {
+      payload.links = this.links;
     }
     if (this.meta) {
       payload.meta = this.meta;

--- a/packages/store/addon/-private/system/many-array.js
+++ b/packages/store/addon/-private/system/many-array.js
@@ -13,7 +13,8 @@ import { PromiseArray } from './promise-proxies';
 import { _objectIsAlive } from './store/common';
 import diffArray from './diff-array';
 import recordDataFor from './record-data-for';
-import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
+import { CUSTOM_MODEL_CLASS, FULL_LINKS_ON_RELATIONSHIPS } from '@ember-data/canary-features';
+
 /**
   A `ManyArray` is a `MutableArray` that represents the contents of a has-many
   relationship.
@@ -229,8 +230,10 @@ export default EmberObject.extend(MutableArray, DeprecatedEvent, {
     if (jsonApi.meta) {
       this.set('meta', jsonApi.meta);
     }
-    if (jsonApi.links) {
-      this.set('links', jsonApi.links);
+    if (FULL_LINKS_ON_RELATIONSHIPS) {
+      if (jsonApi.links) {
+        this.set('links', jsonApi.links);
+      }
     }
     this.flushCanonical(internalModels, true);
   },

--- a/packages/store/addon/-private/system/many-array.js
+++ b/packages/store/addon/-private/system/many-array.js
@@ -229,6 +229,9 @@ export default EmberObject.extend(MutableArray, DeprecatedEvent, {
     if (jsonApi.meta) {
       this.set('meta', jsonApi.meta);
     }
+    if (jsonApi.links) {
+      this.set('links', jsonApi.links);
+    }
     this.flushCanonical(internalModels, true);
   },
 

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -27,6 +27,7 @@ import {
   RECORD_DATA_STATE,
   REQUEST_SERVICE,
   CUSTOM_MODEL_CLASS,
+  FULL_LINKS_ON_RELATIONSHIPS,
 } from '@ember-data/canary-features';
 import { identifierCacheFor } from '../../identifiers/cache';
 import { StableRecordIdentifier } from '../../ts-interfaces/identifier';
@@ -729,7 +730,7 @@ export default class InternalModel {
         type: this.store.modelFor(relationshipMeta.type),
         recordData: this._recordData,
         meta: jsonApi.meta,
-        links: jsonApi.links,
+        links: FULL_LINKS_ON_RELATIONSHIPS ? jsonApi.links : undefined,
         key,
         isPolymorphic: relationshipMeta.options.polymorphic,
         initialState: initialState.slice(),
@@ -1138,7 +1139,7 @@ export default class InternalModel {
   }
 
   notifyStateChange(key?) {
-    assert('Cannot notify state change if Record Data State flag is not on', RECORD_DATA_STATE);
+    assert('Cannot notify state change if Record Data State flag is not on', !!RECORD_DATA_STATE);
     if (this.hasRecord) {
       if (CUSTOM_MODEL_CLASS) {
         this.store._notificationManager.notify(this.identifier, 'state');

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -729,6 +729,7 @@ export default class InternalModel {
         type: this.store.modelFor(relationshipMeta.type),
         recordData: this._recordData,
         meta: jsonApi.meta,
+        links: jsonApi.links,
         key,
         isPolymorphic: relationshipMeta.options.polymorphic,
         initialState: initialState.slice(),

--- a/packages/store/addon/-private/system/promise-proxies.js
+++ b/packages/store/addon/-private/system/promise-proxies.js
@@ -128,6 +128,8 @@ export function proxyToContent(method) {
   @extends Ember.ArrayProxy
 */
 export const PromiseManyArray = PromiseArray.extend({
+  links: reads('content.links'),
+
   reload(options) {
     assert('You are trying to reload an async manyArray before it has been created', get(this, 'content'));
     this.set('promise', this.get('content').reload(options));

--- a/packages/store/addon/-private/system/promise-proxies.js
+++ b/packages/store/addon/-private/system/promise-proxies.js
@@ -5,6 +5,7 @@ import { get, computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import { Promise } from 'rsvp';
 import { assert } from '@ember/debug';
+import { FULL_LINKS_ON_RELATIONSHIPS } from '@ember-data/canary-features';
 
 /**
   @module @ember-data/store
@@ -128,7 +129,7 @@ export function proxyToContent(method) {
   @extends Ember.ArrayProxy
 */
 export const PromiseManyArray = PromiseArray.extend({
-  links: reads('content.links'),
+  links: FULL_LINKS_ON_RELATIONSHIPS ? reads('content.links') : undefined,
 
   reload(options) {
     assert('You are trying to reload an async manyArray before it has been created', get(this, 'content'));

--- a/packages/store/addon/-private/system/references/reference.ts
+++ b/packages/store/addon/-private/system/references/reference.ts
@@ -2,6 +2,8 @@ import InternalModel from '../model/internal-model';
 import recordDataFor from '../record-data-for';
 import { Object as JSONObject, Value as JSONValue } from 'json-typescript';
 import CoreStore from '../core-store';
+import { PaginationLinks, LinkObject } from '../../ts-interfaces/ember-data-json-api';
+import { JsonApiRelationship } from '../../ts-interfaces/record-data-json-api';
 
 /**
   @module @ember-data/store
@@ -14,7 +16,9 @@ interface ResourceIdentifier {
   meta?: JSONObject;
 }
 
-function isResourceIdentiferWithRelatedLinks(value: any): value is ResourceIdentifier & { links: { related: string } } {
+function isResourceIdentiferWithRelatedLinks(
+  value: any
+): value is ResourceIdentifier & { links: { related: string | LinkObject | null } } {
   return value && value.links && value.links.related;
 }
 
@@ -30,7 +34,7 @@ export default abstract class Reference {
     this.recordData = recordDataFor(this);
   }
 
-  public _resource(): ResourceIdentifier | (JSONObject & { meta?: { [k: string]: JSONValue } }) | void {}
+  public _resource(): ResourceIdentifier | JsonApiRelationship | void {}
 
   /**
    This returns a string that represents how the reference will be
@@ -118,16 +122,22 @@ export default abstract class Reference {
    @method link
    @return {String} The link Ember Data will use to fetch or reload this belongs-to relationship.
    */
-  link() {
-    let link: string | null = null;
+  link(): string | null {
+    let link;
     let resource = this._resource();
 
     if (isResourceIdentiferWithRelatedLinks(resource)) {
       if (resource.links) {
         link = resource.links.related;
+        link = !link || typeof link === 'string' ? link : link.href;
       }
     }
-    return link;
+    return link || null;
+  }
+  links(): PaginationLinks | null {
+    let resource = this._resource();
+
+    return resource && resource.links ? resource.links : null;
   }
 
   /**

--- a/packages/store/addon/-private/system/references/reference.ts
+++ b/packages/store/addon/-private/system/references/reference.ts
@@ -4,6 +4,8 @@ import { Object as JSONObject, Value as JSONValue } from 'json-typescript';
 import CoreStore from '../core-store';
 import { PaginationLinks, LinkObject } from '../../ts-interfaces/ember-data-json-api';
 import { JsonApiRelationship } from '../../ts-interfaces/record-data-json-api';
+import { FULL_LINKS_ON_RELATIONSHIPS } from '@ember-data/canary-features';
+import { Dict } from '../../ts-interfaces/utils';
 
 /**
   @module @ember-data/store
@@ -28,7 +30,10 @@ function isResourceIdentiferWithRelatedLinks(
 
  @class Reference
  */
-export default abstract class Reference {
+interface Reference {
+  links(): PaginationLinks | null;
+}
+abstract class Reference {
   public recordData: InternalModel['_recordData'];
   constructor(public store: CoreStore, public internalModel: InternalModel) {
     this.recordData = recordDataFor(this);
@@ -134,11 +139,6 @@ export default abstract class Reference {
     }
     return link || null;
   }
-  links(): PaginationLinks | null {
-    let resource = this._resource();
-
-    return resource && resource.links ? resource.links : null;
-  }
 
   /**
    The meta data for the belongs-to relationship.
@@ -180,7 +180,7 @@ export default abstract class Reference {
    @return {Object} The meta information for the belongs-to relationship.
    */
   meta() {
-    let meta: { [k: string]: JSONValue } | null = null;
+    let meta: Dict<JSONValue> | null = null;
     let resource = this._resource();
     if (resource && resource.meta && typeof resource.meta === 'object') {
       meta = resource.meta;
@@ -188,3 +188,13 @@ export default abstract class Reference {
     return meta;
   }
 }
+
+if (FULL_LINKS_ON_RELATIONSHIPS) {
+  Reference.prototype.links = function links(): PaginationLinks | null {
+    let resource = this._resource();
+
+    return resource && resource.links ? resource.links : null;
+  };
+}
+
+export default Reference;

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -274,7 +274,8 @@ function validateRelationshipEntry({ id }, { id: parentModelID }) {
 export function _findHasMany(adapter, store, internalModel, link, relationship, options) {
   let snapshot = internalModel.createSnapshot(options);
   let modelClass = store.modelFor(relationship.type);
-  let relatedLink = !link || typeof link === 'string' ? link : link.href;
+  let useLink = !link || typeof link === 'string';
+  let relatedLink = useLink ? link : link.href;
   let promise = adapter.findHasMany(store, snapshot, relatedLink, relationship);
   let label = `DS: Handle Adapter#findHasMany of '${internalModel.modelName}' : '${relationship.type}'`;
 
@@ -303,7 +304,8 @@ export function _findHasMany(adapter, store, internalModel, link, relationship, 
 export function _findBelongsTo(adapter, store, internalModel, link, relationship, options) {
   let snapshot = internalModel.createSnapshot(options);
   let modelClass = store.modelFor(relationship.type);
-  let relatedLink = !link || typeof link === 'string' ? link : link.href;
+  let useLink = !link || typeof link === 'string';
+  let relatedLink = useLink ? link : link.href;
   let promise = adapter.findBelongsTo(store, snapshot, relatedLink, relationship);
   let label = `DS: Handle Adapter#findBelongsTo of ${internalModel.modelName} : ${relationship.type}`;
 

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -274,7 +274,8 @@ function validateRelationshipEntry({ id }, { id: parentModelID }) {
 export function _findHasMany(adapter, store, internalModel, link, relationship, options) {
   let snapshot = internalModel.createSnapshot(options);
   let modelClass = store.modelFor(relationship.type);
-  let promise = adapter.findHasMany(store, snapshot, link, relationship);
+  let relatedLink = !link || typeof link === 'string' ? link : link.href;
+  let promise = adapter.findHasMany(store, snapshot, relatedLink, relationship);
   let label = `DS: Handle Adapter#findHasMany of '${internalModel.modelName}' : '${relationship.type}'`;
 
   promise = guardDestroyedStore(promise, store, label);
@@ -302,7 +303,8 @@ export function _findHasMany(adapter, store, internalModel, link, relationship, 
 export function _findBelongsTo(adapter, store, internalModel, link, relationship, options) {
   let snapshot = internalModel.createSnapshot(options);
   let modelClass = store.modelFor(relationship.type);
-  let promise = adapter.findBelongsTo(store, snapshot, link, relationship);
+  let relatedLink = !link || typeof link === 'string' ? link : link.href;
+  let promise = adapter.findBelongsTo(store, snapshot, relatedLink, relationship);
   let label = `DS: Handle Adapter#findBelongsTo of ${internalModel.modelName} : ${relationship.type}`;
 
   promise = guardDestroyedStore(promise, store, label);


### PR DESCRIPTION
In [RFC 332](https://github.com/emberjs/rfcs/blob/master/text/0332-ember-data-record-links-and-meta.md) we assumed that the full `links` object was supported for relationships. However, our implementation restricted access to just the `related` link and discarded all other links.

This PR

- Preserves all existing behaviors attached to the `related` link
- Adds `reference.links()` for accessing links
- Adds `HasMany.links` and `PromiseHasMany.links` for accessing links
- Ensures that we return links from the cache in whichever format the user supplied us (`{ href }` or `string`).

While the PR is non-breaking it does introduce some new APIs. I would argue given past promises in the linked RFC and around links more generally that this is "API backfill"  that does not require a new RFC, but I am open to authoring a short RFC for these things.