### PR TITLE
Fix changelog for v3.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Ember Data Changelog
 
-## Release 3.16.1 (February 27 2020)
+## Release 3.16.2 (February 27 2020)
 
 - [#7020](https://github.com/emberjs/data/pull/7020) Ensure adapters and serializers are destroyed upon store destruction. (#7020)
 - [#6941](https://github.com/emberjs/data/pull/6941) [BUGFIX] fix jsonapi error handling when not using jquery  (#6941)
+
+## Release 3.16.1 (February 27 2020)
+
+- Never published.
 
 ## Release 3.16.0 (January 24 2020)
 


### PR DESCRIPTION
This fixes the changelog by moving the changelog entries originally
intended for 3.16.1 to the section for 3.16.2.

For some more context, due to an unfortunate mishap by yours truly,
3.16.1 was never actually published to NPM. Instead, 3.16.2 was
published with what should have been 3.16.1. NPM does not support any
way to remedy this after the fact (and with good reason), but it would
still be nice for the changelog to be correct for anyone viewing it via
GitHub.