### PR TITLE
[BUGFIX] Fix headers precedence warning for null headers object

### DIFF
--- a/packages/adapter/addon/rest.js
+++ b/packages/adapter/addon/rest.js
@@ -1083,7 +1083,7 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
     );
 
     let headers = get(this, 'headers');
-    if (headers !== undefined) {
+    if (headers) {
       if (DEBUG) {
         options.headers = options.headers || {};
         let conflictingHeaders = Object.keys(headers).filter(key => options.headers[key] !== undefined);


### PR DESCRIPTION
Ember Observer was failing due to their headers set to null. This original warning did not come with a test, so unfortunately this PR doesn't either.