### PR TITLE
chore: fix or silence-expected deprecations

### DIFF
--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -23,7 +23,7 @@ jobs:
           originSha=$(git rev-parse HEAD^2)
           echo $originSha > tmp/sha-for-commit.txt
           git show --format=short --no-patch $originSha
-      - uses: tracerbench/tracerbench-compare-action@update-configurability
+      - uses: tracerbench/tracerbench-compare-action@master
         with:
           experiment-build-command: yarn workspace relationship-performance-test-app ember build -e production --output-path dist-experiment
           experiment-serve-command: yarn workspace relationship-performance-test-app ember s --path dist-experiment --port 4201
@@ -70,4 +70,3 @@ jobs:
           node ./scripts/perf-tracking/create-comment.js $sha > tracerbench-results/comment.txt
           COMMENT_TEXT="@./tracerbench-results/comment.txt"
           source scripts/asset-size-tracking/src/post-comment.sh
-

--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -597,7 +597,7 @@ module('async belongs-to rendering tests', function (hooks) {
     };
 
     await render(hbs`
-    <p>{{sedona.parent.name}}</p>
+    <p>{{this.sedona.parent.name}}</p>
     `);
 
     const newParent = store.createRecord('person', { name: 'New Person' });

--- a/packages/-ember-data/tests/integration/adapter/find-test.js
+++ b/packages/-ember-data/tests/integration/adapter/find-test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { all, allSettled, Promise, reject, resolve } from 'rsvp';
 
-import Adapter from 'ember-data/adapter';
-import JSONAPISerializer from 'ember-data/serializers/json-api';
 import { setupTest } from 'ember-qunit';
 
+import Adapter from '@ember-data/adapter';
 import Model, { attr } from '@ember-data/model';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
 import testInDebug from '@ember-data/unpublished-test-infra/test-support/test-in-debug';
 
 module('integration/adapter/find - Finding Records', function (hooks) {

--- a/packages/-ember-data/tests/integration/application-test.js
+++ b/packages/-ember-data/tests/integration/application-test.js
@@ -1,6 +1,7 @@
 import Application from '@ember/application';
 import Namespace from '@ember/application/namespace';
 import Controller from '@ember/controller';
+import { assign } from '@ember/polyfills';
 import Service, { inject as service } from '@ember/service';
 
 import { module, test } from 'qunit';
@@ -25,7 +26,7 @@ module('integration/application - Injecting a Custom Store', function (hooks) {
       'controller:baz',
       class Controller {
         constructor(args) {
-          Object.assign(this, args);
+          assign(this, args);
         }
         @service('store') store;
         static create(args) {
@@ -87,7 +88,7 @@ module('integration/application - Injecting the Default Store', function (hooks)
 
   test('If a store is instantiated, it should be made available to each controller.', async function (assert) {
     let fooController = this.owner.lookup('controller:foo');
-    assert.ok(fooController.get('store') instanceof Store, 'the store was injected');
+    assert.ok(fooController.store instanceof Store, 'the store was injected');
   });
 
   test('the DS namespace should be accessible', async function (assert) {

--- a/packages/-ember-data/tests/integration/application-test.js
+++ b/packages/-ember-data/tests/integration/application-test.js
@@ -96,7 +96,7 @@ module('integration/application - Injecting the Default Store', function (hooks)
       () => {
         assert.ok(Namespace.byName('DS') instanceof Namespace, 'the DS namespace is accessible');
       },
-      { id: 'ember-global', count: 2 }
+      { id: 'ember-global', count: 2, when: { ember: '>=3.27.0' } }
     );
   });
 });

--- a/packages/-ember-data/tests/integration/application-test.js
+++ b/packages/-ember-data/tests/integration/application-test.js
@@ -7,11 +7,11 @@ import Service, { inject as service } from '@ember/service';
 import { module, test } from 'qunit';
 
 import initializeEmberData from 'ember-data/setup-container';
-import Store from 'ember-data/store';
 import { setupTest } from 'ember-qunit';
 import Resolver from 'ember-resolver';
 
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import Store from '@ember-data/store';
 
 module('integration/application - Injecting a Custom Store', function (hooks) {
   setupTest(hooks);

--- a/packages/-ember-data/tests/integration/application-test.js
+++ b/packages/-ember-data/tests/integration/application-test.js
@@ -69,7 +69,7 @@ module('integration/application - Injecting the Default Store', function (hooks)
       'controller:baz',
       class Controller {
         constructor(args) {
-          Object.assign(this, args);
+          assign(this, args);
         }
         @service('store') store;
         static create(args) {
@@ -112,7 +112,7 @@ module('integration/application - Using the store as a service', function (hooks
       'controller:baz',
       class Controller {
         constructor(args) {
-          Object.assign(this, args);
+          assign(this, args);
         }
         @service('store') store;
         static create(args) {

--- a/packages/-ember-data/tests/integration/injection-test.js
+++ b/packages/-ember-data/tests/integration/injection-test.js
@@ -65,7 +65,7 @@ module('integration/injection eager injections', function (hooks) {
         assert.ok(apple === appleService, `'model:foo.apple' should be the apple service`);
         assert.ok(apple instanceof Apple, `'model:foo'.apple should be an instance of 'service:apple'`);
       },
-      { id: 'implicit-injections', count: 1 }
+      { id: 'implicit-injections', count: 1, when: { ember: '>=3.27.0' } }
     );
   });
 });

--- a/packages/-ember-data/tests/integration/injection-test.js
+++ b/packages/-ember-data/tests/integration/injection-test.js
@@ -53,12 +53,19 @@ module('integration/injection eager injections', function (hooks) {
   });
 
   test('did inject', async function (assert) {
-    let foo = store.createRecord('foo');
-    let apple = foo.get('apple');
-    let appleService = this.owner.lookup('service:apple');
+    // TODO likely this test should instead test that we can use service injections
+    // on models (e.g. that owner is properly setup for it).
+    assert.expectDeprecation(
+      () => {
+        let foo = store.createRecord('foo');
+        let apple = foo.get('apple');
+        let appleService = this.owner.lookup('service:apple');
 
-    assert.ok(apple, `'model:foo' instance should have an 'apple' property`);
-    assert.ok(apple === appleService, `'model:foo.apple' should be the apple service`);
-    assert.ok(apple instanceof Apple, `'model:foo'.apple should be an instance of 'service:apple'`);
+        assert.ok(apple, `'model:foo' instance should have an 'apple' property`);
+        assert.ok(apple === appleService, `'model:foo.apple' should be the apple service`);
+        assert.ok(apple instanceof Apple, `'model:foo'.apple should be an instance of 'service:apple'`);
+      },
+      { id: 'implicit-injections', count: 1 }
+    );
   });
 });

--- a/packages/-ember-data/tests/integration/multiple-stores-test.js
+++ b/packages/-ember-data/tests/integration/multiple-stores-test.js
@@ -2,13 +2,13 @@
 // because the ember-data/store uses DefaultRecordData while @ember-data/store does not
 import { module, test } from 'qunit';
 
-import Store from 'ember-data/store';
 import { setupTest } from 'ember-qunit';
 
 import Adapter from '@ember-data/adapter';
 import RESTAdapter from '@ember-data/adapter/rest';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import RESTSerializer, { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
+import Store from '@ember-data/store';
 
 module('integration/multiple_stores - Multiple Stores Tests', function (hooks) {
   setupTest(hooks);

--- a/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
@@ -3,14 +3,13 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { Promise } from 'rsvp';
 
-import Model from 'ember-data/model';
-import Store from 'ember-data/store';
 import { setupTest } from 'ember-qunit';
 
 import { InvalidError } from '@ember-data/adapter/error';
 import { RECORD_DATA_ERRORS } from '@ember-data/canary-features';
-import { attr } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
+import Store from '@ember-data/store';
 
 type RecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').RecordIdentifier;
 type NewRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').NewRecordIdentifier;

--- a/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
@@ -4,13 +4,12 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import { Promise } from 'rsvp';
 
-import Model from 'ember-data/model';
-import Store from 'ember-data/store';
 import { setupTest } from 'ember-qunit';
 
 import { RECORD_DATA_STATE } from '@ember-data/canary-features';
-import { attr } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
+import Store from '@ember-data/store';
 
 type RecordData = import('@ember-data/store/-private/ts-interfaces/record-data').RecordData;
 type NewRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').NewRecordIdentifier;

--- a/packages/-ember-data/tests/integration/record-data/record-data-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-test.ts
@@ -4,13 +4,12 @@ import { settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { Promise } from 'rsvp';
 
-import Model from 'ember-data/model';
-import Store from 'ember-data/store';
 import { setupTest } from 'ember-qunit';
 
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import { attr, belongsTo, hasMany } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
+import Store from '@ember-data/store';
 
 class Person extends Model {
   // TODO fix the typing for naked attrs

--- a/packages/-ember-data/tests/integration/record-data/store-wrapper-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/store-wrapper-test.ts
@@ -1,10 +1,9 @@
 import { module, test } from 'qunit';
 
-import Model from 'ember-data/model';
-import Store from 'ember-data/store';
 import { setupTest } from 'ember-qunit';
 
-import { attr, belongsTo, hasMany } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import Store from '@ember-data/store';
 import publicProps from '@ember-data/unpublished-test-infra/test-support/public-props';
 
 class Person extends Model {

--- a/packages/-ember-data/tests/integration/records/relationship-changes-test.js
+++ b/packages/-ember-data/tests/integration/records/relationship-changes-test.js
@@ -569,7 +569,7 @@ module('integration/records/relationship-changes - Relationship changes', functi
 
         siblings.removeArrayObserver(observer);
       },
-      { id: 'array-observers', count: 2 }
+      { id: 'array-observers', count: 2, when: { ember: '>=3.26.0' } }
     );
   });
 
@@ -649,7 +649,7 @@ module('integration/records/relationship-changes - Relationship changes', functi
 
         siblings.removeArrayObserver(observer);
       },
-      { id: 'array-observers', count: 2 }
+      { id: 'array-observers', count: 2, when: { ember: '>=3.26.0' } }
     );
   });
 
@@ -733,7 +733,7 @@ module('integration/records/relationship-changes - Relationship changes', functi
 
         siblingsProxy.removeArrayObserver(observer);
       },
-      { id: 'array-observers', count: 2 }
+      { id: 'array-observers', count: 2, when: { ember: '>=3.26.0' } }
     );
   });
 
@@ -811,7 +811,7 @@ module('integration/records/relationship-changes - Relationship changes', functi
 
         siblings.removeArrayObserver(observer);
       },
-      { id: 'array-observers', count: 2 }
+      { id: 'array-observers', count: 2, when: { ember: '>=3.26.0' } }
     );
   });
 
@@ -889,7 +889,7 @@ module('integration/records/relationship-changes - Relationship changes', functi
 
         siblings.removeArrayObserver(observer);
       },
-      { id: 'array-observers', count: 2 }
+      { id: 'array-observers', count: 2, when: { ember: '>=3.26.0' } }
     );
   });
 

