### PR TITLE
Backport #6472: Use GitHub Actions for CI (#6472)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,190 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - beta
+      - release
+      - 'release-*'
+      - 'lts-*'
+    tags:
+      - '*'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Yarn install
+        run: yarn
+      - name: Lint features
+        run: yarn lint:features
+      - name: Lint prettier
+        run: yarn lint:prettier
+      - name: Check for TypeScript problems
+        run: yarn problems
+
+  basic-tests:
+    strategy:
+      matrix:
+        os: [macOS-10.14, windows-2016, ubuntu-18.04]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install dependencies
+        run: yarn install
+      - name: Basic tests
+        run: yarn test
+      - name: Encapsulation tests
+        run: yarn test:encapsulation
+      - name: Production build
+        run: yarn test:production
+      - name: Docs tests
+        run: yarn test:docs
+      - name: Node tests
+        run: yarn test:node
+      - if: |
+          github.event_name == 'pull_request' && (
+            github.base_ref == 'master' || github.base_ref == 'beta'
+          ) || github.event_name == 'push' && (
+            endsWith(github.ref, '/master') || endsWith(github.ref, '/beta')
+          )
+        name: In progress features
+        env:
+          EMBER_DATA_FEATURE_OVERRIDE: ENABLE_ALL_OPTIONAL
+        run: yarn test:enabled-in-progress-features
+
+  floating-dependencies:
+    needs: [lint, basic-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install dependencies w/o lockfile
+        run: yarn install --no-lockfile --non-interactive
+      - name: Basic Tests
+        run: yarn test
+
+  lts:
+    needs: [lint, basic-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install dependencies
+        run: yarn install
+      - name: Basic Tests with ember-lts-3.8
+        run: yarn test:try-one ember-lts-3.8
+
+  releases:
+    needs: [lint, basic-tests]
+    if: |
+      github.event_name == 'pull_request' && (
+        github.base_ref == 'master' || github.base_ref == 'beta'
+      ) || github.event_name == 'push' && (
+        endsWith(github.ref, '/master') || endsWith(github.ref, '/beta')
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [
+          ember-release,
+          ember-beta,
+          ember-canary,
+          ember-release-with-jquery
+        ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install dependencies
+        run: yarn install
+      - name: Basic tests with ${{ matrix.scenario }}
+        run: yarn test:try-one ${{ matrix.scenario }}
+
+  additional-scenarios:
+    needs: [lint, basic-tests]
+    strategy:
+      matrix:
+        scenario: [
+          default-with-jquery,
+          with-ember-fetch,
+          with-max-transpilation
+        ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install dependencies
+        run: yarn install
+      - name: Basic tests with ${{ matrix.scenario }}
+        run: yarn test:try-one ${{ matrix.scenario }}
+
+  external-partners:
+    needs: [
+      additional-scenarios,
+      basic-tests,
+      floating-dependencies,
+      lint,
+      lts,
+      releases
+    ]
+    if: |
+      github.event_name == 'pull_request' && (
+        github.base_ref == 'master' || github.base_ref == 'beta'
+      ) || github.event_name == 'push' && (
+        endsWith(github.ref, '/master') || endsWith(github.ref, '/beta')
+      )
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        partner: [
+          ember-data-change-tracker,
+          ember-data-relationship-tracker,
+          ember-m3,
+          ember-observer,
+          ember-resource-metadata,
+          factory-guy,
+          ilios-frontend,
+          model-fragments,
+          storefront,
+          travis-web
+        ]
+        include:
+          - partner: ember-data-change-tracker
+            continue-on-error: true
+          - partner: factory-guy
+            continue-on-error: true
+          - partner: model-fragments
+            continue-on-error: true
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install dependencies
+        run: yarn install
+      - name: Generate package tarballs
+        run: node ./bin/packages-for-commit.js
+      - name: Run Tests
+        env:
+          CI: true
+        run: yarn test-external:${{ matrix.partner }}
+        continue-on-error: ${{ matrix['continue-on-error'] == true }}

--- a/packages/-ember-data/config/ember-try.js
+++ b/packages/-ember-data/config/ember-try.js
@@ -20,6 +20,13 @@ module.exports = function() {
           },
         },
         {
+          name: 'with-max-transpilation',
+          env: {
+            TARGET_IE11: true,
+          },
+          npm: {},
+        },
+        {
           name: 'default-with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),


### PR DESCRIPTION
Backporting #6472 into release branch per #6282 
----

* Use GitHub Actions for CI

This supersedes https://github.com/emberjs/data/pull/6098 but with
[GitHub
actions](https://help.github.com/en/articles/about-github-actions)
rather than Azure Pipelines.

I think we should continue running Travis CI alongside this for a little
while to make sure everything is working correctly but we should remove
the Azure Pipelines config.

Why?

- This GitHub version runs much faster because we're given more
  resources to run jobs concurrently.
- The syntax is also nicer, which is my opinion of course but it seems
  to be shared by others.

Stages

The jobs are configured to run in three stages, each only running once
all of the jobs in the previous stage have passed:

1. lint & basic-tests
1. floating-dependencies, lts, releases, additional-scenarios
1. external-partners

This setup is intended to make sure that one build is not using all of
the repo's allowed jobs. It is a trade off between speed and resource
availability that we might want to tweak in the future.

Allowed failures

GitHub actions, like Azure Pipelines, doesn't provide a feature like
[Travis CI's
`allow_failures`](https://docs.travis-ci.com/user/customizing-the-build/#rows-that-are-allowed-to-fail),
which allows a job to fail without failing the entire build.  As a
workaround, this uses the
[`continue-on-error`](https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error)
feature to allow some external partner tests to fail without failing the
entire build. **The downside** is that it is difficult to know when
these jobs are actually failing since they appear to have passed in
GitHub's UI. We will likely want to do something to address this in the
future.

Downsides

- GitHub Actions Workflows are still in beta so it's possible that there
could be breaking changes.

* Ensure tags start a CI job. (#6475)

Without this change, all pushed tags will *not* do a CI build (because there must be at least one positive match if any filtering is done).

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
