### PR TITLE
Fix nightly run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: 'Nightly'
 
 on:
   schedule:
-    - cron: '* 14 * * *' # 14:00 in UTC is 6am PST
+    - cron: '0 14 * * *' # 14:00 in UTC is 6am PST
 
 jobs:
   test-all-deprecations:


### PR DESCRIPTION

    cron * 14 means every minute of the 14th hour.  GitHub Actions will
    limit this to the minimum of every 5 minutes, although it didn't
    actually run 12 times presumably because of the length of the jobs
    themselves.

    Fix the cron schedule so the job only runs once per night.

