### PR TITLE
[DOC EmbeddedRecordsMixin] Assert from JSONAPISerializer

### DIFF
--- a/packages/-ember-data/tests/integration/serializers/json-api-serializer-test.js
+++ b/packages/-ember-data/tests/integration/serializers/json-api-serializer-test.js
@@ -714,10 +714,18 @@ module('integration/serializers/json-api-serializer - JSONAPISerializer', functi
     });
   });
 
-  testInDebug('JSON warns when combined with EmbeddedRecordsMixin', function(assert) {
-    assert.expectWarning(function() {
+  testInDebug('Asserts when combined with EmbeddedRecordsMixin', function(assert) {
+    assert.expectAssertion(function() {
       DS.JSONAPISerializer.extend(DS.EmbeddedRecordsMixin).create();
-    }, /The JSONAPISerializer does not work with the EmbeddedRecordsMixin/);
+    }, /You've used the EmbeddedRecordsMixin in/);
+  });
+
+  testInDebug('Allows EmbeddedRecordsMixin if isEmbeddedRecordsMixinCompatible is true', function(assert) {
+    assert.expectNoAssertion(function() {
+      DS.JSONAPISerializer.extend(DS.EmbeddedRecordsMixin, {
+        isEmbeddedRecordsMixinCompatible: true,
+      }).create();
+    });
   });
 
   testInDebug('Asserts when normalized attribute key is not found in payload but original key is', function(assert) {

--- a/packages/serializer/addon/json-api.js
+++ b/packages/serializer/addon/json-api.js
@@ -559,6 +559,17 @@ const JSONAPISerializer = JSONSerializer.extend({
 
 if (DEBUG) {
   JSONAPISerializer.reopen({
+    init(...args) {
+      this._super(...args);
+
+      assert(
+        `You've used the EmbeddedRecordsMixin in ${this.toString()} which is not fully compatible with the JSON:API specification. Please confirm that this works for your specific API and add \`this.isEmbeddedRecordsMixinCompatible = true\` to your serializer.`,
+        !this.isEmbeddedRecordsMixin || this.isEmbeddedRecordsMixinCompatible === true,
+        {
+          id: 'ds.serializer.embedded-records-mixin-not-supported',
+        }
+      );
+    },
     willMergeMixin(props) {
       let constructor = this.constructor;
       warn(
@@ -566,13 +577,6 @@ if (DEBUG) {
         isNone(props.extractMeta) || props.extractMeta === JSONSerializer.prototype.extractMeta,
         {
           id: 'ds.serializer.json-api.extractMeta',
-        }
-      );
-      warn(
-        'The JSONAPISerializer does not work with the EmbeddedRecordsMixin because the JSON API spec does not describe how to format embedded resources.',
-        !props.isEmbeddedRecordsMixin,
-        {
-          id: 'ds.serializer.embedded-records-mixin-not-supported',
         }
       );
     },


### PR DESCRIPTION
Use of EmbeddedRecordsMixin and JSONAPISerializer together asserts instead of warns. Allows for setting "isEmbeddedRecordsMixinCompatible" on the serializer for when parts of the API are compatible.

Closes #6991
