### PR TITLE
fixed serialize example

### DIFF
--- a/packages/store/addon/-private/ts-interfaces/minimum-serializer-interface.ts
+++ b/packages/store/addon/-private/ts-interfaces/minimum-serializer-interface.ts
@@ -33,7 +33,7 @@
 
     serialize(snapshot, options) {
       const serializedResource = {
-        id: snapshot.id(),
+        id: snapshot.id,
         type: snapshot.modelName,
         attributes: snapshot.attributes()
       };


### PR DESCRIPTION
I saw in the [documentation](https://api.emberjs.com/ember-data/release/modules/@ember-data%2Fserializer) the example code for the `serialize` method and it shows the `snapshot.id` property as a function instead of a string. I [double checked it](https://github.com/emberjs/data/blob/master/packages/store/addon/-private/system/snapshot.js#L65) to be sure it is just a string :) I hope this is the right place to make the fix to the documentation.

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
