### PR TITLE
[BUGFIX release] Fix testing incompatibilities with modern Ember.

### DIFF
--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -775,7 +775,6 @@ module('unit/model - Model', function(hooks) {
     testInDebug('A subclass of Model throws an error when calling create() directly', async function(assert) {
       class NativePerson extends Model {}
       const LegacyPerson = Model.extend({});
-      const EmberObjectNewError = 'was not instantiated correctly.';
 
       assert.throws(
         () => {
@@ -787,44 +786,10 @@ module('unit/model - Model', function(hooks) {
 
       assert.throws(
         () => {
-          try {
-            // the `{}` here is so that in recent ember we throw a nice error vs an
-            // obtuse error. An error will thrown in any case though.
-            new NativePerson({});
-          } catch (e) {
-            if (e.message.indexOf(EmberObjectNewError) !== -1) {
-              throw new Error('You should not call `create` on a model');
-            }
-            throw e;
-          }
-        },
-        /You should not call `create` on a model/,
-        'Throws an error when calling instantiating via new Model'
-      );
-
-      assert.throws(
-        () => {
           LegacyPerson.create();
         },
         /You should not call `create` on a model/,
         'Throws an error when calling create() on model'
-      );
-
-      assert.throws(
-        () => {
-          try {
-            // the `{}` here is so that in recent ember we throw a nice error vs an
-            // obtuse error. An error will thrown in any case though.
-            new LegacyPerson({});
-          } catch (e) {
-            if (e.message.indexOf(EmberObjectNewError) !== -1) {
-              throw new Error('You should not call `create` on a model');
-            }
-            throw e;
-          }
-        },
-        /You should not call `create` on a model/,
-        'Throws an error when calling instantiating view new Model()'
       );
     });
   });

--- a/packages/serializer/addon/json-api.js
+++ b/packages/serializer/addon/json-api.js
@@ -569,12 +569,11 @@ if (DEBUG) {
           id: 'ds.serializer.embedded-records-mixin-not-supported',
         }
       );
-    },
-    willMergeMixin(props) {
+
       let constructor = this.constructor;
       warn(
         `You've defined 'extractMeta' in ${constructor.toString()} which is not used for serializers extending JSONAPISerializer. Read more at https://api.emberjs.com/ember-data/release/classes/JSONAPISerializer on how to customize meta when using JSON API.`,
-        isNone(props.extractMeta) || props.extractMeta === JSONSerializer.prototype.extractMeta,
+        this.extractMeta === JSONSerializer.prototype.extractMeta,
         {
           id: 'ds.serializer.json-api.extractMeta',
         }


### PR DESCRIPTION
* Calling `new EmberObject()` hasn't worked for some period of time (Ember itself forbids `new EmberObject()`), removing the test for `new` since it is tested upstream by Ember.
* Remove usage/reliance on `willMergeMixin`, it was private API and has been removed. We were only using it for a warning that can easily be migrated to `init`.

---

@igorT - This resolves one of the failures that occurs for `release`/`beta`/`canary`.