### PR TITLE
Pass lid from relationship data to get record data

### DIFF
--- a/packages/-ember-data/tests/integration/identifiers/lid-reflection-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/lid-reflection-test.ts
@@ -154,7 +154,7 @@ module('Integration | Identifiers - lid reflection', function(hooks) {
 
     class Cake extends Model {
       @attr name;
-      @hasMany('ingredient', { async: false }) ingredients;
+      @hasMany('ingredient', { inverse: null, async: false }) ingredients;
     }
 
     this.owner.register('model:ingredient', Ingredient);
@@ -165,8 +165,10 @@ module('Integration | Identifiers - lid reflection', function(hooks) {
         return payload;
       }
     }
+
     class TestAdapter extends Adapter {
       createRecord(store, ModelClass, snapshot) {
+        const lid = recordIdentifierFor(snapshot.record.ingredients.firstObject).lid;
         return resolve({
           data: {
             type: 'cake',
@@ -180,7 +182,7 @@ module('Integration | Identifiers - lid reflection', function(hooks) {
                   {
                     type: 'ingredient',
                     id: '2',
-                    lid: cheeseIdentifier.lid,
+                    lid,
                   },
                 ],
               },
@@ -190,7 +192,7 @@ module('Integration | Identifiers - lid reflection', function(hooks) {
             {
               type: 'ingredient',
               id: '2',
-              lid: cheeseIdentifier.lid,
+              lid,
               attributes: {
                 name: 'Cheese',
               },
@@ -213,11 +215,81 @@ module('Integration | Identifiers - lid reflection', function(hooks) {
     const cheese = store.createRecord('ingredient', { name: 'Cheese' });
     const cake = store.createRecord('cake', { name: 'Cheesecake', ingredients: [cheese] });
 
-    const cheeseIdentifier = recordIdentifierFor(cheese);
-
     await cake.save();
 
     assert.deepEqual(cake.hasMany('ingredients').ids(), ['2']);
     assert.equal(cake.ingredients.objectAt(0).name, 'Cheese');
+  });
+
+  test('belongsTo() has correct state after .save() on a newly created record with sideposted child record when lid is provided in the response payload', async function(assert) {
+    class Topping extends Model {
+      @attr name;
+    }
+
+    class Cake extends Model {
+      @attr name;
+      @belongsTo('topping', { inverse: null, async: false }) topping;
+    }
+
+    this.owner.register('model:topping', Topping);
+    this.owner.register('model:cake', Cake);
+
+    class TestSerializer extends Serializer {
+      normalizeResponse(_, __, payload) {
+        return payload;
+      }
+    }
+
+    class TestAdapter extends Adapter {
+      createRecord(store, ModelClass, snapshot) {
+        const lid = recordIdentifierFor(snapshot.record.topping).lid;
+        return resolve({
+          data: {
+            type: 'cake',
+            id: '1',
+            attributes: {
+              name: 'Cheesecake',
+            },
+            relationships: {
+              topping: {
+                data: {
+                  type: 'topping',
+                  id: '2',
+                  lid,
+                },
+              },
+            },
+          },
+          included: [
+            {
+              type: 'topping',
+              id: '2',
+              lid,
+              attributes: {
+                name: 'Cheese',
+              },
+              relationships: {
+                cake: {
+                  data: {
+                    type: 'cake',
+                    id: '1',
+                  },
+                },
+              },
+            },
+          ],
+        });
+      }
+    }
+    this.owner.register('serializer:application', TestSerializer);
+    this.owner.register('adapter:application', TestAdapter);
+
+    const cheese = store.createRecord('topping', { name: 'Cheese' });
+    const cake = store.createRecord('cake', { name: 'Cheesecake', topping: cheese });
+
+    await cake.save();
+
+    assert.deepEqual(cake.belongsTo('topping').id(), '2');
+    assert.equal(cake.topping.name, 'Cheese');
   });
 });

--- a/packages/record-data/addon/-private/relationships/state/belongs-to.ts
+++ b/packages/record-data/addon/-private/relationships/state/belongs-to.ts
@@ -193,7 +193,7 @@ export default class BelongsToRelationship extends Relationship {
     );
 
     if (recordData !== null) {
-      recordData = this.recordData.storeWrapper.recordDataFor(data.type, data.id);
+      recordData = this.recordData.storeWrapper.recordDataFor(data.type, data.id, data.lid);
     }
     this.setCanonicalRecordData(recordData);
   }


### PR DESCRIPTION
This PR aims to fix #7424.
The issue appeared in the sideposting scenario:

- model A has belongs to relationship to model B.
- instance of model A and instance of model B are created on the client,
- model A is saved along with model B sent in `include` section of payload; the linking is done through `lid`
- server persisted both models and sent the response with server-generated `id` along with `lid` sent by the client.
- when belongsTo.updateData() was called while the response payload was pushed to the store it couldn't match the record which was already in the store with the record data contained in the relationship data  because `lid` was omitted.

Add a test which ensures that the belongsTo() relationship has correct status in the sideposting with lid scenario.

