### PR TITLE
[CHORE] feature flag reversal test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,10 +59,20 @@ jobs:
           ) || github.event_name == 'push' && (
             endsWith(github.ref, '/master') || endsWith(github.ref, '/beta')
           )
-        name: In progress features
+        name: Enable All In progress features
         env:
           EMBER_DATA_FEATURE_OVERRIDE: ENABLE_ALL_OPTIONAL
-        run: yarn test:enabled-in-progress-features
+        run: yarn test
+      - if: |
+          github.event_name == 'pull_request' && (
+            github.base_ref == 'master' || github.base_ref == 'beta'
+          ) || github.event_name == 'push' && (
+            endsWith(github.ref, '/master') || endsWith(github.ref, '/beta')
+          )
+        name: Disabled All In progress features
+        env:
+          EMBER_DATA_FEATURE_OVERRIDE: DISABLE_ALL
+        run: yarn test
 
   floating-dependencies:
     needs: [lint, basic-tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,7 @@ jobs:
 
     - stage: additional tests
 
-      name: 'Enabled In-Progress Features'
-      if: NOT tag IS present AND NOT (branch ~= /^(emberjs:release|emberjs:lts|release|lts).*/)
-      install: yarn install
-      env: EMBER_DATA_FEATURE_OVERRIDE: ENABLE_ALL_OPTIONAL
-      script: yarn test
-
-    - name: 'Floating Dependencies'
+      name: 'Floating Dependencies'
       install: yarn install --no-lockfile --non-interactive
       script: yarn test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ jobs:
       name: 'Enabled In-Progress Features'
       if: NOT tag IS present AND NOT (branch ~= /^(emberjs:release|emberjs:lts|release|lts).*/)
       install: yarn install
-      script: yarn test:enabled-in-progress-features
+      env: EMBER_DATA_FEATURE_OVERRIDE: ENABLE_ALL_OPTIONAL
+      script: yarn test
 
     - name: 'Floating Dependencies'
       install: yarn install --no-lockfile --non-interactive

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,10 +100,16 @@ jobs:
           yarn
 
       - script: |
-          yarn test:enabled-in-progress-features
+          yarn test
         env:
           EMBER_DATA_FEATURE_OVERRIDE: ENABLE_ALL_OPTIONAL
-          displayName: 'In progress features'
+          displayName: 'Enable All In progress features'
+
+      - script: |
+          yarn test
+        env:
+          EMBER_DATA_FEATURE_OVERRIDE: DISABLE_ALL
+          displayName: 'Disable All In progress features'
 
       - script: |
           yarn test:production
@@ -150,8 +156,16 @@ jobs:
         displayName: 'Basic Tests'
 
       - script: |
-          yarn test:enabled-in-progress-features
-        displayName: 'In progress features'
+          yarn test
+        env:
+          EMBER_DATA_FEATURE_OVERRIDE: ENABLE_ALL_OPTIONAL
+          displayName: 'Enable All In progress features'
+
+      - script: |
+          yarn test
+        env:
+          EMBER_DATA_FEATURE_OVERRIDE: DISABLE_ALL
+          displayName: 'Disable All In progress features'
 
       - script: |
           yarn test:production

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test:docs": "yarn workspace ember-data test:docs",
     "test:encapsulation": "lerna run --scope='*-encapsulation-test-app' test",
     "test:fastboot": "yarn workspace fastboot-test-app test",
-    "test:enabled-in-progress-features": "yarn workspace ember-data test:optional-features",
     "test-external:ember-m3": "./bin/test-external-partner-project.js ember-m3 https://github.com/hjdivad/ember-m3.git",
     "test-external:ember-data-change-tracker": "./bin/test-external-partner-project.js ember-data-change-tracker https://github.com/danielspaniel/ember-data-change-tracker.git",
     "test-external:model-fragments": "./bin/test-external-partner-project.js ember-data-model-fragments https://github.com/lytics/ember-data-model-fragments.git",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -15,7 +15,6 @@
     "test": "ember test",
     "test:all": "ember try:each",
     "test:production": "ember test -e production",
-    "test:optional-features": "ember test",
     "test:try-one": "ember try:one",
     "test:docs": "mkdir -p dist && qunit node-tests/docs/test-coverage.js",
     "prepublishOnly": "mkdir -p dist && ember ember-cli-yuidoc"

--- a/packages/private-build-infra/src/features.js
+++ b/packages/private-build-infra/src/features.js
@@ -30,6 +30,11 @@ function getFeatures(isProd) {
         features[feature] = true;
       }
     }
+  } else if (FEATURE_OVERRIDES === 'DISABLE_ALL') {
+    // disable all features, including those with a value of `true`
+    for (let feature in features) {
+      features[feature] = false;
+    }
   } else if (FEATURE_OVERRIDES) {
     // enable only the specific features listed in the environment
     // variable (comma separated)


### PR DESCRIPTION
Previously once we turned a feature flag on we would stop running any tests against the "off" state. This makes reverting the state of a feature flag once "on" risky.

This reduces that risk by ensuring we always run the tests at least once with all flags off.