### PR TITLE
[CHORE] AssetSize check for both modern and IE11 builds

### DIFF
--- a/.github/workflows/asset-size-check.yml
+++ b/.github/workflows/asset-size-check.yml
@@ -29,18 +29,14 @@ jobs:
       - name: Install dependencies for master
         run: yarn install
       - name: Build Production master (IE11)
-        # This will leave the assets in a dist that is maintained when
-        #  We switch back to the primary branch
         run: |
           mkdir -p packages/-ember-data/dists
           TARGET_IE11=true yarn workspace ember-data ember build -e production --output-path dists/control-ie11
       - name: Build Production master
-        # This will leave the assets in a dist that is maintained when
-        #  We switch back to the primary branch
         run: yarn workspace ember-data ember build -e production --output-path dists/control
+      - name: Build Production master (no rollup)
+        run: EMBER_DATA_ROLLUP_PRIVATE=false yarn workspace ember-data ember build -e production --output-path dists/control-no-rollup
       - name: Checkout ${{github.ref}}
-        # We checkout the PR Branch before parsing the master vendor file
-        #  So that we are always using the current analysis tooling
         run: |
           sha=$(cat tmp/sha-for-check.txt)
           git checkout --progress --force $sha
@@ -50,6 +46,8 @@ jobs:
         run: TARGET_IE11=true yarn workspace ember-data ember build -e production --output-path dists/experiment-ie11
       - name: Build Production ${{github.ref}}
         run: yarn workspace ember-data ember build -e production --output-path dists/experiment
+      - name: Build Production ${{github.ref}} (no rollup)
+        run: EMBER_DATA_ROLLUP_PRIVATE=false yarn workspace ember-data ember build -e production --output-path dists/experiment-no-rollup
       - name: Analyze Master Assets (IE11)
         run: |
           node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/control-ie11 ./control-ie11-data.json
@@ -60,6 +58,10 @@ jobs:
         run: |
           node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/control ./control-data.json
           node ./bin/asset-size-tracking/print-analysis.js ./control-data.json -show > tmp/asset-sizes/master-analysis.txt
+      - name: Analyze Master Assets (no rollup)
+        run: |
+          node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/control-no-rollup ./control-data-no-rollup.json
+          node ./bin/asset-size-tracking/print-analysis.js ./control-data-no-rollup.json -show > tmp/asset-sizes/master-analysis-no-rollup.txt
       - name: Analyze ${{github.ref}} Assets (IE11)
         run: |
           node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/experiment-ie11 ./experiment-ie11-data.json
@@ -68,6 +70,10 @@ jobs:
         run: |
           node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/experiment ./experiment-data.json
           node ./bin/asset-size-tracking/print-analysis.js ./experiment-data.json > tmp/asset-sizes/experiment-analysis.txt
+      - name: Analyze ${{github.ref}} Assets
+        run: |
+          node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/experiment-no-rollup ./experiment-data-no-rollup.json
+          node ./bin/asset-size-tracking/print-analysis.js ./experiment-data-no-rollup.json > tmp/asset-sizes/experiment-analysis-no-rollup.txt
       - name: Test Asset Sizes (IE11)
         run: |
           set -o pipefail
@@ -77,6 +83,11 @@ jobs:
         run: |
           set -o pipefail
           node ./bin/asset-size-tracking/generate-diff.js ./control-data.json ./experiment-data.json | tee tmp/asset-sizes/diff.txt
+      - name: Test Asset Sizes
+        if: failure() || success()
+        run: |
+          # we don't set -o pipefail as this should always pass, we just want the diff
+          node ./bin/asset-size-tracking/generate-diff.js ./control-data-no-rollup.json ./experiment-data-no-rollup.json | tee tmp/asset-sizes/diff-no-rollup.txt
       - name: Upload Dist Artifacts
         if: failure() || success()
         uses: actions/upload-artifact@v1

