### PR TITLE
[BUGFIX] New test and possible fix for issue #7265 (self-referent rel)

### DIFF
--- a/packages/store/addon/-private/system/model/record-data.ts
+++ b/packages/store/addon/-private/system/model/record-data.ts
@@ -316,14 +316,14 @@ export default class RecordDataDefault implements RelationshipRecordData {
     this._isNew = false;
     let newCanonicalAttributes: AttributesHash | null = null;
     if (data) {
-      // this.store._internalModelDidReceiveRelationshipData(this.modelName, this.id, data.relationships);
-      if (data.relationships) {
-        this._setupRelationships(data);
-      }
       if (data.id) {
         // didCommit provided an ID, notify the store of it
         this.storeWrapper.setRecordId(this.modelName, data.id, this.clientId);
         this.id = coerceId(data.id);
+      }
+      // this.store._internalModelDidReceiveRelationshipData(this.modelName, this.id, data.relationships);
+      if (data.relationships) {
+        this._setupRelationships(data);
       }
       newCanonicalAttributes = data.attributes || null;
     }


### PR DESCRIPTION
This addresses issue #7265 (Self-Referent Relationship in Save Response Blows Up Save).

It includes a new test that replicates the problem - saving a record, and having the 'backend' return a relationship that is self-referent, thus blowing up Ember Data when it checks to see if the just-saved id has already been used.  (Said id was added to the store as part of the relationships-handling.)

It also includes a patch to record-data.ts that solves the problem in the test, and does not cause any other tests to fail.  HOWEVER, it does this by simply re-ordering the handling of relationships and the 'set the record id' call - I don't know if there is a reason that they were done in the opposite order originally, and thus don't know for certain if this will break something else.  (I'm hoping the tests would have shown that, but perhaps wiser eyes can take a look to make certain.)

Thanks!