### PR TITLE
chore: Improved test coverage for internal relationship state

### DIFF
--- a/packages/record-data/addon/-private/record-data.ts
+++ b/packages/record-data/addon/-private/record-data.ts
@@ -8,6 +8,7 @@ import { isEqual } from '@ember/utils';
 import { DEBUG } from '@glimmer/env';
 
 import { RECORD_DATA_ERRORS, RECORD_DATA_STATE } from '@ember-data/canary-features';
+import { removeRecordDataFor } from '@ember-data/store/-private';
 
 import coerceId from './coerce-id';
 import Relationships from './relationships/state/create';
@@ -450,6 +451,9 @@ export default class RecordDataDefault implements RelationshipRecordData {
       for (let i = 0; i < relatedRecordDatas.length; ++i) {
         let recordData = relatedRecordDatas[i];
         if (!recordData.isDestroyed) {
+          // TODO @runspired we do not currently destroy RecordData instances *except* via this relationship
+          // traversal. This seems like an oversight since the store should be able to notify destroy.
+          removeRecordDataFor(recordData.identifier);
           recordData.destroy();
         }
       }

--- a/packages/record-data/addon/-private/ts-interfaces/relationship-record-data.ts
+++ b/packages/record-data/addon/-private/ts-interfaces/relationship-record-data.ts
@@ -1,3 +1,4 @@
+type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
 type SingleResourceRelationship = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').SingleResourceRelationship;
 type CollectionResourceRelationship = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').CollectionResourceRelationship;
 type RecordData = import('@ember-data/store/-private/ts-interfaces/record-data').RecordData;
@@ -21,6 +22,7 @@ export interface RelationshipRecordData extends RecordData {
   isNew(): boolean;
   modelName: string;
   storeWrapper: RecordDataStoreWrapper;
+  identifier: StableRecordIdentifier;
   id: string | null;
   clientId: string | null;
   isEmpty(): boolean;

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -52,6 +52,7 @@
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",
     "qunit": "^2.10.0",
+    "qunit-console-grouper": "^0.3.0",
     "qunit-dom": "^1.2.0",
     "silent-error": "^1.1.1"
   },

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -29,6 +29,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
+    "@ember-data/model": "3.28.0-alpha.0",
     "@ember-data/unpublished-test-infra": "3.28.0-alpha.0",
     "@ember/optional-features": "^1.3.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/record-data/tests/integration/graph/edge-removal/abstract-edge-removal-test.ts
+++ b/packages/record-data/tests/integration/graph/edge-removal/abstract-edge-removal-test.ts
@@ -1,0 +1,251 @@
+import { assign } from '@ember/polyfills';
+import settled from '@ember/test-helpers/settled';
+
+import { module, test } from 'qunit';
+
+import { setInitialState, testFinalState } from './helpers';
+import { setupGraphTest } from './setup';
+
+type TestConfig = import('./helpers').TestConfig;
+type Context = import('./setup').Context;
+
+module('Integration | Graph | Nodes', function(hooks) {
+  setupGraphTest(hooks);
+
+  /**
+   * These are the various configurations we run tests for on the graph
+   * to ensure things are working.
+   *
+   * We don't currently test 1:many or many:1 relationships. It's unclear
+   * if the semantics of these are different enough to require additional
+   * scenarios.
+   *
+   * name: the name of the test
+   * async: whether the relationship should be async or sync (both sides will conform to this)
+   * relType: whether the relationship should be belongsTo (1:1) or hasMany (many:many)
+   * inverseNull: whether the relationships should specify inverse: null instead of an explicit inverse.
+   */
+  const TestScenarios: TestConfig[] = [
+    {
+      name: 'sync belongsTo',
+      async: false,
+      relType: 'belongsTo',
+      inverseNull: false,
+    },
+    {
+      name: 'async belongsTo',
+      async: true,
+      relType: 'belongsTo',
+      inverseNull: false,
+    },
+    {
+      name: 'sync implicit belongsTo',
+      async: false,
+      relType: 'belongsTo',
+      inverseNull: true,
+    },
+    {
+      name: 'async implicit belongsTo',
+      async: true,
+      relType: 'belongsTo',
+      inverseNull: true,
+    },
+    {
+      name: 'sync hasMany',
+      async: false,
+      relType: 'hasMany',
+      inverseNull: false,
+    },
+    {
+      name: 'async hasMany',
+      async: true,
+      relType: 'hasMany',
+      inverseNull: false,
+    },
+    {
+      name: 'sync implicit hasMany',
+      async: false,
+      relType: 'hasMany',
+      inverseNull: true,
+    },
+    {
+      name: 'async implicit hasMany',
+      async: true,
+      relType: 'hasMany',
+      inverseNull: true,
+    },
+  ].map(v => (Object.freeze ? Object.freeze(v) : v) as TestConfig);
+
+  module('Unpersisted Deletion of Record does not remove it from the graph', function() {
+    function unpersistedDeletionTest(config: TestConfig) {
+      test(config.name, async function(this: Context, assert) {
+        const testState = await setInitialState(this, config, assert);
+        const { john } = testState;
+
+        // now we delete
+        john.deleteRecord();
+
+        // just in case there is a backburner flush
+        await settled();
+
+        /**
+         * For deletions, since no state change has been persisted, we expect the cache to still
+         * reflect the same state of the relationship as prior to the call to deleteRecord.
+         *
+         * Ergo we expect no entries removed (`removed: false`) and for no caches
+         * to have been deleted (`cleared: false`)
+         *
+         * However: for a newly created record any form of rollback, unload or persisted delete
+         * will result in it being destroyed and cleared
+         */
+        await testFinalState(
+          this,
+          testState,
+          config,
+          { removed: !!config.useCreate, cleared: !!config.useCreate, implicitCleared: !!config.useCreate },
+          assert
+        );
+      });
+    }
+
+    TestScenarios.forEach(unpersistedDeletionTest);
+    TestScenarios.forEach(testConfig => {
+      const config = assign({}, testConfig, { name: `[Newly Created] ${testConfig.name}`, useCreate: true });
+      unpersistedDeletionTest(config);
+    });
+    TestScenarios.forEach(testConfig => {
+      const config = assign({}, testConfig, { name: `[LOCAL STATE] ${testConfig.name}`, dirtyLocal: true });
+      unpersistedDeletionTest(config);
+    });
+  });
+
+  module('Unload of a Record does not remove it from the graph', function() {
+    function unloadTest(_config: TestConfig) {
+      test(_config.name, async function(this: Context, assert) {
+        const config = assign({}, _config, { isUnloadAsDelete: true });
+        const testState = await setInitialState(this, config, assert);
+        const { john } = testState;
+
+        // now we unload
+        john.unloadRecord();
+
+        // just in case there is a backburner flush
+        await settled();
+
+        /**
+         * For unload, we treat it as a persisted deletion for new records and for sync relationships and
+         * as no-change for async relationships.
+         *
+         * For local-changes of implicit hasMany relationships we expect the relationships to be cleared as well,
+         * this special case is handled within ./helpers.ts and is something we can ideally delete as a behavior
+         * in the future.
+         *
+         * For newly created records we expect the inverse to be cleaned up (chris) but for the relationships
+         * for the newly created record to be fully intact. There's no particularly good reason for this other than
+         * we've counted on the record's destroyed state removing these objects from the graph. The inverse relationship
+         * state containers will have removed any retained info about the newly created record.
+         *
+         * Finally, we expect that even though the relationships on `john` could have been removed in the `sync` case
+         * that they won't be removed in either case from local and only if from remote if dirtyLocal or useCreate is true.
+         * The relationships in this case will still be removed from chris. We are possibly retaining these relationships
+         * despite transitioning the record to an `empty` state in the off chance we need to rematerialize the record.
+         * Likely for most cases this is just a bug.
+         *
+         * If this is confusing that's exactly why we've now added this test suite. People depend on this weirdly
+         * observable behavior, so we want to know when it changes.
+         */
+
+        // we remove if the record was new or if the relationship was sync (client side delete semantics)
+        let removed = config.useCreate || !config.async;
+        // we clear sync non-implicit relationships (client side delete semantics)
+        let cleared = !config.async && !config.inverseNull;
+
+        await testFinalState(this, testState, config, { removed, cleared, implicitCleared: true }, assert);
+      });
+    }
+
+    TestScenarios.forEach(unloadTest);
+    TestScenarios.forEach(testConfig => {
+      const config = assign({}, testConfig, { name: `[Newly Created] ${testConfig.name}`, useCreate: true });
+      unloadTest(config);
+    });
+    TestScenarios.forEach(testConfig => {
+      const config = assign({}, testConfig, { name: `[LOCAL STATE] ${testConfig.name}`, dirtyLocal: true });
+      unloadTest(config);
+    });
+  });
+
+  module('Persisted Deletion w/o dematerialization of Record removes it from the graph', function(hooks) {
+    function persistedDeletionTest(config: TestConfig) {
+      test(config.name, async function(this: Context, assert) {
+        const testState = await setInitialState(this, config, assert);
+        const { john } = testState;
+
+        // now we delete
+        john.deleteRecord();
+
+        // persist the deletion (but note no call to unloadRecord)
+        await john.save();
+
+        /**
+         * For persisted deletions, we expect the cache to have removed all entries for
+         * the deleted record from both explicit and implicit inverses.
+         *
+         * Ergo we expect entries removed (`removed: true`) and for all caches
+         * to have been deleted (`cleared: true`)
+         *
+         * For unclear reasons, currently sync hasMany relationships are emptied
+         * but not cleared prior to dematerialization after a persisted delete
+         * only when there is dirty local state. (`cleared: false`) while the
+         * implicit caches are still cleared.
+         *
+         * This could be either an intentional or unintentional bug caused by the need
+         * to be able to sometimes resurrect a many array during unload.
+         */
+        let cleared = true;
+        if (config.relType === 'hasMany' && !config.async && config.dirtyLocal) {
+          cleared = false;
+        }
+        await testFinalState(this, testState, config, { removed: true, cleared, implicitCleared: true }, assert);
+      });
+    }
+
+    TestScenarios.forEach(persistedDeletionTest);
+    TestScenarios.forEach(testConfig => {
+      const config = assign({}, testConfig, { name: `[Newly Created] ${testConfig.name}`, useCreate: true });
+      persistedDeletionTest(config);
+    });
+    TestScenarios.forEach(testConfig => {
+      const config = assign({}, testConfig, { name: `[LOCAL STATE] ${testConfig.name}`, dirtyLocal: true });
+      persistedDeletionTest(config);
+    });
+  });
+
+  module('Persisted Deletion + dematerialization of Record removes it from the graph and cleans up', function(hooks) {
+    function persistedDeletionUnloadedTest(config: TestConfig) {
+      test(config.name, async function(this: Context, assert) {
+        const testState = await setInitialState(this, config, assert);
+        const { john } = testState;
+
+        // now we delete
+        john.deleteRecord();
+        await john.save();
+        john.unloadRecord();
+
+        await settled();
+
+        await testFinalState(this, testState, config, { removed: true, cleared: true }, assert);
+      });
+    }
+
+    TestScenarios.forEach(persistedDeletionUnloadedTest);
+    TestScenarios.forEach(testConfig => {
+      const config = assign({}, testConfig, { name: `[Newly Created] ${testConfig.name}`, useCreate: true });
+      persistedDeletionUnloadedTest(config);
+    });
+    TestScenarios.forEach(testConfig => {
+      const config = assign({}, testConfig, { name: `[LOCAL STATE] ${testConfig.name}`, dirtyLocal: true });
+      persistedDeletionUnloadedTest(config);
+    });
+  });
+});

--- a/packages/record-data/tests/integration/graph/edge-removal/abstract-edge-removal-test.ts
+++ b/packages/record-data/tests/integration/graph/edge-removal/abstract-edge-removal-test.ts
@@ -1,10 +1,30 @@
 import { assign } from '@ember/polyfills';
 import settled from '@ember/test-helpers/settled';
 
-import { module, test } from 'qunit';
+import { module, test as runTest } from 'qunit';
 
 import { setInitialState, testFinalState } from './helpers';
 import { setupGraphTest } from './setup';
+
+/**
+ * qunit-console-grouper groups by test but includes setup/teardown
+ * and in-test as all one block. Adding this grouping allows us to
+ * clearly notice when a log came during the test vs during setup/teardown.
+ *
+ * We should upstream this behavior to qunit-console-grouper
+ */
+async function test(name: string, callback) {
+  const fn = async function(...args) {
+    console.groupCollapsed(name); // eslint-disable-line no-console
+    try {
+      await callback.call(this, ...args);
+    } finally {
+      console.groupEnd(); // eslint-disable-line no-console
+      console.log(`====(Begin Test Teardown)====`); // eslint-disable-line no-console
+    }
+  };
+  return runTest(name, fn);
+}
 
 type TestConfig = import('./helpers').TestConfig;
 type Context = import('./setup').Context;

--- a/packages/record-data/tests/integration/graph/edge-removal/helpers.ts
+++ b/packages/record-data/tests/integration/graph/edge-removal/helpers.ts
@@ -1,0 +1,401 @@
+import settled from '@ember/test-helpers/settled';
+
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import { recordIdentifierFor } from '@ember-data/store';
+
+import { stateOf } from './setup';
+
+type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
+type Relationship = import('@ember-data/record-data/-private').Relationship;
+
+type Context = import('./setup').Context;
+type UserRecord = import('./setup').UserRecord;
+
+export interface TestConfig {
+  /**
+   * name for the test
+   */
+  name: string;
+  /**
+   * whether the relationships should be async
+   */
+  async: boolean;
+  /**
+   * whether the relationships should use inverse: null
+   * which causes each side to have an implicit inverse
+   */
+  inverseNull: boolean;
+  /**
+   * whether the relationships should be belongsTo (1:1)
+   * or hasMany (many:many) in configuration.
+   */
+  relType: 'hasMany' | 'belongsTo';
+  /**
+   * By default both chris and john will be in a clean fully canonical
+   * state to start (default `false`).
+   *
+   * `true` will cause `john` to be created client side instead,
+   * which is useful for testing the outcome of `isNew` on relationship
+   * removal.
+   */
+  useCreate?: boolean;
+  /**
+   * By default both chris and john will be in a clean fully canonical
+   * state to start (default `false`).
+   *
+   * `true` will cause `john` to be added locally to `chris` and,
+   * `chris` to be added locally to `john`. E.g. both will have an
+   * empty remote state and a populated local state.
+   */
+  dirtyLocal?: boolean;
+  /**
+   * `unloadRecord` has some special semantics to account for on a clean record
+   */
+  isUnloadAsDelete?: boolean;
+}
+
+interface ExpectedTestOutcomes {
+  // whether the test expects `john` to have been removed from relationships
+  removed: boolean;
+  // whether the test expects the relationship cache for `john` to have been cleared
+  cleared: boolean;
+  // whether the test expects the implicit relationship cache for `john` to have been cleared, defaults to `cleared`
+  implicitCleared?: boolean;
+}
+
+/**
+ * Setup state and run initial assertions that are true for
+ * all tests in the group.
+ */
+interface TestState {
+  chris: UserRecord;
+  john: UserRecord;
+  chrisIdentifier: StableRecordIdentifier;
+  johnIdentifier: StableRecordIdentifier;
+  chrisInverseKey: string;
+  johnInverseKey: string;
+}
+
+export async function setInitialState(context: Context, config: TestConfig, assert): Promise<TestState> {
+  const { owner, store, graph } = context;
+  const { identifierCache } = store;
+  const isMany = config.relType === 'hasMany';
+
+  const relFn = isMany ? hasMany : belongsTo;
+  const relConfig = {
+    async: config.async,
+    inverse: config.inverseNull ? null : 'bestFriends',
+  };
+
+  class User extends Model {
+    @attr name;
+    @relFn('user', relConfig) bestFriends;
+  }
+  owner.register('model:user', User);
+
+  function makeRel(id: string | null): any {
+    let ref = { type: 'user', id };
+    const data = isMany ? (id === null ? [] : [ref]) : id === null ? null : ref;
+
+    return { bestFriends: { data } };
+  }
+
+  let chris, john, johnIdentifier;
+  if (!config.useCreate) {
+    const data = {
+      data: [
+        {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Chris' },
+          relationships: makeRel(config.dirtyLocal ? null : '2'),
+        },
+        {
+          type: 'user',
+          id: '2',
+          attributes: { name: 'John' },
+          relationships: makeRel(config.dirtyLocal ? null : '1'),
+        },
+      ],
+    };
+
+    [chris, john] = store.push(data);
+    johnIdentifier = identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '2' });
+  } else {
+    chris = store.push({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Chris' },
+      },
+    });
+    john = store.createRecord('user', { name: 'John', bestFriends: isMany ? [chris] : chris });
+    johnIdentifier = recordIdentifierFor(john);
+  }
+
+  if (config.dirtyLocal) {
+    if (isMany) {
+      let friends = await john.bestFriends;
+      friends.pushObject(chris);
+      friends = await chris.bestFriends;
+      friends.pushObject(john);
+    } else {
+      john.bestFriends = chris;
+      chris.bestFriends = john;
+    }
+  }
+
+  await settled();
+
+  const chrisIdentifier = identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+  const chrisBestFriend = graph.get(chrisIdentifier).get('bestFriends');
+  const johnBestFriend = graph.get(johnIdentifier).get('bestFriends');
+
+  // pre-conds
+  assert.strictEqual(chris.name, 'Chris', 'PreCond: We have chris');
+  assert.strictEqual(john.name, 'John', 'PreCond: We have john');
+  assert.false(chris.isDeleted, 'PreCond: Chris is not deleted');
+  assert.false(john.isDeleted, 'PreCond: John is not deleted');
+
+  const chrisState = stateOf(chrisBestFriend);
+  const johnState = stateOf(johnBestFriend);
+
+  assert.deepEqual(
+    chrisState.remote,
+    config.dirtyLocal || config.useCreate ? [] : [johnIdentifier],
+    config.dirtyLocal || config.useCreate
+      ? 'PreCond: Chris has no best friend (remote)'
+      : 'PreCond: Chris has John as a best friend (remote)'
+  );
+  assert.deepEqual(
+    chrisState.local,
+    config.useCreate && config.inverseNull ? [] : [johnIdentifier],
+    config.useCreate && config.inverseNull
+      ? 'PreCond: Chris has no best friend (local)'
+      : 'PreCond: Chris has John as a best friend (local)'
+  );
+  assert.deepEqual(
+    johnState.remote,
+    config.dirtyLocal || config.useCreate ? [] : [chrisIdentifier],
+    config.dirtyLocal || config.useCreate
+      ? 'PreCond: John has no best friend (remote)'
+      : 'PreCond: John has Chris as a best friend (remote)'
+  );
+  assert.deepEqual(johnState.local, [chrisIdentifier], 'PreCond: John has Chris as a best friend (local)');
+
+  if (config.inverseNull) {
+    const chrisImplicits = graph.getImplicit(chrisIdentifier);
+    const johnImplicits = graph.getImplicit(johnIdentifier);
+
+    assert.strictEqual(Object.keys(chrisImplicits).length, 1, 'PreCond: Chris has one implicit relationship');
+
+    const chrisImplicitFriend = chrisImplicits[chrisBestFriend.inverseKey] as Relationship;
+    const johnImplicitFriend = johnImplicits[johnBestFriend.inverseKey] as Relationship;
+
+    assert.ok(chrisImplicitFriend, 'PreCond: Chris has an implicit best friend');
+
+    const chrisImplicitState = stateOf(chrisImplicitFriend);
+
+    assert.deepEqual(
+      chrisImplicitState.remote,
+      config.dirtyLocal || config.useCreate ? [] : [johnIdentifier],
+      config.dirtyLocal || config.useCreate
+        ? 'PreCond: Chris has no implicit best friend (remote)'
+        : 'PreCond: Chris has John as an implicit best friend (remote)'
+    );
+    assert.deepEqual(
+      chrisImplicitState.local,
+      [johnIdentifier],
+      'PreCond: Chris has John as an implicit best friend (local)'
+    );
+
+    // implicits on john are managed by chris, so with inverseNull
+    // the implicit on john will be empty since chris should have no state.
+    if (config.useCreate) {
+      assert.strictEqual(Object.keys(johnImplicits).length, 0, 'PreCond: John has no implicit relationship');
+      assert.notOk(johnImplicitFriend, 'PreCond: John has no implicit best friend');
+    } else {
+      assert.strictEqual(Object.keys(johnImplicits).length, 1, 'PreCond: John has one implicit relationship');
+      assert.ok(johnImplicitFriend, 'PreCond: John has no implicit best friend');
+      const johnImplicitState = stateOf(johnImplicitFriend);
+      assert.deepEqual(
+        johnImplicitState.remote,
+        config.dirtyLocal || config.useCreate ? [] : [chrisIdentifier],
+        config.dirtyLocal || config.useCreate
+          ? 'PreCond: John has no implicit best friend (remote)'
+          : 'PreCond: John has Chris as an implicit best friend (remote)'
+      );
+      assert.deepEqual(
+        johnImplicitState.local,
+        config.useCreate ? [] : [chrisIdentifier],
+        config.useCreate
+          ? 'PreCond: John has no implicit best friend (local)'
+          : 'PreCond: John has Chris as an implicit best friend (local)'
+      );
+    }
+  } else {
+    assert.false(graph.implicit.has(chrisIdentifier), 'PreCond: no implicits for chris');
+    assert.false(graph.implicit.has(johnIdentifier), 'PreCond: no implicits for john');
+  }
+
+  return {
+    chris,
+    john,
+    chrisIdentifier,
+    johnIdentifier,
+    chrisInverseKey: chrisBestFriend.inverseKey,
+    johnInverseKey: johnBestFriend.inverseKey,
+  };
+}
+
+export async function testFinalState(
+  context: Context,
+  testState: TestState,
+  config: TestConfig,
+  statuses: ExpectedTestOutcomes,
+  assert
+) {
+  const { graph } = context;
+  const { chrisIdentifier, johnIdentifier } = testState;
+
+  const chrisBestFriend = graph.get(chrisIdentifier).get('bestFriends');
+  const chrisState = stateOf(chrisBestFriend);
+
+  // this one specific case gets it's own WAT
+  // this is something ideally a refactor should do away with.
+  const isUnloadOfImplictAsyncHasManyWithLocalChange =
+    config.isUnloadAsDelete && config.dirtyLocal && config.async && config.relType === 'hasMany' && config.inverseNull;
+
+  // related to above another WAT that refactor should cleanup
+  // in this case we don't care if sync/async
+  const isUnloadOfImplictHasManyWithLocalChange =
+    config.isUnloadAsDelete && config.dirtyLocal && config.relType === 'hasMany' && config.inverseNull;
+
+  // in the dirtyLocal and useCreate case there is no remote data
+  const chrisRemoteRemoved = config.dirtyLocal || config.useCreate || statuses.removed;
+  const chrisLocalRemoved = statuses.removed && !isUnloadOfImplictAsyncHasManyWithLocalChange;
+
+  // for the isUnloadAsDelete case we don't remove unless dirtyLocal or useCreate
+  // this may be a bug but likely is related to retaining info for rematerialization.
+  // as the RecordData is in an empty state but not destroyed.
+  const johnRemoteRemoved = config.dirtyLocal || config.useCreate || (!config.isUnloadAsDelete && statuses.removed);
+  const johnLocalRemoved = !config.isUnloadAsDelete && statuses.removed;
+  const johnCleared = statuses.cleared || isUnloadOfImplictHasManyWithLocalChange;
+
+  const _removed = config.isUnloadAsDelete ? statuses.cleared && statuses.removed : statuses.removed;
+  // in the dirtyLocal and useCreate case there is no remote data
+  const chrisImplicitRemoteRemoved = config.dirtyLocal || config.useCreate || _removed;
+  const chrisImplicitLocalRemoved = _removed || isUnloadOfImplictHasManyWithLocalChange;
+  const johnImplicitsCleared = statuses.implicitCleared || statuses.cleared;
+  // in the dirtyLocal and useCreate case there is no remote data
+  const johnImplicitRemoteRemoved = config.dirtyLocal || config.useCreate || statuses.removed;
+  const johnImplicitLocalRemoved = statuses.removed;
+
+  const OUTCOMES = {
+    chrisRemoteRemoved,
+    chrisLocalRemoved,
+    johnCleared,
+    johnRemoteRemoved,
+    johnLocalRemoved,
+    chrisImplicitRemoteRemoved,
+    chrisImplicitLocalRemoved,
+    johnImplicitsCleared,
+    johnImplicitRemoteRemoved,
+    johnImplicitLocalRemoved,
+  };
+
+  assert.deepEqual(
+    chrisState.remote,
+    OUTCOMES.chrisRemoteRemoved ? [] : [johnIdentifier],
+    OUTCOMES.chrisRemoteRemoved
+      ? 'Result: Chris has no best friend (remote)'
+      : 'Result: Chris has John as a best friend (remote)'
+  );
+  assert.deepEqual(
+    chrisState.local,
+    OUTCOMES.chrisLocalRemoved ? [] : [johnIdentifier],
+    OUTCOMES.chrisLocalRemoved
+      ? 'Result: Chris has no best friend (local)'
+      : 'Result: Chris has John as a best friend (local)'
+  );
+
+  if (OUTCOMES.johnCleared) {
+    assert.false(graph.identifiers.has(johnIdentifier), 'Result: Relationships for John were cleared from the cache');
+  } else {
+    const johnBestFriend = graph.get(johnIdentifier).get('bestFriends');
+    const johnState = stateOf(johnBestFriend);
+
+    assert.deepEqual(
+      johnState.remote,
+      OUTCOMES.johnRemoteRemoved ? [] : [chrisIdentifier],
+      OUTCOMES.johnRemoteRemoved
+        ? 'Result: John has no best friend (remote)'
+        : 'Result: John has Chris as a best friend (remote)'
+    );
+    assert.deepEqual(
+      johnState.local,
+      OUTCOMES.johnLocalRemoved ? [] : [chrisIdentifier],
+      OUTCOMES.johnLocalRemoved
+        ? 'Result: John has no best friend (local)'
+        : 'Result: John has Chris as a best friend (local)'
+    );
+  }
+
+  if (config.inverseNull) {
+    const chrisImplicits = graph.getImplicit(chrisIdentifier);
+
+    assert.strictEqual(Object.keys(chrisImplicits).length, 1, 'Result: Chris has one implicit relationship key');
+
+    const chrisImplicitFriend = chrisImplicits[testState.chrisInverseKey] as Relationship;
+
+    assert.ok(chrisImplicitFriend, 'Result: Chris has an implicit relationship for best friend');
+    const chrisImplicitState = stateOf(chrisImplicitFriend);
+
+    assert.deepEqual(
+      chrisImplicitState.remote,
+      OUTCOMES.chrisImplicitRemoteRemoved ? [] : [johnIdentifier],
+      OUTCOMES.chrisImplicitRemoteRemoved
+        ? 'Result: Chris has no implicit best friend (remote)'
+        : 'Result: John implicitly has Chris as a best friend (remote)'
+    );
+    assert.deepEqual(
+      chrisImplicitState.local,
+      OUTCOMES.chrisImplicitLocalRemoved ? [] : [johnIdentifier],
+      OUTCOMES.chrisImplicitLocalRemoved
+        ? 'Result: Chris has no implicit best friend (local)'
+        : 'Result: John implicitly has Chris as a best friend (local)'
+    );
+
+    if (OUTCOMES.johnImplicitsCleared) {
+      assert.false(graph.implicit.has(johnIdentifier), 'implicit cache for john has been removed');
+    } else {
+      const johnImplicits = graph.getImplicit(johnIdentifier);
+      const johnImplicitFriend = johnImplicits[testState.johnInverseKey] as Relationship;
+      assert.strictEqual(
+        Object.keys(johnImplicits).length,
+        1,
+        'Result: John has one implicit relationship in the cache'
+      );
+      assert.ok(johnImplicitFriend, 'Result: John has an implicit key for best friend');
+      const johnImplicitState = stateOf(johnImplicitFriend);
+
+      assert.deepEqual(
+        johnImplicitState.remote,
+        OUTCOMES.johnImplicitRemoteRemoved ? [] : [chrisIdentifier],
+        OUTCOMES.johnImplicitRemoteRemoved
+          ? 'Result: John has no implicit best friend (remote)'
+          : 'Result: Chris implicitly has John as a best friend (remote)'
+      );
+      assert.deepEqual(
+        johnImplicitState.local,
+        OUTCOMES.johnImplicitLocalRemoved ? [] : [chrisIdentifier],
+        OUTCOMES.johnImplicitLocalRemoved
+          ? 'Result: John has no implicit best friend (local)'
+          : 'Result: Chris implicitly has John as a best friend (local)'
+      );
+    }
+  } else {
+    assert.false(graph.implicit.has(chrisIdentifier), 'Result: no implicits for chris');
+    assert.false(graph.implicit.has(johnIdentifier), 'Result: no implicits for john');
+  }
+}

