### PR TITLE
[CHORE] remove unneeded configs

### DIFF
--- a/packages/-ember-data/tsconfig.json
+++ b/packages/-ember-data/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../tsconfig.json"
-}

--- a/packages/adapter/tsconfig.json
+++ b/packages/adapter/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../tsconfig.json"
-}

--- a/packages/debug/tsconfig.json
+++ b/packages/debug/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../tsconfig.json"
-}

--- a/packages/model/tsconfig.json
+++ b/packages/model/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../tsconfig.json"
-}

--- a/packages/record-data/tsconfig.json
+++ b/packages/record-data/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../tsconfig.json"
-}

--- a/packages/serializer/tsconfig.json
+++ b/packages/serializer/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../tsconfig.json"
-}

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../tsconfig.json"
-}

--- a/packages/unpublished-test-infra/tsconfig.json
+++ b/packages/unpublished-test-infra/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../tsconfig.json"
-}


### PR DESCRIPTION
These configs simply re-export our root config, which doesn't provide any value over just having the root config but does introduce the risk that we make config edits in some packages we don't intend.

tsc uses our root config and vscode will always find it there as well. ember-cli-typescript likely doesn't need it at all but if it does we can point it to the right place.