### PR TITLE
Backport #6738 & #7067 for LTS

### DIFF
--- a/packages/-build-infra/package.json
+++ b/packages/-build-infra/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-block-scoping": "^7.5.5",
+    "@ember-data/canary-features": "3.12.5",
     "babel-plugin-debug-macros": "^0.3.2",
     "babel-plugin-feature-flags": "^0.3.1",
     "babel-plugin-filter-imports": "^3.0.0",

--- a/packages/-build-infra/src/features.js
+++ b/packages/-build-infra/src/features.js
@@ -1,8 +1,17 @@
 'use strict';
 
+function isCanary() {
+  const version = require('../package.json').version;
+  return version.indexOf('alpha') !== -1;
+}
+
 const requireEsm = require('esm')(module);
 function getFeatures() {
   const { default: features } = requireEsm('@ember-data/canary-features/addon/default-features.js');
+
+  if (!isCanary) {
+    return features;
+  }
 
   const FEATURE_OVERRIDES = process.env.EMBER_DATA_FEATURE_OVERRIDE;
   if (FEATURE_OVERRIDES === 'ENABLE_ALL_OPTIONAL') {


### PR DESCRIPTION
Backports the following PRs to the current LTS branch (lts-3-12):

- [BUGFIX] only allow feature flag alterations in canary #6738 
- Add @canary-features as -build-infra dep #7067