### PR TITLE
test: Updating syntax of rest-adapter-test.js - Only findRecord

### DIFF
--- a/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -131,136 +131,6 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     };
   }
 
-  test('findRecord - basic payload', async function (assert) {
-    ajaxResponse({ posts: [{ id: 1, name: 'Rails is omakase' }] });
-
-    let post = await store.findRecord('post', 1);
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'GET');
-    assert.deepEqual(passedHash.data, {});
-
-    assert.equal(post.get('id'), '1');
-    assert.equal(post.get('name'), 'Rails is omakase');
-  });
-
-  test('findRecord - passes buildURL a requestType', async function (assert) {
-    adapter.buildURL = function (type, id, snapshot, requestType) {
-      return '/' + requestType + '/post/' + id;
-    };
-
-    ajaxResponse({ posts: [{ id: 1, name: 'Rails is omakase' }] });
-
-    await store.findRecord('post', 1);
-    assert.equal(passedUrl, '/findRecord/post/1');
-  });
-
-  test('findRecord - basic payload (with legacy singular name)', async function (assert) {
-    ajaxResponse({ post: { id: 1, name: 'Rails is omakase' } });
-
-    let post = await store.findRecord('post', 1);
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'GET');
-    assert.deepEqual(passedHash.data, {});
-
-    assert.equal(post.get('id'), '1');
-    assert.equal(post.get('name'), 'Rails is omakase');
-  });
-
-  test('findRecord - payload with sideloaded records of the same type', async function (assert) {
-    ajaxResponse({
-      posts: [
-        { id: 1, name: 'Rails is omakase' },
-        { id: 2, name: 'The Parley Letter' },
-      ],
-    });
-
-    let post = await store.findRecord('post', 1);
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'GET');
-    assert.deepEqual(passedHash.data, {});
-
-    assert.equal(post.get('id'), '1');
-    assert.equal(post.get('name'), 'Rails is omakase');
-
-    let post2 = store.peekRecord('post', 2);
-    assert.equal(post2.get('id'), '2');
-    assert.equal(post2.get('name'), 'The Parley Letter');
-  });
-
-  test('findRecord - payload with sideloaded records of a different type', async function (assert) {
-    ajaxResponse({
-      posts: [{ id: 1, name: 'Rails is omakase' }],
-      comments: [{ id: 1, name: 'FIRST' }],
-    });
-
-    let post = await store.findRecord('post', 1);
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'GET');
-    assert.deepEqual(passedHash.data, {});
-
-    assert.equal(post.get('id'), '1');
-    assert.equal(post.get('name'), 'Rails is omakase');
-
-    let comment = store.peekRecord('comment', 1);
-    assert.equal(comment.get('id'), '1');
-    assert.equal(comment.get('name'), 'FIRST');
-  });
-
-  test('findRecord - payload with an serializer-specified primary key', async function (assert) {
-    this.owner.register(
-      'serializer:post',
-      DS.RESTSerializer.extend({
-        primaryKey: '_ID_',
-      })
-    );
-
-    ajaxResponse({ posts: [{ _ID_: 1, name: 'Rails is omakase' }] });
-
-    let post = await store.findRecord('post', 1);
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'GET');
-    assert.deepEqual(passedHash.data, {});
-
-    assert.equal(post.get('id'), '1');
-    assert.equal(post.get('name'), 'Rails is omakase');
-  });
-
-  test('findRecord - payload with a serializer-specified attribute mapping', async function (assert) {
-    this.owner.register(
-      'serializer:post',
-      DS.RESTSerializer.extend({
-        attrs: {
-          name: '_NAME_',
-          createdAt: { key: '_CREATED_AT_', someOtherOption: 'option' },
-        },
-      })
-    );
-
-    Post.reopen({
-      createdAt: DS.attr('number'),
-    });
-
-    ajaxResponse({ posts: [{ id: 1, _NAME_: 'Rails is omakase', _CREATED_AT_: 2013 }] });
-
-    let post = await store.findRecord('post', 1);
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'GET');
-    assert.deepEqual(passedHash.data, {});
-
-    assert.equal(post.get('id'), '1');
-    assert.equal(post.get('name'), 'Rails is omakase');
-    assert.equal(post.get('createdAt'), 2013);
-  });
-
-  test('findRecord - passes `include` as a query parameter to ajax', async function (assert) {
-    ajaxResponse({
-      post: { id: 1, name: 'Rails is very expensive sushi' },
-    });
-
-    await store.findRecord('post', 1, { include: 'comments' });
-    assert.deepEqual(passedHash.data, { include: 'comments' }, '`include` parameter sent to adapter.ajax');
-  });
-
   test('createRecord - an empty payload is a basic success if an id was specified', async function (assert) {
     ajaxResponse();
 
@@ -2106,7 +1976,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
           return underscore(attr);
         },
 
-        keyForBelongsTo(belongsTo) {},
+        keyForBelongsTo(belongsTo) { },
 
         keyForRelationship(rel, kind) {
           if (kind === 'belongsTo') {

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -1976,7 +1976,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
           return underscore(attr);
         },
 
-        keyForBelongsTo(belongsTo) { },
+        keyForBelongsTo(belongsTo) {},
 
         keyForRelationship(rel, kind) {
           if (kind === 'belongsTo') {

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter/find-record-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter/find-record-test.js
@@ -1,0 +1,318 @@
+import Pretender from 'pretender';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import RESTAdapter from '@ember-data/adapter/rest';
+import RESTSerializer from '@ember-data/serializer/rest';
+import deepCopy from '@ember-data/unpublished-test-infra/test-support/deep-copy';
+import { resolve } from 'rsvp';
+import Model, { attr } from '@ember-data/model';
+
+let server;
+
+/**
+ * @description Helper function to mock the response of an adapter in order to
+ * Test is behaviour.
+ * @param { adapter } RESTAdapter instance
+ * @param { response } Response to return from the adapter
+ * @returns { ajaxCallback } Function that returns information about the last
+ * call to the ajax method of the adapter.
+ */
+function ajaxResponse(adapter, value) {
+  let passedUrl = null;
+  let passedVerb = null;
+  let passedHash = null;
+
+  adapter._fetchRequest = (hash) => {
+    passedHash = hash;
+    passedUrl = passedHash.url;
+    passedVerb = passedHash.method;
+    return resolve({
+      text() {
+        return resolve(JSON.stringify(deepCopy(value)));
+      },
+      ok: true,
+      status: 200,
+    });
+  };
+
+  adapter.ajax = (url, verb, hash) => {
+    passedUrl = url;
+    passedVerb = verb;
+    passedHash = hash;
+
+    return resolve(deepCopy(value));
+  };
+
+  return () => { return { passedUrl, passedVerb, passedHash } };
+}
+
+module('integration/adapter/rest_adapter - REST Adapter - findRecord', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    server = new Pretender();
+  });
+
+  hooks.afterEach(function () {
+    if (server) {
+      server.shutdown();
+      server = null;
+    }
+  });
+
+  test('findRecord - basic payload', async function (assert) {
+    const Post = Model.extend({
+      name: attr('string'),
+    });
+    const Comment = Model.extend({
+      name: attr('string'),
+    });
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, { posts: [{ id: '1', name: 'Rails is omakase' }] });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+
+    const post = await store.findRecord('post', '1');
+    const { passedUrl, passedVerb, passedHash } = ajaxCallback();
+
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'GET');
+    assert.deepEqual(passedHash.data, {});
+
+    assert.strictEqual(post.get('id'), '1');
+    assert.strictEqual(post.get('name'), 'Rails is omakase');
+  });
+
+  test('findRecord - passes buildURL a requestType', async function (assert) {
+    const Post = Model.extend({
+      name: attr('string'),
+    });
+    const Comment = Model.extend({
+      name: attr('string'),
+    });
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, { posts: [{ id: '1', name: 'Rails is omakase' }] });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+
+    adapter.buildURL = function (_type, id, _snapshot, requestType) {
+      return '/' + requestType + '/post/' + id;
+    };
+
+    await store.findRecord('post', '1');
+
+    const { passedUrl } = ajaxCallback();
+
+    assert.strictEqual(passedUrl, '/findRecord/post/1');
+  });
+
+  test('findRecord - basic payload (with legacy singular name)', async function (assert) {
+    const Post = Model.extend({
+      name: attr('string'),
+    });
+    const Comment = Model.extend({
+      name: attr('string'),
+    });
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, { post: { id: '1', name: 'Rails is omakase' } });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+
+    const post = await store.findRecord('post', '1');
+
+    const { passedUrl, passedVerb, passedHash } = ajaxCallback();
+
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'GET');
+    assert.deepEqual(passedHash.data, {});
+    assert.strictEqual(post.get('id'), '1');
+    assert.strictEqual(post.get('name'), 'Rails is omakase');
+  });
+
+  test('findRecord - payload with sideloaded records of the same type', async function (assert) {
+    const Post = Model.extend({
+      name: attr('string'),
+    });
+    const Comment = Model.extend({
+      name: attr('string'),
+    });
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, {
+      posts: [
+        { id: '1', name: 'Rails is omakase' },
+        { id: '2', name: 'The Parley Letter' },
+      ],
+    });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+
+    const post = await store.findRecord('post', '1');
+
+    const { passedUrl, passedVerb, passedHash } = ajaxCallback();
+
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'GET');
+    assert.deepEqual(passedHash.data, {});
+
+    assert.strictEqual(post.get('id'), '1');
+    assert.strictEqual(post.get('name'), 'Rails is omakase');
+
+    const post2 = await store.peekRecord('post', '2');
+
+    assert.strictEqual(post2.get('id'), '2');
+    assert.strictEqual(post2.get('name'), 'The Parley Letter');
+  });
+
+  test('findRecord - payload with sideloaded records of a different type', async function (assert) {
+    const Post = Model.extend({
+      name: attr('string'),
+    });
+    const Comment = Model.extend({
+      name: attr('string'),
+    });
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, {
+      posts: [{ id: 1, name: 'Rails is omakase' }],
+      comments: [{ id: 1, name: 'FIRST' }],
+    });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+
+    const post = await store.findRecord('post', '1');
+
+    const { passedUrl, passedVerb, passedHash } = ajaxCallback();
+
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'GET');
+    assert.deepEqual(passedHash.data, {});
+    assert.strictEqual(post.get('id'), '1');
+    assert.strictEqual(post.get('name'), 'Rails is omakase');
+
+    const comment = await store.peekRecord('comment', '1');
+
+    assert.strictEqual(comment.get('id'), '1');
+  });
+
+  test('findRecord - payload with an serializer-specified primary key', async function (assert) {
+    const Post = Model.extend({
+      name: attr('string'),
+    });
+    const Comment = Model.extend({
+      name: attr('string'),
+    });
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, { posts: [{ _ID_: '1', name: 'Rails is omakase' }] });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+
+    this.owner.register(
+      'serializer:post',
+      RESTSerializer.extend({
+        primaryKey: '_ID_',
+      })
+    );
+
+    const post = await store.findRecord('post', '1');
+
+    const { passedUrl, passedVerb, passedHash } = ajaxCallback();
+
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'GET');
+    assert.deepEqual(passedHash.data, {});
+    assert.strictEqual(post.get('id'), '1');
+    assert.strictEqual(post.get('name'), 'Rails is omakase');
+  });
+
+  test('findRecord - payload with a serializer-specified attribute mapping', async function (assert) {
+    const Post = Model.extend({
+      name: attr('string'),
+      createdAt: attr('number')
+    });
+    const Comment = Model.extend({
+      name: attr('string'),
+    });
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, {
+      posts: [
+        { id: '1', _NAME_: 'Rails is omakase', _CREATED_AT_: 2013 }
+      ]
+    });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+    this.owner.register(
+      'serializer:post',
+      RESTSerializer.extend({
+        attrs: {
+          name: '_NAME_',
+          createdAt: { key: '_CREATED_AT_', someOtherOption: 'option' },
+        },
+      })
+    );
+    this.owner.register('model:post', Post);
+
+    const post = await store.findRecord('post', '1');
+
+    const { passedUrl, passedVerb, passedHash } = ajaxCallback();
+
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'GET');
+    assert.deepEqual(passedHash.data, {});
+    assert.strictEqual(post.get('id'), '1');
+    assert.strictEqual(post.get('name'), 'Rails is omakase');
+    assert.strictEqual(post.get('createdAt'), 2013);
+  });
+
+  test('findRecord - passes `include` as a query parameter to ajax', async function (assert) {
+    const Post = Model.extend({
+      name: attr('string'),
+    });
+    const Comment = Model.extend({
+      name: attr('string'),
+    });
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+
+    const ajaxCallback = ajaxResponse(adapter, {
+      post: { id: '1', name: 'Rails is very expensive sushi' },
+    });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+
+    await store.findRecord('post', 1, { include: 'comments' });
+
+    const { passedHash } = ajaxCallback();
+
+    assert.deepEqual(passedHash.data, { include: 'comments' }, '`include` parameter sent to adapter.ajax');
+  });
+});

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter/find-record-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter/find-record-test.js
@@ -1,11 +1,13 @@
 import Pretender from 'pretender';
 import { module, test } from 'qunit';
