### PR TITLE
[DOC] Close code block in the description

### DIFF
--- a/packages/store/addon/-private/system/snapshot-record-array.js
+++ b/packages/store/addon/-private/system/snapshot-record-array.js
@@ -109,6 +109,7 @@ export default class SnapshotRecordArray {
           return fetch(url).then((response) => response.json())
         }
       });
+      ```
 
       @property include
       @type {String|Array}


### PR DESCRIPTION
This has been broken for a few releases & this PR fixes the messed up code block in the API docs.