### PR TITLE
[Build]: disable esm cache (#7322)

### DIFF
--- a/packages/private-build-infra/src/deprecations.js
+++ b/packages/private-build-infra/src/deprecations.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const requireEsm = require('esm')(module);
+const requireEsm = require('esm')(module, { cache: false });
 const semver = require('semver');
 
 function deprecationIsResolved(deprecatedSince, compatVersion) {

--- a/packages/private-build-infra/src/features.js
+++ b/packages/private-build-infra/src/features.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const requireEsm = require('esm')(module);
+const requireEsm = require('esm')(module, { cache: false });
 
 const version = require('../package.json').version;
 

--- a/packages/private-build-infra/src/packages.js
+++ b/packages/private-build-infra/src/packages.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const requireEsm = require('esm')(module);
+const requireEsm = require('esm')(module, { cache: false });
 
 function detectPackage(dep, packageName, seen) {
   let isFirst = !seen;


### PR DESCRIPTION
ref #7322 

While not strictly necessary, this will help those that upgrade from 3.16 to 3.20 avoid having to remove node_modules and reinstall.  Explanation in ref PR.