### PR TITLE
[DOC] Fixes broken EmberObject links and updates this._super in native class examples

### DIFF
--- a/packages/adapter/addon/error.js
+++ b/packages/adapter/addon/error.js
@@ -42,7 +42,7 @@ import EmberError from '@ember/error';
         return new MaintenanceError();
       }
 
-      return this._super(...arguments);
+      return super.handleResponse(...arguments);
     }
   }
   ```

--- a/packages/adapter/addon/index.ts
+++ b/packages/adapter/addon/index.ts
@@ -200,7 +200,7 @@ type SnapshotRecordArray = import('@ember-data/store/-private/system/snapshot-re
 
   @class Adapter
   @public
-  @extends EmberObject
+  @extends Ember.EmberObject
 */
 export default class Adapter extends EmberObject implements MinimumAdapterInterface {
   declare _coalesceFindRequests: boolean;

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -104,10 +104,10 @@ function computeOnce(target, key, desc) {
 
 /**
   Base class from which Models can be define.
-  
+
   ```js
   import Model, { attr } from '@ember-data/model';
-  
+
   export default class User extends Model {
     @attr name;
   }
@@ -115,7 +115,7 @@ function computeOnce(target, key, desc) {
 
   @class Model
   @public
-  @extends EmberObject
+  @extends Ember.EmberObject
   @uses EmberData.DeprecatedEvented
 */
 class Model extends EmberObject {

--- a/packages/model/addon/-private/system/many-array.js
+++ b/packages/model/addon/-private/system/many-array.js
@@ -54,7 +54,7 @@ import diffArray from './diff-array';
 
   @class ManyArray
   @public
-  @extends EmberObject
+  @extends Ember.EmberObject
   @uses Ember.MutableArray, DeprecatedEvented
 */
 export default EmberObject.extend(MutableArray, DeprecatedEvented, {
@@ -115,7 +115,7 @@ export default EmberObject.extend(MutableArray, DeprecatedEvented, {
 
     /**
      * Retrieve the links for this relationship
-     * 
+     *
      @property {Object | null} links
      @public
      */
@@ -314,7 +314,7 @@ export default EmberObject.extend(MutableArray, DeprecatedEvented, {
     ```javascript
     let user = store.peekRecord('user', '1')
     await login(user);
- 
+
     let permissions = await user.permissions;
     await permissions.reload();
     ```

--- a/packages/serializer/addon/index.ts
+++ b/packages/serializer/addon/index.ts
@@ -118,7 +118,7 @@ import EmberObject from '@ember/object';
 
   @class Serializer
   @public
-  @extends EmberObject
+  @extends Ember.EmberObject
 */
 
 export default EmberObject.extend({

--- a/packages/serializer/addon/json.js
+++ b/packages/serializer/addon/json.js
@@ -218,7 +218,7 @@ const JSONSerializer = Serializer.extend({
     the `requestType`.
 
     To override this method with a custom one, make sure to call
-    `return this._super(store, primaryModelClass, payload, id, requestType)` with your
+    `return super.normalizeResponse(store, primaryModelClass, payload, id, requestType)` with your
     pre-processed data.
 
     Here's an example of using `normalizeResponse` manually:

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -1020,7 +1020,7 @@ abstract class CoreStore extends Service {
 
     ```app/adapters/application.js
     buildQuery(snapshot) {
-      let query = this._super(...arguments);
+      let query = super.buildQuery(...arguments);
 
       let { fields } = snapshot.adapterOptions;
 


### PR DESCRIPTION
Fixes broken `EmberObject` link mentioned in https://github.com/ember-learn/ember-api-docs/issues/759