### PR TITLE
[CHORE] Lint enforcement of type-only imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,12 +43,13 @@ module.exports = {
       parserOptions: {
         sourceType: 'module',
       },
-      plugins: ['@typescript-eslint'],
+      plugins: ['@typescript-eslint', 'ember-data'],
       extends: ['eslint:recommended', 'plugin:@typescript-eslint/eslint-recommended'],
       rules: {
         '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
         'no-unused-vars': 'off',
         'require-atomic-updates': 'off',
+        'ember-data/prefer-type-only-import': 'error',
       },
     },
 
@@ -61,6 +62,7 @@ module.exports = {
         'bin/**',
         'packages/private-build-infra/src/**/*.js',
         'packages/unpublished-test-infra/src/**/*.js',
+        'packages/unpublished-eslint-rules/src/**/*.js',
         'packages/*/.ember-cli.js',
         'packages/*/.eslintrc.js',
         'packages/*/.template-lintrc.js',

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-qunit": "^4.0.0",
+    "eslint-plugin-ember-data": "3.16.0-alpha.2",
     "execa": "^3.4.0",
     "fromentries": "^1.2.0",
     "fs-extra": "^8.1.0",

--- a/packages/-ember-data/tests/integration/identifiers/configuration-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/configuration-test.ts
@@ -14,12 +14,12 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 import Adapter from '@ember-data/adapter';
 import Serializer from '@ember-data/serializer';
 import { resolve, all } from 'rsvp';
-import { ExistingResourceObject } from '@ember-data/store/-private/ts-interfaces/ember-data-json-api';
-import { StableRecordIdentifier } from '@ember-data/store/-private/ts-interfaces/identifier';
 import { set } from '@ember/object';
 import { run } from '@ember/runloop';
 import { settled } from '@ember/test-helpers';
 import { identifierCacheFor } from '@ember-data/store/-private';
+type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
+type ExistingResourceObject = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').ExistingResourceObject;
 
 if (IDENTIFIERS) {
   module('Integration | Identifiers - configuration', function(hooks) {

--- a/packages/-ember-data/tests/integration/identifiers/scenarios-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/scenarios-test.ts
@@ -12,11 +12,11 @@ import Model, { attr } from '@ember-data/model';
 import Adapter from '@ember-data/adapter';
 import Serializer from '@ember-data/serializer';
 import { resolve, all } from 'rsvp';
-import { ExistingResourceObject } from '@ember-data/store/-private/ts-interfaces/ember-data-json-api';
-import { ConfidentDict } from '@ember-data/store/-private/ts-interfaces/utils';
-import { StableRecordIdentifier } from '@ember-data/store/-private/ts-interfaces/identifier';
 import { identifierCacheFor } from '@ember-data/store/-private';
 import { set } from '@ember/object';
+type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
+type ConfidentDict<T> = import('@ember-data/store/-private/ts-interfaces/utils').ConfidentDict<T>;
+type ExistingResourceObject = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').ExistingResourceObject;
 
 function isNonEmptyString(str: any): str is string {
   return typeof str === 'string' && str.length > 0;

--- a/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
@@ -5,12 +5,12 @@ import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import { attr } from '@ember-data/model';
 import { InvalidError } from '@ember-data/adapter/error';
-import { JsonApiValidationError } from '@ember-data/store/-private/ts-interfaces/record-data-json-api';
-import { RecordData } from '@ember-data/store/-private/ts-interfaces/record-data';
-import { RecordIdentifier } from '@ember-data/store/-private/ts-interfaces/identifier';
 import { RECORD_DATA_ERRORS } from '@ember-data/canary-features';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { Promise } from 'rsvp';
+type RecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').RecordIdentifier;
+type RecordData = import('@ember-data/store/-private/ts-interfaces/record-data').RecordData;
+type JsonApiValidationError = import('@ember-data/store/-private/ts-interfaces/record-data-json-api').JsonApiValidationError;
 
 class Person extends Model {
   // TODO fix the typing for naked attrs

--- a/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
@@ -5,10 +5,10 @@ import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import { attr } from '@ember-data/model';
 import Ember from 'ember';
-import { RecordData } from '@ember-data/store/-private/ts-interfaces/record-data';
 import { RECORD_DATA_STATE } from '@ember-data/canary-features';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { Promise } from 'rsvp';
+type RecordData = import('@ember-data/store/-private/ts-interfaces/record-data').RecordData;
 
 class Person extends Model {
   // TODO fix the typing for naked attrs

--- a/packages/-ember-data/tests/integration/request-state-service-test.ts
+++ b/packages/-ember-data/tests/integration/request-state-service-test.ts
@@ -1,14 +1,14 @@
 import { setupTest } from 'ember-qunit';
 import Model from 'ember-data/model';
-import Store from 'ember-data/store';
 import { module, test } from 'qunit';
 import { identifierCacheFor } from '@ember-data/store/-private';
 import EmberObject from '@ember/object';
 import { attr } from '@ember-data/model';
 import { REQUEST_SERVICE } from '@ember-data/canary-features';
-import { RequestStateEnum } from '@ember-data/store/-private/ts-interfaces/fetch-manager';
 import JSONSerializer from '@ember-data/serializer/json';
 import { Promise } from 'rsvp';
+type RequestStateEnum = import('@ember-data/store/-private/ts-interfaces/fetch-manager').RequestStateEnum;
+type Store = import('ember-data/store').default;
 
 class Person extends Model {
   // TODO fix the typing for naked attrs

--- a/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -3,13 +3,14 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import JSONAPIAdapter from 'ember-data/adapters/json-api';
 import JSONAPISerializer from 'ember-data/serializers/json-api';
-import { Snapshot } from 'ember-data/-private';
 import Store from 'ember-data/store';
 import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
-import CoreStore from '@ember-data/store/-private/system/core-store';
-import { StableRecordIdentifier, RecordIdentifier } from '@ember-data/store/-private/ts-interfaces/identifier';
-import NotificationManager from '@ember-data/store/-private/system/record-notification-manager';
-import { RecordDataRecordWrapper } from '@ember-data/store/-private/ts-interfaces/record-data-record-wrapper';
+type RecordDataRecordWrapper = import('@ember-data/store/-private/ts-interfaces/record-data-record-wrapper').RecordDataRecordWrapper;
+type NotificationManager = import('@ember-data/store/-private/system/record-notification-manager').default;
+type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
+type RecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').RecordIdentifier;
+type CoreStore = import('@ember-data/store/-private/system/core-store').default;
+type Snapshot = import('ember-data/-private').Snapshot;
 
 let CustomStore, store, schemaDefinition;
 if (CUSTOM_MODEL_CLASS) {

--- a/packages/record-data/addon/-private/record-data-for.ts
+++ b/packages/record-data/addon/-private/record-data-for.ts
@@ -1,10 +1,10 @@
 import { recordDataFor } from '@ember-data/store/-private';
-import Relationships from './relationships/state/create';
-import Relationship from './relationships/state/relationship';
-import BelongsToRelationship from './relationships/state/belongs-to';
-import ManyRelationship from './relationships/state/has-many';
-import { ConfidentDict } from '@ember-data/store/-private/ts-interfaces/utils';
-import { RelationshipRecordData } from './ts-interfaces/relationship-record-data';
+type RelationshipRecordData = import('./ts-interfaces/relationship-record-data').RelationshipRecordData;
+type ConfidentDict<T> = import('@ember-data/store/-private/ts-interfaces/utils').ConfidentDict<T>;
+type ManyRelationship = import('./relationships/state/has-many').default;
+type BelongsToRelationship = import('./relationships/state/belongs-to').default;
+type Relationship = import('./relationships/state/relationship').default;
+type Relationships = import('./relationships/state/create').default;
 
 export function relationshipsFor(instance: any): Relationships {
   let recordData = (recordDataFor(instance) || instance) as RelationshipRecordData;

--- a/packages/record-data/addon/-private/record-data.ts
+++ b/packages/record-data/addon/-private/record-data.ts
@@ -8,23 +8,20 @@ import { assert, warn, inspect } from '@ember/debug';
 import { run } from '@ember/runloop';
 import Relationships from './relationships/state/create';
 import coerceId from './coerce-id';
-import BelongsToRelationship from './relationships/state/belongs-to';
-import ManyRelationship from './relationships/state/has-many';
-import Relationship from './relationships/state/relationship';
-import { RecordData, ChangedAttributesHash } from '@ember-data/store/-private/ts-interfaces/record-data';
-import {
-  JsonApiResource,
-  JsonApiValidationError,
-  AttributesHash,
-} from '@ember-data/store/-private/ts-interfaces/record-data-json-api';
-import {
-  DefaultSingleResourceRelationship,
-  DefaultCollectionResourceRelationship,
-} from './ts-interfaces/relationship-record-data';
-import { RelationshipRecordData } from './ts-interfaces/relationship-record-data';
-import { RecordDataStoreWrapper } from '@ember-data/store/-private/ts-interfaces/record-data-store-wrapper';
 import { IDENTIFIERS, RECORD_DATA_ERRORS, RECORD_DATA_STATE } from '@ember-data/canary-features';
-import { RecordIdentifier } from '@ember-data/store/-private/ts-interfaces/identifier';
+type RecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').RecordIdentifier;
+type RecordDataStoreWrapper = import('@ember-data/store/-private/ts-interfaces/record-data-store-wrapper').RecordDataStoreWrapper;
+type RelationshipRecordData = import('./ts-interfaces/relationship-record-data').RelationshipRecordData;
+type DefaultSingleResourceRelationship = import('./ts-interfaces/relationship-record-data').DefaultSingleResourceRelationship;
+type DefaultCollectionResourceRelationship = import('./ts-interfaces/relationship-record-data').DefaultCollectionResourceRelationship;
+type JsonApiResource = import('@ember-data/store/-private/ts-interfaces/record-data-json-api').JsonApiResource;
+type JsonApiValidationError = import('@ember-data/store/-private/ts-interfaces/record-data-json-api').JsonApiValidationError;
+type AttributesHash = import('@ember-data/store/-private/ts-interfaces/record-data-json-api').AttributesHash;
+type RecordData = import('@ember-data/store/-private/ts-interfaces/record-data').RecordData;
+type ChangedAttributesHash = import('@ember-data/store/-private/ts-interfaces/record-data').ChangedAttributesHash;
+type Relationship = import('./relationships/state/relationship').default;
+type ManyRelationship = import('./relationships/state/has-many').default;
+type BelongsToRelationship = import('./relationships/state/belongs-to').default;
 
 let nextBfsId = 1;
 

--- a/packages/record-data/addon/-private/relationships/state/belongs-to.ts
+++ b/packages/record-data/addon/-private/relationships/state/belongs-to.ts
@@ -2,12 +2,10 @@ import { assert, inspect } from '@ember/debug';
 import { assertPolymorphicType } from '@ember-data/store/-debug';
 import { isNone } from '@ember/utils';
 import Relationship from './relationship';
-import {
-  RelationshipRecordData,
-  DefaultSingleResourceRelationship,
-} from '../../ts-interfaces/relationship-record-data';
-import { RelationshipSchema } from '@ember-data/store/-private/ts-interfaces/record-data-schemas';
-import { ExistingResourceIdentifierObject } from '@ember-data/store/-private/ts-interfaces/ember-data-json-api';
+type ExistingResourceIdentifierObject = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').ExistingResourceIdentifierObject;
+type RelationshipSchema = import('@ember-data/store/-private/ts-interfaces/record-data-schemas').RelationshipSchema;
+type RelationshipRecordData = import('../../ts-interfaces/relationship-record-data').RelationshipRecordData;
+type DefaultSingleResourceRelationship = import('../../ts-interfaces/relationship-record-data').DefaultSingleResourceRelationship;
 
 export default class BelongsToRelationship extends Relationship {
   inverseRecordData: RelationshipRecordData | null;

--- a/packages/record-data/addon/-private/relationships/state/create.ts
+++ b/packages/record-data/addon/-private/relationships/state/create.ts
@@ -1,10 +1,11 @@
 import ManyRelationship from './has-many';
 import BelongsToRelationship from './belongs-to';
 
-import { RelationshipRecordData } from '../../ts-interfaces/relationship-record-data';
-import { RelationshipSchema } from '@ember-data/store/-private/ts-interfaces/record-data-schemas';
-import { RecordDataStoreWrapper, upgradeForInternal } from '@ember-data/store/-private';
-import CoreStore from '@ember-data/store/-private/system/core-store';
+import { upgradeForInternal } from '@ember-data/store/-private';
+type CoreStore = import('@ember-data/store/-private/system/core-store').default;
+type RecordDataStoreWrapper = import('@ember-data/store/-private').RecordDataStoreWrapper;
+type RelationshipSchema = import('@ember-data/store/-private/ts-interfaces/record-data-schemas').RelationshipSchema;
+type RelationshipRecordData = import('../../ts-interfaces/relationship-record-data').RelationshipRecordData;
 
 function createRelationshipFor(
   relationshipMeta: RelationshipSchema,

--- a/packages/record-data/addon/-private/relationships/state/has-many.ts
+++ b/packages/record-data/addon/-private/relationships/state/has-many.ts
@@ -2,12 +2,10 @@ import { assertPolymorphicType } from '@ember-data/store/-debug';
 import Relationship from './relationship';
 import OrderedSet from '../../ordered-set';
 import { isNone } from '@ember/utils';
-import {
-  RelationshipRecordData,
-  DefaultCollectionResourceRelationship,
-} from '../../ts-interfaces/relationship-record-data';
-import { RelationshipSchema } from '@ember-data/store/-private/ts-interfaces/record-data-schemas';
 import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
+type RelationshipSchema = import('@ember-data/store/-private/ts-interfaces/record-data-schemas').RelationshipSchema;
+type RelationshipRecordData = import('../../ts-interfaces/relationship-record-data').RelationshipRecordData;
+type DefaultCollectionResourceRelationship = import('../../ts-interfaces/relationship-record-data').DefaultCollectionResourceRelationship;
 
 /**
   @module @ember-data/store

--- a/packages/record-data/addon/-private/relationships/state/relationship.ts
+++ b/packages/record-data/addon/-private/relationships/state/relationship.ts
@@ -4,11 +4,11 @@ import { relationshipStateFor, implicitRelationshipStateFor } from '../../record
 import { assert, warn } from '@ember/debug';
 import OrderedSet from '../../ordered-set';
 import _normalizeLink from '../../normalize-link';
-import { RelationshipRecordData } from '../../ts-interfaces/relationship-record-data';
-import { JsonApiRelationship } from '@ember-data/store/-private/ts-interfaces/record-data-json-api';
-import { RelationshipSchema } from '@ember-data/store/-private/ts-interfaces/record-data-schemas';
 import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
-import { PaginationLinks } from '@ember-data/store/-private/ts-interfaces/ember-data-json-api';
+type PaginationLinks = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').PaginationLinks;
+type RelationshipSchema = import('@ember-data/store/-private/ts-interfaces/record-data-schemas').RelationshipSchema;
+type JsonApiRelationship = import('@ember-data/store/-private/ts-interfaces/record-data-json-api').JsonApiRelationship;
+type RelationshipRecordData = import('../../ts-interfaces/relationship-record-data').RelationshipRecordData;
 
 /**
   @module @ember-data/store

--- a/packages/record-data/addon/-private/ts-interfaces/relationship-record-data.ts
+++ b/packages/record-data/addon/-private/ts-interfaces/relationship-record-data.ts
@@ -1,15 +1,15 @@
-import Relationships from '../relationships/state/create';
-import Relationship from '../relationships/state/relationship';
 import { RecordData } from '@ember-data/store/-private/ts-interfaces/record-data';
 import {
   SingleResourceRelationship,
   CollectionResourceRelationship,
 } from '@ember-data/store/-private/ts-interfaces/ember-data-json-api';
-import { RecordIdentifier } from '@ember-data/store/-private/ts-interfaces/identifier';
-import { RecordDataStoreWrapper } from '@ember-data/store/-private/ts-interfaces/record-data-store-wrapper';
-import BelongsToRelationship from '../relationships/state/belongs-to';
-import HasManyRelationship from '../relationships/state/has-many';
-import { ConfidentDict } from '@ember-data/store/-private/ts-interfaces/utils';
+type ConfidentDict<T> = import('@ember-data/store/-private/ts-interfaces/utils').ConfidentDict<T>;
+type HasManyRelationship = import('../relationships/state/has-many').default;
+type BelongsToRelationship = import('../relationships/state/belongs-to').default;
+type RecordDataStoreWrapper = import('@ember-data/store/-private/ts-interfaces/record-data-store-wrapper').RecordDataStoreWrapper;
+type RecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').RecordIdentifier;
+type Relationship = import('../relationships/state/relationship').default;
+type Relationships = import('../relationships/state/create').default;
 
 export interface DefaultSingleResourceRelationship extends SingleResourceRelationship {
   _relationship: BelongsToRelationship;

--- a/packages/store/addon/-private/identifiers/cache.ts
+++ b/packages/store/addon/-private/identifiers/cache.ts
@@ -1,24 +1,22 @@
 import { DEBUG } from '@glimmer/env';
 import { warn } from '@ember/debug';
-import { ConfidentDict } from '../ts-interfaces/utils';
-import { ResourceIdentifierObject, ExistingResourceObject } from '../ts-interfaces/ember-data-json-api';
-import {
-  StableRecordIdentifier,
-  DEBUG_CLIENT_ORIGINATED,
-  DEBUG_IDENTIFIER_BUCKET,
-  GenerationMethod,
-  UpdateMethod,
-  ForgetMethod,
-  ResetMethod,
-  RecordIdentifier,
-} from '../ts-interfaces/identifier';
+import { DEBUG_CLIENT_ORIGINATED, DEBUG_IDENTIFIER_BUCKET } from '../ts-interfaces/identifier';
 import coerceId from '../system/coerce-id';
 import uuidv4 from './utils/uuid-v4';
 import normalizeModelName from '../system/normalize-model-name';
 import isStableIdentifier, { markStableIdentifier, unmarkStableIdentifier } from './is-stable-identifier';
 import isNonEmptyString from '../utils/is-non-empty-string';
-import CoreStore from '../system/core-store';
 import { addSymbol } from '../ts-interfaces/utils/symbol';
+type CoreStore = import('../system/core-store').default;
+type StableRecordIdentifier = import('../ts-interfaces/identifier').StableRecordIdentifier;
+type GenerationMethod = import('../ts-interfaces/identifier').GenerationMethod;
+type UpdateMethod = import('../ts-interfaces/identifier').UpdateMethod;
+type ForgetMethod = import('../ts-interfaces/identifier').ForgetMethod;
+type ResetMethod = import('../ts-interfaces/identifier').ResetMethod;
+type RecordIdentifier = import('../ts-interfaces/identifier').RecordIdentifier;
+type ResourceIdentifierObject = import('../ts-interfaces/ember-data-json-api').ResourceIdentifierObject;
+type ExistingResourceObject = import('../ts-interfaces/ember-data-json-api').ExistingResourceObject;
+type ConfidentDict<T> = import('../ts-interfaces/utils').ConfidentDict<T>;
 
 function freeze<T>(obj: T): T {
   if (typeof Object.freeze === 'function') {

--- a/packages/store/addon/-private/identifiers/is-stable-identifier.ts
+++ b/packages/store/addon/-private/identifiers/is-stable-identifier.ts
@@ -1,5 +1,4 @@
-import { StableRecordIdentifier } from '../ts-interfaces/identifier';
-
+type StableRecordIdentifier = import('../ts-interfaces/identifier').StableRecordIdentifier;
 /**
   @module @ember-data/store
 */

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -33,7 +33,7 @@ import { _find, _findMany, _findHasMany, _findBelongsTo, _findAll, _query, _quer
 
 import coerceId, { ensureStringId } from './coerce-id';
 import RecordArrayManager from './record-array-manager';
-import InternalModel, {
+import {
   assertRecordsPassedToHasMany,
   extractRecordDataFromRecord,
   extractRecordDatasFromRecords,
@@ -54,14 +54,11 @@ import {
 } from '@ember-data/private-build-infra';
 
 import promiseRecord from '../utils/promise-record';
-import { identifierCacheFor, IdentifierCache } from '../identifiers/cache';
+import { identifierCacheFor } from '../identifiers/cache';
 import { internalModelFactoryFor, setRecordIdentifier, recordIdentifierFor } from './store/internal-model-factory';
-import { RecordReference, HasManyReference, BelongsToReference } from './references';
-import { Backburner } from '@ember/runloop/-private/backburner';
-import Snapshot from './snapshot';
 import { RequestPromise } from './request-cache';
 import NotificationManager from './record-notification-manager';
-import ShimModelClass, { getShimClass } from './model/shim-model-class';
+import { getShimClass } from './model/shim-model-class';
 
 import constructResource from '../utils/construct-resource';
 import { errorsArrayToHash } from './errors-utils';
@@ -74,6 +71,14 @@ import {
 // TODO this comes from ts-interfaces but it is a function we ship
 // so needs to be moved somewhere else
 import { addSymbol } from '../ts-interfaces/utils/symbol';
+type ShimModelClass = import('./model/shim-model-class').default;
+type Snapshot = import('./snapshot').default;
+type Backburner = import('@ember/runloop/-private/backburner').Backburner;
+type RecordReference = import('./references').RecordReference;
+type HasManyReference = import('./references').HasManyReference;
+type BelongsToReference = import('./references').BelongsToReference;
+type IdentifierCache = import('../identifiers/cache').IdentifierCache;
+type InternalModel = import('./model/internal-model').default;
 
 type JsonApiRelationship = import('../ts-interfaces/record-data-json-api').JsonApiRelationship;
 type ResourceIdentifierObject = import('../ts-interfaces/ember-data-json-api').ResourceIdentifierObject;

--- a/packages/store/addon/-private/system/ds-model-store.ts
+++ b/packages/store/addon/-private/system/ds-model-store.ts
@@ -10,17 +10,18 @@ import { isPresent } from '@ember/utils';
 import { deprecate } from '@ember/application/deprecations';
 import EmberError from '@ember/error';
 import { get } from '@ember/object';
-import ShimModelClass, { getShimClass } from './model/shim-model-class';
+import { getShimClass } from './model/shim-model-class';
 import { setOwner, getOwner } from '@ember/application';
-import { DSModel } from '../ts-interfaces/ds-model';
-import NotificationManager from './record-notification-manager';
-import { StableRecordIdentifier } from '../ts-interfaces/identifier';
 import { DSModelSchemaDefinitionService, getModelFactory } from './schema-definition-service';
 import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
-import { RecordDataRecordWrapper } from '../ts-interfaces/record-data-record-wrapper';
-import { SchemaDefinitionService } from '../ts-interfaces/schema-definition-service';
-import { RelationshipsSchema } from '../ts-interfaces/record-data-schemas';
 import notifyChanges from './model/notify-changes';
+type RelationshipsSchema = import('../ts-interfaces/record-data-schemas').RelationshipsSchema;
+type SchemaDefinitionService = import('../ts-interfaces/schema-definition-service').SchemaDefinitionService;
+type RecordDataRecordWrapper = import('../ts-interfaces/record-data-record-wrapper').RecordDataRecordWrapper;
+type StableRecordIdentifier = import('../ts-interfaces/identifier').StableRecordIdentifier;
+type NotificationManager = import('./record-notification-manager').default;
+type DSModel = import('../ts-interfaces/ds-model').DSModel;
+type ShimModelClass = import('./model/shim-model-class').default;
 type DSModelClass = import('@ember-data/model').default;
 
 /**

--- a/packages/store/addon/-private/system/identity-map.ts
+++ b/packages/store/addon/-private/system/identity-map.ts
@@ -1,5 +1,5 @@
 import InternalModelMap from './internal-model-map';
-import { ConfidentDict } from '../ts-interfaces/utils';
+type ConfidentDict<T> = import('../ts-interfaces/utils').ConfidentDict<T>;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/system/internal-model-map.ts
+++ b/packages/store/addon/-private/system/internal-model-map.ts
@@ -1,6 +1,6 @@
 import { assert } from '@ember/debug';
 import InternalModel from './model/internal-model';
-import { ConfidentDict } from '../ts-interfaces/utils';
+type ConfidentDict<T> = import('../ts-interfaces/utils').ConfidentDict<T>;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -36,9 +36,7 @@ type JsonApiValidationError = import('../../ts-interfaces/record-data-json-api')
 type RecordData = import('../../ts-interfaces/record-data').RecordData;
 type RecordArray = import('../record-arrays/record-array').default;
 type Store = import('../ds-model-store').default;
-
 type DefaultRecordData = import('@ember-data/record-data/-private').RecordData;
-type RecordArray = InstanceType<typeof RecordArray>;
 type RelationshipRecordData = import('@ember-data/record-data/-private/ts-interfaces/relationship-record-data').RelationshipRecordData;
 type Relationships = import('@ember-data/record-data/-private/relationships/state/create').default;
 

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -10,15 +10,9 @@ import { DEBUG } from '@glimmer/env';
 import { assert, inspect } from '@ember/debug';
 import RootState from './states';
 import Snapshot from '../snapshot';
-import Store from '../ds-model-store';
 import { errorsHashToArray } from '../errors-utils';
-import RecordArray from '../record-arrays/record-array';
 
 import { RecordReference, BelongsToReference, HasManyReference } from '../references';
-import { RecordData } from '../../ts-interfaces/record-data';
-import { JsonApiResource, JsonApiValidationError } from '../../ts-interfaces/record-data-json-api';
-import { RecordInstance } from '../../ts-interfaces/record-instance';
-import { ConfidentDict, Dict } from '../../ts-interfaces/utils';
 import {
   IDENTIFIERS,
   RECORD_DATA_ERRORS,
@@ -28,12 +22,20 @@ import {
   FULL_LINKS_ON_RELATIONSHIPS,
 } from '@ember-data/canary-features';
 import { identifierCacheFor } from '../../identifiers/cache';
-import { StableRecordIdentifier } from '../../ts-interfaces/identifier';
 import { internalModelFactoryFor, setRecordIdentifier } from '../store/internal-model-factory';
-import CoreStore from '../core-store';
 import coerceId from '../coerce-id';
 import recordDataFor from '../record-data-for';
 import { HAS_MODEL_PACKAGE } from '@ember-data/private-build-infra';
+type CoreStore = import('../core-store').default;
+type StableRecordIdentifier = import('../../ts-interfaces/identifier').StableRecordIdentifier;
+type ConfidentDict<T> = import('../../ts-interfaces/utils').ConfidentDict<T>;
+type Dict<T> = import('../../ts-interfaces/utils').Dict<T>;
+type RecordInstance = import('../../ts-interfaces/record-instance').RecordInstance;
+type JsonApiResource = import('../../ts-interfaces/record-data-json-api').JsonApiResource;
+type JsonApiValidationError = import('../../ts-interfaces/record-data-json-api').JsonApiValidationError;
+type RecordData = import('../../ts-interfaces/record-data').RecordData;
+type RecordArray = import('../record-arrays/record-array').default;
+type Store = import('../ds-model-store').default;
 
 type DefaultRecordData = import('@ember-data/record-data/-private').RecordData;
 type RecordArray = InstanceType<typeof RecordArray>;

--- a/packages/store/addon/-private/system/model/notify-changes.ts
+++ b/packages/store/addon/-private/system/model/notify-changes.ts
@@ -1,7 +1,7 @@
-import { StableRecordIdentifier } from '../../ts-interfaces/identifier';
-import { DSModel } from '../../ts-interfaces/ds-model';
-import Store from '../ds-model-store';
 import { cacheFor } from '@ember/object/internals';
+type Store = import('../ds-model-store').default;
+type DSModel = import('../../ts-interfaces/ds-model').DSModel;
+type StableRecordIdentifier = import('../../ts-interfaces/identifier').StableRecordIdentifier;
 
 export default function notifyChanges(
   identifier: StableRecordIdentifier,

--- a/packages/store/addon/-private/system/model/shim-model-class.ts
+++ b/packages/store/addon/-private/system/model/shim-model-class.ts
@@ -1,7 +1,8 @@
-import CoreStore from '../core-store';
-import { RelationshipSchema, AttributeSchema } from '../../ts-interfaces/record-data-schemas';
-import { Dict } from '../../ts-interfaces/utils';
 import { ModelSchema } from '../../ts-interfaces/ds-model';
+type Dict<T> = import('../../ts-interfaces/utils').Dict<T>;
+type RelationshipSchema = import('../../ts-interfaces/record-data-schemas').RelationshipSchema;
+type AttributeSchema = import('../../ts-interfaces/record-data-schemas').AttributeSchema;
+type CoreStore = import('../core-store').default;
 
 const AvailableShims = new WeakMap<CoreStore, Dict<ShimModelClass>>();
 

--- a/packages/store/addon/-private/system/record-data-for.ts
+++ b/packages/store/addon/-private/system/record-data-for.ts
@@ -1,4 +1,4 @@
-import { RecordData } from '../ts-interfaces/record-data';
+type RecordData = import('../ts-interfaces/record-data').RecordData;
 /*
  * Returns the RecordData instance associated with a given
  * Model or InternalModel.

--- a/packages/store/addon/-private/system/record-notification-manager.ts
+++ b/packages/store/addon/-private/system/record-notification-manager.ts
@@ -1,6 +1,7 @@
-import { RecordIdentifier, StableRecordIdentifier } from '../ts-interfaces/identifier';
-import CoreStore from './core-store';
 import { identifierCacheFor } from '../identifiers/cache';
+type CoreStore = import('./core-store').default;
+type RecordIdentifier = import('../ts-interfaces/identifier').RecordIdentifier;
+type StableRecordIdentifier = import('../ts-interfaces/identifier').StableRecordIdentifier;
 
 type UnsubscribeToken = Object;
 

--- a/packages/store/addon/-private/system/references/record.ts
+++ b/packages/store/addon/-private/system/references/record.ts
@@ -1,7 +1,7 @@
 import RSVP, { resolve } from 'rsvp';
 import Reference from './reference';
-import { RecordInstance } from '../../ts-interfaces/record-instance';
-import { SingleResourceDocument } from '../../ts-interfaces/ember-data-json-api';
+type SingleResourceDocument = import('../../ts-interfaces/ember-data-json-api').SingleResourceDocument;
+type RecordInstance = import('../../ts-interfaces/record-instance').RecordInstance;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/system/references/reference.ts
+++ b/packages/store/addon/-private/system/references/reference.ts
@@ -1,11 +1,13 @@
-import InternalModel from '../model/internal-model';
 import recordDataFor from '../record-data-for';
-import { Object as JSONObject, Value as JSONValue } from 'json-typescript';
-import CoreStore from '../core-store';
-import { PaginationLinks, LinkObject } from '../../ts-interfaces/ember-data-json-api';
-import { JsonApiRelationship } from '../../ts-interfaces/record-data-json-api';
 import { FULL_LINKS_ON_RELATIONSHIPS } from '@ember-data/canary-features';
-import { Dict } from '../../ts-interfaces/utils';
+type Dict<T> = import('../../ts-interfaces/utils').Dict<T>;
+type JsonApiRelationship = import('../../ts-interfaces/record-data-json-api').JsonApiRelationship;
+type PaginationLinks = import('../../ts-interfaces/ember-data-json-api').PaginationLinks;
+type LinkObject = import('../../ts-interfaces/ember-data-json-api').LinkObject;
+type CoreStore = import('../core-store').default;
+type JSONObject = import('json-typescript').Object;
+type JSONValue = import('json-typescript').Value;
+type InternalModel = import('../model/internal-model').default;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/system/relationship-meta.ts
+++ b/packages/store/addon/-private/system/relationship-meta.ts
@@ -3,7 +3,7 @@ import { DEBUG } from '@glimmer/env';
 import normalizeModelName from './normalize-model-name';
 import { RelationshipSchema } from '../ts-interfaces/record-data-schemas';
 import { BRAND_SYMBOL } from '../ts-interfaces/utils/brand';
-import CoreStore from './core-store';
+type CoreStore = import('./core-store').default;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/system/request-cache.ts
+++ b/packages/store/addon/-private/system/request-cache.ts
@@ -1,13 +1,11 @@
-import { RecordIdentifier } from '../ts-interfaces/identifier';
-import {
-  FindRecordQuery,
-  SaveRecordMutation,
-  Request,
-  RequestState,
-  Operation,
-  RequestStateEnum,
-} from '../ts-interfaces/fetch-manager';
+import { RequestStateEnum } from '../ts-interfaces/fetch-manager';
 import { symbol, addSymbol } from '../ts-interfaces/utils/symbol';
+type FindRecordQuery = import('../ts-interfaces/fetch-manager').FindRecordQuery;
+type SaveRecordMutation = import('../ts-interfaces/fetch-manager').SaveRecordMutation;
+type Request = import('../ts-interfaces/fetch-manager').Request;
+type RequestState = import('../ts-interfaces/fetch-manager').RequestState;
+type Operation = import('../ts-interfaces/fetch-manager').Operation;
+type RecordIdentifier = import('../ts-interfaces/identifier').RecordIdentifier;
 
 const Touching: unique symbol = symbol('touching');
 export const RequestPromise: unique symbol = symbol('promise');

--- a/packages/store/addon/-private/system/schema-definition-service.ts
+++ b/packages/store/addon/-private/system/schema-definition-service.ts
@@ -1,11 +1,12 @@
-import Store from './ds-model-store';
-import { RecordIdentifier } from '../ts-interfaces/identifier';
 import { get } from '@ember/object';
 import { getOwner } from '@ember/application';
 import normalizeModelName from './normalize-model-name';
-import { RelationshipsSchema, AttributesSchema } from '../ts-interfaces/record-data-schemas';
 import require from 'require';
 import { HAS_MODEL_PACKAGE } from '@ember-data/private-build-infra';
+type RelationshipsSchema = import('../ts-interfaces/record-data-schemas').RelationshipsSchema;
+type AttributesSchema = import('../ts-interfaces/record-data-schemas').AttributesSchema;
+type RecordIdentifier = import('../ts-interfaces/identifier').RecordIdentifier;
+type Store = import('./ds-model-store').default;
 
 type Model = import('@ember-data/model').default;
 type ModelForMixin = (store: Store, normalizedModelName: string) => Model | null;

--- a/packages/store/addon/-private/system/snapshot-record-array.ts
+++ b/packages/store/addon/-private/system/snapshot-record-array.ts
@@ -1,5 +1,4 @@
-import { Dict } from '../ts-interfaces/utils';
-
+type Dict<T> = import('../ts-interfaces/utils').Dict<T>;
 /**
   @module @ember-data/store
 */

--- a/packages/store/addon/-private/system/store/internal-model-factory.ts
+++ b/packages/store/addon/-private/system/store/internal-model-factory.ts
@@ -1,20 +1,19 @@
 import { assert, warn } from '@ember/debug';
-import { IdentifierCache, identifierCacheFor } from '../../identifiers/cache';
+import { identifierCacheFor } from '../../identifiers/cache';
 import InternalModel from '../model/internal-model';
 import IdentityMap from '../identity-map';
-import { StableRecordIdentifier } from '../../ts-interfaces/identifier';
-import InternalModelMap from '../internal-model-map';
 import { isNone } from '@ember/utils';
 import { IDENTIFIERS } from '@ember-data/canary-features';
-import { RecordInstance } from '../../ts-interfaces/record-instance';
-import {
-  ResourceIdentifierObject,
-  ExistingResourceObject,
-  NewResourceIdentifierObject,
-} from '../../ts-interfaces/ember-data-json-api';
 import { DEBUG } from '@glimmer/env';
-import CoreStore from '../core-store';
 import constructResource from '../../utils/construct-resource';
+type CoreStore = import('../core-store').default;
+type ResourceIdentifierObject = import('../../ts-interfaces/ember-data-json-api').ResourceIdentifierObject;
+type ExistingResourceObject = import('../../ts-interfaces/ember-data-json-api').ExistingResourceObject;
+type NewResourceIdentifierObject = import('../../ts-interfaces/ember-data-json-api').NewResourceIdentifierObject;
+type RecordInstance = import('../../ts-interfaces/record-instance').RecordInstance;
+type InternalModelMap = import('../internal-model-map').default;
+type StableRecordIdentifier = import('../../ts-interfaces/identifier').StableRecordIdentifier;
+type IdentifierCache = import('../../identifiers/cache').IdentifierCache;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
+++ b/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
@@ -1,14 +1,16 @@
 import { RecordDataStoreWrapper as IRecordDataStoreWrapper } from '../../ts-interfaces/record-data-store-wrapper';
-import { AttributesSchema, RelationshipsSchema } from '../../ts-interfaces/record-data-schemas';
 import { BRAND_SYMBOL } from '../../ts-interfaces/utils/brand';
 import { upgradeForInternal } from '../ts-upgrade-map';
-import { RecordData } from '../../ts-interfaces/record-data';
 import { internalModelFactoryFor } from './internal-model-factory';
 import { IDENTIFIERS, CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
-import { identifierCacheFor, IdentifierCache } from '../../identifiers/cache';
-import CoreStore from '../core-store';
+import { identifierCacheFor } from '../../identifiers/cache';
 import constructResource from '../../utils/construct-resource';
-import { StableRecordIdentifier } from '../../ts-interfaces/identifier';
+type StableRecordIdentifier = import('../../ts-interfaces/identifier').StableRecordIdentifier;
+type CoreStore = import('../core-store').default;
+type IdentifierCache = import('../../identifiers/cache').IdentifierCache;
+type RecordData = import('../../ts-interfaces/record-data').RecordData;
+type AttributesSchema = import('../../ts-interfaces/record-data-schemas').AttributesSchema;
+type RelationshipsSchema = import('../../ts-interfaces/record-data-schemas').RelationshipsSchema;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/system/ts-upgrade-map.ts
+++ b/packages/store/addon/-private/system/ts-upgrade-map.ts
@@ -3,8 +3,8 @@
 */
 
 import { BRAND_SYMBOL } from '../ts-interfaces/utils/brand';
-import RecordDataStoreWrapper from './store/record-data-store-wrapper';
-import { RelationshipDefinition } from './relationship-meta';
+type RelationshipDefinition = import('./relationship-meta').RelationshipDefinition;
+type RecordDataStoreWrapper = import('./store/record-data-store-wrapper').default;
 
 /**
  * Maps public interfaces to internal class implementations

--- a/packages/store/addon/-private/ts-interfaces/ds-model.ts
+++ b/packages/store/addon/-private/ts-interfaces/ds-model.ts
@@ -1,8 +1,9 @@
 import RSVP from 'rsvp';
 import EmberObject from '@ember/object';
-import { JsonApiValidationError } from './record-data-json-api';
 import { RecordInstance } from './record-instance';
-import { RelationshipSchema, AttributeSchema } from './record-data-schemas';
+type RelationshipSchema = import('./record-data-schemas').RelationshipSchema;
+type AttributeSchema = import('./record-data-schemas').AttributeSchema;
+type JsonApiValidationError = import('./record-data-json-api').JsonApiValidationError;
 
 // Placeholder until model.js is typed
 export interface DSModel extends RecordInstance, EmberObject {

--- a/packages/store/addon/-private/ts-interfaces/ember-data-json-api.ts
+++ b/packages/store/addon/-private/ts-interfaces/ember-data-json-api.ts
@@ -1,5 +1,5 @@
-import { Value as JSONValue } from 'json-typescript';
-import { Dict } from './utils';
+type Dict<T> = import('./utils').Dict<T>;
+type JSONValue = import('json-typescript').Value;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/ts-interfaces/fetch-manager.ts
+++ b/packages/store/addon/-private/ts-interfaces/fetch-manager.ts
@@ -1,5 +1,4 @@
-import { RecordIdentifier } from './identifier';
-
+type RecordIdentifier = import('./identifier').RecordIdentifier;
 export interface Operation {
   op: string;
 }

--- a/packages/store/addon/-private/ts-interfaces/minimum-serializer-interface.ts
+++ b/packages/store/addon/-private/ts-interfaces/minimum-serializer-interface.ts
@@ -100,12 +100,13 @@
   @public
 */
 
-import { Object as JSONObject } from 'json-typescript';
-import Store from '../system/core-store';
-import { JsonApiDocument, SingleResourceDocument } from './ember-data-json-api';
-import Snapshot from '../system/snapshot';
-import { ModelSchema } from './ds-model';
-import { Dict } from './utils';
+type Dict<T> = import('./utils').Dict<T>;
+type ModelSchema = import('./ds-model').ModelSchema;
+type Snapshot = import('../system/snapshot').default;
+type JsonApiDocument = import('./ember-data-json-api').JsonApiDocument;
+type SingleResourceDocument = import('./ember-data-json-api').SingleResourceDocument;
+type Store = import('../system/core-store').default;
+type JSONObject = import('json-typescript').Object;
 
 type OptionsHash = Dict<any>;
 

--- a/packages/store/addon/-private/ts-interfaces/record-data-json-api.ts
+++ b/packages/store/addon/-private/ts-interfaces/record-data-json-api.ts
@@ -1,5 +1,5 @@
-import { SingleResourceRelationship, CollectionResourceRelationship } from './ember-data-json-api';
-
+type SingleResourceRelationship = import('./ember-data-json-api').SingleResourceRelationship;
+type CollectionResourceRelationship = import('./ember-data-json-api').CollectionResourceRelationship;
 /**
   @module @ember-data/store
 */

--- a/packages/store/addon/-private/ts-interfaces/record-data-record-wrapper.ts
+++ b/packages/store/addon/-private/ts-interfaces/record-data-record-wrapper.ts
@@ -1,7 +1,8 @@
-import { JsonApiValidationError } from './record-data-json-api';
-import { SingleResourceRelationship, CollectionResourceRelationship } from './ember-data-json-api';
-import { RecordIdentifier } from './identifier';
-import { ChangedAttributesHash } from './record-data';
+type ChangedAttributesHash = import('./record-data').ChangedAttributesHash;
+type RecordIdentifier = import('./identifier').RecordIdentifier;
+type SingleResourceRelationship = import('./ember-data-json-api').SingleResourceRelationship;
+type CollectionResourceRelationship = import('./ember-data-json-api').CollectionResourceRelationship;
+type JsonApiValidationError = import('./record-data-json-api').JsonApiValidationError;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/ts-interfaces/record-data-store-wrapper.ts
+++ b/packages/store/addon/-private/ts-interfaces/record-data-store-wrapper.ts
@@ -1,5 +1,6 @@
-import { RelationshipsSchema, AttributesSchema } from './record-data-schemas';
 import { BRAND_SYMBOL } from './utils/brand';
+type RelationshipsSchema = import('./record-data-schemas').RelationshipsSchema;
+type AttributesSchema = import('./record-data-schemas').AttributesSchema;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/ts-interfaces/record-data.ts
+++ b/packages/store/addon/-private/ts-interfaces/record-data.ts
@@ -1,7 +1,8 @@
-import { JsonApiResource, JsonApiValidationError } from './record-data-json-api';
-import { SingleResourceRelationship, CollectionResourceRelationship } from './ember-data-json-api';
-
-import { RecordIdentifier } from './identifier';
+type RecordIdentifier = import('./identifier').RecordIdentifier;
+type SingleResourceRelationship = import('./ember-data-json-api').SingleResourceRelationship;
+type CollectionResourceRelationship = import('./ember-data-json-api').CollectionResourceRelationship;
+type JsonApiResource = import('./record-data-json-api').JsonApiResource;
+type JsonApiValidationError = import('./record-data-json-api').JsonApiValidationError;
 
 /**
   @module @ember-data/store

--- a/packages/store/addon/-private/ts-interfaces/schema-definition-service.ts
+++ b/packages/store/addon/-private/ts-interfaces/schema-definition-service.ts
@@ -1,8 +1,10 @@
 /**
   @module @ember-data/store
 */
-import { RecordIdentifier } from './identifier';
-import { AttributesSchema, RelationshipsSchema } from './record-data-schemas';
+
+type AttributesSchema = import('./record-data-schemas').AttributesSchema;
+type RelationshipsSchema = import('./record-data-schemas').RelationshipsSchema;
+type RecordIdentifier = import('./identifier').RecordIdentifier;
 
 export interface SchemaDefinitionService {
   doesTypeExist(modelName: string): boolean;

--- a/packages/store/addon/-private/utils/construct-resource.ts
+++ b/packages/store/addon/-private/utils/construct-resource.ts
@@ -1,6 +1,6 @@
 import isNonEmptyString from './is-non-empty-string';
-import { ResourceIdentifierObject } from '../ts-interfaces/ember-data-json-api';
 import coerceId from '../system/coerce-id';
+type ResourceIdentifierObject = import('../ts-interfaces/ember-data-json-api').ResourceIdentifierObject;
 
 export default function constructResource(
   type: string,

--- a/packages/store/addon/-private/utils/promise-record.ts
+++ b/packages/store/addon/-private/utils/promise-record.ts
@@ -1,7 +1,7 @@
-import InternalModel from '../system/model/internal-model';
 import { promiseObject } from '../system/promise-proxies';
-import { PromiseProxy } from '../ts-interfaces/promise-proxies';
-import { DSModel } from '../ts-interfaces/ds-model';
+type DSModel = import('../ts-interfaces/ds-model').DSModel;
+type PromiseProxy<T> = import('../ts-interfaces/promise-proxies').PromiseProxy<T>;
+type InternalModel = import('../system/model/internal-model').default;
 /**
   @module @ember-data/store
 */

--- a/packages/unpublished-eslint-rules/package.json
+++ b/packages/unpublished-eslint-rules/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "eslint-plugin-ember-data",
+  "main": "./src/index.js",
+  "version": "3.16.0-alpha.2",
+  "private": true
+}

--- a/packages/unpublished-eslint-rules/src/index.js
+++ b/packages/unpublished-eslint-rules/src/index.js
@@ -1,0 +1,7 @@
+const preferTypeOnlyImport = require('./rules/prefer-type-only-import');
+
+module.exports = {
+  rules: {
+    'prefer-type-only-import': preferTypeOnlyImport,
+  },
+};

--- a/packages/unpublished-eslint-rules/src/rules/prefer-type-only-import.js
+++ b/packages/unpublished-eslint-rules/src/rules/prefer-type-only-import.js
@@ -1,0 +1,362 @@
+const collapseRanges = require('./utils/collapse-ranges');
+const createParamStringForGenerics = require('./utils/create-param-string-for-generics');
+const RULE_FAILURE_MESSAGE = `ES Import Declaration should be converted to Typescript type only import.`;
+
+function identifierIsModuleScopeReference(identifier, scope) {
+  // determine if this Identifier is declared in module scope
+  // (vs. potentially a shadowed variable instance)
+  for (let i = 0; i < scope.references.length; i++) {
+    let ref = scope.references[i];
+    if (ref.identifier === identifier) {
+      if (ref.resolved.scope.type === 'module') {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/*
+ Checks if an identifier could potentially be the usage of something imported.
+ This is useful for preventing the more expensive "scope check" on the identifier
+ needed to confirm something is indeed the thing imported for cases where it is
+ obvious that it could not be.
+*/
+function isMaybeUsage(identifier, imports) {
+  if (imports[identifier.name] === undefined) {
+    return false;
+  }
+
+  let type = identifier.parent.type;
+  // weed out declarations or accessors that can't
+  // possibly be a reference to an import
+  if (
+    type === 'ImportSpecifier' ||
+    type === 'ImportDefaultSpecifier' ||
+    type === 'TSTypeReference' ||
+    type === 'TSClassImplements' ||
+    type === 'TSInterfaceHeritage' ||
+    type === 'TSQualifiedName' ||
+    type === 'TSEmptyBodyFunctionExpression' ||
+    type === 'TSPropertySignature' ||
+    type === 'TSMethodSignature' ||
+    type === 'TSTypeQuery' ||
+    type === 'TSTypeAliasDeclaration' ||
+    type === 'TSImportType' ||
+    type === 'TSModuleDeclaration' ||
+    (type === 'MemberExpression' && identifier.parent.property === identifier) ||
+    (type === 'ClassDeclaration' && identifier.parent.id === identifier) ||
+    (type === 'VariableDeclarator' && identifier.parent.id === identifier) ||
+    (type === 'AssignmentPattern' && identifier.parent.left === identifier) ||
+    type === 'FunctionDeclaration' ||
+    type === 'FunctionExpression' ||
+    (type === 'ClassProperty' && identifier.parent.key === identifier) ||
+    (type === 'MethodDefinition' && identifier.parent.key === identifier) ||
+    (type === 'AssignmentExpression' && identifier.parent.left === identifier) ||
+    (type === 'Property' && identifier.parent.key === identifier && identifier.parent.value !== identifier) ||
+    (type === 'Property' && identifier.parent.key === identifier && identifier.parent.parent.type === 'ObjectPattern')
+  ) {
+    return false;
+  }
+  /*
+  if (
+    type !== 'MemberExpression' &&
+    type !== 'CallExpression' &&
+    type !== 'IfStatement' &&
+    type !== 'BinaryExpression' &&
+    type !== 'ClassDeclaration' &&
+    type !== 'VariableDeclaration' &&
+    type !== 'AssignmentPattern' &&
+    type !== 'ClassProperty' &&
+    type !== 'NewExpression' &&
+    type !== 'ConditionalExpression' &&
+    type !== 'UnaryExpression' &&
+    type !== 'LogicalExpression' &&
+    type !== 'ExportDefaultDeclaration' &&
+    type !== 'Property' &&
+    type !== 'ExportSpecifier' &&
+    type !== 'VariableDeclarator'
+  ) {
+    console.log(type, identifier.name);
+  }
+  */
+  return true;
+}
+
+/*
+  return specifiers for a declaration that were-not-used by any JS code
+*/
+function getSpecifiersNotUsedByJS(declaration, used) {
+  return declaration.specifiers.filter(s => used[s.local.name] !== true);
+}
+
+/*
+ return specifiers that are type-only by the union of the the list of
+ specifiers for a declaration that are not-used-by-JS and the list of
+ specifiers that were-used-as-types
+*/
+function getTypeOnlySpecifiers(specifiers, usedTypes) {
+  return specifiers.filter(s => usedTypes[s.local.name]);
+}
+
+/*
+  return whatever specifiers are not type-only specifiers for a declaration
+  some of which may be unused as either types or in JS code
+*/
+function getRemainingSpecifiers(declaration, typeSpecifiers) {
+  return declaration.specifiers.filter(s => typeSpecifiers.indexOf(s) === -1);
+}
+
+/*
+ Given a specifier intended for removal, get the full range we should remove.
+
+ This adusts the range to account for removing both the specifier and
+ when needed either the rest of the declaration or any associated syntax
+ like extraneous brackets {} or commas and newlines.
+*/
+function getRangeToRemove(importSpecifierToRemove) {
+  let declaration = importSpecifierToRemove.parent;
+  let specifiers = declaration.specifiers;
+  let defaultImport;
+
+  if (specifiers.length && specifiers[0].type === 'ImportDefaultSpecifier') {
+    defaultImport = specifiers[0];
+    specifiers = [...specifiers];
+    specifiers.shift();
+  }
+
+  if (importSpecifierToRemove === defaultImport) {
+    if (specifiers.length === 0) {
+      // remove the whole declaration + the newLine
+      let [start, end] = declaration.range;
+      return [start, end + 1];
+    }
+    // remove the defaultImport + a comma
+    let [start, end] = importSpecifierToRemove.range;
+    return [start, end + 1];
+  }
+
+  let index = specifiers.indexOf(importSpecifierToRemove);
+  let isFirst = index === 0;
+  let isOnly = specifiers.length === 1;
+  let isLast = specifiers.length - 1 === index;
+
+  let prevSibling = isOnly || isFirst ? null : specifiers[index - 1];
+  let nextSibling = isOnly || isLast ? null : specifiers[index + 1];
+
+  if (isOnly) {
+    if (!defaultImport) {
+      // console.log(`removing full declaration with removal of named import ${exportToRemove.local.name}`);
+      // remove the whole declaration + the newLine
+      let [start, end] = declaration.range;
+      return [start, end + 1];
+    }
+    // remove the entirety of {}
+    // console.log(`removing all named imports with removal of named import ${exportToRemove.local.name}`);
+    let start = defaultImport.range[1];
+    let end = importSpecifierToRemove.range[1] + 2;
+    return [start, end];
+  }
+
+  if (isLast) {
+    // console.log(`removing from preceding named import for ${exportToRemove.local.name}`);
+    // remove starting with preceding `,`
+    // which is possibly on a different line
+    let start = prevSibling.range[1];
+    let isMultiLine = prevSibling.loc.end.column !== importSpecifierToRemove.loc.end.column;
+    let end = isMultiLine ? importSpecifierToRemove.range[1] + 1 : importSpecifierToRemove.range[1];
+    return [start, end];
+  }
+
+  // remove starting with our imported and ending where the next specifier begins
+  // console.log(`removing up to next named import for ${exportToRemove.local.name}`);
+  let start = importSpecifierToRemove.range[0];
+  let end = nextSibling.range[0];
+  return [start, end];
+}
+
+function reportRuleViolation(violation) {
+  let { context, declaration, lastImportNode, rangesToRemove, newTypeImports } = violation;
+
+  context.report({
+    message: RULE_FAILURE_MESSAGE,
+    node: declaration,
+    fix(fixer) {
+      let changes = [];
+      if (lastImportNode) {
+        // place at the end of all import statements
+        changes.push(fixer.insertTextAfter(lastImportNode, newTypeImports));
+      } else {
+        // no more ES imports remain after we remove this one
+        changes.push(fixer.insertTextBeforeRange(declaration.range, newTypeImports));
+      }
+      rangesToRemove.forEach(range => {
+        changes.push(fixer.removeRange(range));
+      });
+      return changes;
+    },
+  });
+}
+
+function lintDeclarationForTypeOnlyImports(declaration, usageData, context) {
+  let { imports, usedImports, usedTypes, paramsForType, lastImportNode } = usageData;
+  let unusedImports = getSpecifiersNotUsedByJS(declaration, usedImports);
+  let typeOnlyImports = getTypeOnlySpecifiers(unusedImports, usedTypes);
+
+  if (typeOnlyImports.length === 0) {
+    // nothing to do for this declaration
+    return;
+  }
+
+  let remaining = getRemainingSpecifiers(declaration, typeOnlyImports);
+  let importStatements = typeOnlyImports.map(specifier => {
+    let name = specifier.local.name;
+    let info = imports[name];
+    let realName = info.isDefault ? 'default' : info.imported.name;
+
+    // curry type generics params if necessary
+    let paramString = createParamStringForGenerics(paramsForType[name]);
+
+    return `\ntype ${name}${paramString} = import('${imports[name].from.value}').${realName}${paramString};`;
+  });
+
+  let newTypeImports = importStatements.join('');
+  let rangesToRemove;
+
+  if (remaining.length === 0) {
+    // if this is the import we are removing
+    // we have to alter where we will do insertion
+    if (lastImportNode === declaration) {
+      let decs = usageData.declarations;
+
+      if (decs.length > 1) {
+        lastImportNode = decs[decs.length - 2];
+      } else {
+        lastImportNode = null;
+      }
+    }
+
+    // if nothing remains everything converts to a type Import
+    let [start, end] = declaration.range;
+    let range = [start, end + 1];
+    rangesToRemove = [range];
+  } else {
+    let removedRanges = [];
+    typeOnlyImports.forEach(specifier => {
+      removedRanges.push(getRangeToRemove(specifier));
+    });
+    rangesToRemove = collapseRanges(removedRanges);
+  }
+
+  reportRuleViolation({
+    context,
+    declaration,
+    lastImportNode,
+    rangesToRemove,
+    newTypeImports,
+  });
+}
+
+module.exports = {
+  name: 'prefer-type-only-import',
+  meta: {
+    type: 'Suggestion',
+    docs: {
+      description:
+        "Requires using type-only import syntax `type X = import('./foo').X`" +
+        'for imports that are only used for type information. This prevents cycles' +
+        ' from developing in ES Imports, simplifies things for rollup, and avoids ' +
+        'accidental library size bloat from imports and exports that are left behind ' +
+        'after stripping away type information.',
+      category: 'Stylistic Issues',
+      recommended: true,
+    },
+    schema: [],
+    messages: {},
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create(context) {
+    let imports, usedImports, usedTypes, paramsForType, lastImportNode, declarations;
+    return {
+      Program() {
+        declarations = [];
+        imports = {};
+        usedImports = {};
+        usedTypes = {};
+        paramsForType = {};
+        lastImportNode = null;
+      },
+      'Program:exit'() {
+        // console.log('\n\n\nProgram:exitBegin\n======\n');
+        // eslint will only pass over a file 10x before bailing
+        // our approach lets us autofix more things by collapsing fixes for
+        // a single import declaration into one error+change instead of fix
+        // by individual imports within a declaration
+        let usageData = {
+          imports,
+          usedImports,
+          usedTypes,
+          paramsForType,
+          lastImportNode,
+          declarations,
+        };
+        for (let i = 0; i < declarations.length; i++) {
+          lintDeclarationForTypeOnlyImports(declarations[i], usageData, context);
+        }
+        // console.log('\nProgram:exitEnd\n======\n\n\n');
+      },
+      ImportDeclaration(node) {
+        declarations.push(node);
+        lastImportNode = node;
+      },
+      ImportDefaultSpecifier(node) {
+        imports[node.local.name] = {
+          local: node.local,
+          imported: node.imported || node.local,
+          from: node.parent.source,
+          isDefault: true,
+        };
+      },
+      ImportSpecifier(node) {
+        imports[node.local.name] = {
+          local: node.local,
+          imported: node.imported || node.local,
+          from: node.parent.source,
+          isDefault: false,
+        };
+      },
+      Identifier(node) {
+        if (!isMaybeUsage(node, imports)) {
+          return;
+        }
+
+        let scope = context.getScope();
+        if (scope.type === 'class') {
+          usedImports[node.name] = true;
+        } else if (identifierIsModuleScopeReference(node, scope)) {
+          usedImports[node.name] = true;
+        }
+      },
+      TSTypeReference(node) {
+        let identifier = node.typeName;
+        if (imports[identifier.name] !== undefined) {
+          // console.log(`found used type ${identifier.name}`);
+          usedTypes[identifier.name] = true;
+          let maxParamsSeen = paramsForType[identifier.name] || 0;
+
+          if (node.typeParameters && node.typeParameters.params.length > maxParamsSeen) {
+            // this type usage contains generics e.g. `Dict<Thing>`
+            // so we save off how many params it uses to fix up the import
+            // later
+            maxParamsSeen = node.typeParameters.params.length;
+            usedTypes[identifier.name] = node.typeParameters.params.length;
+          }
+
+          paramsForType[identifier.name] = maxParamsSeen;
+        }
+      },
+    };
+  },
+};

--- a/packages/unpublished-eslint-rules/src/rules/utils/collapse-ranges.js
+++ b/packages/unpublished-eslint-rules/src/rules/utils/collapse-ranges.js
@@ -1,0 +1,55 @@
+/*
+  return `true` if a number is between or equal to either of two other numbers
+  or if the number is directly adjacent to either end
+*/
+function isBetweenOrAdjacent(num, start, end) {
+  return (num >= start && num <= end) || num === start - 1 || num === end + 1;
+}
+
+/*
+  given an array of ranges (where a range is an array of two numbers [start, end])
+  combine any overlapping or adjacent ranges.
+
+  [
+    [0, 3],
+    [5, 9],
+    [2, 4],
+    [4, 8],
+    [10, 11],
+    [18, 25],
+    [13, 16],
+    [11, 15],
+    [17, 17],
+  ]
+
+  =>
+
+  [
+    [0, 25],
+  ]
+*/
+module.exports = function collapseRanges(ranges) {
+  let finalRanges = [];
+  for (let i = 0; i < ranges.length; i++) {
+    let [start, end] = ranges[i];
+
+    // scan forward for unprocessed ranges
+    for (let j = i + 1; j < ranges.length; ) {
+      let [nextStart, nextEnd] = ranges[j];
+      if (isBetweenOrAdjacent(nextStart, start, end) || isBetweenOrAdjacent(nextEnd, start, end)) {
+        start = start > nextStart ? nextStart : start;
+        end = end > nextEnd ? end : nextEnd;
+        // remove the collapsed range
+        ranges.splice(j, 1);
+        // invalidate our forward scan
+        j = i + 1;
+      } else {
+        // move forward
+        j++;
+      }
+    }
+    finalRanges.push([start, end]);
+  }
+
+  return finalRanges;
+};

--- a/packages/unpublished-eslint-rules/src/rules/utils/create-param-string-for-generics.js
+++ b/packages/unpublished-eslint-rules/src/rules/utils/create-param-string-for-generics.js
@@ -1,0 +1,21 @@
+// nice conventional naming schemes for using <= 4 generics
+const TypeParamNamingSchema = [['T'], ['K', 'V'], ['T', 'K', 'V'], ['T', 'K', 'V', 'R']];
+// if the type uses more generics than this then WAT
+const Alphabet = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P'];
+
+module.exports = function createParamStringForGenerics(numberOfGenerics) {
+  let hasParams = typeof numberOfGenerics === 'number' && numberOfGenerics !== 0;
+  let paramString = '';
+  if (hasParams) {
+    let alphabet = Alphabet;
+    let params = [];
+    if (numberOfGenerics <= TypeParamNamingSchema.length) {
+      alphabet = TypeParamNamingSchema[numberOfGenerics - 1];
+    }
+    for (let i = 0; i < numberOfGenerics; i++) {
+      params.push(alphabet[i]);
+    }
+    paramString = `<${params.join(', ')}>`;
+  }
+  return paramString;
+};

--- a/packages/unpublished-fastboot-test-app/types/global.d.ts
+++ b/packages/unpublished-fastboot-test-app/types/global.d.ts
@@ -1,6 +1,6 @@
 // Types for compiled templates
 declare module 'fastboot-test-app/templates/*' {
-  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  type TemplateFactory = import('htmlbars-inline-precompile').TemplateFactory;
   const tmpl: TemplateFactory;
   export default tmpl;
 }


### PR DESCRIPTION
resolves #6804 

Also runs the `--fix` for it.

~~This likely will reduce our asset-sizes.~~
**Edit:** looks like thanks to previous manual optimization of this + rollup we don't see a win here (previous manual optimization did result in wins). But this will help avoid future regressions :) 

Will revisit #6849 once this lands.