### PR TITLE
[BUGFIX] Updated the yuidocs for the broken ember-data links linking to elsewhere on the page.

### DIFF
--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -187,12 +187,12 @@ function deprecateTestRegistration(
   The store provides multiple ways to create new record objects. They have
   some subtle differences in their use which are detailed below:
 
-  [createRecord](createRecord?anchor=createRecord) is used for creating new
+  [createRecord](../methods/createRecord?anchor=createRecord) is used for creating new
   records on the client side. This will return a new record in the
   `created.uncommitted` state. In order to persist this record to the
   backend, you will need to call `record.save()`.
 
-  [push](push?anchor=push) is used to notify Ember Data's store of new or
+  [push](../methods/push?anchor=push) is used to notify Ember Data's store of new or
   updated records that exist in the backend. This will return a record
   in the `loaded.saved` state. The primary use-case for `store#push` is
   to notify Ember Data about record updates (full or partial) that happen
@@ -200,7 +200,7 @@ function deprecateTestRegistration(
   [SSE](http://dev.w3.org/html5/eventsource/) or [Web
   Sockets](http://www.w3.org/TR/2009/WD-websockets-20091222/)).
 
-  [pushPayload](pushPayload?anchor=pushPayload) is a convenience wrapper for
+  [pushPayload](../methods/pushPayload?anchor=pushPayload) is a convenience wrapper for
   `store#push` that will deserialize payloads if the
   Serializer implements a `pushPayload` method.
 
@@ -933,7 +933,7 @@ abstract class CoreStore extends Service {
     }
     ```
 
-    See [peekRecord](peekRecord?anchor=peekRecord) to get the cached version of a record.
+    See [peekRecord](../methods/peekRecord?anchor=peekRecord) to get the cached version of a record.
 
     ### Retrieving Related Model Records
 
@@ -1504,7 +1504,7 @@ abstract class CoreStore extends Service {
     otherwise it will return `null`. A record is available if it has been fetched earlier, or
     pushed manually into the store.
 
-    See [findRecord](findRecord?anchor=findRecord) if you would like to request this record from the backend.
+    See [findRecord](../methods/findRecord?anchor=findRecord) if you would like to request this record from the backend.
 
     _Note: This is a synchronous method and does not return a promise._
 
@@ -1969,7 +1969,7 @@ abstract class CoreStore extends Service {
 
   /**
     This method makes a request for one record, where the `id` is not known
-    beforehand (if the `id` is known, use [`findRecord`](findRecord?anchor=findRecord)
+    beforehand (if the `id` is known, use [`findRecord`](../methods/findRecord?anchor=findRecord)
     instead).
 
     This method can be used when it is certain that the server will return a
@@ -2240,7 +2240,7 @@ abstract class CoreStore extends Service {
     }
     ```
 
-    See [peekAll](peekAll?anchor=peekAll) to get an array of current records in the
+    See [peekAll](../methods/peekAll?anchor=peekAll) to get an array of current records in the
     store, without waiting until a reload is finished.
 
     ### Retrieving Related Model Records
@@ -2281,7 +2281,7 @@ abstract class CoreStore extends Service {
     }
     ```
 
-    See [query](query?anchor=query) to only get a subset of records from the server.
+    See [query](../methods/query?anchor=query) to only get a subset of records from the server.
 
     @since 1.13.0
     @method findAll
@@ -2371,7 +2371,7 @@ abstract class CoreStore extends Service {
     locally created records of the type, however, it will not make a
     request to the backend to retrieve additional records. If you
     would like to request all the records from the backend please use
-    [store.findAll](findAll?anchor=findAll).
+    [store.findAll](../methods/findAll?anchor=findAll).
 
     Also note that multiple calls to `peekAll` for a given type will always
     return the same `RecordArray`.
@@ -2848,7 +2848,7 @@ abstract class CoreStore extends Service {
 
     If you're streaming data or implementing an adapter, make sure
     that you have converted the incoming data into this form. The
-    store's [normalize](normalize?anchor=normalize) method is a convenience
+    store's [normalize](../methods/normalize?anchor=normalize) method is a convenience
     helper for converting a json payload into the form Ember Data
     expects.
 
@@ -3208,7 +3208,7 @@ abstract class CoreStore extends Service {
 
   /**
     `normalize` converts a json payload into the normalized form that
-    [push](push?anchor=push) expects.
+    [push](../methods/push?anchor=push) expects.
 
     Example
 

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -187,12 +187,12 @@ function deprecateTestRegistration(
   The store provides multiple ways to create new record objects. They have
   some subtle differences in their use which are detailed below:
 
-  [createRecord](../classes/Store/methods/createRecord?anchor=createRecord) is used for creating new
+  [createRecord](createRecord?anchor=createRecord) is used for creating new
   records on the client side. This will return a new record in the
   `created.uncommitted` state. In order to persist this record to the
   backend, you will need to call `record.save()`.
 
-  [push](../classes/Store/methods/push?anchor=push) is used to notify Ember Data's store of new or
+  [push](push?anchor=push) is used to notify Ember Data's store of new or
   updated records that exist in the backend. This will return a record
   in the `loaded.saved` state. The primary use-case for `store#push` is
   to notify Ember Data about record updates (full or partial) that happen
@@ -200,7 +200,7 @@ function deprecateTestRegistration(
   [SSE](http://dev.w3.org/html5/eventsource/) or [Web
   Sockets](http://www.w3.org/TR/2009/WD-websockets-20091222/)).
 
-  [pushPayload](../classes/Store/methods/pushPayload?anchor=pushPayload) is a convenience wrapper for
+  [pushPayload](pushPayload?anchor=pushPayload) is a convenience wrapper for
   `store#push` that will deserialize payloads if the
   Serializer implements a `pushPayload` method.
 
@@ -933,7 +933,7 @@ abstract class CoreStore extends Service {
     }
     ```
 
-    See [peekRecord](../classes/Store/methods/peekRecord?anchor=peekRecord) to get the cached version of a record.
+    See [peekRecord](peekRecord?anchor=peekRecord) to get the cached version of a record.
 
     ### Retrieving Related Model Records
 
@@ -1504,7 +1504,7 @@ abstract class CoreStore extends Service {
     otherwise it will return `null`. A record is available if it has been fetched earlier, or
     pushed manually into the store.
 
-    See [findRecord](../classes/Store/methods/findRecord?anchor=findRecord) if you would like to request this record from the backend.
+    See [findRecord](findRecord?anchor=findRecord) if you would like to request this record from the backend.
 
     _Note: This is a synchronous method and does not return a promise._
 
@@ -1969,7 +1969,7 @@ abstract class CoreStore extends Service {
 
   /**
     This method makes a request for one record, where the `id` is not known
-    beforehand (if the `id` is known, use [`findRecord`](../classes/Store/methods/findRecord?anchor=findRecord)
+    beforehand (if the `id` is known, use [`findRecord`](findRecord?anchor=findRecord)
     instead).
 
     This method can be used when it is certain that the server will return a
@@ -2240,7 +2240,7 @@ abstract class CoreStore extends Service {
     }
     ```
 
-    See [peekAll](../classes/Store/methods/peekAll?anchor=peekAll) to get an array of current records in the
+    See [peekAll](peekAll?anchor=peekAll) to get an array of current records in the
     store, without waiting until a reload is finished.
 
     ### Retrieving Related Model Records
@@ -2281,7 +2281,7 @@ abstract class CoreStore extends Service {
     }
     ```
 
-    See [query](../classes/Store/methods/query?anchor=query) to only get a subset of records from the server.
+    See [query](query?anchor=query) to only get a subset of records from the server.
 
     @since 1.13.0
     @method findAll
@@ -2371,7 +2371,7 @@ abstract class CoreStore extends Service {
     locally created records of the type, however, it will not make a
     request to the backend to retrieve additional records. If you
     would like to request all the records from the backend please use
-    [store.findAll](../classes/Store/methods/findAll?anchor=findAll).
+    [store.findAll](findAll?anchor=findAll).
 
     Also note that multiple calls to `peekAll` for a given type will always
     return the same `RecordArray`.
@@ -2848,7 +2848,7 @@ abstract class CoreStore extends Service {
 
     If you're streaming data or implementing an adapter, make sure
     that you have converted the incoming data into this form. The
-    store's [normalize](../classes/Store/methods/normalize?anchor=normalize) method is a convenience
+    store's [normalize](normalize?anchor=normalize) method is a convenience
     helper for converting a json payload into the form Ember Data
     expects.
 
@@ -3208,7 +3208,7 @@ abstract class CoreStore extends Service {
 
   /**
     `normalize` converts a json payload into the normalized form that
-    [push](../classes/Store/methods/push?anchor=push) expects.
+    [push](push?anchor=push) expects.
 
     Example
 


### PR DESCRIPTION
For [issue 737 in the ember-api-docs repository,](https://github.com/ember-learn/ember-api-docs/issues/737) it turned out the fix needed to be made in the yuidocs that are used to generate the markup for the ember-data docs page.

11 links throughout the page, which are intended to link internally to other parts of the page, were all broken because of an incorrect filepath in the docs. They prepended `classes/Store/` to the path unnecessarily.

I am uncertain of valid tests to add for this, as there doesn't appear to be any current testing for the yuidocs generating the docs page.

I also am aware that to fully update the docs--which will likely want to be done for all versions of Ember-Data's docs--the files on s3 will need to be replaced, which is not something I am able to generate or have access to, though would be happy to assist with given the blessing/credentials.