### PR TITLE
[DOC store] convert api examples to native classes/Octane

### DIFF
--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -853,7 +853,7 @@ abstract class CoreStore extends Service {
 
     ```js
     // app/adapters/post.js
-    import ApplicationAdapter from - "./application";
+    import ApplicationAdapter from "./application";
 
     export default class PostAdapter extends ApplicationAdapter {
       shouldReloadRecord(store, snapshot) {

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -853,10 +853,9 @@ abstract class CoreStore extends Service {
 
     ```js
     // app/adapters/post.js
-    import ApplicationAdapter from "./application";
+    import ApplicationAdapter from - "./application";
 
     export default class PostAdapter extends ApplicationAdapter {
-    export default ApplicationAdapter.extend({
       shouldReloadRecord(store, snapshot) {
         return false;
       },

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -154,8 +154,7 @@ function deprecateTestRegistration(
   ```app/services/store.js
   import Store from '@ember-data/store';
 
-  export default Store.extend({
-  });
+  export default class MyStore extends Store {}
   ```
 
   Most Ember.js applications will only have a single `Store` that is
@@ -176,8 +175,8 @@ function deprecateTestRegistration(
   ```app/adapters/application.js
   import Adapter from '@ember-data/adapter';
 
-  export default Adapter.extend({
-  });
+  export default class ApplicationAdapter extends Adapter {
+  }
   ```
 
   You can learn more about writing a custom adapter by reading the `Adapter`
@@ -270,12 +269,12 @@ abstract class CoreStore extends Service {
     ```js
     import Store from '@ember-data/store';
 
-    export default Store.extend({
+    export default class MyStore extends Store {
       init() {
         this._super(...arguments);
         this.adapter = 'custom';
       }
-    });
+    }
     ```
 
     @property adapter
@@ -779,11 +778,11 @@ abstract class CoreStore extends Service {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostRoute extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id);
       }
-    });
+    }
     ```
 
     If the record is not yet available, the store will ask the adapter's `find`
@@ -856,6 +855,7 @@ abstract class CoreStore extends Service {
     // app/adapters/post.js
     import ApplicationAdapter from "./application";
 
+    export default class PostAdapter extends ApplicationAdapter {
     export default ApplicationAdapter.extend({
       shouldReloadRecord(store, snapshot) {
         return false;
@@ -899,11 +899,11 @@ abstract class CoreStore extends Service {
     ```app/routes/post/edit.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostEditRoute extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id, { backgroundReload: false });
       }
-    });
+    }
     ```
 
     If you pass an object on the `adapterOptions` property of the options
@@ -912,26 +912,26 @@ abstract class CoreStore extends Service {
     ```app/routes/post/edit.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostEditRoute extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id, {
           adapterOptions: { subscribe: false }
         });
       }
-    });
+    }
     ```
 
     ```app/adapters/post.js
     import MyCustomAdapter from './custom-adapter';
 
-    export default MyCustomAdapter.extend({
+    export default class PostAdapter extends MyCustomAdapter {
       findRecord(store, type, id, snapshot) {
         if (snapshot.adapterOptions.subscribe) {
           // ...
         }
         // ...
       }
-    });
+    }
     ```
 
     See [peekRecord](../classes/Store/methods/peekRecord?anchor=peekRecord) to get the cached version of a record.
@@ -953,11 +953,11 @@ abstract class CoreStore extends Service {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostRoute extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id, { include: 'comments' });
       }
-    });
+    }
 
     ```
     In this case, the post's comments would then be available in your template as
