### PR TITLE
[ON_HOLD] feat: custom decorators

### DIFF
--- a/packages/-ember-data/tests/integration/relationships/one-to-one-test.js
+++ b/packages/-ember-data/tests/integration/relationships/one-to-one-test.js
@@ -1,3 +1,4 @@
+import { set } from '@ember/object';
 import { run } from '@ember/runloop';
 
 import { module, test } from 'qunit';
@@ -583,7 +584,8 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
 
     assert.expectAssertion(function() {
       run(function() {
-        stanley.set('bestFriend', resolve(igor));
+        // stanley.set('bestFriend', resolve(igor));
+        set(stanley, 'bestFriend', resolve(igor));
       });
     }, /You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo or hasMany relationship to the get call./);
   });

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -772,7 +772,6 @@ module('unit/model - Model', function(hooks) {
           [prop]: DSattr('string'),
           name: DSattr('string'),
         });
-        this.owner.register('model:native-post', NativePost);
         this.owner.register('model:legacy-post', LegacyPost);
 
         const msg = `'${prop}' is a reserved property name on instances of classes extending Model.`;

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -742,21 +742,25 @@ module('unit/model - Model', function(hooks) {
       }, /Cannot set property isLoaded of \[object Object\] which has only a getter/);
     });
 
-    class NativePostWithInternalModel extends Model {
-      @attr('string')
-      _internalModel;
-      @attr('string')
-      name;
-    }
-    class NativePostWithCurrentState extends Model {
-      @attr('string')
-      currentState;
-      @attr('string')
-      name;
-    }
+    const makeNativePostWithInternalModel = () => {
+      return class NativePostWithInternalModel extends Model {
+        @attr('string')
+        _internalModel;
+        @attr('string')
+        name;
+      };
+    };
+    const makeNativePostWithCurrentState = () => {
+      return class NativePostWithCurrentState extends Model {
+        @attr('string')
+        currentState;
+        @attr('string')
+        name;
+      };
+    };
     const PROP_MAP = {
-      _internalModel: NativePostWithInternalModel,
-      currentState: NativePostWithCurrentState,
+      _internalModel: makeNativePostWithInternalModel,
+      currentState: makeNativePostWithCurrentState,
     };
 
     function testReservedProperty(prop) {
@@ -775,7 +779,7 @@ module('unit/model - Model', function(hooks) {
 
         assert.throws(
           () => {
-            store.createRecord('native-post', { name: 'TomHuda' });
+            NativePost();
           },
           function(e) {
             return e.message.indexOf(msg) === 0;

--- a/packages/-ember-data/tests/unit/model/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/unit/model/relationships/belongs-to-test.js
@@ -726,6 +726,9 @@ module('unit/model/relationships - DS.belongsTo', function(hooks) {
       name: DS.attr('string'),
       hobby: DS.belongsTo('hobby', { serialize: true, async: true }),
     });
+    Person.toString = () => {
+      return 'model:person';
+    };
 
     this.owner.register('model:hobby', Hobby);
     this.owner.register('model:person', Person);
@@ -735,46 +738,9 @@ module('unit/model/relationships - DS.belongsTo', function(hooks) {
 
     adapter.shouldBackgroundReloadRecord = () => false;
 
-    run(() => {
-      store.push({
-        data: [
-          {
-            type: 'hobby',
-            id: '1',
-            attributes: {
-              name: 'fishing',
-            },
-          },
-          {
-            type: 'hobby',
-            id: '2',
-            attributes: {
-              name: 'coding',
-            },
-          },
-          {
-            type: 'person',
-            id: '1',
-            attributes: {
-              name: 'Tom Dale',
-            },
-            relationships: {
-              hobby: {
-                data: { type: 'hobby', id: '1' },
-              },
-            },
-          },
-        ],
-      });
-    });
-
-    return run(() => {
-      return store.findRecord('person', 1).then(person => {
-        assert.expectWarning(() => {
-          get(person, 'hobby');
-        }, /You provided a serialize option on the "hobby" property in the "person" class, this belongs in the serializer. See Serializer and it's implementations/);
-      });
-    });
+    assert.expectWarning(() => {
+      store.modelFor('person');
+    }, /You provided a serialize option on the "hobby" property in the "model:person" class, this belongs in the serializer. See Serializer and it's implementations/);
   });
 
   testInDebug('belongsTo gives a warning when provided with an embedded option', function(assert) {
@@ -786,55 +752,19 @@ module('unit/model/relationships - DS.belongsTo', function(hooks) {
       name: DS.attr('string'),
       hobby: DS.belongsTo('hobby', { embedded: true, async: true }),
     });
+    Person.toString = () => {
+      return 'model:person';
+    };
 
     this.owner.register('model:hobby', Hobby);
     this.owner.register('model:person', Person);
 
     let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
-
     adapter.shouldBackgroundReloadRecord = () => false;
-
-    run(() => {
-      store.push({
-        data: [
-          {
-            type: 'hobby',
-            id: '1',
-            attributes: {
-              name: 'fishing',
-            },
-          },
-          {
-            type: 'hobby',
-            id: '2',
-            attributes: {
-              name: 'coding',
-            },
-          },
-          {
-            type: 'person',
-            id: '1',
-            attributes: {
-              name: 'Tom Dale',
-            },
-            relationships: {
-              hobby: {
-                data: { type: 'hobby', id: '1' },
-              },
-            },
-          },
-        ],
-      });
-    });
-
-    return run(() => {
-      return store.findRecord('person', 1).then(person => {
-        assert.expectWarning(() => {
-          get(person, 'hobby');
-        }, /You provided an embedded option on the "hobby" property in the "person" class, this belongs in the serializer. See EmbeddedRecordsMixin/);
-      });
-    });
+    assert.expectWarning(() => {
+      store.modelFor('person');
+    }, /You provided an embedded option on the "hobby" property in the "model:person" class, this belongs in the serializer. See EmbeddedRecordsMixin/);
   });
 
   test('belongsTo should be async by default', function(assert) {

--- a/packages/adapter/addon/index.ts
+++ b/packages/adapter/addon/index.ts
@@ -127,7 +127,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
   */
   findRecord(store: Store, type: ShimModelClass, id: string, snapshot: Snapshot): Promise<unknown> {
     if (DEBUG) {
-      throw new Error('You subclassed the Adapter class but missing a findRecord override');
+      throw new Error('You subclassed the Adapter class but are missing a findRecord override');
     }
 
     return RSVPPromise.resolve();

--- a/packages/model/addon/-private/belongs-to.js
+++ b/packages/model/addon/-private/belongs-to.js
@@ -108,11 +108,13 @@ import { makeDecorator } from './util';
 export default makeDecorator('belongsTo', {
   getter(key) {
     return function() {
+      debugger;
       return this._internalModel.getBelongsTo(key);
     };
   },
   setter(key) {
     return function(value) {
+      debugger;
       this._internalModel.setDirtyBelongsTo(key, value);
     };
   },

--- a/packages/model/addon/-private/belongs-to.js
+++ b/packages/model/addon/-private/belongs-to.js
@@ -1,9 +1,4 @@
-import { assert, inspect, warn } from '@ember/debug';
-import { computed } from '@ember/object';
-import { DEBUG } from '@glimmer/env';
-
-import { computedMacroWithOptionalParams } from './util';
-
+import { makeDecorator } from './util';
 /**
   @module @ember-data/model
 */
@@ -109,78 +104,16 @@ import { computedMacroWithOptionalParams } from './util';
   @param {Object} options (optional) a hash of options
   @return {Ember.computed} relationship
 */
-function belongsTo(modelName, options) {
-  let opts, userEnteredModelName;
-  if (typeof modelName === 'object') {
-    opts = modelName;
-    userEnteredModelName = undefined;
-  } else {
-    opts = options;
-    userEnteredModelName = modelName;
-  }
 
-  assert(
-    'The first argument to belongsTo must be a string representing a model type key, not an instance of ' +
-      inspect(userEnteredModelName) +
-      ". E.g., to define a relation to the Person model, use belongsTo('person')",
-    typeof userEnteredModelName === 'string' || typeof userEnteredModelName === 'undefined'
-  );
-
-  opts = opts || {};
-
-  let meta = {
-    type: userEnteredModelName,
-    isRelationship: true,
-    options: opts,
-    kind: 'belongsTo',
-    name: 'Belongs To',
-    key: null,
-  };
-
-  return computed({
-    get(key) {
-      if (DEBUG) {
-        if (['_internalModel', 'recordData', 'currentState'].indexOf(key) !== -1) {
-          throw new Error(
-            `'${key}' is a reserved property name on instances of classes extending Model. Please choose a different property name for your belongsTo on ${this.constructor.toString()}`
-          );
-        }
-        if (Object.prototype.hasOwnProperty.call(opts, 'serialize')) {
-          warn(
-            `You provided a serialize option on the "${key}" property in the "${this._internalModel.modelName}" class, this belongs in the serializer. See Serializer and it's implementations https://api.emberjs.com/ember-data/release/classes/Serializer`,
-            false,
-            {
-              id: 'ds.model.serialize-option-in-belongs-to',
-            }
-          );
-        }
-
-        if (Object.prototype.hasOwnProperty.call(opts, 'embedded')) {
-          warn(
-            `You provided an embedded option on the "${key}" property in the "${this._internalModel.modelName}" class, this belongs in the serializer. See EmbeddedRecordsMixin https://api.emberjs.com/ember-data/release/classes/EmbeddedRecordsMixin`,
-            false,
-            {
-              id: 'ds.model.embedded-option-in-belongs-to',
-            }
-          );
-        }
-      }
-
+export default makeDecorator('belongsTo', {
+  getter(key) {
+    return function() {
       return this._internalModel.getBelongsTo(key);
-    },
-    set(key, value) {
-      if (DEBUG) {
-        if (['_internalModel', 'recordData', 'currentState'].indexOf(key) !== -1) {
-          throw new Error(
-            `'${key}' is a reserved property name on instances of classes extending Model. Please choose a different property name for your belongsTo on ${this.constructor.toString()}`
-          );
-        }
-      }
+    };
+  },
+  setter(key) {
+    return function(value) {
       this._internalModel.setDirtyBelongsTo(key, value);
-
-      return this._internalModel.getBelongsTo(key);
-    },
-  }).meta(meta);
-}
-
-export default computedMacroWithOptionalParams(belongsTo);
+    };
+  },
+});

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -433,6 +433,15 @@ class Model extends EmberObject {
     }
   }
 
+  set(key, value) {
+    // prevent _setProp within Ember.set from reading before writing.
+    // when obj.set is called directly
+    if (this.constructor.fields.has(key)) {
+      this[key] = value;
+    }
+    super.set(key, value);
+  }
+
   /**
     If this property is `true` the record is in the `new` state. A
     record will be in the `new` state when it has been created on the

--- a/packages/model/addon/-private/util.ts
+++ b/packages/model/addon/-private/util.ts
@@ -1,8 +1,18 @@
+import { assert, deprecate, inspect, warn } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+import Ember from 'ember';
+
 import { gte } from 'ember-compatibility-helpers';
 
-export type DecoratorPropertyDescriptor = (PropertyDescriptor & { initializer?: any }) | undefined;
+import { schemaCacheFor, tagged } from './model';
 
-export function isElementDescriptor(args: any[]): args is [object, string, DecoratorPropertyDescriptor] {
+type Dict<T> = import('@ember-data/store/-private/ts-interfaces/utils').Dict<T>;
+
+const { _setClassicDecorator } = Ember;
+
+type DecoratorPropertyDescriptor = (PropertyDescriptor & { initializer?: any }) | undefined;
+
+function isElementDescriptor(args: any[]): args is [object, string, DecoratorPropertyDescriptor] {
   let [maybeTarget, maybeKey, maybeDesc] = args;
 
   return (
@@ -22,10 +32,135 @@ export function isElementDescriptor(args: any[]): args is [object, string, Decor
   );
 }
 
-export function computedMacroWithOptionalParams(fn) {
+function computedMacroWithOptionalParams(fn) {
   if (gte('3.10.0')) {
     return (...maybeDesc: any[]) => (isElementDescriptor(maybeDesc) ? fn()(...maybeDesc) : fn(...maybeDesc));
   } else {
     return fn;
   }
+}
+
+interface PropertyMeta {
+  type?: string;
+  options: Dict<any>;
+  kind: string;
+  name: string;
+  /**
+   * @deprecated
+   */
+  key: string;
+  isRelationship?: true;
+  isAttribute?: true;
+}
+
+const assertProps =
+  DEBUG &&
+  function assertProps(target, meta) {
+    const { name, kind, options } = meta;
+    if (['_internalModel', 'recordData', 'currentState'].indexOf(name) !== -1) {
+      throw new Error(
+        `'${name}' is a reserved property name on instances of classes extending Model. Please choose a different property name for your belongsTo on ${target.toString()}`
+      );
+    }
+    if (kind !== 'attribute') {
+      if (Object.prototype.hasOwnProperty.call(options, 'serialize')) {
+        warn(
+          `You provided a serialize option on the "${name}" property in the "${target.toString()}" class, this belongs in the serializer. See Serializer and it's implementations https://api.emberjs.com/ember-data/release/classes/Serializer`,
+          false,
+          {
+            id: 'ds.model.serialize-option-in-belongs-to',
+          }
+        );
+      }
+      if (Object.prototype.hasOwnProperty.call(options, 'embedded')) {
+        warn(
+          `You provided an embedded option on the "${name}" property in the "${target.toString()}" class, this belongs in the serializer. See EmbeddedRecordsMixin https://api.emberjs.com/ember-data/release/classes/EmbeddedRecordsMixin`,
+          false,
+          {
+            id: 'ds.model.embedded-option-in-belongs-to',
+          }
+        );
+      }
+    }
+  };
+
+export function makeDecorator(kind, descriptor) {
+  function relationship(type, options) {
+    if (typeof type === 'object') {
+      options = type;
+      type = undefined;
+    }
+
+    if (kind !== 'attribute') {
+      assert(
+        `The first argument to a ${kind} must be a string representing a model type, not an instance of ${inspect(
+          type
+        )}. E.g., to define a relation to the Comment model, use ${kind}('comment')`,
+        typeof type === 'string' || typeof type === 'undefined'
+      );
+    }
+
+    options = options || {};
+
+    // Metadata about relationships is stored on the meta of
+    // the relationship. This is used for introspection and
+    // serialization. Note that `name` is populated lazily
+    // the first time the CP is called.
+    // `key` is a to-be deprecated alias to `name`.
+    const meta: PropertyMeta = {
+      type,
+      options,
+      kind: kind,
+      name: '',
+      key: '',
+    };
+    const schemaKind = kind === 'attribute' ? 'attributes' : 'relationships';
+    if (kind !== 'attribute') {
+      meta.isRelationship = true;
+    } else {
+      meta.isAttribute = true;
+    }
+
+    function buildDescriptor(target, key) {
+      meta.name = key;
+      meta.key = key;
+      if (DEBUG && assertProps) {
+        assertProps(target.constructor, meta);
+      }
+      let schema = schemaCacheFor(target.constructor);
+      schema[schemaKind] = schema[schemaKind] || new Map();
+      schema[schemaKind].set(key, meta);
+      const get = descriptor.getter(key, meta);
+      const set = descriptor.setter(key, meta);
+
+      const desc = tagged(target, key, {
+        configurable: true,
+        enumerable: true,
+        get,
+        set,
+      });
+
+      return desc;
+    }
+
+    // enable use with `Model.extend({})` syntax
+    _setClassicDecorator(buildDescriptor, true);
+
+    buildDescriptor.meta = function() {
+      deprecate(`calling this is deprecated`, false, {
+        id: 'ember-data:computed-meta',
+        until: '4.3',
+        for: '@ember-data/model',
+        since: {
+          available: '3.28',
+          enabled: '4.1',
+        },
+      });
+      return meta;
+    };
+
+    return buildDescriptor;
+  }
+
+  return computedMacroWithOptionalParams(relationship);
 }

--- a/packages/model/addon/-private/util.ts
+++ b/packages/model/addon/-private/util.ts
@@ -46,9 +46,10 @@ interface PropertyMeta {
   kind: string;
   name: string;
   /**
+   * Alias of name
    * @deprecated
    */
-  key: string;
+  key?: string;
   isRelationship?: true;
   isAttribute?: true;
 }
@@ -57,7 +58,7 @@ const assertProps =
   DEBUG &&
   function assertProps(target, meta) {
     const { name, kind, options } = meta;
-    if (['_internalModel', 'recordData', 'currentState'].indexOf(name) !== -1) {
+    if (['_internalModel', 'currentState'].indexOf(name) !== -1) {
       throw new Error(
         `'${name}' is a reserved property name on instances of classes extending Model. Please choose a different property name for your belongsTo on ${target.toString()}`
       );
@@ -93,7 +94,7 @@ export function makeDecorator(kind, descriptor) {
 
     if (kind !== 'attribute') {
       assert(
-        `The first argument to a ${kind} must be a string representing a model type, not an instance of ${inspect(
+        `The first argument to ${kind} must be a string representing a model type, not an instance of ${inspect(
           type
         )}. E.g., to define a relation to the Comment model, use ${kind}('comment')`,
         typeof type === 'string' || typeof type === 'undefined'
@@ -112,7 +113,6 @@ export function makeDecorator(kind, descriptor) {
       options,
       kind: kind,
       name: '',
-      key: '',
     };
     const schemaKind = kind === 'attribute' ? 'attributes' : 'relationships';
     if (kind !== 'attribute') {
@@ -123,7 +123,9 @@ export function makeDecorator(kind, descriptor) {
 
     function buildDescriptor(target, key) {
       meta.name = key;
-      meta.key = key;
+      if (meta.isRelationship) {
+        meta.key = key;
+      }
       if (DEBUG && assertProps) {
         assertProps(target.constructor, meta);
       }

--- a/packages/record-data/addon/-private/relationships/state/has-many.ts
+++ b/packages/record-data/addon/-private/relationships/state/has-many.ts
@@ -114,6 +114,7 @@ export default class ManyRelationship extends Relationship {
 
     //a hack for not removing new records
     //TODO remove once we have proper diffing
+    let originalState = this.currentState.slice();
     let newRecordDatas = this.currentState.filter(
       // only add new internalModels which are not yet in the canonical state of this
       // relationship (a new internalModel can be in the canonical state if it has
@@ -129,10 +130,24 @@ export default class ManyRelationship extends Relationship {
       this._manyArray.flushCanonical(toSet);
     }
     */
+    let stateDidChange = !(originalState.length === toSet.length);
     this.currentState = toSet;
     super.flushCanonical();
-    // Once we clean up all the flushing, we will be left with at least the notifying part
-    this.notifyHasManyChange();
+
+    // avoid overly notifying if we didn't actually change anything.
+    if (!stateDidChange) {
+      for (let i = 0; i < originalState.length; i++) {
+        if (originalState[i] !== toSet[i]) {
+          stateDidChange = true;
+          break;
+        }
+      }
+    }
+
+    if (stateDidChange) {
+      // Once we clean up all the flushing, we will be left with at least the notifying part
+      this.notifyHasManyChange();
+    }
   }
 
   //TODO(Igor) idx not used currently, fix

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -6,7 +6,7 @@ import { get, notifyPropertyChange, set } from '@ember/object';
 import { assign } from '@ember/polyfills';
 import { _backburner as emberBackburner, cancel } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
-import { cached, tracked } from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
 import Ember from 'ember';
 
 import RSVP, { Promise } from 'rsvp';
@@ -1014,6 +1014,7 @@ export default class InternalModel {
           //
           //  that said, also not clear why we haven't moved this to retainedmanyarray so maybe that's the bit that's just not working
           manyArray.retrieveLatest();
+          this._record.notifyPropertyChange(key);
         }
       }
     }
@@ -1580,7 +1581,7 @@ function _notifyProperties(target, keys) {
     let key;
     for (let i = 0, length = keys.length; i < length; i++) {
       key = keys[i];
-      target.notifyPropertyChange(key);
+      target.notifyPropertyChange(key, true);
     }
   });
 }

--- a/packages/store/types/@glimmer/tracking/index.d.ts
+++ b/packages/store/types/@glimmer/tracking/index.d.ts
@@ -1,0 +1,3 @@
+export { tracked } from '@glimmer/tracking';
+
+export function cached(target: any, key: string, desc: PropertyDescriptor): void;

--- a/packages/store/types/ember/index.d.ts
+++ b/packages/store/types/ember/index.d.ts
@@ -2,3 +2,10 @@ export function run(callback: Function);
 export const ENV: {
   DS_WARN_ON_UNKNOWN_KEYS?: boolean;
 };
+
+export function _setClassicDecorator(
+  descFn: (target: any, key: string, desc: PropertyDescriptor) => PropertyDescriptor,
+  isDesc: true
+): void;
+
+export function changeProperties(fn: () => void): void;

--- a/packages/store/types/ember/index.d.ts
+++ b/packages/store/types/ember/index.d.ts
@@ -9,3 +9,5 @@ export function _setClassicDecorator(
 ): void;
 
 export function changeProperties(fn: () => void): void;
+
+export function meta(obj: any): any;

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-warning.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-warning.ts
@@ -58,23 +58,28 @@ function verifyWarning(config: WarningConfig, label?: string): AssertSomeResult 
     }
     return isMatched;
   });
+  // remove the handled warnings from WARNINGS_FOR_TEST
   WARNINGS_FOR_TEST = WARNINGS_FOR_TEST.filter(warning => {
-    matchedWarnings.indexOf(warning) === -1;
+    return matchedWarnings.indexOf(warning) === -1;
   });
   HANDLED_WARNINGS_FOR_TEST.push(...matchedWarnings);
 
   let expectedCount = typeof config.count === 'number' ? config.count : 1;
   let passed = matchedWarnings.length === expectedCount;
+  let message =
+    label ||
+    `Expected ${expectedCount} warning${expectedCount === 1 ? '' : 's'} for ${config.id} during test, ${
+      passed ? expectedCount : 'but ' + matchedWarnings.length
+    } warnings were found.`;
+  if (!passed) {
+    message += `\n\nOther warnings found:\n\t${WARNINGS_FOR_TEST.map(w => w.message).join('\n\t')}`;
+  }
 
   return {
     result: passed,
     actual: { id: config.id, count: matchedWarnings.length },
     expected: { id: config.id, count: expectedCount },
-    message:
-      label ||
-      `Expected ${expectedCount} warning${expectedCount === 1 ? '' : 's'} for ${config.id} during test, ${
-        passed ? expectedCount : 'but ' + matchedWarnings.length
-      } warnings were found.`,
+    message,
   };
 }
 


### PR DESCRIPTION
This allows Ember to more easily remove support for some aspects of ComputedProperty, computed.meta etc. while also giving us better access to the schema at runtime. This is the first step towards being able to compile schema at build time, some deprecations are necessary to take that step.

In theory, this should provide a significant performance boost for accessing static schema and/or accessing a value. However, do to the complexity of also supporting sync-observers and async-proxies there are some caveats that may negate these wins. Benchmarking is needed.

**Edit** Going to put this on hold for now because (1) the various workarounds for `reopen` and `sync observers` seem to nuke perf in addition to adding a lot more size and complexity and (2) there's no clear path forward for this issue: https://github.com/emberjs/ember.js/pull/19504