### PR TITLE
[BUGFIX] modelFor should return a stable ShimModelClass

### DIFF
--- a/packages/-ember-data/tests/integration/relationships/inverse-relationships-test.js
+++ b/packages/-ember-data/tests/integration/relationships/inverse-relationships-test.js
@@ -627,7 +627,7 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
 
       assert.expectAssertion(() => {
         store.createRecord('user', { post: null });
-      }, /No model was found for/);
+      }, /No model was found for 'post' and no schema handles the type/);
 
       // but don't error if the relationship is not used
       store.createRecord('user', {});

--- a/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -54,7 +54,6 @@ if (CUSTOM_MODEL_CLASS) {
         teardownRecord(record) {},
       });
 
-      owner.register('model:person', Person);
       owner.register(
         'adapter:application',
         JSONAPIAdapter.extend({

--- a/packages/record-data/addon/-private/relationships/state/belongs-to.ts
+++ b/packages/record-data/addon/-private/relationships/state/belongs-to.ts
@@ -95,7 +95,6 @@ export default class BelongsToRelationship extends Relationship {
       this.notifyBelongsToChange();
     }
   }
-
   removeCompletelyFromInverse() {
     super.removeCompletelyFromInverse();
 

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -68,7 +68,7 @@ import { DSModel } from '../ts-interfaces/ds-model';
 import NotificationManager from './record-notification-manager';
 import { AttributesSchema } from '../ts-interfaces/record-data-schemas';
 import { SchemaDefinitionService } from '../ts-interfaces/schema-definition-service';
-import ShimModelClass from './model/shim-model-class';
+import ShimModelClass, { getShimClass } from './model/shim-model-class';
 import RecordDataRecordWrapper from '../ts-interfaces/record-data-record-wrapper';
 import RecordData from '../ts-interfaces/record-data';
 import { Dict } from '../ts-interfaces/utils';
@@ -513,7 +513,7 @@ abstract class CoreStore extends Service {
       assertDestroyedStoreOnly(this, 'modelFor');
     }
 
-    return new ShimModelClass(this, modelName);
+    return getShimClass(this, modelName);
   }
 
   // Feature Flagged in DSModelStore

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -758,7 +758,7 @@ export default class InternalModel {
 
     loadingPromise = this.store
       ._findHasManyByJsonApiResource(jsonApi, this, relationshipMeta, options)
-      .then(initialState => {
+      .then(() => {
         // TODO why don't we do this in the store method
         manyArray.retrieveLatest();
         manyArray.set('isLoaded', true);

--- a/packages/store/addon/-private/system/model/shim-model-class.ts
+++ b/packages/store/addon/-private/system/model/shim-model-class.ts
@@ -1,5 +1,24 @@
 import CoreStore from '../core-store';
 import { RelationshipSchema, AttributeSchema } from '../../ts-interfaces/record-data-schemas';
+import { Dict } from '../../ts-interfaces/utils';
+
+const AvailableShims = new WeakMap<CoreStore, Dict<ShimModelClass>>();
+
+export function getShimClass(store: CoreStore, modelName: string): ShimModelClass {
+  let shims = AvailableShims.get(store);
+
+  if (shims === undefined) {
+    shims = Object.create(null) as Dict<ShimModelClass>;
+    AvailableShims.set(store, shims);
+  }
+
+  let shim = shims[modelName];
+  if (shim === undefined) {
+    shim = shims[modelName] = new ShimModelClass(store, modelName);
+  }
+
+  return shim;
+}
 
 // Mimics the static apis of DSModel
 export default class ShimModelClass {

--- a/packages/store/addon/-private/system/schema-definition-service.ts
+++ b/packages/store/addon/-private/system/schema-definition-service.ts
@@ -5,6 +5,8 @@ import { getOwner } from '@ember/application';
 import normalizeModelName from './normalize-model-name';
 import { RelationshipsSchema, AttributesSchema } from '../ts-interfaces/record-data-schemas';
 import require, { has } from 'require';
+import CoreStore from './core-store';
+type Model = import('@ember-data/model').default;
 
 const HAS_MODEL_PACKAGE = has('@ember-data/model');
 let _Model;
@@ -80,7 +82,7 @@ export class DSModelSchemaDefinitionService {
  * @param normalizedModelName already normalized modelName
  * @return {*}
  */
-export function getModelFactory(store, cache, normalizedModelName) {
+export function getModelFactory(store: CoreStore, cache, normalizedModelName: string): Model | null {
   let factory = cache[normalizedModelName];
 
   if (!factory) {
@@ -97,9 +99,7 @@ export function getModelFactory(store, cache, normalizedModelName) {
     }
 
     let klass = factory.class;
-    // assert(`'${inspect(klass)}' does not appear to be an ember-data model`, klass.isModel);
 
-    // TODO: deprecate this
     if (klass.isModel) {
       let hasOwnModelNameSet = klass.modelName && Object.prototype.hasOwnProperty.call(klass, 'modelName');
       if (!hasOwnModelNameSet) {

--- a/packages/unpublished-model-encapsulation-test-app/app/app.js
+++ b/packages/unpublished-model-encapsulation-test-app/app/app.js
@@ -3,6 +3,13 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
+window.EmberDataENV = {
+  ENABLE_OPTIONAL_FEATURES: true,
+  FEATURES: {
+    CUSTOM_MODEL_CLASS: true,
+  },
+};
+
 const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,

--- a/packages/unpublished-model-encapsulation-test-app/tests/integration/model-for-test.js
+++ b/packages/unpublished-model-encapsulation-test-app/tests/integration/model-for-test.js
@@ -1,0 +1,97 @@
+import Store from '@ember-data/store';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('modelFor without @ember-data/model', function(hooks) {
+  setupTest(hooks);
+
+  test('We can call modelFor', function(assert) {
+    this.owner.register(
+      'service:store',
+      class TestStore extends Store {
+        instantiateRecord() {
+          return {
+            id: '1',
+            type: 'user',
+            name: 'Chris Thoburn',
+          };
+        }
+        teardownRecord() {
+          return;
+        }
+      }
+    );
+    const store = this.owner.lookup('service:store');
+    store.registerSchemaDefinitionService({
+      attributesDefinitionFor(identifier) {
+        return {
+          name: {
+            name: 'name',
+          },
+        };
+      },
+      relationshipsDefinitionFor(identifier) {
+        return {};
+      },
+      doesTypeExist(type) {
+        return type === 'user';
+      },
+    });
+
+    try {
+      store.modelFor('user');
+      assert.ok(true, 'We should not throw an eror when schema is available');
+    } catch (e) {
+      assert.ok(false, `We threw an unexpected error when schema is available: ${e.message}`);
+    }
+
+    try {
+      store.modelFor('person');
+      assert.ok(false, 'We should throw an eror when no schema is available');
+    } catch (e) {
+      assert.strictEqual(
+        e.message,
+        "No model was found for 'person' and no schema handles the type",
+        'We throw an error when no schema is available'
+      );
+    }
+  });
+
+  test('modelFor returns a stable reference', function(assert) {
+    this.owner.register(
+      'service:store',
+      class TestStore extends Store {
+        instantiateRecord() {
+          return {
+            id: '1',
+            type: 'user',
+            name: 'Chris Thoburn',
+          };
+        }
+        teardownRecord() {
+          return;
+        }
+      }
+    );
+    const store = this.owner.lookup('service:store');
+    store.registerSchemaDefinitionService({
+      attributesDefinitionFor(identifier) {
+        return {
+          name: {
+            name: 'name',
+          },
+        };
+      },
+      relationshipsDefinitionFor(identifier) {
+        return {};
+      },
+      doesTypeExist(type) {
+        return type === 'user';
+      },
+    });
+
+    const ShimUser1 = store.modelFor('user');
+    const ShimUser2 = store.modelFor('user');
+    assert.strictEqual(ShimUser1, ShimUser2, 'Repeat modelFor calls return the same shim');
+  });
+});


### PR DESCRIPTION
While working to encapsulate some Model related things I noticed that there are some unintentional changes in the custom-model-class feature flag branch.

- [x] ShimModelClass should be a stable reference per-type
- [x] Test for ShimModelClass stability
- [x] Test that we are able to call `modelFor` for a `type` handled by `instantiateRecord` that has no `ModelClass`
- [x] Fix for the above since the test failed
- [x] Fix for the custom-model-class tests since they should have failed before
