### PR TITLE
[CI]: simplify test run with smaller footprint for browser tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [with-native-fetch, with-ember-fetch-no-jquery, with-ember-fetch-and-jquery, with-jquery]
         launcher: [Chrome, Firefox, IE]
         os: [macos-latest, windows-latest, ubuntu-latest]
         exclude:
@@ -164,7 +163,7 @@ jobs:
           - os: windows-latest
             launcher: Chrome
     runs-on: ${{ matrix.os }}
-    name: ${{matrix.scenario}} ${{matrix.launcher}} on ${{matrix.os}}
+    name: ${{matrix.launcher}} on ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
@@ -181,7 +180,7 @@ jobs:
           TESTEM_CI_LAUNCHER: ${{ matrix.launcher }}
           CI: true
         run:
-          yarn test:try-one ${{ matrix.scenario }} --- ember test -e production
+          yarn test:production
 
   floating-dependencies:
     timeout-minutes: 6


### PR DESCRIPTION
A proposal.  Often, I'm seeing these type of tests flakey.

This PR removes all the different scenarios for `browser tests` and just does on production test run.

![Screen Shot 2021-01-05 at 8 46 24 AM](https://user-images.githubusercontent.com/7374640/103660314-1178fc00-4f33-11eb-91fa-6f2dcd1ab5e5.png)
