### PR TITLE
[CHORE] allow asserting all tests for deprecations

### DIFF
--- a/packages/-ember-data/tests/helpers/deprecated-test.js
+++ b/packages/-ember-data/tests/helpers/deprecated-test.js
@@ -2,6 +2,11 @@ import { test } from 'qunit';
 import VERSION from 'ember-data/version';
 import { DEBUG } from '@glimmer/env';
 
+// temporary so that we can split out test fixes
+// from landing this. If working locally turn this
+// on to have tests fail that require being fixed.
+export const SHOULD_ASSERT_ALL = false;
+
 // small comparison function for major and minor semver values
 function gte(EDVersion, DeprecationVersion) {
   let _edv = EDVersion.split('.');
@@ -26,10 +31,12 @@ export function deprecatedTest(testName, deprecation, testCallback) {
   async function interceptor(assert) {
     await testCallback.call(this, assert);
     if (DEBUG) {
-      if (typeof assert.test.expected === 'number') {
-        assert.test.expected += 1;
+      if (SHOULD_ASSERT_ALL) {
+        if (typeof assert.test.expected === 'number') {
+          assert.test.expected += 1;
+        }
+        assert.expectDeprecation(deprecation);
       }
-      assert.expectDeprecation(deprecation);
     }
   }
 

--- a/packages/-ember-data/tests/helpers/deprecated-test.js
+++ b/packages/-ember-data/tests/helpers/deprecated-test.js
@@ -1,5 +1,6 @@
 import { test } from 'qunit';
 import VERSION from 'ember-data/version';
+import { DEBUG } from '@glimmer/env';
 
 // small comparison function for major and minor semver values
 function gte(EDVersion, DeprecationVersion) {
@@ -22,8 +23,18 @@ export function deprecatedTest(testName, deprecation, testCallback) {
     throw new Error(`deprecatedTest expects { id } to be a meaningful string`);
   }
 
+  async function interceptor(assert) {
+    await testCallback.call(this, assert);
+    if (DEBUG) {
+      if (typeof assert.test.expected === 'number') {
+        assert.test.expected += 1;
+      }
+      assert.expectDeprecation(deprecation);
+    }
+  }
+
   if (gte(VERSION, deprecation.until)) {
-    test(`DEPRECATION ${deprecation.id} until ${deprecation.until} | ${testName}`, testCallback);
+    test(`DEPRECATION ${deprecation.id} until ${deprecation.until} | ${testName}`, interceptor);
   } else {
     test(`DEPRECATION ${deprecation.id} until ${deprecation.until} | ${testName}`, function(assert) {
       if (deprecation.refactor === true) {

--- a/packages/-ember-data/tests/helpers/test-in-debug.js
+++ b/packages/-ember-data/tests/helpers/test-in-debug.js
@@ -1,10 +1,10 @@
 import { DEBUG } from '@glimmer/env';
 import { test, skip } from 'qunit';
 
-export default function testInDebug() {
+export default function testInDebug(label, callback) {
   if (DEBUG) {
-    test(...arguments);
+    test(`[DEBUG-ONLY] ${label}`, callback);
   } else {
-    skip(...arguments);
+    skip(`[DEBUG-ONLY] ${label}`, callback);
   }
 }

--- a/packages/-ember-data/tests/test-helper.js
+++ b/packages/-ember-data/tests/test-helper.js
@@ -8,6 +8,7 @@ import { DEBUG } from '@glimmer/env';
 import QUnit from 'qunit';
 import { wait, asyncEqual, invokeAsync } from 'dummy/tests/helpers/async';
 import configureAsserts from 'dummy/tests/helpers/qunit-asserts';
+import { SHOULD_ASSERT_ALL } from './helpers/deprecated-test';
 
 configureAsserts();
 
@@ -40,7 +41,9 @@ QUnit.begin(() => {
       const hooks = (mod.hooks.afterEach = mod.hooks.afterEach || []);
 
       if (mod.tests.length !== 0) {
-        hooks.unshift(assertAllDeprecations);
+        if (SHOULD_ASSERT_ALL) {
+          hooks.unshift(assertAllDeprecations);
+        }
       }
     });
   }

--- a/packages/-ember-data/tests/test-helper.js
+++ b/packages/-ember-data/tests/test-helper.js
@@ -3,9 +3,9 @@ import config from '../config/environment';
 import RSVP from 'rsvp';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import { DEBUG } from '@glimmer/env';
 
 import QUnit from 'qunit';
-import DS from 'ember-data';
 import { wait, asyncEqual, invokeAsync } from 'dummy/tests/helpers/async';
 import configureAsserts from 'dummy/tests/helpers/qunit-asserts';
 
@@ -14,29 +14,45 @@ configureAsserts();
 setApplication(Application.create(config.APP));
 
 const { assert } = QUnit;
-const transforms = {
-  boolean: DS.BooleanTransform.create(),
-  date: DS.DateTransform.create(),
-  number: DS.NumberTransform.create(),
-  string: DS.StringTransform.create(),
-};
 
 QUnit.begin(() => {
+  function assertAllDeprecations(assert) {
+    if (typeof assert.test.expected === 'number') {
+      assert.test.expected += 1;
+    }
+    assert.expectNoDeprecation(undefined, undefined, deprecation => {
+      // only assert EmberData deprecations
+      const id = deprecation.options.id;
+      const isEmberDataDeprecation = id.includes('DS') || id.includes('EmberData') || id.includes('ember-data');
+
+      if (!isEmberDataDeprecation) {
+        // eslint-disable-next-line no-console
+        console.log('Detected Non-Ember-Data Deprecation', deprecation);
+      }
+
+      return isEmberDataDeprecation;
+    });
+  }
+  // ensure we don't regress quietly
+  // this plays nicely with `expectDeprecation`
+  if (DEBUG) {
+    QUnit.config.modules.forEach(mod => {
+      const hooks = (mod.hooks.afterEach = mod.hooks.afterEach || []);
+
+      if (mod.tests.length !== 0) {
+        hooks.unshift(assertAllDeprecations);
+      }
+    });
+  }
+
   RSVP.configure('onerror', reason => {
     // only print error messages if they're exceptions;
     // otherwise, let a future turn of the event loop
     // handle the error.
+    // TODO kill this off
     if (reason && reason instanceof Error) {
       throw reason;
     }
-  });
-
-  // Prevent all tests involving serialization to require a container
-  // TODO kill the need for this
-  DS.JSONSerializer.reopen({
-    transformFor(attributeType) {
-      return this._super(attributeType, true) || transforms[attributeType];
-    },
   });
 });
 


### PR DESCRIPTION
turned off until we fix tests in follow up PR, but have written all necessary test fixes locally already.

This gives us guarantees we don't regress on our own deprecations

It introduces: 

- [x] deprecatedTest now auto asserts deprecations it surrounds
- [x] all tests now assert unexpected ember-data deprecations

There's a LOT more we can do from here for things like asserting encountered deprecations have `url` and `until` attached to them for instance, or making a report that errors if we have deprecations coming from `Ember` itself.

I also think we should wrap the deprecation and warning helpers in `if (DEBUG)` and make them pass in prod automatically to reduce the number of tests that require `testInDebug`.