### PR TITLE
[FIX] comment-bot, partner-tests: use yarn lock-file when we can

### DIFF
--- a/bin/asset-size-tracking/src/post-comment.sh
+++ b/bin/asset-size-tracking/src/post-comment.sh
@@ -38,7 +38,9 @@ update_comment_if_exists() {
   body=$(curl -sSL -H "${AUTH_HEADER}" -H "${API_HEADER}" "${URI}/repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/comments")
   FOUND_EXISTING=1
 
+  echo "Parsing response body"
   for row in $(echo -E "${body}" | jq --raw-output  '.[] | @base64'); do
+    echo "Parsing response body row"
     comment=$(echo -E "${row}" | base64 --decode | jq --raw-output '{id: .id, body: .body, author: .user.login}')
     id=$(echo -E "$comment" | jq -r '.id')
     b=$(echo -E "$comment" | jq -r '.body')

--- a/bin/asset-size-tracking/src/post-comment.sh
+++ b/bin/asset-size-tracking/src/post-comment.sh
@@ -76,7 +76,9 @@ main() {
   echo "running $GITHUB_ACTION for PR #${NUMBER}"
 
   update_comment_if_exists
-  if [ $? -eq 1 ]; then
+  C=$?
+  echo "pre cond"
+  if [ $C -eq 1 ]; then
   echo "in cond";
     post_comment;
   fi

--- a/bin/asset-size-tracking/src/post-comment.sh
+++ b/bin/asset-size-tracking/src/post-comment.sh
@@ -76,7 +76,8 @@ main() {
   echo "running $GITHUB_ACTION for PR #${NUMBER}"
 
   update_comment_if_exists
-  if [ "$?" -eq "1" ]; then
+  if [ $? -eq 1 ]; then
+  echo "in cond";
     post_comment;
   fi
 }

--- a/bin/asset-size-tracking/src/post-comment.sh
+++ b/bin/asset-size-tracking/src/post-comment.sh
@@ -38,9 +38,7 @@ update_comment_if_exists() {
   # Get all the comments for the pull request.
   body=$(curl -sSL -H "${AUTH_HEADER}" -H "${API_HEADER}" "${URI}/repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/comments")
 
-  echo "Parsing response body"
   for row in $(echo -E "${body}" | jq --raw-output  '.[] | @base64'); do
-    echo "Parsing response body row"
     comment=$(echo -E "${row}" | base64 --decode | jq --raw-output '{id: .id, body: .body, author: .user.login}')
     id=$(echo -E "$comment" | jq -r '.id')
     b=$(echo -E "$comment" | jq -r '.body')
@@ -49,9 +47,8 @@ update_comment_if_exists() {
       # We have found our comment.
       # Delete it.
 
-      echo "Updating existing comment ID: $id"
+      echo "Updating Existing Comment: $id"
       UPDATE_URL="${URI}/repos/${GITHUB_REPOSITORY}/issues/comments/${id}"
-      echo $UPDATE_URL;
       curl -sSL -H "${AUTH_HEADER}" -H "${API_HEADER}" -d "$COMMENT_TEXT" -H "Content-Type: application/json" -X PATCH $UPDATE_URL
       FOUND_EXISTING=0
       return 0;
@@ -64,7 +61,7 @@ update_comment_if_exists() {
 }
 
 post_comment() {
-  echo "Posting new comment"
+  echo "Posting A New Comment"
   curl -sSL -H "${AUTH_HEADER}" -H "${API_HEADER}" -d "$COMMENT_TEXT" -H "Content-Type: application/json" -X POST "${URI}/repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/comments"
 }
 
@@ -77,9 +74,7 @@ main() {
   echo "running $GITHUB_ACTION for PR #${NUMBER}"
 
   update_comment_if_exists
-  echo "pre cond"
   if [ $FOUND_EXISTING -eq 1 ]; then
-  echo "in cond";
     post_comment;
   fi
 }

--- a/bin/asset-size-tracking/src/post-comment.sh
+++ b/bin/asset-size-tracking/src/post-comment.sh
@@ -57,6 +57,8 @@ update_comment_if_exists() {
     fi
   done
 
+  echo "exiting with $FOUND_EXISTING"
+
   return $FOUND_EXISTING;
 }
 

--- a/bin/asset-size-tracking/src/post-comment.sh
+++ b/bin/asset-size-tracking/src/post-comment.sh
@@ -72,7 +72,7 @@ main() {
   echo "running $GITHUB_ACTION for PR #${NUMBER}"
 
   update_comment_if_exists
-  if [ $? -eq 1 ]; then
+  if [ "$?" -eq "1" ]; then
     post_comment;
   fi
 }

--- a/bin/test-external-partner-project.js
+++ b/bin/test-external-partner-project.js
@@ -24,10 +24,12 @@ cliOptionsDef = [
   { name: 'skipSmokeTest', type: Boolean, defaultValue: false },
   { name: 'skipClone', type: Boolean, defaultValue: false },
   { name: 'skipTest', type: Boolean, defaultValue: false },
+  { name: 'noLockFile', type: Boolean, defaultValue: false },
+  { name: 'useCache', type: Boolean, defaultValue: false },
 ];
 cliOptions = cliArgs(cliOptionsDef, { argv });
 
-const { skipSmokeTest, skipClone, skipTest } = cliOptions;
+const { skipSmokeTest, skipClone, skipTest, noLockFile, useCache } = cliOptions;
 
 // we share this for the build
 const cachePath = '../__external-test-cache';
@@ -129,7 +131,7 @@ try {
   //
   // For this reason we don't trust the lock file
   // we also can't trust the cache
-  execExternal(`yarn install --no-lockfile --cache-folder=tmp/yarn-cache`);
+  execExternal(`yarn install${noLockFile ? ' --no-lockfile' : ''}${useCache ? '' : ' --cache-folder=tmp/yarn-cache'}`);
 } catch (e) {
   console.log(`Unable to npm install tarballs for ember-data\` for ${externalProjectName}. Original error below:`);
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test-external:storefront": "./bin/test-external-partner-project.js storefront https://github.com/embermap/ember-data-storefront.git",
     "test-external:factory-guy": "./bin/test-external-partner-project.js factory-guy https://github.com/danielspaniel/ember-data-factory-guy.git",
     "test-external:ilios-frontend": "./bin/test-external-partner-project.js ilios-frontend https://github.com/ilios/frontend.git --skipSmokeTest",
-    "test-external:ember-resource-metadata": "./bin/test-external-partner-project.js ember-resource-metadata https://github.com/ef4/ember-resource-metadata.git",
+    "test-external:ember-resource-metadata": "./bin/test-external-partner-project.js ember-resource-metadata https://github.com/ef4/ember-resource-metadata.git --noLockFile",
     "test-external:ember-data-relationship-tracker": "./bin/test-external-partner-project.js ember-data-relationship-tracker https://github.com/ef4/ember-data-relationship-tracker.git"
   },
   "devDependencies": {


### PR DESCRIPTION
Our recent upgrade to the partner tests was primarily to use yarn + resolutions while avoiding the cache. If a partner uses yarn and had a lock file we can very likely still trust it and so continuing to use it will reduce the potential for unexpected failures due to drift (such as we are currently seeing with ilios and storefront).