### PR TITLE
Fix broken link

### DIFF
--- a/packages/store/addon/-private/system/promise-proxies.js
+++ b/packages/store/addon/-private/system/promise-proxies.js
@@ -17,7 +17,7 @@ import { Promise } from 'rsvp';
   updated when the promise resolves.
 
   For more information see the [Ember.PromiseProxyMixin
-  documentation](/api/classes/PromiseProxyMixin.html).
+  documentation](/ember/release/classes/PromiseProxyMixin).
 
   Example
 

--- a/packages/store/addon/-private/system/promise-proxies.js
+++ b/packages/store/addon/-private/system/promise-proxies.js
@@ -49,7 +49,7 @@ export const PromiseArray = ArrayProxy.extend(PromiseProxyMixin, {
   be updated when the promise resolves.
 
   For more information see the [Ember.PromiseProxyMixin
-  documentation](/api/classes/PromiseProxyMixin.html).
+  documentation](/ember/release/classes/PromiseProxyMixin.html).
 
   Example
 

--- a/packages/store/addon/-private/system/promise-proxies.js
+++ b/packages/store/addon/-private/system/promise-proxies.js
@@ -17,7 +17,7 @@ import { Promise } from 'rsvp';
   updated when the promise resolves.
 
   For more information see the [Ember.PromiseProxyMixin
-  documentation](/api/classes/Ember.PromiseProxyMixin.html).
+  documentation](/api/classes/PromiseProxyMixin.html).
 
   Example
 
@@ -49,7 +49,7 @@ export const PromiseArray = ArrayProxy.extend(PromiseProxyMixin, {
   be updated when the promise resolves.
 
   For more information see the [Ember.PromiseProxyMixin
-  documentation](/api/classes/Ember.PromiseProxyMixin.html).
+  documentation](/api/classes/PromiseProxyMixin.html).
 
   Example
 


### PR DESCRIPTION
Relates to: https://github.com/ember-learn/ember-api-docs/pull/726

There seem to be other instances of broken links in this repo with this format:
- Go to https://api.emberjs.com/ember-data/3.10/classes/DS.RESTAdapter and click on the link for `volatile`, which is from this code: https://github.com/emberjs/data/blob/d6bd5f1b82f0ae6424f381f55574a54ea0684aff/packages/adapter/addon/rest.js#L269

I'm not sure how to test this locally with ember-api-docs so any guidance on that would be appreciated!

cc @MelSumner @kategengler from Discord convo