### PR TITLE
[CHORE] refactor: Remove runloop usage in destroy module of integration/store…

### DIFF
--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -1,5 +1,5 @@
 import { Promise, resolve } from 'rsvp';
-import { run, next } from '@ember/runloop';
+import { run } from '@ember/runloop';
 import { setupTest } from 'ember-qunit';
 import Ember from 'ember';
 import testInDebug from 'dummy/tests/helpers/test-in-debug';

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -509,7 +509,7 @@ const RootState = {
 
     // Record is already in an empty state, triggering transition to empty here
     // produce an error.
-    notFound() {}
+    notFound() {},
   },
 
   // A record enters this state when the store asks

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -506,6 +506,10 @@ const RootState = {
       internalModel.triggerLater('didLoad');
       internalModel.triggerLater('ready');
     },
+
+    // Record is already in an empty state, triggering transition to empty here
+    // produce an error.
+    notFound() {}
   },
 
   // A record enters this state when the store asks


### PR DESCRIPTION
## Description

* Remove run loop from tests when possible.
* Add `notFound` function to empty state to prevent error from being triggered when a record is unloaded while processing a `findRecord`.

<img width="1425" alt="Screenshot 2019-10-27 at 22 55 19" src="https://user-images.githubusercontent.com/344518/67642521-e21d3700-f90c-11e9-9a62-d4da3699e807.png">

