### PR TITLE
Optimize the update of a has-many relationship.

### DIFF
--- a/packages/record-data/addon/-private/ordered-set.ts
+++ b/packages/record-data/addon/-private/ordered-set.ts
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
 import EmberOrderedSet from '@ember/ordered-set';
 
@@ -26,5 +27,26 @@ export default class EmberDataOrderedSet<T> extends EmberOrderedSet<T> {
     this.size += 1;
 
     return this;
+  }
+
+  deleteWithIndex(obj: T | null, idx?: number): boolean {
+    let guid = guidFor(obj);
+    let presenceSet = this.presenceSet;
+    let list = this.list;
+
+    if (presenceSet[guid] === true) {
+      delete presenceSet[guid];
+
+      assert('object is not present at specified index', idx === undefined || list[idx] === obj);
+
+      let index = idx !== undefined ? idx : list.indexOf(obj);
+      if (index > -1) {
+        list.splice(index, 1);
+      }
+      this.size = list.length;
+      return true;
+    } else {
+      return false;
+    }
   }
 }

--- a/packages/record-data/addon/-private/relationships/state/belongs-to.ts
+++ b/packages/record-data/addon/-private/relationships/state/belongs-to.ts
@@ -154,14 +154,14 @@ export default class BelongsToRelationship extends Relationship {
     storeWrapper.notifyBelongsToChange(recordData.modelName, recordData.id, recordData.clientId, this.key);
   }
 
-  removeCanonicalRecordDataFromOwn(recordData: RelationshipRecordData) {
+  removeCanonicalRecordDataFromOwn(recordData: RelationshipRecordData, idx?: number) {
     if (!this.canonicalMembers.has(recordData)) {
       return;
     }
     this.canonicalState = null;
     this.setHasAnyRelationshipData(true);
     this.setRelationshipIsEmpty(true);
-    super.removeCanonicalRecordDataFromOwn(recordData);
+    super.removeCanonicalRecordDataFromOwn(recordData, idx);
   }
 
   removeAllCanonicalRecordDatasFromOwn() {

--- a/packages/record-data/addon/-private/relationships/state/has-many.ts
+++ b/packages/record-data/addon/-private/relationships/state/has-many.ts
@@ -3,7 +3,6 @@ import { isNone } from '@ember/utils';
 import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
 import { assertPolymorphicType } from '@ember-data/store/-debug';
 
-import OrderedSet from '../../ordered-set';
 import Relationship from './relationship';
 
 type RelationshipSchema = import('@ember-data/store/-private/ts-interfaces/record-data-schemas').RelationshipSchema;
@@ -156,24 +155,12 @@ export default class ManyRelationship extends Relationship {
   }
 
   computeChanges(recordDatas: RelationshipRecordData[] = []) {
-    let members = this.canonicalMembers;
-    let recordDatasToRemove: RelationshipRecordData[] = [];
-    let recordDatasSet = setForArray(recordDatas);
-
-    members.forEach(member => {
-      if (recordDatasSet.has(member)) {
-        return;
-      }
-
-      recordDatasToRemove.push(member);
-    });
-
-    this.removeCanonicalRecordDatas(recordDatasToRemove);
-
+    const members = this.canonicalMembers.toArray();
+    for (let i = members.length - 1; i >= 0; i--) {
+      this.removeCanonicalRecordData(members[i], i);
+    }
     for (let i = 0, l = recordDatas.length; i < l; i++) {
-      let recordData = recordDatas[i];
-      this.removeCanonicalRecordData(recordData);
-      this.addCanonicalRecordData(recordData, i);
+      this.addCanonicalRecordData(recordDatas[i], i);
     }
   }
 
@@ -254,16 +241,4 @@ export default class ManyRelationship extends Relationship {
       this.updateRecordDatasFromAdapter(recordDatas);
     }
   }
-}
-
-function setForArray(array) {
-  var set = new OrderedSet();
-
-  if (array) {
-    for (var i = 0, l = array.length; i < l; i++) {
-      set.add(array[i]);
-    }
-  }
-
-  return set;
 }

--- a/packages/record-data/addon/-private/relationships/state/relationship.ts
+++ b/packages/record-data/addon/-private/relationships/state/relationship.ts
@@ -392,7 +392,7 @@ export default class Relationship {
 
   removeCanonicalRecordData(recordData: RelationshipRecordData, idx?: number) {
     if (this.canonicalMembers.has(recordData)) {
-      this.removeCanonicalRecordDataFromOwn(recordData);
+      this.removeCanonicalRecordDataFromOwn(recordData, idx);
       if (this.inverseKey) {
         this.removeCanonicalRecordDataFromInverse(recordData);
       } else {
@@ -478,7 +478,7 @@ export default class Relationship {
   }
 
   removeCanonicalRecordDataFromOwn(recordData: RelationshipRecordData | null, idx?: number) {
-    this.canonicalMembers.delete(recordData);
+    this.canonicalMembers.deleteWithIndex(recordData, idx);
     this.flushCanonicalLater();
   }
 


### PR DESCRIPTION
Analyzing a performance issue in our application, I noticed that updating an existing relationship (with a large number of records) is very expensive. A lot of time is consumed in `Array.splice`.
By changing the order: first remove all records in reverse order and then add all records in correct order, is a quick win.
See output of test application that adds each time 200 records to the same relationship until 20.000 
Test application can be found [ember-has-many-update](https://github.com/pieter-v/ember-has-many-update)

**Before**
![before](https://user-images.githubusercontent.com/7090162/76307849-e2b9d700-62c9-11ea-9818-98e321e8370f.png)

**After**
![after](https://user-images.githubusercontent.com/7090162/76307852-e5b4c780-62c9-11ea-972f-8caf2698c1a6.png)