+import { resolve } from 'rsvp';
+
 import { setupTest } from 'ember-qunit';
+
 import RESTAdapter from '@ember-data/adapter/rest';
+import Model, { attr } from '@ember-data/model';
 import RESTSerializer from '@ember-data/serializer/rest';
 import deepCopy from '@ember-data/unpublished-test-infra/test-support/deep-copy';
-import { resolve } from 'rsvp';
-import Model, { attr } from '@ember-data/model';
 
 let server;
 
@@ -43,7 +45,9 @@ function ajaxResponse(adapter, value) {
     return resolve(deepCopy(value));
   };
 
-  return () => { return { passedUrl, passedVerb, passedHash } };
+  return () => {
+    return { passedUrl, passedVerb, passedHash };
+  };
 }
 
 module('integration/adapter/rest_adapter - REST Adapter - findRecord', function (hooks) {
@@ -250,7 +254,7 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
   test('findRecord - payload with a serializer-specified attribute mapping', async function (assert) {
     const Post = Model.extend({
       name: attr('string'),
-      createdAt: attr('number')
+      createdAt: attr('number'),
     });
     const Comment = Model.extend({
       name: attr('string'),
@@ -258,9 +262,7 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
     const store = this.owner.lookup('service:store');
     const adapter = store.adapterFor('application');
     const ajaxCallback = ajaxResponse(adapter, {
-      posts: [
-        { id: '1', _NAME_: 'Rails is omakase', _CREATED_AT_: 2013 }
-      ]
+      posts: [{ id: '1', _NAME_: 'Rails is omakase', _CREATED_AT_: 2013 }],
     });
 
     this.owner.register('model:post', Post);

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter/find-record-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter/find-record-test.js
@@ -71,15 +71,14 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
     const Comment = Model.extend({
       name: attr('string'),
     });
-    const store = this.owner.lookup('service:store');
-    const adapter = store.adapterFor('application');
-    const ajaxCallback = ajaxResponse(adapter, { posts: [{ id: '1', name: 'Rails is omakase' }] });
-
     this.owner.register('model:post', Post);
     this.owner.register('model:comment', Comment);
     this.owner.register('adapter:application', RESTAdapter.extend());
     this.owner.register('serializer:application', RESTSerializer.extend());
 
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, { posts: [{ id: '1', name: 'Rails is omakase' }] });
     const post = await store.findRecord('post', '1');
     const { passedUrl, passedVerb, passedHash } = ajaxCallback();
 
@@ -98,14 +97,15 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
     const Comment = Model.extend({
       name: attr('string'),
     });
-    const store = this.owner.lookup('service:store');
-    const adapter = store.adapterFor('application');
-    const ajaxCallback = ajaxResponse(adapter, { posts: [{ id: '1', name: 'Rails is omakase' }] });
 
     this.owner.register('model:post', Post);
     this.owner.register('model:comment', Comment);
     this.owner.register('adapter:application', RESTAdapter.extend());
     this.owner.register('serializer:application', RESTSerializer.extend());
+
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, { posts: [{ id: '1', name: 'Rails is omakase' }] });
 
     adapter.buildURL = function (_type, id, _snapshot, requestType) {
       return '/' + requestType + '/post/' + id;
@@ -125,14 +125,15 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
     const Comment = Model.extend({
       name: attr('string'),
     });
-    const store = this.owner.lookup('service:store');
-    const adapter = store.adapterFor('application');
-    const ajaxCallback = ajaxResponse(adapter, { post: { id: '1', name: 'Rails is omakase' } });
 
     this.owner.register('model:post', Post);
     this.owner.register('model:comment', Comment);
     this.owner.register('adapter:application', RESTAdapter.extend());
     this.owner.register('serializer:application', RESTSerializer.extend());
+
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, { post: { id: '1', name: 'Rails is omakase' } });
 
     const post = await store.findRecord('post', '1');
 
@@ -152,6 +153,12 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
     const Comment = Model.extend({
       name: attr('string'),
     });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+
     const store = this.owner.lookup('service:store');
     const adapter = store.adapterFor('application');
     const ajaxCallback = ajaxResponse(adapter, {
@@ -160,11 +167,6 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
         { id: '2', name: 'The Parley Letter' },
       ],
     });
-
-    this.owner.register('model:post', Post);
-    this.owner.register('model:comment', Comment);
-    this.owner.register('adapter:application', RESTAdapter.extend());
-    this.owner.register('serializer:application', RESTSerializer.extend());
 
     const post = await store.findRecord('post', '1');
 
@@ -190,17 +192,18 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
     const Comment = Model.extend({
       name: attr('string'),
     });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+
     const store = this.owner.lookup('service:store');
     const adapter = store.adapterFor('application');
     const ajaxCallback = ajaxResponse(adapter, {
       posts: [{ id: 1, name: 'Rails is omakase' }],
       comments: [{ id: 1, name: 'FIRST' }],
     });
-
-    this.owner.register('model:post', Post);
-    this.owner.register('model:comment', Comment);
-    this.owner.register('adapter:application', RESTAdapter.extend());
-    this.owner.register('serializer:application', RESTSerializer.extend());
 
     const post = await store.findRecord('post', '1');
 
@@ -224,14 +227,15 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
     const Comment = Model.extend({
       name: attr('string'),
     });
-    const store = this.owner.lookup('service:store');
-    const adapter = store.adapterFor('application');
-    const ajaxCallback = ajaxResponse(adapter, { posts: [{ _ID_: '1', name: 'Rails is omakase' }] });
 
     this.owner.register('model:post', Post);
     this.owner.register('model:comment', Comment);
     this.owner.register('adapter:application', RESTAdapter.extend());
     this.owner.register('serializer:application', RESTSerializer.extend());
+
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, { posts: [{ _ID_: '1', name: 'Rails is omakase' }] });
 
     this.owner.register(
       'serializer:post',
@@ -259,11 +263,6 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
     const Comment = Model.extend({
       name: attr('string'),
     });
-    const store = this.owner.lookup('service:store');
-    const adapter = store.adapterFor('application');
-    const ajaxCallback = ajaxResponse(adapter, {
-      posts: [{ id: '1', _NAME_: 'Rails is omakase', _CREATED_AT_: 2013 }],
-    });
 
     this.owner.register('model:post', Post);
     this.owner.register('model:comment', Comment);
@@ -279,6 +278,12 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
       })
     );
     this.owner.register('model:post', Post);
