### PR TITLE
chore: set alpha release github action to run on Wednesdays

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -2,7 +2,7 @@ name: Alpha Releases
 
 on:
   schedule:
-    - cron: '0 20 * * *' # daily 12 PM PST
+    - cron: '0 20 * * 3' # weekly (Wednesday) 12 PM PST
 
 jobs:
   test:


### PR DESCRIPTION
Now that the alpha release action is [verified](https://github.com/emberjs/data/actions/runs/823765513) working, we can set the schedule back to Wednesday.