### PR TITLE
[FIX] RecordData is not a constructor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,8 @@
 
 # compiled output
 **/dist/
+**/dist-control/
+**/dist-experiment/
 **/tmp/
 /packages/-ember-data/docs/
 

--- a/packages/-ember-data/addon/index.js
+++ b/packages/-ember-data/addon/index.js
@@ -26,7 +26,7 @@ import JSONSerializer from '@ember-data/serializer/json';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import RESTSerializer, { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
 import Transform from '@ember-data/serializer/transform';
-import { normalizeModelName } from '@ember-data/store';
+import Store, { normalizeModelName } from '@ember-data/store';
 
 import {
   AdapterPopulatedRecordArray,
@@ -45,7 +45,6 @@ import {
 } from './-private';
 import initializeStoreService from './initialize-store-service';
 import setupContainer from './setup-container';
-import Store from './store';
 
 if (VERSION.match(/^1\.([0-9]|1[0-2])\./)) {
   throw new EmberError(

--- a/packages/record-data/addon/-private/ts-interfaces/relationship-record-data.ts
+++ b/packages/record-data/addon/-private/ts-interfaces/relationship-record-data.ts
@@ -1,9 +1,6 @@
-import {
-  CollectionResourceRelationship,
-  SingleResourceRelationship,
-} from '@ember-data/store/-private/ts-interfaces/ember-data-json-api';
-import { RecordData } from '@ember-data/store/-private/ts-interfaces/record-data';
-
+type SingleResourceRelationship = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').SingleResourceRelationship;
+type CollectionResourceRelationship = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').CollectionResourceRelationship;
+type RecordData = import('@ember-data/store/-private/ts-interfaces/record-data').RecordData;
 type ConfidentDict<T> = import('@ember-data/store/-private/ts-interfaces/utils').ConfidentDict<T>;
 type HasManyRelationship = import('../relationships/state/has-many').default;
 type BelongsToRelationship = import('../relationships/state/belongs-to').default;

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -29,6 +29,7 @@ import {
   HAS_ADAPTER_PACKAGE,
   HAS_EMBER_DATA_PACKAGE,
   HAS_MODEL_PACKAGE,
+  HAS_RECORD_DATA_PACKAGE,
   HAS_SERIALIZER_PACKAGE,
 } from '@ember-data/private-build-infra';
 import {
@@ -94,7 +95,9 @@ type AttributesSchema = import('../ts-interfaces/record-data-schemas').Attribute
 type SchemaDefinitionService = import('../ts-interfaces/schema-definition-service').SchemaDefinitionService;
 type PrivateSnapshot = import('./snapshot').PrivateSnapshot;
 type Relationship = import('@ember-data/record-data/-private').Relationship;
+type RecordDataClass = typeof import('@ember-data/record-data/-private').RecordData;
 
+let _RecordData: RecordDataClass | undefined;
 const emberRun = emberRunLoop.backburner;
 
 const { ENV } = Ember;
@@ -412,14 +415,16 @@ abstract class CoreStore extends Service {
     if (REQUEST_SERVICE) {
       return this._fetchManager.requestCache;
     }
-    throw new Error('RequestService is not available unless the feature flag is on and running on a canary build');
+
+    assertInDebug('RequestService is not available unless the feature flag is on and running on a canary build', false);
   }
 
   get identifierCache(): IdentifierCache {
-    if (!IDENTIFIERS) {
-      throw new Error(`Store.identifierCache is unavailable in this build of EmberData`);
+    if (IDENTIFIERS) {
+      return identifierCacheFor(this);
     }
-    return identifierCacheFor(this);
+
+    assertInDebug(`Store.identifierCache is unavailable in this build of EmberData`, false);
   }
 
   _instantiateRecord(
@@ -475,9 +480,9 @@ abstract class CoreStore extends Service {
       setRecordIdentifier(record, identifier);
       //recordToInternalModelMap.set(record, internalModel);
       return record;
-    } else {
-      throw new Error('should not be here, custom model class ff error');
     }
+
+    assertInDebug('should not be here, custom model class ff error', false);
   }
 
   abstract instantiateRecord(
@@ -517,9 +522,9 @@ abstract class CoreStore extends Service {
   getSchemaDefinitionService(): SchemaDefinitionService {
     if (CUSTOM_MODEL_CLASS) {
       return this._schemaDefinitionService;
-    } else {
-      throw new Error('need to enable CUSTOM_MODEL_CLASS feature flag in order to access SchemaDefinitionService');
     }
+
+    assertInDebug('need to enable CUSTOM_MODEL_CLASS feature flag in order to access SchemaDefinitionService', false);
   }
 
   // TODO Double check this return value is correct
@@ -3060,9 +3065,9 @@ abstract class CoreStore extends Service {
       let internalModel = internalModelFactoryFor(this).peek(identifier);
       // TODO we used to check if the record was destroyed here
       return internalModel!.createSnapshot(options).serialize(options);
-    } else {
-      throw new Error('serializeRecord is only available when CUSTOM_MODEL_CLASS ff is on');
     }
+
+    assertInDebug('serializeRecord is only available when CUSTOM_MODEL_CLASS ff is on', false);
   }
 
   saveRecord(record: RecordInstance, options?: Dict<unknown>): RSVP.Promise<RecordInstance> {
@@ -3073,9 +3078,9 @@ abstract class CoreStore extends Service {
       // Casting can be removed once REQUEST_SERVICE ff is turned on
       // because a `Record` is provided there will always be a matching internalModel
       return (internalModel!.save(options) as RSVP.Promise<void>).then(() => record);
-    } else {
-      throw new Error('saveRecord is only available when CUSTOM_MODEL_CLASS ff is on');
     }
+
+    assertInDebug('saveRecord is only available when CUSTOM_MODEL_CLASS ff is on', false);
   }
 
   relationshipReferenceFor(identifier: RecordIdentifier, key: string): BelongsToReference | HasManyReference {
@@ -3084,9 +3089,9 @@ abstract class CoreStore extends Service {
       let internalModel = internalModelFactoryFor(this).peek(stableIdentifier);
       // TODO we used to check if the record was destroyed here
       return internalModel!.referenceFor(null, key);
-    } else {
-      throw new Error('relationshipReferenceFor is only available when CUSTOM_MODEL_CLASS ff is on');
     }
+
+    assertInDebug('relationshipReferenceFor is only available when CUSTOM_MODEL_CLASS ff is on', false);
   }
 
   /**
@@ -3111,7 +3116,26 @@ abstract class CoreStore extends Service {
     clientId: string,
     storeWrapper: RecordDataStoreWrapper
   ): RecordData {
-    throw new Error(`Expected store.createRecordDataFor to be implemented but it wasn't`);
+    if (HAS_RECORD_DATA_PACKAGE) {
+      // we can't greedily use require as this causes
+      // a cycle we can't easily fix (or clearly pin point) at present.
+      if (_RecordData === undefined) {
+        _RecordData = require('@ember-data/record-data/-private').RecordData as RecordDataClass;
+      }
+
+      if (IDENTIFIERS) {
+        let identifier = identifierCacheFor(this).getOrCreateRecordIdentifier({
+          type: modelName,
+          id,
+          lid: clientId,
+        });
+        return new _RecordData(identifier, storeWrapper);
+      } else {
+        return new _RecordData(modelName, id, clientId, storeWrapper);
+      }
+    }
+
+    assertInDebug(`Expected store.createRecordDataFor to be implemented but it wasn't`, false);
   }
 
   /**
@@ -3179,10 +3203,11 @@ abstract class CoreStore extends Service {
   }
 
   newClientId() {
-    if (IDENTIFIERS) {
-      throw new Error(`Private API Removed`);
+    if (!IDENTIFIERS) {
+      return globalClientIdCounter++;
     }
-    return globalClientIdCounter++;
+
+    assertInDebug(`Private API Removed`, false);
   }
 
   // ...............
@@ -3732,10 +3757,14 @@ function internalModelForRelatedResource(
   return store._internalModelForResource(identifier);
 }
 
+function assertInDebug(msg: string, cond: boolean = false): asserts cond is true {
+  if (DEBUG && cond) {
+    throw new Error(msg);
+  }
+}
+
 function assertIdentifierHasId(
   identifier: StableRecordIdentifier
 ): asserts identifier is StableExistingRecordIdentifier {
-  if (DEBUG && identifier.id === null) {
-    throw new Error(`Attempted to schedule a fetch for a record without an id.`);
-  }
+  assertInDebug(`Attempted to schedule a fetch for a record without an id.`, identifier.id === null);
 }

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -3119,6 +3119,9 @@ abstract class CoreStore extends Service {
     if (HAS_RECORD_DATA_PACKAGE) {
       // we can't greedily use require as this causes
       // a cycle we can't easily fix (or clearly pin point) at present.
+      //
+      // it can be reproduced in partner tests by running
+      // node ./bin/packages-for-commit.js && yarn test-external:ember-observer
       if (_RecordData === undefined) {
         _RecordData = require('@ember-data/record-data/-private').RecordData as RecordDataClass;
       }

--- a/packages/store/addon/-private/system/ds-model-store.ts
+++ b/packages/store/addon/-private/system/ds-model-store.ts
@@ -10,19 +10,13 @@ import { assign } from '@ember/polyfills';
 import { isPresent } from '@ember/utils';
 import { DEBUG } from '@glimmer/env';
 
-import { CUSTOM_MODEL_CLASS, IDENTIFIERS } from '@ember-data/canary-features';
-import { HAS_RECORD_DATA_PACKAGE } from '@ember-data/private-build-infra';
+import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
 
-import { identifierCacheFor } from '../identifiers/cache';
 import CoreStore from './core-store';
 import notifyChanges from './model/notify-changes';
 import { getShimClass } from './model/shim-model-class';
 import normalizeModelName from './normalize-model-name';
 import { DSModelSchemaDefinitionService, getModelFactory } from './schema-definition-service';
-
-type RecordDataStoreWrapper = import('./store/record-data-store-wrapper').default;
-
-const RecordData = HAS_RECORD_DATA_PACKAGE ? require('@ember-data/record-data/-private').RecordData : null;
 
 type RelationshipsSchema = import('../ts-interfaces/record-data-schemas').RelationshipsSchema;
 type SchemaDefinitionService = import('../ts-interfaces/schema-definition-service').SchemaDefinitionService;
@@ -142,31 +136,14 @@ class Store extends CoreStore {
     record.destroy();
   }
 
-  createRecordDataFor(modelName: string, id: string | null, clientId: string, storeWrapper: RecordDataStoreWrapper) {
-    if (HAS_RECORD_DATA_PACKAGE) {
-      if (IDENTIFIERS) {
-        let identifier = identifierCacheFor(this).getOrCreateRecordIdentifier({
-          type: modelName,
-          id,
-          lid: clientId,
-        });
-        return new RecordData(identifier, storeWrapper);
-      } else {
-        return new RecordData(modelName, id, clientId, storeWrapper);
-      }
-    } else {
-      throw new Error(`Expected store.createRecordDataFor to be implemented but it wasn't`);
-    }
-  }
-
   /**
   Returns the model class for the particular `modelName`.
- 
+
   The class of a model might be useful if you want to get a list of all the
   relationship names of the model, see
   [`relationshipNames`](/ember-data/release/classes/Model?anchor=relationshipNames)
   for example.
- 
+
   @method modelFor
   @param {String} modelName
   @return {Model}
@@ -215,10 +192,10 @@ class Store extends CoreStore {
   This exists for legacy support for the RESTSerializer,
   which due to how it must guess whether a key is a model
   must query for whether a match exists.
- 
+
   We should investigate an RFC to make this public or removing
   this requirement.
- 
+
   @private
  */
   _hasModelFor(modelName) {

--- a/packages/unpublished-relationship-performance-test-app/app/routes/application.js
+++ b/packages/unpublished-relationship-performance-test-app/app/routes/application.js
@@ -20,7 +20,10 @@ export default Route.extend({
     });
   },
   afterModel() {
-    if (document.location.href.indexOf('?tracing') !== -1 || document.location.href.indexOf('?tracerbench=true') !== -1) {
+    if (
+      document.location.href.indexOf('?tracing') !== -1 ||
+      document.location.href.indexOf('?tracerbench=true') !== -1
+    ) {
       endTrace();
     }
   },


### PR DESCRIPTION
Fixes issue spotted by partner tests for Storefront/Observer/Travis-web
This fix will need to be back ported alongside the fix for `RecordData not implemented` to 3.16 beta and 3.15 release

Also fixes (separate commit) lint issue that crept in and a lint perf issue where we would attempt lint the dists created for the performance checks.