### PR TITLE
[CHORE] adds asset reporting infra

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,7 @@ module.exports = {
         '.mocharc.js',
         '.eslintrc.js',
         '.prettierrc.js',
-        'bin/*',
+        'bin/**',
         'packages/private-build-infra/src/**/*.js',
         'packages/unpublished-test-infra/src/**/*.js',
         'packages/*/.ember-cli.js',
@@ -108,12 +108,13 @@ module.exports = {
 
     // bin files
     {
-      files: ['bin/*'],
+      files: ['bin/**'],
       // eslint-disable-next-line node/no-unpublished-require
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         'no-console': 'off',
         'no-process-exit': 'off',
         'node/no-unpublished-require': 'off',
+        'node/no-unsupported-features/node-builtins': 'off',
       }),
     },
   ],

--- a/.github/workflows/asset-size-check.yml
+++ b/.github/workflows/asset-size-check.yml
@@ -71,5 +71,5 @@ jobs:
         run: |
           COMMENT_MARKER="Asset Size Report for "
           node ./bin/asset-size-tracking/src/create-comment-text.js $GITHUB_SHA > tmp/asset-sizes/comment.txt
-          COMMENT_TEXT=$(cat tmp/asset-sizes/comment.txt)
+          COMMENT_TEXT="@./tmp/asset-sizes/comment.txt"
           source bin/asset-size-tracking/src/post-comment.sh

--- a/.github/workflows/asset-size-check.yml
+++ b/.github/workflows/asset-size-check.yml
@@ -1,0 +1,75 @@
+name: AssetSizeCheck
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  asset-size-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout master
+        run: git checkout master
+      - name: Install dependencies for master
+        run: yarn install
+      - name: Build Production master
+        # This will leave the assets in a dist that is maintained when
+        #  We switch back to the primary branch
+        run: yarn workspace ember-data ember build -e production
+      - name: Checkout ${{github.ref}}
+        # We checkout the PR Branch before parsing the master vendor file
+        #  So that we are always using the current analysis tooling
+        run: git checkout --progress --force $GITHUB_SHA
+      - name: Install dependencies for ${{github.ref}}
+        run: yarn install
+      - name: Parse Master Assets
+        run: |
+          node ./bin/asset-size-tracking/generate-analysis.js
+          mkdir -p tmp
+          mkdir -p tmp/asset-sizes
+          node ./bin/asset-size-tracking/print-analysis.js -show > tmp/asset-sizes/master-analysis.txt
+      - name: Upload Master Dist Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: master-dist
+          path: packages/-ember-data/dist/assets
+      - name: Build Production ${{github.ref}}
+        run: yarn workspace ember-data ember build -e production
+      - name: Test Asset Sizes
+        run: |
+          mkdir -p tmp
+          mkdir -p tmp/asset-sizes
+          node ./bin/asset-size-tracking/generate-diff.js | tee tmp/asset-sizes/diff.txt
+      - name: Prepare Data For Report
+        if: failure() || success()
+        run: |
+          node ./bin/asset-size-tracking/generate-analysis.js
+      - name: Print Asset Size Report
+        if: failure() || success()
+        run: |
+          node ./bin/asset-size-tracking/print-analysis.js | tee tmp/asset-sizes/commit-analysis.txt
+      - name: Upload ${{github.ref}} Dist Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: commit-dist
+          path: packages/-ember-data/dist/assets
+      - name: Upload Report Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: reports
+          path: tmp/asset-sizes
+      - name: Report Asset Sizes
+        if: failure() || success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMENT_MARKER="Asset Size Report for "
+          node ./bin/asset-size-tracking/src/create-comment-text.js $GITHUB_SHA > tmp/asset-sizes/comment.txt
+          COMMENT_TEXT=$(cat tmp/asset-sizes/comment.txt)
+          source bin/asset-size-tracking/src/post-comment.sh

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tmp
 # dependencies
 bower_components
 node_modules
+bin/asset-size-tracking/current-data.json
 
 # misc
 .env*

--- a/bin/asset-size-tracking/generate-analysis.js
+++ b/bin/asset-size-tracking/generate-analysis.js
@@ -1,0 +1,20 @@
+'use strict';
+/**
+ * Analyze Ember-Data Modules
+ *
+ * Generates a JSON file with details of size costs of each individual module
+ * and package. You should crate a production build of the ember-data
+ * package prior to running this script.
+ *
+ */
+const fs = require('fs');
+const path = require('path');
+let INPUT_FILE = process.argv[2] || false;
+const parseModules = require('./src/parse-modules');
+const getBuiltDist = require('./src/get-built-dist');
+
+const builtAsset = getBuiltDist(INPUT_FILE);
+const library = parseModules(builtAsset);
+const outputPath = path.resolve(__dirname, './current-data.json');
+
+fs.writeFileSync(outputPath, JSON.stringify(library, null, 2));

