### PR TITLE
[DOC adapter] convert examples to native/Octane class syntax

### DIFF
--- a/packages/adapter/addon/-private/build-url-mixin.js
+++ b/packages/adapter/addon/-private/build-url-mixin.js
@@ -20,7 +20,7 @@ import { pluralize } from 'ember-inflector';
   import Adapter, { BuildURLMixin } from '@ember-data/adapter';
 
   export default class ApplicationAdapter extends Adapter.extend(BuildURLMixin) {
-    findRecord: function(store, type, id, snapshot) {
+    findRecord(store, type, id, snapshot) {
       var url = this.buildURL(type.modelName, id, snapshot, 'findRecord');
       return this.ajax(url, 'GET');
     }
@@ -439,7 +439,7 @@ export default Mixin.create({
     import { pluralize } from 'ember-inflector';
 
     export default class ApplicationAdapter extends RESTAdapter {
-      pathForType: function(modelName) {
+      pathForType(modelName) {
         var decamelized = decamelize(modelName);
         return pluralize(decamelized);
       }

--- a/packages/adapter/addon/-private/build-url-mixin.js
+++ b/packages/adapter/addon/-private/build-url-mixin.js
@@ -19,12 +19,12 @@ import { pluralize } from 'ember-inflector';
   ```javascript
   import Adapter, { BuildURLMixin } from '@ember-data/adapter';
 
-  export default Adapter.extend(BuildURLMixin, {
+  export default class ApplicationAdapter extends Adapter.extend(BuildURLMixin) {
     findRecord: function(store, type, id, snapshot) {
       var url = this.buildURL(type.modelName, id, snapshot, 'findRecord');
       return this.ajax(url, 'GET');
     }
-  });
+  }
   ```
 
   ### Attributes
@@ -125,12 +125,12 @@ export default Mixin.create({
    ```app/adapters/user.js
    import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-   export default JSONAPIAdapter.extend({
+   export default class ApplicationAdapter extends JSONAPIAdapter {
      urlForFindRecord(id, modelName, snapshot) {
        let baseUrl = this.buildURL(modelName, id, snapshot);
        return `${baseUrl}/users/${snapshot.adapterOptions.user_id}/playlists/${id}`;
      }
-   });
+   }
    ```
 
    @method urlForFindRecord
@@ -152,12 +152,12 @@ export default Mixin.create({
    ```app/adapters/comment.js
    import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-   export default JSONAPIAdapter.extend({
+   export default class ApplicationAdapter extends JSONAPIAdapter {
      urlForFindAll(modelName, snapshot) {
        let baseUrl = this.buildURL(modelName);
        return `${baseUrl}/data/comments.json`;
      }
-   });
+   }
    ```
 
    @method urlForFindAll
@@ -177,8 +177,8 @@ export default Mixin.create({
    ```app/adapters/application.js
    import RESTAdapter from '@ember-data/adapter/rest';
 
-   export default RESTAdapter.extend({
-     host: 'https://api.github.com',
+   export default class ApplicationAdapter extends RESTAdapter {
+     host = 'https://api.github.com';
      urlForQuery (query, modelName) {
        switch(modelName) {
          case 'repo':
@@ -187,7 +187,7 @@ export default Mixin.create({
            return this._super(...arguments);
        }
      }
-   });
+   }
    ```
 
    @method urlForQuery
@@ -207,12 +207,12 @@ export default Mixin.create({
    ```app/adapters/application.js
    import RESTAdapter from '@ember-data/adapter/rest';
 
-   export default RESTAdapter.extend({
+   export default class ApplicationAdapter extends RESTAdapter {
      urlForQueryRecord({ slug }, modelName) {
        let baseUrl = this.buildURL();
        return `${baseUrl}/${encodeURIComponent(slug)}`;
      }
-   });
+   }
    ```
 
    @method urlForQueryRecord
@@ -234,12 +234,12 @@ export default Mixin.create({
    ```app/adapters/application.js
    import RESTAdapter from '@ember-data/adapter/rest';
 
-   export default RESTAdapter.extend({
+   export default class ApplicationAdapter extends RESTAdapter {
      urlForFindMany(ids, modelName) {
        let baseUrl = this.buildURL();
        return `${baseUrl}/coalesce`;
      }
-   });
+   }
    ```
 
    @method urlForFindMany
@@ -261,12 +261,12 @@ export default Mixin.create({
    ```app/adapters/application.js
    import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-   export default JSONAPIAdapter.extend({
+   export default class ApplicationAdapter extends JSONAPIAdapter {
      urlForFindHasMany(id, modelName, snapshot) {
        let baseUrl = this.buildURL(modelName, id);
        return `${baseUrl}/relationships`;
      }
-   });
+   }
    ```
 
    @method urlForFindHasMany
@@ -288,12 +288,12 @@ export default Mixin.create({
    ```app/adapters/application.js
    import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-   export default JSONAPIAdapter.extend({
+   export default class ApplicationAdapter extends JSONAPIAdapter {
      urlForFindBelongsTo(id, modelName, snapshot) {
        let baseUrl = this.buildURL(modelName, id);
        return `${baseUrl}/relationships`;
      }
-   });
+   }
    ```
 
    @method urlForFindBelongsTo
@@ -315,11 +315,11 @@ export default Mixin.create({
    ```app/adapters/application.js
    import RESTAdapter from '@ember-data/adapter/rest';
 
-   export default RESTAdapter.extend({
+   export default class ApplicationAdapter extends RESTAdapter {
      urlForCreateRecord(modelName, snapshot) {
        return this._super(...arguments) + '/new';
      }
-   });
+   }
    ```
 
    @method urlForCreateRecord
@@ -339,11 +339,11 @@ export default Mixin.create({
    ```app/adapters/application.js
    import RESTAdapter from '@ember-data/adapter/rest';
 
-   export default RESTAdapter.extend({
+   export default class ApplicationAdapter extends RESTAdapter {
      urlForUpdateRecord(id, modelName, snapshot) {
        return `/${id}/feed?access_token=${snapshot.adapterOptions.token}`;
      }
-   });
+   }
    ```
 
    @method urlForUpdateRecord
@@ -364,11 +364,11 @@ export default Mixin.create({
    ```app/adapters/application.js
    import RESTAdapter from '@ember-data/adapter/rest';
 
-   export default RESTAdapter.extend({
+   export default class ApplicationAdapter extends RESTAdapter {
      urlForDeleteRecord(id, modelName, snapshot) {
        return this._super(...arguments) + '/destroy';
      }
-   });
+   }
    ```
 
    @method urlForDeleteRecord
@@ -438,12 +438,12 @@ export default Mixin.create({
     import { decamelize } from '@ember/string';
     import { pluralize } from 'ember-inflector';
 
-    export default RESTAdapter.extend({
+    export default class ApplicationAdapter extends RESTAdapter {
       pathForType: function(modelName) {
         var decamelized = decamelize(modelName);
         return pluralize(decamelized);
       }
-    });
+    }
     ```
 
     @method pathForType

--- a/packages/adapter/addon/error.js
+++ b/packages/adapter/addon/error.js
@@ -37,7 +37,7 @@ import EmberError from '@ember/error';
   import JSONAPIAdapter from '@ember-data/adapter/json-api';
   import MaintenanceError from './maintenance-error';
 
-  export default JSONAPIAdapter.extend({
+  export default class ApplicationAdapter extends JSONAPIAdapter {
     handleResponse(status) {
       if (503 === status) {
         return new MaintenanceError();
@@ -45,7 +45,7 @@ import EmberError from '@ember/error';
 
       return this._super(...arguments);
     }
-  });
+  }
   ```
 
   And can then be detected in an application and used to send the user to an
@@ -55,7 +55,7 @@ import EmberError from '@ember/error';
   import Route from '@ember/routing/route';
   import MaintenanceError from '../adapters/maintenance-error';
 
-  export default Route.extend({
+  export default class ApplicationRoute extends Route {
     actions: {
       error(error, transition) {
         if (error instanceof MaintenanceError) {
@@ -66,7 +66,7 @@ import EmberError from '@ember/error';
         // ...other error handling logic
       }
     }
-  });
+  }
   ```
 
   @class AdapterError
@@ -136,10 +136,10 @@ AdapterError.extend = extendFn(AdapterError);
   ```app/models/post.js
   import Model, { attr } from '@ember-data/model';
 
-  export default Model.extend({
-    title: attr('string'),
-    content: attr('string')
-  });
+  export default class PostModel extends Model {
+    @attr('string') title;
+    @attr('string') content;
+  }
   ```
 
   To show an error from the server related to the `title` and
@@ -151,7 +151,7 @@ AdapterError.extend = extendFn(AdapterError);
   import RESTAdapter from '@ember-data/adapter/rest';
   import { InvalidError } from '@ember-data/adapter/error';
 
-  export default RESTAdapter.extend({
+  export default class ApplicationAdapter extends RESTAdapter {
     updateRecord() {
       // Fictional adapter that always rejects
       return RSVP.reject(new InvalidError([
@@ -165,7 +165,7 @@ AdapterError.extend = extendFn(AdapterError);
         }
       ]));
     }
-  });
+  }
   ```
 
   Your backend may use different property names for your records the

--- a/packages/adapter/addon/index.js
+++ b/packages/adapter/addon/index.js
@@ -93,7 +93,7 @@ export default EmberObject.extend({
     import RSVP from 'RSVP';
     import $ from 'jquery';
 
-    export default Adapter.extend({
+    export default class ApplicationAdapter extends Adapter {
       findRecord(store, type, id, snapshot) {
         return new RSVP.Promise(function(resolve, reject) {
           $.getJSON(`/${type.modelName}/${id}`).then(function(data) {
@@ -103,7 +103,7 @@ export default EmberObject.extend({
           });
         });
       }
-    });
+    }
     ```
 
     @method findRecord
@@ -125,7 +125,7 @@ export default EmberObject.extend({
     import RSVP from 'RSVP';
     import $ from 'jquery';
 
-    export default Adapter.extend({
+    export default class ApplicationAdapter extends Adapter {
       findAll(store, type) {
         return new RSVP.Promise(function(resolve, reject) {
           $.getJSON(`/${type.modelName}`).then(function(data) {
@@ -135,7 +135,7 @@ export default EmberObject.extend({
           });
         });
       }
-    });
+    }
     ```
 
     @method findAll
@@ -157,7 +157,7 @@ export default EmberObject.extend({
     import RSVP from 'RSVP';
     import $ from 'jquery';
 
-    export default Adapter.extend({
+    export default class ApplicationAdapter extends Adapter {
       query(store, type, query) {
         return new RSVP.Promise(function(resolve, reject) {
           $.getJSON(`/${type.modelName}`, query).then(function(data) {
@@ -167,7 +167,7 @@ export default EmberObject.extend({
           });
         });
       }
-    });
+    }
     ```
 
     @method query
@@ -196,7 +196,7 @@ export default EmberObject.extend({
     import RSVP from 'RSVP';
     import $ from 'jquery';
 
-    export default Adapter.extend(BuildURLMixin, {
+    export default class ApplicationAdapter extends Adapter.extend(BuildURLMixin) {
       queryRecord(store, type, query) {
         return new RSVP.Promise(function(resolve, reject) {
           $.getJSON(`/${type.modelName}`, query).then(function(data) {
@@ -206,7 +206,7 @@ export default EmberObject.extend({
           });
         });
       }
-    });
+    }
     ```
 
     @method queryRecord
@@ -235,11 +235,11 @@ export default EmberObject.extend({
     import Adapter from '@ember-data/adapter';
     import { v4 } from 'uuid';
 
-    export default Adapter.extend({
+    export default class ApplicationAdapter extends Adapter {
       generateIdForRecord(store, type, inputProperties) {
         return v4();
       }
-    });
+    }
     ```
 
     @method generateIdForRecord
@@ -259,14 +259,14 @@ export default EmberObject.extend({
     ```app/adapters/application.js
     import Adapter from '@ember-data/adapter';
 
-    export default Adapter.extend({
+    export default class ApplicationAdapter extends Adapter {
       createRecord(store, type, snapshot) {
         let data = this.serialize(snapshot, { includeId: true });
         let url = `/${type.modelName}`;
 
         // ...
       }
-    });
+    }
     ```
 
     @method serialize
@@ -292,25 +292,25 @@ export default EmberObject.extend({
     import RSVP from 'RSVP';
     import $ from 'jquery';
 
-    export default Adapter.extend({
+    export default class ApplicationAdapter extends Adapter {
       createRecord(store, type, snapshot) {
         let data = this.serialize(snapshot, { includeId: true });
 
-        return new RSVP.Promise(function(resolve, reject) {
+        return new RSVP.Promise(function (resolve, reject) {
           $.ajax({
             type: 'POST',
             url: `/${type.modelName}`,
             dataType: 'json',
             data: data
-          }).then(function(data) {
+          }).then(function (data) {
             run(null, resolve, data);
-          }, function(jqXHR) {
+          }, function (jqXHR) {
             jqXHR.then = null; // tame jQuery's ill mannered promises
             run(null, reject, jqXHR);
           });
         });
       }
-    });
+    }
     ```
 
     @method createRecord
@@ -343,7 +343,7 @@ export default EmberObject.extend({
     import RSVP from 'RSVP';
     import $ from 'jquery';
 
-    export default Adapter.extend({
+    export default class ApplicationAdapter extends Adapter {
       updateRecord(store, type, snapshot) {
         let data = this.serialize(snapshot, { includeId: true });
         let id = snapshot.id;
@@ -362,7 +362,7 @@ export default EmberObject.extend({
           });
         });
       }
-    });
+    }
     ```
 
     @method updateRecord
@@ -387,7 +387,7 @@ export default EmberObject.extend({
     import RSVP from 'RSVP';
     import $ from 'jquery';
 
-    export default Adapter.extend({
+    export default class ApplicationAdapter extends Adapter {
       deleteRecord(store, type, snapshot) {
         let data = this.serialize(snapshot, { includeId: true });
         let id = snapshot.id;
@@ -406,7 +406,7 @@ export default EmberObject.extend({
           });
         });
       }
-    });
+    }
     ```
 
     @method deleteRecord
@@ -439,7 +439,7 @@ export default EmberObject.extend({
     import RSVP from 'RSVP';
     import $ from 'jquery';
 
-    export default Adapter.extend({
+    export default class ApplicationAdapter extends Adapter {
       findMany(store, type, ids, snapshots) {
         return new RSVP.Promise(function(resolve, reject) {
           $.ajax({
@@ -455,7 +455,7 @@ export default EmberObject.extend({
           });
         });
       }
-    });
+    }
     ```
 
     @method findMany

--- a/packages/adapter/addon/json-api.js
+++ b/packages/adapter/addon/json-api.js
@@ -117,9 +117,9 @@ import RESTAdapter from './rest';
   ```app/adapters/application.js
   import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-  export default JSONAPIAdapter.extend({
-    namespace: 'api/1'
-  });
+  export default class ApplicationAdapter extends JSONAPIAdapter {
+    namespace = 'api/1';
+  }
   ```
   Requests for the `person` model would now target `/api/1/people/1`.
 
@@ -130,9 +130,9 @@ import RESTAdapter from './rest';
   ```app/adapters/application.js
   import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-  export default JSONAPIAdapter.extend({
-    host: 'https://api.example.com'
-  });
+  export default class ApplicationAdapter extends JSONAPIAdapter {
+    host = 'https://api.example.com';
+  }
   ```
 
   Requests for the `person` model would now target

--- a/packages/adapter/addon/rest.js
+++ b/packages/adapter/addon/rest.js
@@ -206,9 +206,9 @@ const hasNajax = typeof najax !== 'undefined';
   ```app/adapters/application.js
   import RESTAdapter from '@ember-data/adapter/rest';
 
-  export default RESTAdapter.extend({
-    namespace: 'api/1'
-  });
+  export default class ApplicationAdapter extends RESTAdapter {
+    namespace = 'api/1';
+  }
   ```
   Requests for the `Person` model would now target `/api/1/people/1`.
 
@@ -219,9 +219,9 @@ const hasNajax = typeof najax !== 'undefined';
   ```app/adapters/application.js
   import RESTAdapter from '@ember-data/adapter/rest';
 
-  export default RESTAdapter.extend({
-    host: 'https://api.example.com'
-  });
+  export default class ApplicationAdapter extends RESTAdapter {
+    host = 'https://api.example.com';
+  }
   ```
 
   ### Headers customization
@@ -235,14 +235,14 @@ const hasNajax = typeof najax !== 'undefined';
   import RESTAdapter from '@ember-data/adapter/rest';
   import { computed } from '@ember/object';
 
-  export default RESTAdapter.extend({
+  export default class ApplicationAdapter extends RESTAdapter {
     headers: computed(function() {
       return {
         'API_KEY': 'secret key',
         'ANOTHER_HEADER': 'Some header value'
       };
     }
-  });
+  }
   ```
 
   `headers` can also be used as a computed property to support dynamic
@@ -253,14 +253,14 @@ const hasNajax = typeof najax !== 'undefined';
   import RESTAdapter from '@ember-data/adapter/rest';
   import { computed } from '@ember/object';
 
-  export default RESTAdapter.extend({
+  export default class ApplicationAdapter extends RESTAdapter {
     headers: computed('session.authToken', function() {
       return {
         'API_KEY': this.get('session.authToken'),
         'ANOTHER_HEADER': 'Some header value'
       };
     })
-  });
+  }
   ```
 
   In some cases, your dynamic headers may require data from some
@@ -275,14 +275,14 @@ const hasNajax = typeof najax !== 'undefined';
   import { get } from '@ember/object';
   import { computed } from '@ember/object';
 
-  export default RESTAdapter.extend({
+  export default class ApplicationAdapter extends RESTAdapter {
     headers: computed(function() {
       return {
         'API_KEY': get(document.cookie.match(/apiKey\=([^;]*)/), '1'),
         'ANOTHER_HEADER': 'Some header value'
       };
     }).volatile()
-  });
+  }
   ```
 
   @class RESTAdapter
@@ -347,7 +347,7 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
     ```app/adapters/application.js
     import RESTAdapter from '@ember-data/adapter/rest';
 
-    export default RESTAdapter.extend({
+    export default class ApplicationAdapter extends RESTAdapter {
       sortQueryParams(params) {
         let sortedKeys = Object.keys(params).sort().reverse();
         let len = sortedKeys.length, newParams = {};
@@ -358,7 +358,7 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
 
         return newParams;
       }
-    });
+    }
     ```
 
     @method sortQueryParams
@@ -436,9 +436,9 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
     ```app/adapters/application.js
     import RESTAdapter from '@ember-data/adapter/rest';
 
-    export default RESTAdapter.extend({
-      namespace: 'api/1'
-    });
+    export default class ApplicationAdapter extends RESTAdapter {
+      namespace = 'api/1';
+    }
     ```
 
     Requests for the `Post` model would now target `/api/1/post/`.
@@ -453,9 +453,9 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
     ```app/adapters/application.js
     import RESTAdapter from '@ember-data/adapter/rest';
 
-    export default RESTAdapter.extend({
-      host: 'https://api.example.com'
-    });
+    export default class ApplicationAdapter extends RESTAdapter {
+      host = 'https://api.example.com';
+    }
     ```
 
     Requests for the `Post` model would now target `https://api.example.com/post/`.
@@ -475,14 +475,14 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
     import RESTAdapter from '@ember-data/adapter/rest';
     import { computed } from '@ember/object';
 
-    export default RESTAdapter.extend({
+    export default class ApplicationAdapter extends RESTAdapter {
       headers: computed(function() {
         return {
           'API_KEY': 'secret key',
           'ANOTHER_HEADER': 'Some header value'
         };
       })
-    });
+    }
     ```
 
     @property headers


### PR DESCRIPTION
Updated adapter examples - reference #7256. Will continue work on the remaining packages.

I noticed that the AdapterError [page](https://api.emberjs.com/ember-data/3.20/classes/AdapterError) in the api reference is blank. I don't think that's intentional and I can open a separate issue.
