### PR TITLE
Pass lid from belongsTo relationship data to get record data

### DIFF
--- a/packages/record-data/addon/-private/relationships/state/belongs-to.ts
+++ b/packages/record-data/addon/-private/relationships/state/belongs-to.ts
@@ -193,7 +193,7 @@ export default class BelongsToRelationship extends Relationship {
     );
 
     if (recordData !== null) {
-      recordData = this.recordData.storeWrapper.recordDataFor(data.type, data.id);
+      recordData = this.recordData.storeWrapper.recordDataFor(data.type, data.id, data.lid);
     }
     this.setCanonicalRecordData(recordData);
   }


### PR DESCRIPTION
This patch is on tag 3.24, can it be delivered along with the next release?

This PR aims to fix #7424.
The issue appeared in the sideposting scenario:

- model A has belongs to relationship to model B.
- instance of model A and instance of model B are created on the client,
- model A is saved along with model B sent in `include` section of payload; the linking is done through `lid`
- server persisted both models and sent the response with server-generated `id` along with `lid` sent by the client.
- when belongsTo.updateData() was called while the response payload was pushed to the store it couldn't match the record which was already in the store with the record data contained in the relationship data  because `lid` was omitted.

Add a test which ensures that the belongsTo() relationship has correct status in the sideposting with lid scenario.