### PR TITLE
[CHORE] Fix workflow and enable partner test debugging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,4 +217,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.partner }}-dist
-          path: ../../data/__external-test-cache/${{ matrix.partner }}/tmp/
+          path: ../../data/__external-test-cache/${{ matrix.partner }}/dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   lint:
+    timeout-minutes: 4
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -30,21 +31,27 @@ jobs:
         run: yarn problems
 
   basic-tests:
+    timeout-minutes: 15
     strategy:
       matrix:
-        os: [macOS-10.14, windows-2016, ubuntu-18.04]
-    runs-on: ubuntu-latest
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
+      - if: matrix.os == 'macos-latest'
+        run: |
+          brew update
+          brew cask install google-chrome
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
       - name: Install dependencies
         run: yarn install
+      - name: Launcher Info
+        run: |
+          yarn run testem launchers
       - name: Basic tests
         run: yarn test
-      - name: Encapsulation tests
-        run: yarn test:encapsulation
       - name: Fastboot tests
         run: yarn test:fastboot
       - name: Production build
@@ -53,7 +60,11 @@ jobs:
         run: yarn test:docs
       - name: Node tests
         run: yarn test:node
+      - if: matrix.os == 'ubuntu-latest'
+        name: Encapsulation tests
+        run: yarn test:encapsulation
       - if: |
+          matrix.os == 'ubuntu-latest' &&
           github.event_name == 'pull_request' && (
             github.base_ref == 'master' || github.base_ref == 'beta'
           ) || github.event_name == 'push' && (
@@ -64,6 +75,7 @@ jobs:
           EMBER_DATA_FEATURE_OVERRIDE: ENABLE_ALL_OPTIONAL
         run: yarn test
       - if: |
+          matrix.os == 'ubuntu-latest' &&
           github.event_name == 'pull_request' && (
             github.base_ref == 'master' || github.base_ref == 'beta'
           ) || github.event_name == 'push' && (
@@ -75,6 +87,7 @@ jobs:
         run: yarn test
 
   floating-dependencies:
+    timeout-minutes: 4
     needs: [lint, basic-tests]
     runs-on: ubuntu-latest
     steps:
@@ -88,6 +101,7 @@ jobs:
         run: yarn test
 
   lts:
+    timeout-minutes: 4
     needs: [lint, basic-tests]
     strategy:
       fail-fast: false
@@ -107,6 +121,7 @@ jobs:
         run: yarn test:try-one ${{ matrix.scenario }}
 
   releases:
+    timeout-minutes: 4
     needs: [lint, basic-tests]
     if: |
       github.event_name == 'pull_request' && (
@@ -132,6 +147,7 @@ jobs:
         run: yarn test:try-one ${{ matrix.scenario }}
 
   additional-scenarios:
+    timeout-minutes: 4
     needs: [lint, basic-tests]
     strategy:
       matrix:
@@ -150,6 +166,7 @@ jobs:
         run: yarn test:try-one ${{ matrix.scenario }}
 
   external-partners:
+    timeout-minutes: 15
     needs: [additional-scenarios, basic-tests, floating-dependencies, lint, lts, releases]
     if: |
       github.event_name == 'pull_request' && (
@@ -195,3 +212,8 @@ jobs:
           CI: true
         run: yarn test-external:${{ matrix.partner }}
         continue-on-error: ${{ matrix['continue-on-error'] == true }}
+      - name: upload built assets
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.partner }}-dist
+          path: ../../data/__external-test-cache/${{ matrix.partner }}/tmp/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,6 +214,7 @@ jobs:
         run: yarn test-external:${{ matrix.partner }}
         continue-on-error: ${{ matrix['continue-on-error'] == true }}
       - name: upload built assets
+        if: failure() || success()
         uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.partner }}-dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,8 @@ jobs:
         run: yarn test:production
       - name: Docs tests
         run: yarn test:docs
-      - name: Node tests
+      - if: matrix.os != 'windows-latest'
+        name: Node tests
         run: yarn test:node
       - if: matrix.os == 'ubuntu-latest'
         name: Encapsulation tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,3 +218,4 @@ jobs:
         with:
           name: ${{ matrix.partner }}-dist
           path: ../../data/__external-test-cache/${{ matrix.partner }}/dist
