### PR TITLE
ci: skip model-fragments until fixed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -315,6 +315,8 @@ jobs:
             continue-on-error: true
           - partner: travis-web
             continue-on-error: true
+          - partner: model-fragments
+            continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta


### PR DESCRIPTION
cc @patocallaghan this is potentially related to https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/393

I'll unskip model-fragments once I've gotten a fix in place, but initial investigation suggested the fix needed to be upstream.