### PR TITLE
chore: fix factory-guy link, activate model-fragments, remove ember-data-change-tracker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -313,13 +313,13 @@ jobs:
           ]
         include:
           - partner: ember-data-change-tracker
-            continue-on-error: true
+            continue-on-error: false
           - partner: factory-guy
-            continue-on-error: true
+            continue-on-error: false
           - partner: model-fragments
-            continue-on-error: true
+            continue-on-error: false
           - partner: travis-web
-            continue-on-error: true
+            continue-on-error: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -300,7 +300,6 @@ jobs:
       matrix:
         partner:
           [
-            ember-data-change-tracker,
             ember-data-relationship-tracker,
             ember-m3,
             ember-observer,
@@ -312,14 +311,10 @@ jobs:
             travis-web,
           ]
         include:
-          - partner: ember-data-change-tracker
-            continue-on-error: false
           - partner: factory-guy
-            continue-on-error: false
-          - partner: model-fragments
-            continue-on-error: false
+            continue-on-error: true
           - partner: travis-web
-            continue-on-error: false
+            continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test-external:ember-observer": "./bin/test-external-partner-project.js ember-observer https://github.com/emberobserver/client.git --noLockFile",
     "test-external:travis-web": "./bin/test-external-partner-project.js travis-web https://github.com/travis-ci/travis-web.git",
     "test-external:storefront": "./bin/test-external-partner-project.js storefront https://github.com/embermap/ember-data-storefront.git",
-    "test-external:factory-guy": "./bin/test-external-partner-project.js factory-guy https://github.com/danielspaniel/ember-data-factory-guy.git",
+    "test-external:factory-guy": "./bin/test-external-partner-project.js factory-guy https://github.com/adopted-ember-addons/ember-data-factory-guy.git",
     "test-external:ilios-frontend": "./bin/test-external-partner-project.js ilios-frontend https://github.com/ilios/frontend.git --skipSmokeTest",
     "test-external:ember-resource-metadata": "./bin/test-external-partner-project.js ember-resource-metadata https://github.com/ef4/ember-resource-metadata.git --noLockFile",
     "test-external:ember-data-relationship-tracker": "./bin/test-external-partner-project.js ember-data-relationship-tracker https://github.com/ef4/ember-data-relationship-tracker.git"


### PR DESCRIPTION
cc @patocallaghan we were skipping the factory-guy tests since they were failing for so long. Now that it's maintained I've updated the link and if passing will allow it to fail our test suite again.