### PR TITLE
CHORE: configure alpha-releases to use deploymeent environment

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -31,6 +31,7 @@ jobs:
     name: Run publish script
     runs-on: ubuntu-latest
     needs: [ test ]
+    environment: deloyment
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Adding `environment` entry with `deployment` value for the release job
