### PR TITLE
[BUGFIX] ensure MandatorySetter does not trigger for modelName

### DIFF
--- a/packages/-ember-data/tests/integration/store/model-name-test.js
+++ b/packages/-ember-data/tests/integration/store/model-name-test.js
@@ -1,0 +1,83 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Model, { attr } from '@ember-data/model';
+import { computed } from '@ember/object';
+import Service, { inject } from '@ember/service';
+import Store from '@ember-data/store';
+import { P } from 'Object/_api';
+
+module('@ember-data/model klass.modelName', function(hooks) {
+  setupTest(hooks);
+
+  test('Extending a model properly sets the modelName', function(assert) {
+    const { owner } = this;
+    class Animal extends Model {
+      @attr() species;
+    }
+    class Pet extends Animal {
+      @attr() name;
+    }
+    class AnimalHelper extends Service {
+      @inject store;
+
+      @computed('animal.constructor.modelName')
+      get animalModelName() {
+        return this.animal.constructor.modelName;
+      }
+    }
+    owner.register('model:animal', Animal);
+    owner.register('model:pet', Pet);
+    owner.register('service:animal-helper', AnimalHelper);
+    owner.register('sercice:store', Store);
+    const store = owner.lookup('service:store');
+    const animalHelper = owner.lookup('service:animal-helper');
+
+    // first we push the base class
+    const snake = store.push({
+      data: {
+        type: 'animal',
+        id: '1',
+        attributes: { species: 'snake' },
+      },
+    });
+
+    // then we do a thing that could install a MandatorySetter
+    // on the modelName property on the `Animal` class.
+    animalHelper.set('animal', snake);
+    assert.strictEqual(snake.constructor.modelName, 'animal', 'Snake has the right modelName');
+    assert.strictEqual(animalHelper.animalModelName, 'animal', 'We got the modelName');
+
+    // ensure modelName is immutable
+    try {
+      snake.constructor.modelName = 'bear';
+      assert.ok(false, 'expected modelName to be immutable');
+    } catch (e) {
+      assert.strictEqual(
+        e.message.startsWith(`Cannot assign to read only property 'modelName' of `),
+        true,
+        'modelName is immutable'
+      );
+    }
+
+    // this will error if we installed a MandatorySetter
+    // when we try to set the modelName property on the `Pet` class.
+    try {
+      const fido = store.push({
+        data: {
+          type: 'pet',
+          id: '1',
+          attribute: { species: 'dog', name: 'fido' },
+        },
+      });
+
+      assert.strictEqual(fido.constructor.modelName, 'pet', 'Fido has the right modelName');
+      assert.strictEqual(snake.constructor.modelName, 'animal', 'Snake has the right modelName');
+      assert.strictEqual(animalHelper.animalModelName, 'animal', 'AnimalHelper has the right modelName');
+    } catch (e) {
+      assert.ok(
+        false,
+        `Failed to add fido to the store, likely encountered an unexpected MandatorySetter. Full error below:\n\n${e.message}`
+      );
+    }
+  });
+});

--- a/packages/-ember-data/tests/integration/store/model-name-test.js
+++ b/packages/-ember-data/tests/integration/store/model-name-test.js
@@ -4,7 +4,6 @@ import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 import Service, { inject } from '@ember/service';
 import Store from '@ember-data/store';
-import { P } from 'Object/_api';
 
 module('@ember-data/model klass.modelName', function(hooks) {
   setupTest(hooks);

--- a/packages/store/addon/-private/system/schema-definition-service.ts
+++ b/packages/store/addon/-private/system/schema-definition-service.ts
@@ -7,7 +7,7 @@ import { RelationshipsSchema, AttributesSchema } from '../ts-interfaces/record-d
 import require from 'require';
 import CoreStore from './core-store';
 import { HAS_MODEL_PACKAGE } from '@ember-data/private-build-infra';
-import { assert } from '@ember/debug';
+
 type Model = import('@ember-data/model').default;
 
 let _Model;

--- a/packages/store/addon/-private/system/schema-definition-service.ts
+++ b/packages/store/addon/-private/system/schema-definition-service.ts
@@ -7,6 +7,7 @@ import { RelationshipsSchema, AttributesSchema } from '../ts-interfaces/record-d
 import require from 'require';
 import CoreStore from './core-store';
 import { HAS_MODEL_PACKAGE } from '@ember-data/private-build-infra';
+import { assert } from '@ember/debug';
 type Model = import('@ember-data/model').default;
 
 let _Model;
@@ -103,7 +104,7 @@ export function getModelFactory(store: CoreStore, cache, normalizedModelName: st
     if (klass.isModel) {
       let hasOwnModelNameSet = klass.modelName && Object.prototype.hasOwnProperty.call(klass, 'modelName');
       if (!hasOwnModelNameSet) {
-        klass.modelName = normalizedModelName;
+        Object.defineProperty(klass, 'modelName', { value: normalizedModelName });
       }
     }
 


### PR DESCRIPTION
resolves #6143 

Users who extend a model from another model (not constrained to polymorphism) will encounter a potential race condition when upgrading to ember-source 3.13 or later.

- If the model being extended is looked up prior to the model doing the extending
- and if the model being extended has it's modelName accessed in a manner that would install a MandatorySetter prior to the lookup of the model doing the extending

Then setting the static modelName property of the extended class would error.

## Backporting Notes

We should attempt to backport the fix as far as possible; however, due to file re-arrangements and refactoring while the fix will remain the same the location is likely to change for 3.12 and again for 3.8.