### PR TITLE
[CI]: remove Chrome and Firefox install from Github Actions and Azure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,10 +69,6 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - if: matrix.os == 'macos-latest'
-        run: |
-          brew update
-          brew cask install google-chrome
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
@@ -135,10 +131,6 @@ jobs:
         scenario: [fastboot-with-ember-fetch, fastboot-with-jquery]
     runs-on: ${{ matrix.os }}
     steps:
-      - if: matrix.os == 'macos-latest'
-        run: |
-          brew update
-          brew cask install google-chrome
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,8 +71,6 @@ jobs:
 
       - script: |
           yarn
-          brew update
-          brew cask install google-chrome
 
       - script: |
           yarn test
@@ -95,8 +93,6 @@ jobs:
           versionSpec: '12.x' # The version we're installing
 
       - script: |
-          brew update
-          brew cask install google-chrome
           yarn
 
       - script: |
@@ -186,8 +182,6 @@ jobs:
           versionSpec: '12.x' # The version we're installing
 
       - script: |
-          brew update
-          brew cask install google-chrome
           yarn install --no-lockfile --non-interactive
 
       - script: |
@@ -219,8 +213,6 @@ jobs:
           versionSpec: '12.x' # The version we're installing
 
       - script: |
-          brew update
-          brew cask install google-chrome
           yarn install --no-lockfile --non-interactive
 
       - script: |
@@ -240,8 +232,6 @@ jobs:
           versionSpec: '12.x' # The version we're installing
 
       - script: |
-          brew update
-          brew cask install google-chrome
           yarn
 
       - script: |
@@ -282,8 +272,6 @@ jobs:
           versionSpec: '12.x' # The version we're installing
 
       - script: |
-          brew update
-          brew cask install firefox
           yarn
           node ./bin/packages-for-commit.js
 
@@ -304,9 +292,6 @@ jobs:
           versionSpec: '12.x' # The version we're installing
 
       - script: |
-          brew update
-          brew cask install google-chrome
-          brew cask install firefox
           yarn
           node ./bin/packages-for-commit.js
 
@@ -328,9 +313,6 @@ jobs:
           versionSpec: '12.x' # The version we're installing
 
       - script: |
-          brew update
-          brew cask install google-chrome
-          brew cask install firefox
           yarn
           node ./bin/packages-for-commit.js
 
@@ -351,9 +333,6 @@ jobs:
           versionSpec: '12.x' # The version we're installing
 
       - script: |
-          brew update
-          brew cask install google-chrome
-          brew cask install firefox
           yarn
           node ./bin/packages-for-commit.js
         condition: succeededOrFailed()


### PR DESCRIPTION
Checking to see if the default image now has Chrome and Firefox installed.  If so, we can remove `brew` commands.

Reference for MacOS and Linux images - 

https://github.com/actions/virtual-environments/blob/bb03b541e0a63c964dcf851817585d4bb4b38675/images/linux/Ubuntu1804-README.md
https://github.com/actions/virtual-environments/blob/bb03b541e0a63c964dcf851817585d4bb4b38675/images/macos/macos-10.15-Readme.md