### PR TITLE
[CHORE] adds infra for testing calls to Ember warn|deprecate|assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "ember-load-initializers": "^2.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
-    "ember-qunit-assert-helpers": "^0.2.2",
     "ember-resolver": "^5.3.0",
     "ember-simple-tree": "^0.7.0",
     "ember-source": "^3.13.3",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -74,7 +74,6 @@
     "ember-load-initializers": "^2.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
-    "ember-qunit-assert-helpers": "^0.2.2",
     "ember-resolver": "^5.3.0",
     "ember-source": "^3.13.3",
     "ember-source-channel-url": "^2.0.1",

--- a/packages/-ember-data/tests/helpers/qunit-asserts/assert-assertion.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/assert-assertion.ts
@@ -1,0 +1,76 @@
+import QUnit from 'qunit';
+import { checkMatcher } from './check-matcher';
+import RSVP from 'rsvp';
+
+let HAS_REGISTERED = false;
+
+interface AssertSomeResult {
+  result: boolean;
+  actual: string;
+  expected: string;
+  message: string;
+}
+interface AssertNoneResult {
+  result: boolean;
+  actual: string;
+  expected: '';
+  message: string;
+}
+
+function expectAssertion(message: string, matcher: string | RegExp): AssertSomeResult {
+  let passed = checkMatcher(message, matcher);
+
+  return {
+    result: passed,
+    actual: message,
+    expected: String(matcher),
+    message: `Expected an assertion during the test`,
+  };
+}
+
+function expectNoAssertion(message: string | undefined): AssertNoneResult {
+  let passed = !message;
+  return {
+    result: passed,
+    actual: message || '',
+    expected: '',
+    message: `Expected no assertions during test`,
+  };
+}
+
+export function configureAssertionHandler() {
+  if (HAS_REGISTERED === true) {
+    throw new Error(`Attempting to re-register the assert-assertion handler`);
+  }
+  HAS_REGISTERED = true;
+
+  QUnit.assert.expectAssertion = async function(cb: () => unknown, matcher: string | RegExp): Promise<void> {
+    let outcome;
+    try {
+      let result = cb();
+      if (result instanceof Promise || result instanceof RSVP.Promise) {
+        await result;
+      }
+      outcome = expectAssertion('', matcher);
+    } catch (e) {
+      outcome = expectAssertion(e.message, matcher);
+    }
+
+    this.pushResult(outcome);
+  };
+
+  QUnit.assert.expectNoAssertion = async function(cb: () => unknown) {
+    let outcome;
+    try {
+      let result = cb();
+      if (result instanceof Promise || result instanceof RSVP.Promise) {
+        await result;
+      }
+      outcome = expectNoAssertion('');
+    } catch (e) {
+      outcome = expectNoAssertion(e.message);
+    }
+
+    this.pushResult(outcome);
+  };
+}

--- a/packages/-ember-data/tests/helpers/qunit-asserts/assert-assertion.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/assert-assertion.ts
@@ -18,24 +18,24 @@ interface AssertNoneResult {
   message: string;
 }
 
