### PR TITLE
[CHORE] Identifier relationships

### DIFF
--- a/packages/-ember-data/addon/store.ts
+++ b/packages/-ember-data/addon/store.ts
@@ -3,7 +3,7 @@ import { RecordData } from '@ember-data/record-data/-private';
 import Store from '@ember-data/store';
 import { identifierCacheFor } from '@ember-data/store/-private';
 
-type RecordDataStoreWrapper = import('@ember-data/store/-private/ts-interfaces/record-data-store-wrapper').RecordDataStoreWrapper;
+type RecordDataStoreWrapper = import('@ember-data/store/-private/system/store/record-data-store-wrapper').default;
 
 export default class DefaultStore extends Store {
   createRecordDataFor(modelName: string, id: string | null, clientId: string, storeWrapper: RecordDataStoreWrapper) {

--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -12,6 +12,10 @@ import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import Store from '@ember-data/store';
+import { ServerError } from '@ember-data/adapter/error';
+import Ember from 'ember';
+import { attr, hasMany, belongsTo } from '@ember-data/model';
+import { implicitRelationshipsFor } from '@ember-data/record-data/-private';
 
 class Person extends Model {
   @attr()
@@ -241,6 +245,9 @@ module('async belongs-to rendering tests', function(hooks) {
           attributes: { name: 'Pete' },
         },
       });
+      const storeWrapper = pete._internalModel._recordData.storeWrapper;
+      const identifier = pete._internalModel.identifier;
+      const implicitRelationships = implicitRelationshipsFor(storeWrapper, identifier);
 
       const goofy = store.push({
         data: {
@@ -255,7 +262,7 @@ module('async belongs-to rendering tests', function(hooks) {
         },
       });
 
-      assert.equal(pete._internalModel.__recordData.__implicitRelationships.undefinedpetOwner.canonicalMembers.size, 1);
+      assert.equal(implicitRelationships.undefinedpetOwner.canonicalMembers.size, 1);
 
       const tweety = store.push({
         data: {
@@ -270,7 +277,7 @@ module('async belongs-to rendering tests', function(hooks) {
         },
       });
 
-      assert.equal(pete._internalModel.__recordData.__implicitRelationships.undefinedpetOwner.canonicalMembers.size, 2);
+      assert.equal(implicitRelationships.undefinedpetOwner.canonicalMembers.size, 2);
 
       let petOwner = await goofy.get('petOwner');
       assert.equal(petOwner.get('name'), 'Pete');
@@ -284,7 +291,7 @@ module('async belongs-to rendering tests', function(hooks) {
       await tweety.destroyRecord();
       assert.ok(tweety.isDeleted);
 
-      assert.equal(pete._internalModel.__recordData.__implicitRelationships.undefinedpetOwner.canonicalMembers.size, 0);
+      assert.equal(implicitRelationships.undefinedpetOwner.canonicalMembers.size, 0);
 
       const jerry = store.push({
         data: {
@@ -302,7 +309,7 @@ module('async belongs-to rendering tests', function(hooks) {
       petOwner = await jerry.get('petOwner');
       assert.equal(petOwner.get('name'), 'Pete');
 
-      assert.equal(pete._internalModel.__recordData.__implicitRelationships.undefinedpetOwner.canonicalMembers.size, 1);
+      assert.equal(implicitRelationships.undefinedpetOwner.canonicalMembers.size, 1);
 
       await settled();
     });

--- a/packages/-ember-data/tests/integration/records/unload-test.js
+++ b/packages/-ember-data/tests/integration/records/unload-test.js
@@ -2,22 +2,21 @@
 
 import { get } from '@ember/object';
 import { run } from '@ember/runloop';
+import { settled } from '@ember/test-helpers';
 
 import { module, test } from 'qunit';
 import { Promise as EmberPromise, resolve } from 'rsvp';
 
-import DS from 'ember-data';
 import { setupTest } from 'ember-qunit';
 
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { recordDataFor } from '@ember-data/store/-private';
 
 function idsFromOrderedSet(set) {
   return set.list.map(i => i.id);
 }
-
-const { attr, belongsTo, hasMany, Model } = DS;
 
 const Person = Model.extend({
   name: attr('string'),
@@ -99,7 +98,7 @@ Boat.toString = function() {
 };
 
 const Bike = Model.extend({
-  name: DS.attr(),
+  name: attr(),
 });
 Bike.toString = function() {
   return 'Bike';
@@ -681,7 +680,7 @@ module('integration/unload - Unloading Records', function(hooks) {
     );
   });
 
-  test('unloading a disconnected subgraph clears the relevant internal models', function(assert) {
+  test('unloading a disconnected subgraph clears the relevant internal models', async function(assert) {
     adapter.shouldBackgroundReloadRecord = () => false;
 
     run(() => {
@@ -740,9 +739,9 @@ module('integration/unload - Unloading Records', function(hooks) {
 
     assert.equal(store._internalModelsFor('person').models.length, 1, 'one person record is loaded');
     assert.equal(store._internalModelsFor('boat').models.length, 2, 'two boat records are loaded');
-    assert.equal(store.hasRecordForId('person', 1), true);
-    assert.equal(store.hasRecordForId('boat', 1), true);
-    assert.equal(store.hasRecordForId('boat', 2), true);
+    assert.equal(store.hasRecordForId('person', 1), true, 'we have person 1');
+    assert.equal(store.hasRecordForId('boat', 1), true, 'we have boat 1');
+    assert.equal(store.hasRecordForId('boat', 2), true, 'we have boat 2');
 
     let checkOrphanCalls = 0;
     let cleanupOrphanCalls = 0;
@@ -768,22 +767,17 @@ module('integration/unload - Unloading Records', function(hooks) {
     countOrphanCalls(store.peekRecord('boat', 2));
 
     // make sure relationships are initialized
-    return store
-      .peekRecord('person', 1)
-      .get('boats')
-      .then(() => {
-        run(() => {
-          store.peekRecord('person', 1).unloadRecord();
-          store.peekRecord('boat', 1).unloadRecord();
-          store.peekRecord('boat', 2).unloadRecord();
-        });
+    await store.peekRecord('person', 1).get('boats');
+    store.peekRecord('person', 1).unloadRecord();
+    store.peekRecord('boat', 1).unloadRecord();
+    store.peekRecord('boat', 2).unloadRecord();
+    await settled();
 
-        assert.equal(store._internalModelsFor('person').models.length, 0);
-        assert.equal(store._internalModelsFor('boat').models.length, 0);
+    assert.equal(store._internalModelsFor('person').models.length, 0, 'no more internal models for person');
+    assert.equal(store._internalModelsFor('boat').models.length, 0, 'no more internal models for boat');
 
-        assert.equal(checkOrphanCalls, 3, 'each internalModel checks for cleanup');
-        assert.equal(cleanupOrphanCalls, 3, 'each model data tries to cleanup');
-      });
+    assert.equal(checkOrphanCalls, 3, 'each internalModel checks for cleanup');
+    assert.equal(cleanupOrphanCalls, 3, 'each model data tries to cleanup');
   });
 
   test('Unloading a record twice only schedules destroy once', function(assert) {

--- a/packages/-ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/integration/relationships/belongs-to-test.js
@@ -3,23 +3,18 @@ import { run } from '@ember/runloop';
 import { setupContext, teardownContext } from '@ember/test-helpers';
 
 import { module, test } from 'qunit';
-import RSVP, { resolve } from 'rsvp';
+import RSVP, { hash, resolve } from 'rsvp';
 
-import DS from 'ember-data';
-import { setupTest } from 'ember-qunit';
+import { setupTest, skip } from 'ember-qunit';
 
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { IDENTIFIERS } from '@ember-data/canary-features';
-import Model from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { RecordData, relationshipsFor, relationshipStateFor } from '@ember-data/record-data/-private';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import Store from '@ember-data/store';
 import { identifierCacheFor, recordDataFor } from '@ember-data/store/-private';
 import testInDebug from '@ember-data/unpublished-test-infra/test-support/test-in-debug';
-
-const { attr: DSattr, hasMany: DShasMany, belongsTo: DSbelongsTo } = DS;
-const { hash } = RSVP;
-const { attr, belongsTo } = DS;
 
 let store, User, Message, Post, Comment, Book, Book1, Chapter, Author, Section;
 
@@ -190,49 +185,49 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
   setupTest(hooks);
 
   hooks.beforeEach(function() {
-    User = DS.Model.extend({
-      name: DSattr('string'),
-      messages: DShasMany('message', { polymorphic: true, async: false }),
-      favouriteMessage: DSbelongsTo('message', { polymorphic: true, inverse: null, async: false }),
+    User = Model.extend({
+      name: attr('string'),
+      messages: hasMany('message', { polymorphic: true, async: false }),
+      favouriteMessage: belongsTo('message', { polymorphic: true, inverse: null, async: false }),
     });
 
-    Message = DS.Model.extend({
-      user: DSbelongsTo('user', { inverse: 'messages', async: false }),
-      created_at: DSattr('date'),
+    Message = Model.extend({
+      user: belongsTo('user', { inverse: 'messages', async: false }),
+      created_at: attr('date'),
     });
 
     Post = Message.extend({
-      title: DSattr('string'),
-      comments: DShasMany('comment', { async: false, inverse: null }),
+      title: attr('string'),
+      comments: hasMany('comment', { async: false, inverse: null }),
     });
 
     Comment = Message.extend({
-      body: DS.attr('string'),
-      message: DS.belongsTo('message', { polymorphic: true, async: false, inverse: null }),
+      body: attr('string'),
+      message: belongsTo('message', { polymorphic: true, async: false, inverse: null }),
     });
 
-    Book = DS.Model.extend({
-      name: DSattr('string'),
-      author: DSbelongsTo('author', { async: false }),
-      chapters: DShasMany('chapters', { async: false, inverse: 'book' }),
+    Book = Model.extend({
+      name: attr('string'),
+      author: belongsTo('author', { async: false }),
+      chapters: hasMany('chapters', { async: false, inverse: 'book' }),
     });
 
-    Book1 = DS.Model.extend({
-      name: DSattr('string'),
+    Book1 = Model.extend({
+      name: attr('string'),
     });
 
-    Chapter = DS.Model.extend({
-      title: DSattr('string'),
-      book: DSbelongsTo('book', { async: false, inverse: 'chapters' }),
+    Chapter = Model.extend({
+      title: attr('string'),
+      book: belongsTo('book', { async: false, inverse: 'chapters' }),
     });
 
-    Author = DS.Model.extend({
-      name: DSattr('string'),
-      books: DShasMany('books', { async: false }),
+    Author = Model.extend({
+      name: attr('string'),
+      books: hasMany('books', { async: false }),
     });
 
-    Section = DS.Model.extend({
-      name: DSattr('string'),
+    Section = Model.extend({
+      name: attr('string'),
     });
 
     this.owner.register('model:user', User);
@@ -250,7 +245,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
     this.owner.register(
       'serializer:user',
-      DS.JSONAPISerializer.extend({
+      JSONAPISerializer.extend({
         attrs: {
           favouriteMessage: { embedded: 'always' },
         },
@@ -271,15 +266,15 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
   test('returning a null relationship from payload sets the relationship to null on both sides', function(assert) {
     this.owner.register(
       'model:app',
-      DS.Model.extend({
-        name: DSattr('string'),
-        team: DSbelongsTo('team', { async: true }),
+      Model.extend({
+        name: attr('string'),
+        team: belongsTo('team', { async: true }),
       })
     );
     this.owner.register(
       'model:team',
-      DS.Model.extend({
-        apps: DShasMany('app', { async: true }),
+      Model.extend({
+        apps: hasMany('app', { async: true }),
       })
     );
 
@@ -372,7 +367,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     let adapter = store.adapterFor('application');
 
     store.modelFor('post').reopen({
-      user: DS.belongsTo('user', {
+      user: belongsTo('user', {
         async: true,
         inverse: 'messages',
       }),
@@ -648,12 +643,12 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
     adapter.shouldBackgroundReloadRecord = () => false;
 
-    let Group = DS.Model.extend({
-      people: DS.hasMany('person', { async: false }),
+    let Group = Model.extend({
+      people: hasMany('person', { async: false }),
     });
 
-    let Person = DS.Model.extend({
-      group: DS.belongsTo({ async: true }),
+    let Person = Model.extend({
+      group: belongsTo({ async: true }),
     });
 
     this.owner.register('model:group', Group);
@@ -716,12 +711,12 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
     adapter.shouldBackgroundReloadRecord = () => false;
 
-    let Seat = DS.Model.extend({
-      person: DS.belongsTo('person', { async: false }),
+    let Seat = Model.extend({
+      person: belongsTo('person', { async: false }),
     });
 
-    let Person = DS.Model.extend({
-      seat: DS.belongsTo('seat', { async: true }),
+    let Person = Model.extend({
+      seat: belongsTo('seat', { async: true }),
     });
 
     this.owner.register('model:seat', Seat);
@@ -771,12 +766,12 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
     adapter.shouldBackgroundReloadRecord = () => false;
 
-    let Group = DS.Model.extend({
-      people: DS.hasMany('person', { async: false }),
+    let Group = Model.extend({
+      people: hasMany('person', { async: false }),
     });
 
-    let Person = DS.Model.extend({
-      group: DS.belongsTo({ async: true }),
+    let Person = Model.extend({
+      group: belongsTo({ async: true }),
     });
 
     this.owner.register('model:group', Group);
@@ -824,12 +819,12 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
     adapter.shouldBackgroundReloadRecord = () => false;
 
-    let Group = DS.Model.extend({
-      people: DS.hasMany('person', { async: false }),
+    let Group = Model.extend({
+      people: hasMany('person', { async: false }),
     });
 
-    let Person = DS.Model.extend({
-      group: DS.belongsTo({ async: true }),
+    let Person = Model.extend({
+      group: belongsTo({ async: true }),
     });
 
     this.owner.register('model:group', Group);
@@ -934,14 +929,14 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     let adapter = store.adapterFor('application');
 
     store.modelFor('post').reopen({
-      comments: DS.hasMany('comment', {
+      comments: hasMany('comment', {
         async: true,
         inverse: 'post',
       }),
     });
 
     store.modelFor('comment').reopen({
-      post: DS.belongsTo('post', { async: false }),
+      post: belongsTo('post', { async: false }),
     });
 
     let comment;
@@ -1013,13 +1008,13 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     let post;
 
     store.modelFor('message').reopen({
-      user: DS.hasMany('user', {
+      user: hasMany('user', {
         async: true,
       }),
     });
 
     store.modelFor('post').reopen({
-      user: DS.belongsTo('user', {
+      user: belongsTo('user', {
         async: true,
         inverse: 'messages',
       }),
@@ -1100,7 +1095,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
   test('Rollbacking attributes for a deleted record restores implicit relationship - async', function(assert) {
     Book.reopen({
-      author: DS.belongsTo('author', { async: true }),
+      author: belongsTo('author', { async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1190,10 +1185,10 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.expect(1);
 
     assert.expectAssertion(() => {
-      User = DS.Model.extend();
+      User = Model.extend();
 
-      DS.Model.extend({
-        user: DSbelongsTo(User, { async: false }),
+      Model.extend({
+        user: belongsTo(User, { async: false }),
       });
     }, /The first argument to belongsTo must be a string/);
   });
@@ -1202,7 +1197,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.expect(1);
 
     Book.reopen({
-      author: DSbelongsTo('author', { async: true }),
+      author: belongsTo('author', { async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1260,7 +1255,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.expect(1);
 
     Book.reopen({
-      author: DSbelongsTo('author', { async: true }),
+      author: belongsTo('author', { async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1315,7 +1310,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.expect(2);
 
     Book.reopen({
-      author: DSbelongsTo('author', { async: true }),
+      author: belongsTo('author', { async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1425,7 +1420,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.expect(3);
 
     Book.reopen({
-      author: DS.belongsTo('author', { async: true }),
+      author: belongsTo('author', { async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1468,7 +1463,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.expect(2);
 
     Book.reopen({
-      author: DS.belongsTo('author', { async: true }),
+      author: belongsTo('author', { async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1513,7 +1508,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.expect(1);
 
     Book.reopen({
-      author: DS.belongsTo('author', { async: true }),
+      author: belongsTo('author', { async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1563,7 +1558,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.expect(3);
 
     Book.reopen({
-      author: DS.belongsTo('author', { async: true }),
+      author: belongsTo('author', { async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1625,7 +1620,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.expect(4);
 
     Book.reopen({
-      author: DS.belongsTo('author', { async: true }),
+      author: belongsTo('author', { async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1705,7 +1700,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.expect(2);
 
     Book.reopen({
-      author: DS.belongsTo('author', { async: true }),
+      author: belongsTo('author', { async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1773,7 +1768,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
   test('A belongsTo relationship can be reloaded using the reference if it was fetched via link', function(assert) {
     Chapter.reopen({
-      book: DS.belongsTo({ async: true }),
+      book: belongsTo({ async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1836,7 +1831,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
   test('A synchronous belongsTo relationship can be reloaded using a reference if it was fetched via id', function(assert) {
     Chapter.reopen({
-      book: DS.belongsTo({ async: false }),
+      book: belongsTo({ async: false }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1891,7 +1886,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
   test('A belongsTo relationship can be reloaded using a reference if it was fetched via id', function(assert) {
     Chapter.reopen({
-      book: DS.belongsTo({ async: true }),
+      book: belongsTo({ async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -1969,7 +1964,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
   test("belongsTo relationship with links doesn't trigger extra change notifications - #4942", function(assert) {
     Chapter.reopen({
-      book: DS.belongsTo({ async: true }),
+      book: belongsTo({ async: true }),
     });
 
     let store = this.owner.lookup('service:store');
@@ -2004,12 +1999,10 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     assert.equal(count, 0);
   });
 
-  test("belongsTo relationship doesn't trigger when model data doesn't support implicit relationship", function(assert) {
+  skip("belongsTo relationship doesn't trigger when model data doesn't support implicit relationship", function(assert) {
     class TestRecordData extends RecordData {
       constructor(...args) {
         super(...args);
-        delete this.__implicitRelationships;
-        delete this.__relationships;
       }
 
       _destroyRelationships() {}
@@ -2026,20 +2019,13 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
         this.isDestroyed = true;
         this.storeWrapper.disconnectRecord(this.modelName, this.id, this.clientId);
       }
-
-      get _implicitRelationships() {
-        return undefined;
-      }
-      get _relationships() {
-        return undefined;
-      }
     }
 
     Chapter.reopen({
       // book is still an inverse from prior to the reopen
-      sections: DS.hasMany('section', { async: false }),
-      book1: DS.belongsTo('book1', { async: false, inverse: 'chapters' }), // incorrect inverse
-      book2: DS.belongsTo('book1', { async: false, inverse: null }), // correct inverse
+      sections: hasMany('section', { async: false }),
+      book1: belongsTo('book1', { async: false, inverse: 'chapters' }), // incorrect inverse
+      book2: belongsTo('book1', { async: false, inverse: null }), // correct inverse
     });
 
     let store = this.owner.lookup('service:store');
@@ -2101,7 +2087,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     // Expect assertion failure as Book1 RecordData
     // doesn't have relationship attribute
     // and inverse is not set to null in
-    // DSbelongsTo
+    // belongsTo
     assert.expectAssertion(() => {
       run(() => {
         store.push(data);
@@ -2112,9 +2098,9 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
     // with inverse set to null
     // no errors thrown
     Chapter.reopen({
-      book1: DS.belongsTo({ async: false }),
-      sections: DS.hasMany('section', { async: false }),
-      book: DS.belongsTo({ async: false, inverse: null }),
+      book1: belongsTo({ async: false }),
+      sections: hasMany('section', { async: false }),
+      book: belongsTo({ async: false, inverse: null }),
     });
 
     run(() => {

--- a/packages/record-data/addon/-private/index.ts
+++ b/packages/record-data/addon/-private/index.ts
@@ -2,4 +2,5 @@ export { default as RecordData } from './record-data';
 export { default as Relationship } from './relationships/state/relationship';
 export { default as BelongsToRelationship } from './relationships/state/belongs-to';
 export { default as ManyRelationship } from './relationships/state/has-many';
-export { relationshipStateFor, relationshipsFor } from './record-data-for';
+export { relationshipStateFor, implicitRelationshipsFor, relationshipsFor } from './record-data-for';
+export { peekGraph } from './relationships/state/graph';

--- a/packages/record-data/addon/-private/record-data-for.ts
+++ b/packages/record-data/addon/-private/record-data-for.ts
@@ -1,28 +1,54 @@
-import { recordDataFor } from '@ember-data/store/-private';
+import { upgradeForInternal } from '@ember-data/store/-private';
+
+import { graphFor } from './relationships/state/graph';
 
 type RelationshipRecordData = import('./ts-interfaces/relationship-record-data').RelationshipRecordData;
-type ConfidentDict<T> = import('@ember-data/store/-private/ts-interfaces/utils').ConfidentDict<T>;
-type ManyRelationship = import('./relationships/state/has-many').default;
-type BelongsToRelationship = import('./relationships/state/belongs-to').default;
 type Relationship = import('./relationships/state/relationship').default;
+type ManyRelationship = import('./relationships/state/has-many').default;
 type Relationships = import('./relationships/state/create').default;
+type InternalModel = import('@ember-data/store/-private').InternalModel;
+type BelongsToRelationship = import('./relationships/state/belongs-to').default;
+type RecordDataStoreWrapper = import('@ember-data/store/-private/system/store/record-data-store-wrapper').default;
+type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
+type RelationshipDict = import('@ember-data/store/-private/ts-interfaces/utils').ConfidentDict<Relationship>;
 
-export function relationshipsFor(instance: any): Relationships {
-  let recordData = (recordDataFor(instance) || instance) as RelationshipRecordData;
-
-  return recordData._relationships;
+export function relationshipsFor(
+  storeWrapper: RecordDataStoreWrapper,
+  identifier: StableRecordIdentifier
+): Relationships {
+  if (!identifier) {
+    let internalModel = ((storeWrapper as unknown) as { _internalModel: InternalModel })._internalModel;
+    identifier = internalModel.identifier;
+    storeWrapper = upgradeForInternal((internalModel._recordData as RelationshipRecordData).storeWrapper);
+  }
+  return graphFor(storeWrapper).get(identifier);
 }
 
-export function relationshipStateFor(instance: any, propertyName: string): BelongsToRelationship | ManyRelationship {
-  return relationshipsFor(instance).get(propertyName);
+export function relationshipStateFor(
+  storeWrapper: RecordDataStoreWrapper,
+  identifier: StableRecordIdentifier,
+  propertyName: string
+): BelongsToRelationship | ManyRelationship {
+  if (!propertyName) {
+    let internalModel = ((storeWrapper as unknown) as { _internalModel: InternalModel })._internalModel;
+    propertyName = (identifier as unknown) as string;
+    identifier = internalModel.identifier;
+    storeWrapper = upgradeForInternal((internalModel._recordData as RelationshipRecordData).storeWrapper);
+  }
+  return relationshipsFor(storeWrapper, identifier).get(propertyName);
 }
 
-export function implicitRelationshipsFor(instance: any): ConfidentDict<Relationship> {
-  let recordData = (recordDataFor(instance) || instance) as RelationshipRecordData;
-
-  return recordData._implicitRelationships;
+export function implicitRelationshipsFor(
+  storeWrapper: RecordDataStoreWrapper,
+  identifier: StableRecordIdentifier
+): RelationshipDict {
+  return graphFor(storeWrapper).getImplicit(identifier);
 }
 
-export function implicitRelationshipStateFor(instance: any, propertyName: string): Relationship {
-  return implicitRelationshipsFor(instance)[propertyName];
+export function implicitRelationshipStateFor(
+  storeWrapper: RecordDataStoreWrapper,
+  identifier: StableRecordIdentifier,
+  propertyName: string
+): Relationship {
+  return implicitRelationshipsFor(storeWrapper, identifier)[propertyName];
 }

--- a/packages/record-data/addon/-private/relationships/state/create.ts
+++ b/packages/record-data/addon/-private/relationships/state/create.ts
@@ -1,39 +1,35 @@
-import { upgradeForInternal } from '@ember-data/store/-private';
-
 import BelongsToRelationship from './belongs-to';
 import ManyRelationship from './has-many';
 
-type CoreStore = import('@ember-data/store/-private/system/core-store').default;
-type RecordDataStoreWrapper = import('@ember-data/store/-private').RecordDataStoreWrapper;
 type RelationshipSchema = import('@ember-data/store/-private/ts-interfaces/record-data-schemas').RelationshipSchema;
-type RelationshipRecordData = import('../../ts-interfaces/relationship-record-data').RelationshipRecordData;
+type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
+type RecordDataStoreWrapper = import('@ember-data/store/-private/ts-interfaces/record-data-store-wrapper').RecordDataStoreWrapper;
+type Graph = import('./graph').Graph;
 
 function createRelationshipFor(
   relationshipMeta: RelationshipSchema,
-  store: CoreStore,
-  recordData: RelationshipRecordData,
+  storeWrapper: RecordDataStoreWrapper,
+  identifier: StableRecordIdentifier,
   key: string
 ) {
-  let inverseKey = recordData.storeWrapper.inverseForRelationship(recordData.modelName, key);
-  let inverseIsAsync = recordData.storeWrapper.inverseIsAsyncForRelationship(recordData.modelName, key);
+  let inverseKey = storeWrapper.inverseForRelationship(identifier.type, key);
+  let inverseIsAsync = storeWrapper.inverseIsAsyncForRelationship(identifier.type, key);
 
   if (relationshipMeta.kind === 'hasMany') {
-    return new ManyRelationship(store, inverseKey, relationshipMeta, recordData, inverseIsAsync);
+    return new ManyRelationship(storeWrapper, inverseKey, relationshipMeta, identifier, inverseIsAsync);
   } else {
-    return new BelongsToRelationship(store, inverseKey, relationshipMeta, recordData, inverseIsAsync);
+    return new BelongsToRelationship(storeWrapper, inverseKey, relationshipMeta, identifier, inverseIsAsync);
   }
 }
 
 export default class Relationships {
-  _store: CoreStore;
-  _storeWrapper: RecordDataStoreWrapper;
+  private _storeWrapper: RecordDataStoreWrapper;
   initializedRelationships: {
     [key: string]: BelongsToRelationship | ManyRelationship;
   };
-  constructor(public recordData: RelationshipRecordData) {
+  constructor(public graph: Graph, public identifier: StableRecordIdentifier) {
     this.initializedRelationships = Object.create(null);
-    this._storeWrapper = upgradeForInternal(recordData.storeWrapper);
-    this._store = this._storeWrapper._store;
+    this._storeWrapper = graph.storeWrapper;
   }
 
   has(key: string) {
@@ -52,11 +48,10 @@ export default class Relationships {
     let relationship = relationships[key];
 
     if (!relationship) {
-      let recordData = this.recordData;
-      let rel = this.recordData.storeWrapper.relationshipsDefinitionFor(this.recordData.modelName)[key];
+      let rel = this._storeWrapper.relationshipsDefinitionFor(this.identifier.type)[key];
 
       if (rel) {
-        relationship = relationships[key] = createRelationshipFor(rel, this._store, recordData, key);
+        relationship = relationships[key] = createRelationshipFor(rel, this._storeWrapper, this.identifier, key);
       }
     }
 

--- a/packages/record-data/addon/-private/relationships/state/graph.ts
+++ b/packages/record-data/addon/-private/relationships/state/graph.ts
@@ -1,0 +1,123 @@
+import Relationships from './create';
+
+type Relationship = import('./relationship').default;
+type JsonApiRelationship = import('@ember-data/store/-private/ts-interfaces/record-data-json-api').JsonApiRelationship;
+type RecordDataStoreWrapper = import('@ember-data/store/-private/system/store/record-data-store-wrapper').default;
+type RelationshipDict = import('@ember-data/store/-private/ts-interfaces/utils').ConfidentDict<Relationship>;
+type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
+
+const Graphs = new WeakMap<RecordDataStoreWrapper, Graph>();
+
+export function peekGraph(store: RecordDataStoreWrapper): Graph | undefined {
+  return Graphs.get(store);
+}
+
+export function graphFor(store: RecordDataStoreWrapper): Graph {
+  let graph = Graphs.get(store);
+  if (graph === undefined) {
+    graph = new Graph(store);
+    Graphs.set(store, graph);
+  }
+  return graph;
+}
+
+export class Graph {
+  _queued: { belongsTo: any[]; hasMany: any[] } = { belongsTo: [], hasMany: [] };
+  _nextFlush: boolean = false;
+  identifiers: Map<StableRecordIdentifier, Relationships> = new Map();
+  implicitMap: Map<StableRecordIdentifier, RelationshipDict> = new Map();
+  constructor(public storeWrapper: RecordDataStoreWrapper) {}
+
+  get(identifier: StableRecordIdentifier): Relationships {
+    let relationships = this.identifiers.get(identifier);
+
+    if (relationships === undefined) {
+      relationships = new Relationships(this, identifier);
+      this.identifiers.set(identifier, relationships);
+    }
+
+    return relationships;
+  }
+
+  getImplicit(identifier: StableRecordIdentifier): RelationshipDict {
+    let relationships = this.implicitMap.get(identifier);
+
+    if (relationships === undefined) {
+      relationships = Object.create(null) as RelationshipDict;
+      this.implicitMap.set(identifier, relationships);
+    }
+
+    return relationships;
+  }
+
+  unload(identifier: StableRecordIdentifier) {
+    const relationships = this.identifiers.get(identifier);
+
+    if (relationships) {
+      // in an unload we go further
+      // cleanup doesn't mean the graph is invalid
+      relationships.forEach((name, rel) => destroyRelationship(rel));
+    }
+
+    const implicit = this.implicitMap.get(identifier);
+    if (implicit) {
+      Object.keys(implicit).forEach(key => {
+        let rel = implicit[key];
+        destroyRelationship(rel);
+      });
+    }
+  }
+
+  push(identifier: StableRecordIdentifier, propertyName: string, payload: JsonApiRelationship) {
+    const relationship = this.get(identifier).get(propertyName);
+    const backburner = this.storeWrapper._store._backburner;
+
+    this._queued[relationship.kind].push(relationship, payload);
+    if (this._nextFlush === false) {
+      backburner.join(() => {
+        // TODO this join seems to only be necessary for
+        // some older style tests (causes 7 failures if removed)
+        backburner.schedule('flushRelationships', this, this.flush);
+      });
+      this._nextFlush = true;
+    }
+  }
+
+  flush() {
+    this._nextFlush = false;
+    const { belongsTo, hasMany } = this._queued;
+    this._queued = { belongsTo: [], hasMany: [] };
+    for (let i = 0; i < hasMany.length; i += 2) {
+      hasMany[i].push(hasMany[i + 1]);
+    }
+    for (let i = 0; i < belongsTo.length; i += 2) {
+      belongsTo[i].push(belongsTo[i + 1]);
+    }
+  }
+
+  destroy() {
+    this.identifiers.clear();
+    this.implicitMap.clear();
+    Graphs.delete(this.storeWrapper);
+    this.storeWrapper = (null as unknown) as RecordDataStoreWrapper;
+  }
+}
+
+// Handle dematerialization for relationship `rel`.  In all cases, notify the
+// relationship of the dematerialization: this is done so the relationship can
+// notify its inverse which needs to update state
+//
+// If the inverse is sync, unloading this record is treated as a client-side
+// delete, so we remove the inverse records from this relationship to
+// disconnect the graph.  Because it's not async, we don't need to keep around
+// the internalModel as an id-wrapper for references and because the graph is
+// disconnected we can actually destroy the internalModel when checking for
+// orphaned models.
+function destroyRelationship(rel) {
+  rel.identifierDidDematerialize();
+
+  if (rel._inverseIsSync()) {
+    rel.removeAllIdentifiersFromOwn();
+    rel.removeAllCanonicalIdentifiersFromOwn();
+  }
+}

--- a/packages/record-data/addon/-private/ts-interfaces/relationship-record-data.ts
+++ b/packages/record-data/addon/-private/ts-interfaces/relationship-record-data.ts
@@ -1,16 +1,12 @@
-import {
-  CollectionResourceRelationship,
-  SingleResourceRelationship,
-} from '@ember-data/store/-private/ts-interfaces/ember-data-json-api';
-import { RecordData } from '@ember-data/store/-private/ts-interfaces/record-data';
-
-type ConfidentDict<T> = import('@ember-data/store/-private/ts-interfaces/utils').ConfidentDict<T>;
+type CollectionResourceRelationship = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').CollectionResourceRelationship;
+type SingleResourceRelationship = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').SingleResourceRelationship;
+type RecordData = import('@ember-data/store/-private/ts-interfaces/record-data').RecordData;
 type HasManyRelationship = import('../relationships/state/has-many').default;
-type BelongsToRelationship = import('../relationships/state/belongs-to').default;
-type RecordDataStoreWrapper = import('@ember-data/store/-private/ts-interfaces/record-data-store-wrapper').RecordDataStoreWrapper;
-type RecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').RecordIdentifier;
-type Relationship = import('../relationships/state/relationship').default;
 type Relationships = import('../relationships/state/create').default;
+type BelongsToRelationship = import('../relationships/state/belongs-to').default;
+type RecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').RecordIdentifier;
+type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
+type RecordDataStoreWrapper = import('@ember-data/store/-private/ts-interfaces/record-data-store-wrapper').RecordDataStoreWrapper;
 
 export interface DefaultSingleResourceRelationship extends SingleResourceRelationship {
   _relationship: BelongsToRelationship;
@@ -27,10 +23,9 @@ export interface RelationshipRecordData extends RecordData {
   id: string | null;
   clientId: string | null;
   isEmpty(): boolean;
+  identifier: StableRecordIdentifier;
   getResourceIdentifier(): RecordIdentifier;
   _relationships: Relationships;
-  _implicitRelationships: ConfidentDict<Relationship>;
-  __implicitRelationships: ConfidentDict<Relationship> | null;
   getBelongsTo(key: string): DefaultSingleResourceRelationship;
   getHasMany(key: string): DefaultCollectionResourceRelationship;
 }

--- a/packages/store/addon/-private/system/backburner.js
+++ b/packages/store/addon/-private/system/backburner.js
@@ -6,7 +6,7 @@ import { registerWaiter } from '@ember/test';
 import { DEBUG } from '@glimmer/env';
 import Ember from 'ember';
 
-const backburner = new Ember._Backburner(['normalizeRelationships', 'syncRelationships', 'finished']);
+const backburner = new Ember._Backburner(['flushRelationships', 'syncRelationships', 'finished']);
 
 if (DEBUG) {
   registerWaiter(() => {

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -56,7 +56,7 @@ import { getShimClass } from './model/shim-model-class';
 import normalizeModelName from './normalize-model-name';
 import { promiseArray, promiseObject } from './promise-proxies';
 import RecordArrayManager from './record-array-manager';
-import recordDataFor from './record-data-for';
+import recordDataFor, { setRecordDataFor } from './record-data-for';
 import NotificationManager from './record-notification-manager';
 import { RequestPromise } from './request-cache';
 import { _bind, _guard, _objectIsAlive, guardDestroyedStore } from './store/common';
@@ -229,7 +229,7 @@ abstract class CoreStore extends Service {
   public _notificationManager: NotificationManager;
   private _adapterCache = Object.create(null);
   private _serializerCache = Object.create(null);
-  private _storeWrapper = new RecordDataStoreWrapper(this);
+  public _storeWrapper = new RecordDataStoreWrapper(this);
 
   /*
     Ember Data uses several specialized micro-queues for organizing
@@ -3093,7 +3093,11 @@ abstract class CoreStore extends Service {
    * @internal
    */
   _createRecordData(identifier: StableRecordIdentifier): RecordData {
-    return this.createRecordDataFor(identifier.type, identifier.id, identifier.lid, this._storeWrapper);
+    const recordData = this.createRecordDataFor(identifier.type, identifier.id, identifier.lid, this._storeWrapper);
+
+    setRecordDataFor(identifier, recordData);
+
+    return recordData;
   }
 
   /**
@@ -3485,6 +3489,7 @@ abstract class CoreStore extends Service {
     identifierCacheFor(this).destroy();
 
     this.unloadAll();
+    this._storeWrapper.destroy();
 
     if (DEBUG) {
       unregisterWaiter(this.__asyncWaiter);

--- a/packages/store/addon/-private/system/record-data-for.ts
+++ b/packages/store/addon/-private/system/record-data-for.ts
@@ -1,4 +1,8 @@
+import { DEBUG } from '@glimmer/env';
+
+type StableRecordIdentifier = import('../ts-interfaces/identifier').StableRecordIdentifier;
 type RecordData = import('../ts-interfaces/record-data').RecordData;
+
 /*
  * Returns the RecordData instance associated with a given
  * Model or InternalModel.
@@ -16,14 +20,28 @@ interface InternalModel {
   _recordData: RecordData;
 }
 
+const IdentifierCache = new WeakMap<StableRecordIdentifier, RecordData>();
+
+export function setRecordDataFor(identifier: StableRecordIdentifier, recordData: RecordData) {
+  if (DEBUG) {
+    if (IdentifierCache.has(identifier)) {
+      throw new Error(`Illegal set of identifier`);
+    }
+  }
+  IdentifierCache.set(identifier, recordData);
+}
+
 type DSModelOrSnapshot = { _internalModel: InternalModel };
 type Reference = { internalModel: InternalModel };
 
-type Instance = InternalModel | RecordData | DSModelOrSnapshot | Reference;
+type Instance = InternalModel | RecordData | DSModelOrSnapshot | Reference | StableRecordIdentifier;
 
 export default function recordDataFor(instance: Instance): RecordData;
 export default function recordDataFor(instance: object): null;
 export default function recordDataFor(instance: Instance | object): RecordData | null {
+  if (IdentifierCache.has(instance as StableRecordIdentifier)) {
+    return IdentifierCache.get(instance as StableRecordIdentifier) as RecordData;
+  }
   let internalModel =
     (instance as DSModelOrSnapshot)._internalModel || (instance as Reference).internalModel || instance;
 

--- a/packages/store/addon/-private/system/references/belongs-to.js
+++ b/packages/store/addon/-private/system/references/belongs-to.js
@@ -5,7 +5,6 @@ import { resolve } from 'rsvp';
 import { DEPRECATE_BELONGS_TO_REFERENCE_PUSH } from '@ember-data/private-build-infra/deprecations';
 import { assertPolymorphicType } from '@ember-data/store/-debug';
 
-import recordDataFor from '../record-data-for';
 import { peekRecordIdentifier } from '../store/internal-model-factory';
 import Reference from './reference';
 
@@ -151,7 +150,7 @@ export default class BelongsToReference extends Reference {
       );
 
       //TODO Igor cleanup, maybe move to relationship push
-      this.belongsToRelationship.setCanonicalRecordData(recordDataFor(record));
+      this.belongsToRelationship.setCanonicalIdentifier(peekRecordIdentifier(record));
 
       return record;
     });

--- a/packages/store/addon/-private/system/references/has-many.js
+++ b/packages/store/addon/-private/system/references/has-many.js
@@ -189,7 +189,7 @@ export default class HasManyReference extends Reference {
         return recordDataFor(record);
       });
 
-      this.hasManyRelationship.computeChanges(internalModels);
+      this.hasManyRelationship.computeChanges(internalModels.map(i => i.identifier));
 
       return this.internalModel.getHasMany(this.hasManyRelationship.key);
       // TODO IGOR it seems wrong that we were returning the many array here
@@ -206,9 +206,9 @@ export default class HasManyReference extends Reference {
     let members = this.hasManyRelationship.members.toArray();
 
     //TODO Igor cleanup
-    return members.every(recordData => {
+    return members.every(identifier => {
       let store = this.parentInternalModel.store;
-      let internalModel = store._internalModelForResource(recordData.getResourceIdentifier());
+      let internalModel = store._internalModelForResource(identifier);
       return internalModel.isLoaded() === true;
     });
   }

--- a/packages/store/addon/-private/ts-interfaces/record-data-store-wrapper.ts
+++ b/packages/store/addon/-private/ts-interfaces/record-data-store-wrapper.ts
@@ -1,5 +1,7 @@
 import { BRAND_SYMBOL } from './utils/brand';
 
+type RecordData = import('./record-data').RecordData;
+type RelationshipRecordData = import('@ember-data/record-data/-private/ts-interfaces/relationship-record-data').RelationshipRecordData;
 type RelationshipsSchema = import('./record-data-schemas').RelationshipsSchema;
 type AttributesSchema = import('./record-data-schemas').AttributesSchema;
 
@@ -40,7 +42,9 @@ export interface RecordDataStoreWrapper {
   notifyHasManyChange(modelName: string, id: string, clientId: string | null | undefined, key: string): void;
   notifyHasManyChange(modelName: string, id: string | null, clientId: string | null | undefined, key: string): void;
 
-  recordDataFor(modelName: string, id: string, clientId?: string): unknown;
+  recordDataFor(modelName: string, id: string, clientId?: null | string): RecordData | RelationshipRecordData;
+  recordDataFor(modelName: string, id: null, clientId: string): RecordData | RelationshipRecordData;
+  recordDataFor(modelName: string, id: string | null, clientId?: null | string): RecordData | RelationshipRecordData;
 
   notifyBelongsToChange(modelName: string, id: string | null, clientId: string, key: string): void;
   notifyBelongsToChange(modelName: string, id: string, clientId: string | null | undefined, key: string): void;

--- a/packages/unpublished-relationship-performance-test-app/app/serializers/application.js
+++ b/packages/unpublished-relationship-performance-test-app/app/serializers/application.js
@@ -1,7 +1,8 @@
-import DS from 'ember-data';
-
-export default DS.JSONAPISerializer.extend({
-  normalizeResponse(store, primaryModelClass, payload) {
+export default class Serializer {
+  normalizeResponse(_, __, payload) {
     return payload;
-  },
-});
+  }
+  static create() {
+    return new this();
+  }
+}


### PR DESCRIPTION
Refactors the internals of our relationship layer to use identifiers and avoid RecordData while keeping the API 1:1. This will allow us to refactor the relationship layer more substantially more neatly.

The ultimate goal for Project Trim is to disentangle the relationship layer enough that we can disentangle more of the relationship fetch logic from the store more easily as well as simplify the path for landing Singleton RecordData.

The ultimate goal for the Relationship Refactor is to speed up the relationship layer. While this does provide a boost, we still spend close to 700ms in relationship setup codepaths that are unneeded on the performance benchmark.