### PR TITLE
fix creation recursion with ember-data-model-fragments

### DIFF
--- a/packages/-ember-data/tests/integration/store/store-creation-recursion-test.js
+++ b/packages/-ember-data/tests/integration/store/store-creation-recursion-test.js
@@ -1,5 +1,7 @@
 import { module, test } from 'qunit';
+
 import { setupTest } from 'ember-qunit';
+
 import Transform from '@ember-data/serializer/transform';
 
 module('integration/store/creation-recursion', function(hooks) {

--- a/packages/-ember-data/tests/integration/store/store-creation-recursion-test.js
+++ b/packages/-ember-data/tests/integration/store/store-creation-recursion-test.js
@@ -1,10 +1,6 @@
-import { run } from '@ember/runloop';
-
 import { module, test } from 'qunit';
-import RSVP from 'rsvp';
-
-import Transform from '@ember-data/serializer/transform';
 import { setupTest } from 'ember-qunit';
+import Transform from '@ember-data/serializer/transform';
 
 module('integration/store/creation-recursion', function(hooks) {
   setupTest(hooks);

--- a/packages/-ember-data/tests/integration/store/store-creation-recursion-test.js
+++ b/packages/-ember-data/tests/integration/store/store-creation-recursion-test.js
@@ -1,0 +1,42 @@
+import { run } from '@ember/runloop';
+
+import { module, test } from 'qunit';
+import RSVP from 'rsvp';
+
+import Transform from '@ember-data/serializer/transform';
+import { setupTest } from 'ember-qunit';
+
+module('integration/store/creation-recursion', function(hooks) {
+  setupTest(hooks);
+
+  test('store construction does not construct transforms', function(assert) {
+    let storeFactory = this.owner.factoryFor('service:store');
+
+    this.owner.unregister('service:store');
+    this.owner.register('service:store', storeFactory);
+
+    let test = this;
+    test.dateTransformCreated = false;
+    class MockDateTransform extends Transform {
+      constructor(...args) {
+        super(...args);
+        test.dateTransformCreated = true;
+      }
+    }
+
+    this.owner.unregister('transform:date');
+    this.owner.register('transform:date', MockDateTransform);
+
+    assert.notOk(this.dateTransformCreated, 'date transform is not yet created');
+
+    // construct a store - it should now be created
+    this.owner.lookup('service:store');
+
+    assert.notOk(this.dateTransformCreated, 'date transform is not yet created');
+
+    // construct a date transform - it should now be created
+    this.owner.lookup('transform:date');
+
+    assert.ok(this.dateTransformCreated, 'date transform is now created');
+  });
+});

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -331,15 +331,16 @@ abstract class CoreStore extends Service {
         };
         let shouldWarn = false;
 
+        let owner = getOwner(this);
         Object.keys(Mapping).forEach((attributeType: keyof typeof Mapping) => {
-          const transform = getOwner(this).lookup(`transform:${attributeType}`);
+          const transformFactory = owner.factoryFor(`transform:${attributeType}`);
 
-          if (!transform) {
+          if (!transformFactory) {
             // we don't deprecate this because the moduleFor style tests with the closed
             // resolver will be deprecated on their own. When that deprecation completes
             // we can drop this.
             const Transform = require(`@ember-data/serializer/-private`)[Mapping[attributeType]];
-            getOwner(this).register(`transform:${attributeType}`, Transform);
+            owner.register(`transform:${attributeType}`, Transform);
             shouldWarn = true;
           }
         });


### PR DESCRIPTION
Lazily create transforms in core-store constructor by checking for factoryFor, instead of lookup