### PR TITLE
test: ensure coalesced find requests properly associate options and includes with their snapshot

### DIFF
--- a/packages/-ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/-ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -236,7 +236,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
 
     adapter.buildURL = function (type, ids, snapshots) {
       if (Array.isArray(snapshots)) {
-        return '/posts/' + snapshots.firstObject.belongsTo('post', { id: true }) + '/comments/';
+        return '/posts/' + snapshots[0].belongsTo('post', { id: true }) + '/comments/';
       }
       return '';
     };

--- a/packages/store/addon/-private/system/store/finders.js
+++ b/packages/store/addon/-private/system/store/finders.js
@@ -1,4 +1,3 @@
-import { A } from '@ember/array';
 import { assert, deprecate, warn } from '@ember/debug';
 import { assign } from '@ember/polyfills';
 import { DEBUG } from '@glimmer/env';
@@ -76,7 +75,7 @@ export function _find(adapter, store, modelClass, id, internalModel, options) {
 }
 
 export function _findMany(adapter, store, modelName, ids, internalModels, optionsMap) {
-  let snapshots = A(internalModels.map((internalModel) => internalModel.createSnapshot(optionsMap.get(internalModel))));
+  let snapshots = internalModels.map((internalModel) => internalModel.createSnapshot(optionsMap.get(internalModel)));
   let modelClass = store.modelFor(modelName); // `adapter.findMany` gets the modelClass still
   let promise = adapter.findMany(store, modelClass, ids, snapshots);
   let label = `DS: Handle Adapter#findMany of '${modelName}'`;


### PR DESCRIPTION
The underlying issue was resolved with the `optionsMap` passed to _findMany. So the test from #5054 is passing without the other changes. I think this test should be kept, because I didn't see other scenarios where both coalescing+adapterOptions where tested at the same time.

closes #5054 
resolves #5050