--- a/bin/asset-size-tracking/generate-diff.js
+++ b/bin/asset-size-tracking/generate-diff.js
@@ -27,8 +27,8 @@ function getDiff(oldLibrary, newLibrary) {
     name: oldLibrary.name,
     currentSize: oldLibrary.absoluteSize,
     newSize: newLibrary.absoluteSize,
-    currentSizeGzip: oldLibrary.gzipSize,
-    newSizeGzip: newLibrary.gzipSize,
+    currentSizeCompressed: oldLibrary.compressedSize,
+    newSizeCompressed: newLibrary.compressedSize,
     packages: {},
   };
   oldLibrary.packages.forEach(pkg => {
@@ -36,8 +36,8 @@ function getDiff(oldLibrary, newLibrary) {
       name: pkg.name,
       currentSize: pkg.absoluteSize,
       newSize: 0,
-      currentSizeGzip: pkg.gzipSize,
-      newSizeGzip: 0,
+      currentSizeCompressed: pkg.compressedSize,
+      newSizeCompressed: 0,
       modules: {},
     };
     let modules = diff.packages[pkg.name].modules;
@@ -46,8 +46,8 @@ function getDiff(oldLibrary, newLibrary) {
         name: m.name,
         currentSize: m.absoluteSize,
         newSize: 0,
-        currentSizeGzip: m.gzipSize,
-        newSizeGzip: 0,
+        currentSizeCompressed: m.compressedSize,
+        newSizeCompressed: 0,
       };
     });
   });
@@ -56,23 +56,23 @@ function getDiff(oldLibrary, newLibrary) {
       name: pkg.name,
       currentSize: 0,
       newSize: pkg.absoluteSize,
-      currentSizeGzip: 0,
-      newSizeGzip: pkg.gzipSize,
+      currentSizeCompressed: 0,
+      newSizeCompressed: pkg.compressedSize,
       modules: {},
     };
     diff.packages[pkg.name].newSize = pkg.absoluteSize;
-    diff.packages[pkg.name].newSizeGzip = pkg.gzipSize;
+    diff.packages[pkg.name].newSizeCompressed = pkg.compressedSize;
     let modules = diff.packages[pkg.name].modules;
     pkg.modules.forEach(m => {
       modules[m.name] = modules[m.name] || {
         name: m.name,
         currentSize: 0,
         newSize: m.absoluteSize,
-        currentSizeGzip: 0,
-        newSizeGzip: m.gzipSize,
+        currentSizeCompressed: 0,
+        newSizeCompressed: m.compressedSize,
       };
       modules[m.name].newSize = m.absoluteSize;
-      modules[m.name].newSizeGzip = m.gzipSize;
+      modules[m.name].newSizeCompressed = m.compressedSize;
     });
   });
   diff.packages = Object.values(diff.packages);