--- a/packages/-ember-data/tests/integration/records/relationship-changes-test.js
+++ b/packages/-ember-data/tests/integration/records/relationship-changes-test.js
@@ -498,374 +498,399 @@ module('integration/records/relationship-changes - Relationship changes', functi
   });
 
   test('Calling push with relationship triggers willChange and didChange with detail when appending', async function (assert) {
-    let store = this.owner.lookup('service:store');
+    assert.expectDeprecation(
+      async () => {
+        let store = this.owner.lookup('service:store');
 
-    let willChangeCount = 0;
-    let didChangeCount = 0;
+        let willChangeCount = 0;
+        let didChangeCount = 0;
 
-    let observer = {
-      arrayWillChange(array, start, removing, adding) {
-        willChangeCount++;
-        assert.equal(start, 1, 'willChange.start');
-        assert.equal(removing, 0, 'willChange.removing');
-        assert.equal(adding, 1, 'willChange.adding');
-      },
-
-      arrayDidChange(array, start, removed, added) {
-        didChangeCount++;
-        assert.equal(start, 1, 'didChange.start');
-        assert.equal(removed, 0, 'didChange.removed');
-        assert.equal(added, 1, 'didChange.added');
-      },
-    };
-
-    store.push({
-      data: {
-        type: 'person',
-        id: 'wat',
-        attributes: {
-          firstName: 'Yehuda',
-          lastName: 'Katz',
-        },
-        relationships: {
-          siblings: {
-            data: [sibling1Ref],
+        let observer = {
+          arrayWillChange(array, start, removing, adding) {
+            willChangeCount++;
+            assert.equal(start, 1, 'willChange.start');
+            assert.equal(removing, 0, 'willChange.removing');
+            assert.equal(adding, 1, 'willChange.adding');
           },
-        },
-      },
-      included: [sibling1],
-    });
 
-    let person = store.peekRecord('person', 'wat');
-    let siblings = await person.siblings;
-
-    // flush initial state since
-    // nothing is consuming us.
-    // else the test will fail because we will
-    // (correctly) not notify the array observer
-    // as there is still a pending notification
-    siblings.length;
-
-    siblings.addArrayObserver(observer);
-
-    store.push({
-      data: {
-        type: 'person',
-        id: 'wat',
-        attributes: {},
-        relationships: {
-          siblings: {
-            data: [sibling1Ref, sibling2Ref],
+          arrayDidChange(array, start, removed, added) {
+            didChangeCount++;
+            assert.equal(start, 1, 'didChange.start');
+            assert.equal(removed, 0, 'didChange.removed');
+            assert.equal(added, 1, 'didChange.added');
           },
-        },
+        };
+
+        store.push({
+          data: {
+            type: 'person',
+            id: 'wat',
+            attributes: {
+              firstName: 'Yehuda',
+              lastName: 'Katz',
+            },
+            relationships: {
+              siblings: {
+                data: [sibling1Ref],
+              },
+            },
+          },
+          included: [sibling1],
+        });
+
+        let person = store.peekRecord('person', 'wat');
+        let siblings = await person.siblings;
+
+        // flush initial state since
+        // nothing is consuming us.
+        // else the test will fail because we will
+        // (correctly) not notify the array observer
+        // as there is still a pending notification
+        siblings.length;
+
+        siblings.addArrayObserver(observer);
+
+        store.push({
+          data: {
+            type: 'person',
+            id: 'wat',
+            attributes: {},
+            relationships: {
+              siblings: {
+                data: [sibling1Ref, sibling2Ref],
+              },
+            },
+          },
+          included: [sibling2],
+        });
+
+        assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
+        assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+
+        siblings.removeArrayObserver(observer);
       },
-      included: [sibling2],
-    });
-
-    assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-    assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
-
-    siblings.removeArrayObserver(observer);
+      { id: 'array-observers', count: 2 }
+    );
   });
 
   test('Calling push with relationship triggers willChange and didChange with detail when truncating', function (assert) {
-    let store = this.owner.lookup('service:store');
+    assert.expectDeprecation(
+      async () => {
+        let store = this.owner.lookup('service:store');
 
-    let willChangeCount = 0;
-    let didChangeCount = 0;
+        let willChangeCount = 0;
+        let didChangeCount = 0;
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'person',
-          id: 'wat',
-          attributes: {
-            firstName: 'Yehuda',
-            lastName: 'Katz',
-          },
-          relationships: {
-            siblings: {
-              data: [sibling1Ref, sibling2Ref],
+        run(() => {
+          store.push({
+            data: {
+              type: 'person',
+              id: 'wat',
+              attributes: {
+                firstName: 'Yehuda',
+                lastName: 'Katz',
+              },
+              relationships: {
+                siblings: {
+                  data: [sibling1Ref, sibling2Ref],
+                },
+              },
             },
+            included: [sibling1, sibling2],
+          });
+        });
+
+        let person = store.peekRecord('person', 'wat');
+        let siblings = run(() => person.get('siblings'));
+
+        // flush initial state since
+        // nothing is consuming us.
+        // else the test will fail because we will
+        // (correctly) not notify the array observer
+        // as there is still a pending notification
+        siblings.length;
+
+        let observer = {
+          arrayWillChange(array, start, removing, adding) {
+            willChangeCount++;
+            assert.equal(start, 1);
+            assert.equal(removing, 1);
+            assert.equal(adding, 0);
           },
-        },
-        included: [sibling1, sibling2],
-      });
-    });
 
-    let person = store.peekRecord('person', 'wat');
-    let siblings = run(() => person.get('siblings'));
+          arrayDidChange(array, start, removed, added) {
+            didChangeCount++;
+            assert.equal(start, 1);
+            assert.equal(removed, 1);
+            assert.equal(added, 0);
+          },
+        };
 
-    // flush initial state since
-    // nothing is consuming us.
-    // else the test will fail because we will
-    // (correctly) not notify the array observer
-    // as there is still a pending notification
-    siblings.length;
+        siblings.addArrayObserver(observer);
 
-    let observer = {
-      arrayWillChange(array, start, removing, adding) {
-        willChangeCount++;
-        assert.equal(start, 1);
-        assert.equal(removing, 1);
-        assert.equal(adding, 0);
-      },
-
-      arrayDidChange(array, start, removed, added) {
-        didChangeCount++;
-        assert.equal(start, 1);
-        assert.equal(removed, 1);
-        assert.equal(added, 0);
-      },
-    };
-
-    siblings.addArrayObserver(observer);
-
-    run(() => {
-      store.push({
-        data: {
-          type: 'person',
-          id: 'wat',
-          attributes: {},
-          relationships: {
-            siblings: {
-              data: [sibling1Ref],
+        run(() => {
+          store.push({
+            data: {
+              type: 'person',
+              id: 'wat',
+              attributes: {},
+              relationships: {
+                siblings: {
+                  data: [sibling1Ref],
+                },
+              },
             },
-          },
-        },
-        included: [],
-      });
-    });
+            included: [],
+          });
+        });
 
-    assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-    assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+        assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
+        assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
 
-    siblings.removeArrayObserver(observer);
+        siblings.removeArrayObserver(observer);
+      },
+      { id: 'array-observers', count: 2 }
+    );
   });
 
   test('Calling push with relationship triggers willChange and didChange with detail when inserting at front', async function (assert) {
-    let store = this.owner.lookup('service:store');
+    assert.expectDeprecation(
+      async () => {
+        let store = this.owner.lookup('service:store');
 
-    let willChangeCount = 0;
-    let didChangeCount = 0;
+        let willChangeCount = 0;
+        let didChangeCount = 0;
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'person',
-          id: 'wat',
-          attributes: {
-            firstName: 'Yehuda',
-            lastName: 'Katz',
+        run(() => {
+          store.push({
+            data: {
+              type: 'person',
+              id: 'wat',
+              attributes: {
+                firstName: 'Yehuda',
+                lastName: 'Katz',
+              },
+              relationships: {
+                siblings: {
+                  data: [sibling2Ref],
+                },
+              },
+            },
+            included: [sibling2],
+          });
+        });
+        let person = store.peekRecord('person', 'wat');
+
+        let observer = {
+          arrayWillChange(array, start, removing, adding) {
+            willChangeCount++;
+            assert.equal(start, 0, 'change will start at the beginning');
+            assert.equal(removing, 0, 'we have no removals');
+            assert.equal(adding, 1, 'we have one insertion');
           },
-          relationships: {
-            siblings: {
-              data: [sibling2Ref],
+
+          arrayDidChange(array, start, removed, added) {
+            didChangeCount++;
+            assert.equal(start, 0, 'change did start at the beginning');
+            assert.equal(removed, 0, 'change had no removals');
+            assert.equal(added, 1, 'change had one insertion');
+          },
+        };
+
+        const siblingsProxy = person.siblings;
+        const siblings = await siblingsProxy;
+
+        // flush initial state since
+        // nothing is consuming us.
+        // else the test will fail because we will
+        // (correctly) not notify the array observer
+        // as there is still a pending notification
+        siblingsProxy.length;
+
+        siblingsProxy.addArrayObserver(observer);
+
+        store.push({
+          data: {
+            type: 'person',
+            id: 'wat',
+            attributes: {},
+            relationships: {
+              siblings: {
+                data: [sibling1Ref, sibling2Ref],
+              },
             },
           },
-        },
-        included: [sibling2],
-      });
-    });
-    let person = store.peekRecord('person', 'wat');
+          included: [sibling1],
+        });
 
-    let observer = {
-      arrayWillChange(array, start, removing, adding) {
-        willChangeCount++;
-        assert.equal(start, 0, 'change will start at the beginning');
-        assert.equal(removing, 0, 'we have no removals');
-        assert.equal(adding, 1, 'we have one insertion');
+        assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
+        assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+        assert.deepEqual(
+          siblings.map((i) => i.id),
+          ['1', '2'],
+          'We have the correct siblings'
+        );
+
+        siblingsProxy.removeArrayObserver(observer);
       },
-
-      arrayDidChange(array, start, removed, added) {
-        didChangeCount++;
-        assert.equal(start, 0, 'change did start at the beginning');
-        assert.equal(removed, 0, 'change had no removals');
-        assert.equal(added, 1, 'change had one insertion');
-      },
-    };
-
-    const siblingsProxy = person.siblings;
-    const siblings = await siblingsProxy;
-
-    // flush initial state since
-    // nothing is consuming us.
-    // else the test will fail because we will
-    // (correctly) not notify the array observer
-    // as there is still a pending notification
-    siblingsProxy.length;
-
-    siblingsProxy.addArrayObserver(observer);
-
-    store.push({
-      data: {
-        type: 'person',
-        id: 'wat',
-        attributes: {},
-        relationships: {
-          siblings: {
-            data: [sibling1Ref, sibling2Ref],
-          },
-        },
-      },
-      included: [sibling1],
-    });
-
-    assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-    assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
-    assert.deepEqual(
-      siblings.map((i) => i.id),
-      ['1', '2'],
-      'We have the correct siblings'
+      { id: 'array-observers', count: 2 }
     );
-
-    siblingsProxy.removeArrayObserver(observer);
   });
 
   test('Calling push with relationship triggers willChange and didChange with detail when inserting in middle', function (assert) {
-    let store = this.owner.lookup('service:store');
+    assert.expectDeprecation(
+      async () => {
+        let store = this.owner.lookup('service:store');
 
-    let willChangeCount = 0;
-    let didChangeCount = 0;
+        let willChangeCount = 0;
+        let didChangeCount = 0;
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'person',
-          id: 'wat',
-          attributes: {
-            firstName: 'Yehuda',
-            lastName: 'Katz',
-          },
-          relationships: {
-            siblings: {
-              data: [sibling1Ref, sibling3Ref],
+        run(() => {
+          store.push({
+            data: {
+              type: 'person',
+              id: 'wat',
+              attributes: {
+                firstName: 'Yehuda',
+                lastName: 'Katz',
+              },
+              relationships: {
+                siblings: {
+                  data: [sibling1Ref, sibling3Ref],
+                },
+              },
             },
+            included: [sibling1, sibling3],
+          });
+        });
+        let person = store.peekRecord('person', 'wat');
+        let observer = {
+          arrayWillChange(array, start, removing, adding) {
+            willChangeCount++;
+            assert.equal(start, 1);
+            assert.equal(removing, 0);
+            assert.equal(adding, 1);
           },
-        },
-        included: [sibling1, sibling3],
-      });
-    });
-    let person = store.peekRecord('person', 'wat');
-    let observer = {
-      arrayWillChange(array, start, removing, adding) {
-        willChangeCount++;
-        assert.equal(start, 1);
-        assert.equal(removing, 0);
-        assert.equal(adding, 1);
-      },
-      arrayDidChange(array, start, removed, added) {
-        didChangeCount++;
-        assert.equal(start, 1);
-        assert.equal(removed, 0);
-        assert.equal(added, 1);
-      },
-    };
+          arrayDidChange(array, start, removed, added) {
+            didChangeCount++;
+            assert.equal(start, 1);
+            assert.equal(removed, 0);
+            assert.equal(added, 1);
+          },
+        };
 
-    let siblings = run(() => person.get('siblings'));
+        let siblings = run(() => person.get('siblings'));
 
-    // flush initial state since
-    // nothing is consuming us.
-    // else the test will fail because we will
-    // (correctly) not notify the array observer
-    // as there is still a pending notification
-    siblings.length;
+        // flush initial state since
+        // nothing is consuming us.
+        // else the test will fail because we will
+        // (correctly) not notify the array observer
+        // as there is still a pending notification
+        siblings.length;
 
-    siblings.addArrayObserver(observer);
+        siblings.addArrayObserver(observer);
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'person',
-          id: 'wat',
-          attributes: {},
-          relationships: {
-            siblings: {
-              data: [sibling1Ref, sibling2Ref, sibling3Ref],
+        run(() => {
+          store.push({
+            data: {
+              type: 'person',
+              id: 'wat',
+              attributes: {},
+              relationships: {
+                siblings: {
+                  data: [sibling1Ref, sibling2Ref, sibling3Ref],
+                },
+              },
             },
-          },
-        },
-        included: [sibling2],
-      });
-    });
+            included: [sibling2],
+          });
+        });
 