-function verifyAssertion(message: string, matcher: string | RegExp): AssertSomeResult {
+function verifyAssertion(message: string, matcher: string | RegExp, label?: string): AssertSomeResult {
   let passed = checkMatcher(message, matcher);
 
   return {
     result: passed,
     actual: message,
     expected: String(matcher),
-    message: `Expected an assertion during the test`,
+    message: label || `Expected an assertion during the test`,
   };
 }
 
-function verifyNoAssertion(message: string | undefined): AssertNoneResult {
+function verifyNoAssertion(message: string | undefined, label?: string): AssertNoneResult {
   let passed = !message;
   return {
     result: passed,
     actual: message || '',
     expected: '',
-    message: `Expected no assertions during test`,
+    message: label || `Expected no assertions during test`,
   };
 }
 
@@ -45,7 +45,11 @@ export function configureAssertionHandler() {
   }
   HAS_REGISTERED = true;
 
-  QUnit.assert.expectAssertion = async function(cb: () => unknown, matcher: string | RegExp): Promise<void> {
+  QUnit.assert.expectAssertion = async function(
+    cb: () => unknown,
+    matcher: string | RegExp,
+    label?: string
+  ): Promise<void> {
     let outcome;
     if (DEBUG) {
       try {
@@ -53,9 +57,9 @@ export function configureAssertionHandler() {
         if (isThenable(result)) {
           await result;
         }
-        outcome = verifyAssertion('', matcher);
+        outcome = verifyAssertion('', matcher, label);
       } catch (e) {
-        outcome = verifyAssertion(e.message, matcher);
+        outcome = verifyAssertion(e.message, matcher, label);
       }
     } else {
       outcome = {
@@ -69,16 +73,16 @@ export function configureAssertionHandler() {
     this.pushResult(outcome);
   };
 
-  QUnit.assert.expectNoAssertion = async function(cb: () => unknown) {
+  QUnit.assert.expectNoAssertion = async function(cb: () => unknown, label?: string) {
     let outcome;
     try {
       let result = cb();
       if (isThenable(result)) {
         await result;
       }
-      outcome = verifyNoAssertion('');
+      outcome = verifyNoAssertion('', label);
     } catch (e) {
-      outcome = verifyNoAssertion(e.message);
+      outcome = verifyNoAssertion(e.message, label);
     }
 
     this.pushResult(outcome);

--- a/packages/-ember-data/tests/helpers/qunit-asserts/assert-assertion.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/assert-assertion.ts
@@ -1,5 +1,6 @@
 import QUnit from 'qunit';
 import { checkMatcher } from './check-matcher';
+import { DEBUG } from '@glimmer/env';
 import RSVP from 'rsvp';
 
 let HAS_REGISTERED = false;
@@ -46,14 +47,23 @@ export function configureAssertionHandler() {
 
   QUnit.assert.expectAssertion = async function(cb: () => unknown, matcher: string | RegExp): Promise<void> {
     let outcome;
-    try {
-      let result = cb();
-      if (result instanceof Promise || result instanceof RSVP.Promise) {
-        await result;
+    if (DEBUG) {
+      try {
+        let result = cb();
+        if (result instanceof Promise || result instanceof RSVP.Promise) {
+          await result;
+        }
+        outcome = expectAssertion('', matcher);
+      } catch (e) {
+        outcome = expectAssertion(e.message, matcher);
       }
-      outcome = expectAssertion('', matcher);
-    } catch (e) {
-      outcome = expectAssertion(e.message, matcher);
+    } else {
+      outcome = {
+        result: true,
+        actual: '',
+        expected: '',
+        message: `Assertions do not run in production environments`,
+      };
     }
 
     this.pushResult(outcome);

--- a/packages/-ember-data/tests/helpers/qunit-asserts/assert-assertion.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/assert-assertion.ts
@@ -1,7 +1,7 @@
 import QUnit from 'qunit';
 import { checkMatcher } from './check-matcher';
 import { DEBUG } from '@glimmer/env';
-import RSVP from 'rsvp';
+import isThenable from './utils/is-thenable';
 
 let HAS_REGISTERED = false;
 
@@ -18,7 +18,7 @@ interface AssertNoneResult {
   message: string;
 }
 
-function expectAssertion(message: string, matcher: string | RegExp): AssertSomeResult {
+function verifyAssertion(message: string, matcher: string | RegExp): AssertSomeResult {
   let passed = checkMatcher(message, matcher);
 
   return {
@@ -29,7 +29,7 @@ function expectAssertion(message: string, matcher: string | RegExp): AssertSomeR
   };
 }
 
-function expectNoAssertion(message: string | undefined): AssertNoneResult {
+function verifyNoAssertion(message: string | undefined): AssertNoneResult {
   let passed = !message;
   return {
     result: passed,
@@ -50,12 +50,12 @@ export function configureAssertionHandler() {
     if (DEBUG) {
       try {
         let result = cb();
-        if (result instanceof Promise || result instanceof RSVP.Promise) {
+        if (isThenable(result)) {
           await result;
         }
-        outcome = expectAssertion('', matcher);
+        outcome = verifyAssertion('', matcher);
       } catch (e) {
-        outcome = expectAssertion(e.message, matcher);
+        outcome = verifyAssertion(e.message, matcher);
       }
     } else {
       outcome = {
@@ -73,12 +73,12 @@ export function configureAssertionHandler() {
     let outcome;
     try {
       let result = cb();
-      if (result instanceof Promise || result instanceof RSVP.Promise) {
+      if (isThenable(result)) {
         await result;
       }
-      outcome = expectNoAssertion('');
+      outcome = verifyNoAssertion('');
     } catch (e) {
-      outcome = expectNoAssertion(e.message);
+      outcome = verifyNoAssertion(e.message);
     }
 
     this.pushResult(outcome);

--- a/packages/-ember-data/tests/helpers/qunit-asserts/assert-deprecation.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/assert-deprecation.ts
@@ -1,0 +1,168 @@
+import QUnit from 'qunit';
+import { registerDeprecationHandler } from '@ember/debug';
+import { checkMatcher } from './check-matcher';
+import RSVP from 'rsvp';
+
+let HAS_REGISTERED = false;
+let DEPRECATIONS_FOR_TEST: FoundDeprecation[];
+let HANDLED_DEPRECATIONS_FOR_TEST: FoundDeprecation[];
+
+interface DeprecationConfig {
+  id: string;
+  count?: number;
+  until: string;
+  message?: string | RegExp;
+  url?: string;
+}
+interface FoundDeprecation {
+  message: string;
+  options: {
+    id: string;
+    message?: string;
+    until: string;
+    url?: string;
+  };
+}
+
+interface AssertSomeResult {
+  result: boolean;
+  actual: { id: string; count: number };
+  expected: { id: string; count: number };
+  message: string;
+}
+interface AssertNoneResult {
+  result: boolean;
+  actual: FoundDeprecation[];
+  expected: FoundDeprecation[];
+  message: string;
+}
+
+/**
+ * Returns a qunit assert result object which passes if the given deprecation
+ * `id` was found *exactly* `count` times.
+ *
+ * Fails if not found or found more or less than `count`.
+ * Fails if `until` not specified
+ * Optionally fails if `until` has been passed.
+ */
+function expectDeprecation(config: DeprecationConfig): AssertSomeResult {
+  // TODO optionally throw if `until` is the current version or older than current version
+  let matchedDeprecations = DEPRECATIONS_FOR_TEST.filter(deprecation => {
+    if (!deprecation.options || !deprecation.options.id) {
+      throw new Error(`Expected deprecation to have an id, found: ${deprecation}`);
+    }
+    let isMatched = deprecation.options.id === config.id;
+    if (!isMatched && config.message) {
+      // TODO when we hit this we should throw an error in the near future
+      isMatched = checkMatcher(deprecation.message, config.message);
+    }
+    return isMatched;
+  });
+  DEPRECATIONS_FOR_TEST = DEPRECATIONS_FOR_TEST.filter(deprecation => {
+    matchedDeprecations.indexOf(deprecation) === -1;
+  });
+  HANDLED_DEPRECATIONS_FOR_TEST.push(...matchedDeprecations);
+
+  let expectedCount = typeof config.count === 'number' && config.count !== 0 ? config.count : 1;
+  let passed = matchedDeprecations.length === expectedCount;
+
+  return {
+    result: passed,
+    actual: { id: config.id, count: matchedDeprecations.length },
+    expected: { id: config.id, count: expectedCount },
+    message: `Expected ${expectedCount} deprecation${expectedCount === 1 ? '' : 's'} for ${config.id} during test, ${
+      passed ? expectedCount : 'but ' + matchedDeprecations.length
+    } deprecations were found.`,
+  };
+}
+
+function expectNoDeprecation(): AssertNoneResult {
+  const UNHANDLED_DEPRECATIONS = DEPRECATIONS_FOR_TEST;
+  DEPRECATIONS_FOR_TEST = [];
+
+  let deprecationStr = UNHANDLED_DEPRECATIONS.reduce((a, b) => {
+    return `${a}${b.message}\n`;
+  }, '');
+
+  let passed = UNHANDLED_DEPRECATIONS.length === 0;
+
+  return {
+    result: passed,
+    actual: UNHANDLED_DEPRECATIONS,
+    expected: [],
+    message: `Expected 0 deprecations during test, ${
+      passed ? '0' : 'but ' + UNHANDLED_DEPRECATIONS.length
+    } deprecations were found.\n${deprecationStr}`,
+  };
+}
+
+export function configureDeprecationHandler() {
+  if (HAS_REGISTERED === true) {
+    throw new Error(`Attempting to re-register the assert-deprecation handler`);
+  }
+  HAS_REGISTERED = true;
+
+  QUnit.testStart(function() {
+    DEPRECATIONS_FOR_TEST = [];
+    HANDLED_DEPRECATIONS_FOR_TEST = [];
+  });
+
+  registerDeprecationHandler(function(message, options /*, next*/) {
+    if (DEPRECATIONS_FOR_TEST) {
+      DEPRECATIONS_FOR_TEST.push({ message, options });
+    }
+    // we do not call next to avoid spamming the console
+  });
+
+  QUnit.assert.expectDeprecation = async function(
+    cb: () => unknown,
+    config: string | RegExp | DeprecationConfig
+  ): Promise<void> {
+    let origDeprecations = DEPRECATIONS_FOR_TEST;
+    let callback: (() => unknown) | null = null;
+
+    if (typeof cb !== 'function') {
+      config = cb;
+      callback = null;
+    } else {
+      callback = cb;
+    }
+
+    if (typeof config === 'string' || config instanceof RegExp) {
+      config = {
+        id: 'unknown-data-deprecation',
+        count: 1,
+        message: config,
+        until: '4.0',
+      };
+    }
+
+    if (callback) {
+      DEPRECATIONS_FOR_TEST = [];
+      let result = callback();
+      if (result instanceof Promise || result instanceof RSVP.Promise) {
+        await result;
+      }
+    }
+
+    let result = expectDeprecation(config);
+    this.pushResult(result);
+    DEPRECATIONS_FOR_TEST = origDeprecations.concat(DEPRECATIONS_FOR_TEST);
+  };
+
+  QUnit.assert.expectNoDeprecation = async function(cb) {
+    let origDeprecations = DEPRECATIONS_FOR_TEST;
+
+    if (cb) {
+      DEPRECATIONS_FOR_TEST = [];
+      let result = cb();
+      if (result instanceof Promise || result instanceof RSVP.Promise) {
+        await result;
+      }
+    }
+
+    let result = expectNoDeprecation();
+    this.pushResult(result);
+    DEPRECATIONS_FOR_TEST = origDeprecations.concat(DEPRECATIONS_FOR_TEST);
+  };
+}

--- a/packages/-ember-data/tests/helpers/qunit-asserts/assert-deprecation.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/assert-deprecation.ts
@@ -48,9 +48,6 @@ interface AssertNoneResult {
 function verifyDeprecation(config: DeprecationConfig, label?: string): AssertSomeResult {
   // TODO optionally throw if `until` is the current version or older than current version
   let matchedDeprecations = DEPRECATIONS_FOR_TEST.filter(deprecation => {
-    if (!deprecation.options || !deprecation.options.id) {
-      throw new Error(`Expected deprecation to have an id, found: ${deprecation}`);
-    }
     let isMatched = deprecation.options.id === config.id;
     if (!isMatched && config.message) {
       // TODO when we hit this we should throw an error in the near future

--- a/packages/-ember-data/tests/helpers/qunit-asserts/assert-warning.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/assert-warning.ts
@@ -45,7 +45,7 @@ interface AssertNoneResult {
  * Fails if `until` not specified
  * Optionally fails if `until` has been passed.
  */
-function verifyWarning(config: WarningConfig): AssertSomeResult {
+function verifyWarning(config: WarningConfig, label?: string): AssertSomeResult {
   // TODO optionally throw if `until` is the current version or older than current version
   let matchedWarnings = WARNINGS_FOR_TEST.filter(warning => {
     if (!warning.options || !warning.options.id) {
@@ -70,13 +70,15 @@ function verifyWarning(config: WarningConfig): AssertSomeResult {
     result: passed,
     actual: { id: config.id, count: matchedWarnings.length },
     expected: { id: config.id, count: expectedCount },
-    message: `Expected ${expectedCount} warning${expectedCount === 1 ? '' : 's'} for ${config.id} during test, ${
-      passed ? expectedCount : 'but ' + matchedWarnings.length
-    } warnings were found.`,
+    message:
+      label ||
+      `Expected ${expectedCount} warning${expectedCount === 1 ? '' : 's'} for ${config.id} during test, ${
+        passed ? expectedCount : 'but ' + matchedWarnings.length
+      } warnings were found.`,
   };
 }
 
-function verifyNoWarning(): AssertNoneResult {
+function verifyNoWarning(label?: string): AssertNoneResult {
   const UNHANDLED_WARNINGS = WARNINGS_FOR_TEST;
   WARNINGS_FOR_TEST = [];
 
@@ -90,9 +92,11 @@ function verifyNoWarning(): AssertNoneResult {
     result: passed,
     actual: UNHANDLED_WARNINGS,
     expected: [],
-    message: `Expected 0 warnings during test, ${
-      passed ? '0' : 'but ' + UNHANDLED_WARNINGS.length
-    } warnings were found.\n${warningStr}`,
+    message:
+      label ||
+      `Expected 0 warnings during test, ${
+        passed ? '0' : 'but ' + UNHANDLED_WARNINGS.length
+      } warnings were found.\n${warningStr}`,
   };
 }
 
@@ -116,7 +120,8 @@ export function configureWarningHandler() {
 
   QUnit.assert.expectWarning = async function(
     cb: () => unknown,
-    config: string | RegExp | WarningConfig
+    config: string | RegExp | WarningConfig,
+    label?: string
   ): Promise<void> {
     let origWarnings = WARNINGS_FOR_TEST;
     let callback: (() => unknown) | null = null;
@@ -145,12 +150,12 @@ export function configureWarningHandler() {
       }
     }
 
-    let result = verifyWarning(config);
+    let result = verifyWarning(config, label);
     this.pushResult(result);
     WARNINGS_FOR_TEST = origWarnings.concat(WARNINGS_FOR_TEST);
   };
 
-  QUnit.assert.expectNoWarning = async function(cb) {
+  QUnit.assert.expectNoWarning = async function(cb, label?: string) {
     let origWarnings = WARNINGS_FOR_TEST;
 
     if (cb) {
@@ -161,7 +166,7 @@ export function configureWarningHandler() {
       }
     }
 
-    let result = verifyNoWarning();
+    let result = verifyNoWarning(label);
     this.pushResult(result);
     WARNINGS_FOR_TEST = origWarnings.concat(WARNINGS_FOR_TEST);
   };

--- a/packages/-ember-data/tests/helpers/qunit-asserts/assert-warning.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/assert-warning.ts
@@ -1,0 +1,168 @@
+import QUnit from 'qunit';
+import { registerWarnHandler } from '@ember/debug';
+import { checkMatcher } from './check-matcher';
+import RSVP from 'rsvp';
+
+let HAS_REGISTERED = false;
+let WARNINGS_FOR_TEST: FoundWarning[];
+let HANDLED_WARNINGS_FOR_TEST: FoundWarning[];
+
+interface WarningConfig {
+  id: string;
+  count?: number;
+  until?: string;
+  message?: string | RegExp;
+  url?: string;
+}
+interface FoundWarning {
+  message: string;
+  options: {
+    id: string;
+    message?: string;
+    until?: string;
+    url?: string;
+  };
+}
+
+interface AssertSomeResult {
+  result: boolean;
+  actual: { id: string; count: number };
+  expected: { id: string; count: number };
+  message: string;
+}
+interface AssertNoneResult {
+  result: boolean;
+  actual: FoundWarning[];
+  expected: FoundWarning[];
+  message: string;
+}
+
+/**
+ * Returns a qunit assert result object which passes if the given warning
+ * `id` was found *exactly* `count` times.
+ *
+ * Fails if not found or found more or less than `count`.
+ * Fails if `until` not specified
+ * Optionally fails if `until` has been passed.
+ */
+function expectWarning(config: WarningConfig): AssertSomeResult {
+  // TODO optionally throw if `until` is the current version or older than current version
+  let matchedWarnings = WARNINGS_FOR_TEST.filter(warning => {
+    if (!warning.options || !warning.options.id) {
+      throw new Error(`Expected warning to have an id, found: ${warning}`);
+    }
+    let isMatched = warning.options.id === config.id;
+    if (!isMatched && config.message) {
+      // TODO when we hit this we should throw an error in the near future
+      isMatched = checkMatcher(warning.message, config.message);
+    }
+    return isMatched;
+  });
+  WARNINGS_FOR_TEST = WARNINGS_FOR_TEST.filter(warning => {
+    matchedWarnings.indexOf(warning) === -1;
+  });
+  HANDLED_WARNINGS_FOR_TEST.push(...matchedWarnings);
+
+  let expectedCount = typeof config.count === 'number' && config.count !== 0 ? config.count : 1;
+  let passed = matchedWarnings.length === expectedCount;
+
+  return {
+    result: passed,
+    actual: { id: config.id, count: matchedWarnings.length },
+    expected: { id: config.id, count: expectedCount },
+    message: `Expected ${expectedCount} warning${expectedCount === 1 ? '' : 's'} for ${config.id} during test, ${
+      passed ? expectedCount : 'but ' + matchedWarnings.length
+    } warnings were found.`,
+  };
+}
+
+function expectNoWarning(): AssertNoneResult {
+  const UNHANDLED_WARNINGS = WARNINGS_FOR_TEST;
+  WARNINGS_FOR_TEST = [];
+
+  let warningStr = UNHANDLED_WARNINGS.reduce((a, b) => {
+    return `${a}${b.message}\n`;
+  }, '');
+
+  let passed = UNHANDLED_WARNINGS.length === 0;
+
+  return {
+    result: passed,
+    actual: UNHANDLED_WARNINGS,
+    expected: [],
+    message: `Expected 0 warnings during test, ${
+      passed ? '0' : 'but ' + UNHANDLED_WARNINGS.length
+    } warnings were found.\n${warningStr}`,
+  };
+}
+
+export function configureWarningHandler() {
+  if (HAS_REGISTERED === true) {
+    throw new Error(`Attempting to re-register the assert-warning handler`);
+  }
+  HAS_REGISTERED = true;
+
+  QUnit.testStart(function() {
+    WARNINGS_FOR_TEST = [];
+    HANDLED_WARNINGS_FOR_TEST = [];
+  });
+
+  registerWarnHandler(function(message, options /*, next*/) {
+    if (WARNINGS_FOR_TEST) {
+      WARNINGS_FOR_TEST.push({ message, options });
+    }
+    // we do not call next to avoid spamming the console
+  });
+
+  QUnit.assert.expectWarning = async function(
+    cb: () => unknown,
+    config: string | RegExp | WarningConfig
+  ): Promise<void> {
+    let origWarnings = WARNINGS_FOR_TEST;
+    let callback: (() => unknown) | null = null;
+
+    if (typeof cb !== 'function') {
+      config = cb;
+      callback = null;
+    } else {
+      callback = cb;
+    }
+
+    if (typeof config === 'string' || config instanceof RegExp) {
+      config = {
+        id: 'unknown-data-warning',
+        count: 1,
+        message: config,
+        until: '4.0',
+      };
+    }
+
+    if (callback) {
+      WARNINGS_FOR_TEST = [];
+      let result = callback();
+      if (result instanceof Promise || result instanceof RSVP.Promise) {
+        await result;
+      }
+    }
+
+    let result = expectWarning(config);
+    this.pushResult(result);
+    WARNINGS_FOR_TEST = origWarnings.concat(WARNINGS_FOR_TEST);
+  };
+
+  QUnit.assert.expectNoWarning = async function(cb) {
+    let origWarnings = WARNINGS_FOR_TEST;
+
+    if (cb) {
+      WARNINGS_FOR_TEST = [];
+      let result = cb();
+      if (result instanceof Promise || result instanceof RSVP.Promise) {
+        await result;
+      }
+    }
+
+    let result = expectNoWarning();
+    this.pushResult(result);
+    WARNINGS_FOR_TEST = origWarnings.concat(WARNINGS_FOR_TEST);
+  };
+}

--- a/packages/-ember-data/tests/helpers/qunit-asserts/assert-warning.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/assert-warning.ts
@@ -48,9 +48,6 @@ interface AssertNoneResult {
 function verifyWarning(config: WarningConfig, label?: string): AssertSomeResult {
   // TODO optionally throw if `until` is the current version or older than current version
   let matchedWarnings = WARNINGS_FOR_TEST.filter(warning => {
-    if (!warning.options || !warning.options.id) {
-      throw new Error(`Expected warning to have an id, found: ${warning}`);
-    }
     let isMatched = warning.options.id === config.id;
     if (!isMatched && config.message) {
       // TODO when we hit this we should throw an error in the near future

--- a/packages/-ember-data/tests/helpers/qunit-asserts/check-matcher.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/check-matcher.ts
@@ -1,0 +1,16 @@
+function includes(message, search) {
+  return message.includes ? message.includes(search) : message.indexOf(search) !== -1;
+}
+
+export function checkMatcher(message, matcher) {
+  if (typeof matcher === 'string') {
+    return includes(message, matcher);
+  } else if (matcher instanceof RegExp) {
+    return !!message.match(matcher);
+  } else if (matcher) {
+    throw new Error(`Assert helpers can only match Strings and RegExps. "${typeof matcher}" was provided.`);
+  }
+
+  // No matcher always returns true. Makes the code easier elsewhere.
+  return true;
+}

--- a/packages/-ember-data/tests/helpers/qunit-asserts/index.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/index.ts
@@ -1,0 +1,9 @@
+import { configureAssertionHandler } from './assert-assertion';
+import { configureDeprecationHandler } from './assert-deprecation';
+import { configureWarningHandler } from './assert-warning';
+
+export default function configureAsserts() {
+  configureAssertionHandler();
+  configureDeprecationHandler();
+  configureWarningHandler();
+}

--- a/packages/-ember-data/tests/helpers/qunit-asserts/utils/is-thenable.ts
+++ b/packages/-ember-data/tests/helpers/qunit-asserts/utils/is-thenable.ts
@@ -1,0 +1,3 @@
+export default function isThenable(obj: unknown): boolean {
+  return typeof obj === 'object' && obj !== null && 'then' in obj;
+}

--- a/packages/-ember-data/tests/integration/relationships/inverse-relationship-load-test.js
+++ b/packages/-ember-data/tests/integration/relationships/inverse-relationship-load-test.js
@@ -1523,7 +1523,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let dogs = await person.get('dogs');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 2,
+      });
       assert.equal(person.hasMany('dogs').hasManyRelationship.relationshipIsEmpty, false);
       assert.equal(dogs.get('length'), 2);
 
@@ -1629,7 +1632,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let dogs = await person.get('dogs');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 2,
+      });
       assert.equal(person.hasMany('dogs').hasManyRelationship.relationshipIsEmpty, false);
       assert.equal(dogs.get('length'), 2);
 
@@ -1729,7 +1735,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let dogs = await person.get('dogs');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 2,
+      });
       assert.equal(person.hasMany('dogs').hasManyRelationship.relationshipIsEmpty, false);
       assert.equal(dogs.get('length'), 2);
 
@@ -1829,7 +1838,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let dogs = await person.get('dogs');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 2,
+      });
       assert.equal(person.hasMany('dogs').hasManyRelationship.relationshipIsEmpty, false);
       assert.equal(dogs.get('length'), 2);
 
@@ -1918,7 +1930,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let dog = await person.get('dog');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 1,
+      });
 
       let dogFromStore = await store.peekRecord('dog', '1');
 
@@ -2010,7 +2025,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let dog = await person.get('dog');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 1,
+      });
 
       let dogFromStore = store.peekRecord('dog', '1');
 
@@ -2100,7 +2118,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let dog = await person.get('dog');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 1,
+      });
 
       let dogFromStore = await store.peekRecord('dog', '1');
 
@@ -2190,7 +2211,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let dog = await person.get('dog');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 1,
+      });
 
       let dogFromStore = await store.peekRecord('dog', '1');
 
@@ -2285,7 +2309,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let person = await dog.get('person');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 1,
+      });
       let dogFromStore = await store.peekRecord('dog', '1');
 
       assert.equal(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
@@ -2370,7 +2397,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let person = await dog.get('person');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 1,
+      });
       let dogFromStore = await store.peekRecord('dog', '1');
 
       assert.equal(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
@@ -2450,7 +2480,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let person = await dog.get('person');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 1,
+      });
       let dogFromStore = await store.peekRecord('dog', '1');
 
       assert.equal(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
@@ -2530,7 +2563,10 @@ module('inverse relationship load test', function(hooks) {
       });
 
       let person = await dog.get('person');
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 1,
+      });
       let dogFromStore = await store.peekRecord('dog', '1');
 
       assert.equal(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
@@ -2644,7 +2680,10 @@ module('inverse relationship load test', function(hooks) {
 
       let person1Dogs = await person1.get('dogs');
 
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 2,
+      });
       assert.equal(person1.hasMany('dogs').hasManyRelationship.relationshipIsEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
@@ -2817,7 +2856,10 @@ module('inverse relationship load test', function(hooks) {
 
       let person1Dogs = await person1.get('dogs');
 
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 2,
+      });
       assert.equal(person1.hasMany('dogs').hasManyRelationship.relationshipIsEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
@@ -2971,7 +3013,10 @@ module('inverse relationship load test', function(hooks) {
 
       await person.get('dogs');
 
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 2,
+      });
       assert.equal(person.hasMany('dogs').hasManyRelationship.relationshipIsEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
@@ -3090,7 +3135,10 @@ module('inverse relationship load test', function(hooks) {
 
       await person.get('dogs');
 
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 2,
+      });
       assert.equal(person.hasMany('dogs').hasManyRelationship.relationshipIsEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
@@ -3209,7 +3257,10 @@ module('inverse relationship load test', function(hooks) {
 
       let dogs = await person.get('dogs');
 
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 2,
+      });
       assert.equal(person.hasMany('dogs').hasManyRelationship.relationshipIsEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
@@ -3327,7 +3378,10 @@ module('inverse relationship load test', function(hooks) {
 
       let dogs = await person.get('dogs');
 
-      assert.expectDeprecation(/Encountered mismatched relationship/);
+      assert.expectDeprecation({
+        id: 'mismatched-inverse-relationship-data-from-payload',
+        count: 2,
+      });
       assert.equal(person.hasMany('dogs').hasManyRelationship.relationshipIsEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');

--- a/packages/-ember-data/tests/test-helper.js
+++ b/packages/-ember-data/tests/test-helper.js
@@ -7,6 +7,9 @@ import { start } from 'ember-qunit';
 import QUnit from 'qunit';
 import DS from 'ember-data';
 import { wait, asyncEqual, invokeAsync } from 'dummy/tests/helpers/async';
+import configureAsserts from 'dummy/tests/helpers/qunit-asserts';
+
+configureAsserts();
 
 setApplication(Application.create(config.APP));
 

--- a/packages/-serializer-encapsulation-test-app/package.json
+++ b/packages/-serializer-encapsulation-test-app/package.json
@@ -38,7 +38,6 @@
     "ember-load-initializers": "^2.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.5.1",
-    "ember-qunit-assert-helpers": "^0.2.2",
     "ember-resolver": "^5.3.0",
     "ember-source": "^3.13.3",
     "eslint": "^6.5.1",

--- a/packages/-serializer-encapsulation-test-app/tests/integration/normalize-test.js
+++ b/packages/-serializer-encapsulation-test-app/tests/integration/normalize-test.js
@@ -83,7 +83,7 @@ module('integration/serializer - normalize method forwards to Serializer#normali
 
     const store = this.owner.lookup('service:store');
 
-    assert.expectAssertion(() => {
+    assert.throws(() => {
       store.normalize('person', {
         id: '1',
         type: 'person',

--- a/packages/-serializer-encapsulation-test-app/tests/integration/push-payload-test.js
+++ b/packages/-serializer-encapsulation-test-app/tests/integration/push-payload-test.js
@@ -90,7 +90,7 @@ module('integration/push-payload - pushPayload method forwards to Serializer#pus
 
     const store = this.owner.lookup('service:store');
 
-    assert.expectAssertion(() => {
+    assert.throws(() => {
       store.pushPayload('person', {
         data: {
           id: '1',

--- a/packages/-test-infra/package.json
+++ b/packages/-test-infra/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ember-data/-test-infra",
   "version": "3.15.0-alpha.1",
+  "private": true,
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [],
   "repository": "",

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -178,7 +178,7 @@ function ensureRelationshipIsSetToParent(payload, parentInternalModel, store, pa
       let expectedModel = Ember.inspect(parentInternalModel);
       let got = Ember.inspect(relationshipData);
       let prefix = typeof index === 'number' ? `data[${index}]` : `data`;
-      let path = `${prefix}.relationships.${inverse}.data`;
+      let path = `${prefix}.relationships.${inverseKey}.data`;
       let other = relationshipData ? `<${relationshipData.type}:${relationshipData.id}>` : null;
       let relationshipFetched = `${Ember.inspect(parentInternalModel)}.${parentRelationship.kind}("${
         parentRelationship.name

--- a/packages/store/types/qunit/index.d.ts
+++ b/packages/store/types/qunit/index.d.ts
@@ -3,17 +3,33 @@ interface DeprecationConfig {
   count?: number;
   until: string;
   message?: string;
+  url?: string;
+}
+interface WarningConfig {
+  id: string;
+  count?: number;
+  until?: string;
+  message?: string;
+  url?: string;
 }
 
 interface Assert {
-  expectDeprecation(callback: () => unknown, options: DeprecationConfig | string): Promise<void>;
+  expectDeprecation(callback: () => unknown, options: DeprecationConfig | string | RegExp): Promise<void>;
   expectNoDeprecation(callback: () => unknown): Promise<void>;
+  expectWarning(callback: () => unknown, options: WarningConfig | string | RegExp): Promise<void>;
+  expectNoWarning(callback: () => unknown): Promise<void>;
+  expectAssertion(callback: () => unknown, matcher: string | RegExp): Promise<void>;
+  expectNoAssertion(callback: () => unknown): Promise<void>;
 }
 
 declare namespace QUnit {
   export interface Assert {
-    expectDeprecation(callback: () => unknown, options: DeprecationConfig | string): Promise<void>;
+    expectDeprecation(callback: () => unknown, options: DeprecationConfig | string | RegExp): Promise<void>;
     expectNoDeprecation(callback: () => unknown): Promise<void>;
+    expectWarning(callback: () => unknown, options: WarningConfig | string | RegExp): Promise<void>;
+    expectNoWarning(callback: () => unknown): Promise<void>;
+    expectAssertion(callback: () => unknown, matcher: string | RegExp): Promise<void>;
+    expectNoAssertion(callback: () => unknown): Promise<void>;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3688,7 +3688,7 @@ broccoli-file-creator@^2.1.1:
     broccoli-plugin "^1.1.0"
     mkdirp "^0.5.1"
 
-broccoli-filter@^1.0.1, broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
+broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.3.0"
   resolved "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-1.3.0.tgz#71e3a8e32a17f309e12261919c5b1006d6766de6"
   integrity sha512-VXJXw7eBfG82CFxaBDjYmyN7V72D4In2zwLVQJd/h3mBfF3CMdRTsv2L20lmRTtCv1sAHcB+LgMso90e/KYiLw==
@@ -5744,7 +5744,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.18.0"
   resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -6306,14 +6306,6 @@ ember-maybe-import-regenerator@^0.1.6:
     broccoli-merge-trees "^1.0.0"
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
-
-ember-qunit-assert-helpers@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.npmjs.org/ember-qunit-assert-helpers/-/ember-qunit-assert-helpers-0.2.2.tgz#6fec8a33fd0d2c3fb6202f849291a309581727a4"
-  integrity sha512-P5eAqD753+p/qEeBi6OGpl2EzRxx8O9dUnr6HgyxU9fqQsSNQkJNGZ+ajbtePI8oMDGm+X7uOnf1+BgQ7eJ7qg==
-  dependencies:
-    broccoli-filter "^1.0.1"
-    ember-cli-babel "^6.9.0"
 
 ember-qunit@^4.5.1:
   version "4.5.1"


### PR DESCRIPTION
Depends on #6625 for tsconfig fixes

This:

- Allows us to remove more run loops.
- Gives us the ability to expand how we handle managing deprecations (done in a follow up commit)

It introduces:

- [x] expected deprecations/warnings are now removed from the list of encountered deprecations/warnings so that expectNo<Deprecation|Warning> can correctly assert no other deprecations or warnings were encountered
 - [x] assert.expectDeprecation | assert.expectAssertion | assert.expectWarning allow for async
 - [x] deprecations and warnings can be matched by id
