### PR TITLE
Optimize visiting the relating records

### DIFF
--- a/packages/-ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/integration/relationships/belongs-to-test.js
@@ -2013,13 +2013,11 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function(
 
       _destroyRelationships() {}
 
-      _allRelatedRecordDatas() {}
+      _allRelatedRecordDatas() {
+        return [this];
+      }
 
       _cleanupOrphanedRecordDatas() {}
-
-      _directlyRelatedRecordDatas() {
-        return [];
-      }
 
       destroy() {
         this.isDestroyed = true;


### PR DESCRIPTION
Visiting all related records during `_cleanupOrphanedRecordDatas` allocates and copies a large amount of unnecessary data. Using an `Iterable` this allocation is not done anymore.
In one of our applications we have a large dataset with complex relations. Destroying a large number of records timed out after 10 minutes, with this fix it still takes two minutes (but it is already a big improvement)