### PR TITLE
[BREAKING BUGFIX] eliminate infrastructure for filter record arrays

### DIFF
--- a/packages/-ember-data/tests/unit/store/asserts-test.js
+++ b/packages/-ember-data/tests/unit/store/asserts-test.js
@@ -73,7 +73,6 @@ module('unit/store/asserts - DS.Store methods produce useful assertion messages'
     '_push',
     'pushPayload',
     'normalize',
-    'recordWasLoaded',
     'adapterFor',
     'serializerFor',
   ];

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -2613,10 +2613,8 @@ abstract class CoreStore extends Service {
 
     internalModel.setupData(data);
 
-    if (isUpdate) {
+    if (!isUpdate) {
       this.recordArrayManager.recordDidChange(internalModel);
-    } else {
-      this.recordArrayManager.recordWasLoaded(internalModel);
     }
 
     return internalModel;
@@ -3141,14 +3139,6 @@ abstract class CoreStore extends Service {
       throw new Error(`Private API Removed`);
     }
     return globalClientIdCounter++;
-  }
-
-  //Called by the state machine to notify the store that the record is ready to be interacted with
-  recordWasLoaded(record) {
-    if (DEBUG) {
-      assertDestroyingStore(this, 'recordWasLoaded');
-    }
-    this.recordArrayManager.recordWasLoaded(record);
   }
 
   // ...............

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -545,7 +545,6 @@ export default class InternalModel {
         )
         .finally(function() {
           internalModel.finishedReloading();
-          internalModel.updateRecordArrays();
         });
     } else {
       this.startedReloading();
@@ -568,7 +567,6 @@ export default class InternalModel {
         )
         .finally(function() {
           internalModel.finishedReloading();
-          internalModel.updateRecordArrays();
         });
     }
   }
@@ -1041,7 +1039,6 @@ export default class InternalModel {
   */
   adapterDidDirty() {
     this.send('becomeDirty');
-    this.updateRecordArrays();
   }
 
   /*
@@ -1087,7 +1084,6 @@ export default class InternalModel {
           manyArray.retrieveLatest();
         }
       }
-      this.updateRecordArrays();
     }
   }
 
@@ -1098,7 +1094,6 @@ export default class InternalModel {
       } else {
         this._record.notifyBelongsToChange(key, this._record);
       }
-      this.updateRecordArrays();
     }
   }
 
@@ -1123,7 +1118,6 @@ export default class InternalModel {
       } else {
         this._record.notifyPropertyChange(key);
       }
-      this.updateRecordArrays();
     }
     if (!CUSTOM_MODEL_CLASS) {
       let manyArray = this._manyArrayCache[key] || this._retainedManyArrayCache[key];
@@ -1236,8 +1230,6 @@ export default class InternalModel {
     for (i = 0, l = setups.length; i < l; i++) {
       setups[i].setup(this);
     }
-
-    this.updateRecordArrays();
   }
 
   _unhandledEvent(state, name, context) {

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -177,8 +177,6 @@ function didSetProperty(internalModel, context) {
   } else {
     internalModel.send('propertyWasReset');
   }
-
-  internalModel.updateRecordArrays();
 }
 
 // Implementation notes:
@@ -396,6 +394,10 @@ const createdState = dirtyState({
   dirtyType: 'created',
   // FLAGS
   isNew: true,
+
+  setup(internalModel) {
+    internalModel.updateRecordArrays();
+  },
 });
 
 createdState.invalid.rolledBack = function(internalModel) {

--- a/packages/store/addon/-private/system/record-array-manager.js
+++ b/packages/store/addon/-private/system/record-array-manager.js
@@ -27,18 +27,6 @@ export default class RecordArrayManager {
   }
 
   recordDidChange(internalModel) {
-    // TODO: change name
-    // TODO: track that it was also a change
-    this.internalModelDidChange(internalModel);
-  }
-
-  recordWasLoaded(internalModel) {
-    // TODO: change name
-    // TODO: track that it was also that it was first loaded
-    this.internalModelDidChange(internalModel);
-  }
-
-  internalModelDidChange(internalModel) {
     let modelName = internalModel.modelName;
 
     if (internalModel._pendingRecordArrayManagerFlush) {
@@ -74,7 +62,7 @@ export default class RecordArrayManager {
     if (array) {
       // TODO: skip if it only changed
       // process liveRecordArrays
-      this.updateLiveRecordArray(array, internalModels);
+      updateLiveRecordArray(array, internalModels);
     }
 
     // process adapterPopulatedRecordArrays
@@ -90,10 +78,6 @@ export default class RecordArrayManager {
     for (let modelName in pending) {
       this._flushPendingInternalModelsForModelName(modelName, pending[modelName]);
     }
-  }
-
-  updateLiveRecordArray(array, internalModels) {
-    return updateLiveRecordArray(array, internalModels);
   }
 
   _syncLiveRecordArray(array, modelName) {
@@ -343,10 +327,6 @@ function updateLiveRecordArray(array, internalModels) {
   if (modelsToRemove.length > 0) {
     array._removeInternalModels(modelsToRemove);
   }
-
-  // return whether we performed an update.
-  // Necessary until 3.5 allows us to finish off ember-data-filter support.
-  return (modelsToAdd.length || modelsToRemove.length) > 0;
 }
 
 function removeFromAdapterPopulatedRecordArrays(internalModels) {


### PR DESCRIPTION
We deprecated filters ages ago and completed killing them off after 3.4. This is the scheduled removal of some secret notification infra we had left in place to keep them working a tad longer if needed.

**⚠️ WARNING**

This infrastructure had the unintended bug of making us notify array `length` and `[]` over-eagerly.
Due to this, the change **MAY** break apps that were using observers or computed properties on the `length` or `[]` properties of `RecordArray`s when intending to observe changes to properties on records inside these arrays.

For such cases there is an easy refactor to more standard Ember computed property usage ala `allRecords.@each.{aProp,bProp}`. This risk may be lower in versions of Ember in which @tracked is in use.