### PR TITLE
chore: fix alpha release script attempt 2 - set registry

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
+          registry-url: 'https://registry.npmjs.org'
           node-version: 12.x
       - name: Install dependencies for master
         run: yarn install --frozen-lockfile --non-interactive

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -317,7 +317,7 @@ let cli = readline.createInterface({
  * @param {string} otp - Token to make publish requests to npm
  */
 function publishPackage(distTag, tarball, otp) {
-  let cmd = `npm publish ${tarball} --tag=${distTag} --access=public`;
+  let cmd = `npm publish ${tarball} --tag=${distTag} --access=public --verbose`;
 
   if (otp) {
     cmd += ` --otp=${otp}`;


### PR DESCRIPTION
The saga continues.  The latest run of Alpha release failed today: https://github.com/emberjs/data/actions/runs/818083776. 

@runspired suggested we set explicitly registry like in this reported issue: https://github.com/actions/setup-node/issues/130

I added `--verbose` to the publish command executed in the publish script to get more information. I Will remove it once everything works