-    assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-    assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+        assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
+        assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
 
-    siblings.removeArrayObserver(observer);
+        siblings.removeArrayObserver(observer);
+      },
+      { id: 'array-observers', count: 2 }
+    );
   });
 
   test('Calling push with relationship triggers willChange and didChange with detail when replacing different length in middle', function (assert) {
-    let store = this.owner.lookup('service:store');
+    assert.expectDeprecation(
+      async () => {
+        let store = this.owner.lookup('service:store');
 
-    let willChangeCount = 0;
-    let didChangeCount = 0;
+        let willChangeCount = 0;
+        let didChangeCount = 0;
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'person',
-          id: 'wat',
-          attributes: {
-            firstName: 'Yehuda',
-            lastName: 'Katz',
-          },
-          relationships: {
-            siblings: {
-              data: [sibling1Ref, sibling2Ref, sibling3Ref],
+        run(() => {
+          store.push({
+            data: {
+              type: 'person',
+              id: 'wat',
+              attributes: {
+                firstName: 'Yehuda',
+                lastName: 'Katz',
+              },
+              relationships: {
+                siblings: {
+                  data: [sibling1Ref, sibling2Ref, sibling3Ref],
+                },
+              },
             },
+            included: [sibling1, sibling2, sibling3],
+          });
+        });
+
+        let person = store.peekRecord('person', 'wat');
+        let observer = {
+          arrayWillChange(array, start, removing, adding) {
+            willChangeCount++;
+            assert.equal(start, 1);
+            assert.equal(removing, 1);
+            assert.equal(adding, 2);
           },
-        },
-        included: [sibling1, sibling2, sibling3],
-      });
-    });
 
-    let person = store.peekRecord('person', 'wat');
-    let observer = {
-      arrayWillChange(array, start, removing, adding) {
-        willChangeCount++;
-        assert.equal(start, 1);
-        assert.equal(removing, 1);
-        assert.equal(adding, 2);
-      },
+          arrayDidChange(array, start, removed, added) {
+            didChangeCount++;
+            assert.equal(start, 1);
+            assert.equal(removed, 1);
+            assert.equal(added, 2);
+          },
+        };
 
-      arrayDidChange(array, start, removed, added) {
-        didChangeCount++;
-        assert.equal(start, 1);
-        assert.equal(removed, 1);
-        assert.equal(added, 2);
-      },
-    };
+        let siblings = run(() => person.get('siblings'));
+        // flush initial state since
+        // nothing is consuming us.
+        // else the test will fail because we will
+        // (correctly) not notify the array observer
+        // as there is still a pending notification
+        siblings.length;
+        siblings.addArrayObserver(observer);
 
-    let siblings = run(() => person.get('siblings'));
-    // flush initial state since
-    // nothing is consuming us.
-    // else the test will fail because we will
-    // (correctly) not notify the array observer
-    // as there is still a pending notification
-    siblings.length;
-    siblings.addArrayObserver(observer);
-
-    run(() => {
-      store.push({
-        data: {
-          type: 'person',
-          id: 'wat',
-          attributes: {},
-          relationships: {
-            siblings: {
-              data: [sibling1Ref, sibling4Ref, sibling5Ref, sibling3Ref],
+        run(() => {
+          store.push({
+            data: {
+              type: 'person',
+              id: 'wat',
+              attributes: {},
+              relationships: {
+                siblings: {
+                  data: [sibling1Ref, sibling4Ref, sibling5Ref, sibling3Ref],
+                },
+              },
             },
-          },
-        },
-        included: [sibling4, sibling5],
-      });
-    });
+            included: [sibling4, sibling5],
+          });
+        });
 
-    assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-    assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+        assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
+        assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
 
-    siblings.removeArrayObserver(observer);
+        siblings.removeArrayObserver(observer);
+      },
+      { id: 'array-observers', count: 2 }
+    );
   });
 
   test('Calling push with updated belongsTo relationship trigger observer', function (assert) {

--- a/packages/-ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/has-many-test.js
@@ -2638,134 +2638,142 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
   });
 
   test('ManyArray notifies the array observers and flushes bindings when removing', function (assert) {
-    assert.expect(2);
+    assert.expect(3);
+    assert.expectDeprecation(
+      () => {
+        let store = this.owner.lookup('service:store');
 
-    let store = this.owner.lookup('service:store');
+        let chapter, page2;
+        let observe = false;
 
-    let chapter, page2;
-    let observe = false;
-
-    run(() => {
-      store.push({
-        data: [
-          {
-            type: 'page',
-            id: '1',
-            attributes: {
-              number: 1,
-            },
-          },
-          {
-            type: 'page',
-            id: '2',
-            attributes: {
-              number: 2,
-            },
-          },
-          {
-            type: 'chapter',
-            id: '1',
-            attributes: {
-              title: 'Sailing the Seven Seas',
-            },
-            relationships: {
-              pages: {
-                data: [
-                  { type: 'page', id: '1' },
-                  { type: 'page', id: '2' },
-                ],
+        run(() => {
+          store.push({
+            data: [
+              {
+                type: 'page',
+                id: '1',
+                attributes: {
+                  number: 1,
+                },
               },
+              {
+                type: 'page',
+                id: '2',
+                attributes: {
+                  number: 2,
+                },
+              },
+              {
+                type: 'chapter',
+                id: '1',
+                attributes: {
+                  title: 'Sailing the Seven Seas',
+                },
+                relationships: {
+                  pages: {
+                    data: [
+                      { type: 'page', id: '1' },
+                      { type: 'page', id: '2' },
+                    ],
+                  },
+                },
+              },
+            ],
+          });
+          let page = store.peekRecord('page', 1);
+          page2 = store.peekRecord('page', 2);
+          chapter = store.peekRecord('chapter', 1);
+
+          chapter.get('pages').addArrayObserver(this, {
+            willChange(pages, index, removeCount, addCount) {
+              if (observe) {
+                assert.equal(pages.objectAt(index), page2, 'page2 is passed to willChange');
+              }
             },
-          },
-        ],
-      });
-      let page = store.peekRecord('page', 1);
-      page2 = store.peekRecord('page', 2);
-      chapter = store.peekRecord('chapter', 1);
+            didChange(pages, index, removeCount, addCount) {
+              if (observe) {
+                assert.equal(removeCount, 1, 'removeCount is correct');
+              }
+            },
+          });
+        });
 
-      chapter.get('pages').addArrayObserver(this, {
-        willChange(pages, index, removeCount, addCount) {
-          if (observe) {
-            assert.equal(pages.objectAt(index), page2, 'page2 is passed to willChange');
-          }
-        },
-        didChange(pages, index, removeCount, addCount) {
-          if (observe) {
-            assert.equal(removeCount, 1, 'removeCount is correct');
-          }
-        },
-      });
-    });
-
-    run(() => {
-      observe = true;
-      page2.set('chapter', null);
-      observe = false;
-    });
+        run(() => {
+          observe = true;
+          page2.set('chapter', null);
+          observe = false;
+        });
+      },
+      { id: 'array-observers', count: 1 }
+    );
   });
 
   test('ManyArray notifies the array observers and flushes bindings when adding', function (assert) {
-    assert.expect(2);
+    assert.expect(3);
+    assert.expectDeprecation(
+      () => {
+        let store = this.owner.lookup('service:store');
 
-    let store = this.owner.lookup('service:store');
+        let chapter, page2;
+        let observe = false;
 
-    let chapter, page2;
-    let observe = false;
-
-    run(() => {
-      store.push({
-        data: [
-          {
-            type: 'page',
-            id: '1',
-            attributes: {
-              number: 1,
-            },
-          },
-          {
-            type: 'page',
-            id: '2',
-            attributes: {
-              number: 2,
-            },
-          },
-          {
-            type: 'chapter',
-            id: '1',
-            attributes: {
-              title: 'Sailing the Seven Seas',
-            },
-            relationships: {
-              pages: {
-                data: [{ type: 'page', id: '1' }],
+        run(() => {
+          store.push({
+            data: [
+              {
+                type: 'page',
+                id: '1',
+                attributes: {
+                  number: 1,
+                },
               },
+              {
+                type: 'page',
+                id: '2',
+                attributes: {
+                  number: 2,
+                },
+              },
+              {
+                type: 'chapter',
+                id: '1',
+                attributes: {
+                  title: 'Sailing the Seven Seas',
+                },
+                relationships: {
+                  pages: {
+                    data: [{ type: 'page', id: '1' }],
+                  },
+                },
+              },
+            ],
+          });
+          let page = store.peekRecord('page', 1);
+          page2 = store.peekRecord('page', 2);
+          chapter = store.peekRecord('chapter', 1);
+
+          chapter.get('pages').addArrayObserver(this, {
+            willChange(pages, index, removeCount, addCount) {
+              if (observe) {
+                assert.equal(addCount, 1, 'addCount is correct');
+              }
             },
-          },
-        ],
-      });
-      let page = store.peekRecord('page', 1);
-      page2 = store.peekRecord('page', 2);
-      chapter = store.peekRecord('chapter', 1);
+            didChange(pages, index, removeCount, addCount) {
+              if (observe) {
+                assert.equal(pages.objectAt(index), page2, 'page2 is passed to didChange');
+              }
+            },
+          });
+        });
 
-      chapter.get('pages').addArrayObserver(this, {
-        willChange(pages, index, removeCount, addCount) {
-          if (observe) {
-            assert.equal(addCount, 1, 'addCount is correct');
-          }
-        },
-        didChange(pages, index, removeCount, addCount) {
-          if (observe) {
-            assert.equal(pages.objectAt(index), page2, 'page2 is passed to didChange');
-          }
-        },
-      });
-    });
-
-    run(() => {
-      observe = true;
-      page2.set('chapter', chapter);
-      observe = false;
-    });
+        run(() => {
+          observe = true;
+          page2.set('chapter', chapter);
+          observe = false;
+        });
+      },
+      { id: 'array-observers', count: 1 }
+    );
   });
 
   testInDebug('Passing a model as type to hasMany should not work', function (assert) {

--- a/packages/-ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/has-many-test.js
@@ -2704,7 +2704,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           observe = false;
         });
       },
-      { id: 'array-observers', count: 1 }
+      { id: 'array-observers', count: 1, when: { ember: '>=3.26.0' } }
     );
   });
 
