### PR TITLE
[Chore]: shouldAssertMethodCallsOnDestroyedStore: true

### DIFF
--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -252,7 +252,7 @@ abstract class CoreStore extends Service {
 
   // DEBUG-only properties
   declare _trackedAsyncRequests: AsyncTrackingToken[];
-  shouldAssertMethodCallsOnDestroyedStore: boolean = false;
+  shouldAssertMethodCallsOnDestroyedStore: boolean = true;
   shouldTrackAsyncRequests: boolean = false;
   generateStackTracesForTrackedRequests: boolean = false;
   declare _trackAsyncRequestStart: (str: string) => void;


### PR DESCRIPTION
Step 1: turn on `assert` (instead of deprecate)
Step 2: After full release cycle, remove `deprecate` block.