### PR TITLE
Revert dependency updates requiring Node 10+.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "babel-plugin-filter-imports": "^4.0.0",
     "babel6-plugin-strip-class-callcheck": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
-    "broccoli-concat": "^4.2.0",
+    "broccoli-concat": "^3.7.5",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-stew": "^3.0.0",
     "broccoli-string-replace": "^0.1.2",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -50,7 +50,7 @@
     "@types/ember__test-helpers": "~0.7.9",
     "@types/qunit": "^2.5.3",
     "@types/rsvp": "^4.0.3",
-    "broccoli-concat": "^4.2.0",
+    "broccoli-concat": "^3.7.5",
     "broccoli-stew": "^3.0.0",
     "broccoli-string-replace": "^0.1.2",
     "broccoli-test-helper": "^2.0.0",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -32,7 +32,7 @@
     "@ember/edition-utils": "^1.1.1",
     "@ember/ordered-set": "^2.0.3",
     "@glimmer/env": "^0.1.7",
-    "broccoli-merge-trees": "^4.0.0",
+    "broccoli-merge-trees": "^3.0.2",
     "ember-cli-babel": "^7.13.0",
     "ember-cli-typescript": "^3.1.1",
     "ember-inflector": "^3.0.1"

--- a/packages/private-build-infra/package.json
+++ b/packages/private-build-infra/package.json
@@ -23,7 +23,7 @@
     "broccoli-debug": "^0.6.5",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-funnel": "^3.0.0",
-    "broccoli-merge-trees": "^4.0.0",
+    "broccoli-merge-trees": "^3.0.2",
     "broccoli-rollup": "^4.1.1",
     "calculate-cache-key-for-tree": "^2.0.0",
     "chalk": "^3.0.0",

--- a/packages/private-build-infra/package.json
+++ b/packages/private-build-infra/package.json
@@ -22,7 +22,7 @@
     "babel6-plugin-strip-class-callcheck": "^6.0.0",
     "broccoli-debug": "^0.6.5",
     "broccoli-file-creator": "^2.1.1",
-    "broccoli-funnel": "^3.0.0",
+    "broccoli-funnel": "^2.0.2",
     "broccoli-merge-trees": "^3.0.2",
     "broccoli-rollup": "^4.1.1",
     "calculate-cache-key-for-tree": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,14 +4229,6 @@ broccoli-merge-trees@^3.0.0, broccoli-merge-trees@^3.0.1, broccoli-merge-trees@^
     broccoli-plugin "^1.3.0"
     merge-trees "^2.0.0"
 
-broccoli-merge-trees@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.0.0.tgz#57c7993cc74bf16efed8df7a5188a0202a70216d"
-  integrity sha512-FJ1dTqxzDmpqbQFxuhicPbA6URV0D1XCKHFIvKwi6Y70pxuYLMpyRfjNv6iNSwSq/juxGubunKiLb8U2dM+a2A==
-  dependencies:
-    broccoli-plugin "^3.1.0"
-    merge-trees "^2.0.0"
-
 broccoli-middleware@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/broccoli-middleware/-/broccoli-middleware-2.1.0.tgz#cbb458cb6360bdd79aa75a54057f10fe918157e6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4165,24 +4165,6 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1, broccoli-funnel@^2.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.0.tgz#46fa8b570eccdfa9f66c71e85ce4a5dc68ec2ad6"
-  integrity sha512-BzqVvCXQt/d0Lk9fmT8Z/34rt2BB1OjQe1+e5w29ZXkg7pBlvRIYiPq3M+1Hy0E6jJ/ASB6m/d7TBl7cTHjEFQ==
-  dependencies:
-    array-equal "^1.0.0"
-    blank-object "^1.0.1"
-    broccoli-plugin "^3.0.0"
-    debug "^4.1.1"
-    fast-ordered-set "^1.0.0"
-    fs-tree-diff "^2.0.1"
-    heimdalljs "^0.2.0"
-    minimatch "^3.0.0"
-    path-posix "^1.0.0"
-    rimraf "^3.0.0"
-    symlink-or-copy "^1.0.0"
-    walk-sync "^0.3.1"
-
 broccoli-kitchen-sink-helpers@^0.2.5:
   version "0.2.9"
   resolved "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz#a5e0986ed8d76fb5984b68c3f0450d3a96e36ecc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4026,7 +4026,7 @@ broccoli-clean-css@^1.1.0:
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
 
