### PR TITLE
[CHORE] Bump ordered-set to get on ember-cli-babel v7

### DIFF
--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -23,7 +23,7 @@
     "@ember-data/private-build-infra": "3.24.0-alpha.0",
     "@ember-data/store": "3.24.0-alpha.0",
     "@ember/edition-utils": "^1.2.0",
-    "@ember/ordered-set": "^2.0.3",
+    "@ember/ordered-set": "^3.0.0",
     "ember-cli-babel": "^7.18.0",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^3.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,6 +1605,14 @@
     ember-cli-babel "^6.16.0"
     ember-compatibility-helpers "^1.1.1"
 
+"@ember/ordered-set@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@ember/ordered-set/-/ordered-set-3.0.0.tgz#99a7cb4ec7ed7ca9dafb671b993d630c53cbe824"
+  integrity sha512-BNknCgOA7bLMzlOIPoCmeiOvn+EWP6sUoG4JHYYxLka5wsKvD/Oma1ftPazlWYkav6M8jHy5sCcfCu9qVlFsEQ==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+    ember-compatibility-helpers "^1.1.1"
+
 "@ember/string@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@ember/string/-/string-1.0.0.tgz#3a2254caedacb95e09071204d36cad49e0f8b855"


### PR DESCRIPTION
Bumping `@ember/ordered-set` to a version running ember-cli-babel v7