### PR TITLE
restore inital checkout when running perf analysis

### DIFF
--- a/bin/relationship-performance-tracking/generate-analysis.sh
+++ b/bin/relationship-performance-tracking/generate-analysis.sh
@@ -3,6 +3,7 @@
 HAR_REMIX_SCRIPT="bin/relationship-performance-tracking/src/har-remix.js"
 WORKSPACE="relationship-performance-test-app"
 TEST_APP_PATH="packages/unpublished-relationship-performance-test-app"
+INITIAL_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
 
 if [[ -z "$USE_EXISTING_DISTS" ]]; then
   echo "Creating production builds for commits"
@@ -31,3 +32,4 @@ HR_PORT=4201 HR_GROUP=experiment pm2 start $HAR_REMIX_SCRIPT --name experiment
 node ./bin/relationship-performance-tracking/src/tracerbench.js
 tracerbench compare:analyze "$TEST_APP_PATH/tracerbench-results/trace-results.json"
 pm2 kill
+git checkout "$INITIAL_BRANCH"


### PR DESCRIPTION
This ensures we checkout whatever branch the user had when they launched the script.
Further improvements would be to bail if there are staged changes since they could violate the principles of reproducible measurements. I'm waiting to do those since we are considering migrating this script to JS for consistency.