### PR TITLE
[ON_HOLD] feat: add additional state-machine states to handle unload/loading edge cases

### DIFF
--- a/packages/-ember-data/tests/integration/records/load-test.js
+++ b/packages/-ember-data/tests/integration/records/load-test.js
@@ -9,7 +9,6 @@ import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import Model, { attr, belongsTo } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import Store from '@ember-data/store';
-import todo from '@ember-data/unpublished-test-infra/test-support/todo';
 
 class Person extends Model {
   @attr()
@@ -45,7 +44,7 @@ module('integration/load - Loading Records', function(hooks) {
     });
   });
 
-  todo('Empty records remain in the empty state while data is being fetched', async function(assert) {
+  test('Empty records remain in the empty state while data is being fetched', async function(assert) {
     let payloads = [
       {
         data: {
@@ -123,23 +122,23 @@ module('integration/load - Loading Records', function(hooks) {
     let internalModel = store._internalModelForId('person', '1');
 
     // test that our initial state is correct
-    assert.equal(internalModel.currentState.isEmpty, true, 'We begin in the empty state');
-    assert.equal(internalModel.currentState.isLoading, false, 'We have not triggered a load');
-    assert.equal(internalModel.isReloading, false, 'We are not reloading');
+    assert.true(internalModel.currentState.isEmpty, 'We begin in the empty state');
+    assert.false(internalModel.currentState.isLoading, 'We have not triggered a load');
+    assert.false(internalModel.isReloading, 'We are not reloading');
 
     let recordPromise = store.findRecord('person', '1');
 
     // test that during the initial load our state is correct
-    assert.todo.equal(internalModel.currentState.isEmpty, true, 'awaiting first fetch: We remain in the empty state');
-    assert.equal(internalModel.currentState.isLoading, true, 'awaiting first fetch: We have now triggered a load');
-    assert.equal(internalModel.isReloading, false, 'awaiting first fetch: We are not reloading');
+    assert.true(internalModel.currentState.isEmpty, 'awaiting first fetch: We remain in the empty state');
+    assert.true(internalModel.currentState.isLoading, 'awaiting first fetch: We have now triggered a load');
+    assert.false(internalModel.isReloading, 'awaiting first fetch: We are not reloading');
 
     let record = await recordPromise;
 
     // test that after the initial load our state is correct
-    assert.equal(internalModel.currentState.isEmpty, false, 'after first fetch: We are no longer empty');
-    assert.equal(internalModel.currentState.isLoading, false, 'after first fetch: We have loaded');
-    assert.equal(internalModel.isReloading, false, 'after first fetch: We are not reloading');
+    assert.false(internalModel.currentState.isEmpty, 'after first fetch: We are no longer empty');
+    assert.false(internalModel.currentState.isLoading, 'after first fetch: We have loaded');
+    assert.false(internalModel.isReloading, 'after first fetch: We are not reloading');
 
     let bestFriend = await record.get('bestFriend');
     let trueBestFriend = await bestFriend.get('bestFriend');
@@ -155,37 +154,97 @@ module('integration/load - Loading Records', function(hooks) {
     recordPromise = record.reload();
 
     // test that during a reload our state is correct
-    assert.equal(internalModel.currentState.isEmpty, false, 'awaiting reload: We remain non-empty');
-    assert.equal(internalModel.currentState.isLoading, false, 'awaiting reload: We are not loading again');
-    assert.equal(internalModel.isReloading, true, 'awaiting reload: We are reloading');
+    assert.false(internalModel.currentState.isEmpty, 'awaiting reload: We remain non-empty');
+    assert.false(internalModel.currentState.isLoading, 'awaiting reload: We are not loading again');
+    assert.true(internalModel.isReloading, 'awaiting reload: We are reloading');
 
     await recordPromise;
 
     // test that after a reload our state is correct
-    assert.equal(internalModel.currentState.isEmpty, false, 'after reload: We remain non-empty');
-    assert.equal(internalModel.currentState.isLoading, false, 'after reload: We have loaded');
-    assert.equal(internalModel.isReloading, false, 'after reload:: We are not reloading');
+    assert.false(internalModel.currentState.isEmpty, 'after reload: We remain non-empty');
+    assert.false(internalModel.currentState.isLoading, 'after reload: We have loaded');
+    assert.false(internalModel.isReloading, 'after reload:: We are not reloading');
 
     run(() => record.unloadRecord());
 
     // test that after an unload our state is correct
-    assert.equal(internalModel.currentState.isEmpty, true, 'after unload: We are empty again');
-    assert.equal(internalModel.currentState.isLoading, false, 'after unload: We are not loading');
-    assert.equal(internalModel.isReloading, false, 'after unload:: We are not reloading');
+    assert.true(internalModel.currentState.isEmpty, 'after unload: We are empty again');
+    assert.false(internalModel.currentState.isLoading, 'after unload: We are not loading');
+    assert.false(internalModel.isReloading, 'after unload:: We are not reloading');
 
     recordPromise = store.findRecord('person', '1');
 
     // test that during a reload-due-to-unload our state is correct
     //   This requires a retainer (the async bestFriend relationship)
-    assert.todo.equal(internalModel.currentState.isEmpty, true, 'awaiting second find: We remain empty');
-    assert.equal(internalModel.currentState.isLoading, true, 'awaiting second find: We are loading again');
-    assert.equal(internalModel.isReloading, false, 'awaiting second find: We are not reloading');
+    assert.true(internalModel.currentState.isEmpty, 'awaiting second find: We remain empty');
+    assert.true(internalModel.currentState.isLoading, 'awaiting second find: We are loading again');
+    assert.false(internalModel.isReloading, 'awaiting second find: We are not reloading');
 
     await recordPromise;
 
     // test that after the reload-due-to-unload our state is correct
-    assert.equal(internalModel.currentState.isEmpty, false, 'after second find: We are no longer empty');
-    assert.equal(internalModel.currentState.isLoading, false, 'after second find: We have loaded');
-    assert.equal(internalModel.isReloading, false, 'after second find: We are not reloading');
+    assert.false(internalModel.currentState.isEmpty, 'after second find: We are no longer empty');
+    assert.false(internalModel.currentState.isLoading, 'after second find: We have loaded');
+    assert.false(internalModel.isReloading, 'after second find: We are not reloading');
+  });
+
+  test('Preloaded records do not remain in the empty state while data is being fetched', async function(assert) {
+    let payloads = [
+      {
+        data: {
+          type: 'person',
+          id: '1',
+          attributes: { name: 'Chris' },
+          relationships: {},
+        },
+        included: [],
+      },
+    ];
+
+    this.owner.register(
+      'adapter:application',
+      JSONAPIAdapter.extend({
+        findRecord() {
+          let payload = payloads.shift();
+
+          if (payload === undefined) {
+            return reject(new Error('Invalid Request'));
+          }
+
+          return resolve(payload);
+        },
+      })
+    );
+    this.owner.register(
+      'serializer:application',
+      JSONAPISerializer.extend({
+        normalizeResponse(_, __, data) {
+          return data;
+        },
+      })
+    );
+
+    let internalModel = store._internalModelForId('person', '1');
+
+    // test that our initial state is correct
+    assert.true(internalModel.currentState.isEmpty, 'We begin in the empty state');
+    assert.false(internalModel.currentState.isLoading, 'We have not triggered a load');
+    assert.false(internalModel.isReloading, 'We are not reloading');
+
+    let recordPromise = store.findRecord('person', '1', { preload: { name: 'Chris' } });
+
+    // test that during the initial load our state is correct
+    assert.false(internalModel.currentState.isEmpty, 'awaiting first fetch: We are no longer in the empty state');
+    assert.true(internalModel.currentState.isPreloaded, 'awaiting first fetch: We are in a preloaded state');
+    assert.true(internalModel.currentState.isLoading, 'awaiting first fetch: We have now triggered a load');
+    assert.false(internalModel.isReloading, 'awaiting first fetch: We are not reloading');
+
+    await recordPromise;
+
+    // test that after the initial load our state is correct
+    assert.false(internalModel.currentState.isEmpty, 'after first fetch: We are no longer empty');
+    assert.false(internalModel.currentState.isPreloaded, 'awaiting first fetch: We are no longer in a preloaded state');
+    assert.false(internalModel.currentState.isLoading, 'after first fetch: We have loaded');
+    assert.false(internalModel.isReloading, 'after first fetch: We are not reloading');
   });
 });

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -2569,7 +2569,7 @@ abstract class CoreStore extends Service {
           operation = 'updateRecord';
         }
       } else {
-        if (internalModel.currentState.stateName === 'root.deleted.saved') {
+        if (internalModel.currentState.stateName.indexOf('root.deleted.saved') === 0) {
           resolver.resolve();
           continue;
         } else if (internalModel.isNew()) {
@@ -2698,9 +2698,9 @@ abstract class CoreStore extends Service {
     let internalModel = internalModelFactoryFor(this).lookup(resource, data);
 
     // store.push will be from empty
-    // findRecord will be from root.loading
+    // findRecord will be from root.loading.{empty,preloaded}
     // all else will be updates
-    const isLoading = internalModel.currentState.stateName === 'root.loading';
+    const isLoading = internalModel.currentState.stateName.indexOf('root.loading') === 0;
     const isUpdate = internalModel.currentState.isEmpty === false && !isLoading;
 
     // exclude store.push (root.empty) case

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -416,7 +416,7 @@ const updatedState = dirtyState({
 });
 
 function createdStateDeleteRecord(internalModel) {
-  internalModel.transitionTo('deleted.saved');
+  internalModel.transitionTo('deleted.saved.new');
   internalModel.send('invokeLifecycleCallbacks');
 }
 
@@ -469,6 +469,7 @@ const RootState = {
   isDeleted: false,
   isNew: false,
   isValid: true,
+  isPreloaded: false,
 
   // DEFAULT EVENTS
 
@@ -491,12 +492,21 @@ const RootState = {
   empty: {
     isEmpty: true,
 
+    deleted: {
+      isDeleted: true,
+    },
+
+    preloaded: {
+      isPreloaded: true,
+    },
+
     // EVENTS
     loadingData(internalModel, promise) {
       if (!REQUEST_SERVICE) {
         internalModel._promiseProxy = promise;
       }
-      internalModel.transitionTo('loading');
+      // internalModel.transitionTo('loading');
+      internalModel.transitionTo(this.isPreloaded ? 'loading.preloaded' : 'loading.empty');
     },
 
     loadedData(internalModel) {
@@ -527,6 +537,14 @@ const RootState = {
 
     exit(internalModel) {
       internalModel._promiseProxy = null;
+    },
+
+    empty: {
+      isEmpty: true,
+    },
+
+    preloaded: {
+      isPreloaded: true,
     },
 
     loadingData() {},
@@ -697,8 +715,12 @@ const RootState = {
       // FLAGS
       isDirty: false,
 
+      new: {
+        isNew: true,
+      },
+
       setup(internalModel) {
-        internalModel.removeFromInverseRelationships();
+        internalModel.removeFromInverseRelationships(internalModel.currentState.isNew);
       },
 
       invokeLifecycleCallbacks(internalModel) {


### PR DESCRIPTION
resolves https://github.com/emberjs/rfcs/issues/358
resolves https://github.com/emberjs/rfcs/issues/359

While working on #7470 and #7471 I noticed that we don't properly inform RecordData today whether the teardown of relationships is occurring for a new record or not. This is primarily because the context is lost. It's also currently impossible to tell internally if an empty record is empty because it was unloaded after a persisted deletion, has never been fetched, or has been unloaded but retained. This resolves this which will allow us to do nicer things internally in many locations.

We may desire to RFC these, though in most ways this is additive backfill to fix existing bugs with the state machine. It's unclear whether new substates which result in new `currentState.stateName` strings require RFC or not.

I scanned ember-observer and no actively maintained addons will be affected (two that were never published and haven't been touched in years would have had a marginal migration to make).