### PR TITLE
Fix repository URL

### DIFF
--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "https://github.com/emberjs/data/tree/master/packages/adapter",
+  "repository": "https://github.com/emberjs/data/tree/master/packages/record-data",
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
I assume this was just an oversight. I clicked the NPM repo link and was very confused for a minute.
