### PR TITLE
Beta backports

### DIFF
--- a/packages/-ember-data/node-tests/fixtures/expected.js
+++ b/packages/-ember-data/node-tests/fixtures/expected.js
@@ -148,6 +148,7 @@ module.exports = {
     '(public) @ember-data/adapter MinimumAdapterInterface#shouldReloadAll [OPTIONAL]',
     '(public) @ember-data/adapter MinimumAdapterInterface#shouldReloadRecord [OPTIONAL]',
     '(public) @ember-data/adapter MinimumAdapterInterface#updateRecord',
+    '(public) @ember-data/adapter MinimumAdapterInterface#destroy [OPTIONAL]',
     '(public) @ember-data/adapter RESTAdapter#coalesceFindRequests',
     '(public) @ember-data/adapter RESTAdapter#createRecord',
     '(public) @ember-data/adapter RESTAdapter#deleteRecord',

--- a/packages/-ember-data/tests/integration/store/adapter-for-test.js
+++ b/packages/-ember-data/tests/integration/store/adapter-for-test.js
@@ -1,4 +1,5 @@
 import { assign } from '@ember/polyfills';
+import { run } from '@ember/runloop';
 
 import { module, test } from 'qunit';
 
@@ -277,5 +278,32 @@ module('integration/store - adapterFor', function(hooks) {
       'We fell back to the -json-api adapter instance for the fallback -not-a-real-adapter'
     );
     assert.ok(jsonApiAdapter === adapter, 'We fell back to the -json-api adapter instance for the per-type adapter');
+  });
+
+  test('adapters are destroyed', async function(assert) {
+    let { owner } = this;
+    let didInstantiate = false;
+    let didDestroy = false;
+
+    class AppAdapter extends TestAdapter {
+      didInit() {
+        didInstantiate = true;
+      }
+
+      destroy() {
+        didDestroy = true;
+      }
+    }
+
+    owner.register('adapter:application', AppAdapter);
+
+    let adapter = store.adapterFor('application');
+
+    assert.ok(adapter instanceof AppAdapter, 'precond - We found the correct adapter');
+    assert.ok(didInstantiate, 'precond - We instantiated the adapter');
+
+    run(store, 'destroy');
+
+    assert.ok(didDestroy, 'adapter was destroyed');
   });
 });

--- a/packages/-ember-data/tests/integration/store/serializer-for-test.js
+++ b/packages/-ember-data/tests/integration/store/serializer-for-test.js
@@ -1,4 +1,5 @@
 import { assign } from '@ember/polyfills';
+import { run } from '@ember/runloop';
 
 import { module, test } from 'qunit';
 
@@ -454,4 +455,31 @@ module('integration/store - serializerFor', function(hooks) {
       );
     }
   );
+
+  test('serializers are destroyed', async function(assert) {
+    let { owner } = this;
+    let didInstantiate = false;
+    let didDestroy = false;
+
+    class AppSerializer extends TestSerializer {
+      didInit() {
+        didInstantiate = true;
+      }
+
+      destroy() {
+        didDestroy = true;
+      }
+    }
+
+    owner.register('serializer:application', AppSerializer);
+
+    let serializer = store.serializerFor('application');
+
+    assert.ok(serializer instanceof AppSerializer, 'precond - We found the correct serializer');
+    assert.ok(didInstantiate, 'precond - We instantiated the serializer');
+
+    run(store, 'destroy');
+
+    assert.ok(didDestroy, 'serializer was destroyed');
+  });
 });

--- a/packages/adapter/addon/rest.js
+++ b/packages/adapter/addon/rest.js
@@ -1301,11 +1301,13 @@ function fetchSuccessHandler(adapter, payload, response, requestData) {
 
 function fetchErrorHandler(adapter, payload, response, errorThrown, requestData) {
   let responseData = fetchResponseData(response);
+
   if (responseData.status === 200 && payload instanceof Error) {
     responseData.errorThrown = payload;
     payload = responseData.errorThrown.payload;
   } else {
     responseData.errorThrown = errorThrown;
+    payload = adapter.parseErrorResponse(payload);
   }
   return ajaxError(adapter, payload, requestData, responseData);
 }

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -3487,13 +3487,28 @@ abstract class CoreStore extends Service {
     }
   }
 
+  destroy() {
+    // enqueue destruction of any adapters/serializers we have created
+    for (let adapterName in this._adapterCache) {
+      let adapter = this._adapterCache[adapterName];
+      if (typeof adapter.destroy === 'function') {
+        adapter.destroy();
+      }
+    }
+
+    for (let serializerName in this._serializerCache) {
+      let serializer = this._serializerCache[serializerName];
+      if (typeof serializer.destroy === 'function') {
+        serializer.destroy();
+      }
+    }
+
+    return super.destroy();
+  }
+
   willDestroy() {
     super.willDestroy();
     this.recordArrayManager.destroy();
-
-    // Check if we need to null this out
-    // this._adapterCache = null;
-    // this._serializerCache = null;
 
     identifierCacheFor(this).destroy();
 

--- a/packages/store/addon/-private/ts-interfaces/minimum-adapter-interface.ts
+++ b/packages/store/addon/-private/ts-interfaces/minimum-adapter-interface.ts
@@ -699,6 +699,18 @@ interface Adapter {
    * @return {boolean} true if the a new request for all records of the type in SnapshotRecordArray should be made in the background, false otherwise
    */
   shouldBackgroundReloadAll?(store: Store, snapshotArray: SnapshotRecordArray): boolean;
+
+  /**
+   * In some situations the adapter may need to perform cleanup when destroyed,
+   * that cleanup can be done in `destroy`.
+   *
+   * If not implemented, the store does not inform the adapter of destruction.
+   *
+   * @method destroy [OPTIONAL]
+   * @public
+   * @optional
+   */
+  destroy?(): void;
 }
 
 export default Adapter;


### PR DESCRIPTION
Backports the following PRs to the beta branch:

- [Ensure adapters and serializers are destroyed upon store destruction.](https://github.com/emberjs/data/pull/7020)
- [[BUGFIX] fix jsonapi error handling when not using query](https://github.com/emberjs/data/pull/6941)