@@ -971,12 +971,11 @@ abstract class CoreStore extends Service {
     ```app/routes/post.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostRoute extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id, { include: 'comments,comments.author' });
       }
-    });
-
+    }
     ```
 
     @since 1.13.0
@@ -1145,7 +1144,7 @@ abstract class CoreStore extends Service {
 
   _scheduleFetchThroughFetchManager(internalModel: InternalModel, options = {}): RSVP.Promise<InternalModel> {
     let generateStackTrace = this.generateStackTracesForTrackedRequests;
-    // TODO  remove this once we dont rely on state machine
+    // TODO  remove this once we don't rely on state machine
     internalModel.loadingData();
     let identifier = internalModel.identifier;
 
@@ -1159,7 +1158,7 @@ abstract class CoreStore extends Service {
           payload.data.lid = identifier.lid;
         }
 
-        // Returning this._push here, breaks typing but not any tests, invesstigate potential missing tests
+        // Returning this._push here, breaks typing but not any tests, investigate potential missing tests
         let potentiallyNewIm = this._push(payload);
         if (potentiallyNewIm && !Array.isArray(potentiallyNewIm)) {
           return potentiallyNewIm;
@@ -1168,7 +1167,7 @@ abstract class CoreStore extends Service {
         }
       },
       error => {
-        // TODO  remove this once we dont rely on state machine
+        // TODO  remove this once we don't rely on state machine
         internalModel.notFound();
         if (internalModel.isEmpty()) {
           internalModel.unloadRecord();
@@ -1950,14 +1949,14 @@ abstract class CoreStore extends Service {
     The request is made through the adapters' `queryRecord`:
 
     ```app/adapters/user.js
-    import $ from 'jquery';
     import Adapter from '@ember-data/adapter';
+    import $ from 'jquery';
 
-    export default Adapter.extend({
+    export default class UserAdapter extends Adapter {
       queryRecord(modelName, query) {
         return $.getJSON('/api/current_user');
       }
-    });
+    }
     ```
 
     Note: the primary use case for `store.queryRecord` is when a single record
@@ -2058,11 +2057,11 @@ abstract class CoreStore extends Service {
     ```app/routes/authors.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class AuthorsRoute extends Route {
       model(params) {
         return this.store.findAll('author');
       }
-    });
+    }
     ```
 
     _When_ the returned promise resolves depends on the reload behavior,
@@ -2107,7 +2106,8 @@ abstract class CoreStore extends Service {
 
     ```app/adapters/application.js
     import Adapter from '@ember-data/adapter';
-    export default Adapter.extend({
+
+    export default class ApplicationAdapter extends Adapter {
       shouldReloadAll(store, snapshotsArray) {
         return false;
       },
@@ -2151,11 +2151,11 @@ abstract class CoreStore extends Service {
     ```app/routes/post/edit.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostEditRoute extends Route {
       model() {
         return this.store.findAll('post', { backgroundReload: false });
       }
-    });
+    }
     ```
 
     If you pass an object on the `adapterOptions` property of the options
@@ -2164,26 +2164,26 @@ abstract class CoreStore extends Service {
     ```app/routes/posts.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostsRoute extends Route {
       model(params) {
         return this.store.findAll('post', {
           adapterOptions: { subscribe: false }
         });
       }
-    });
+    }
     ```
 
     ```app/adapters/post.js
     import MyCustomAdapter from './custom-adapter';
 
-    export default MyCustomAdapter.extend({
+    export default class UserAdapter extends MyCustomAdapter {
       findAll(store, type, sinceToken, snapshotRecordArray) {
         if (snapshotRecordArray.adapterOptions.subscribe) {
           // ...
         }
         // ...
       }
-    });
+    }
     ```
 
     See [peekAll](../classes/Store/methods/peekAll?anchor=peekAll) to get an array of current records in the
@@ -2206,12 +2206,11 @@ abstract class CoreStore extends Service {
     ```app/routes/posts.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostsRoute extends Route {
       model() {
         return this.store.findAll('post', { include: 'comments' });
       }
-    });
-
+    }
     ```
     Multiple relationships can be requested using an `include` parameter consisting of a
     comma-separated list (without white-space) while nested relationships can be specified
@@ -2221,12 +2220,11 @@ abstract class CoreStore extends Service {
     ```app/routes/posts.js
     import Route from '@ember/routing/route';
 
-    export default Route.extend({
+    export default class PostsRoute extends Route {
       model() {
         return this.store.findAll('post', { include: 'comments,comments.author' });
       }
-    });
-
+    }
     ```
 
     See [query](../classes/Store/methods/query?anchor=query) to only get a subset of records from the server.
@@ -2733,12 +2731,12 @@ abstract class CoreStore extends Service {
     ```app/models/person.js
     import Model, { attr, hasMany } from '@ember-data/model';
 
-    export default Model.extend({
-      firstName: attr('string'),
-      lastName: attr('string'),
+    export default class PersonRoute extends Route {
+      @attr('string') firstName;
+      @attr('string') lastName;
 
-      children: hasMany('person')
-    });
+      @hasMany('person') children;
+    }
     ```
 
     To represent the children as IDs:
@@ -2962,7 +2960,7 @@ abstract class CoreStore extends Service {
     ```app/serializers/application.js
     import RESTSerializer from '@ember-data/serializer/rest';
 
-    export default RESTSerializer;
+    export default class ApplicationSerializer extends RESTSerializer;
     ```
 
     ```js
@@ -2987,7 +2985,7 @@ abstract class CoreStore extends Service {
     ```app/serializers/application.js
     import RESTSerializer from '@ember-data/serializer/rest';
 
-    export default RESTSerializer;
+     export default class ApplicationSerializer extends RESTSerializer;
     ```
 
     ```app/serializers/post.js

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -269,9 +269,9 @@ abstract class CoreStore extends Service {
     ```js
     import Store from '@ember-data/store';
 
-    export default class MyStore extends Store {
-      init() {
-        this._super(...arguments);
+    export default Store.extend({
+      constructor() {
+        super(...arguments);
         this.adapter = 'custom';
       }
     }

--- a/packages/store/addon/-private/system/errors-utils.js
+++ b/packages/store/addon/-private/system/errors-utils.js
@@ -13,7 +13,9 @@ const PRIMARY_ATTRIBUTE_KEY = 'base';
   Convert an hash of errors into an array with errors in JSON-API format.
    ```javascript
   import DS from 'ember-data';
+
    const { errorsHashToArray } = DS;
+   
    let errors = {
     base: 'Invalid attributes on saving this record',
     name: 'Must be present',

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -461,7 +461,7 @@ export default class InternalModel {
   dematerializeRecord() {
     this._isDematerializing = true;
 
-    // TODO IGOR add a test that fails when this is missing, something that involves canceliing a destroy
+    // TODO IGOR add a test that fails when this is missing, something that involves canceling a destroy
     // and the destroy not happening, and then later on trying to destroy
     this._doNotDestroy = false;
 
@@ -1092,7 +1092,7 @@ export default class InternalModel {
           //  probably we don't want to retrieve latest eagerly when notifyhasmany changed
           //  but rather lazily when someone actually asks for a manyarray
           //
-          //  that said, also not clear why we haven't moved this to retainedmanyarray so maybe that's the bit that's just not workign
+          //  that said, also not clear why we haven't moved this to retainedmanyarray so maybe that's the bit that's just not working
           manyArray.retrieveLatest();
         }
       }
@@ -1580,7 +1580,7 @@ export default class InternalModel {
 }
 
 if (RECORD_ARRAY_MANAGER_IDENTIFIERS) {
-  // in production code, this is only accesssed in `record-array-manager`
+  // in production code, this is only accessed in `record-array-manager`
   // if LEGACY_COMPAT is also on
   if (!REMOVE_RECORD_ARRAY_MANAGER_LEGACY_COMPAT) {
     Object.defineProperty(InternalModel.prototype, '_recordArrays', {

--- a/packages/store/addon/-private/system/record-arrays/record-array.js
+++ b/packages/store/addon/-private/system/record-arrays/record-array.js
@@ -58,7 +58,7 @@ let RecordArray = ArrayProxy.extend(DeprecatedEvented, {
     Example
 
     ```javascript
-    var people = store.peekAll('person');
+    let people = store.peekAll('person');
     people.get('isLoaded'); // true
     ```
 
@@ -72,7 +72,7 @@ let RecordArray = ArrayProxy.extend(DeprecatedEvented, {
     Example
 
     ```javascript
-    var people = store.peekAll('person');
+    let people = store.peekAll('person');
     people.get('isUpdating'); // false
     people.update();
     people.get('isUpdating'); // true
@@ -138,7 +138,7 @@ let RecordArray = ArrayProxy.extend(DeprecatedEvented, {
     Example
 
     ```javascript
-    var people = store.peekAll('person');
+    let people = store.peekAll('person');
     people.get('isUpdating'); // false
 
     people.update().then(function() {
@@ -184,7 +184,7 @@ let RecordArray = ArrayProxy.extend(DeprecatedEvented, {
     Example
 
     ```javascript
-    var messages = store.peekAll('message');
+    let messages = store.peekAll('message');
     messages.forEach(function(message) {
       message.set('hasBeenSeen', true);
     });

--- a/packages/store/addon/-private/system/references/belongs-to.js
+++ b/packages/store/addon/-private/system/references/belongs-to.js
@@ -44,9 +44,11 @@ export default class BelongsToReference extends Reference {
 
    ```javascript
    // models/blog.js
-   export default Model.extend({
-      user: belongsTo({ async: true })
-    });
+   import Model, { belongsTo } from '@ember-data/model';
+
+   export default class BlogModel extends Model {
+    @belongsTo({ async: true }) user;
+   }
 
    let blog = store.push({
       data: {
@@ -85,7 +87,7 @@ export default class BelongsToReference extends Reference {
 
   /**
    `push` can be used to update the data in the relationship and Ember
-   Data will treat the new data as the conanical value of this
+   Data will treat the new data as the canonical value of this
    relationship on the backend.
 
    Example
@@ -93,9 +95,9 @@ export default class BelongsToReference extends Reference {
    ```app/models/blog.js
    import Model, { belongsTo } from '@ember-data/model';
 
-   export default Model.extend({
-      user: belongsTo({ async: true })
-    });
+   export default class BlogModel extends Model {
+      @belongsTo({ async: true }) user;
+    }
 
    let blog = store.push({
       data: {
@@ -170,9 +172,9 @@ export default class BelongsToReference extends Reference {
    // models/blog.js
    import Model, { belongsTo } from '@ember-data/model';
 
-   export default Model.extend({
-      user: belongsTo({ async: true })
-    });
+   export default class BlogModel extends Model {
+     @belongsTo({ async: true }) user;
+   }
 
    let blog = store.push({
       data: {
@@ -230,9 +232,9 @@ export default class BelongsToReference extends Reference {
    // models/blog.js
    import Model, { belongsTo } from '@ember-data/model';
 
-   export default Model.extend({
-      user: belongsTo({ async: true })
-    });
+   export default class BlogModel extends Model {
+     @belongsTo({ async: true }) user;
+   }
 
    let blog = store.push({
       data: {
@@ -265,9 +267,10 @@ export default class BelongsToReference extends Reference {
      userRef.value() === user;
    });
    ```
-
    ```app/adapters/user.js
-   export default ApplicationAdapter.extend({
+   import Adapter from '@ember-data/adapter';
+
+   export default class UserAdapter extends Adapter {
      findRecord(store, type, id, snapshot) {
        // In the adapter you will have access to adapterOptions.
        let adapterOptions = snapshot.adapterOptions;
@@ -294,9 +297,10 @@ export default class BelongsToReference extends Reference {
    ```javascript
    // models/blog.js
    import Model, { belongsTo } from '@ember-data/model';
-   export default Model.extend({
-      user: belongsTo({ async: true })
-    });
+
+   export default class BlogModel extends Model {
+     @belongsTo({ async: true }) user;
+   }
 
    let blog = store.push({
       data: {

--- a/packages/store/addon/-private/system/references/has-many.js
+++ b/packages/store/addon/-private/system/references/has-many.js
@@ -43,9 +43,10 @@ export default class HasManyReference extends Reference {
 
    ```app/models/post.js
    import Model, { hasMany } from '@ember-data/model';
-   export default Model.extend({
-     comments: hasMany({ async: true })
-   });
+
+   export default class PostModel extends Model {
+     @hasMany({ async: true }) comments;
+   }
    ```
 
    ```javascript
@@ -90,9 +91,10 @@ export default class HasManyReference extends Reference {
 
    ```app/models/post.js
    import Model, { hasMany } from '@ember-data/model';
-   export default Model.extend({
-     comments: hasMany({ async: true })
-   });
+
+   export default class PostModel extends Model {
+     @hasMany({ async: true }) comments;
+   }
    ```
 
    ```javascript
@@ -136,9 +138,10 @@ export default class HasManyReference extends Reference {
 
    ```app/models/post.js
    import Model, { hasMany } from '@ember-data/model';
-   export default Model.extend({
-     comments: hasMany({ async: true })
-   });
+
+   export default class PostModel extends Model {
+     @hasMany({ async: true }) comments;
+   }
    ```
 
    ```
@@ -225,9 +228,10 @@ export default class HasManyReference extends Reference {
 
    ```app/models/post.js
    import Model, { hasMany } from '@ember-data/model';
-   export default Model.extend({
-     comments: hasMany({ async: true })
-   });
+
+   export default class PostModel extends Model {
+     @hasMany({ async: true }) comments;
+   }
    ```
 
    ```javascript
@@ -272,9 +276,10 @@ export default class HasManyReference extends Reference {
 
    ```app/models/post.js
    import Model, { hasMany } from '@ember-data/model';
-   export default Model.extend({
-     comments: hasMany({ async: true })
-   });
+
+   export default class PostModel extends Model {
+     @hasMany({ async: true }) comments;
+   }
    ```
 
    ```javascript
@@ -337,9 +342,10 @@ export default class HasManyReference extends Reference {
 
    ```app/models/post.js
    import Model, { hasMany } from '@ember-data/model';
-   export default Model.extend({
-     comments: hasMany({ async: true })
-   });
+
+   export default class PostModel extends Model {
+     @hasMany({ async: true }) comments;
+   }
    ```
 
    ```javascript

--- a/packages/store/addon/-private/system/snapshot-record-array.ts
+++ b/packages/store/addon/-private/system/snapshot-record-array.ts
@@ -50,8 +50,8 @@ export default class SnapshotRecordArray {
       export default class PostAdapter extends JSONAPIAdapter {
         shouldReloadAll(store, snapshotRecordArray) {
           return !snapshotRecordArray.length;
-        },
-      }
+        }
+      });
       ```
 
       @property length
@@ -74,8 +74,8 @@ export default class SnapshotRecordArray {
           let lastRequestTime = snapshotRecordArray.meta.lastRequestTime;
           let twentyMinutes = 20 * 60 * 1000;
           return Date.now() > lastRequestTime + twentyMinutes;
-        },
-      }
+        }
+      });
       ```
 
       @property meta

--- a/packages/store/addon/-private/system/snapshot-record-array.ts
+++ b/packages/store/addon/-private/system/snapshot-record-array.ts
@@ -47,11 +47,11 @@ export default class SnapshotRecordArray {
       ```app/adapters/post.js
       import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-      export default JSONAPIAdapter.extend({
+      export default class PostAdapter extends JSONAPIAdapter {
         shouldReloadAll(store, snapshotRecordArray) {
           return !snapshotRecordArray.length;
         },
-      });
+      }
       ```
 
       @property length
@@ -69,13 +69,13 @@ export default class SnapshotRecordArray {
       ```app/adapters/post.js
       import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-      export default JSONAPIAdapter.extend({
+      export default class PostAdapter extends JSONAPIAdapter {
         shouldReloadAll(store, snapshotRecordArray) {
-          var lastRequestTime = snapshotRecordArray.meta.lastRequestTime;
-          var twentyMinutes = 20 * 60 * 1000;
+          let lastRequestTime = snapshotRecordArray.meta.lastRequestTime;
+          let twentyMinutes = 20 * 60 * 1000;
           return Date.now() > lastRequestTime + twentyMinutes;
         },
-      });
+      }
       ```
 
       @property meta
@@ -91,14 +91,14 @@ export default class SnapshotRecordArray {
       ```app/adapters/post.js
       import MyCustomAdapter from './custom-adapter';
 
-      export default MyCustomAdapter.extend({
+      export default class PostAdapter extends MyCustomAdapter {
         findAll(store, type, sinceToken, snapshotRecordArray) {
           if (snapshotRecordArray.adapterOptions.subscribe) {
             // ...
           }
           // ...
         }
-      });
+      }
       ```
 
       @property adapterOptions
@@ -114,13 +114,13 @@ export default class SnapshotRecordArray {
       ```app/adapters/application.js
       import Adapter from '@ember-data/adapter';
 
-      export default Adapter.extend({
+      export default class ApplicationAdapter extends Adapter {
         findAll(store, type, snapshotRecordArray) {
-          var url = `/${type.modelName}?include=${encodeURIComponent(snapshotRecordArray.include)}`;
+          let url = `/${type.modelName}?include=${encodeURIComponent(snapshotRecordArray.include)}`;
 
           return fetch(url).then((response) => response.json())
         }
-      });
+      }
       ```
 
       @property include
@@ -154,12 +154,12 @@ export default class SnapshotRecordArray {
     ```app/adapters/post.js
     import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-    export default JSONAPIAdapter.extend({
+    export default class PostAdapter extends JSONAPIAdapter {
       shouldReloadAll(store, snapshotArray) {
-        var snapshots = snapshotArray.snapshots();
+        let snapshots = snapshotArray.snapshots();
 
         return snapshots.any(function(ticketSnapshot) {
-          var timeDiff = moment().diff(ticketSnapshot.attr('lastAccessedAt'), 'minutes');
+          let timeDiff = moment().diff(ticketSnapshot.attr('lastAccessedAt'), 'minutes');
           if (timeDiff > 20) {
             return true;
           } else {
@@ -167,7 +167,7 @@ export default class SnapshotRecordArray {
           }
         });
       }
-    });
+    }
     ```
 
     @method snapshots

--- a/packages/store/addon/-private/system/snapshot.ts
+++ b/packages/store/addon/-private/system/snapshot.ts
@@ -497,8 +497,8 @@ export default class Snapshot implements Snapshot {
 
     export default Adapter.extend({
       createRecord(store, type, snapshot) {
-        var data = snapshot.serialize({ includeId: true });
-        var url = `/${type.modelName}`;
+        let data = snapshot.serialize({ includeId: true });
+        let url = `/${type.modelName}`;
 
         return fetch(url, {
           method: 'POST',


### PR DESCRIPTION
Updated store examples - this is last PR to resolve #7256.

I'm going to open a new issue because I realized that we document two different imports for the base adapter but only one is generated with the blueprints.

```javascript
// generated
import ApplicationAdapter from "./application";

// used but not generated
import Adapter from '@ember-data/adapter';
```
