### PR TITLE
[CHORE] IE11 Testing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
   plugins: ['prettier', 'qunit', 'mocha'],
   extends: ['eslint:recommended', 'prettier'],
   rules: {
+    // 'no-restricted-globals': ['error', { name: 'Promise', message: 'Global Promise does not work in IE11' }],
     'mocha/no-exclusive-tests': 'error',
     'prettier/prettier': 'error',
     'no-unused-vars': ['error', { args: 'none' }],
@@ -28,6 +29,7 @@ module.exports = {
     Map: false,
     WeakMap: true,
     Set: true,
+    Promise: false,
   },
   env: {
     browser: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   plugins: ['prettier', 'qunit', 'mocha'],
   extends: ['eslint:recommended', 'prettier'],
   rules: {
-    // 'no-restricted-globals': ['error', { name: 'Promise', message: 'Global Promise does not work in IE11' }],
+    'no-restricted-globals': ['error', { name: 'Promise', message: 'Global Promise does not work in IE11' }],
     'mocha/no-exclusive-tests': 'error',
     'prettier/prettier': 'error',
     'no-unused-vars': ['error', { args: 'none' }],
@@ -89,6 +89,9 @@ module.exports = {
       },
       plugins: ['node'],
       extends: 'plugin:node/recommended',
+      rules: {
+        'no-restricted-globals': 'off',
+      },
     },
 
     // node tests
@@ -96,6 +99,9 @@ module.exports = {
       files: ['packages/*/node-tests/**', 'packages/unpublished-test-infra/src/node-test-helpers/**/*'],
       env: {
         mocha: true,
+      },
+      rules: {
+        'no-restricted-globals': 'off',
       },
     },
 
@@ -105,6 +111,9 @@ module.exports = {
       env: {
         qunit: true,
         es6: false,
+      },
+      rules: {
+        'no-restricted-globals': 'off',
       },
     },
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,10 +91,7 @@ jobs:
       - name: Launcher Info
         run: |
           yarn run testem launchers
-      - name: Basic tests
-        run: yarn test
       - name: Production build
-        if: failure() || success()
         run: yarn test:production
       - name: Fastboot tests
         run: yarn test:fastboot -e production

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,7 @@ jobs:
       - name: Basic tests
         run: yarn test
       - name: Production build
+        if: failure() || success()
         run: yarn test:production
       - name: Fastboot tests
         run: yarn test:fastboot -e production

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,30 @@ jobs:
           EMBER_DATA_FEATURE_OVERRIDE: DISABLE_ALL
         run: yarn test
 
+  basic-tests-ie11:
+    needs: [lint]
+    timeout-minutes: 20
+    runs-on: windows-latest
+    env:
+      TEST_IE11: true
+      TARGET_IE11: true
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Install dependencies
+        run: yarn install
+      - name: Launcher Info
+        run: |
+          yarn run testem launchers
+      - name: Basic tests
+        run: yarn test
+      - name: Production build
+        run: yarn test:production
+      - name: Fastboot tests
+        run: yarn test:fastboot -e production
+
   floating-dependencies:
     needs: [lint, basic-tests]
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,8 +93,6 @@ jobs:
           yarn run testem launchers
       - name: Production build
         run: yarn test:production
-      - name: Fastboot tests
-        run: yarn test:fastboot -e production
 
   floating-dependencies:
     needs: [lint, basic-tests]

--- a/packages/-ember-data/testem.js
+++ b/packages/-ember-data/testem.js
@@ -1,8 +1,14 @@
+const TestIE = process.env.TEST_IE11;
+
+if (TestIE) {
+  // eslint-disable-next-line no-console
+  console.log('\n\nLaunching with IE\n\n');
+}
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   reporter: 'dot',
-  launch_in_ci: ['Chrome'],
+  launch_in_ci: TestIE ? ['IE'] : ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
   browser_args: {

--- a/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
@@ -10,6 +10,7 @@ import { RecordData } from '@ember-data/store/-private/ts-interfaces/record-data
 import { RecordIdentifier } from '@ember-data/store/-private/ts-interfaces/identifier';
 import { RECORD_DATA_ERRORS } from '@ember-data/canary-features';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
+import { Promise } from 'rsvp';
 
 class Person extends Model {
   // TODO fix the typing for naked attrs

--- a/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
@@ -8,6 +8,7 @@ import Ember from 'ember';
 import { RecordData } from '@ember-data/store/-private/ts-interfaces/record-data';
 import { RECORD_DATA_STATE } from '@ember-data/canary-features';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
+import { Promise } from 'rsvp';
 
 class Person extends Model {
   // TODO fix the typing for naked attrs

--- a/packages/-ember-data/tests/integration/record-data/record-data-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-test.ts
@@ -9,6 +9,7 @@ import { settled } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import { attr, hasMany, belongsTo } from '@ember-data/model';
 import { RECORD_DATA_ERRORS } from '@ember-data/canary-features';
+import { Promise } from 'rsvp';
 
 class Person extends Model {
   // TODO fix the typing for naked attrs

--- a/packages/-ember-data/tests/integration/relationships/inverse-relationship-load-test.js
+++ b/packages/-ember-data/tests/integration/relationships/inverse-relationship-load-test.js
@@ -4019,7 +4019,7 @@ module('inverse relationship load test', function(hooks) {
 
     let allDogs = store.peekAll('dogs').toArray();
     for (let i = 0; i < allDogs.length; i++) {
-      let dog = docs[i];
+      let dog = allDogs[i];
       let dogPerson = await dog.get('person');
       assert.equal(dogPerson.get('id'), person2.get('id'), 'right hand side has correct belongsTo value');
     }

--- a/packages/-ember-data/tests/integration/relationships/inverse-relationship-load-test.js
+++ b/packages/-ember-data/tests/integration/relationships/inverse-relationship-load-test.js
@@ -4017,7 +4017,9 @@ module('inverse relationship load test', function(hooks) {
       'hasMany relationship on specified record has correct number of associated records'
     );
 
-    for (let dog of store.peekAll('dogs').toArray()) {
+    let allDogs = store.peekAll('dogs').toArray();
+    for (let i = 0; i < allDogs.length; i++) {
+      let dog = docs[i];
       let dogPerson = await dog.get('person');
       assert.equal(dogPerson.get('id'), person2.get('id'), 'right hand side has correct belongsTo value');
     }
@@ -4142,7 +4144,9 @@ module('inverse relationship load test', function(hooks) {
       'hasMany relationship on specified record has correct number of associated records'
     );
 
-    for (let dog of store.peekAll('dogs').toArray()) {
+    let allDogs = store.peekAll('dogs').toArray();
+    for (let i = 0; i < allDogs.length; i++) {
+      let dog = allDogs[i];
       let dogPerson = await dog.get('person');
       assert.equal(dogPerson.get('id'), person2.get('id'), 'right hand side has correct belongsTo value');
     }
@@ -4244,7 +4248,9 @@ module('inverse relationship load test', function(hooks) {
 
     assert.equal(personDogs.get('length'), 0, 'hasMany relationship for parent is empty');
 
-    for (let dog of store.peekAll('dogs').toArray()) {
+    let allDogs = store.peekAll('dogs').toArray();
+    for (let i = 0; i < allDogs.length; i++) {
+      let dog = allDogs[i];
       let dogPerson = await dog.get('person');
       assert.equal(dogPerson, null, 'right hand side has correct belongsTo value');
     }
@@ -4346,7 +4352,9 @@ module('inverse relationship load test', function(hooks) {
 
     assert.equal(personDogs.get('length'), 0, 'hasMany relationship for parent is empty');
 
-    for (let dog of store.peekAll('dogs').toArray()) {
+    let allDogs = store.peekAll('dogs').toArray();
+    for (let i = 0; i < allDogs.length; i++) {
+      let dog = allDogs[i];
       let dogPerson = await dog.get('person');
       assert.equal(dogPerson, null, 'right hand side has correct belongsTo value');
     }
@@ -4471,7 +4479,9 @@ module('inverse relationship load test', function(hooks) {
       'hasMany relationship on specified record has correct number of associated records'
     );
 
-    for (let dog of store.peekAll('dogs').toArray()) {
+    let allDogs = store.peekAll('dogs').toArray();
+    for (let i = 0; i < allDogs.length; i++) {
+      let dog = allDogs[i];
       let dogPerson = await dog.get('pal');
       assert.equal(dogPerson.get('id'), pal2.get('id'), 'right hand side has correct belongsTo value');
     }
@@ -4596,7 +4606,9 @@ module('inverse relationship load test', function(hooks) {
       'hasMany relationship on specified record has correct number of associated records'
     );
 
-    for (let dog of store.peekAll('dogs').toArray()) {
+    let allDogs = store.peekAll('dogs').toArray();
+    for (let i = 0; i < allDogs.length; i++) {
+      let dog = allDogs[i];
       let dogPerson = await dog.get('pal');
       assert.equal(dogPerson.get('id'), pal2.get('id'), 'right hand side has correct belongsTo value');
     }

--- a/packages/-ember-data/tests/integration/request-state-service-test.ts
+++ b/packages/-ember-data/tests/integration/request-state-service-test.ts
@@ -8,6 +8,7 @@ import { attr } from '@ember-data/model';
 import { REQUEST_SERVICE } from '@ember-data/canary-features';
 import { RequestStateEnum } from '@ember-data/store/-private/ts-interfaces/fetch-manager';
 import JSONSerializer from '@ember-data/serializer/json';
+import { Promise } from 'rsvp';
 
 class Person extends Model {
   // TODO fix the typing for naked attrs

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -274,17 +274,19 @@ module('integration/store - destroy', function(hooks) {
 
 module('integration/store - findRecord', function(hooks) {
   setupTest(hooks);
+  let store;
 
   hooks.beforeEach(function() {
     this.owner.register('model:car', Car);
     this.owner.register('adapter:application', RESTAdapter.extend());
     this.owner.register('serializer:application', RESTSerializer.extend());
+    store = this.owner.lookup('service:store');
+    store.shouldTrackAsyncRequests = true;
   });
 
   test('store#findRecord fetches record from server when cached record is not present', async function(assert) {
     assert.expect(2);
 
-    let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
     adapter.ajax = ajaxResponse({
@@ -309,7 +311,6 @@ module('integration/store - findRecord', function(hooks) {
   test('store#findRecord returns cached record immediately and reloads record in the background', async function(assert) {
     assert.expect(4);
 
-    let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
     adapter.shouldReloadRecord = () => false;
@@ -363,7 +364,6 @@ module('integration/store - findRecord', function(hooks) {
 
     this.owner.register('adapter:application', testAdapter);
 
-    let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
     store.push({
@@ -426,8 +426,6 @@ module('integration/store - findRecord', function(hooks) {
     this.owner.register('adapter:application', testAdapter);
     this.owner.register('serializer:application', JSONAPISerializer.extend());
 
-    let store = this.owner.lookup('service:store');
-
     let car = await store.findRecord('car', '1');
 
     assert.strictEqual(calls, 1, 'We made one call to findRecord');
@@ -457,8 +455,6 @@ module('integration/store - findRecord', function(hooks) {
     });
 
     this.owner.register('adapter:application', testAdapter);
-
-    let store = this.owner.lookup('service:store');
 
     store.push({
       data: {
@@ -491,8 +487,6 @@ module('integration/store - findRecord', function(hooks) {
 
     this.owner.register('adapter:application', testAdapter);
 
-    let store = this.owner.lookup('service:store');
-    store.shouldTrackAsyncRequests = true;
     let adapter = store.adapterFor('application');
 
     store.push({
@@ -547,7 +541,6 @@ module('integration/store - findRecord', function(hooks) {
 
     this.owner.register('adapter:application', testAdapter);
 
-    let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
     store.push({
@@ -590,8 +583,6 @@ module('integration/store - findRecord', function(hooks) {
       const badValues = ['', undefined, null, NaN, false];
 
       assert.expect(badValues.length);
-
-      let store = this.owner.lookup('service:store');
 
       badValues.map(item => {
         assert.expectAssertion(() => {

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -328,7 +328,7 @@ module('integration/store - findRecord', function(hooks) {
     });
 
     adapter.ajax = async () => {
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await resolve();
 
       return {
         cars: [
@@ -408,7 +408,7 @@ module('integration/store - findRecord', function(hooks) {
       async findRecord() {
         calls++;
 
-        await new Promise(resolve => setTimeout(resolve, 1));
+        await resolve();
 
         return {
           data: {
@@ -501,7 +501,7 @@ module('integration/store - findRecord', function(hooks) {
     });
 
     adapter.ajax = async function() {
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await resolve();
 
       return deepCopy({
         cars: [
@@ -555,7 +555,7 @@ module('integration/store - findRecord', function(hooks) {
     });
 
     adapter.ajax = async function() {
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await resolve();
 
       return deepCopy({
         cars: [
@@ -772,7 +772,7 @@ module('integration/store - findAll', function(hooks) {
     });
 
     adapter.ajax = async () => {
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await resolve();
 
       return {
         cars: [
@@ -798,9 +798,7 @@ module('integration/store - findAll', function(hooks) {
     await settled();
 
     // IE11 hack
-    run(() => {
-      cars = store.peekAll('car');
-    });
+    cars = store.peekAll('car');
     assert.equal(cars.length, 2, 'multiple cars now in the store');
     assert.equal(cars.firstObject.model, 'New Mini', 'existing record updated correctly');
     assert.equal(cars.lastObject.model, 'Isetta', 'new record added to the store');

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -492,6 +492,7 @@ module('integration/store - findRecord', function(hooks) {
     this.owner.register('adapter:application', testAdapter);
 
     let store = this.owner.lookup('service:store');
+    store.shouldTrackAsyncRequests = true;
     let adapter = store.adapterFor('application');
 
     store.push({

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -797,8 +797,10 @@ module('integration/store - findAll', function(hooks) {
 
     await settled();
 
-    cars = store.peekAll('car');
-
+    // IE11 hack
+    run(() => {
+      cars = store.peekAll('car');
+    });
     assert.equal(cars.length, 2, 'multiple cars now in the store');
     assert.equal(cars.firstObject.model, 'New Mini', 'existing record updated correctly');
     assert.equal(cars.lastObject.model, 'Isetta', 'new record added to the store');

--- a/packages/-ember-data/tests/integration/store/adapter-for-test.js
+++ b/packages/-ember-data/tests/integration/store/adapter-for-test.js
@@ -1,10 +1,11 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import Store from 'ember-data/store';
+import { assign } from '@ember/polyfills';
 
 class TestAdapter {
   constructor(args) {
-    Object.assign(this, args);
+    assign(this, args);
     this.didInit();
   }
 

--- a/packages/-ember-data/tests/integration/store/model-name-test.js
+++ b/packages/-ember-data/tests/integration/store/model-name-test.js
@@ -61,7 +61,7 @@ module('@ember-data/model klass.modelName', function(hooks) {
       assert.strictEqual(
         startsWith(e.message, `Cannot assign to read only property 'modelName' of `),
         true,
-        'modelName is immutable'
+        `modelName is immutable: ${e.message}`
       );
     }
 

--- a/packages/-ember-data/tests/integration/store/model-name-test.js
+++ b/packages/-ember-data/tests/integration/store/model-name-test.js
@@ -59,7 +59,9 @@ module('@ember-data/model klass.modelName', function(hooks) {
       assert.ok(false, 'expected modelName to be immutable');
     } catch (e) {
       assert.strictEqual(
-        startsWith(e.message, `Cannot assign to read only property 'modelName' of `),
+        startsWith(e.message, `Cannot assign to read only property 'modelName' of `) ||
+          // IE11 has a different message
+          startsWith(e.message, `Assignment to read-only properties is not allowed in strict mode`),
         true,
         `modelName is immutable: ${e.message}`
       );

--- a/packages/-ember-data/tests/integration/store/model-name-test.js
+++ b/packages/-ember-data/tests/integration/store/model-name-test.js
@@ -5,6 +5,13 @@ import { computed } from '@ember/object';
 import Service, { inject } from '@ember/service';
 import Store from '@ember-data/store';
 
+function startsWith(str, substr) {
+  if (typeof str.startsWith === 'function') {
+    return str.startsWith(substr);
+  }
+  return str.indexOf(substr) === 0;
+}
+
 module('@ember-data/model klass.modelName', function(hooks) {
   setupTest(hooks);
 
@@ -52,7 +59,7 @@ module('@ember-data/model klass.modelName', function(hooks) {
       assert.ok(false, 'expected modelName to be immutable');
     } catch (e) {
       assert.strictEqual(
-        e.message.startsWith(`Cannot assign to read only property 'modelName' of `),
+        startsWith(e.message, `Cannot assign to read only property 'modelName' of `),
         true,
         'modelName is immutable'
       );

--- a/packages/-ember-data/tests/integration/store/serializer-for-test.js
+++ b/packages/-ember-data/tests/integration/store/serializer-for-test.js
@@ -2,10 +2,11 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import { deprecatedTest } from '@ember-data/unpublished-test-infra/test-support/deprecated-test';
 import Store from 'ember-data/store';
+import { assign } from '@ember/polyfills';
 
 class TestAdapter {
   constructor(args) {
-    Object.assign(this, args);
+    assign(this, args);
     this.didInit();
   }
 
@@ -18,7 +19,7 @@ class TestAdapter {
 
 class TestSerializer {
   constructor(args) {
-    Object.assign(this, args);
+    assign(this, args);
     this.didInit();
   }
 

--- a/packages/-ember-data/tests/test-helper.js
+++ b/packages/-ember-data/tests/test-helper.js
@@ -9,6 +9,11 @@ import QUnit from 'qunit';
 import { wait, asyncEqual, invokeAsync } from '@ember-data/unpublished-test-infra/test-support/async';
 import configureAsserts from '@ember-data/unpublished-test-infra/test-support/qunit-asserts';
 
+window.Promise = RSVP.Promise;
+window.Symbol = function FakeSymbol(str) {
+  return `${Date.now()}-${str}`;
+};
+
 configureAsserts();
 
 setApplication(Application.create(config.APP));

--- a/packages/-ember-data/tests/test-helper.js
+++ b/packages/-ember-data/tests/test-helper.js
@@ -9,11 +9,6 @@ import QUnit from 'qunit';
 import { wait, asyncEqual, invokeAsync } from '@ember-data/unpublished-test-infra/test-support/async';
 import configureAsserts from '@ember-data/unpublished-test-infra/test-support/qunit-asserts';
 
-window.Promise = RSVP.Promise;
-window.Symbol = function FakeSymbol(str) {
-  return `${Date.now()}-${str}`;
-};
-
 configureAsserts();
 
 setApplication(Application.create(config.APP));

--- a/packages/-ember-data/tests/test-helper.js
+++ b/packages/-ember-data/tests/test-helper.js
@@ -9,6 +9,10 @@ import QUnit from 'qunit';
 import { wait, asyncEqual, invokeAsync } from '@ember-data/unpublished-test-infra/test-support/async';
 import configureAsserts from '@ember-data/unpublished-test-infra/test-support/qunit-asserts';
 
+if (window.Promise === undefined) {
+  window.Promise = RSVP.Promise;
+}
+
 configureAsserts();
 
 setApplication(Application.create(config.APP));

--- a/packages/store/addon/-private/identifiers/cache.ts
+++ b/packages/store/addon/-private/identifiers/cache.ts
@@ -18,20 +18,7 @@ import normalizeModelName from '../system/normalize-model-name';
 import isStableIdentifier, { markStableIdentifier, unmarkStableIdentifier } from './is-stable-identifier';
 import isNonEmptyString from '../utils/is-non-empty-string';
 import CoreStore from '../system/core-store';
-
-function addSymbol(obj: object, symbol: Symbol | string, value: any): void {
-  if (typeof symbol === 'string') {
-    Object.defineProperty(obj, symbol, {
-      value,
-      configurable: false,
-      enumerable: false,
-      writable: false,
-    });
-  } else {
-    // Typescript doesn't allow Symbol as an index type
-    obj[(symbol as unknown) as string] = value;
-  }
-}
+import { addSymbol } from '../ts-interfaces/utils/symbol';
 
 function freeze<T>(obj: T): T {
   if (typeof Object.freeze === 'function') {
@@ -464,7 +451,7 @@ function makeStableRecordIdentifier(
     };
     addSymbol(wrapper, DEBUG_CLIENT_ORIGINATED, clientOriginated);
     addSymbol(wrapper, DEBUG_IDENTIFIER_BUCKET, bucket);
-    freeze(wrapper);
+    wrapper = freeze(wrapper);
     markStableIdentifier(wrapper);
     DEBUG_MAP.set(wrapper, recordIdentifier);
     return wrapper;

--- a/packages/store/addon/-private/identifiers/cache.ts
+++ b/packages/store/addon/-private/identifiers/cache.ts
@@ -433,8 +433,6 @@ function makeStableRecordIdentifier(
     // we enforce immutability in dev
     //  but preserve our ability to do controlled updates to the reference
     let wrapper = {
-      [DEBUG_CLIENT_ORIGINATED]: clientOriginated,
-      [DEBUG_IDENTIFIER_BUCKET]: bucket,
       get lid() {
         return recordIdentifier.lid;
       },

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -114,6 +114,13 @@ function getModel() {
   return _Model;
 }
 
+function freeze<T>(obj: T): T {
+  if (typeof Object.freeze === 'function') {
+    return Object.freeze(obj);
+  }
+  return obj;
+}
+
 function deprecateTestRegistration(factoryType: 'adapter', factoryName: '-json-api'): void;
 function deprecateTestRegistration(factoryType: 'serializer', factoryName: '-json-api' | '-rest' | '-default'): void;
 function deprecateTestRegistration(
@@ -348,13 +355,6 @@ abstract class CoreStore extends Service {
       }
       if (this.generateStackTracesForTrackedRequests === undefined) {
         this.generateStackTracesForTrackedRequests = false;
-      }
-
-      function freeze<T>(obj: T): T {
-        if (typeof Object.freeze === 'function') {
-          return Object.freeze(obj);
-        }
-        return obj;
       }
 
       this._trackedAsyncRequests = [];

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -13,6 +13,7 @@ import { default as RSVP, all, resolve, Promise, defer } from 'rsvp';
 import Service from '@ember/service';
 import { typeOf, isPresent, isNone } from '@ember/utils';
 
+import { addSymbol } from '../ts-interfaces/utils/symbol';
 import require from 'require';
 import Ember from 'ember';
 import { assert, warn, inspect } from '@ember/debug';
@@ -2418,7 +2419,8 @@ abstract class CoreStore extends Service {
       } else if (recordData.isDeleted && recordData.isDeleted()) {
         operation = 'deleteRecord';
       }
-      options[SaveOp] = operation;
+
+      addSymbol(options, SaveOp, operation);
 
       let fetchManagerPromise = this._fetchManager.scheduleSave(internalModel.identifier, options);
       let promise = fetchManagerPromise.then(

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -350,6 +350,13 @@ abstract class CoreStore extends Service {
         this.generateStackTracesForTrackedRequests = false;
       }
 
+      function freeze<T>(obj: T): T {
+        if (typeof Object.freeze === 'function') {
+          return Object.freeze(obj);
+        }
+        return obj;
+      }
+
       this._trackedAsyncRequests = [];
       this._trackAsyncRequestStart = label => {
         let trace =
@@ -363,7 +370,7 @@ abstract class CoreStore extends Service {
           }
         }
 
-        let token = Object.freeze({
+        let token = freeze({
           label,
           trace,
         });

--- a/packages/store/addon/-private/system/fetch-manager.ts
+++ b/packages/store/addon/-private/system/fetch-manager.ts
@@ -14,7 +14,6 @@ import { FindRecordQuery, SaveRecordMutation, Request } from '../ts-interfaces/f
 import { symbol } from '../ts-interfaces/utils/symbol';
 import CoreStore from './core-store';
 import { errorsArrayToHash } from './errors-utils';
-import { addSymbol } from '../ts-interfaces/utils/symbol';
 
 function payloadIsNotBlank(adapterPayload): boolean {
   if (Array.isArray(adapterPayload)) {

--- a/packages/store/addon/-private/system/fetch-manager.ts
+++ b/packages/store/addon/-private/system/fetch-manager.ts
@@ -14,6 +14,7 @@ import { FindRecordQuery, SaveRecordMutation, Request } from '../ts-interfaces/f
 import { symbol } from '../ts-interfaces/utils/symbol';
 import CoreStore from './core-store';
 import { errorsArrayToHash } from './errors-utils';
+import { addSymbol } from '../ts-interfaces/utils/symbol';
 
 function payloadIsNotBlank(adapterPayload): boolean {
   if (Array.isArray(adapterPayload)) {

--- a/packages/store/addon/-private/system/request-cache.ts
+++ b/packages/store/addon/-private/system/request-cache.ts
@@ -7,9 +7,9 @@ import {
   Operation,
   RequestStateEnum,
 } from '../ts-interfaces/fetch-manager';
-import { symbol } from '../ts-interfaces/utils/symbol';
+import { symbol, addSymbol } from '../ts-interfaces/utils/symbol';
 
-export const Touching: unique symbol = symbol('touching');
+const Touching: unique symbol = symbol('touching');
 export const RequestPromise: unique symbol = symbol('promise');
 
 interface InternalRequest extends RequestState {
@@ -40,9 +40,9 @@ export default class RequestCache {
         state: RequestStateEnum.pending,
         request: queryRequest,
         type,
-        [Touching]: [query.recordIdentifier],
-        [RequestPromise]: promise,
-      };
+      } as InternalRequest;
+      addSymbol(request, Touching, [query.recordIdentifier]);
+      addSymbol(request, RequestPromise, promise);
       this._pending[lid].push(request);
       this._triggerSubscriptions(request);
       promise.then(
@@ -52,9 +52,9 @@ export default class RequestCache {
             state: RequestStateEnum.fulfilled,
             request: queryRequest,
             type,
-            [Touching]: request[Touching],
             response: { data: result },
-          };
+          } as InternalRequest;
+          addSymbol(finalizedRequest, Touching, request[Touching]);
           this._addDone(finalizedRequest);
           this._triggerSubscriptions(finalizedRequest);
         },
@@ -64,9 +64,9 @@ export default class RequestCache {
             state: RequestStateEnum.rejected,
             request: queryRequest,
             type,
-            [Touching]: request[Touching],
             response: { data: error && error.error },
-          };
+          } as InternalRequest;
+          addSymbol(finalizedRequest, Touching, request[Touching]);
           this._addDone(finalizedRequest);
           this._triggerSubscriptions(finalizedRequest);
         }

--- a/packages/store/addon/-private/ts-interfaces/utils/symbol.ts
+++ b/packages/store/addon/-private/ts-interfaces/utils/symbol.ts
@@ -17,3 +17,17 @@ export const symbol =
   typeof Symbol !== 'undefined'
     ? Symbol
     : (key: string) => `__${key}${Math.floor(Math.random() * Date.now())}__` as any;
+
+export function addSymbol(obj: object, symbol: Symbol | string, value: any): void {
+  if (typeof symbol === 'string') {
+    Object.defineProperty(obj, symbol, {
+      value,
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    });
+  } else {
+    // Typescript doesn't allow Symbol as an index type
+    obj[(symbol as unknown) as string] = value;
+  }
+}

--- a/packages/unpublished-test-infra/addon-test-support/public-props.js
+++ b/packages/unpublished-test-infra/addon-test-support/public-props.js
@@ -1,10 +1,12 @@
+import { assign } from '@ember/polyfills';
+
 // publicProps(['prop1', 'prop2'], { prop1: val, prop2: val2, privatePro: val3 }) -> { prop1: val, prop2: val2 }
 export default function publicProps(publicArgs, obj) {
-  return Object.assign.apply(
+  return assign.apply(
     this,
     [{}].concat(
       Object.keys(obj).map(key => ({
-        [key]: Object.assign.apply(this, [{}].concat(publicArgs.map(prop => ({ [prop]: obj[key][prop] })))),
+        [key]: assign.apply(this, [{}].concat(publicArgs.map(prop => ({ [prop]: obj[key][prop] })))),
       }))
     )
   );

--- a/packages/unpublished-test-infra/addon-test-support/todo.js
+++ b/packages/unpublished-test-infra/addon-test-support/todo.js
@@ -1,15 +1,19 @@
 /* global Proxy */
-import QUnit, { test } from 'qunit';
+import QUnit, { test, skip } from 'qunit';
 
 export default function todo(description, callback) {
-  test(`[TODO] ${description}`, async function todoTest(assert) {
-    let todos = [];
-    hijackAssert(assert, todos);
+  if (DEBUG) {
+    test(`[TODO] ${description}`, async function todoTest(assert) {
+      let todos = [];
+      hijackAssert(assert, todos);
 
-    await callback.call(this, assert);
+      await callback.call(this, assert);
 
-    assertTestStatus(assert, todos);
-  });
+      assertTestStatus(assert, todos);
+    });
+  } else {
+    skip(`[TODO] ${description}`, callback);
+  }
 }
 
 function hijackAssert(assert, todos) {

--- a/packages/unpublished-test-infra/addon-test-support/todo.js
+++ b/packages/unpublished-test-infra/addon-test-support/todo.js
@@ -1,5 +1,6 @@
 /* global Proxy */
 import QUnit, { test, skip } from 'qunit';
+import { DEBUG } from '@glimmer/env';
 
 export default function todo(description, callback) {
   if (DEBUG) {

--- a/packages/unpublished-test-infra/addon-test-support/watch-property.js
+++ b/packages/unpublished-test-infra/addon-test-support/watch-property.js
@@ -1,6 +1,13 @@
 import { removeObserver, addObserver } from '@ember/object/observers';
 import QUnit from 'qunit';
 
+function freeze(obj) {
+  if (typeof Object.freeze === 'function') {
+    return Object.freeze(obj);
+  }
+  return obj;
+}
+
 function makeCounter() {
   let count = 0;
   const counter = Object.create(null);
@@ -17,7 +24,7 @@ function makeCounter() {
     enumerable: true,
   });
 
-  Object.freeze(counter);
+  freeze(counter);
 
   function increment() {
     count++;


### PR DESCRIPTION
We're still a ways (if ever) from being able to run the full test suite in IE11 https://github.com/emberjs/data/pull/6830/checks?check_run_id=327832618

But this lets us run the production tests.

The small number of changes to EmberData itself are mostly for dev-time support of IE11 (which I got pretty far with but ultimately the widespread lack of support for IE11 at dev time in Ember itself prevents us from getting any further).

Some of the changes will affect prod builds but only once feature flags are turned on (request-state cache for instance).