--- a/packages/record-data/tests/integration/graph/edge-removal/helpers.ts
+++ b/packages/record-data/tests/integration/graph/edge-removal/helpers.ts
@@ -261,7 +261,7 @@ export async function testFinalState(
   const chrisBestFriend = graph.get(chrisIdentifier).get('bestFriends');
   const chrisState = stateOf(chrisBestFriend);
 
-  // this one specific case gets it's own WAT
+  // this specific case gets it's own WAT
   // this is something ideally a refactor should do away with.
   const isUnloadOfImplictAsyncHasManyWithLocalChange =
     config.isUnloadAsDelete && config.dirtyLocal && config.async && config.relType === 'hasMany' && config.inverseNull;
@@ -270,6 +270,10 @@ export async function testFinalState(
   // in this case we don't care if sync/async
   const isUnloadOfImplictHasManyWithLocalChange =
     config.isUnloadAsDelete && config.dirtyLocal && config.relType === 'hasMany' && config.inverseNull;
+
+  // a final WAT likely related to the first two, persisted delete w/o unload of
+  // a sync hasMany with local changes is not cleared. This final WAT is handled
+  // within the abstract-edge-removal-test configuration.
 
   // in the dirtyLocal and useCreate case there is no remote data
   const chrisRemoteRemoved = config.dirtyLocal || config.useCreate || statuses.removed;

--- a/packages/record-data/tests/integration/graph/edge-removal/setup.ts
+++ b/packages/record-data/tests/integration/graph/edge-removal/setup.ts
@@ -1,0 +1,145 @@
+import { setupTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
+
+import Store from '@ember-data/store';
+import { recordDataFor } from '@ember-data/store/-private';
+import { DSModel } from '@ember-data/store/-private/ts-interfaces/ds-model';
+
+type CollectionResourceDocument = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').CollectionResourceDocument;
+type EmptyResourceDocument = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').EmptyResourceDocument;
+type JsonApiDocument = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').JsonApiDocument;
+type SingleResourceDocument = import('@ember-data/store/-private/ts-interfaces/ember-data-json-api').SingleResourceDocument;
+
+type BelongsToRelationship = import('@ember-data/record-data/-private').BelongsToRelationship;
+
+type RecordData = import('@ember-data/record-data/-private').RecordData;
+
+type CoreStore = import('@ember-data/store/-private/system/core-store').default;
+
+type Dict<T> = import('@ember-data/store/-private/ts-interfaces/utils').Dict<T>;
+type Relationship = import('@ember-data/record-data/-private').Relationship;
+
+type Relationships = import('@ember-data/record-data/-private/relationships/state/create').default;
+type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
+
+class AbstractMap {
+  constructor(private store: CoreStore, private prop: string) {}
+
+  has(identifier: StableRecordIdentifier) {
+    let recordData = recordDataFor(identifier) as RecordData;
+    // debugger;
+    return !!recordData && !!recordData[this.prop];
+  }
+}
+
+class AbstractGraph {
+  public identifiers: AbstractMap;
+  public implicit: AbstractMap;
+  private cachedRelationships: WeakMap<StableRecordIdentifier, Relationships>;
+  private cachedImplicits: WeakMap<StableRecordIdentifier, Dict<Relationship>>;
+
+  constructor(private store: CoreStore) {
+    this.identifiers = new AbstractMap(store, '__relationships');
+    this.implicit = new AbstractMap(store, '__implicitRelationships');
+    this.cachedRelationships = new WeakMap();
+    this.cachedImplicits = new WeakMap();
+  }
+
+  get(identifier: StableRecordIdentifier): Relationships {
+    const recordData = recordDataFor(identifier) as RecordData;
+    // avoid re-materializing the relationship state cache
+    if (!recordData || !recordData.__relationships) {
+      let relationships = this.cachedRelationships.get(identifier);
+      if (relationships) {
+        throw new Error(`accessed destroyed relationships within graph`);
+      }
+    }
+    let relationships = recordData._relationships;
+    this.cachedRelationships.set(identifier, relationships);
+    return relationships;
+  }
+
+  getImplicit(identifier: StableRecordIdentifier): Dict<Relationship> {
+    const recordData = recordDataFor(identifier) as RecordData;
+    // avoid re-materializing the relationship state cache
+    if (!recordData || !recordData.__implicitRelationships) {
+      let relationships = this.cachedImplicits.get(identifier);
+      if (relationships) {
+        throw new Error(`accessed destroyed implicit relationships within graph`);
+      }
+    }
+    let relationships = recordData._implicitRelationships;
+    this.cachedImplicits.set(identifier, relationships);
+    return relationships;
+  }
+}
+
+function graphForTest(store: CoreStore) {
+  return new AbstractGraph(store);
+}
+
+function isBelongsTo(rel: Relationship): rel is BelongsToRelationship {
+  return rel.kind === 'belongsTo';
+}
+
+export function stateOf(rel: Relationship) {
+  let local, remote;
+  if (isBelongsTo(rel)) {
+    // we cast these to array form to make the tests more legible
+    local = rel.inverseRecordData && rel.inverseRecordData.identifier ? [rel.inverseRecordData.identifier] : [];
+    remote = rel.canonicalState && rel.canonicalState.identifier ? [rel.canonicalState.identifier] : [];
+  } else {
+    local = rel.members.list.map(m => (m ? m.identifier : null));
+    remote = rel.canonicalMembers.list.map(m => (m ? m.identifier : null));
+  }
+  return {
+    local,
+    remote,
+  };
+}
+
+class Adapter {
+  static create() {
+    return new this();
+  }
+  async deleteRecord() {
+    return { data: null };
+  }
+}
+class Serializer {
+  static create() {
+    return new this();
+  }
+  normalizeResponse(_, __, data) {
+    return data;
+  }
+}
+
+export interface UserRecord extends DSModel {
+  name?: string;
+  bestFriend?: UserRecord;
+  bestFriends?: UserRecord[];
+}
+
+export interface Context extends TestContext {
+  store: TestStore<UserRecord>;
+  graph: AbstractGraph;
+}
+
+interface TestStore<T> extends CoreStore {
+  push(data: EmptyResourceDocument): null;
+  push(data: SingleResourceDocument): T;
+  push(data: CollectionResourceDocument): T[];
+  push(data: JsonApiDocument): T | T[] | null;
+}
+
+export function setupGraphTest(hooks) {
+  setupTest(hooks);
+  hooks.beforeEach(function(this: Context) {
+    this.owner.register('service:store', Store);
+    this.owner.register('adapter:application', Adapter);
+    this.owner.register('serializer:application', Serializer);
+    this.store = this.owner.lookup('service:store');
+    this.graph = graphForTest(this.store);
+  });
+}

--- a/packages/store/addon/-private/index.ts
+++ b/packages/store/addon/-private/index.ts
@@ -36,7 +36,7 @@ export { default as diffArray } from './system/diff-array';
 export { default as SnapshotRecordArray } from './system/snapshot-record-array';
 
 // New
-export { default as recordDataFor } from './system/record-data-for';
+export { default as recordDataFor, removeRecordDataFor } from './system/record-data-for';
 export { default as RecordDataStoreWrapper } from './system/store/record-data-store-wrapper';
 export { upgradeForInternal } from './system/ts-upgrade-map';
 export { _bind, _guard, _objectIsAlive, guardDestroyedStore } from './system/store/common';

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -53,7 +53,7 @@ import { getShimClass } from './model/shim-model-class';
 import normalizeModelName from './normalize-model-name';
 import { promiseArray, promiseObject } from './promise-proxies';
 import RecordArrayManager from './record-array-manager';
-import recordDataFor from './record-data-for';
+import { setRecordDataFor } from './record-data-for';
 import NotificationManager from './record-notification-manager';
 import { RecordReference } from './references';
 import { RequestPromise } from './request-cache';
@@ -3157,7 +3157,9 @@ abstract class CoreStore extends Service {
    * @internal
    */
   _createRecordData(identifier: StableRecordIdentifier): RecordData {
-    return this.createRecordDataFor(identifier.type, identifier.id, identifier.lid, this._storeWrapper);
+    const recordData = this.createRecordDataFor(identifier.type, identifier.id, identifier.lid, this._storeWrapper);
+    setRecordDataFor(identifier, recordData);
+    return recordData;
   }
 
   /**
@@ -3217,7 +3219,7 @@ abstract class CoreStore extends Service {
       internalModel = internalModelFactoryFor(this).lookup(identifier as StableRecordIdentifier);
     }
 
-    return recordDataFor(internalModel);
+    return internalModel._recordData;
   }
 
   /**

--- a/packages/store/addon/-private/ts-interfaces/ds-model.ts
+++ b/packages/store/addon/-private/ts-interfaces/ds-model.ts
@@ -16,6 +16,9 @@ export interface DSModel extends RecordInstance, EmberObject {
   eachAttribute<T>(callback: (this: T, key: string, meta: AttributeSchema) => void, binding?: T): void;
   invalidErrorsChanged(errors: JsonApiValidationError[]): void;
   [key: string]: unknown;
+  isDeleted: boolean;
+  deleteRecord(): void;
+  unloadRecord(): void;
 }
 
 // Implemented by both ShimModelClass and DSModel

--- a/yarn.lock
+++ b/yarn.lock
@@ -7493,6 +7493,10 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+"eslint-plugin-ember-data@link:./packages/unpublished-eslint-rules":
+  version "0.0.0"
+  uid ""
+
 eslint-plugin-ember@^10.3.0:
   version "10.3.0"
   resolved "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-10.3.0.tgz#2e53ad334dc7f7f66f6cba890b9c01a64817d1c1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7493,10 +7493,6 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-"eslint-plugin-ember-data@link:./packages/unpublished-eslint-rules":
-  version "0.0.0"
-  uid ""
-
 eslint-plugin-ember@^10.3.0:
   version "10.3.0"
   resolved "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-10.3.0.tgz#2e53ad334dc7f7f66f6cba890b9c01a64817d1c1"
@@ -12752,6 +12748,13 @@ quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
     mktemp "~0.4.0"
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
+
+qunit-console-grouper@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/qunit-console-grouper/-/qunit-console-grouper-0.3.0.tgz#6b13de524fdb080af9519ca30d428d1c1d815f4a"
+  integrity sha512-uHg5kcjyEGX85Rh9mimWoXsqeGmJZxfNLqmVxA5O2xJW+JAlQ0r0JFA07lHqlOQcegs5CAhvioKUXpjicDra6g==
+  dependencies:
+    broccoli-funnel "^3.0.3"
 
 qunit-dom@^1.2.0:
   version "1.6.0"


### PR DESCRIPTION
While refactoring the relationship layer in #7470 I noticed that some of the changes I was making did not fail very many tests despite altering semantics of the relationship layer we ought to have been aware of changes happening to.

This adds test coverage to the relationship cache to a wide range of scenarios. I've written the tests in a way where the underlying implementation can be easily swapped out with only minor alterations to how the tests in the test suite gain access to the cache data. This will let us more easily spot semantics changes and evaluate if that change is a regression or improvement.

The test matrix for the graph covers 96 unique situations around what happens when a record is either `unloaded/deleted/deleted+persisted/deleted+persisted+unloaded` from a `clean/dirty/new` state for `1:1 / many:many / 1:1(implicit) / many:many(implicit)` for both the `sync` and `async` cases.

The semantics it covers are at times implementation dependent, but the idea is that we should know when we've changed them.

Asset size increase is because I needed to port the coming additions to `recordDataFor` in order to enable peeking a recordData. In the process this surfaced a bug with our current `recordData` destroy calls that may require amending the v2 RecordData RFC as I do not believe it currently has a sufficient destroy lifecycle hook. More investigation needed.

**Fixed** ~~The failure for the `model-fragments` external partner test is because master is currently failing for that test. A backwards compatible fix has been submitted to that library, see note here: https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/396~~