### PR TITLE
[BUGFIX] reset previously failed linked async belongs-to now works

### DIFF
--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -580,7 +580,7 @@ module('async belongs-to rendering tests', function (hooks) {
   });
 
   test('Can reset a previously failed linked async belongs-to', async function (assert) {
-    assert.expect(4);
+    assert.expect(5);
     let people = makePeopleWithRelationshipData();
     let sedona = store.push({
       data: people.dict['6:has-linked-parent'],

--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -611,7 +611,13 @@ module('async belongs-to rendering tests', function (hooks) {
     newParent.unloadRecord();
     await settled();
     assert.equal(this.element.textContent.trim(), '', 'after unloading the record it shows no content on page');
-    await sedona.belongsTo('parent').reload();
+    try {
+      await sedona.belongsTo('parent').reload();
+      assert.ok(false, 'we should have thrown an error');
+    } catch (e) {
+      assert.strictEqual(e.message, 'person not found', 'we threw a not found error');
+      assert.strictEqual(adapter.__payloads.length, 0, 'we hit network again');
+    }
     Ember.onerror = originalOnError;
   });
 });

--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -616,7 +616,7 @@ module('async belongs-to rendering tests', function (hooks) {
       assert.ok(false, 'we should have thrown an error');
     } catch (e) {
       assert.strictEqual(e.message, 'person not found', 'we threw a not found error');
-      assert.strictEqual(adapter.__payloads.length, 0, 'we hit network again');
+      assert.strictEqual(adapter._payloads.length, 0, 'we hit network again');
     }
     Ember.onerror = originalOnError;
   });

--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -611,7 +611,7 @@ module('async belongs-to rendering tests', function (hooks) {
     newParent.unloadRecord();
     await settled();
     assert.equal(this.element.textContent.trim(), '', 'after unloading the record it shows no content on page');
-    sedona.reload();
+    await sedona.belongsTo('parent').reload();
     Ember.onerror = originalOnError;
   });
 });

--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -612,7 +612,6 @@ module('async belongs-to rendering tests', function (hooks) {
     await settled();
     assert.equal(this.element.textContent.trim(), '', 'after unloading the record it shows no content on page');
     sedona.reload();
-    await settled();
     Ember.onerror = originalOnError;
   });
 });

--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -578,4 +578,41 @@ module('async belongs-to rendering tests', function (hooks) {
       }
     });
   });
+
+  test('Can reset a previously failed linked async belongs-to', async function (assert) {
+    assert.expect(4);
+    let people = makePeopleWithRelationshipData();
+    let sedona = store.push({
+      data: people.dict['6:has-linked-parent'],
+    });
+
+    adapter.setupPayloads(assert, [new ServerError([], 'person not found'), new ServerError([], 'person not found')]);
+
+    // render
+    this.set('sedona', sedona);
+
+    let originalOnError = Ember.onerror;
+    Ember.onerror = function (e) {
+      assert.ok(true, 'Rejects the first time');
+    };
+
+    await render(hbs`
+    <p>{{sedona.parent.name}}</p>
+    `);
+
+    const newParent = store.createRecord('person', { name: 'New Person' });
+    sedona.set('parent', newParent);
+    await settled();
+    assert.equal(
+      this.element.textContent.trim(),
+      'New Person',
+      'after resetting to a new record, shows new content on page'
+    );
+    newParent.unloadRecord();
+    await settled();
+    assert.equal(this.element.textContent.trim(), '', 'after unloading the record it shows no content on page');
+    sedona.reload();
+    await settled();
+    Ember.onerror = originalOnError;
+  });
 });

--- a/packages/record-data/addon/-private/graph/operations/replace-related-record.ts
+++ b/packages/record-data/addon/-private/graph/operations/replace-related-record.ts
@@ -94,6 +94,8 @@ export default function replaceRelatedRecord(graph: Graph, op: ReplaceRelatedRec
   relationship[prop] = op.value;
   state.hasReceivedData = true;
   state.isEmpty = op.value === null;
+  state.isStale = false;
+  state.hasFailedLoadAttempt = false;
 
   if (op.value) {
     if (definition.type !== op.value.type) {


### PR DESCRIPTION
resolves #6867
closes #6874

Thank you again @runspired for this quick (and dirty :sweat_smile: ) pairing session
<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
