### PR TITLE
[DOC] Update embedded-records-mixin.js

### DIFF
--- a/packages/serializer/addon/-private/embedded-records-mixin.js
+++ b/packages/serializer/addon/-private/embedded-records-mixin.js
@@ -19,6 +19,8 @@ import { typeOf } from '@ember/utils';
 
   Note that embedded records will serialize with the serializer for their model instead of the serializer in which they are defined.
 
+  Note also that this mixin does not work with JSONAPISerializer because the JSON:API specification does not describe how to format embedded resources.
+
   Below is an example of a per-type serializer (`post` type).
 
   ```app/serializers/post.js


### PR DESCRIPTION
Adding documentation on the embedded records mixin explaining that it does not work with JSONAPISerializer. This should be noted more prominently rather than in a passive warning message (which might get buried under a sea of deprecation warnings in the test suite).