### PR TITLE
Strip FeatureFlagged code in non canary builds

### DIFF
--- a/packages/private-build-infra/src/features.js
+++ b/packages/private-build-infra/src/features.js
@@ -1,15 +1,20 @@
 'use strict';
 
-function isCanary() {
-  const version = require('../package.json').version;
-  return version.indexOf('alpha') !== -1;
-}
+const version = require('../package.json').version;
+const isCanary = version.includes('alpha');
 
 const requireEsm = require('esm')(module);
 function getFeatures() {
   const { default: features } = requireEsm('@ember-data/canary-features/addon/default-features.ts');
 
   if (!isCanary) {
+    for (let feature in features) {
+      let featureValue = features[feature];
+
+      if (featureValue === null) {
+        features[feature] = false;
+      }
+    }
     return features;
   }
 


### PR DESCRIPTION
Also changes `isCanary` to not be a function and fixes the bug with the function not being invoked