### PR TITLE
improve performance app documentation

### DIFF
--- a/packages/unpublished-relationship-performance-test-app/PERFORMANCE_BENCHMARKING.md
+++ b/packages/unpublished-relationship-performance-test-app/PERFORMANCE_BENCHMARKING.md
@@ -6,19 +6,21 @@ npm install -g tracerbench@2.3.0 pm2
 
 Next, run the following from the root of this repository:
 
-```
+```sh
 ./bin/relationship-performance-tracking/head-vs-master.sh
 ```
 
 Note: This uses a HAR file (`bin/relationship-performance-tracking/src/trace.har`) that was manually downloaded. Ideally this will be created on the fly, but I had some trouble getting TracerBench to create it with all the necessary information for HAR Remix to serve it.
 
-To create the HAR file:
+## manually create HAR capture
 
-```
-cd packages/unpublished-relationship-performance-test-app/
-ember build -prod
-cd dist
-php -S localhost:5000 # or any other web server
-```
-
-Visit http://localhost:5000, open the Network panel in Chrome Dev Tools, right click on "localhost", then select "Save all as HAR with content".
+- `cd packages/unpublished-relationship-performance-test-app/ && ember serve -prod --port 5000`
+   - *Note* some shells may error on the `&&` operator. If so execute each command separately:
+     ```sh
+      $ cd packages/unpublished-relationship-performance-test-app/
+      $ ember serve -prod --port 5000
+     ```
+- Visit [http://localhost:5000](http://localhost:5000)
+- open the Network panel in Chrome Dev Tools
+- right click on "localhost"
+- select "Save all as HAR with content"

--- a/packages/unpublished-relationship-performance-test-app/PERFORMANCE_BENCHMARKING.md
+++ b/packages/unpublished-relationship-performance-test-app/PERFORMANCE_BENCHMARKING.md
@@ -22,5 +22,5 @@ Note: This uses a HAR file (`bin/relationship-performance-tracking/src/trace.har
      ```
 - Visit [http://localhost:5000](http://localhost:5000)
 - open the Network panel in Chrome Dev Tools
-- right click on "localhost"
+- right click on any of loaded network assets such as vendor.css
 - select "Save all as HAR with content"

--- a/packages/unpublished-relationship-performance-test-app/PERFORMANCE_BENCHMARKING.md
+++ b/packages/unpublished-relationship-performance-test-app/PERFORMANCE_BENCHMARKING.md
@@ -14,11 +14,11 @@ Note: This uses a HAR file (`bin/relationship-performance-tracking/src/trace.har
 
 ## manually create HAR capture
 
-- `cd packages/unpublished-relationship-performance-test-app/ && ember serve -prod --port 5000`
+- `cd packages/unpublished-relationship-performance-test-app/ && ember serve -prod --live-reload false --port 5000`
    - *Note* some shells may error on the `&&` operator. If so execute each command separately:
      ```sh
       $ cd packages/unpublished-relationship-performance-test-app/
-      $ ember serve -prod --port 5000
+      $ ember serve -prod --live-reload false --port 5000
      ```
 - Visit [http://localhost:5000](http://localhost:5000)
 - open the Network panel in Chrome Dev Tools


### PR DESCRIPTION
I removed `php` server recommendation since we can use ember-cli's
server.

Is there a specific reason we pin tracerbench to 2.3?

/cc @skaterdav85 @runspired 