### PR TITLE
Revert "Bump broccoli-merge-trees from 3.0.2 to 4.0.0"

### DIFF
--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -32,7 +32,7 @@
     "@ember/edition-utils": "^1.1.1",
     "@ember/ordered-set": "^2.0.3",
     "@glimmer/env": "^0.1.7",
-    "broccoli-merge-trees": "^4.0.0",
+    "broccoli-merge-trees": "^3.0.2",
     "ember-cli-babel": "^7.13.0",
     "ember-cli-typescript": "^3.1.1",
     "ember-inflector": "^3.0.1"

--- a/packages/private-build-infra/package.json
+++ b/packages/private-build-infra/package.json
@@ -23,7 +23,7 @@
     "broccoli-debug": "^0.6.5",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-funnel": "^3.0.0",
-    "broccoli-merge-trees": "^4.0.0",
+    "broccoli-merge-trees": "^3.0.2",
     "broccoli-rollup": "^4.1.1",
     "calculate-cache-key-for-tree": "^2.0.0",
     "chalk": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,14 +4229,6 @@ broccoli-merge-trees@^3.0.0, broccoli-merge-trees@^3.0.1, broccoli-merge-trees@^
     broccoli-plugin "^1.3.0"
     merge-trees "^2.0.0"
 
-broccoli-merge-trees@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.0.0.tgz#57c7993cc74bf16efed8df7a5188a0202a70216d"
-  integrity sha512-FJ1dTqxzDmpqbQFxuhicPbA6URV0D1XCKHFIvKwi6Y70pxuYLMpyRfjNv6iNSwSq/juxGubunKiLb8U2dM+a2A==
-  dependencies:
-    broccoli-plugin "^3.1.0"
-    merge-trees "^2.0.0"
-
 broccoli-middleware@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/broccoli-middleware/-/broccoli-middleware-2.1.0.tgz#cbb458cb6360bdd79aa75a54057f10fe918157e6"


### PR DESCRIPTION
Reverts emberjs/data#6863

This version drops support for Node 8, ember-data cannot upgrade until it is also ready to drop support (likely about a month from now...). CI in that PR passed because we do not actually run any CI jobs in Node 8 (maybe we should?).