@@ -91,7 +91,7 @@ function analyzeDiff(diff) {
 
   if (diff.currentSize < diff.newSize) {
     let delta = diff.newSize - diff.currentSize;
-    let compressedDelta = diff.newSizeGzip - diff.currentSizeGzip;
+    let compressedDelta = diff.newSizeCompressed - diff.currentSizeCompressed;
     if (delta > library_failure_threshold) {
       failures.push(
         `The size of the library ${diff.name} has increased by ${formatBytes(delta)} (${formatBytes(
@@ -128,7 +128,7 @@ function printItem(item, indent = 0) {
     const indentColor = indent >= 4 ? 'grey' : indent >= 2 ? 'yellow' : indent >= 0 ? 'magenta' : 'green';
     console.log(
       leftPad(
-        chalk[indentColor](item.name) + ' ' + chalk.white(formatBytes(item.newSizeGzip)) + formatDelta(item),
+        chalk[indentColor](item.name) + ' ' + chalk.white(formatBytes(item.newSizeCompressed)) + formatDelta(item),
         indent * 2
       )
     );
@@ -140,9 +140,9 @@ function formatDelta(item) {
     return '';
   }
   if (item.currentSize > item.newSize) {
-    return chalk.green(` (- ${formatBytes(item.currentSizeGzip - item.newSizeGzip)})`);
+    return chalk.green(` (- ${formatBytes(item.currentSizeCompressed - item.newSizeCompressed)})`);
   } else {
-    return chalk.red(` (+ ${formatBytes(item.newSizeGzip - item.currentSizeGzip)})`);
+    return chalk.red(` (+ ${formatBytes(item.newSizeCompressed - item.currentSizeCompressed)})`);
   }
 }
 
@@ -190,13 +190,13 @@ if (failures.length) {
   } else if (delta > 0) {
     console.log(
       `\n<detail>\n  <summary>${diff.name} shrank by ${formatBytes(delta)} (${formatBytes(
-        diff.currentSizeGzip - diff.newSizeGzip
+        diff.currentSizeCompressed - diff.newSizeCompressed
       )} compressed)</summary>`
     );
   } else {
     console.log(
       `\n${diff.name} increased by ${formatBytes(-1 * delta)} (${formatBytes(
-        diff.newSizeGzip - diff.currentSizeGzip
+        diff.newSizeCompressed - diff.currentSizeCompressed
       )} compressed) which is within the allowed tolerance of ${library_failure_threshold} bytes uncompressed`
     );
   }

--- a/bin/asset-size-tracking/generate-diff.js
+++ b/bin/asset-size-tracking/generate-diff.js
@@ -1,0 +1,213 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Library = require('./src/library');
+const parseModules = require('./src/parse-modules');
+const getBuiltDist = require('./src/get-built-dist');
+const chalk = require('chalk');
+const library_failure_threshold = 15;
+const package_warn_threshold = 0;
+
+let BASE_DATA_FILE = process.argv[2] || false;
+let NEW_VENDOR_FILE = process.argv[3] || false;
+
+if (!BASE_DATA_FILE) {
+  BASE_DATA_FILE = path.resolve(__dirname, './current-data.json');
+}
+
+const data = fs.readFileSync(BASE_DATA_FILE, 'utf-8');
+const current_library = Library.fromData(JSON.parse(data));
+
+const builtAsset = getBuiltDist(NEW_VENDOR_FILE);
+const new_library = parseModules(builtAsset);
+
+function getDiff(oldLibrary, newLibrary) {
+  const diff = {
+    name: oldLibrary.name,
+    currentSize: oldLibrary.absoluteSize,
+    newSize: newLibrary.absoluteSize,
+    currentSizeGzip: oldLibrary.gzipSize,
+    newSizeGzip: newLibrary.gzipSize,
+    packages: {},
+  };
+  oldLibrary.packages.forEach(pkg => {
+    diff.packages[pkg.name] = {
+      name: pkg.name,
+      currentSize: pkg.absoluteSize,
+      newSize: 0,
+      currentSizeGzip: pkg.gzipSize,
+      newSizeGzip: 0,
+      modules: {},
+    };
+    let modules = diff.packages[pkg.name].modules;
+    pkg.modules.forEach(m => {
+      modules[m.name] = {
+        name: m.name,
+        currentSize: m.absoluteSize,
+        newSize: 0,
+        currentSizeGzip: m.gzipSize,
+        newSizeGzip: 0,
+      };
+    });
+  });
+  newLibrary.packages.forEach(pkg => {
+    diff.packages[pkg.name] = diff.packages[pkg.name] || {
+      name: pkg.name,
+      currentSize: 0,
+      newSize: pkg.absoluteSize,
+      currentSizeGzip: 0,
+      newSizeGzip: pkg.gzipSize,
+      modules: {},
+    };
+    diff.packages[pkg.name].newSize = pkg.absoluteSize;
+    diff.packages[pkg.name].newSizeGzip = pkg.gzipSize;
+    let modules = diff.packages[pkg.name].modules;
+    pkg.modules.forEach(m => {
+      modules[m.name] = modules[m.name] || {
+        name: m.name,
+        currentSize: 0,
+        newSize: m.absoluteSize,
+        currentSizeGzip: 0,
+        newSizeGzip: m.gzipSize,
+      };
+      modules[m.name].newSize = m.absoluteSize;
+      modules[m.name].newSizeGzip = m.gzipSize;
+    });
+  });
+  diff.packages = Object.values(diff.packages);
+  diff.packages.forEach(pkg => {
+    pkg.modules = Object.values(pkg.modules);
+  });
+
+  return diff;
+}
+
+const diff = getDiff(current_library, new_library);
+
+function analyzeDiff(diff) {
+  let failures = [];
+  let warnings = [];
+
+  if (diff.currentSize < diff.newSize) {
+    let delta = diff.newSize - diff.currentSize;
+    let compressedDelta = diff.newSizeGzip - diff.currentSizeGzip;
+    if (delta > library_failure_threshold) {
+      failures.push(
+        `The size of the library ${diff.name} has increased by ${formatBytes(delta)} (${formatBytes(
+          compressedDelta
+        )} compressed) which exceeds the failure threshold of ${library_failure_threshold} bytes.`
+      );
+    }
+  }
+
+  diff.packages.forEach(pkg => {
+    if (pkg.currentSize < pkg.newSize) {
+      let delta = pkg.newSize - pkg.currentSize;
+      if (delta > package_warn_threshold) {
+        warnings.push(`The uncompressed size of the package ${pkg.name} has increased by ${formatBytes(delta)}.`);
+      }
+    }
+  });
+
+  return { failures, warnings };
+}
+
+function printDiff(diff) {
+  printItem(diff);
+  diff.packages.forEach(pkg => {
+    printItem(pkg, 2);
+    pkg.modules.forEach(m => {
+      printItem(m, 4);
+    });
+  });
+}
+
+function printItem(item, indent = 0) {
+  if (item.currentSize !== item.newSize) {
+    const indentColor = indent >= 4 ? 'grey' : indent >= 2 ? 'yellow' : indent >= 0 ? 'magenta' : 'green';
+    console.log(
+      leftPad(
+        chalk[indentColor](item.name) + ' ' + chalk.white(formatBytes(item.newSizeGzip)) + formatDelta(item),
+        indent * 2
+      )
+    );
+  }
+}
+
+function formatDelta(item) {
+  if (item.currentSize === item.newSize) {
+    return '';
+  }
+  if (item.currentSize > item.newSize) {
+    return chalk.green(` (- ${formatBytes(item.currentSizeGzip - item.newSizeGzip)})`);
+  } else {
+    return chalk.red(` (+ ${formatBytes(item.newSizeGzip - item.currentSizeGzip)})`);
+  }
+}
+
+function formatBytes(b) {
+  let str;
+  if (b > 1024) {
+    str = (b / 1024).toFixed(2) + ' KB';
+  } else {
+    str = b + ' B';
+  }
+
+  return str;
+}
+
+function leftPad(str, len, char = ' ') {
+  for (let i = 0; i < len; i++) {
+    str = char + str;
+  }
+  return str;
+}
+
+printDiff(diff);
+const { failures, warnings } = analyzeDiff(diff);
+
+if (failures.length) {
+  console.log(`\n<details>\n  <summary>${failures[0]}</summary>`);
+  if (failures.length > 1) {
+    console.log('\nFailed Checks\n-----------------------');
+    failures.forEach(f => {
+      console.log(f);
+    });
+  }
+  if (warnings.length) {
+    console.log('\nWarnings\n-----------------------');
+    warnings.forEach(w => {
+      console.log(w);
+    });
+  }
+  console.log('\n</details>');
+  process.exit(1);
+} else {
+  let delta = diff.currentSize - diff.newSize;
+  if (delta === 0) {
+    console.log(`\n<details>\n  <summary>${diff.name} has not changed in size</summary>`);
+  } else if (delta > 0) {
+    console.log(
+      `\n<detail>\n  <summary>${diff.name} shrank by ${formatBytes(delta)} (${formatBytes(
+        diff.currentSizeGzip - diff.newSizeGzip
+      )} compressed)</summary>`
+    );
+  } else {
+    console.log(
+      `\n${diff.name} increased by ${formatBytes(-1 * delta)} (${formatBytes(
+        diff.newSizeGzip - diff.currentSizeGzip
+      )} compressed) which is within the allowed tolerance of ${library_failure_threshold} bytes uncompressed`
+    );
+  }
+  if (warnings.length) {
+    console.log('\nWarnings\n-----------------------');
+    warnings.forEach(w => {
+      console.log(w);
+    });
+  } else {
+    console.log('\nIf any packages had changed sizes they would be listed here.');
+  }
+  console.log('\n</details>');
+  process.exit(0);
+}

--- a/bin/asset-size-tracking/print-analysis.js
+++ b/bin/asset-size-tracking/print-analysis.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Library = require('./src/library');
+
+let INPUT_FILE = process.argv[2] !== '-show' ? process.argv[2] : false;
+let SHOW_MODULES = process.argv[2] === '-show' || process.argv[3] === '-show';
+
+if (!INPUT_FILE) {
+  INPUT_FILE = path.resolve(__dirname, './current-data.json');
+}
+
+const data = fs.readFileSync(INPUT_FILE, 'utf-8');
+
+const library = Library.fromData(JSON.parse(data));
+library.print(SHOW_MODULES);

--- a/bin/asset-size-tracking/src/create-comment-text.js
+++ b/bin/asset-size-tracking/src/create-comment-text.js
@@ -7,6 +7,9 @@ const analysisPath = path.resolve(__dirname, '../../../tmp/asset-sizes/commit-an
 const diffText = fs.readFileSync(diffPath);
 const analysisText = fs.readFileSync(analysisPath);
 
-console.log(
-  `Asset Size Report for ${GITHUB_SHA}\n${diffText}\n<details>\n  <summary>Full Asset Analysis</summary>\n\n\`\`\`${analysisText}\n\`\`\`\n</details>`
-);
+const commentText = `Asset Size Report for ${GITHUB_SHA}\n${diffText}\n<details>\n  <summary>Full Asset Analysis</summary>\n\n\`\`\`${analysisText}\n\`\`\`\n</details>`;
+const commentJSON = {
+  body: commentText,
+};
+
+console.log(JSON.stringify(commentJSON, null, 2));

--- a/bin/asset-size-tracking/src/create-comment-text.js
+++ b/bin/asset-size-tracking/src/create-comment-text.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+const GITHUB_SHA = process.argv[2];
+
+const diffPath = path.resolve(__dirname, '../../../tmp/asset-sizes/diff.txt');
+const analysisPath = path.resolve(__dirname, '../../../tmp/asset-sizes/commit-analysis.txt');
+const diffText = fs.readFileSync(diffPath);
+const analysisText = fs.readFileSync(analysisPath);
+
+console.log(
+  `Asset Size Report for ${GITHUB_SHA}\n${diffText}\n<details>\n  <summary>Full Asset Analysis</summary>\n\n\`\`\`${analysisText}\n\`\`\`\n</details>`
+);

--- a/bin/asset-size-tracking/src/get-built-dist.js
+++ b/bin/asset-size-tracking/src/get-built-dist.js
@@ -1,0 +1,37 @@
+'use strict';
+/**
+ * Analyze Ember-Data Modules
+ *
+ * Generates a JSON file with details of size costs of each individual module
+ * and package. You should crate a production build of the ember-data
+ * package prior to running this script.
+ *
+ */
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function getDistFile(INPUT_FILE) {
+  if (!INPUT_FILE) {
+    try {
+      let dirPath = path.resolve(__dirname, '../../../packages/-ember-data/dist/assets');
+      let dir = fs.readdirSync(dirPath, 'utf-8');
+
+      for (let i = 0; i < dir.length; i++) {
+        let name = dir[i];
+        if (name.indexOf('vendor') !== -1 && name.indexOf('.js') !== -1) {
+          INPUT_FILE = path.resolve(dirPath, name);
+        }
+      }
+    } catch (e) {
+      console.log(`No vendor.js file found to process: ${e.message}`);
+      process.exit(1);
+    }
+
+    if (!INPUT_FILE) {
+      console.log('No vendor.js file found to process');
+      process.exit(1);
+    }
+  }
+
+  return fs.readFileSync(INPUT_FILE, 'utf-8');
+};

--- a/bin/asset-size-tracking/src/library.js
+++ b/bin/asset-size-tracking/src/library.js
@@ -1,0 +1,225 @@
+const gzipSize = require('gzip-size').sync;
+const TablePads = {
+  name: 45,
+  bytes: 9,
+  gzipBytes: 10,
+  percentOfPackage: 13,
+};
+
+class Library {
+  constructor(name) {
+    this.name = name;
+    this.packages = [];
+    this._packageMap = {};
+    this._concatModule = '';
+  }
+  getPackage(name) {
+    let pkg = this._packageMap[name];
+
+    if (!pkg) {
+      pkg = this._packageMap[name] = new Package(name, this);
+      this.packages.push(pkg);
+    }
+
+    return pkg;
+  }
+  get concatModule() {
+    return this._concatModule;
+  }
+  get absoluteSize() {
+    return byteCount(this.concatModule);
+  }
+  get gzipSize() {
+    return gzipSize(this.concatModule);
+  }
+  sort() {
+    this.packages = this.packages.sort((a, b) => {
+      return a.gzipSize > b.gzipSize ? -1 : 1;
+    });
+    this.packages.forEach(p => p.sort());
+  }
+  print(showModules) {
+    console.log('\n\nAsset Size Report');
+    console.log('=================\n\n');
+
+    console.log(`Library: ${this.name}`);
+    console.table({
+      bytes: formatBytes(this.absoluteSize),
+      compressed: formatBytes(this.gzipSize),
+      packages: this.packages.length,
+      modules: this.packages.reduce((v, c) => v + c.modules.length, 0),
+    });
+    this.packages.forEach(p => p.print());
+    if (showModules) {
+      this.packages.forEach(p => {
+        p.modules.forEach(m => {
+          console.log('\n\n');
+          console.log(m.code);
+        });
+      });
+    }
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      packages: this.packages,
+    };
+  }
+
+  static fromData(data) {
+    const library = new Library(data.name);
+    data.packages.forEach(p => {
+      const pkg = library.getPackage(p.name);
+      p.modules.forEach(m => {
+        pkg.addModule(m.name, m.code);
+      });
+    });
+    return library;
+  }
+}
+
+class Package {
+  constructor(name, library) {
+    this.name = name;
+    this.library = library;
+    this.modules = [];
+    this._concatModule = '';
+  }
+  addModule(name, code) {
+    let mod = new Module(name, this, code);
+    this.modules.push(mod);
+    this._concatModule += code;
+    this.library._concatModule += code;
+    return mod;
+  }
+  get concatModule() {
+    return this._concatModule;
+  }
+  get absoluteSize() {
+    return byteCount(this.concatModule);
+  }
+  get gzipSize() {
+    return (
+      Math.floor((this.concatModule.length / this.library.concatModule.length) * this.library.gzipSize * 100) / 100
+    );
+  }
+  get percentOfLibrary() {
+    return getRelativeSizeOf(this.library, this);
+  }
+  sort() {
+    this.modules = this.modules.sort((a, b) => {
+      return a.gzipSize > b.gzipSize ? -1 : 1;
+    });
+  }
+  print() {
+    console.log('\nPackage: ' + this.name);
+    console.table({
+      bytes: formatBytes(this.absoluteSize),
+      compressed: formatBytes(this.gzipSize),
+      '% Of Library': this.percentOfLibrary,
+    });
+    console.log(
+      `\t${rightPad('Module', TablePads.name)} | ` +
+        `${rightPad('Bytes', TablePads.bytes)} | ` +
+        `${rightPad('Compressed', TablePads.gzipBytes)} | ` +
+        `${rightPad('% of Package', TablePads.percentOfPackage)} | ` +
+        `% Of Library`
+    );
+    console.log(
+      '\t-----------------------------------------------------------------------------------------------------'
+    );
+    this.modules.forEach(s => s.print());
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      modules: this.modules,
+    };
+  }
+}
+
+class Module {
+  constructor(name, pkg, code) {
+    this.name = name;
+    this.package = pkg;
+    this.code = code;
+  }
+  get size() {
+    return this.code.length;
+  }
+  get absoluteSize() {
+    return byteCount(this.code);
+  }
+  get gzipSize() {
+    return (
+      Math.floor((this.size / this.package.library.concatModule.length) * this.package.library.gzipSize * 100) / 100
+    );
+  }
+  get bytes() {
+    return formatBytes(this.absoluteSize);
+  }
+  get gzipBytes() {
+    return formatBytes(this.gzipSize);
+  }
+  get percentOfPackage() {
+    return getRelativeSizeOf(this.package, this);
+  }
+  get percentOfLibrary() {
+    return getRelativeSizeOf(this.package.library, this);
+  }
+  print() {
+    console.log(
+      '\t' +
+        rightPad(this.name, TablePads.name) +
+        ' | ' +
+        rightPad(this.bytes, TablePads.bytes) +
+        ' | ' +
+        rightPad(this.gzipBytes, TablePads.gzipBytes) +
+        ' | ' +
+        rightPad(this.percentOfPackage, TablePads.percentOfPackage) +
+        ' | ' +
+        this.percentOfLibrary
+    );
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      code: this.code,
+    };
+  }
+}
+
+function rightPad(str, len, char = ' ') {
+  while (str.length < len) {
+    str += char;
+  }
+  return str;
+}
+
+function getRelativeSizeOf(base, component) {
+  const { absoluteSize } = component;
+  const { absoluteSize: totalSize } = base;
+
+  return `${per(absoluteSize, totalSize)}`;
+}
+
+function per(size, total) {
+  return ((size / total) * 100).toFixed(1);
+}
+
+function formatBytes(b) {
+  let str;
+  if (b > 1024) {
+    str = (b / 1024).toFixed(2) + ' KB';
+  } else {
+    str = b + ' B';
+  }
+
+  return str;
+}
+
+function byteCount(s) {
+  return encodeURI(s).split(/%..|./).length - 1;
+}
+
+module.exports = Library;