+
+    const store = this.owner.lookup('service:store');
+    const adapter = store.adapterFor('application');
+    const ajaxCallback = ajaxResponse(adapter, {
+      posts: [{ id: '1', _NAME_: 'Rails is omakase', _CREATED_AT_: 2013 }],
+    });
 
     const post = await store.findRecord('post', '1');
 
@@ -299,17 +304,18 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
     const Comment = Model.extend({
       name: attr('string'),
     });
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    this.owner.register('adapter:application', RESTAdapter.extend());
+    this.owner.register('serializer:application', RESTSerializer.extend());
+
     const store = this.owner.lookup('service:store');
     const adapter = store.adapterFor('application');
 
     const ajaxCallback = ajaxResponse(adapter, {
       post: { id: '1', name: 'Rails is very expensive sushi' },
     });
-
-    this.owner.register('model:post', Post);
-    this.owner.register('model:comment', Comment);
-    this.owner.register('adapter:application', RESTAdapter.extend());
-    this.owner.register('serializer:application', RESTSerializer.extend());
 
     await store.findRecord('post', 1, { include: 'comments' });
 


### PR DESCRIPTION
## Description

Update tests for `findRecord` functionality in test adapter. Since the rest-adapter tests file is quite long, it is hard to make some changes that involve not using global variables and defining all test requirements within the test context. 

This is a follow up on this one: https://github.com/emberjs/data/pull/7522

**What has changed**

- Separate the tests of the adapter in multiple files within a rest-adapter folder. Let me know if it is ok.
- Change imports to stop using global DS import and use the specific packages instead.
- I made some changes to how the `ajaxResponse` works, instead of using a global share adapter variable, it is getting the adapter as a function param and returning a callback function to get the information about the ajax execution. It was just an experiment, so, looking forward to getting feedback on it.
