### PR TITLE
Support for multiple routes in performance-test-app

### DIFF
--- a/bin/relationship-performance-tracking/generate-analysis.sh
+++ b/bin/relationship-performance-tracking/generate-analysis.sh
@@ -38,6 +38,11 @@ fi
 HR_PORT=4200 HR_GROUP=control pm2 start $HAR_REMIX_SCRIPT --name control
 HR_PORT=4201 HR_GROUP=experiment pm2 start $HAR_REMIX_SCRIPT --name experiment
 node ./bin/relationship-performance-tracking/src/tracerbench.js
-tracerbench compare:analyze "$TEST_APP_PATH/tracerbench-results/trace-results.json"
+for result in "$TEST_APP_PATH"/tracerbench-results/*-trace-results.json; do
+  echo
+  echo ===============================================================================
+  echo Processing $(basename ${result} -trace-results.json)
+  tracerbench compare:analyze "${result}";
+done
 pm2 kill
 git checkout "$INITIAL_BRANCH"

--- a/bin/relationship-performance-tracking/src/har-remix.js
+++ b/bin/relationship-performance-tracking/src/har-remix.js
@@ -15,6 +15,11 @@ const VENDOR_FILE = path.resolve(
   `../../../packages/unpublished-relationship-performance-test-app/dist-${HR_GROUP}/assets/vendor.js`
 );
 
+const RELATIONSHIP_PERFORMANCE_TEST_APP_FILE = path.resolve(
+  __dirname,
+  '../../../packages/unpublished-relationship-performance-test-app/dist-experiment/assets/relationship-performance-test-app.js'
+);
+
 const harRemix = new HARRemix({
   keyForArchiveEntry(entry) {
     let { request, response } = entry;
@@ -39,6 +44,10 @@ const harRemix = new HARRemix({
   textFor(entry, key, text) {
     if (key.includes('vendor.js')) {
       return fs.readFileSync(VENDOR_FILE, 'utf8');
+    }
+
+    if (key.includes('relationship-performance-test-app.js')) {
+      return fs.readFileSync(RELATIONSHIP_PERFORMANCE_TEST_APP_FILE, 'utf8');
     }
 
     return text;

--- a/packages/unpublished-relationship-performance-test-app/PERFORMANCE_BENCHMARKING.md
+++ b/packages/unpublished-relationship-performance-test-app/PERFORMANCE_BENCHMARKING.md
@@ -24,3 +24,12 @@ Note: This uses a HAR file (`bin/relationship-performance-tracking/src/trace.har
 - open the Network panel in Chrome Dev Tools
 - right click on any of loaded network assets such as vendor.css
 - select "Save all as HAR with content"
+
+## adding extra tests
+
+- create a new route
+- in the `model` hook add markers where appropriate `performance.mark`
+- you can add `performance.measure` calls to visualize some markers in chrome performance view
+- in the `afterModel` hook call `endTrace` to stop tracing
+- modify `../../bin/relationship-performance-tracking/src/tracerbench.js ` to include the new route and its markers
+  

--- a/packages/unpublished-relationship-performance-test-app/app/router.js
+++ b/packages/unpublished-relationship-performance-test-app/app/router.js
@@ -7,6 +7,8 @@ const Router = EmberRouter.extend({
   rootURL: config.rootURL,
 });
 
-Router.map(function() {});
+Router.map(function() {
+  this.route('materialization');
+});
 
 export default Router;

--- a/packages/unpublished-relationship-performance-test-app/app/routes/materialization.js
+++ b/packages/unpublished-relationship-performance-test-app/app/routes/materialization.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
 
+import { endTrace } from '../utils/end-trace';
+
 export default Route.extend({
   model() {
     performance.mark('start-find-all');
@@ -15,26 +17,14 @@ export default Route.extend({
         };
       });
       performance.mark('stop-outer-materialization');
+      performance.measure('outer-materialization', 'start-outer-materialization', 'stop-outer-materialization');
       performance.mark('end-find-all');
+      performance.measure('find-all', 'start-find-all', 'end-find-all');
       return flattened;
     });
   },
+
   afterModel() {
-    if (
-      document.location.href.indexOf('?tracing') !== -1 ||
-      document.location.href.indexOf('?tracerbench=true') !== -1
-    ) {
-      endTrace();
-    }
+    endTrace();
   },
 });
-
-function endTrace() {
-  // just before paint
-  requestAnimationFrame(() => {
-    // after paint
-    requestAnimationFrame(() => {
-      document.location.href = 'about:blank';
-    });
-  });
-}

--- a/packages/unpublished-relationship-performance-test-app/app/utils/end-trace.js
+++ b/packages/unpublished-relationship-performance-test-app/app/utils/end-trace.js
@@ -1,0 +1,11 @@
+export function endTrace() {
+  if (document.location.href.indexOf('?tracing') !== -1 || document.location.href.indexOf('?tracerbench=true') !== -1) {
+    // just before paint
+    requestAnimationFrame(() => {
+      // after paint
+      requestAnimationFrame(() => {
+        document.location.href = 'about:blank';
+      });
+    });
+  }
+}

--- a/packages/unpublished-relationship-performance-test-app/config/environment.js
+++ b/packages/unpublished-relationship-performance-test-app/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function(environment) {
     modulePrefix: 'relationship-performance-test-app',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'hash',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
Add support for multiple routes in the relationship performance test application