### PR TITLE
[CHORE CI] fix timeout issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,6 @@ jobs:
         run: yarn test
 
   lts:
-    timeout-minutes: 4
     needs: [lint, basic-tests]
     strategy:
       fail-fast: false
@@ -162,6 +161,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Basic tests with ${{ matrix.scenario }}
+        timeout-minutes: 4
         env:
           CI: true
         run: yarn test:try-one ${{ matrix.scenario }}

--- a/packages/unpublished-fastboot-test-app/testem.js
+++ b/packages/unpublished-fastboot-test-app/testem.js
@@ -4,6 +4,7 @@ module.exports = {
   reporter: 'dot',
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       ci: [


### PR DESCRIPTION
A few of our jobs are timing out, this addresses that.

For some the issue is the testem timeout needs to be lengthened (our basic tests already do this but fastboot still needed it).

For others it's the job timeout being hit. I'd intentionally set aggressive timeouts for our github actions recently to be sure we weren't spending needless time waiting for them (we had jobs going for 6 hours), so one or two more tweaks may occur in the near future but overall they seem to be settling into a good set of budgets.