--- a/.github/workflows/asset-size-check.yml
+++ b/.github/workflows/asset-size-check.yml
@@ -63,11 +63,11 @@ jobs:
       - name: Analyze ${{github.ref}} Assets (IE11)
         run: |
           node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/experiment-ie11 ./experiment-ie11-data.json
-          node ./bin/asset-size-tracking/print-analysis.js ./experiment-ie11-data.json -show > tmp/asset-sizes/experiment-analysis-ie11.txt
+          node ./bin/asset-size-tracking/print-analysis.js ./experiment-ie11-data.json > tmp/asset-sizes/experiment-analysis-ie11.txt
       - name: Analyze ${{github.ref}} Assets
         run: |
           node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/experiment ./experiment-data.json
-          node ./bin/asset-size-tracking/print-analysis.js ./experiment-data.json -show > tmp/asset-sizes/experiment-analysis.txt
+          node ./bin/asset-size-tracking/print-analysis.js ./experiment-data.json > tmp/asset-sizes/experiment-analysis.txt
       - name: Test Asset Sizes (IE11)
         run: |
           set -o pipefail

--- a/.github/workflows/asset-size-check.yml
+++ b/.github/workflows/asset-size-check.yml
@@ -28,10 +28,16 @@ jobs:
         run: git checkout master
       - name: Install dependencies for master
         run: yarn install
-      - name: Build Production master
+      - name: Build Production master (IE11)
         # This will leave the assets in a dist that is maintained when
         #  We switch back to the primary branch
-        run: yarn workspace ember-data ember build -e production
+        run: |
+        mkdir -p packages/-ember-data/dists
+        TARGET_IE11=true yarn workspace ember-data ember build -e production --output-path dists/control-ie11
+       - name: Build Production master
+        # This will leave the assets in a dist that is maintained when
+        #  We switch back to the primary branch
+        run: yarn workspace ember-data ember build -e production --output-path dists/control
       - name: Checkout ${{github.ref}}
         # We checkout the PR Branch before parsing the master vendor file
         #  So that we are always using the current analysis tooling
@@ -40,40 +46,45 @@ jobs:
           git checkout --progress --force $sha
       - name: Install dependencies for ${{github.ref}}
         run: yarn install
-      - name: Parse Master Assets
+      - name: Build Production ${{github.ref}} (IE11)
+        run: TARGET_IE11=true yarn workspace ember-data ember build -e production --output-path dists/experiment-ie11
+       - name: Build Production ${{github.ref}}
+        run: yarn workspace ember-data ember build -e production --output-path dists/experiment
+      - name: Analyze Master Assets (IE11)
         run: |
-          node ./bin/asset-size-tracking/generate-analysis.js
+          node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/control-ie11 ./control-ie11-data.json
           mkdir -p tmp
           mkdir -p tmp/asset-sizes
-          node ./bin/asset-size-tracking/print-analysis.js -show > tmp/asset-sizes/master-analysis.txt
-      - name: Upload Master Dist Artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: master-dist
-          path: packages/-ember-data/dist/assets
-      - name: Build Production ${{github.ref}}
-        run: yarn workspace ember-data ember build -e production
+          node ./bin/asset-size-tracking/print-analysis.js ./control-ie11-data.json -show > tmp/asset-sizes/master-analysis-ie11.txt
+      - name: Analyze Master Assets
+        run: |
+          node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/control ./control-data.json
+          node ./bin/asset-size-tracking/print-analysis.js ./control-data.json -show > tmp/asset-sizes/master-analysis.txt
+      - name: Analyze ${{github.ref}} Assets (IE11)
+        run: |
+          node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/experiment-ie11 ./experiment-ie11-data.json
+          node ./bin/asset-size-tracking/print-analysis.js ./experiment-ie11-data.json -show > tmp/asset-sizes/experiment-analysis-ie11.txt
+      - name: Analyze ${{github.ref}} Assets
+        run: |
+          node ./bin/asset-size-tracking/generate-analysis.js packages/-ember-data/dists/experiment ./experiment-data.json
+          node ./bin/asset-size-tracking/print-analysis.js ./experiment-data.json -show > tmp/asset-sizes/experiment-analysis.txt
+      - name: Test Asset Sizes (IE11)
+        run: |
+          set -o pipefail
+          node ./bin/asset-size-tracking/generate-diff.js ./control-ie11-data.json ./experiment-ie11-data.json | tee tmp/asset-sizes/diff-ie11.txt
       - name: Test Asset Sizes
