### PR TITLE
[BUGFIX] fix no-rollup check

### DIFF
--- a/packages/-ember-data/index.js
+++ b/packages/-ember-data/index.js
@@ -18,6 +18,9 @@ module.exports = Object.assign({}, addonBaseConfig, {
     ];
   },
   treeForAddon(tree) {
+    // if we don't do this we won't have a super in addonBaseConfig
+    // as a regex is used to decide if to add one for the method
+    this._originalSuper = this._super;
     tree = merge([tree, version()]);
     return addonBaseConfig.treeForAddon.call(this, tree);
   },

--- a/packages/private-build-infra/src/addon-build-config-for-data-package.js
+++ b/packages/private-build-infra/src/addon-build-config-for-data-package.js
@@ -128,7 +128,7 @@ function addonBuildConfigForDataPackage(PackageName) {
     },
 
     treeForAddon(tree) {
-      if (process.env.EMBER_DATA_ROLLUP_PRIVATE !== 'false' && this.shouldRollupPrivate !== true) {
+      if (process.env.EMBER_DATA_ROLLUP_PRIVATE === 'false' || this.shouldRollupPrivate !== true) {
         return this._super.treeForAddon.call(this, tree);
       }
 


### PR DESCRIPTION
currently the process env conditional is incorrect, and turning off rollup errors for some packages due to lack of a _super assignment. This fixes the conditional and lets us turn off rollup if we desire again.

specifically we are working around this: https://github.com/ember-cli/core-object/blob/master/lib/assign-properties.js#L48