### PR TITLE
chore: resolve implicit this and deprecation-staging deprecations

### DIFF
--- a/packages/-ember-data/addon/setup-container.js
+++ b/packages/-ember-data/addon/setup-container.js
@@ -20,6 +20,11 @@ function initializeStore(application) {
       {
         id: 'ember-data:legacy-test-helper-support',
         until: '3.17',
+        for: 'ember-data',
+        since: {
+          available: '3.15',
+          enabled: '3.15',
+        },
       }
     );
 

--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -354,7 +354,7 @@ module('async belongs-to rendering tests', function(hooks) {
       this.set('chris', chris);
 
       await render(hbs`
-      <p>{{chris.bestDog.name}}</p>
+      <p>{{this.chris.bestDog.name}}</p>
       `);
       await settled();
 
@@ -405,7 +405,7 @@ module('async belongs-to rendering tests', function(hooks) {
       this.set('sedona', sedona);
 
       await render(hbs`
-      <p>{{sedona.parent.name}}</p>
+      <p>{{this.sedona.parent.name}}</p>
       `);
 
       assert.equal(this.element.textContent.trim(), 'Kevin has two children and one parent');
@@ -423,7 +423,7 @@ module('async belongs-to rendering tests', function(hooks) {
       this.set('sedona', sedona);
 
       await render(hbs`
-      <p>{{sedona.parent.name}}</p>
+      <p>{{this.sedona.parent.name}}</p>
       `);
 
       let parent = await sedona.get('parent');
@@ -453,7 +453,7 @@ module('async belongs-to rendering tests', function(hooks) {
       this.set('sedona', sedona);
 
       await render(hbs`
-      <p>{{sedona.parent.name}}</p>
+      <p>{{this.sedona.parent.name}}</p>
       `);
 
       assert.equal(this.element.textContent.trim(), 'Kevin has two children and one parent');
@@ -494,7 +494,7 @@ module('async belongs-to rendering tests', function(hooks) {
       };
 
       await render(hbs`
-      <p>{{sedona.parent.name}}</p>
+      <p>{{this.sedona.parent.name}}</p>
       `);
 
       assert.equal(this.element.textContent.trim(), '', 'we have no parent');
@@ -548,7 +548,7 @@ module('async belongs-to rendering tests', function(hooks) {
       }
 
       await render(hbs`
-      <p>{{sedona.parent.name}}</p>
+      <p>{{this.sedona.parent.name}}</p>
       `);
 
       assert.equal(this.element.textContent.trim(), '', 'we have no parent');

--- a/packages/-ember-data/tests/acceptance/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/has-many-test.js
@@ -225,7 +225,7 @@ module('async has-many rendering tests', function(hooks) {
 
       await render(hbs`
       <ul>
-      {{#each parent.children as |child|}}
+      {{#each this.parent.children as |child|}}
         <li>{{child.name}}</li>
       {{/each}}
       </ul>
@@ -252,7 +252,7 @@ module('async has-many rendering tests', function(hooks) {
 
       await render(hbs`
       <ul>
-      {{#each parent.children as |child|}}
+      {{#each this.parent.children as |child|}}
         <li>{{child.name}}</li>
       {{/each}}
       </ul>
@@ -302,7 +302,7 @@ module('async has-many rendering tests', function(hooks) {
 
       await render(hbs`
       <ul>
-      {{#each parent.children as |child|}}
+      {{#each this.parent.children as |child|}}
         <li>{{child.name}}</li>
       {{/each}}
       </ul>
@@ -343,7 +343,7 @@ module('async has-many rendering tests', function(hooks) {
 
       await render(hbs`
       <ul>
-      {{#each parent.children as |child|}}
+      {{#each this.parent.children as |child|}}
         <li>{{child.name}}</li>
       {{/each}}
       </ul>
@@ -367,7 +367,7 @@ module('async has-many rendering tests', function(hooks) {
 
       await render(hbs`
       <ul>
-      {{#each parent.children as |child|}}
+      {{#each this.parent.children as |child|}}
         <li>{{child.name}}</li>
       {{/each}}
       </ul>
@@ -418,7 +418,7 @@ module('async has-many rendering tests', function(hooks) {
 
       await render(hbs`
       <ul>
-      {{#each parent.children as |child|}}
+      {{#each this.parent.children as |child|}}
         <li>{{child.name}}</li>
       {{/each}}
       </ul>
@@ -462,7 +462,7 @@ module('async has-many rendering tests', function(hooks) {
 
       await render(hbs`
       <ul>
-      {{#each parent.children as |child|}}
+      {{#each this.parent.children as |child|}}
         <li>{{child.name}}</li>
       {{/each}}
       </ul>
@@ -488,7 +488,7 @@ module('async has-many rendering tests', function(hooks) {
 
       await render(hbs`
       <ul>
-      {{#each parent.children as |child|}}
+      {{#each this.parent.children as |child|}}
         <li>{{child.name}}</li>
       {{/each}}
       </ul>
@@ -512,7 +512,7 @@ module('async has-many rendering tests', function(hooks) {
 
       await render(hbs`
       <ul>
-      {{#each parent.children as |child|}}
+      {{#each this.parent.children as |child|}}
         <li>{{child.name}}</li>
       {{/each}}
       </ul>

--- a/packages/adapter/addon/rest.ts
+++ b/packages/adapter/addon/rest.ts
@@ -1555,6 +1555,11 @@ if (DEPRECATE_NAJAX) {
             {
               id: 'ember-data:najax-fallback',
               until: '4.0',
+              for: '@ember-data/adapter',
+              since: {
+                available: '3.22',
+                enabled: '3.22',
+              },
             }
           );
         } else {
@@ -1564,6 +1569,11 @@ if (DEPRECATE_NAJAX) {
             {
               id: 'ember-data:najax-fallback',
               until: '4.0',
+              for: '@ember-data/adapter',
+              since: {
+                available: '3.22',
+                enabled: '3.22',
+              },
             }
           );
         }

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -1325,6 +1325,11 @@ if (DEPRECATE_MODEL_TOJSON) {
           id: 'ember-data:model.toJSON',
           until: '4.0',
           url: 'https://deprecations.emberjs.com/ember-data/v3.x#toc_record-toJSON',
+          for: '@ember-data/model',
+          since: {
+            available: '3.15',
+            enabled: '3.15',
+          },
         }
       );
       let serializer = this._internalModel.store.serializerFor('-default');
@@ -1455,6 +1460,11 @@ if (DEBUG) {
                 id: 'ember-data:record-lifecycle-event-methods',
                 until: '4.0',
                 url: 'https://deprecations.emberjs.com/ember-data/v3.x#toc_record-lifecycle-event-methods',
+                for: '@ember-data/model',
+                since: {
+                  available: '3.12',
+                  enabled: '3.12',
+                },
               }
             );
 

--- a/packages/serializer/addon/rest.js
+++ b/packages/serializer/addon/rest.js
@@ -291,6 +291,11 @@ const RESTSerializer = JSONSerializer.extend({
           until: '3.0',
           url:
             'https://deprecations.emberjs.com/ember-data/v2.x/#toc_store-queryrecord-array-response-with-restserializer',
+          for: '@ember-data/serializer',
+          since: {
+            available: '3.0',
+            enabled: '3.0',
+          },
         });
       }
 

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -141,6 +141,11 @@ function deprecateTestRegistration(
     {
       id: 'ember-data:-legacy-test-registrations',
       until: '3.17',
+      for: '@ember-data/store',
+      since: {
+        available: '3.15',
+        enabled: '3.15',
+      },
     }
   );
 }
@@ -351,6 +356,11 @@ abstract class CoreStore extends Service {
             {
               id: 'ember-data:-legacy-test-registrations',
               until: '3.17',
+              for: '@ember-data/store',
+              since: {
+                available: '3.15',
+                enabled: '3.15',
+              },
             }
           );
         }
@@ -3466,6 +3476,11 @@ abstract class CoreStore extends Service {
           id: 'ember-data:default-serializer',
           until: '4.0',
           url: 'https://deprecations.emberjs.com/ember-data/v3.x/#toc_ember-data-default-serializers',
+          for: '@ember-data/store',
+          since: {
+            available: '3.15',
+            enabled: '3.15',
+          },
         }
       );
 
@@ -3522,6 +3537,11 @@ abstract class CoreStore extends Service {
           id: 'ember-data:default-serializer',
           until: '4.0',
           url: 'https://deprecations.emberjs.com/ember-data/v3.x/#toc_ember-data-default-serializers',
+          for: '@ember-data/store',
+          since: {
+            available: '3.15',
+            enabled: '3.15',
+          },
         }
       );
 
@@ -3648,6 +3668,11 @@ if (DEPRECATE_DEFAULT_ADAPTER) {
           id: 'ember-data:default-adapter',
           until: '4.0',
           url: 'https://deprecations.emberjs.com/ember-data/v3.x/#toc_ember-data-default-adapter',
+          for: '@ember-data/store',
+          since: {
+            available: '3.15',
+            enabled: '3.15',
+          },
         }
       );
       let adapter = this.adapter || '-json-api';
@@ -3743,6 +3768,11 @@ if (DEBUG) {
         {
           id: 'ember-data:method-calls-on-destroyed-store',
           until: '3.8',
+          for: '@ember-data/store',
+          since: {
+            available: '3.8',
+            enabled: '3.8',
+          },
         }
       );
     } else {
@@ -3760,6 +3790,11 @@ if (DEBUG) {
         {
           id: 'ember-data:method-calls-on-destroyed-store',
           until: '3.8',
+          for: '@ember-data/store',
+          since: {
+            available: '3.8',
+            enabled: '3.8',
+          },
         }
       );
     } else {

--- a/packages/store/addon/-private/system/deprecated-evented.js
+++ b/packages/store/addon/-private/system/deprecated-evented.js
@@ -48,6 +48,11 @@ if (DEBUG) {
         id: 'ember-data:evented-api-usage',
         until: '4.0',
         url: 'https://deprecations.emberjs.com/ember-data/v3.x/#deprecatingrecordlifecycleeventmethods',
+        for: '@ember-data/model',
+        since: {
+          available: '3.12',
+          enabled: '3.12',
+        },
       });
       deprecations[eventName] = true;
     },

--- a/packages/store/addon/-private/system/ds-model-store.ts
+++ b/packages/store/addon/-private/system/ds-model-store.ts
@@ -299,6 +299,11 @@ if (DEBUG) {
         {
           id: 'ember-data:method-calls-on-destroyed-store',
           until: '3.8',
+          for: '@ember-data/store',
+          since: {
+            available: '3.8',
+            enabled: '3.8',
+          },
         }
       );
     } else {
@@ -316,6 +321,11 @@ if (DEBUG) {
         {
           id: 'ember-data:method-calls-on-destroyed-store',
           until: '3.8',
+          for: '@ember-data/store',
+          since: {
+            available: '3.8',
+            enabled: '3.8',
+          },
         }
       );
     } else {

--- a/packages/store/addon/-private/system/references/belongs-to.js
+++ b/packages/store/addon/-private/system/references/belongs-to.js
@@ -139,6 +139,11 @@ export default class BelongsToReference extends Reference {
         deprecate('Pushing a record into a BelongsToReference is deprecated', false, {
           id: 'ember-data:belongs-to-reference-push-record',
           until: '4.0',
+          for: '@ember-data/store',
+          since: {
+            available: '3.16',
+            enabled: '3.16',
+          },
         });
         record = data;
       } else {

--- a/packages/store/addon/-private/system/references/reference.ts
+++ b/packages/store/addon/-private/system/references/reference.ts
@@ -217,6 +217,11 @@ if (DEPRECATE_REFERENCE_INTERNAL_MODEL) {
       deprecate('Accessing the internalModel property of Reference is deprecated', false, {
         id: 'ember-data:reference-internal-model',
         until: '3.21',
+        for: '@ember-data/store',
+        since: {
+          available: '3.19',
+          enabled: '3.19',
+        },
       });
 
       return REFERENCE_CACHE.get(this);

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -194,6 +194,11 @@ function ensureRelationshipIsSetToParent(payload, parentInternalModel, store, pa
       deprecate(message + '\n', false, {
         id: 'mismatched-inverse-relationship-data-from-payload',
         until: '3.8',
+        for: '@ember-data/store',
+        since: {
+          available: '3.8',
+          enabled: '3.8',
+        },
       });
     }
 
@@ -408,10 +413,7 @@ export function _queryRecord(adapter, store, modelName, query, options) {
 
       assert(
         `Expected the primary data returned by the serializer for a 'queryRecord' response to be a single object or null but instead it was an array.`,
-        !Array.isArray(payload.data),
-        {
-          id: 'ds.store.queryRecord-array-response',
-        }
+        !Array.isArray(payload.data)
       );
 
       return store._push(payload);

--- a/packages/store/types/@ember/debug/index.d.ts
+++ b/packages/store/types/@ember/debug/index.d.ts
@@ -1,0 +1,120 @@
+/*
+  Copied from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52397
+  to unblock while waiting for a new version.
+*/
+// Type definitions for non-npm package @ember/debug 3.24
+// Project: https://emberjs.com/api/ember/3.24/modules/@ember%2Fdebug
+// Definitions by: Mike North <https://github.com/mike-north>
+//                 Chris Krycho <https://github.com/chriskrycho>
+//                 Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.7
+
+/**
+ * Define an assertion that will throw an exception if the condition is not met.
+ */
+export function assert(desc: string): never;
+export function assert(desc: string, test: unknown): asserts test;
+
+/**
+ * Display a debug notice.
+ */
+export function debug(message: string): void;
+
+/**
+ * Convenience method to inspect an object. This method will attempt to
+ * convert the object into a useful string description.
+ */
+export function inspect(obj: any): string;
+/**
+ * Allows for runtime registration of handler functions that override the default deprecation behavior.
+ * Deprecations are invoked by calls to [Ember.deprecate](http://emberjs.com/api/classes/Ember.html#method_deprecate).
+ * The following example demonstrates its usage by registering a handler that throws an error if the
+ * message contains the word "should", otherwise defers to the default handler.
+ */
+export function registerDeprecationHandler(
+  handler: (message: string, options: { id: string; until: string }, next: () => void) => void
+): void;
+/**
+ * Allows for runtime registration of handler functions that override the default warning behavior.
+ * Warnings are invoked by calls made to [Ember.warn](http://emberjs.com/api/classes/Ember.html#method_warn).
+ * The following example demonstrates its usage by registering a handler that does nothing overriding Ember's
+ * default warning behavior.
+ */
+export function registerWarnHandler(
+  handler: (
+    message: string,
+    options: { id: string },
+    next: (message?: string, options?: { id: string }) => void
+  ) => void
+): void;
+
+/**
+ * Run a function meant for debugging.
+ */
+export function runInDebug(func: () => any): void;
+
+/**
+ * Display a warning with the provided message.
+ */
+export function warn(message: string, test: boolean, options: { id: string }): void;
+export function warn(message: string, options: { id: string }): void;
+/**
+ * @deprecated Missing deprecation options: https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options
+ */
+export function warn(message: string, test: boolean, options?: { id?: string }): void;
+/**
+ * @deprecated Missing deprecation options: https://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options
+ */
+export function warn(message: string, options?: { id?: string }): void;
+
+/**
+ * Display a deprecation warning with the provided message and a stack trace
+ * (Chrome and Firefox only).
+ *
+ * In a production build, this method is defined as an empty function (NOP).
+ * Uses of this method in Ember itself are stripped from the ember.prod.js build.
+ *
+ * @param message A description of the deprecation.
+ * @param test If falsy, the deprecation will be displayed.
+ * @param options The deprecation options.
+ */
+export function deprecate(
+  message: string,
+  test: boolean,
+  options: {
+    /**
+     * A unique id for this deprecation. The id can be used by Ember debugging
+     * tools to change the behavior (raise, log or silence) for that specific
+     * deprecation. The id should be namespaced by dots, e.g.
+     * `"view.helper.select"`.
+     */
+    id: string;
+    /**
+     * The version of Ember when this deprecation warning will be removed.
+     */
+    until: string;
+    /**
+     * An optional url to the transition guide on the emberjs.com website.
+     */
+    url?: string;
+    /**
+     * The library emitting this deprecation
+     */
+    for: string;
+    /**
+     * Information about the stage for this deprecation
+     */
+    since: {
+      /**
+       * The version this deprecation was added in (but not necessarily activated)
+       */
+      available?: string;
+      /**
+       * The version this deprecation was/will-be activated
+       */
+      enabled: string;
+    };
+  }
+): void;

--- a/packages/unpublished-test-infra/addon-test-support/assert-all-deprecations.js
+++ b/packages/unpublished-test-infra/addon-test-support/assert-all-deprecations.js
@@ -36,6 +36,7 @@ export default function configureAssertAllDeprecations() {
           if (ASSERT_ALL_DEPRECATIONS) {
             pushDeprecation((deprecation.options && deprecation.options.id) || deprecation);
           } else {
+            console.count(deprecation.options.id);
             console.warn('Detected Non-Ember-Data Deprecation:', deprecation.message, deprecation.options.stacktrace);
           }
         }


### PR DESCRIPTION
- fixes all but 20 deprecations we encounter running the test suite.
- adds a types file that can be removed as soon as this PR is merged to DefinitelyTyped: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52397

Remaining deprecations we will need to investigate

- 2 for use of Globals Resolver (potentially intentional testing?)
- 3 for use of injected store (potentially intentional testing?)
- 15 for use of array observers (more than likely intentional for these tests)