### PR TITLE
fix: #7039 Ensure meta and links update when fetched relationship is empty or does not include the data key

### DIFF
--- a/packages/-ember-data/tests/integration/references/belongs-to-test.js
+++ b/packages/-ember-data/tests/integration/references/belongs-to-test.js
@@ -541,9 +541,7 @@ module('integration/references/belongs-to', function (hooks) {
     });
   });
 
-  test('meta can be retrieved, even if the fetched data is null', function (assert) {
-    var done = assert.async();
-
+  test('meta can be retrieved, even if the fetched data is null', async function (assert) {
     let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
@@ -551,7 +549,7 @@ module('integration/references/belongs-to', function (hooks) {
 
     adapter.findBelongsTo = function (store, snapshot, link) {
       assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
-      assert.equal(link, '/families/1');
+      assert.equal(link, '/families/1', 'link was passed correctly');
 
       return resolve({
         data: null,
@@ -559,31 +557,25 @@ module('integration/references/belongs-to', function (hooks) {
       });
     };
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: 1,
-          relationships: {
-            family: {
-              links: { related: '/families/1' },
-            },
+    const person = store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        relationships: {
+          family: {
+            links: { related: '/families/1' },
           },
         },
-      });
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    const familyReference = person.belongsTo('family');
     assert.equal(familyReference.remoteType(), 'link');
 
-    run(function () {
-      familyReference.load({ adapterOptions }).then(function (record) {
-        assert.equal(record, null);
-        assert.equal(familyReference.meta().it, 'works');
-        done();
-      });
-    });
+    const record = await familyReference.load({ adapterOptions });
+    const meta = familyReference.meta();
+    assert.equal(record, null, 'we have no record');
+    assert.deepEqual(meta, { it: 'works' }, 'meta is available');
   });
 
   test('reload() - loads the record when not yet loaded', function (assert) {


### PR DESCRIPTION
resolves #7039 