### PR TITLE
Backport #7020 for LTS

### DIFF
--- a/packages/-ember-data/tests/integration/store/adapter-for-test.js
+++ b/packages/-ember-data/tests/integration/store/adapter-for-test.js
@@ -1,4 +1,7 @@
 import { setupTest } from 'ember-qunit';
+import { assign } from '@ember/polyfills';
+import { run } from '@ember/runloop';
+
 import { module, test } from 'qunit';
 import Store from 'ember-data/store';
 
@@ -296,5 +299,32 @@ module('integration/store - adapterFor', function(hooks) {
       'We fell back to the -json-api adapter instance for the fallback -not-a-real-adapter'
     );
     assert.ok(jsonApiAdapter === adapter, 'We fell back to the -json-api adapter instance for the per-type adapter');
+  });
+
+  test('adapters are destroyed', async function(assert) {
+    let { owner } = this;
+    let didInstantiate = false;
+    let didDestroy = false;
+
+    class AppAdapter extends TestAdapter {
+      didInit() {
+        didInstantiate = true;
+      }
+
+      destroy() {
+        didDestroy = true;
+      }
+    }
+
+    owner.register('adapter:application', AppAdapter);
+
+    let adapter = store.adapterFor('application');
+
+    assert.ok(adapter instanceof AppAdapter, 'precond - We found the correct adapter');
+    assert.ok(didInstantiate, 'precond - We instantiated the adapter');
+
+    run(store, 'destroy');
+
+    assert.ok(didDestroy, 'adapter was destroyed');
   });
 });

--- a/packages/-ember-data/tests/integration/store/serializer-for-test.js
+++ b/packages/-ember-data/tests/integration/store/serializer-for-test.js
@@ -1,4 +1,6 @@
 import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
 import { module, test } from 'qunit';
 import Store from 'ember-data/store';
 
@@ -409,5 +411,32 @@ module('integration/store - serializerFor', function(hooks) {
       defaultSerializer === fallbackSerializer,
       'We fell back to the -default serializer instance for the adapter defaultSerializer'
     );
+  });
+
+  test('serializers are destroyed', async function(assert) {
+    let { owner } = this;
+    let didInstantiate = false;
+    let didDestroy = false;
+
+    class AppSerializer extends TestSerializer {
+      didInit() {
+        didInstantiate = true;
+      }
+
+      destroy() {
+        didDestroy = true;
+      }
+    }
+
+    owner.register('serializer:application', AppSerializer);
+
+    let serializer = store.serializerFor('application');
+
+    assert.ok(serializer instanceof AppSerializer, 'precond - We found the correct serializer');
+    assert.ok(didInstantiate, 'precond - We instantiated the serializer');
+
+    run(store, 'destroy');
+
+    assert.ok(didDestroy, 'serializer was destroyed');
   });
 });

--- a/packages/adapter/addon/index.js
+++ b/packages/adapter/addon/index.js
@@ -669,6 +669,18 @@ export default EmberObject.extend({
   shouldBackgroundReloadAll(store, snapshotRecordArray) {
     return true;
   },
+
+  /**
+    In some situations the adapter may need to perform cleanup when destroyed,
+    that cleanup can be done in `destroy`.
+
+    If not implemented, the store does not inform the adapter of destruction.
+
+    @method destroy [OPTIONAL]
+    @public
+    @optional
+  */
+  destroy: null
 });
 
 export { BuildURLMixin } from './-private';

--- a/packages/store/addon/-private/system/store.ts
+++ b/packages/store/addon/-private/system/store.ts
@@ -2920,13 +2920,29 @@ const Store = Service.extend({
     return serializer;
   },
 
+  destroy() {
+    // enqueue destruction of any adapters/serializers we have created
+    for (let adapterName in this._adapterCache) {
+      let adapter = this._adapterCache[adapterName];
+      if (typeof adapter.destroy === 'function') {
+        adapter.destroy();
+      }
+    }
+
+    for (let serializerName in this._serializerCache) {
+      let serializer = this._serializerCache[serializerName];
+      if (typeof serializer.destroy === 'function') {
+        serializer.destroy();
+      }
+    }
+
+    return this._super();
+  },
+
   willDestroy() {
     this._super(...arguments);
     this._pushedInternalModels = null;
     this.recordArrayManager.destroy();
-
-    this._adapterCache = null;
-    this._serializerCache = null;
 
     this.unloadAll();
 


### PR DESCRIPTION
Backports Ensure adapters and serializers are destroyed upon store destruction. #7020 for LTS 3.12

This required a few changes:

- The [changes to packages/-ember-data/node-tests/fixtures/expected.js](https://github.com/emberjs/data/pull/7020/files#diff-90207ce76d6fc168c717eecca7fd82a5R148-R154) were not included because that test file does not exist in the branch
- the documentation for `Adapter#destroy()` was added to the base `Adapter` class rather than the `MinimumAdapterInterface` because that interface did not yet exist