### PR TITLE
Do not explode when getting back an empty payload with the accept json header

### DIFF
--- a/packages/adapter/addon/-private/utils/determine-body-promise.ts
+++ b/packages/adapter/addon/-private/utils/determine-body-promise.ts
@@ -22,6 +22,25 @@ function _determineContent(response: Response, requestData: JQueryAjaxSettings, 
     return payload;
   }
 
+  let status = response.status;
+  let payloadIsEmpty = payload === '' || payload === null;
+  let statusIndicatesEmptyResponse = status === 204 || status === 205 || requestData.method === 'HEAD';
+
+  if (DEBUG) {
+    if (payloadIsEmpty && !statusIndicatesEmptyResponse) {
+      let message = `The server returned an empty string for ${requestData.method} ${requestData.url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
+      if (payload === '') {
+        warn(message, {
+          id: 'ds.adapter.returned-empty-string-as-JSON',
+        });
+      }
+    }
+  }
+
+  if (response.ok && (statusIndicatesEmptyResponse || payloadIsEmpty)) {
+    return;
+  }
+
   try {
     ret = JSON.parse(payload as string);
   } catch (e) {
@@ -30,20 +49,6 @@ function _determineContent(response: Response, requestData: JQueryAjaxSettings, 
     }
     (e as CustomSyntaxError).payload = payload;
     error = e;
-  }
-
-  const status = response.status;
-  if (response.ok && (status === 204 || status === 205 || requestData.method === 'HEAD')) {
-    return;
-  }
-
-  if (DEBUG) {
-    let message = `The server returned an empty string for ${requestData.method} ${requestData.url}, which cannot be parsed into a valid JSON. Return either null or {}.`;
-    if (payload === '') {
-      warn(message, true, {
-        id: 'ds.adapter.returned-empty-string-as-JSON',
-      });
-    }
   }
 
   if (error) {


### PR DESCRIPTION
Even though this goes against the spec, we decided that it is better to be more accepting in the incoming requests, as the downside seemed low, and people seem to be running into this issue when migrating away from jquery to fetch.