### PR TITLE
[CI]: remove erroneous `name` without `run` in node-version-test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -261,6 +261,7 @@ jobs:
         run: yarn test:try-one ${{ matrix.scenario }}
 
   node-version-test:
+    name: Use Node.js ${{ matrix.node-version }}
     timeout-minutes: 6
     needs: [lint, basic-tests]
     runs-on: ubuntu-latest
@@ -274,7 +275,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies w/o lockfile
         run: yarn install --no-lockfile --non-interactive
-      - name: Basic Tests with Node.js ${{ matrix.node-version }}
+      - name: Basic Tests
         run: yarn test
 
   external-partners:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,13 +269,12 @@ jobs:
         node-version: [10.x, 14.x]
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies w/o lockfile
         run: yarn install --no-lockfile --non-interactive
-      - name: Basic Tests
+      - name: Basic Tests with Node.js ${{ matrix.node-version }}
         run: yarn test
 
   external-partners:


### PR DESCRIPTION
Follow up #7243 

Ref - https://github.com/emberjs/data/actions/runs/170550412