--- a/bin/asset-size-tracking/src/library.js
+++ b/bin/asset-size-tracking/src/library.js
@@ -12,7 +12,7 @@ const BROTLI_OPTIONS = {
 };
 
 function getCompressedSize(code) {
-  return zlib.brotliCompressSync(code, BROTLI_OPTIONS);
+  return Buffer.byteLength(zlib.brotliCompressSync(code, BROTLI_OPTIONS));
 }
 
 class Library {
@@ -21,6 +21,7 @@ class Library {
     this.packages = [];
     this._packageMap = {};
     this._concatModule = '';
+    this._compressedSize = null;
   }
   getPackage(name) {
     let pkg = this._packageMap[name];
@@ -39,7 +40,7 @@ class Library {
     return byteCount(this.concatModule);
   }
   get compressedSize() {
-    return getCompressedSize(this.concatModule);
+    return this._compressedSize || (this._compressedSize = getCompressedSize(this.concatModule));
   }
   sort() {
     this.packages = this.packages.sort((a, b) => {

--- a/bin/asset-size-tracking/src/parse-modules.js
+++ b/bin/asset-size-tracking/src/parse-modules.js
@@ -1,0 +1,42 @@
+const Library = require('./library');
+const moduleNames = ['ember-data', '@ember-data', '@ember/ordered-set', 'ember-inflector'];
+
+module.exports = function parseModules(builtAsset) {
+  let modules = builtAsset
+    .split('define(')
+    .join('MODULE_SPLIT_POINTdefine(')
+    .split('MODULE_SPLIT_POINT');
+
+  modules = modules.filter(mod => {
+    for (let i = 0; i < moduleNames.length; i++) {
+      let projectName = moduleNames[i];
+      if (mod.indexOf(projectName) === 8) {
+        return true;
+      }
+    }
+    return false;
+  });
+
+  let library = new Library('EmberData');
+
+  modules.forEach(m => {
+    let end = m.indexOf(',', 8) - 1;
+    let name = m.substring(8, end);
+
+    let packageName = 'ember-data';
+
+    if (name.indexOf('@ember-data/') === 0) {
+      let subPackageEnd = name.indexOf('/', 12);
+      packageName = name.substring(0, subPackageEnd);
+    } else if (name.indexOf('ember-inflector') === 0) {
+      packageName = 'ember-inflector';
+    } else if (name.indexOf('@ember/ordered-set') === 0) {
+      packageName = '@ember/ordered-set';
+    }
+
+    library.getPackage(packageName).addModule(name, m);
+  });
+
+  library.sort();
+  return library;
+};

--- a/bin/asset-size-tracking/src/post-comment.sh
+++ b/bin/asset-size-tracking/src/post-comment.sh
@@ -1,0 +1,76 @@
+ #!/bin/bash
+
+# Shamelessly stolen from the very awesome ShakingFingerAction
+#  Written by the amazing https://twitter.com/jessfraz
+#  https://github.com/jessfraz/shaking-finger-action
+# Generified to enable this form of comment management
+#  for our CI Reports (AssetSize | Perf Analysis etc.)
+
+if [[ -z "$COMMENT_MARKER" ]]; then
+  echo "Set the COMMENT_MARKER env variable."
+  return 1
+fi
+
+if [[ -z "$COMMENT_TEXT" ]]; then
+  echo "Set the COMMENT_TEXT env variable."
+  return 1
+fi
+
+if [[ -z "$GITHUB_REPOSITORY" ]]; then
+  echo "Set the GITHUB_REPOSITORY env variable."
+  return 1
+fi
+
+# Github seems to be playin coy, getting access from
+# a sourced script is extremely hard
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+  echo "Configure the env to include the GITHUB_TOKEN secret variable."
+  return 1
+fi
+
+URI=https://api.github.com
+API_VERSION=v3
+API_HEADER="Accept: application/vnd.github.${API_VERSION}+json; application/vnd.github.antiope-preview+json"
+AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
+
+delete_comment_if_exists() {
+  # Get all the comments for the pull request.
+  body=$(curl -sSL -H "${AUTH_HEADER}" -H "${API_HEADER}" "${URI}/repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/comments")
+
+  for row in $(echo -E "${body}" | jq --raw-output  '.[] | @base64'); do
+    comment=$(echo -E "${row}" | base64 --decode | jq --raw-output '{id: .id, body: .body, author: .user.login}')
+    id=$(echo -E "$comment" | jq -r '.id')
+    b=$(echo -E "$comment" | jq -r '.body')
+
+    if [[ "$b" == *"${COMMENT_MARKER}"* ]]; then
+      # We have found our comment.
+      # Delete it.
+
+      echo "Deleting old comment ID: $id"
+      DELETE_URL="${URI}/repos/${GITHUB_REPOSITORY}/issues/comments/${id}"
+      echo $DELETE_URL;
+      curl -sSL -H "${AUTH_HEADER}" -H "${API_HEADER}" -X DELETE $DELETE_URL
+    fi
+  done
+}
+
+post_comment() {
+  echo 'Attempting JSON creation'
+  description=$(jq -n --arg b "$COMMENT_TEXT" '{ "body": $b }')
+  echo 'Attempting Curl'
+  curl -sSL -H "${AUTH_HEADER}" -H "${API_HEADER}" -d "$description" -H "Content-Type: application/json" -X POST "${URI}/repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/comments"
+}
+
+main() {
+  # Validate the GitHub token.
+  curl -o /dev/null -sSL -H "${AUTH_HEADER}" -H "${API_HEADER}" "${URI}/repos/${GITHUB_REPOSITORY}" || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
+
+  # Get the pull request number.
+  NUMBER=$(jq --raw-output .number "$GITHUB_EVENT_PATH")
+  echo "running $GITHUB_ACTION for PR #${NUMBER}"
+
+  delete_comment_if_exists;
+  post_comment;
+}
+
+main

--- a/bin/asset-size-tracking/src/post-comment.sh
+++ b/bin/asset-size-tracking/src/post-comment.sh
@@ -55,10 +55,7 @@ delete_comment_if_exists() {
 }
 
 post_comment() {
-  echo 'Attempting JSON creation'
-  description=$(jq -n --arg b "$COMMENT_TEXT" '{ "body": $b }')
-  echo 'Attempting Curl'
-  curl -sSL -H "${AUTH_HEADER}" -H "${API_HEADER}" -d "$description" -H "Content-Type: application/json" -X POST "${URI}/repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/comments"
+  curl -sSL -H "${AUTH_HEADER}" -H "${API_HEADER}" -d "$COMMENT_TEXT" -H "Content-Type: application/json" -X POST "${URI}/repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/comments"
 }
 
 main() {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test-external:ember-data-relationship-tracker": "./bin/test-external-partner-project.js ember-data-relationship-tracker https://github.com/ef4/ember-data-relationship-tracker.git"
   },
   "devDependencies": {
+    "gzip-size": "^3.0.0",
     "@babel/plugin-transform-typescript": "^7.6.3",
     "@ember/optional-features": "^1.1.0",
     "@types/ember": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test-external:ember-data-relationship-tracker": "./bin/test-external-partner-project.js ember-data-relationship-tracker https://github.com/ef4/ember-data-relationship-tracker.git"
   },
   "devDependencies": {
-    "gzip-size": "^3.0.0",
+    "zlib": "1.0.5",
     "@babel/plugin-transform-typescript": "^7.6.3",
     "@ember/optional-features": "^1.1.0",
     "@types/ember": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7945,6 +7945,13 @@ growly@^1.3.0:
   resolved "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
+gzip-size@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
+  integrity sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=
+  dependencies:
+    duplexer "^0.1.1"
+
 handlebars@^4.0.11, handlebars@^4.0.13, handlebars@^4.0.4, handlebars@^4.3.1, handlebars@^4.4.0:
   version "4.4.5"
   resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz#1b1f94f9bfe7379adda86a8b73fb570265a0dddd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7945,13 +7945,6 @@ growly@^1.3.0:
   resolved "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-gzip-size@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
-  integrity sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=
-  dependencies:
-    duplexer "^0.1.1"
-
 handlebars@^4.0.11, handlebars@^4.0.13, handlebars@^4.0.4, handlebars@^4.3.1, handlebars@^4.4.0:
   version "4.4.5"
   resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz#1b1f94f9bfe7379adda86a8b73fb570265a0dddd"
@@ -14028,3 +14021,8 @@ yuidocjs@^0.10.0:
     minimatch "^3.0.2"
     rimraf "^2.4.1"
     yui "^3.18.1"
+
+zlib@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz#6e7c972fc371c645a6afb03ab14769def114fcc0"
+  integrity sha1-bnyXL8NxxkWmr7A6sUdp3vEU/MA=


### PR DESCRIPTION
Before running these commands you will want to run

```
yarn workspace ember-data ember b -e production
```

- [x] snapshot the state ` node ./bin/asset-size-tracking/generate-analysis.js`
- [x] see an analysis `node ./bin/asset-size-tracking/print-analysis.js`
- [x] diff the current vendor file against the snapshot `node ./bin/asset-size-tracking/generate-diff.js`
- [x] generate diff as gh-action that fails if package sizes regress
- [x] post analysis as comment for clear visibility
- [x] make analysis and dist files downloadable artifacts