@@ -2772,7 +2772,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           observe = false;
         });
       },
-      { id: 'array-observers', count: 1 }
+      { id: 'array-observers', count: 1, when: { ember: '>=3.26.0' } }
     );
   });
 

--- a/packages/-ember-data/tests/integration/request-state-service-test.ts
+++ b/packages/-ember-data/tests/integration/request-state-service-test.ts
@@ -3,16 +3,15 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { Promise } from 'rsvp';
 
-import Model from 'ember-data/model';
 import { setupTest } from 'ember-qunit';
 
 import { REQUEST_SERVICE } from '@ember-data/canary-features';
-import { attr } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 import JSONSerializer from '@ember-data/serializer/json';
 import { identifierCacheFor } from '@ember-data/store/-private';
 
 type RequestStateEnum = import('@ember-data/store/-private/ts-interfaces/fetch-manager').RequestStateEnum;
-type Store = import('ember-data/store').default;
+type Store = import('@ember-data/store').default;
 
 class Person extends Model {
   // TODO fix the typing for naked attrs

--- a/packages/-ember-data/tests/integration/snapshot-test.js
+++ b/packages/-ember-data/tests/integration/snapshot-test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
 import { resolve } from 'rsvp';
 
-import { Snapshot } from 'ember-data/-private';
 import { setupTest } from 'ember-qunit';
 
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
+import { Snapshot } from '@ember-data/store/-private';
 
 let owner, store, _Post;
 

--- a/packages/-ember-data/tests/integration/store/adapter-for-test.js
+++ b/packages/-ember-data/tests/integration/store/adapter-for-test.js
@@ -3,8 +3,9 @@ import { run } from '@ember/runloop';
 
 import { module, test } from 'qunit';
 
-import Store from 'ember-data/store';
 import { setupTest } from 'ember-qunit';
+
+import Store from '@ember-data/store';
 
 class TestAdapter {
   constructor(args) {

--- a/packages/-ember-data/tests/integration/store/serializer-for-test.js
+++ b/packages/-ember-data/tests/integration/store/serializer-for-test.js
@@ -3,9 +3,9 @@ import { run } from '@ember/runloop';
 
 import { module, test } from 'qunit';
 
-import Store from 'ember-data/store';
 import { setupTest } from 'ember-qunit';
 
+import Store from '@ember-data/store';
 import { deprecatedTest } from '@ember-data/unpublished-test-infra/test-support/deprecated-test';
 
 class TestAdapter {

--- a/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -17,7 +17,7 @@ type RecordDataRecordWrapper =
 type NotificationManager = import('@ember-data/store/-private/system/record-notification-manager').default;
 type StableRecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').StableRecordIdentifier;
 type RecordIdentifier = import('@ember-data/store/-private/ts-interfaces/identifier').RecordIdentifier;
-type Snapshot = import('ember-data/-private').Snapshot;
+type Snapshot = import('@ember-data/store/-private').Snapshot;
 
 if (CUSTOM_MODEL_CLASS) {
   module('unit/model - Custom Class Model', function (hooks) {

--- a/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -8,10 +8,13 @@ import { setupTest } from 'ember-qunit';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
-import Store from '@ember-data/store';
+import Store, { recordIdentifierFor } from '@ember-data/store';
 
+type RelationshipsSchema = import('@ember-data/store/-private/ts-interfaces/record-data-schemas').RelationshipsSchema;
+type SchemaDefinitionService =
+  import('@ember-data/store/-private/ts-interfaces/schema-definition-service').SchemaDefinitionService;
+type CoreStore = import('@ember-data/store/-private/system/core-store').default;
 type AttributesSchema = import('@ember-data/store/-private/ts-interfaces/record-data-schemas').AttributesSchema;
-
 type RecordDataRecordWrapper =
   import('@ember-data/store/-private/ts-interfaces/record-data-record-wrapper').RecordDataRecordWrapper;
 type NotificationManager = import('@ember-data/store/-private/system/record-notification-manager').default;
@@ -21,7 +24,7 @@ type Snapshot = import('@ember-data/store/-private').Snapshot;
 
 if (CUSTOM_MODEL_CLASS) {
   module('unit/model - Custom Class Model', function (hooks) {
-    let store;
+    let store: CoreStore;
     class Person {
       constructor(public store: Store) {
         this.store = store;
@@ -108,7 +111,7 @@ if (CUSTOM_MODEL_CLASS) {
       });
       this.owner.register('service:store', CreationStore);
       store = this.owner.lookup('service:store');
-      store.push({ data: { id: '1', type: 'person', name: 'chris' } });
+      store.push({ data: { id: '1', type: 'person', attributes: { name: 'chris' } } });
       recordData.storeWrapper.notifyHasManyChange(identifier.type, identifier.id, identifier.lid, 'key');
       recordData.storeWrapper.notifyBelongsToChange(identifier.type, identifier.id, identifier.lid, 'key');
       recordData.storeWrapper.notifyStateChange(identifier.type, identifier.id, identifier.lid, 'key');
@@ -151,18 +154,18 @@ if (CUSTOM_MODEL_CLASS) {
       });
       this.owner.register('service:store', CreationStore);
       store = this.owner.lookup('service:store');
-      let schema = {
-        attributesDefinitionFor(modelName: string) {
+      let schema: SchemaDefinitionService = {
+        attributesDefinitionFor(modelName: string): AttributesSchema {
           return {
             name: {
               type: 'string',
-              key: 'name',
+              options: {},
               name: 'name',
               kind: 'attribute',
             },
           };
         },
-        relationshipsDefinitionFor(modelName: string) {
+        relationshipsDefinitionFor(modelName: string): RelationshipsSchema {
           return {};
         },
         doesTypeExist() {
@@ -185,10 +188,18 @@ if (CUSTOM_MODEL_CLASS) {
             snapshot.eachAttribute((attr, attrDef) => {
               if (count === 0) {
                 assert.equal(attr, 'name', 'attribute key is correct');
-                assert.deepEqual(attrDef, { type: 'string', key: 'name', name: 'name' }, 'attribute def matches schem');
+                assert.deepEqual(
+                  attrDef,
+                  { kind: 'attribute', type: 'string', options: {}, name: 'name' },
+                  'attribute def matches schem'
+                );
               } else if (count === 1) {
                 assert.equal(attr, 'age', 'attribute key is correct');
-                assert.deepEqual(attrDef, { type: 'number', key: 'age', name: 'age' }, 'attribute def matches schem');
+                assert.deepEqual(
+                  attrDef,
+                  { kind: 'attribute', type: 'number', options: {}, name: 'age' },
+                  'attribute def matches schem'
+                );
               }
               count++;
             });
@@ -201,8 +212,10 @@ if (CUSTOM_MODEL_CLASS) {
                   {
                     type: 'ship',
                     kind: 'hasMany',
-                    inverse: null,
-                    options: {},
+                    options: {
+                      inverse: null,
+                    },
+                    name: 'boats',
                     key: 'boats',
                   },
                   'relationships def matches schem'
@@ -211,7 +224,7 @@ if (CUSTOM_MODEL_CLASS) {
                 assert.equal(rel, 'house', 'relationship key is correct');
                 assert.deepEqual(
                   relDef,
-                  { type: 'house', kind: 'belongsTo', inverse: null, options: {}, key: 'house', name: 'house' },
+                  { type: 'house', kind: 'belongsTo', options: { inverse: null }, key: 'house', name: 'house' },
                   'relationship def matches schem'
                 );
               }
@@ -223,8 +236,8 @@ if (CUSTOM_MODEL_CLASS) {
       );
       this.owner.register('service:store', CustomStore);
       store = this.owner.lookup('service:store');
-      let schema = {
-        attributesDefinitionFor(identifier: string | RecordIdentifier) {
+      let schema: SchemaDefinitionService = {
+        attributesDefinitionFor(identifier: string | RecordIdentifier): AttributesSchema {
           if (typeof identifier === 'string') {
             assert.equal(identifier, 'person', 'type passed in to the schema hooks');
           } else {
@@ -233,17 +246,19 @@ if (CUSTOM_MODEL_CLASS) {
           return {
             name: {
               type: 'string',
-              key: 'name',
+              kind: 'attribute',
+              options: {},
               name: 'name',
             },
             age: {
               type: 'number',
-              key: 'age',
+              kind: 'attribute',
+              options: {},
               name: 'age',
             },
           };
         },
-        relationshipsDefinitionFor(identifier: string | RecordIdentifier) {
+        relationshipsDefinitionFor(identifier: string | RecordIdentifier): RelationshipsSchema {
           if (typeof identifier === 'string') {
             assert.equal(identifier, 'person', 'type passed in to the schema hooks');
           } else {
@@ -253,15 +268,18 @@ if (CUSTOM_MODEL_CLASS) {
             boats: {
               type: 'ship',
               kind: 'hasMany',
-              inverse: null,
-              options: {},
+              options: {
+                inverse: null,
+              },
               key: 'boats',
+              name: 'boats',
             },
             house: {
               type: 'house',
               kind: 'belongsTo',
-              inverse: null,
-              options: {},
+              options: {
+                inverse: null,
+              },
               key: 'house',
               name: 'house',
             },
@@ -370,14 +388,15 @@ if (CUSTOM_MODEL_CLASS) {
       );
       this.owner.register('service:store', CustomStore);
       store = this.owner.lookup('service:store');
-      let schema = {
-        attributesDefinitionFor(identifier: string | RecordIdentifier) {
+      let schema: SchemaDefinitionService = {
+        attributesDefinitionFor(identifier: string | RecordIdentifier): AttributesSchema {
           let modelName = (identifier as RecordIdentifier).type || identifier;
           if (modelName === 'person') {
             return {
               name: {
                 type: 'string',
-                key: 'name',
+                kind: 'attribute',
+                options: {},
                 name: 'name',
               },
             };
@@ -385,19 +404,25 @@ if (CUSTOM_MODEL_CLASS) {
             return {
               address: {
                 type: 'string',
+                kind: 'attribute',
+                options: {},
+                name: 'address',
               },
             };
+          } else {
+            return {};
           }
         },
-        relationshipsDefinitionFor(identifier: string | RecordIdentifier) {
+        relationshipsDefinitionFor(identifier: string | RecordIdentifier): RelationshipsSchema {
           let modelName = (identifier as RecordIdentifier).type || identifier;
           if (modelName === 'person') {
             return {
               house: {
                 type: 'house',
                 kind: 'belongsTo',
-                inverse: null,
-                options: {},
+                options: {
+                  inverse: null,
+                },
                 key: 'house',
                 name: 'house',
               },
@@ -447,13 +472,14 @@ if (CUSTOM_MODEL_CLASS) {
       assert.expect(3);
       this.owner.register('service:store', CustomStore);
       store = this.owner.lookup('service:store');
-      let schema = {
-        attributesDefinitionFor(modelName: string) {
+      let schema: SchemaDefinitionService = {
+        attributesDefinitionFor(modelName: string): AttributesSchema {
           if (modelName === 'person') {
             return {
               name: {
                 type: 'string',
-                key: 'name',
+                kind: 'attribute',
+                options: {},
                 name: 'name',
               },
             };
@@ -461,18 +487,25 @@ if (CUSTOM_MODEL_CLASS) {
             return {
               address: {
                 type: 'string',
+                kind: 'attribute',
+                options: {},
+                name: 'address',
               },
             };
+          } else {
+            return {};
           }
         },
-        relationshipsDefinitionFor(modelName: string) {
+        relationshipsDefinitionFor(modelName: string): RelationshipsSchema {
           if (modelName === 'person') {
             return {
               house: {
                 type: 'house',
                 kind: 'belongsTo',
-                inverse: null,
-                options: {},
+                options: {
+                  inverse: null,
+                },
+                key: 'house',
                 name: 'house',
               },
             };
@@ -492,7 +525,7 @@ if (CUSTOM_MODEL_CLASS) {
           attributes: { address: 'boat' },
         },
       });
-      store.push({
+      let person = store.push({
         data: {
           type: 'person',
           id: '7',
@@ -500,7 +533,8 @@ if (CUSTOM_MODEL_CLASS) {
           relationships: { house: { data: { type: 'house', id: '1' } } },
         },
       });
-      let relationship = store.relationshipReferenceFor({ type: 'person', id: '7' }, 'house');
+      let identifier = recordIdentifierFor(person);
+      let relationship = store.relationshipReferenceFor({ type: 'person', id: '7', lid: identifier.lid }, 'house');
       assert.equal(relationship.id(), '1', 'house relationship id found');
       assert.equal(relationship.type, 'house', 'house relationship type found');
       assert.equal(relationship.parent.id(), '7', 'house relationship parent found');
@@ -510,13 +544,14 @@ if (CUSTOM_MODEL_CLASS) {
       assert.expect(3);
       this.owner.register('service:store', CustomStore);
       store = this.owner.lookup('service:store');
-      let schema = {
-        attributesDefinitionFor(modelName: string) {
+      let schema: SchemaDefinitionService = {
+        attributesDefinitionFor(modelName: string): AttributesSchema {
           if (modelName === 'person') {
             return {
               name: {
                 type: 'string',
-                key: 'name',
+                kind: 'attribute',
+                options: {},
                 name: 'name',
               },
             };
@@ -524,18 +559,25 @@ if (CUSTOM_MODEL_CLASS) {
             return {
               address: {
                 type: 'string',
+                kind: 'attribute',
+                options: {},
+                name: 'address',
               },
             };
+          } else {
+            return {};
           }
         },
-        relationshipsDefinitionFor(modelName: string) {
+        relationshipsDefinitionFor(modelName: string): RelationshipsSchema {
           if (modelName === 'person') {
             return {
               house: {
                 type: 'house',
                 kind: 'hasMany',
-                inverse: null,
-                options: {},
+                options: {
+                  inverse: null,
+                },
+                key: 'house',
                 name: 'house',
               },
             };
@@ -555,7 +597,7 @@ if (CUSTOM_MODEL_CLASS) {
           attributes: { address: 'boat' },
         },
       });
-      store.push({
+      let person = store.push({
         data: {
           type: 'person',
           id: '7',
@@ -570,7 +612,8 @@ if (CUSTOM_MODEL_CLASS) {
           },
         },
       });
-      let relationship = store.relationshipReferenceFor({ type: 'person', id: '7' }, 'house');
+      let identifier = recordIdentifierFor(person);
+      let relationship = store.relationshipReferenceFor({ type: 'person', id: '7', lid: identifier.lid }, 'house');
       assert.deepEqual(relationship.ids(), ['1', '2'], 'relationship found');
       assert.equal(relationship.type, 'house', 'house relationship type found');
       assert.equal(relationship.parent.id(), '7', 'house relationship parent found');

--- a/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
+++ b/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
@@ -495,7 +495,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
         }
       }
 
-      assert.expectDeprecation({ id: 'array-observers', count: 1 });
+      assert.expectDeprecation({ id: 'array-observers', count: 1, when: { ember: '>=3.26.0' } });
     });
   });
 

--- a/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
+++ b/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
@@ -494,6 +494,8 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
           assert.equal(dog.get('rolledBackCount'), 1, 'we only rolled back once');
         }
       }
+
+      assert.expectDeprecation({ id: 'array-observers', count: 1 });
     });
   });
 

--- a/packages/-ember-data/tests/unit/system/snapshot-record-array-test.js
+++ b/packages/-ember-data/tests/unit/system/snapshot-record-array-test.js
@@ -2,7 +2,7 @@ import { A } from '@ember/array';
 
 import { module, test } from 'qunit';
 
-import { SnapshotRecordArray } from 'ember-data/-private';
+import { SnapshotRecordArray } from '@ember-data/store/-private';
 
 module('Unit - snapshot-record-array', function () {
   test('constructor', function (assert) {

--- a/packages/adapter/addon/index.ts
+++ b/packages/adapter/addon/index.ts
@@ -144,7 +144,7 @@ type Dict<T> = import('@ember-data/store/-private/ts-interfaces/utils').Dict<T>;
 type MinimumAdapterInterface = import('@ember-data/store/-private/ts-interfaces/minimum-adapter-interface').default;
 type ShimModelClass = import('@ember-data/store/-private/system/model/shim-model-class').default;
 type Store = import('@ember-data/store/-private/system/core-store').default;
-type Snapshot = import('ember-data/-private').Snapshot;
+type Snapshot = import('@ember-data/store/-private').Snapshot;
 type SnapshotRecordArray = import('@ember-data/store/-private/system/snapshot-record-array').default;
 
 /**

--- a/packages/adapter/addon/rest.ts
+++ b/packages/adapter/addon/rest.ts
@@ -11,7 +11,10 @@ import { DEBUG } from '@glimmer/env';
 import { has } from 'require';
 import { Promise as RSVPPromise } from 'rsvp';
 
-import Adapter, { BuildURLMixin } from '@ember-data/adapter';
+import { DEPRECATE_NAJAX } from '@ember-data/private-build-infra/deprecations';
+import { addSymbol, symbol } from '@ember-data/store/-private';
+
+import { determineBodyPromise, fetch, parseResponseHeaders, serializeIntoHash, serializeQueryParams } from './-private';
 import AdapterError, {
   AbortError,
   ConflictError,
@@ -21,11 +24,8 @@ import AdapterError, {
   ServerError,
   TimeoutError,
   UnauthorizedError,
-} from '@ember-data/adapter/error';
-import { DEPRECATE_NAJAX } from '@ember-data/private-build-infra/deprecations';
-import { addSymbol, symbol } from '@ember-data/store/-private';
-
-import { determineBodyPromise, fetch, parseResponseHeaders, serializeIntoHash, serializeQueryParams } from './-private';
+} from './error';
+import Adapter, { BuildURLMixin } from './index';
 
 type Dict<T> = import('@ember-data/store/-private/ts-interfaces/utils').Dict<T>;
 type FastBoot = import('./-private/fastboot-interface').FastBoot;

--- a/packages/store/types/@ember/version.d.ts
+++ b/packages/store/types/@ember/version.d.ts
@@ -1,0 +1,1 @@
+export const VERSION: string = '';

--- a/packages/store/types/ember-compatibility-helpers/index.d.ts
+++ b/packages/store/types/ember-compatibility-helpers/index.d.ts
@@ -1,0 +1,17 @@
+export function gte(library: string, version: string): boolean;
+export function gte(version: string): boolean;
+export function lte(library: string, version: string): boolean;
+export function lte(version: string): boolean;
+export const HAS_UNDERSCORE_ACTIONS: boolean;
+export const HAS_MODERN_FACTORY_INJECTIONS: boolean;
+export const HAS_DESCRIPTOR_TRAP: boolean;
+export const HAS_NATIVE_COMPUTED_GETTERS: boolean;
+export const IS_GLIMMER_2: boolean;
+export const IS_RECORD_DATA: boolean;
+export const SUPPORTS_FACTORY_FOR: boolean;
+export const SUPPORTS_GET_OWNER: boolean;
+export const SUPPORTS_SET_OWNER: boolean;
+export const SUPPORTS_NEW_COMPUTED: boolean;
+export const SUPPORTS_INVERSE_BLOCK: boolean;
+export const SUPPORTS_CLOSURE_ACTIONS: boolean;
+export const SUPPORTS_UNIQ_BY_COMPUTED: boolean;

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-deprecation.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-deprecation.ts
@@ -1,12 +1,20 @@
 import { registerDeprecationHandler } from '@ember/debug';
+import { VERSION } from '@ember/version';
 import { DEBUG } from '@glimmer/env';
 
 import QUnit from 'qunit';
-
-import { gte, lte } from 'ember-compatibility-helpers';
+import semver from 'semver';
 
 import { checkMatcher } from './check-matcher';
 import isThenable from './utils/is-thenable';
+
+function gte(version: string): boolean {
+  return semver.satisfies(VERSION, version);
+}
+
+function lte(version: string): boolean {
+  return semver.satisfies(VERSION, version);
+}
 
 type Dict<T> = import('@ember-data/store/-private/ts-interfaces/utils').Dict<T>;
 
@@ -167,14 +175,17 @@ export function configureDeprecationHandler() {
       for (let i = 0; i < libs.length; i++) {
         let library = libs[i];
         let version = config.when[library]!;
-        let sanitizedVersion = version.replace(/[\^><=~]/g, '');
+
+        if (library !== 'ember') {
+          throw new Error(`when only supports setting a version for 'ember' currently.`);
+        }
 
         if (version.indexOf('<=') === 0) {
-          if (!lte(library, sanitizedVersion)) {
+          if (!lte(version)) {
             skipAssert = true;
           }
         } else if (version.indexOf('>=') === 0) {
-          if (!gte(library, sanitizedVersion)) {
+          if (!gte(version)) {
             skipAssert = true;
           }
         } else {

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-deprecation.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-deprecation.ts
@@ -158,10 +158,7 @@ export function configureDeprecationHandler() {
 
     if (callback) {
       DEPRECATIONS_FOR_TEST = [];
-      let result = callback();
-      if (isThenable(result)) {
-        await result;
-      }
+      await callback();
     }
 
     let result = verifyDeprecation(config, label);

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-deprecation.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-deprecation.ts
@@ -161,7 +161,8 @@ export function configureDeprecationHandler() {
       };
     }
 
-    if (config.when) {
+    let skipAssert = !DEBUG;
+    if (!skipAssert && config.when) {
       let libs = Object.keys(config.when);
       for (let i = 0; i < libs.length; i++) {
         let library = libs[i];
@@ -170,11 +171,11 @@ export function configureDeprecationHandler() {
 
         if (version.indexOf('<=') === 0) {
           if (!lte(library, sanitizedVersion)) {
-            return;
+            skipAssert = true;
           }
         } else if (version.indexOf('>=') === 0) {
           if (!gte(library, sanitizedVersion)) {
-            return;
+            skipAssert = true;
           }
         } else {
           throw new Error(
@@ -189,15 +190,16 @@ export function configureDeprecationHandler() {
       await callback();
     }
 
-    let result = verifyDeprecation(config, label);
-
-    if (!DEBUG) {
+    let result;
+    if (skipAssert) {
       result = {
         result: true,
         actual: { id: config.id, count: 0 },
         expected: { id: config.id, count: 0 },
         message: `Deprecations do not trigger in production environments`,
       };
+    } else {
+      result = verifyDeprecation(config, label);
     }
 
     this.pushResult(result);

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-deprecation.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-deprecation.ts
@@ -1,3 +1,5 @@
+import './utils/symbol-ponyfill';
+
 import { registerDeprecationHandler } from '@ember/debug';
 import { VERSION } from '@ember/version';
 import { DEBUG } from '@glimmer/env';

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/utils/symbol-ponyfill.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/utils/symbol-ponyfill.ts
@@ -1,0 +1,6 @@
+const d = Date.now();
+function FakeSymbol(str: string): string {
+  return `symbol:${d}-${str}`;
+}
+
+window.Symbol = typeof window.Symbol !== 'undefined' ? window.Symbol : (FakeSymbol as unknown as SymbolConstructor);

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -23,7 +23,13 @@
     "ember-cli-blueprint-test-helpers": "^0.19.2",
     "ember-cli-typescript": "^4.1.0",
     "ember-get-config": "^0.3.0",
-    "testem": "^3.0.3"
+    "ember-auto-import": "^2.0.1",
+    "qunit": "^2.15.0",
+    "qunit-dom": "^1.6.0",
+    "rsvp": "^4.8.5",
+    "semver": "^7.3.5",
+    "testem": "^3.0.3",
+    "webpack": "^5.37.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -43,11 +49,7 @@
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
     "ember-source": "~3.27.1",
-    "loader.js": "^4.7.0",
-    "qunit": "^2.15.0",
-    "qunit-dom": "^1.6.0",
-    "rsvp": "^4.8.5",
-    "webpack": "^5.37.1"
+    "loader.js": "^4.7.0"
   },
   "engines": {
     "node": "12.* || >= 14.*"


### PR DESCRIPTION
Resolves the issues causing canary publish and nightly chrons to fail.

Note: we will still need to "actually" resolve many of these deprecations for 4.0, but this wraps the ones that we know of currently in `expectDeprecation` to prevent the test suite from failing.

The `ember-global` deprecation when accessing Namespace is not expected, and the message it prints is a red-herring (that ember-cli-babel brought by ember-maybe-import-regenerator-runtime is outdated). That addon is not using Ember in any capacity, so while it should be updated it is not what is causing the deprecation spew.

When accessing:

```ts
import Namespace from '@ember/application/namespace';
Namespace.byName('DS');
```

Ember iterates through all the keys of `window`, and if they start with a capital letter it accesses them and checks if they may be a namespace. This leads to both the `Ember` global and the `Em` alias to the global triggering the globals deprecation, which sees the outdated ember-cli-babel and incorrectly directs attention there (this message would usually be correct, just in this instance it is not). cc @rwjblue 

We also now must set the `Resolver` and `moduleName` for the couple of tests where we create our own Application instance to test our initializer. These tests are mostly unnecessary at this point but for now I've just gone ahead and added these things. I'm not sure what shifted that we didn't encounter the `globals-resolver` deprecation for this previously, but I assume either the `Resolver` property is now eagerly checked or something is attempted to eagerly resolve that didn't before.