### PR TITLE
[CHORE] 11!

### DIFF
--- a/bin/asset-size-tracking/generate-diff.js
+++ b/bin/asset-size-tracking/generate-diff.js
@@ -25,7 +25,7 @@ const new_library = parseModules(builtAsset);
 function getDiff(oldLibrary, newLibrary) {
   const compressionDelta = newLibrary.compressedSize - oldLibrary.compressedSize;
 
-  function getCompressionDelta(item) {
+  function getRelativeDeltaForItem(item) {
     const itemDelta = item.newSize - item.currentSize;
     const libDelta = newLibrary.absoluteSize - oldLibrary.absoluteSize;
     const itemDeltaRelativeSize = itemDelta / libDelta;
@@ -88,10 +88,10 @@ function getDiff(oldLibrary, newLibrary) {
   });
   diff.packages = Object.values(diff.packages);
   diff.packages.forEach(pkg => {
-    pkg.compressionDelta = getCompressionDelta(pkg);
+    pkg.compressionDelta = getRelativeDeltaForItem(pkg);
     pkg.modules = Object.values(pkg.modules);
     pkg.modules.forEach(m => {
-      m.compressionDelta = getCompressionDelta(m);
+      m.compressionDelta = getRelativeDeltaForItem(m);
     });
   });
 

--- a/bin/asset-size-tracking/src/library.js
+++ b/bin/asset-size-tracking/src/library.js
@@ -13,8 +13,8 @@ const BROTLI_OPTIONS = {
   },
 };
 
-function getCompressedSize(code) {
-  return byteCount(zlib.brotliCompressSync(code, BROTLI_OPTIONS));
+function compress(code) {
+  zlib.brotliCompressSync(code, BROTLI_OPTIONS);
 }
 
 class Library {
@@ -43,7 +43,7 @@ class Library {
     return byteCount(this.concatModule);
   }
   get compressedSize() {
-    return this._compressedSize || (this._compressedSize = getCompressedSize(this.concatModule));
+    return this._compressedSize || (this._compressedSize = byteCount(compress(this.concatModule)));
   }
   sort() {
     this.packages = this.packages.sort((a, b) => {

--- a/bin/asset-size-tracking/src/library.js
+++ b/bin/asset-size-tracking/src/library.js
@@ -14,7 +14,7 @@ const BROTLI_OPTIONS = {
 };
 
 function compress(code) {
-  zlib.brotliCompressSync(code, BROTLI_OPTIONS);
+  return zlib.brotliCompressSync(code, BROTLI_OPTIONS);
 }
 
 class Library {


### PR DESCRIPTION
We've been compressing at max because the default brotli setting is 11, but this makes it explicit just in case that default is ever different.

It also tidies up a bit how we do our compression math, which makes it easier to improve our diff.

We improve our diff by adjusting the formula for how we calculate the delta in compression.

Before, the delta for individual modules and packages was calculated like this:

```
LibraryDelta = NewLibraryCompressedSize - OldLibraryCompressedSize;
CompressedSizeInitial = OldSize / OldLibrarySize * OldLibraryCompressedSize;
CompressedSizeFinal = NewSize / NewLibrarySize * NewLibraryCompressedSize;
CompressionDelta = CompressedSizeFinal - CompressedSizeInitial;
```

While on the surface this equation seems to make sense, because compression is not directly related to the relative size of a package it results in module/package compression deltas that do not sum to the overall compression delta of the library. Because the module or package changes its "% of the library", the two sizes are not directly comparable leading to an exaggerated compression delta that is less meaningful.

In this PR we shift to a strategy that is comparable and will sum to the overall library compression delta.

```
LibraryCompressionDelta = NewLibCompressedSize - OldLibCompressedSize;
LibraryDelta = NewLibSize - OldLibSize
ItemDelta = NewItemSize - OldItemSize;
RelativeDelta = ItemDelta / LibraryDelta;
CompressionDelta = RelativeDelta * LibraryCompressionDelta;
```

From a Math perspective we've made the following change in our formula;

Given the following:

```
M1 = item's initial size
M2 = item's final size
L1 = library's initial size
L2 = library's final size
LC1 = library's initial compressed size
LC2 = library's final compressed size
ΔMC = the change in the item's compression size
```

Our initial formula was:

```
ΔMC = (M2/L2*LC2) - (M1/L1*LC1)
```

And our new formula is:

```
ΔMC = (M2-M1) / (L2-L1) * (LC2-LC1)
```

These equations are not equivalent.

Example Analysis of an asset size change prior to this formula update: https://github.com/emberjs/data/pull/6814#issuecomment-558996967

Example Analysis of an asset size change after this formula update:
https://github.com/emberjs/data/pull/6814#issuecomment-559248467