### PR TITLE
Remove type check that prevents polymorphic types in API responses

### DIFF
--- a/packages/-ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -240,6 +240,48 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function(hooks) 
     assert.equal(posts.get('firstObject.title'), 'Ember.js rocks', 'Sets correct title to record');
   });
 
+  test('find many polymorphic records', async function(assert) {
+    assert.expect(4);
+
+    ajaxResponse([
+      {
+        data: [
+          {
+            type: 'github-handles',
+            id: '1',
+            attributes: {
+              username: 'ykatz',
+            },
+          },
+          {
+            type: 'twitter-handles',
+            id: '2',
+            attributes: {
+              nickname: 'ykatz',
+            },
+          },
+        ],
+        included: [],
+      },
+    ]);
+
+    let handles = await store.findAll('handle');
+
+    let twitter_handles = store.peekAll('twitter-handles');
+    let github_handles = store.peekAll('github-handles');
+
+    //This should work b/c we loaded these types from the API, but it doesn't
+    assert.equal(twitter_handles.get('length'), 1);
+    assert.equal(github_handles.get('length'), 1);
+
+    assert.equal(passedUrl[0], '/handles', 'Builds correct URL');
+
+    //These won't work because we didn't load anything of the base type 'handles'
+    assert.equal(handles.get('length'), 2, 'Returns the correct number of records');
+    assert.equal(handles.get('firstObject.username'), 'ykatz', 'Sets correct username to record');
+    assert.equal(handles.get('secondObject.nickname'), 'ykatz', 'Sets correct username to record');
+  });
+
   test('queryRecord - primary data being a single record', async function(assert) {
     ajaxResponse([
       {

--- a/packages/store/addon/-private/identifiers/cache.ts
+++ b/packages/store/addon/-private/identifiers/cache.ts
@@ -496,7 +496,6 @@ function performRecordIdentifierUpdate(
   updateFn: UpdateMethod
 ) {
   let { id, lid } = data;
-  let type = data.type && normalizeModelName(data.type);
 
   if (DEBUG) {
     // get the mutable instance behind our proxy wrapper
@@ -524,13 +523,6 @@ function performRecordIdentifierUpdate(
           { id: 'ember-data:multiple-ids-for-identifier' }
         );
       }
-    }
-
-    // TODO consider just ignoring here to allow flexible polymorphic support
-    if (type && type !== identifier.type) {
-      throw new Error(
-        `The 'type' for a RecordIdentifier cannot be updated once it has been set. Attempted to set type for '${wrapper}' to '${type}'.`
-      );
     }
 
     updateFn(wrapper, data, 'record');


### PR DESCRIPTION
This is a PR for the request (https://github.com/emberjs/data/issues/7357) to remove the assertion that prevents different types from being returned in API responses. Tests pass but I think there might need to be some tests added that assert Ember Data does 'the right thing' with varying types returned. (I have no idea how to do that :) )


Details:

tldr; This block: https://github.com/emberjs/data/blob/ff4f9111fcfa7dd9e39804ed17f5af27a4a01378/packages/store/addon/-private/identifiers/cache.ts#L518 which verifies that the returned type matches the requested type is a problem for APIs that have polymorphic types. When we fetch data from the parent type's API endpoint, ember-data throws an exception because the api endpoint returns multiple types. But we do want all the subtypes of the parent type. 

### Example:
Given the JSON api:

```
/api/animals
/api/dogs
/api/cats
```

In our backend, 'dogs' and 'cats' are a subclass of 'animal', and queries to the /api/animals endpoint returns instances of cats and dogs. (This is via flask-restless & SQLAlchemy using the JSONAPI spec). Our Adapter is DS.JSONAPIAdapter

/api/animals returns:
```
{
  "data": [
    {
      "attributes": {
        "animal_type": "cat", <-- type column that SQLAlchemy uses to track the type of object to instantiate from the db row
        "created_at": "2020-10-19T13:29:07",
        "description": "my cat",
        "last_modified": "2020-10-21T15:04:08",
        "name": "foo"
      },
      "id": "1"
      },
      "type": "cat"
    },
    {
      "attributes": {
        "animal_type": "dog",
        "created_at": "2020-10-19T13:29:07",
        "description": "my dog",
        "last_modified": "2020-10-21T15:04:08",
        "name": "bar"
      },
      "id": "2"
      },
      "type": "dog"
    },
],
  "jsonapi": {
    "version": "1.0"
  },
  "links": {
    "first": "http://localhost:5000/api/animals?page[size]=10&page[number]=1",
    "last": "http://localhost:5000/api/animals?page[size]=10&page[number]=1",
    "next": null,
    "prev": null,
    "self": "/api/animals"
  },
  "meta": {
    "total": 2
  }
}
```

We have setup our ember models to have a parent type of 'Animal', 'Dog' and 'Cat' extend it. When we query the store for all animals like so: `this.store.fetchAll('animals')`, the reference error above is thrown because ember data expects only the type 'animal', but received 'dog' and 'cat'. 

What we'd like ember to do is handle this and return an array (or individual object) of the types received. There are many use cases where we want to query and display all animals in the database, but we have to query each subtype separately. We've done some hacks to our API and ember app to support this (forcing all types for /api/animals to be 'animal' and jumping through some hoops after loaded to recreate the actual type on the frontend)

There are also situations when we know the id of the animal, but not type and would like to use `this.store.findRecord('animal', id)` and get back an instance of whatever subtype it is.

I hope this is clear. From the comment in ember-data's code where the exception is thrown, it appears there is awareness that it would help to remove the check. Thank you!