-        run: |
-          mkdir -p tmp
-          mkdir -p tmp/asset-sizes
-          set -o pipefail
-          node ./bin/asset-size-tracking/generate-diff.js | tee tmp/asset-sizes/diff.txt
-      - name: Prepare Data For Report
-        if: failure() || success()
-        run: |
-          node ./bin/asset-size-tracking/generate-analysis.js
-      - name: Print Asset Size Report
         if: failure() || success()
         run: |
           set -o pipefail
-          node ./bin/asset-size-tracking/print-analysis.js | tee tmp/asset-sizes/commit-analysis.txt
-      - name: Upload ${{github.ref}} Dist Artifacts
+          node ./bin/asset-size-tracking/generate-diff.js ./control-data.json ./experiment-data.json | tee tmp/asset-sizes/diff.txt
+      - name: Upload Dist Artifacts
+        if: failure() || success()
         uses: actions/upload-artifact@v1
         with:
-          name: commit-dist
-          path: packages/-ember-data/dist/assets
+          name: dists
+          path: packages/-ember-data/dists
       - name: Upload Report Artifacts
+        if: failure() || success()
         uses: actions/upload-artifact@v1
         with:
           name: reports

--- a/.github/workflows/asset-size-check.yml
+++ b/.github/workflows/asset-size-check.yml
@@ -32,8 +32,8 @@ jobs:
         # This will leave the assets in a dist that is maintained when
         #  We switch back to the primary branch
         run: |
-        mkdir -p packages/-ember-data/dists
-        TARGET_IE11=true yarn workspace ember-data ember build -e production --output-path dists/control-ie11
+          mkdir -p packages/-ember-data/dists
+          TARGET_IE11=true yarn workspace ember-data ember build -e production --output-path dists/control-ie11
       - name: Build Production master
         # This will leave the assets in a dist that is maintained when
         #  We switch back to the primary branch

--- a/.github/workflows/asset-size-check.yml
+++ b/.github/workflows/asset-size-check.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
         mkdir -p packages/-ember-data/dists
         TARGET_IE11=true yarn workspace ember-data ember build -e production --output-path dists/control-ie11
-       - name: Build Production master
+      - name: Build Production master
         # This will leave the assets in a dist that is maintained when
         #  We switch back to the primary branch
         run: yarn workspace ember-data ember build -e production --output-path dists/control
@@ -48,7 +48,7 @@ jobs:
         run: yarn install
       - name: Build Production ${{github.ref}} (IE11)
         run: TARGET_IE11=true yarn workspace ember-data ember build -e production --output-path dists/experiment-ie11
-       - name: Build Production ${{github.ref}}
+      - name: Build Production ${{github.ref}}
         run: yarn workspace ember-data ember build -e production --output-path dists/experiment
       - name: Analyze Master Assets (IE11)
         run: |

--- a/bin/asset-size-tracking/generate-analysis.js
+++ b/bin/asset-size-tracking/generate-analysis.js
@@ -9,12 +9,12 @@
  */
 const fs = require('fs');
 const path = require('path');
-let INPUT_FILE = process.argv[2] || false;
+let INPUT_DIST = process.argv[2] || false;
 let OUTPUT_FILE = process.argv[3] || './current-data.json';
 const parseModules = require('./src/parse-modules');
 const getBuiltDist = require('./src/get-built-dist');
 
