### PR TITLE
fix: add asserts and assert tests for belongsTo/hasMany/findRecord empty responses

### DIFF
--- a/packages/store/addon/-private/system/fetch-manager.ts
+++ b/packages/store/addon/-private/system/fetch-manager.ts
@@ -288,6 +288,10 @@ export default class FetchManager {
           `Ember Data expected the primary data returned from a 'findRecord' response to be an object but instead it found an array.`,
           !Array.isArray(payload.data)
         );
+        assert(
+          `The 'findRecord' request for ${modelName}:${id} resolved indicating success but contained no primary data. To indicate a 404 not found you should either reject the promise returned by the adapter's findRecord method or throw a NotFoundError.`,
+          'data' in payload && payload.data !== null && typeof payload.data === 'object'
+        );
 
         warn(
           `You requested a record of type '${modelName}' with id '${id}' but the adapter returned a payload with primary data having an id of '${payload.data.id}'. Use 'store.findRecord()' when the requested id is the same as the one returned by the adapter. In other cases use 'store.queryRecord()' instead.`,


### PR DESCRIPTION
resolves #7547 
resolves #6920

In the case of belongsTo/hasMany this would already have thrown an error but it would have been a confusing one. You will still get a somewhat more confusing one if the response contains only links but not meta as it will fail `validateDocumentStructure` as JSON:API insists that documents have at-least one-of data/errors/meta