### PR TITLE
CI: add timeout to yarn install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           node-version: 12.x
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile --network-timeout=300000
       - name: Launcher Info
         run: |
           yarn run testem launchers
@@ -136,7 +136,7 @@ jobs:
         with:
           node-version: 12.x
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile --network-timeout=300000
       - name: Fastboot Test ${{ matrix.scenario }}
         timeout-minutes: 6
         run: yarn test:fastboot ${{ matrix.scenario }}
@@ -159,6 +159,10 @@ jobs:
             launcher: Firefox
           - os: windows-latest
             launcher: Firefox
+          - os: macos-latest
+            launcher: Chrome
+          - os: windows-latest
+            launcher: Chrome
     runs-on: ${{ matrix.os }}
     name: ${{matrix.scenario}} ${{matrix.launcher}} on ${{matrix.os}}
     steps:
@@ -167,7 +171,7 @@ jobs:
         with:
           node-version: 12.x
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --network-timeout=300000
       - name: Launcher Info
         run: |
           yarn run testem launchers
@@ -259,7 +263,7 @@ jobs:
         with:
           node-version: 12.x
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile --network-timeout=300000
       - name: Basic tests with ${{ matrix.scenario }}
         env:
           CI: true


### PR DESCRIPTION
https://github.com/yarnpkg/yarn/search?utf8=%E2%9C%93&q=NETWORK_TIMEOUT&type=

Currently set to 1/2 min.  This PR sets it to 5 min.