### PR TITLE
[CHORE] refactor: Remove runloop usage in integration tests for store/ find All module

### DIFF
--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -696,7 +696,9 @@ module('integration/store - findAll', function(hooks) {
 
     assert.equal(cars.length, 1, 'Store resolves with the existing records');
 
-    await resolvefindAll();
+    resolvefindAll();
+
+    await settled();
 
     cars = store.peekAll('car');
 
@@ -930,7 +932,9 @@ module('integration/store - findAll', function(hooks) {
     let mini = cars.findBy('id', '1');
     assert.equal(mini.model, 'Mini', 'Records have not yet been updated');
 
-    await resolvefindAll();
+    resolvefindAll();
+
+    await settled();
 
     assert.equal(cars.length, 2, 'There are still 2 cars in the store after ajax promise resolves');
     const peeked = store.peekAll('car');

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -614,10 +614,8 @@ module('integration/store - findAll', function(hooks) {
     let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
-    adapter.ajax = async () => {
-      await new Promise(resolve => setTimeout(resolve, 1));
-
-      return {
+    adapter.ajax = () => {
+      return resolve({
         cars: [
           {
             id: '1',
@@ -630,7 +628,7 @@ module('integration/store - findAll', function(hooks) {
             model: 'Isetta',
           },
         ],
-      };
+      });
     };
 
     let cars = store.peekAll('car');
@@ -835,10 +833,8 @@ module('integration/store - findAll', function(hooks) {
       },
     });
 
-    adapter.ajax = async () => {
-      await new Promise(resolve => setTimeout(resolve, 1));
-
-      return {
+    adapter.ajax = () => {
+      return resolve({
         cars: [
           {
             id: '1',
@@ -851,7 +847,7 @@ module('integration/store - findAll', function(hooks) {
             model: 'Isetta',
           },
         ],
-      };
+      });
     };
 
     let cars = store.peekAll('car');
@@ -897,10 +893,8 @@ module('integration/store - findAll', function(hooks) {
       ],
     });
 
-    adapter.ajax = async () => {
-      await new Promise(resolve => setTimeout(resolve, 1));
-
-      return {
+    adapter.ajax = () => {
+      return resolve({
         cars: [
           {
             id: '1',
@@ -908,7 +902,7 @@ module('integration/store - findAll', function(hooks) {
             model: 'New Mini',
           },
         ],
-      };
+      });
     };
 
     let cars = store.peekAll('car');
@@ -916,9 +910,6 @@ module('integration/store - findAll', function(hooks) {
     assert.equal(cars.length, 2, 'There is two cars in the store');
 
     cars = await store.findAll('car');
-
-    // Ensure all ember data internals are done before checking if the car records were updated.
-    await settled();
 
     assert.equal(cars.length, 2, 'It returns all cars');
 
@@ -948,10 +939,8 @@ module('integration/store - findAll', function(hooks) {
     let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
-    adapter.ajax = async () => {
-      await new Promise(resolve => setTimeout(resolve, 1));
-
-      return {
+    adapter.ajax = () => {
+      return resolve({
         cars: [
           {
             id: '20',
@@ -959,7 +948,7 @@ module('integration/store - findAll', function(hooks) {
             model: 'Mini',
           },
         ],
-      };
+      });
     };
 
     store.push({

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -863,7 +863,7 @@ module('integration/store - findAll', function(hooks) {
   });
 
   test('store#findAll should eventually return all known records even if they are not in the adapter response', async function(assert) {
-    assert.expect(5);
+    assert.expect(4);
 
     this.owner.register('model:car', Car);
     this.owner.register('adapter:application', RESTAdapter.extend());
@@ -913,19 +913,15 @@ module('integration/store - findAll', function(hooks) {
 
     assert.equal(cars.length, 2, 'It returns all cars');
 
+    await settled();
+
     let carsInStore = store.peekAll('car');
 
-    assert.equal(carsInStore.length, 2, 'There is 2 cars in the store');
-
-    cars = store.peekAll('car');
+    assert.equal(carsInStore.length, 2, 'There is 2 cars in the store after all promises has been resolved');
 
     let mini = cars.findBy('id', '1');
 
     assert.equal(mini.model, 'New Mini', 'Existing records have been updated');
-
-    carsInStore = store.peekAll('car');
-
-    assert.equal(carsInStore.length, 2, 'There is 2 cars in the store');
   });
 
   test('Using store#fetch on an empty record calls find', async function(assert) {


### PR DESCRIPTION
## Description

- [X] Remove usage of runloop in store - findAll module tests.
- [X] Remove beforeEach loop usage in the module and setup data in each test.
