### PR TITLE
[DOCS] Remove blank package '@ember-data'

### DIFF
--- a/packages/-ember-data/addon/-private/core.js
+++ b/packages/-ember-data/addon/-private/core.js
@@ -1,19 +1,7 @@
-/**
- @module @ember-data
- @main @ember-data
- */
-
 import Namespace from '@ember/application/namespace';
 import Ember from 'ember';
 
 import VERSION from 'ember-data/version';
-
-/**
- * @property VERSION
- * @public
- * @static
- * @for @ember-data
- */
 
 const DS = Namespace.create({
   VERSION: VERSION,

--- a/packages/-ember-data/node-tests/fixtures/expected.js
+++ b/packages/-ember-data/node-tests/fixtures/expected.js
@@ -7,8 +7,7 @@ module.exports = {
     '@ember-data/store',
     '@ember-data/deprecations',
     '@ember-data/record-data',
-    '@ember-data/serializer',
-    '@ember-data',
+    '@ember-data/serializer'
   ],
   classitems: [
     '(private) @ember-data/adapter BuildURLMixin#_buildURL',

--- a/packages/-ember-data/node-tests/fixtures/expected.js
+++ b/packages/-ember-data/node-tests/fixtures/expected.js
@@ -99,7 +99,6 @@ module.exports = {
     '(private) @ember-data/store Store#scheduleSave',
     '(private) @ember-data/store Store#setRecordId',
     '(protected) Ember.Inflector#inflect',
-    '(public) @ember-data @ember-data#VERSION',
     '(public) @ember-data/adapter Adapter#coalesceFindRequests',
     '(public) @ember-data/adapter Adapter#createRecord',
     '(public) @ember-data/adapter Adapter#defaultSerializer',


### PR DESCRIPTION
A blank package `@ember-data` shows up due to these yuidoc comments.

I tried to get this working correctly so that an `ember-data` package would show up with a DS and VERSION export, but was unable to figure out how to do it.
