### PR TITLE
[CHORE] cleanup build

### DIFF
--- a/packages/debug/index.js
+++ b/packages/debug/index.js
@@ -4,16 +4,6 @@ const name = require('./package').name;
 const addonBuildConfigForDataPackage = require('@ember-data/private-build-infra/src/addon-build-config-for-data-package');
 const addonBaseConfig = addonBuildConfigForDataPackage(name);
 
-function getApp(addon) {
-  while (addon && !addon.app) {
-    addon = addon.parent;
-  }
-  if (!addon) {
-    throw new Error(`Unable to find the parent application`);
-  }
-  return addon.app;
-}
-
 module.exports = Object.assign({}, addonBaseConfig, {
   shouldRollupPrivate: false,
   __isEnabled: null,
@@ -32,23 +22,11 @@ module.exports = Object.assign({}, addonBaseConfig, {
     if (this.__isEnabled !== null) {
       return this.__isEnabled;
     }
-    const options = this.setupOptions();
-    const env = getApp(this).env;
+    const options = this.getEmberDataConfig();
+    const env = process.env.EMBER_ENV;
 
     this.__isEnabled = env !== 'production' || options.includeDataAdapterInProduction === true;
 
     return this.__isEnabled;
-  },
-  setupOptions() {
-    const app = getApp(this);
-    const parentIsEmberDataAddon = this.parent.pkg.name === 'ember-data';
-
-    let options = (app.options = app.options || {});
-    options.emberData = options.emberData || {};
-
-    if (options.emberData.includeDataAdapterInProduction === undefined) {
-      options.emberData.includeDataAdapterInProduction = parentIsEmberDataAddon;
-    }
-    return options.emberData;
   },
 });

--- a/packages/private-build-infra/src/addon-build-config-for-data-package.js
+++ b/packages/private-build-infra/src/addon-build-config-for-data-package.js
@@ -162,6 +162,23 @@ function addonBuildConfigForDataPackage(PackageName) {
 
       return this.debugTree(merge([publicTree, privateTree]), 'final');
     },
+
+    _emberDataConfig: null,
+    getEmberDataConfig() {
+      if (this._emberDataConfig) {
+        return this._emberDataConfig;
+      }
+      const app = this._findHost();
+      const parentIsEmberDataAddon = this.parent.pkg.name === 'ember-data';
+
+      let options = (app.options = app.options || {});
+      options.emberData = options.emberData || {};
+
+      if (options.emberData.includeDataAdapterInProduction === undefined) {
+        options.emberData.includeDataAdapterInProduction = parentIsEmberDataAddon;
+      }
+      return options.emberData;
+    },
   };
 }
 

--- a/packages/unpublished-test-infra/index.js
+++ b/packages/unpublished-test-infra/index.js
@@ -6,7 +6,9 @@ module.exports = {
   name: require('./package').name,
 
   treeForAddon() {
-    let tree = version();
-    return this._super.treeForAddon.call(this, tree);
+    if (process.env.EMBER_CLI_TEST_COMMAND) {
+      let tree = version();
+      return this._super.treeForAddon.call(this, tree);
+    }
   },
 };


### PR DESCRIPTION
Refactor to use _findHost and provide a shared mechanism for accessing `EmberData` config.

Also removes test-infra's VERSION module from our production output if we aren't in a testing environment.