### PR TITLE
Add failing testcase for the errors autotracking bug

### DIFF
--- a/packages/-ember-data/tests/integration/record-data/model-errors-rendering-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/model-errors-rendering-test.ts
@@ -1,0 +1,70 @@
+import 'qunit-dom'; // tell TS consider *.dom extension for assert
+
+// @ts-ignore
+import { setComponentTemplate } from '@ember/component';
+import { get } from '@ember/object';
+import { render, settled } from '@ember/test-helpers';
+import Component from '@glimmer/component';
+
+import { module, test } from 'qunit';
+
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
+
+import Model, { attr } from '@ember-data/model';
+
+class Tag extends Model {
+  @attr('string', {})
+  name;
+}
+
+class ErrorList extends Component<{ model: Model; field: string }> {
+  get errors() {
+    const { model, field } = this.args;
+    return model.errors.errorsFor(field).map(error => error.message);
+  }
+}
+
+const template = hbs`
+  <ul class="error-list">
+    {{#each this.errors as |error|}}
+      <li class="error-list__error">{{error}}</li>
+    {{/each}}
+  </ul>
+`;
+
+interface CurrentTestContext extends TestContext {
+  tag: Tag;
+}
+
+module('integration/model.errors', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    let { owner } = this;
+
+    owner.register('model:tag', Tag);
+    owner.register('component:error-list', setComponentTemplate(template, ErrorList));
+  });
+
+  test('Model errors are autotracked', async function(this: CurrentTestContext, assert) {
+    this.tag = this.owner.lookup('service:store').createRecord('tag');
+    // @ts-ignore
+    const errors = get(this.tag, 'errors');
+
+    await render(hbs`<ErrorList @model={{this.tag}} @field="name"/>`);
+
+    assert.dom('.error-list__error').doesNotExist();
+
+    errors.add('name', 'the-error');
+    await settled();
+
+    assert.dom('.error-list__error').hasText('the-error');
+
+    errors.remove('name');
+    await settled();
+
+    assert.dom('.error-list__error').doesNotExist();
+  });
+});


### PR DESCRIPTION
The bug is reproducible starting from ember-source@3.20.4.
3.20.5 partially fixed the bug but there is a case when it still
doesn't work. In particular, removing the error from the errors object
is not autotracked.

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
