### PR TITLE
chore: simpler serializer for perf test app to reduce noise

### DIFF
--- a/packages/unpublished-relationship-performance-test-app/app/serializers/application.js
+++ b/packages/unpublished-relationship-performance-test-app/app/serializers/application.js
@@ -1,7 +1,9 @@
-import DS from 'ember-data';
+export default class Serializer {
+  static create() {
+    return new this();
+  }
 
-export default DS.JSONAPISerializer.extend({
-  normalizeResponse(store, primaryModelClass, payload) {
+  normalizeResponse(_, __, payload) {
     return payload;
-  },
-});
+  }
+}


### PR DESCRIPTION
We don't need to process the payloads since they are already JSON:API.