### PR TITLE
[Release]: bump ember-source in packages/ to 3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 - [#7224](https://github.com/emberjs/data/pull/7224) [DOCS] fix links on @ember-data/store package intro
 - [#7228](https://github.com/emberjs/data/pull/7228) chore: remove instance initializer (#7228)
 - [#7232](https://github.com/emberjs/data/pull/7232) [DOC] Fix minor typo in findRecord documentation
-- [fd9ffb8f](https://github.com/emberjs/data/commit/fd9ffb8feeb03d67bbf8bf09072719b03fbb470c) [DOC] Use native syntax in RESTSerializer documentation (#7231)
-- [#7247](https://github.com/emberjs/data/pull/7247) [CI]: remove erroneous `name` without `run` in node-version-test (#7247)
+- [#7231](https://github.com/emberjs/data/pull/7231) [DOC] Use native syntax in RESTSerializer documentation (#7231)
 
 ## Release 3.20.2 (LTS) (August 30, 2020)
 - Rerelease of 3.20.1
@@ -66,6 +65,12 @@
 - [#6968](https://github.com/emberjs/data/pull/6968) remove IDENTIFIERS off branches (#6968)
 - [#6927](https://github.com/emberjs/data/pull/6927) [FIX] groupRecordsForFindMany should be optional (#6927)
 - [#7006](https://github.com/emberjs/data/pull/7006) Make execa use compatible with volta
+
+## Release 3.16.9 (LTS) (August 29, 2020)
+- [d22499d0](https://github.com/emberjs/data/pull/7291) [BUGFIX] Entangle Errors.errorsFor properly
+
+## Release 3.16.8 (LTS) (June 24, 2020)
+- [#7236](https://github.com/emberjs/data/pull/7236) [BUGFIX] Allow createRecord responses without a type (#7236)
 
 ## Release 3.16.7 (LTS) (June 10, 2020)
 

--- a/packages/-ember-data/config/ember-try.js
+++ b/packages/-ember-data/config/ember-try.js
@@ -63,18 +63,18 @@ module.exports = function() {
           },
         },
         {
-          name: 'ember-lts-3.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.12.0',
-            },
-          },
-        },
-        {
           name: 'ember-lts-3.16',
           npm: {
             devDependencies: {
               'ember-source': '~3.16.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.20',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.20.0',
             },
           },
         },

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -76,7 +76,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",
     "github": "^1.1.1",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -44,7 +44,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -42,7 +42,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -49,7 +49,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -45,7 +45,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -44,7 +44,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -45,7 +45,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0"

--- a/packages/unpublished-adapter-encapsulation-test-app/package.json
+++ b/packages/unpublished-adapter-encapsulation-test-app/package.json
@@ -41,7 +41,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^8.5.1",
     "eslint-plugin-node": "^11.0.0",

--- a/packages/unpublished-debug-encapsulation-test-app/package.json
+++ b/packages/unpublished-debug-encapsulation-test-app/package.json
@@ -40,7 +40,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^8.5.1",
     "eslint-plugin-node": "^11.0.0",

--- a/packages/unpublished-fastboot-test-app/package.json
+++ b/packages/unpublished-fastboot-test-app/package.json
@@ -48,7 +48,7 @@
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
     "ember-simple-tree": "^0.8.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "ember-try": "^1.4.0",
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^8.5.1",

--- a/packages/unpublished-model-encapsulation-test-app/package.json
+++ b/packages/unpublished-model-encapsulation-test-app/package.json
@@ -41,7 +41,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^8.5.1",
     "eslint-plugin-node": "^11.0.0",

--- a/packages/unpublished-record-data-encapsulation-test-app/package.json
+++ b/packages/unpublished-record-data-encapsulation-test-app/package.json
@@ -41,7 +41,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^8.5.1",
     "eslint-plugin-node": "^11.0.0",

--- a/packages/unpublished-relationship-performance-test-app/package.json
+++ b/packages/unpublished-relationship-performance-test-app/package.json
@@ -36,7 +36,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^8.5.1",
     "eslint-plugin-node": "^11.0.0",

--- a/packages/unpublished-serializer-encapsulation-test-app/package.json
+++ b/packages/unpublished-serializer-encapsulation-test-app/package.json
@@ -40,7 +40,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^8.5.1",
     "eslint-plugin-node": "^11.0.0",

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -41,7 +41,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
-    "ember-source": "^3.18.1",
+    "ember-source": "^3.20.1",
     "loader.js": "^4.7.0",
     "qunit": "^2.10.0",
     "rsvp": "^4.8.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6971,36 +6971,6 @@ ember-source-channel-url@^2.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@^3.18.1:
-  version "3.18.1"
-  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.18.1.tgz#64ef40261ef1094e529ef6baabd907e6171a51f7"
-  integrity sha512-hfBkU2w+R7zquHpdMI+HCCt51OiBA4vkVd/czm+Xr17+qkxswh748l/VQe0N0IJLhrWlbmeOI6gtrB+Hsk8QAg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.8.3"
-    "@babel/plugin-transform-block-scoping" "^7.8.3"
-    "@babel/plugin-transform-object-assign" "^7.8.3"
-    "@ember/edition-utils" "^1.2.0"
-    babel-plugin-debug-macros "^0.3.3"
-    babel-plugin-filter-imports "^4.0.0"
-    broccoli-concat "^3.7.4"
-    broccoli-debug "^0.6.4"
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.2"
-    chalk "^3.0.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-get-component-path-option "^1.0.0"
-    ember-cli-is-package-missing "^1.0.0"
-    ember-cli-normalize-entity-name "^1.0.0"
-    ember-cli-path-utils "^1.0.0"
-    ember-cli-string-utils "^1.1.0"
-    ember-cli-version-checker "^3.1.3"
-    ember-router-generator "^2.0.0"
-    inflection "^1.12.0"
-    jquery "^3.4.1"
-    resolve "^1.14.2"
-    semver "^6.1.1"
-    silent-error "^1.1.1"
-
 ember-source@^3.20.1:
   version "3.21.1"
   resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.21.1.tgz#e1bfb20a3db91c21415256e5949a32085a2c23ab"
@@ -9762,11 +9732,6 @@ jquery-deferred@^0.3.0:
   version "0.3.1"
   resolved "https://registry.npmjs.org/jquery-deferred/-/jquery-deferred-0.3.1.tgz#596eca1caaff54f61b110962b23cafea74c35355"
   integrity sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=
-
-jquery@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
 
 jquery@^3.5.0:
   version "3.5.1"
@@ -12836,7 +12801,7 @@ resolve@1.9.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1:
   version "1.16.1"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.16.1.tgz#49fac5d8bacf1fd53f200fa51247ae736175832c"
   integrity sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==


### PR DESCRIPTION
My fault.  Improvements made to release docs as well (although I should have noticed this!).

https://github.com/emberjs/data/pull/7304