-const builtAsset = getBuiltDist(INPUT_FILE);
+const builtAsset = getBuiltDist(path.join(INPUT_DIST, 'assets/vendor.js'));
 const library = parseModules(builtAsset);
 const outputPath = path.resolve(__dirname, OUTPUT_FILE);
 

--- a/bin/asset-size-tracking/generate-analysis.js
+++ b/bin/asset-size-tracking/generate-analysis.js
@@ -10,11 +10,12 @@
 const fs = require('fs');
 const path = require('path');
 let INPUT_FILE = process.argv[2] || false;
+let OUTPUT_FILE = process.argv[3] || './current-data.json';
 const parseModules = require('./src/parse-modules');
 const getBuiltDist = require('./src/get-built-dist');
 
 const builtAsset = getBuiltDist(INPUT_FILE);
 const library = parseModules(builtAsset);
-const outputPath = path.resolve(__dirname, './current-data.json');
+const outputPath = path.resolve(__dirname, OUTPUT_FILE);
 
 fs.writeFileSync(outputPath, JSON.stringify(library, null, 2));

--- a/bin/asset-size-tracking/generate-diff.js
+++ b/bin/asset-size-tracking/generate-diff.js
@@ -10,17 +10,23 @@ const library_failure_threshold = 15;
 const package_warn_threshold = 0;
 
 let BASE_DATA_FILE = process.argv[2] || false;
-let NEW_VENDOR_FILE = process.argv[3] || false;
+let NEW_DATA_FILE = process.argv[3] || false;
 
 if (!BASE_DATA_FILE) {
-  BASE_DATA_FILE = path.resolve(__dirname, './current-data.json');
+  BASE_DATA_FILE = './current-data.json';
 }
 
-const data = fs.readFileSync(BASE_DATA_FILE, 'utf-8');
-const current_library = Library.fromData(JSON.parse(data));
+const baseData = fs.readFileSync(path.resolve(__dirname, BASE_DATA_FILE), 'utf-8');
+const current_library = Library.fromData(JSON.parse(baseData));
 
