### PR TITLE
[CHORE] auto publish alpha versions

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -1,0 +1,45 @@
+name: 'Alpha Release'
+
+on:
+  schedule:
+    - cron: '0 20 * * 1' # weekly (Monday)
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Test latest code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: 12.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies for master
+        run: yarn install --frozen-lockfile --non-interactive
+      - name: Basic Tests
+        env:
+          CI: true
+          ASSERT_ALL_DEPRECATIONS: true
+        run: yarn test
+
+  release:
+    name: Run publish script
+    runs-on: ubuntu-latest
+    needs: [ test ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies for master
+        run: yarn install --frozen-lockfile --non-interactive
+      - name: publish with script
+        run: node bin/publish.js canary
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: push branch + tag
+        run: git push origin HEAD --follow-tags

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -2,10 +2,7 @@ name: 'Alpha Release'
 
 on:
   schedule:
-    - cron: '0 20 * * 1' # weekly (Monday)
-  push:
-    branches:
-      - master
+    - cron: '0 20 * * 1' # weekly (Monday) 12 PM PST
 
 jobs:
   test:

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Check should run if HEAD it untagged
-      run: |
-        if [[ "$(git name-rev --tags --name-only $(git rev-parse HEAD))" != "undefined" ]]; then
-          exit 1
-        fi
+        name: Check should run if HEAD is untagged
+        run: |
+          if [[ "$(git name-rev --tags --name-only $(git rev-parse HEAD))" != "undefined" ]]; then
+            exit 1
+          fi
       - uses: actions/setup-node@v2-beta
         with:
           node-version: 12.x

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        name: Check should run if HEAD is untagged
+      - name: Check should run if HEAD is untagged
         run: |
           if [[ "$(git name-rev --tags --name-only $(git rev-parse HEAD))" != "undefined" ]]; then
             exit 1

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Check should run if HEAD it untagged
+      run: |
+        if [[ "$(git name-rev --tags --name-only $(git rev-parse HEAD))" != "undefined" ]]; then
+          exit 1
+        fi
       - uses: actions/setup-node@v2-beta
         with:
           node-version: 12.x
@@ -34,9 +39,15 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies for master
         run: yarn install --frozen-lockfile --non-interactive
-      - name: publish with script
-        run: node bin/publish.js canary
+      - name: Get next alpha version
+        run: echo "NEXT_VERSION=$(node bin/determine-next-alpha-version.js)" >> $GITHUB_ENV
+      - name: Make sure git user is setup
+        run: |
+          git config --local user.email 'cron@example.com'
+          git config --local user.name 'Ember Data Cron CI'
+      - name: Publish with script
+        run: node bin/publish.js canary --useVersion=${{ env.NEXT_VERSION }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: push branch + tag
+      - name: Push branch + tag
         run: git push origin HEAD --follow-tags

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -1,4 +1,4 @@
-name: 'Alpha Release'
+name: Alpha Releases
 
 on:
   schedule:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -294,3 +294,10 @@ Twitter the Crosslinking the announcement to the following Discord channels.
       ```
 
 Congrats, you are finished!
+
+#### Canary Auto Publish
+New canary versions are published to npm every Monday at 12pm PST by the `alpha-release` GitHub action. Depending on the
+current version from `lerna.json`, the next version chosen will be:
+1. If current version is a minor version release such as `3.15.0`, the version picked for the next alpha is `3.15.1-alpha.0`
+2. If current version is an alpha release such as `3.15.1-alpha.0`, the version picked for the next alpha is `3.15.1-alpha.1`
+3. Beta releases would not affect the versioning of the next alpha version as the alpha will continue from the last alpha release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -297,7 +297,7 @@ Congrats, you are finished!
 
 #### Canary Auto Publish
 New canary versions are published to npm every Monday at 12pm PST by the `alpha-release` GitHub action. Depending on the
-current version from `lerna.json`, the next version chosen will be:
+current latest versions returned by `npm view ember-data versions --json`, the next version chosen will be:
 1. If current version is a minor version release such as `3.15.0`, the version picked for the next alpha is `3.15.1-alpha.0`
 2. If current version is an alpha release such as `3.15.1-alpha.0`, the version picked for the next alpha is `3.15.1-alpha.1`
 3. Beta releases would not affect the versioning of the next alpha version as the alpha will continue from the last alpha release.

--- a/bin/determine-next-alpha-version.js
+++ b/bin/determine-next-alpha-version.js
@@ -1,0 +1,59 @@
+'use strict';
+/* eslint-disable node/no-unsupported-features/es-syntax */
+
+const readline = require('readline');
+const process = require('process');
+
+const chalk = require('chalk');
+const execa = require('execa');
+const semver = require('semver');
+const debug = require('debug')('publish-packages');
+
+function execWithLog(command) {
+  debug(chalk.cyan('Executing: ') + chalk.yellow(command));
+  return execa.sync(command, { shell: true, preferLocal: true }).stdout;
+}
+
+async function main() {
+  const versionsJSON = execWithLog('npm view ember-data versions --json');
+  // [
+  //   "3.25.0"
+  //   "3.26.0-alpha.0",
+  //   "3.26.0-beta.0"
+  // ]
+  const versions = JSON.parse(versionsJSON);
+  let idx = versions.length - 1;
+  let lastAlpha;
+  let lastRelease;
+
+  while (idx > -1) {
+    const version = versions[idx];
+    if (version.indexOf('-alpha.') > -1) {
+      lastAlpha = version;
+    } else if (version.split('.').length === 3) {
+      lastRelease = version;
+      break;
+    }
+    idx--;
+  }
+
+  if (lastRelease && !lastAlpha) {
+    return console.log(semver.inc(lastRelease, 'preminor', 'alpha'));
+  } else if (lastAlpha) {
+    return console.log(semver.inc(lastAlpha, 'prerelease', 'alpha'));
+  } else {
+    throw Error('Could not determine next version because no recent release or alpha version');
+  }
+}
+
+let cli = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+main()
+  .finally(() => cli.close())
+  .catch(reason => {
+    console.error(reason);
+    process.exit(1);
+  });

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -383,6 +383,7 @@ async function main() {
   if (!options.skipPublish) {
     const tarballs = collectTarballPaths();
     const npmAuthTokenInEnv = !!process.env.NODE_AUTH_TOKEN;
+    // Assume human ran script if token is missing
     await confirmPublish(tarballs, !npmAuthTokenInEnv);
     console.log(`✅ ` + chalk.cyan(`Successfully Published ${nextVersion}`));
   } else {

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -94,6 +94,7 @@ function getConfig() {
     { name: 'bumpMajor', type: Boolean, defaultValue: false },
     { name: 'bumpMinor', type: Boolean, defaultValue: false },
     { name: 'force', type: Boolean, defaultValue: false },
+    { name: 'useVersion', type: String, defaultValue: false },
   ];
   const options = cliArgs(optionsDefinitions, { argv });
   const currentProjectVersion = require(path.join(__dirname, '../lerna.json')).version;
@@ -367,7 +368,15 @@ async function main() {
     // --force-publish ensures that all packages release a new version regardless
     // of whether changes have occurred in them
     // --yes skips the prompt for confirming the version
-    nextVersion = retrieveNextVersion();
+    if (options.useVersion) {
+      if (semver.valid(options.useVersion)) {
+        nextVersion = options.useVersion;
+      } else {
+        throw Error(`Version "${options.useVersion}" is not a valid semantic version.`);
+      }
+    } else {
+      nextVersion = retrieveNextVersion();
+    }
     execWithLog(`lerna version ${nextVersion} --force-publish --exact --yes`, true);
     console.log(`✅ ` + chalk.cyan(`Successfully Versioned ${nextVersion}`));
   } else {

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -325,7 +325,7 @@ function publishPackage(distTag, tarball, otp) {
   }
 
   console.log(cmd);
-  // execWithLog(`npm publish ${tarball} --tag=${distTag} --access=public --otp=${otp}`);
+  execWithLog(`npm publish ${tarball} --tag=${distTag} --access=public --otp=${otp}`);
 }
 
 async function confirmPublish(tarballs, promptOtp = true) {

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -24,11 +24,11 @@ Inspiration from https://github.com/glimmerjs/glimmer-vm/commit/01e68d7dddf28ac3
 const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
+const process = require('process');
 
 const chalk = require('chalk');
 const execa = require('execa');
 const cliArgs = require('command-line-args');
-const process = require('process');
 const semver = require('semver');
 const debug = require('debug')('publish-packages');
 
@@ -121,18 +121,18 @@ function assertGitIsClean() {
     if (options.force) {
       console.log(
         chalk.white('⚠️ ⚠️ ⚠️  Local Git branch has uncommitted changes!\n\t') +
-        chalk.yellow('Passed option: ') +
-        chalk.white('--force') +
-        chalk.grey(' :: ignoring unclean git working tree')
+          chalk.yellow('Passed option: ') +
+          chalk.white('--force') +
+          chalk.grey(' :: ignoring unclean git working tree')
       );
     } else {
       console.log(
         chalk.red('💥 Git working tree is not clean. 💥 \n\t') +
-        chalk.grey('Use ') +
-        chalk.white('--force') +
-        chalk.grey(' to ignore this warning and publish anyway\n') +
-        chalk.yellow('⚠️  Publishing from an unclean working state may result in a broken release ⚠️\n\n') +
-        chalk.grey(`Status:\n${status}`)
+          chalk.grey('Use ') +
+          chalk.white('--force') +
+          chalk.grey(' to ignore this warning and publish anyway\n') +
+          chalk.yellow('⚠️  Publishing from an unclean working state may result in a broken release ⚠️\n\n') +
+          chalk.grey(`Status:\n${status}`)
       );
       process.exit(1);
     }
@@ -142,18 +142,18 @@ function assertGitIsClean() {
     if (options.force) {
       console.log(
         chalk.white('⚠️ ⚠️ ⚠️  Local Git branch is not in sync with origin branch') +
-        chalk.yellow('\n\tPassed option: ') +
-        chalk.white('--force') +
-        chalk.grey(' :: ignoring unsynced git branch')
+          chalk.yellow('\n\tPassed option: ') +
+          chalk.white('--force') +
+          chalk.grey(' :: ignoring unsynced git branch')
       );
     } else {
       console.log(
         chalk.red('💥 Local Git branch is not in sync with origin branch. 💥 \n\t') +
-        chalk.grey('Use ') +
-        chalk.white('--force') +
-        chalk.grey(' to ignore this warning and publish anyway\n') +
-        chalk.yellow('⚠️  Publishing from an unsynced working state may result in a broken release ⚠️') +
-        chalk.grey(`Status:\n${status}`)
+          chalk.grey('Use ') +
+          chalk.white('--force') +
+          chalk.grey(' to ignore this warning and publish anyway\n') +
+          chalk.yellow('⚠️  Publishing from an unsynced working state may result in a broken release ⚠️') +
+          chalk.grey(`Status:\n${status}`)
       );
       process.exit(1);
     }
@@ -175,19 +175,19 @@ function assertGitIsClean() {
         chalk.white(
           `⚠️ ⚠️ ⚠️  Expected to publish npm tag ${options.distTag} from the git branch ${expectedChannelBranch}, but found ${foundBranch}`
         ) +
-        chalk.yellow('\n\tPassed option: ') +
-        chalk.white('--force') +
-        chalk.grey(' :: ignoring unexpected branch')
+          chalk.yellow('\n\tPassed option: ') +
+          chalk.white('--force') +
+          chalk.grey(' :: ignoring unexpected branch')
       );
     } else {
       console.log(
         chalk.red(
           `💥 Expected to publish npm tag ${options.distTag} from the git branch ${expectedChannelBranch}, but found ${foundBranch} 💥 \n\t`
         ) +
-        chalk.grey('Use ') +
-        chalk.white('--force') +
-        chalk.grey(' to ignore this warning and publish anyway\n') +
-        chalk.yellow('⚠️  Publishing from an incorrect branch may result in a broken release ⚠️')
+          chalk.grey('Use ') +
+          chalk.white('--force') +
+          chalk.grey(' to ignore this warning and publish anyway\n') +
+          chalk.yellow('⚠️  Publishing from an incorrect branch may result in a broken release ⚠️')
       );
       process.exit(1);
     }
@@ -281,9 +281,9 @@ function packAllPackages() {
           if (pkgInfo.scripts.prepublish || pkgInfo.scripts.prepare) {
             console.log(
               `⚠️ ` +
-              chalk.grey(
-                `${pkgInfo.name} has both a 'prepublishOnly' and either 'prepare' or 'publish' scripts. Running prepublishOnly manually before instead of after publish and prepare. See https://github.com/npm/npm/issues/15363`
-              )
+                chalk.grey(
+                  `${pkgInfo.name} has both a 'prepublishOnly' and either 'prepare' or 'publish' scripts. Running prepublishOnly manually before instead of after publish and prepare. See https://github.com/npm/npm/issues/15363`
+                )
             );
           }
           execWithLog(`cd ${pkgDir} && npm run prepublishOnly`);

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -325,8 +325,7 @@ function publishPackage(distTag, tarball, otp) {
     cmd += ` --otp=${otp}`;
   }
 
-  console.log(cmd);
-  execWithLog(`npm publish ${tarball} --tag=${distTag} --access=public --otp=${otp}`);
+  execWithLog(cmd);
 }
 
 async function confirmPublish(tarballs, promptOtp = true) {
@@ -392,6 +391,9 @@ async function main() {
   if (!options.skipPublish) {
     const tarballs = collectTarballPaths();
     const npmAuthTokenInEnv = !!process.env.NODE_AUTH_TOKEN;
+    if (!npmAuthTokenInEnv) {
+      console.log('No NODE_AUTH_TOKEN environment variable. Prompting for OTP.');
+    }
     // Assume human ran script if token is missing
     await confirmPublish(tarballs, !npmAuthTokenInEnv);
     console.log(`✅ ` + chalk.cyan(`Successfully Published ${nextVersion}`));


### PR DESCRIPTION
Hi folks,

Similar to https://github.com/emberjs/ember.js/commit/0079b11d0aaec9980aa5e24d165653faf942a791, I'm adding a cron job that runs at 12pm every Monday that checks out the current master and run the publish script for alpha versions.

Repo owners need to add `NODE_AUTH_TOKEN` to the secrets for this to fully work.