### PR TITLE
[DOC] Fix `JSONAPISerializer` import in docs

### DIFF
--- a/packages/serializer/addon/json-api.js
+++ b/packages/serializer/addon/json-api.js
@@ -103,7 +103,7 @@ import { normalizeModelName } from '@ember-data/store';
   `extractRelationship`.
 
   ```app/serializers/application.js
-  import JSONAPISerializer from '@ember-data/serializer/json';
+  import JSONAPISerializer from '@ember-data/serializer/json-api';
 
   export default class ApplicationSerializer extends JSONAPISerializer {
     normalizeArrayResponse(store, primaryModelClass, payload, id, requestType) {


### PR DESCRIPTION
An example in docs used to incorrectly import the serializer from `@ember-data/serializer/json` instead of `'@ember-data/serializer/json-api'`. This PR fixes that.