### PR TITLE
Add a comment explaining setting an errors status as a string

### DIFF
--- a/packages/adapter/addon/rest.ts
+++ b/packages/adapter/addon/rest.ts
@@ -1275,7 +1275,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     } else {
       return [
         {
-          status: `${status}`,
+          status: `${status}`, // Set to a string per the JSON API spec: https://jsonapi.org/format/#errors
           title: 'The backend responded with an error',
           detail: `${payload}`,
         },


### PR DESCRIPTION
"Fixes" #7590.

I imagine I'm not the first nor the last person to wonder why `status` is a string when everywhere else in the adapter it's an integer.