### PR TITLE
[CHORE] burndown of InternalModel methods that can be eliminated safely

### DIFF
--- a/packages/-ember-data/tests/integration/records/load-test.js
+++ b/packages/-ember-data/tests/integration/records/load-test.js
@@ -123,21 +123,21 @@ module('integration/load - Loading Records', function(hooks) {
     let internalModel = store._internalModelForId('person', '1');
 
     // test that our initial state is correct
-    assert.equal(internalModel.isEmpty(), true, 'We begin in the empty state');
+    assert.equal(internalModel.currentState.isEmpty, true, 'We begin in the empty state');
     assert.equal(internalModel.isLoading(), false, 'We have not triggered a load');
     assert.equal(internalModel.isReloading, false, 'We are not reloading');
 
     let recordPromise = store.findRecord('person', '1');
 
     // test that during the initial load our state is correct
-    assert.todo.equal(internalModel.isEmpty(), true, 'awaiting first fetch: We remain in the empty state');
+    assert.todo.equal(internalModel.currentState.isEmpty, true, 'awaiting first fetch: We remain in the empty state');
     assert.equal(internalModel.isLoading(), true, 'awaiting first fetch: We have now triggered a load');
     assert.equal(internalModel.isReloading, false, 'awaiting first fetch: We are not reloading');
 
     let record = await recordPromise;
 
     // test that after the initial load our state is correct
-    assert.equal(internalModel.isEmpty(), false, 'after first fetch: We are no longer empty');
+    assert.equal(internalModel.currentState.isEmpty, false, 'after first fetch: We are no longer empty');
     assert.equal(internalModel.isLoading(), false, 'after first fetch: We have loaded');
     assert.equal(internalModel.isReloading, false, 'after first fetch: We are not reloading');
 
@@ -155,21 +155,21 @@ module('integration/load - Loading Records', function(hooks) {
     recordPromise = record.reload();
 
     // test that during a reload our state is correct
-    assert.equal(internalModel.isEmpty(), false, 'awaiting reload: We remain non-empty');
+    assert.equal(internalModel.currentState.isEmpty, false, 'awaiting reload: We remain non-empty');
     assert.equal(internalModel.isLoading(), false, 'awaiting reload: We are not loading again');
     assert.equal(internalModel.isReloading, true, 'awaiting reload: We are reloading');
 
     await recordPromise;
 
     // test that after a reload our state is correct
-    assert.equal(internalModel.isEmpty(), false, 'after reload: We remain non-empty');
+    assert.equal(internalModel.currentState.isEmpty, false, 'after reload: We remain non-empty');
     assert.equal(internalModel.isLoading(), false, 'after reload: We have loaded');
     assert.equal(internalModel.isReloading, false, 'after reload:: We are not reloading');
 
     run(() => record.unloadRecord());
 
     // test that after an unload our state is correct
-    assert.equal(internalModel.isEmpty(), true, 'after unload: We are empty again');
+    assert.equal(internalModel.currentState.isEmpty, true, 'after unload: We are empty again');
     assert.equal(internalModel.isLoading(), false, 'after unload: We are not loading');
     assert.equal(internalModel.isReloading, false, 'after unload:: We are not reloading');
 
@@ -177,14 +177,14 @@ module('integration/load - Loading Records', function(hooks) {
 
     // test that during a reload-due-to-unload our state is correct
     //   This requires a retainer (the async bestFriend relationship)
-    assert.todo.equal(internalModel.isEmpty(), true, 'awaiting second find: We remain empty');
+    assert.todo.equal(internalModel.currentState.isEmpty, true, 'awaiting second find: We remain empty');
     assert.equal(internalModel.isLoading(), true, 'awaiting second find: We are loading again');
     assert.equal(internalModel.isReloading, false, 'awaiting second find: We are not reloading');
 
     await recordPromise;
 
     // test that after the reload-due-to-unload our state is correct
-    assert.equal(internalModel.isEmpty(), false, 'after second find: We are no longer empty');
+    assert.equal(internalModel.currentState.isEmpty, false, 'after second find: We are no longer empty');
     assert.equal(internalModel.isLoading(), false, 'after second find: We have loaded');
     assert.equal(internalModel.isReloading, false, 'after second find: We are not reloading');
   });

--- a/packages/-ember-data/tests/integration/records/load-test.js
+++ b/packages/-ember-data/tests/integration/records/load-test.js
@@ -124,21 +124,21 @@ module('integration/load - Loading Records', function(hooks) {
 
     // test that our initial state is correct
     assert.equal(internalModel.currentState.isEmpty, true, 'We begin in the empty state');
-    assert.equal(internalModel.isLoading(), false, 'We have not triggered a load');
+    assert.equal(internalModel.currentState.isLoading, false, 'We have not triggered a load');
     assert.equal(internalModel.isReloading, false, 'We are not reloading');
 
     let recordPromise = store.findRecord('person', '1');
 
     // test that during the initial load our state is correct
     assert.todo.equal(internalModel.currentState.isEmpty, true, 'awaiting first fetch: We remain in the empty state');
-    assert.equal(internalModel.isLoading(), true, 'awaiting first fetch: We have now triggered a load');
+    assert.equal(internalModel.currentState.isLoading, true, 'awaiting first fetch: We have now triggered a load');
     assert.equal(internalModel.isReloading, false, 'awaiting first fetch: We are not reloading');
 
     let record = await recordPromise;
 
     // test that after the initial load our state is correct
     assert.equal(internalModel.currentState.isEmpty, false, 'after first fetch: We are no longer empty');
-    assert.equal(internalModel.isLoading(), false, 'after first fetch: We have loaded');
+    assert.equal(internalModel.currentState.isLoading, false, 'after first fetch: We have loaded');
     assert.equal(internalModel.isReloading, false, 'after first fetch: We are not reloading');
 
     let bestFriend = await record.get('bestFriend');
@@ -156,21 +156,21 @@ module('integration/load - Loading Records', function(hooks) {
 
     // test that during a reload our state is correct
     assert.equal(internalModel.currentState.isEmpty, false, 'awaiting reload: We remain non-empty');
-    assert.equal(internalModel.isLoading(), false, 'awaiting reload: We are not loading again');
+    assert.equal(internalModel.currentState.isLoading, false, 'awaiting reload: We are not loading again');
     assert.equal(internalModel.isReloading, true, 'awaiting reload: We are reloading');
 
     await recordPromise;
 
     // test that after a reload our state is correct
     assert.equal(internalModel.currentState.isEmpty, false, 'after reload: We remain non-empty');
-    assert.equal(internalModel.isLoading(), false, 'after reload: We have loaded');
+    assert.equal(internalModel.currentState.isLoading, false, 'after reload: We have loaded');
     assert.equal(internalModel.isReloading, false, 'after reload:: We are not reloading');
 
     run(() => record.unloadRecord());
 
     // test that after an unload our state is correct
     assert.equal(internalModel.currentState.isEmpty, true, 'after unload: We are empty again');
-    assert.equal(internalModel.isLoading(), false, 'after unload: We are not loading');
+    assert.equal(internalModel.currentState.isLoading, false, 'after unload: We are not loading');
     assert.equal(internalModel.isReloading, false, 'after unload:: We are not reloading');
 
     recordPromise = store.findRecord('person', '1');
@@ -178,14 +178,14 @@ module('integration/load - Loading Records', function(hooks) {
     // test that during a reload-due-to-unload our state is correct
     //   This requires a retainer (the async bestFriend relationship)
     assert.todo.equal(internalModel.currentState.isEmpty, true, 'awaiting second find: We remain empty');
-    assert.equal(internalModel.isLoading(), true, 'awaiting second find: We are loading again');
+    assert.equal(internalModel.currentState.isLoading, true, 'awaiting second find: We are loading again');
     assert.equal(internalModel.isReloading, false, 'awaiting second find: We are not reloading');
 
     await recordPromise;
 
     // test that after the reload-due-to-unload our state is correct
     assert.equal(internalModel.currentState.isEmpty, false, 'after second find: We are no longer empty');
-    assert.equal(internalModel.isLoading(), false, 'after second find: We have loaded');
+    assert.equal(internalModel.currentState.isLoading, false, 'after second find: We have loaded');
     assert.equal(internalModel.isReloading, false, 'after second find: We are not reloading');
   });
 });

--- a/packages/-ember-data/tests/integration/records/unload-test.js
+++ b/packages/-ember-data/tests/integration/records/unload-test.js
@@ -634,7 +634,7 @@ module('integration/unload - Unloading Records', function(hooks) {
       'one boat record is known'
     );
     assert.ok(knownBoats.models[0] === initialBoatInternalModel, 'We still have our boat');
-    assert.true(initialBoatInternalModel.isEmpty(), 'Model is in the empty state');
+    assert.true(initialBoatInternalModel.currentState.isEmpty, 'Model is in the empty state');
     assert.deepEqual(
       idsFromOrderedSet(relationshipState.canonicalMembers),
       ['1'],

--- a/packages/model/addon/-private/attr.js
+++ b/packages/model/addon/-private/attr.js
@@ -24,10 +24,6 @@ function getDefaultValue(record, options, key) {
   }
 }
 
-function hasValue(internalModel, key) {
-  return recordDataFor(internalModel).hasAttr(key);
-}
-
 /**
   `attr` defines an attribute on a [Model](/ember-data/release/classes/Model).
   By default, attributes are passed through as-is, however you can specify an
@@ -52,7 +48,7 @@ function hasValue(internalModel, key) {
   export default class UserModel extends Model {
     @attr('string') username;
     @attr('string') email;
-    @attr('boolean', { defaultValue: false }) verified; 
+    @attr('boolean', { defaultValue: false }) verified;
   }
   ```
 
@@ -140,9 +136,9 @@ function attr(type, options) {
           );
         }
       }
-      let internalModel = this._internalModel;
-      if (hasValue(internalModel, key)) {
-        return internalModel.getAttributeValue(key);
+      let recordData = recordDataFor(this);
+      if (recordData.hasAttr(key)) {
+        return recordData.getAttr(key);
       } else {
         return getDefaultValue(this, options, key);
       }

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -575,18 +575,15 @@ const Model = EmberObject.extend(DeprecatedEvented, {
 
   invalidErrorsChanged(jsonApiErrors) {
     if (RECORD_DATA_ERRORS) {
-      this.get('errors')._clear();
-      let errors = errorsArrayToHash(jsonApiErrors);
-      let errorKeys = Object.keys(errors);
+      const { errors } = this;
+      errors._clear();
+      let newErrors = errorsArrayToHash(jsonApiErrors);
+      let errorKeys = Object.keys(newErrors);
 
       for (let i = 0; i < errorKeys.length; i++) {
-        this._addErrorMessageToAttribute(errorKeys[i], errors[errorKeys[i]]);
+        errors._add(errorKeys[i], newErrors[errorKeys[i]]);
       }
     }
-  },
-
-  _addErrorMessageToAttribute(attribute, message) {
-    this.get('errors')._add(attribute, message);
   },
 
   /**

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -575,7 +575,7 @@ const Model = EmberObject.extend(DeprecatedEvented, {
 
   invalidErrorsChanged(jsonApiErrors) {
     if (RECORD_DATA_ERRORS) {
-      this._clearErrorMessages();
+      this.get('errors')._clear();
       let errors = errorsArrayToHash(jsonApiErrors);
       let errorKeys = Object.keys(errors);
 
@@ -587,10 +587,6 @@ const Model = EmberObject.extend(DeprecatedEvented, {
 
   _addErrorMessageToAttribute(attribute, message) {
     this.get('errors')._add(attribute, message);
-  },
-
-  _clearErrorMessages() {
-    this.get('errors')._clear();
   },
 
   /**
@@ -748,7 +744,7 @@ const Model = EmberObject.extend(DeprecatedEvented, {
         this.model.destroyRecord().then(function() {
           this.transitionToRoute('model.index');
         });
-      } 
+      }
     }
     ```
 

--- a/packages/model/addon/-private/system/many-array.js
+++ b/packages/model/addon/-private/system/many-array.js
@@ -144,7 +144,7 @@ export default EmberObject.extend(MutableArray, DeprecatedEvented, {
   // TODO: if(DEBUG)
   anyUnloaded() {
     // Use `filter[0]` as opposed to `find` because of IE11
-    let unloaded = this.currentState.filter(im => im._isDematerializing || !im.isLoaded())[0];
+    let unloaded = this.currentState.filter(im => im._isDematerializing || !im.currentState.isLoaded)[0];
     return !!unloaded;
   },
 
@@ -155,7 +155,7 @@ export default EmberObject.extend(MutableArray, DeprecatedEvented, {
       if (CUSTOM_MODEL_CLASS) {
         shouldRemove = internalModel._isDematerializing;
       } else {
-        shouldRemove = internalModel._isDematerializing || !internalModel.isLoaded();
+        shouldRemove = internalModel._isDematerializing || !internalModel.currentState.isLoaded;
       }
       if (shouldRemove) {
         this.arrayContentWillChange(i, 1, 0);

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -1199,7 +1199,7 @@ abstract class CoreStore extends Service {
   _scheduleFetchThroughFetchManager(internalModel: InternalModel, options = {}): RSVP.Promise<InternalModel> {
     let generateStackTrace = this.generateStackTracesForTrackedRequests;
     // TODO  remove this once we don't rely on state machine
-    internalModel.loadingData();
+    internalModel.send('loadingData');
     let identifier = internalModel.identifier;
 
     assertIdentifierHasId(identifier);
@@ -1267,7 +1267,7 @@ abstract class CoreStore extends Service {
 
       let promise = resolver.promise;
 
-      internalModel.loadingData(promise);
+      internalModel.send('loadingData', promise);
       if (this._pendingFetch.size === 0) {
         emberBackburner.schedule('actions', this, this.flushAllPendingFetches);
       }

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -1183,7 +1183,7 @@ abstract class CoreStore extends Service {
       typeof adapter.findRecord === 'function'
     );
 
-    return _find(adapter, this, internalModel.type, internalModel.id, internalModel, options);
+    return _find(adapter, this, internalModel.modelClass, internalModel.id, internalModel, options);
   }
 
   _scheduleFetchMany(internalModels, options) {

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -631,7 +631,7 @@ abstract class CoreStore extends Service {
         const factory = internalModelFactoryFor(this);
         const internalModel = factory.build({ type: normalizedModelName, id: properties.id });
 
-        internalModel.loadedData();
+        internalModel.send('loadedData');
         // TODO this exists just to proxy `isNew` to RecordData which is weird
         internalModel.didCreateRecord();
 
@@ -3211,7 +3211,7 @@ abstract class CoreStore extends Service {
     let internalModel;
     if (isCreate === true) {
       internalModel = internalModelFactoryFor(this).build({ type: identifier.type, id: null });
-      internalModel.loadedData();
+      internalModel.send('loadedData');
       internalModel.didCreateRecord();
     } else {
       internalModel = internalModelFactoryFor(this).lookup(identifier as StableRecordIdentifier);

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -1222,7 +1222,7 @@ abstract class CoreStore extends Service {
       },
       error => {
         // TODO  remove this once we don't rely on state machine
-        internalModel.notFound();
+        internalModel.send('notFound');
         if (internalModel.currentState.isEmpty) {
           internalModel.unloadRecord();
         }

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -1120,11 +1120,11 @@ abstract class CoreStore extends Service {
 
     //TODO double check about reloading
     if (!REQUEST_SERVICE) {
-      if (internalModel.isLoading()) {
+      if (internalModel.currentState.isLoading) {
         return internalModel._promiseProxy;
       }
     } else {
-      if (internalModel.isLoading()) {
+      if (internalModel.currentState.isLoading) {
         return this._scheduleFetch(internalModel, options);
       }
     }
@@ -1843,7 +1843,7 @@ abstract class CoreStore extends Service {
           return pendingRequests[0][RequestPromise].then(() => internalModel.getRecord());
         }
       } else {
-        if (internalModel.isLoading()) {
+        if (internalModel.currentState.isLoading) {
           return internalModel._promiseProxy.then(() => {
             return internalModel.getRecord();
           });

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -1114,7 +1114,7 @@ abstract class CoreStore extends Service {
   }
 
   _findEmptyInternalModel(internalModel, options) {
-    if (internalModel.isEmpty()) {
+    if (internalModel.currentState.isEmpty) {
       return this._scheduleFetch(internalModel, options);
     }
 
@@ -1223,7 +1223,7 @@ abstract class CoreStore extends Service {
       error => {
         // TODO  remove this once we don't rely on state machine
         internalModel.notFound();
-        if (internalModel.isEmpty()) {
+        if (internalModel.currentState.isEmpty) {
           internalModel.unloadRecord();
         }
         throw error;
@@ -3822,7 +3822,7 @@ function areAllInverseRecordsLoaded(store: CoreStore, resource: JsonApiRelations
     // treat as collection
     // check for unloaded records
     let hasEmptyRecords = resource.data.reduce((hasEmptyModel, resourceIdentifier) => {
-      return hasEmptyModel || internalModelForRelatedResource(store, cache, resourceIdentifier).isEmpty();
+      return hasEmptyModel || internalModelForRelatedResource(store, cache, resourceIdentifier).currentState.isEmpty;
     }, false);
 
     return !hasEmptyRecords;
@@ -3832,7 +3832,7 @@ function areAllInverseRecordsLoaded(store: CoreStore, resource: JsonApiRelations
       return true;
     } else {
       const internalModel = internalModelForRelatedResource(store, cache, resource.data);
-      return !internalModel.isEmpty();
+      return !internalModel.currentState.isEmpty;
     }
   }
 }

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -1622,7 +1622,7 @@ abstract class CoreStore extends Service {
     const identifier = identifierCacheFor(this).peekRecordIdentifier(resource);
     const internalModel = identifier && internalModelFactoryFor(this).peek(identifier);
 
-    return !!internalModel && internalModel.isLoaded();
+    return !!internalModel && internalModel.currentState.isLoaded;
   }
 
   /**

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -919,14 +919,6 @@ export default class InternalModel {
     this.send('loadedData');
   }
 
-  /*
-    @method notFound
-    @private
-  */
-  notFound() {
-    this.send('notFound');
-  }
-
   hasChangedAttributes() {
     if (REQUEST_SERVICE) {
       if (!this.__recordData) {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -266,7 +266,7 @@ export default class InternalModel {
     // models to rematerialize their records.
 
     // eager checks to avoid instantiating record data if we are empty or loading
-    if (this.isEmpty()) {
+    if (this.currentState.isEmpty) {
       return true;
     }
 
@@ -303,10 +303,6 @@ export default class InternalModel {
       // assert here
       return false;
     }
-  }
-
-  isEmpty() {
-    return this.currentState.isEmpty;
   }
 
   isLoading() {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -1338,10 +1338,6 @@ export default class InternalModel {
     }
   }
 
-  removeErrorMessageFromAttribute(attribute) {
-    get(this.getRecord(), 'errors')._remove(attribute);
-  }
-
   hasErrors() {
     if (RECORD_DATA_ERRORS) {
       if (this._recordData.getErrors) {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -911,14 +911,6 @@ export default class InternalModel {
     }
   }
 
-  /*
-    @method loadedData
-    @private
-  */
-  loadedData() {
-    this.send('loadedData');
-  }
-
   hasChangedAttributes() {
     if (REQUEST_SERVICE) {
       if (!this.__recordData) {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -843,10 +843,6 @@ export default class InternalModel {
     this._isDestroyed = true;
   }
 
-  inverseFor(key) {
-    return this.modelClass.inverseFor(key);
-  }
-
   setupData(data) {
     let changedKeys = this._recordData.pushData(data, this.hasRecord);
     if (this.hasRecord) {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -898,19 +898,6 @@ export default class InternalModel {
     return new Snapshot(options || {}, this.identifier, this.store);
   }
 
-  /*
-    @method loadingData
-    @private
-    @param {Promise} promise
-  */
-  loadingData(promise?) {
-    if (REQUEST_SERVICE) {
-      this.send('loadingData');
-    } else {
-      this.send('loadingData', promise);
-    }
-  }
-
   hasChangedAttributes() {
     if (REQUEST_SERVICE) {
       if (!this.__recordData) {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -271,7 +271,7 @@ export default class InternalModel {
     }
 
     if (RECORD_DATA_STATE) {
-      if (this.isLoading()) {
+      if (this.currentState.isLoading) {
         return false;
       }
     }
@@ -303,10 +303,6 @@ export default class InternalModel {
       // assert here
       return false;
     }
-  }
-
-  isLoading() {
-    return this.currentState.isLoading;
   }
 
   hasDirtyAttributes() {
@@ -972,7 +968,7 @@ export default class InternalModel {
         return false;
       }
     } else {
-      if (this.isLoading() && !this.isReloading) {
+      if (this.currentState.isLoading && !this.isReloading) {
         // no need to calculate changed attributes when calling `findRecord`
         return false;
       }
@@ -994,7 +990,7 @@ export default class InternalModel {
         return {};
       }
     } else {
-      if (this.isLoading() && !this.isReloading) {
+      if (this.currentState.isLoading && !this.isReloading) {
         // no need to calculate changed attributes when calling `findRecord`
         return {};
       }

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -313,10 +313,6 @@ export default class InternalModel {
     return this.currentState.isLoading;
   }
 
-  isLoaded() {
-    return this.currentState.isLoaded;
-  }
-
   hasDirtyAttributes() {
     return this.currentState.hasDirtyAttributes;
   }

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -329,10 +329,6 @@ export default class InternalModel {
     }
   }
 
-  dirtyType() {
-    return this.currentState.dirtyType;
-  }
-
   getRecord(properties?) {
     if (!this._record && !this._isDematerializing) {
       let { store } = this;

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -1346,10 +1346,6 @@ export default class InternalModel {
     get(this.getRecord(), 'errors')._remove(attribute);
   }
 
-  clearErrorMessages() {
-    get(this.getRecord(), 'errors')._clear();
-  }
-
   hasErrors() {
     if (RECORD_DATA_ERRORS) {
       if (this._recordData.getErrors) {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -1338,10 +1338,6 @@ export default class InternalModel {
     }
   }
 
-  addErrorMessageToAttribute(attribute, message) {
-    get(this.getRecord(), 'errors')._add(attribute, message);
-  }
-
   removeErrorMessageFromAttribute(attribute) {
     get(this.getRecord(), 'errors')._remove(attribute);
   }
@@ -1373,7 +1369,7 @@ export default class InternalModel {
         if (!this._recordData.getErrors) {
           for (attribute in parsedErrors) {
             if (hasOwnProperty.call(parsedErrors, attribute)) {
-              this.addErrorMessageToAttribute(attribute, parsedErrors[attribute]);
+              this.getRecord().errors._add(attribute, parsedErrors[attribute]);
             }
           }
         }
@@ -1393,7 +1389,7 @@ export default class InternalModel {
 
       for (attribute in parsedErrors) {
         if (hasOwnProperty.call(parsedErrors, attribute)) {
-          this.addErrorMessageToAttribute(attribute, parsedErrors[attribute]);
+          this.getRecord().errors._add(attribute, parsedErrors[attribute]);
         }
       }
 

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -609,10 +609,6 @@ export default class InternalModel {
     }
   }
 
-  eachRelationship(callback, binding) {
-    return this.modelClass.eachRelationship(callback, binding);
-  }
-
   _findBelongsTo(key, resource, relationshipMeta, options) {
     // TODO @runspired follow up if parent isNew then we should not be attempting load here
     return this.store._findBelongsToByJsonApiResource(resource, this, relationshipMeta, options).then(

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -851,10 +851,6 @@ export default class InternalModel {
     this.send('pushedData');
   }
 
-  getAttributeValue(key) {
-    return this._recordData.getAttr(key);
-  }
-
   setDirtyHasMany(key, records) {
     assertRecordsPassedToHasMany(records);
     return this._recordData.setDirtyHasMany(key, extractRecordDatasFromRecords(records));
@@ -873,7 +869,7 @@ export default class InternalModel {
       }
     }
 
-    let currentValue = this.getAttributeValue(key);
+    let currentValue = this._recordData.getAttr(key);
     if (currentValue !== value) {
       this._recordData.setDirtyAttribute(key, value);
       let isDirty = this._recordData.isAttrDirty(key);

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -441,7 +441,7 @@ export default class InternalModel {
     }
 
     // move to an empty never-loaded state
-    this.updateRecordArrays();
+    this.store.recordArrayManager.recordDidChange(this.identifier);
     this._recordData.unloadRecord();
     this._record = null;
     this.isReloading = false;
@@ -1058,7 +1058,7 @@ export default class InternalModel {
       }
     }
     if (!key || key === 'isDeletionCommitted') {
-      this.updateRecordArrays();
+      this.store.recordArrayManager.recordDidChange(this.identifier);
     }
   }
 
@@ -1251,16 +1251,6 @@ export default class InternalModel {
     return { type: internalModel.modelName, id: internalModel.id };
   }
 
-  /*
-    Used to notify the store to update FilteredRecordArray membership.
-
-    @method updateRecordArrays
-    @private
-  */
-  updateRecordArrays() {
-    this.store.recordArrayManager.recordDidChange(this.identifier);
-  }
-
   setId(id: string) {
     let didChange = id !== this._id;
 
@@ -1326,7 +1316,7 @@ export default class InternalModel {
     let changedKeys = this._recordData.didCommit(data);
 
     this.send('didCommit');
-    this.updateRecordArrays();
+    this.store.recordArrayManager.recordDidChange(this.identifier);
 
     if (!data) {
       return;

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -894,7 +894,7 @@ export default class InternalModel {
     if (this.hasRecord) {
       this._record._notifyProperties(changedKeys);
     }
-    this.pushedData();
+    this.send('pushedData');
   }
 
   getAttributeValue(key) {
@@ -975,14 +975,6 @@ export default class InternalModel {
   */
   notFound() {
     this.send('notFound');
-  }
-
-  /*
-    @method pushedData
-    @private
-  */
-  pushedData() {
-    this.send('pushedData');
   }
 
   hasChangedAttributes() {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -305,10 +305,6 @@ export default class InternalModel {
     }
   }
 
-  hasDirtyAttributes() {
-    return this.currentState.hasDirtyAttributes;
-  }
-
   isDeleted() {
     if (RECORD_DATA_STATE) {
       if (this._recordData.isDeleted) {

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -329,12 +329,6 @@ export default class InternalModel {
     }
   }
 
-  isValid() {
-    if (!RECORD_DATA_ERRORS) {
-      return this.currentState.isValid;
-    }
-  }
-
   dirtyType() {
     return this.currentState.dirtyType;
   }

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -843,10 +843,6 @@ export default class InternalModel {
     this._isDestroyed = true;
   }
 
-  eachAttribute(callback, binding) {
-    return this.modelClass.eachAttribute(callback, binding);
-  }
-
   inverseFor(key) {
     return this.modelClass.inverseFor(key);
   }

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -233,10 +233,6 @@ export default class InternalModel {
     }
   }
 
-  get type() {
-    return this.modelClass;
-  }
-
   get recordReference() {
     if (this._recordReference === null) {
       this._recordReference = new RecordReference(this.store, this.identifier);
@@ -748,7 +744,7 @@ export default class InternalModel {
       return this._updatePromiseProxyFor('hasMany', key, { promise, content: manyArray });
     } else {
       assert(
-        `You looked up the '${key}' relationship on a '${this.type.modelName}' with id ${this.id} but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async ('hasMany({ async: true })')`,
+        `You looked up the '${key}' relationship on a '${this.modelName}' with id ${this.id} but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async ('hasMany({ async: true })')`,
         !manyArray.anyUnloaded()
       );
 

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -305,11 +305,6 @@ export default class InternalModel {
     }
   }
 
-  isRecordInUse() {
-    let record = this._record;
-    return record && !(record.get('isDestroyed') || record.get('isDestroying'));
-  }
-
   isEmpty() {
     return this.currentState.isEmpty;
   }

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -321,10 +321,6 @@ export default class InternalModel {
     return this.currentState.hasDirtyAttributes;
   }
 
-  isSaving() {
-    return this.currentState.isSaving;
-  }
-
   isDeleted() {
     if (RECORD_DATA_STATE) {
       if (this._recordData.isDeleted) {

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -338,12 +338,12 @@ const DirtyState = {
     pushedData() {},
 
     willCommit(internalModel) {
-      internalModel.clearErrorMessages();
+      clearErrorMessages(internalModel);
       internalModel.transitionTo('inFlight');
     },
 
     rolledBack(internalModel) {
-      internalModel.clearErrorMessages();
+      clearErrorMessages(internalModel);
       internalModel.transitionTo('loaded.saved');
       internalModel.triggerLater('ready');
     },
@@ -454,7 +454,7 @@ updatedState.uncommitted.deleteRecord = function(internalModel) {
 };
 
 updatedState.invalid.rolledBack = function(internalModel) {
-  internalModel.clearErrorMessages();
+  clearErrorMessages(internalModel);
   internalModel.transitionTo('loaded.saved');
   internalModel.triggerLater('rolledBack');
 };
@@ -730,7 +730,7 @@ const RootState = {
       willCommit() {},
 
       rolledBack(internalModel) {
-        internalModel.clearErrorMessages();
+        clearErrorMessages(internalModel);
         internalModel.transitionTo('loaded.saved');
         internalModel.triggerLater('ready');
       },
@@ -768,6 +768,10 @@ function wireState(object, parent, name) {
   }
 
   return object;
+}
+
+function clearErrorMessages(internalModel) {
+  internalModel.getRecord().errors._clear();
 }
 
 export default wireState(RootState, null, 'root');

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -397,7 +397,7 @@ const createdState = dirtyState({
   isNew: true,
 
   setup(internalModel) {
-    internalModel.updateRecordArrays();
+    internalModel.store.recordArrayManager.recordDidChange(internalModel.identifier);
   },
 });
 
@@ -628,7 +628,7 @@ const RootState = {
 
     // TRANSITIONS
     setup(internalModel) {
-      internalModel.updateRecordArrays();
+      internalModel.store.recordArrayManager.recordDidChange(internalModel.identifier);
     },
 
     // SUBSTATES

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -324,7 +324,7 @@ const DirtyState = {
     },
 
     didSetProperty(internalModel, context) {
-      internalModel.removeErrorMessageFromAttribute(context.name);
+      internalModel.getRecord().errors._remove(context.name);
 
       didSetProperty(internalModel, context);
 
@@ -715,7 +715,7 @@ const RootState = {
       isValid: false,
 
       didSetProperty(internalModel, context) {
-        internalModel.removeErrorMessageFromAttribute(context.name);
+        internalModel.getRecord().errors._remove(context.name);
 
         didSetProperty(internalModel, context);
 

--- a/packages/store/addon/-private/system/references/belongs-to.js
+++ b/packages/store/addon/-private/system/references/belongs-to.js
@@ -217,7 +217,7 @@ export default class BelongsToReference extends Reference {
     let resource = this._resource();
     if (resource && resource.data) {
       let inverseInternalModel = this.store._internalModelForResource(resource.data);
-      if (inverseInternalModel && inverseInternalModel.isLoaded()) {
+      if (inverseInternalModel && inverseInternalModel.currentState.isLoaded) {
         return inverseInternalModel.getRecord();
       }
     }

--- a/packages/store/addon/-private/system/references/has-many.js
+++ b/packages/store/addon/-private/system/references/has-many.js
@@ -213,7 +213,7 @@ export default class HasManyReference extends Reference {
     //TODO Igor cleanup
     return members.every(recordData => {
       let internalModel = this.store._internalModelForResource(recordData.getResourceIdentifier());
-      return internalModel.isLoaded() === true;
+      return internalModel.currentState.isLoaded === true;
     });
   }
 

--- a/packages/store/addon/-private/system/references/record.ts
+++ b/packages/store/addon/-private/system/references/record.ts
@@ -156,7 +156,7 @@ export default class RecordReference extends Reference {
   value(): RecordInstance | null {
     if (this._id !== null) {
       let internalModel = internalModelForReference(this);
-      if (internalModel && internalModel.isLoaded()) {
+      if (internalModel && internalModel.currentState.isLoaded) {
         return internalModel.getRecord();
       }
     }

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -65,7 +65,7 @@ export function _find(adapter, store, modelClass, id, internalModel, options) {
     },
     error => {
       internalModel.notFound();
-      if (internalModel.isEmpty()) {
+      if (internalModel.currentState.isEmpty) {
         internalModel.unloadRecord();
       }
 

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -64,7 +64,7 @@ export function _find(adapter, store, modelClass, id, internalModel, options) {
       return store._push(payload);
     },
     error => {
-      internalModel.notFound();
+      internalModel.send('notFound');
       if (internalModel.currentState.isEmpty) {
         internalModel.unloadRecord();
       }

--- a/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
+++ b/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
@@ -224,11 +224,14 @@ export default class RecordDataStoreWrapper implements IRecordDataStoreWrapper {
   isRecordInUse(type: string, id: string | null, lid?: string | null): boolean {
     const resource = constructResource(type, id, lid);
     const identifier = identifierCacheFor(this._store).getOrCreateRecordIdentifier(resource);
-    let internalModel = internalModelFactoryFor(this._store).peek(identifier);
+    const internalModel = internalModelFactoryFor(this._store).peek(identifier);
+
     if (!internalModel) {
       return false;
     }
-    return internalModel.isRecordInUse();
+
+    const record = internalModel._record;
+    return record && !(record.isDestroyed || record.isDestroying);
   }
 
   disconnectRecord(type: string, id: string | null, lid: string): void;


### PR DESCRIPTION
Each commit here removes a method or property from InternalModel for which either a different InternalModel codepath is just as efficient to use OR the codepath is unused OR the codepath has a non InternalModel equivalent of the same efficiency.

The motivation is to shrink the surface area of InternalModel until what remains is logic we need to move elsewhere, helping us get a clearer picture of what InternalModel is still handling for us. It comes with the added win of reducing our payload size slightly.