### PR TITLE
[DOC] Add missing `Ember` namespace to annotations

### DIFF
--- a/packages/model/addon/-private/errors.js
+++ b/packages/model/addon/-private/errors.js
@@ -80,8 +80,8 @@ import { DeprecatedEvented } from '@ember-data/store/-private';
   ```
 
   @class Errors
-  @extends ArrayProxy
-  @uses Evented
+  @extends Ember.ArrayProxy
+  @uses Ember.Evented
  */
 export default ArrayProxy.extend(DeprecatedEvented, {
   /**

--- a/packages/store/addon/-private/system/record-arrays/record-array.js
+++ b/packages/store/addon/-private/system/record-arrays/record-array.js
@@ -26,7 +26,7 @@ function recordForIdentifier(store, identifier) {
   in response to queries.
 
   @class RecordArray
-  @extends ArrayProxy
+  @extends Ember.ArrayProxy
   @uses Ember.Evented
 */
 


### PR DESCRIPTION
These classes are defined in ember package, not in ember-data.