### PR TITLE
Feature: Allow fetch to accept credentials

### DIFF
--- a/packages/adapter/addon/rest.js
+++ b/packages/adapter/addon/rest.js
@@ -1366,7 +1366,7 @@ function headersToObject(headers) {
  * @returns {Object}
  */
 export function fetchOptions(options, adapter) {
-  options.credentials = 'same-origin';
+  options.credentials = options.credentials || 'same-origin';
 
   if (options.data) {
     // GET and HEAD requests can't have a `body`


### PR DESCRIPTION
I want to use option credentials : 'include', but I cannot use it because 'same-origin' is fixed.

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
