### PR TITLE
chore: fix automation script - remove debugging info

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -43,8 +43,6 @@ jobs:
         run: |
           git config --local user.email 'tomster@emberjs.com'
           git config --local user.name 'Ember.js Alpha Releaser'
-      - name: Check access to registry and existence of ember-data
-        run: npm view ember-data --verbose
       - name: Publish with script
         run: node bin/publish.js canary
         env:

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -317,7 +317,7 @@ let cli = readline.createInterface({
  * @param {string} otp - Token to make publish requests to npm
  */
 function publishPackage(distTag, tarball, otp) {
-  let cmd = `npm publish ${tarball} --tag=${distTag} --access=public --verbose`;
+  let cmd = `npm publish ${tarball} --tag=${distTag} --access=public`;
 
   if (otp) {
     cmd += ` --otp=${otp}`;


### PR DESCRIPTION
Removing the debugging commands from the github action and publish script.

The solution is ultimately setting the `registry-url` in the github action and ensuring the npmjs package setting allows publishing from an automation token i.e.

![image](https://user-images.githubusercontent.com/2080348/117514661-416bf680-af49-11eb-8729-f006efe21851.png)

I missed that the recent failure for the publish script was a 403 vs before which was a 404. I was able to recreate the issues with a dummy repo. To summarize these are conditions that causes the following issue:

- Valid token + no set registry-url + whatever npmjs security setting = 404
- Valid token + set-registry - 2fa only npmjs security setting = 403


@igorT we need all the ember-data related repos to allow publishing from automation token
