### PR TITLE
chore: fix alpha release script

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -2,7 +2,7 @@ name: Alpha Releases
 
 on:
   schedule:
-    - cron: '0 20 * * 3' # weekly (Wednesday) 12 PM PST
+    - cron: '0 20 * * *' # daily 12 PM PST
 
 jobs:
   test:
@@ -42,6 +42,8 @@ jobs:
         run: |
           git config --local user.email 'tomster@emberjs.com'
           git config --local user.name 'Ember.js Alpha Releaser'
+      - name: Check access to registry and existence of ember-data
+        run: npm view ember-data --verbose
       - name: Publish with script
         run: node bin/publish.js canary
         env:

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -379,6 +379,11 @@ async function main() {
       lernaCommand += ' --no-git-tag-version --no-push';
     }
 
+    // Let the github action determine whether to push the tag to remote
+    if (process.env.CI) {
+      lernaCommand += ' --no-push';
+    }
+
     execWithLog(lernaCommand, true);
     console.log(`✅ ` + chalk.cyan(`Successfully Versioned ${nextVersion}`));
   } else {


### PR DESCRIPTION
Attempting to figure out what issue in CI the publish flow is experiencing in the latest run: https://pipelines.actions.githubusercontent.com/lh3ErhSVHNJYpee7hUnIdVxnbJYs0oNN73X4KLsoKw0nHpv7za/_apis/pipelines/1/runs/9213/signedlogcontent/13?urlExpires=2021-05-05T21%3A29%3A53.3513399Z&urlSigningMethod=HMACV1&urlSignature=rjfTrQNjTyJzW0lZnFR8ouNYMcZ8qPtC78E6EuLfD%2FU%3D

The script is experiencing `npm ERR! 404 Not Found - PUT https://registry.npmjs.org/ember-data - Not found\n` which I have not been able to reproduce.

I'm switching to daily run (will revert back to weekly when we get this fixed) and adding `npm view ember-data --verbose` to be run before the publish script for sanity check