-const builtAsset = getBuiltDist(NEW_VENDOR_FILE);
-const new_library = parseModules(builtAsset);
+let new_library;
+if (!NEW_DATA_FILE) {
+  const builtAsset = getBuiltDist();
+  new_library = parseModules(builtAsset);
+} else {
+  const newData = fs.readFileSync(path.resolve(__dirname, NEW_DATA_FILE), 'utf-8');
+  new_library = Library.fromData(JSON.parse(newData));
+}
 
 function getDiff(oldLibrary, newLibrary) {
   const compressionDelta = newLibrary.compressedSize - oldLibrary.compressedSize;

--- a/bin/asset-size-tracking/print-analysis.js
+++ b/bin/asset-size-tracking/print-analysis.js
@@ -11,7 +11,7 @@ if (!INPUT_FILE) {
   INPUT_FILE = path.resolve(__dirname, './current-data.json');
 }
 
-const data = fs.readFileSync(INPUT_FILE, 'utf-8');
+const data = fs.readFileSync(path.resolve(__dirname, INPUT_FILE), 'utf-8');
 
 const library = Library.fromData(JSON.parse(data));
 library.print(SHOW_MODULES);

--- a/bin/asset-size-tracking/src/create-comment-text.js
+++ b/bin/asset-size-tracking/src/create-comment-text.js
@@ -12,7 +12,7 @@ const IE11AnalysisText = fs.readFileSync(IE11AnalysisPath);
 const ModernDiffText = fs.readFileSync(ModernDiffPath);
 const ModernAnalysisText = fs.readFileSync(ModernAnalysisPath);
 
-const commentText = `Asset Size Report for ${GITHUB_SHA}\n**IE11 Builds**\n${IE11DiffText}\n<details>\n  <summary>Full Asset Analysis (IE11)</summary>\n\n\`\`\`${IE11AnalysisPath}\n\`\`\`\n</details>\n**Modern Builds**\n${ModernDiffText}\n<details>\n  <summary>Full Asset Analysis (Modern)</summary>\n\n\`\`\`${ModernAnalysisPath}\n\`\`\`\n</details>`;
+const commentText = `Asset Size Report for ${GITHUB_SHA}\n**IE11 Builds**\n${IE11DiffText}\n<details>\n  <summary>Full Asset Analysis (IE11)</summary>\n\n\`\`\`${IE11AnalysisText}\n\`\`\`\n</details>\n**Modern Builds**\n${ModernDiffText}\n<details>\n  <summary>Full Asset Analysis (Modern)</summary>\n\n\`\`\`${ModernAnalysisText}\n\`\`\`\n</details>`;
 const commentJSON = {
   body: commentText,
 };

--- a/bin/asset-size-tracking/src/create-comment-text.js
+++ b/bin/asset-size-tracking/src/create-comment-text.js
@@ -2,12 +2,17 @@ const fs = require('fs');
 const path = require('path');
 const GITHUB_SHA = process.argv[2];
 
-const diffPath = path.resolve(__dirname, '../../../tmp/asset-sizes/diff.txt');
-const analysisPath = path.resolve(__dirname, '../../../tmp/asset-sizes/commit-analysis.txt');
-const diffText = fs.readFileSync(diffPath);
-const analysisText = fs.readFileSync(analysisPath);
+const IE11DiffPath = path.resolve(__dirname, '../../../tmp/asset-sizes/diff-ie11.txt');
+const IE11AnalysisPath = path.resolve(__dirname, '../../../tmp/asset-sizes/experiment-analysis-ie11.txt');
+const ModernDiffPath = path.resolve(__dirname, '../../../tmp/asset-sizes/diff.txt');
+const ModernAnalysisPath = path.resolve(__dirname, '../../../tmp/asset-sizes/experiment-analysis.txt');
 
-const commentText = `Asset Size Report for ${GITHUB_SHA}\n${diffText}\n<details>\n  <summary>Full Asset Analysis</summary>\n\n\`\`\`${analysisText}\n\`\`\`\n</details>`;
+const IE11DiffText = fs.readFileSync(IE11DiffPath);
+const IE11AnalysisText = fs.readFileSync(IE11AnalysisPath);
+const ModernDiffText = fs.readFileSync(ModernDiffPath);
+const ModernAnalysisText = fs.readFileSync(ModernAnalysisPath);
+
+const commentText = `Asset Size Report for ${GITHUB_SHA}\n**IE11 Builds**\n${IE11DiffText}\n<details>\n  <summary>Full Asset Analysis (IE11)</summary>\n\n\`\`\`${IE11AnalysisPath}\n\`\`\`\n</details>\n**Modern Builds**\n${ModernDiffText}\n<details>\n  <summary>Full Asset Analysis (Modern)</summary>\n\n\`\`\`${ModernAnalysisPath}\n\`\`\`\n</details>`;
 const commentJSON = {
   body: commentText,
 };

--- a/bin/asset-size-tracking/src/create-comment-text.js
+++ b/bin/asset-size-tracking/src/create-comment-text.js
@@ -6,13 +6,22 @@ const IE11DiffPath = path.resolve(__dirname, '../../../tmp/asset-sizes/diff-ie11
 const IE11AnalysisPath = path.resolve(__dirname, '../../../tmp/asset-sizes/experiment-analysis-ie11.txt');
 const ModernDiffPath = path.resolve(__dirname, '../../../tmp/asset-sizes/diff.txt');
 const ModernAnalysisPath = path.resolve(__dirname, '../../../tmp/asset-sizes/experiment-analysis.txt');
+const ModernDiffPathNoRollup = path.resolve(__dirname, '../../../tmp/asset-sizes/diff-no-rollup.txt');
+const ModernAnalysisPathNoRollup = path.resolve(
+  __dirname,
+  '../../../tmp/asset-sizes/experiment-analysis-no-rollup.txt'
+);
 
 const IE11DiffText = fs.readFileSync(IE11DiffPath);
 const IE11AnalysisText = fs.readFileSync(IE11AnalysisPath);
 const ModernDiffText = fs.readFileSync(ModernDiffPath);
 const ModernAnalysisText = fs.readFileSync(ModernAnalysisPath);
+const ModernDiffTextNoRollup = fs.readFileSync(ModernDiffPathNoRollup);
+const ModernAnalysisTextNoRollup = fs.readFileSync(ModernAnalysisPathNoRollup);
 
-const commentText = `Asset Size Report for ${GITHUB_SHA}\n\n**IE11 Builds**\n${IE11DiffText}\n<details>\n  <summary>Full Asset Analysis (IE11)</summary>\n\n\`\`\`${IE11AnalysisText}\n\`\`\`\n</details>\n\n**Modern Builds**\n${ModernDiffText}\n<details>\n  <summary>Full Asset Analysis (Modern)</summary>\n\n\`\`\`${ModernAnalysisText}\n\`\`\`\n</details>`;
+const commentText = `Asset Size Report for ${GITHUB_SHA}\n\n**IE11 Builds**\n${IE11DiffText}\n<details>\n  <summary>Full Asset Analysis (IE11)</summary>\n\n\`\`\`${IE11AnalysisText}\n\`\`\`\n</details>
+\n**Modern Builds**\n${ModernDiffText}\n<details>\n  <summary>Full Asset Analysis (Modern)</summary>\n\n\`\`\`${ModernAnalysisText}\n\`\`\`\n</details>
+\n**Modern Builds (No Rollup)**\n${ModernDiffTextNoRollup}\n<details>\n  <summary>Full Asset Analysis (Modern)</summary>\n\n\`\`\`${ModernAnalysisTextNoRollup}\n\`\`\`\n</details>`;
 const commentJSON = {
   body: commentText,
 };

--- a/bin/asset-size-tracking/src/create-comment-text.js
+++ b/bin/asset-size-tracking/src/create-comment-text.js
@@ -12,7 +12,7 @@ const IE11AnalysisText = fs.readFileSync(IE11AnalysisPath);
 const ModernDiffText = fs.readFileSync(ModernDiffPath);
 const ModernAnalysisText = fs.readFileSync(ModernAnalysisPath);
 
-const commentText = `Asset Size Report for ${GITHUB_SHA}\n**IE11 Builds**\n${IE11DiffText}\n<details>\n  <summary>Full Asset Analysis (IE11)</summary>\n\n\`\`\`${IE11AnalysisText}\n\`\`\`\n</details>\n**Modern Builds**\n${ModernDiffText}\n<details>\n  <summary>Full Asset Analysis (Modern)</summary>\n\n\`\`\`${ModernAnalysisText}\n\`\`\`\n</details>`;
+const commentText = `Asset Size Report for ${GITHUB_SHA}\n\n**IE11 Builds**\n${IE11DiffText}\n<details>\n  <summary>Full Asset Analysis (IE11)</summary>\n\n\`\`\`${IE11AnalysisText}\n\`\`\`\n</details>\n\n**Modern Builds**\n${ModernDiffText}\n<details>\n  <summary>Full Asset Analysis (Modern)</summary>\n\n\`\`\`${ModernAnalysisText}\n\`\`\`\n</details>`;
 const commentJSON = {
   body: commentText,
 };

--- a/bin/asset-size-tracking/src/library.js
+++ b/bin/asset-size-tracking/src/library.js
@@ -133,8 +133,11 @@ class Package {
       compressed: formatBytes(this.compressedSize),
       '% Of Library': this.percentOfLibrary,
     });
+    const longest = this.modules.reduce((longest, m) => {
+      return m.name.length > longest ? m.name.length : longest;
+    }, 0);
     console.log(
-      `\t${rightPad('Module', TablePads.name)} | ` +
+      `\t${rightPad('Module', longest + 4)} | ` +
         `${rightPad('Bytes', TablePads.bytes)} | ` +
         `${rightPad('Compressed', TablePads.compressedBytes)} | ` +
         `${rightPad('% of Package', TablePads.percentOfPackage)} | ` +
@@ -143,7 +146,7 @@ class Package {
     console.log(
       '\t-----------------------------------------------------------------------------------------------------'
     );
-    this.modules.forEach(s => s.print());
+    this.modules.forEach(s => s.print(longest + 4));
   }
   toJSON() {
     return {
@@ -180,10 +183,10 @@ class Module {
   get percentOfLibrary() {
     return getRelativeSizeOf(this.package.library, this);
   }
-  print() {
+  print(namePadding) {
     console.log(
       '\t' +
-        rightPad(this.name, TablePads.name) +
+        rightPad(this.name, namePadding) +
         ' | ' +
         rightPad(this.bytes, TablePads.bytes) +
         ' | ' +

--- a/bin/asset-size-tracking/src/library.js
+++ b/bin/asset-size-tracking/src/library.js
@@ -135,7 +135,7 @@ class Package {
     });
     const longest = this.modules.reduce((longest, m) => {
       return m.name.length > longest ? m.name.length : longest;
-    }, 0);
+    }, TablePads.name);
     console.log(
       `\t${rightPad('Module', longest + 4)} | ` +
         `${rightPad('Bytes', TablePads.bytes)} | ` +
@@ -143,9 +143,15 @@ class Package {
         `${rightPad('% of Package', TablePads.percentOfPackage)} | ` +
         `% Of Library`
     );
-    console.log(
-      '\t-----------------------------------------------------------------------------------------------------'
-    );
+    const line =
+      '\t-----------------------------------------------------------------------------------------------------';
+    if (longest > TablePads.name) {
+      let toAdd = longest - TablePads.name;
+      for (let i = 0; i < toAdd; i++) {
+        line += '-';
+      }
+    }
+    console.log(line);
     this.modules.forEach(s => s.print(longest + 4));
   }
   toJSON() {

--- a/bin/asset-size-tracking/src/library.js
+++ b/bin/asset-size-tracking/src/library.js
@@ -143,7 +143,7 @@ class Package {
         `${rightPad('% of Package', TablePads.percentOfPackage)} | ` +
         `% Of Library`
     );
-    const line =
+    let line =
       '\t-----------------------------------------------------------------------------------------------------';
     if (longest > TablePads.name) {
       let toAdd = longest - TablePads.name;


### PR DESCRIPTION
**IE11!**

Our targets for builds of `ember-data` are set by the dummy app in tests since we are an addon here: https://github.com/emberjs/data/blob/master/packages/-ember-data/tests/dummy/config/targets.js

Previously we weren't building for IE11 outside of the max transpilation test (I'd assumed we were since often IE11 is the default for production).

This fixes that and takes the opportunity to split out our asset monitoring to monitor BOTH IE11 and No-IE11 sizes (e.g. `latest chrome|safari|firefox`).

Fortunately our delta here wasn't so big (17kb uncompressed, 1kb compressed) so likely our use of rollup and aggressive optimization have already eliminated a lot of the low-hanging fruit of getting off of IE11.

I would expect IE11 support to turn into a more obviously large portion of our codebase as we move away from ObjectProxy, PromiseProxy, and ArrayProxy when IE11 support is unneeded.

**Rollup!**

Additionally since we now have the infra to do this easily we produce and diff the modern assets a second time without rolling up our `-private` directory. This check will always pass, but it allows us to see where we still have modules in our internals that perhaps don't belong more easily.