### PR TITLE
Document adapterOptions on REST adapter

### DIFF
--- a/packages/adapter/addon/rest.ts
+++ b/packages/adapter/addon/rest.ts
@@ -631,7 +631,12 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @param {Object} adapterOptions
     @return {Promise} promise
   */
-  queryRecord(store: Store, type: ShimModelClass, query: Dict<unknown>, adapterOptions: Dict<unknown>): Promise<unknown> {
+  queryRecord(
+    store: Store,
+    type: ShimModelClass,
+    query: Dict<unknown>,
+    adapterOptions: Dict<unknown>
+  ): Promise<unknown> {
     let url = this.buildURL(type.modelName, null, null, 'queryRecord', query);
 
     if (this.sortQueryParams) {

--- a/packages/adapter/addon/rest.ts
+++ b/packages/adapter/addon/rest.ts
@@ -598,6 +598,8 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @param {Store} store
     @param {Model} type
     @param {Object} query
+    @param {AdapterPopulatedRecordArray} recordArray
+    @param {Object} adapterOptions
     @return {Promise} promise
   */
   query(store: Store, type: ShimModelClass, query): Promise<unknown> {
@@ -626,9 +628,10 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @param {Store} store
     @param {Model} type
     @param {Object} query
+    @param {Object} adapterOptions
     @return {Promise} promise
   */
-  queryRecord(store: Store, type: ShimModelClass, query: Dict<unknown>): Promise<unknown> {
+  queryRecord(store: Store, type: ShimModelClass, query: Dict<unknown>, adapterOptions: Dict<unknown>): Promise<unknown> {
     let url = this.buildURL(type.modelName, null, null, 'queryRecord', query);
 
     if (this.sortQueryParams) {


### PR DESCRIPTION
Seems like we aren't documenting adapterOptions for `query` and `queryRecord` in the JSONAPIAdapter.

I've just mirrored the code in the regular adapter:
https://github.com/emberjs/data/blob/master/packages/adapter/addon/index.ts#L248

There are already tests for this, see:
https://github.com/emberjs/data/blob/ff4f9111fcfa7dd9e39804ed17f5af27a4a01378/packages/-ember-data/tests/integration/adapter/store-adapter-test.js#L1526

Support for `adapterOptions` has existed for quite a while, it was initially added in this PR: https://github.com/emberjs/data/pull/4856/

