### PR TITLE
Add @canary-features as -build-infra dep

### DIFF
--- a/packages/-build-infra/package.json
+++ b/packages/-build-infra/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-block-scoping": "^7.5.5",
+    "@ember-data/canary-features": "3.13.2",
     "@ember/edition-utils": "^1.1.1",
     "babel-plugin-debug-macros": "^0.3.2",
     "babel-plugin-feature-flags": "^0.3.1",


### PR DESCRIPTION
This is already a de-facto dep as it's required by `features.js`.
Adding it as an explicit dep to deal with dependency issues.

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
