### PR TITLE
[CHORE] Upgrade ember-inflector to version using babel 7

### DIFF
--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -36,7 +36,7 @@
     "broccoli-merge-trees": "^4.2.0",
     "ember-cli-babel": "^7.18.0",
     "ember-cli-typescript": "^4.0.0",
-    "ember-inflector": "^3.0.1"
+    "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.9.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,8 +932,6 @@
   version "7.12.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz#07640f28867ed16f9511c99c888291f560921cfa"
   integrity sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-function-name@^7.10.4":
   version "7.10.4"
@@ -7229,7 +7227,7 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cl
     rimraf "^3.0.1"
     semver "^5.5.0"
 
-ember-cli-babel@^7.4.0:
+ember-cli-babel@^7.23.0, ember-cli-babel@^7.4.0:
   version "7.23.0"
   resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.23.0.tgz#ec580aa2c115d0810e454dd5c2fffce238284b92"
   integrity sha512-ix58DlRDAbGITtdJoRUPcAoQwKLYr/x/kIXjU9u1ATyhmuUjqb+0FDXghOWbkNihGiNOqBBR49+LBgK9AeBcNw==
@@ -7802,6 +7800,13 @@ ember-inflector@^3.0.1:
   integrity sha512-fngrwMsnhkBt51KZgwNwQYxgURwV4lxtoHdjxf7RueGZ5zM7frJLevhHw7pbQNGqXZ3N+MRkhfNOLkdDK9kFdA==
   dependencies:
     ember-cli-babel "^6.6.0"
+
+ember-inflector@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/ember-inflector/-/ember-inflector-4.0.1.tgz#e0aa9e39119156a278c80bb8cdec8462ecb8e6ab"
+  integrity sha512-D14nH2wVMp13ciOONcHMXwdL/IoMBSDXsGObF2rsQX7F8vGjwp+jnSNzZuGjjIvlBFQydOJ+R2n86J2e8HRTQA==
+  dependencies:
+    ember-cli-babel "^7.23.0"
 
 ember-load-initializers@^2.1.1:
   version "2.1.1"
@@ -8885,9 +8890,6 @@ find-babel-config@^1.1.0, find-babel-config@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
   integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
-  dependencies:
-    json5 "^0.5.1"
-    path-exists "^3.0.0"
 
 find-cache-dir@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Upgrade `ember-inflector` to a version using babel 7.

**EDIT**: Do I need to bump this dep in all the `packages/unpublished-*`? Would love to remove v3 from the yarn.lock file...