### PR TITLE
[DOC] Cleanup JSONSerializer normalize docs

### DIFF
--- a/packages/serializer/addon/json.js
+++ b/packages/serializer/addon/json.js
@@ -67,14 +67,18 @@ import { modelHasAttributeOrRelationshipNamedType } from './-private';
 
   The `JSONSerializer` normalization process follows these steps:
 
-    - `normalizeResponse` - entry method to the serializer.
-    - `normalizeCreateRecordResponse` - a `normalizeResponse` for a specific operation is called.
-    - `normalizeSingleResponse`|`normalizeArrayResponse` - for methods like `createRecord` we expect
-      a single record back, while for methods like `findAll` we expect multiple records back.
-    - `normalize` - `normalizeArrayResponse` iterates and calls `normalize` for each of its records while `normalizeSingle`
-      calls it once. This is the method you most likely want to subclass.
-    - `extractId` | `extractAttributes` | `extractRelationships` - `normalize` delegates to these methods to
-      turn the record payload into the JSON API format.
+    1. `normalizeResponse`
+        - entry method to the serializer.
+    2. `normalizeCreateRecordResponse`
+        - a `normalizeResponse` for a specific operation is called.
+    3. `normalizeSingleResponse`|`normalizeArrayResponse`
+        - for methods like `createRecord` we expect a single record back, while for methods like `findAll` we expect multiple records back.
+    4. `normalize`
+        - `normalizeArrayResponse` iterates and calls `normalize` for each of its records while `normalizeSingle`
+          calls it once. This is the method you most likely want to subclass.
+    5. `extractId` | `extractAttributes` | `extractRelationships`
+        - `normalize` delegates to these methods to
+          turn the record payload into the JSON API format.
 
   @class JSONSerializer
   @extends Serializer


### PR DESCRIPTION
I was having a really hard time parsing the
docs on the normalization process; the combination
of pipes (|) for grouping the method names and
dash (-) to separate the method name(s) from
the description is pretty confusing to me, so
I made a few tweaks:

1. numbered list for the flow
2. line breaks + bullets for the description

I tried a few variations but this is the best
one I could come up with that yuidoc would allow

Before:

<img width="859" alt="Screen Shot 2021-04-30 at 8 23 53 AM" src="https://user-images.githubusercontent.com/81818/116695496-b1e5a700-a98e-11eb-8e78-f563cf1a8fa1.png">

After:

<img width="909" alt="Screen Shot 2021-04-30 at 8 31 07 AM" src="https://user-images.githubusercontent.com/81818/116695514-b6aa5b00-a98e-11eb-9650-86d00f4a1409.png">