-broccoli-concat@^3.7.1, broccoli-concat@^3.7.4:
+broccoli-concat@^3.7.1, broccoli-concat@^3.7.4, broccoli-concat@^3.7.5:
   version "3.7.5"
   resolved "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-3.7.5.tgz#223beda8c1184252cf08ae020a3d45ffa6a48218"
   integrity sha512-rDs1Mej3Ej0Cy5yIO9oIQq5+BCv0opAwS2NW7M0BeCsAMeFM42Z/zacDUC6jKc5OV5wiHvGTyCPLnZkMe0h6kQ==
@@ -4043,23 +4043,6 @@ broccoli-concat@^3.7.1, broccoli-concat@^3.7.4:
     lodash.omit "^4.1.0"
     lodash.uniq "^4.2.0"
     walk-sync "^0.3.2"
-
-broccoli-concat@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-4.2.0.tgz#0118934be80b80d1de52c5b2ee9a7091a5befe07"
-  integrity sha512-tAZ+GQdOt1l+x8nDFkrzDeKdSFxFWe75sUHsGZglkIkOlG2PczWHGnfr6yuZx7DBpOYfrnasCowj+BIJm7hoKw==
-  dependencies:
-    broccoli-debug "^0.6.5"
-    broccoli-kitchen-sink-helpers "^0.3.1"
-    broccoli-plugin "^3.1.0"
-    ensure-posix-path "^1.0.2"
-    fast-sourcemap-concat "^1.4.0"
-    find-index "^1.1.0"
-    fs-extra "^8.1.0"
-    fs-tree-diff "^2.0.1"
-    lodash.merge "^4.6.2"
-    lodash.omit "^4.1.0"
-    lodash.uniq "^4.2.0"
 
 broccoli-config-loader@^1.0.1:
   version "1.0.1"
@@ -4240,7 +4223,7 @@ broccoli-module-unification-reexporter@^1.0.0:
     mkdirp "^0.5.1"
     walk-sync "^0.3.2"
 
-broccoli-node-api@^1.6.0, broccoli-node-api@^1.7.0:
+broccoli-node-api@^1.6.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/broccoli-node-api/-/broccoli-node-api-1.7.0.tgz#391aa6edecd2a42c63c111b4162956b2fa288cb6"
   integrity sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw==
@@ -4254,13 +4237,6 @@ broccoli-node-info@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-2.1.0.tgz#ca84560e8570ff78565bea1699866ddbf58ad644"
   integrity sha512-l6qDuboJThHfRVVWQVaTs++bFdrFTP0gJXgsWenczc1PavRVUmL1Eyb2swTAXXMpDOnr2zhNOBLx4w9AxkqbPQ==
-
-broccoli-output-wrapper@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz#f1e0b9b2f259a67fd41a380141c3c20b096828e6"
-  integrity sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==
-  dependencies:
-    heimdalljs-logger "^0.1.10"
 
 broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.4.3:
   version "1.4.6"
@@ -4331,14 +4307,12 @@ broccoli-plugin@^2.0.0, broccoli-plugin@^2.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^3.0.0, broccoli-plugin@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz#54ba6dd90a42ec3db5624063292610e326b1e542"
-  integrity sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==
+broccoli-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.0.0.tgz#516f2b550ffa2bb111bf54c1afb4bd0b2f02065b"
+  integrity sha512-aEtobBvzAlUIAaY5z+LwW2W3IJ9pruJtrT571CyfjoDFTGa8LZx0qjQG97Z7Guk5YzuxDoDNlM3hGsgBnnReTw==
   dependencies:
     broccoli-node-api "^1.6.0"
-    broccoli-output-wrapper "^2.0.0"
-    fs-merger "^3.0.1"
     promise-map-series "^0.2.1"
     quick-temp "^0.1.3"
     rimraf "^2.3.4"
@@ -7904,18 +7878,6 @@ fs-extra@^8.0.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-merger@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/fs-merger/-/fs-merger-3.0.1.tgz#4fba891e1ac83ce1ea4261b91fee475aaf628cb2"
-  integrity sha512-0DDF7GDMm4roej5N6Z7ZNC2y2VdZdYQtHm32wWluSONyxUMqIAWyD73v0S12GkqO416BGqSHr2tjU4hmIlbylw==
-  dependencies:
-    broccoli-node-api "^1.7.0"
-    broccoli-node-info "^2.1.0"
-    fs-extra "^8.0.1"
-    fs-tree-diff "^2.0.1"
-    rimraf "^2.6.3"
-    walk-sync "^2.0.2"
 
 fs-minipass@^1.2.5:
   version "1.2.7"


### PR DESCRIPTION
All of these depencencies dropped support for Node 8 in their most recent major version bump:

* broccoli-concat@4
* broccoli-funnel@3
* broccoli-merge-trees@4

Unfortunately, the PR's didn't properly fail CI because we use the latest LTS for running all of our CI jobs.