### PR TITLE
Make rollup warnings build errors.

### DIFF
--- a/packages/private-build-infra/src/addon-build-config-for-data-package.js
+++ b/packages/private-build-infra/src/addon-build-config-for-data-package.js
@@ -45,35 +45,28 @@ function addonBuildConfigForDataPackage(PackageName) {
       }
     },
 
-    _suppressUneededRollupWarnings(message, next) {
+    _handleRollupWarning(message) {
       if (message.code === 'CIRCULAR_DEPENDENCY') {
         return;
-      } else if (message.code === 'NON_EXISTENT_EXPORT') {
+      } else if (message.code === 'NON_EXISTENT_EXPORT' && message.message.includes('ts-interfaces')) {
         // ignore ts-interface imports
-        if (message.message.indexOf(`/ts-interfaces/`) !== -1) {
-          return;
-        }
-      } else if (message.code === 'UNRESOLVED_IMPORT') {
-        if (!this.isDevelopingAddon()) {
-          // don't print these for consumers
-          return;
-        } else {
-          const chalk = require('chalk');
-          // make warning actionable
-          // eslint-disable-next-line no-console
-          console.log(
-            chalk.yellow(
-              `\n\n⚠️  Add ${chalk.white(
-                message.source
-              )} to the array returned by externalDependenciesForPrivateModule in index.js of ${chalk.white(
-                this.name
-              )}\n\n`
-            )
-          );
-          throw message.message;
-        }
+        return;
+      } else {
+        const chalk = require('chalk');
+        // make warning actionable
+        // eslint-disable-next-line no-console
+        console.log(
+          chalk.yellow(
+            `\n\n⚠️  Add ${chalk.white(
+              message.source
+            )} to the array returned by externalDependenciesForPrivateModule in index.js of ${chalk.white(
+              this.name
+            )}\n\n`
+          )
+        );
+
+        throw message.message;
       }
-      next(message);
     },
 
     getOutputDirForVersion() {
@@ -141,7 +134,7 @@ function addonBuildConfigForDataPackage(PackageName) {
         packageName: PackageName,
         babelCompiler: babel,
         babelOptions: this.options.babel,
-        onWarn: this._suppressUneededRollupWarnings.bind(this),
+        onWarn: this._handleRollupWarning.bind(this),
         externalDependencies: this.externalDependenciesForPrivateModule(),
         destDir: this.getOutputDirForVersion(),
       });


### PR DESCRIPTION
This will ensure that all messages that are emitted to the console by rollup trigger a build failure and therefore prevent landing any changes to Ember Data that would introduce such a warning.

Follow up to https://github.com/emberjs/data/pull/6809#discussion_r350961572