### PR TITLE
[BUGFIX]: Ensure empty response for hasMany relationship is properly reflected on client

### DIFF
--- a/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -1036,6 +1036,43 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
     assert.equal(post.get('comments.length'), 0, 'the post has the no comments');
   });
 
+  test('updateRecord - hasMany relationships set locally will be removed with empty response', async function(assert) {
+    Post.reopen({ comments: DS.hasMany('comment', { async: false }) });
+    Comment.reopen({ post: DS.belongsTo('post', { async: false }) });
+
+    store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        attributes: {
+          name: 'Not everyone uses Rails',
+        },
+      },
+    });
+
+    store.push({
+      data: {
+        type: 'comment',
+        id: '1',
+        attributes: {
+          name: 'Rails is omakase',
+        },
+      },
+    });
+
+    ajaxResponse({
+      posts: { id: 1, name: 'Everyone uses Rails', comments: [] },
+    });
+
+    let post = await store.peekRecord('post', 1);
+    let comment = await store.peekRecord('comment', 1);
+    post.comments = [comment];
+    assert.equal(post.get('comments.length'), 1, 'the post has one comment');
+    post.set('name', 'Everyone uses Rails');
+    post = await post.save();
+    assert.equal(post.get('comments.length'), 0, 'the post has the no comments');
+  });
+
   test('deleteRecord - an empty payload is a basic success', function(assert) {
     adapter.shouldBackgroundReloadRecord = () => false;
     run(() => {

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -1066,9 +1066,9 @@ module('integration/adapter/rest_adapter - REST Adapter', function(hooks) {
 
     let post = await store.peekRecord('post', 1);
     let comment = await store.peekRecord('comment', 1);
-    post.comments = [comment];
+    let comments = post.comments;
+    comments.pushObject(comment);
     assert.equal(post.get('comments.length'), 1, 'the post has one comment');
-    post.set('name', 'Everyone uses Rails');
     post = await post.save();
     assert.equal(post.get('comments.length'), 0, 'the post has the no comments');
   });

--- a/packages/record-data/addon/-private/relationships/state/has-many.ts
+++ b/packages/record-data/addon/-private/relationships/state/has-many.ts
@@ -110,6 +110,9 @@ export default class ManyRelationship extends Relationship {
     this.removeRecordDataFromOwn(recordData);
   }
 
+  /*
+    sync client and persisted state
+  */
   flushCanonical() {
     let toSet = this.canonicalState;
 
@@ -156,6 +159,9 @@ export default class ManyRelationship extends Relationship {
     this.notifyHasManyChange();
   }
 
+  /*
+    Handle add/removal from adapter
+  */
   computeChanges(recordDatas: RelationshipRecordData[] = []) {
     const members = this.canonicalMembers.toArray();
     for (let i = members.length - 1; i >= 0; i--) {
@@ -164,6 +170,9 @@ export default class ManyRelationship extends Relationship {
     for (let i = 0, l = recordDatas.length; i < l; i++) {
       this.addCanonicalRecordData(recordDatas[i], i);
     }
+
+    // sync with local state
+    this.flushCanonicalLater();
   }
 
   /*


### PR DESCRIPTION
close https://github.com/emberjs/data/issues/7318
ref https://github.com/emberjs/data/issues/5204

- Notes and links in each commit when removing from unused methods.
- flushCanonicalLater to sync local state with "persisted" state.

https://discord.com/channels/480462759797063690/486549196837486592/748932008360542480
https://github.com/amk221/-ember-data-remove-has-many/blob/master/tests/unit/controllers/application-test.js#L53
