### PR TITLE
clear initialState after construction

### DIFF
--- a/packages/-ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/has-many-test.js
@@ -179,7 +179,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function(h
   });
 
   test('hasMany + canonical vs currentState + destroyRecord  ', function(assert) {
-    assert.expect(6);
+    assert.expect(7);
 
     let store = this.owner.lookup('service:store');
 
@@ -265,6 +265,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function(h
       `user's contacts should have expected contacts`
     );
     assert.equal(contacts, user.get('contacts'));
+
+    assert.ok(!user.contacts.initialState || !user.contacts.initialState.find(model => model.id === '2'));
 
     run(() => {
       contacts.addObject(store.createRecord('user', { id: 8 }));

--- a/packages/model/addon/-private/system/many-array.js
+++ b/packages/model/addon/-private/system/many-array.js
@@ -136,6 +136,8 @@ export default EmberObject.extend(MutableArray, DeprecatedEvented, {
     */
     this.currentState = [];
     this.flushCanonical(this.initialState, false);
+    // we don't need this anymore, it just prevents garbage collection the records in the initialState
+    this.initialState = undefined;
   },
 
   // TODO: if(DEBUG)


### PR DESCRIPTION
In our application we have long living objects with a large collection of children. During the lifetime of our application these children get destroyed, but the `has-many` relationship on the parent still keeps track of these children in the `initialState` property. This property is only used during the initial construction of the `has-many` relationship. So, it can easily be cleared after `init`.
This solves a large memory leak in our application.