+        continue-on-error: ${{ matrix['continue-on-error'] == true }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,6 @@ jobs:
         run: yarn test:try-one ${{ matrix.scenario }}
 
   external-partners:
-    timeout-minutes: 15
     needs: [additional-scenarios, basic-tests, floating-dependencies, lint, lts, releases]
     if: |
       github.event_name == 'pull_request' && (
@@ -209,6 +208,7 @@ jobs:
       - name: Generate package tarballs
         run: node ./bin/packages-for-commit.js
       - name: Run Tests
+        timeout-minutes: 12
         env:
           CI: true
         run: yarn test-external:${{ matrix.partner }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
         run: yarn test:try-one ${{ matrix.scenario }}
 
   additional-scenarios:
-    timeout-minutes: 4
+    timeout-minutes: 5
     needs: [lint, basic-tests]
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,5 +218,5 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.partner }}-dist
-          path: ../../data/__external-test-cache/${{ matrix.partner }}/dist
+          path: ../../data/__external-test-cache/${{ matrix.partner }}/dist/assets
         continue-on-error: ${{ matrix['continue-on-error'] == true }}

--- a/bin/test-external-partner-project.js
+++ b/bin/test-external-partner-project.js
@@ -141,7 +141,7 @@ try {
 if (!skipTest) {
   try {
     debug('Running tests against EmberData commit');
-    execExternal(`ember test`, true);
+    execExternal(`ember test --output-path="./dist"`, true);
   } catch (e) {
     commitTestPassed = false;
   }

--- a/bin/test-external-partner-project.js
+++ b/bin/test-external-partner-project.js
@@ -141,6 +141,7 @@ try {
 if (!skipTest) {
   try {
     debug('Running tests against EmberData commit');
+    execExternal(`ember --version`, true);
     execExternal(`ember test --output-path="./dist"`, true);
   } catch (e) {
     commitTestPassed = false;

--- a/bin/test-external-partner-project.js
+++ b/bin/test-external-partner-project.js
@@ -142,7 +142,10 @@ if (!skipTest) {
   try {
     debug('Running tests against EmberData commit');
     execExternal(`ember --version`, true);
-    execExternal(`ember test --output-path="./dist"`, true);
+    // ember-cli test command does not have --output-path available
+    // in all versions of our partner test's
+    execExternal(`ember build`, true);
+    execExternal(`ember test --path="./dist"`, true);
   } catch (e) {
     commitTestPassed = false;
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:fastboot": "yarn workspace fastboot-test-app test",
     "test-external:ember-m3": "./bin/test-external-partner-project.js ember-m3 https://github.com/hjdivad/ember-m3.git",
     "test-external:ember-data-change-tracker": "./bin/test-external-partner-project.js ember-data-change-tracker https://github.com/danielspaniel/ember-data-change-tracker.git",
-    "test-external:model-fragments": "./bin/test-external-partner-project.js ember-data-model-fragments https://github.com/lytics/ember-data-model-fragments.git",
+    "test-external:model-fragments": "./bin/test-external-partner-project.js model-fragments https://github.com/lytics/ember-data-model-fragments.git",
     "test-external:ember-observer": "./bin/test-external-partner-project.js ember-observer https://github.com/emberobserver/client.git",
     "test-external:travis-web": "./bin/test-external-partner-project.js travis-web https://github.com/travis-ci/travis-web.git",
     "test-external:storefront": "./bin/test-external-partner-project.js storefront https://github.com/embermap/ember-data-storefront.git",

--- a/packages/canary-features/addon/index.ts
+++ b/packages/canary-features/addon/index.ts
@@ -17,7 +17,7 @@ interface ConfigEnv {
 declare global {
   export const EmberDataENV: ConfigEnv | undefined | null;
 }
-const ENV: ConfigEnv = typeof EmberDataENV === 'object' && EmberDataENV !== null ? EmberDataENV : {};
+const ENV: ConfigEnv = typeof EmberDataENV !== 'undefined' && EmberDataENV !== null ? EmberDataENV : {};
 
 function featureValue(value: boolean | null): boolean | null {
   if (ENV.ENABLE_OPTIONAL_FEATURES && value === null) {


### PR DESCRIPTION
resolves #6825 

This PR

- Fixes our YML so that we actually run tests on all the Operating Systems we'd specified (they were all running ubuntu before)
- Adds timeouts to our jobs so that they don't hang for hours (the default timeout is 6 hours)
- Uploads artifacts from failed partner-test runs so that we can debug them better
- Fixes the bug it enabled debugging that was causing EmberObserver to fail

## Why EmberObserver was Timing Out in Github Actions only

This turned out to be a canary-only dev-build-only transpilation bug that only affects partners transpiling for IE11 in their tests.

The primary difference between Travis/Azure and Github Actions is that in Github Actions we correctly set `env` to include `CI=true`. This causes ember-observer to target `ie11`, which
introduces a transpilation bug when using `typeof`.

Our code in `canary-features` (this is stripped in production and non-canary builds)

```ts
const ENV = typeof EmberDataENV === 'object' && EmberDataENV !== null ? EmberDataENV : {};
```

Due to this default babel plugin https://babeljs.io/docs/en/babel-plugin-transform-typeof-symbol
this is transpiled to 

```ts
  function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }

  var ENV = _typeof(EmberDataENV) === 'object' && EmberDataENV !== null ? EmberDataENV : {};
```

The above is an error because we call `_typeof` with `EmberDataENV` when it is potentially undefined. We don't hit this in our own `max-transpilation-test` because our tests always have this variable defined via the test's `index.html` file.

Changing the check to this removes the transpilation as we no longer need to check for `symbol`

```ts
const ENV: ConfigEnv = typeof EmberDataENV !== 'undefined' && EmberDataENV !== null ? EmberDataENV : {};
```

Here we are more loosely assuming that if we are defined and not null we are an object, but given the very narrow set of things that hit this code path this seems ok.