### PR TITLE
[CHORE] Install Backport bot

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,6 +11,9 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: gaurav0/backport@v1.0.9
+        uses: Gaurav0/backport@v1.0.24
         with:
+          bot_username: backport-bot-data
+          bot_token: c8164016ab9393cb3ab0c88fc47d9c6738c78648
+          bot_token_key: 4d5430a4248f97b37f658f24432cfb96f045b3ff
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,16 @@
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-18.04
+    name: Backport
+    steps:
+      - name: Backport
+        uses: gaurav0/backport@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,6 +11,6 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: gaurav0/backport@v1
+        uses: gaurav0/backport@v1.0.9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,14 @@ All commits should be tagged. Tags are denoted by square brackets (`[]`) and com
 In general almost all commits should fall into one of the above categories. In the cases where they don't please submit
 your PR untagged.
 
+#### Backporting
+
+This repo uses the backport bot which is available on the Github marketplace at https://github.com/marketplace/actions/backport-bot and is maintained at https://github.com/Gaurav0/backport
+
+To use it, maintainer or collaborator can label a pull request with "backport &lt;branchname&gt;".
+Then after the PR is merged, a new PR will automatically be opened if possible. Please note that the PR
+must have been merged using "squash and merge" in order for the cherry-pick operation to work.
+
 ## Notes
 
 - Commit tagging section taken from [ember.js](https://github.com/emberjs/ember.js/blob/5641c3089180bdd1d4fa54e9dd2d3ac285f088e4/CONTRIBUTING.md#commit-tagging)


### PR DESCRIPTION
<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
For #6103 

I forked https://github.com/tibdex/backport and created a version that will work with forked repos. I have opened https://github.com/tibdex/backport/pull/39 but until it is merged I've published the backport bot on my own username in the Github Marketplace, so we can use it right away. I'd like to go ahead and have us test it out in a large codebase like Ember Data