### PR TITLE
[BUGFIX]: Fix errors while running yarn start

### DIFF
--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "ember build",
     "build:production": "ember build --environment=production",
-    "start": "ember server",
+    "start": "ember serve",
     "docs": "mkdir -p dist && ember ember-cli-yuidoc",
     "test": "ember test",
     "test:all": "ember try:each",

--- a/packages/-ember-data/tests/integration/store/model-name-test.js
+++ b/packages/-ember-data/tests/integration/store/model-name-test.js
@@ -64,7 +64,9 @@ module('@ember-data/model klass.modelName', function(hooks) {
       assert.strictEqual(
         startsWith(e.message, `Cannot assign to read only property 'modelName' of `) ||
           // IE11 has a different message
-          startsWith(e.message, `Assignment to read-only properties is not allowed in strict mode`),
+          startsWith(e.message, `Assignment to read-only properties is not allowed in strict mode`) ||
+          // Safari aso has a different message
+          startsWith(e.message, `Attempted to assign to readonly property`),
         true,
         `modelName is immutable: ${e.message}`
       );

--- a/packages/unpublished-test-infra/addon-test-support/deprecated-test.js
+++ b/packages/unpublished-test-infra/addon-test-support/deprecated-test.js
@@ -2,7 +2,7 @@ import { DEBUG } from '@glimmer/env';
 
 import { skip, test } from 'qunit';
 
-import VERSION, { COMPAT_VERSION } from '@ember-data/unpublished-test-infra/version';
+import VERSION, { COMPAT_VERSION } from '@ember-data/unpublished-test-infra/test-support/version';
 
 // small comparison function for major and minor semver values
 function gte(EDVersion, DeprecationVersion) {

--- a/packages/unpublished-test-infra/index.js
+++ b/packages/unpublished-test-infra/index.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const merge = require('broccoli-merge-trees');
 const version = require('@ember-data/private-build-infra/src/create-version-module');
 const addonBuildConfigForDataPackage = require('@ember-data/private-build-infra/src/addon-build-config-for-data-package');
 
@@ -8,12 +8,11 @@ const name = require('./package').name;
 const addonBaseConfig = addonBuildConfigForDataPackage(name);
 
 module.exports = Object.assign({}, addonBaseConfig, {
-  treeForAddon() {
-    if (process.env.EMBER_CLI_TEST_COMMAND) {
-      const options = this.getEmberDataConfig();
-      let compatVersion = options.compatWith;
-      let tree = version(compatVersion);
-      return this.debugTree(this._super.treeForAddon.call(this, tree), 'addon-output');
-    }
+  treeForAddonTestSupport(existingTree) {
+    const options = this.getEmberDataConfig();
+    let compatVersion = options.compatWith;
+    let tree = merge([existingTree, version(compatVersion)]);
+
+    return this.debugTree(this._super.treeForAddonTestSupport.call(this, tree), 'addon-output');
   },
 });

--- a/packages/unpublished-test-infra/index.js
+++ b/packages/unpublished-test-infra/index.js
@@ -1,4 +1,5 @@
 'use strict';
+// eslint-disable-next-line node/no-unpublished-require
 const merge = require('broccoli-merge-trees');
 const version = require('@ember-data/private-build-infra/src/create-version-module');
 const addonBuildConfigForDataPackage = require('@ember-data/private-build-infra/src/addon-build-config-for-data-package');

--- a/packages/unpublished-test-infra/index.js
+++ b/packages/unpublished-test-infra/index.js
@@ -14,6 +14,6 @@ module.exports = Object.assign({}, addonBaseConfig, {
     let compatVersion = options.compatWith;
     let tree = merge([existingTree, version(compatVersion)]);
 
-    return this.debugTree(this._super.treeForAddonTestSupport.call(this, tree), 'addon-output');
+    return this.debugTree(this._super.treeForAddonTestSupport.call(this, tree), 'test-support');
   },
 });

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -26,6 +26,7 @@
     "testem": "^3.0.3"
   },
   "devDependencies": {
+    "broccoli-merge-trees": "^4.2.0",
     "@ember/optional-features": "^1.3.0",
     "ember-cli": "~3.18.0",
     "ember-cli-dependency-checker": "^3.2.0",


### PR DESCRIPTION
close #7072

<img width="1253" alt="Screen Shot 2020-04-26 at 9 26 59 PM" src="https://user-images.githubusercontent.com/7374640/80334069-f206cc80-8804-11ea-8c02-18ad17dcdde1.png">

This PR allows a developer to execute `yarn start` and run the tests in the browser.

We add the `/version` file with some tag/sha information at build time iff `EMBER_CLI_TEST_COMMAND` is set by Node on the global variable `process.env` at runtime.  

Another option is to be more specific in the if conditional by allowing only development or test.  However, if this module is excluded from production, then this may be sufficient in its current state.  