### PR TITLE
feat: allow .load()ing sync relationships

### DIFF
--- a/packages/model/addon/-private/legacy-relationships-support.ts
+++ b/packages/model/addon/-private/legacy-relationships-support.ts
@@ -749,7 +749,7 @@ function anyUnloaded(store: Store, relationship: ManyRelationship) {
   return unloaded || false;
 }
 
-function areAllInverseRecordsLoaded(store: Store, resource: JsonApiRelationship): boolean {
+export function areAllInverseRecordsLoaded(store: Store, resource: JsonApiRelationship): boolean {
   const instanceCache = store._instanceCache;
   const identifiers = resource.data;
 

--- a/packages/model/addon/-private/references/has-many.ts
+++ b/packages/model/addon/-private/references/has-many.ts
@@ -28,7 +28,7 @@ import type { FindOptions } from '@ember-data/types/q/store';
 import type { Dict } from '@ember-data/types/q/utils';
 
 import { assertPolymorphicType } from '../debug/assert-polymorphic-type';
-import type { LegacySupport } from '../legacy-relationships-support';
+import { areAllInverseRecordsLoaded, LegacySupport } from '../legacy-relationships-support';
 import { LEGACY_SUPPORT } from '../model';
 
 /**
@@ -607,7 +607,11 @@ export default class HasManyReference {
     const support: LegacySupport = (LEGACY_SUPPORT as Map<StableRecordIdentifier, LegacySupport>).get(
       this.___identifier
     )!;
-    return support.getHasMany(this.key, options) as Promise<ManyArray> | ManyArray; // this cast is necessary because typescript does not work properly with custom thenables;
+    const fetchSyncRel =
+      !this.hasManyRelationship.definition.isAsync && !areAllInverseRecordsLoaded(this.store, this._resource());
+    return fetchSyncRel
+      ? (support.reloadHasMany(this.key, options) as Promise<ManyArray>)
+      : (support.getHasMany(this.key, options) as Promise<ManyArray> | ManyArray); // this cast is necessary because typescript does not work properly with custom thenables;
   }
 
   /**

--- a/tests/main/tests/integration/references/belongs-to-test.js
+++ b/tests/main/tests/integration/references/belongs-to-test.js
@@ -1,5 +1,4 @@
 import { get } from '@ember/object';
-import { run } from '@ember/runloop';
 
 import { module, test } from 'qunit';
 import { defer, resolve } from 'rsvp';
@@ -28,7 +27,7 @@ module('integration/references/belongs-to', function (hooks) {
 
     const Person = Model.extend({
       family: belongsTo('family', { async: true, inverse: 'persons' }),
-      team: belongsTo({ async: false, inverse: 'persons' }),
+      team: belongsTo('team', { async: false, inverse: 'persons' }),
     });
 
     this.owner.register('model:family', Family);
@@ -42,20 +41,15 @@ module('integration/references/belongs-to', function (hooks) {
   testInDebug("record#belongsTo asserts when specified relationship doesn't exist", function (assert) {
     let store = this.owner.lookup('service:store');
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-        },
-      });
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+      },
     });
 
     assert.expectAssertion(function () {
-      run(function () {
-        person.belongsTo('unknown-relationship');
-      });
+      person.belongsTo('unknown-relationship');
     }, 'Expected to find a relationship definition for person.unknown-relationship but none was found');
   });
 
@@ -64,20 +58,15 @@ module('integration/references/belongs-to', function (hooks) {
     function (assert) {
       let store = this.owner.lookup('service:store');
 
-      var family;
-      run(function () {
-        family = store.push({
-          data: {
-            type: 'family',
-            id: '1',
-          },
-        });
+      let family = store.push({
+        data: {
+          type: 'family',
+          id: '1',
+        },
       });
 
       assert.expectAssertion(function () {
-        run(function () {
-          family.belongsTo('persons');
-        });
+        family.belongsTo('persons');
       }, "You tried to get the 'persons' relationship on a 'family' via record.belongsTo('persons'), but the relationship is of kind 'hasMany'. Use record.hasMany('persons') instead.");
     }
   );
@@ -85,22 +74,19 @@ module('integration/references/belongs-to', function (hooks) {
   test('record#belongsTo', function (assert) {
     let store = this.owner.lookup('service:store');
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              data: { type: 'family', id: '1' },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            data: { type: 'family', id: '1' },
           },
         },
-      });
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
 
     assert.strictEqual(familyReference.remoteType(), 'id');
     assert.strictEqual(familyReference.type, 'family');
@@ -110,22 +96,19 @@ module('integration/references/belongs-to', function (hooks) {
   test('record#belongsTo for a linked reference', function (assert) {
     let store = this.owner.lookup('service:store');
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              links: { related: '/families/1' },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            links: { related: '/families/1' },
           },
         },
-      });
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
 
     assert.strictEqual(familyReference.remoteType(), 'link');
     assert.strictEqual(familyReference.type, 'family');
@@ -135,71 +118,58 @@ module('integration/references/belongs-to', function (hooks) {
   test('BelongsToReference#meta() returns the most recent meta for the relationship', async function (assert) {
     let store = this.owner.lookup('service:store');
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              links: {
-                related: '/families/1',
-              },
-              meta: {
-                foo: true,
-              },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            links: {
+              related: '/families/1',
+            },
+            meta: {
+              foo: true,
             },
           },
         },
-      });
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
     assert.deepEqual(familyReference.meta(), { foo: true });
   });
 
-  test('push(object)', function (assert) {
-    var done = assert.async();
-
+  test('push(object)', async function (assert) {
     let store = this.owner.lookup('service:store');
     let Family = store.modelFor('family');
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              data: { type: 'family', id: '1' },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            data: { type: 'family', id: '1' },
           },
         },
-      });
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
 
-    run(function () {
-      var data = {
-        data: {
-          type: 'family',
-          id: '1',
-          attributes: {
-            name: 'Coreleone',
-          },
+    let data = {
+      data: {
+        type: 'family',
+        id: '1',
+        attributes: {
+          name: 'Coreleone',
         },
-      };
+      },
+    };
 
-      familyReference.push(data).then(function (record) {
-        assert.ok(Family.detectInstance(record), 'push resolves with the referenced record');
-        assert.strictEqual(get(record, 'name'), 'Coreleone', 'name is set');
-
-        done();
-      });
-    });
+    const record = await familyReference.push(data);
+    assert.ok(Family.detectInstance(record), 'push resolves with the referenced record');
+    assert.strictEqual(get(record, 'name'), 'Coreleone', 'name is set');
   });
 
   deprecatedTest(
@@ -209,10 +179,10 @@ module('integration/references/belongs-to', function (hooks) {
       let store = this.owner.lookup('service:store');
       let Family = store.modelFor('family');
 
-      var push;
-      var deferred = defer();
+      let push;
+      let deferred = defer();
 
-      var person = store.push({
+      let person = store.push({
         data: {
           type: 'person',
           id: '1',
@@ -223,7 +193,7 @@ module('integration/references/belongs-to', function (hooks) {
           },
         },
       });
-      var familyReference = person.belongsTo('family');
+      let familyReference = person.belongsTo('family');
       push = familyReference.push(deferred.promise);
 
       assert.ok(push.then, 'BelongsToReference.push returns a promise');
@@ -311,50 +281,44 @@ module('integration/references/belongs-to', function (hooks) {
   test('value() is null when reference is not yet loaded', function (assert) {
     let store = this.owner.lookup('service:store');
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              data: { type: 'family', id: '1' },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            data: { type: 'family', id: '1' },
           },
         },
-      });
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
     assert.strictEqual(familyReference.value(), null);
   });
 
   test('value() returns the referenced record when loaded', function (assert) {
     let store = this.owner.lookup('service:store');
 
-    var person, family;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              data: { type: 'family', id: '1' },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            data: { type: 'family', id: '1' },
           },
         },
-      });
-      family = store.push({
-        data: {
-          type: 'family',
-          id: '1',
-        },
-      });
+      },
+    });
+    let family = store.push({
+      data: {
+        type: 'family',
+        id: '1',
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
     assert.strictEqual(familyReference.value(), family);
   });
 
@@ -389,9 +353,7 @@ module('integration/references/belongs-to', function (hooks) {
     assert.strictEqual(familyReference.value(), family);
   });
 
-  test('load() fetches the record', function (assert) {
-    var done = assert.async();
-
+  test('load() fetches the record', async function (assert) {
     let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
@@ -408,80 +370,61 @@ module('integration/references/belongs-to', function (hooks) {
       });
     };
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              data: { type: 'family', id: '1' },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            data: { type: 'family', id: '1' },
           },
         },
-      });
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
 
-    run(function () {
-      familyReference.load({ adapterOptions }).then(function (record) {
-        assert.strictEqual(get(record, 'name'), 'Coreleone');
+    const record = await familyReference.load({ adapterOptions });
 
-        done();
-      });
-    });
+    assert.strictEqual(record.name, 'Coreleone');
   });
 
-  test('load() fetches the record (sync belongsTo)', function (assert) {
-    var done = assert.async();
-
+  test('load() fetches the record (sync belongsTo)', async function (assert) {
     let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
     const adapterOptions = { thing: 'one' };
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.deepEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
       return resolve({
         data: {
-          id: 1,
+          id: '1',
           type: 'team',
           attributes: { name: 'Tomsters' },
         },
       });
     };
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: 1,
-          relationships: {
-            team: {
-              data: { type: 'team', id: 1 },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          team: {
+            data: { type: 'team', id: '1' },
           },
         },
-      });
+      },
     });
 
-    var teamReference = person.belongsTo('team');
+    let teamReference = person.belongsTo('team');
 
-    run(function () {
-      teamReference.load({ adapterOptions }).then(function (record) {
-        assert.equal(get(record, 'name'), 'Tomsters');
-
-        done();
-      });
-    });
+    const record = await teamReference.load({ adapterOptions });
+    assert.strictEqual(record.name, 'Tomsters');
   });
 
-  test('load() fetches link when remoteType is link', function (assert) {
-    var done = assert.async();
-
+  test('load() fetches link when remoteType is link', async function (assert) {
     let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
@@ -500,30 +443,23 @@ module('integration/references/belongs-to', function (hooks) {
       });
     };
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              links: { related: '/families/1' },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            links: { related: '/families/1' },
           },
         },
-      });
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
     assert.strictEqual(familyReference.remoteType(), 'link');
 
-    run(function () {
-      familyReference.load({ adapterOptions }).then(function (record) {
-        assert.strictEqual(get(record, 'name'), 'Coreleone');
-
-        done();
-      });
+    await familyReference.load({ adapterOptions }).then(function (record) {
+      assert.strictEqual(get(record, 'name'), 'Coreleone');
     });
   });
 
@@ -564,15 +500,13 @@ module('integration/references/belongs-to', function (hooks) {
     assert.deepEqual(meta, { it: 'works' }, 'meta is available');
   });
 
-  test('reload() - loads the record when not yet loaded', function (assert) {
-    var done = assert.async();
-
+  test('reload() - loads the record when not yet loaded', async function (assert) {
     let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
     const adapterOptions = { thing: 'one' };
 
-    var count = 0;
+    let count = 0;
     adapter.findRecord = function (store, type, id, snapshot) {
       assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
 
@@ -588,41 +522,32 @@ module('integration/references/belongs-to', function (hooks) {
       });
     };
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              data: { type: 'family', id: '1' },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            data: { type: 'family', id: '1' },
           },
         },
-      });
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
 
-    run(function () {
-      familyReference.reload({ adapterOptions }).then(function (record) {
-        assert.strictEqual(get(record, 'name'), 'Coreleone');
-
-        done();
-      });
+    await familyReference.reload({ adapterOptions }).then(function (record) {
+      assert.strictEqual(get(record, 'name'), 'Coreleone');
     });
   });
 
-  test('reload() - reloads the record when already loaded', function (assert) {
-    var done = assert.async();
-
+  test('reload() - reloads the record when already loaded', async function (assert) {
     let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
     const adapterOptions = { thing: 'one' };
 
-    var count = 0;
+    let count = 0;
     adapter.findRecord = function (store, type, id, snapshot) {
       assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
 
@@ -638,41 +563,32 @@ module('integration/references/belongs-to', function (hooks) {
       });
     };
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              data: { type: 'family', id: '1' },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            data: { type: 'family', id: '1' },
           },
         },
-      });
-      store.push({
-        data: {
-          type: 'family',
-          id: '1',
-        },
-      });
+      },
+    });
+    store.push({
+      data: {
+        type: 'family',
+        id: '1',
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
 
-    run(function () {
-      familyReference.reload({ adapterOptions }).then(function (record) {
-        assert.strictEqual(get(record, 'name'), 'Coreleone');
-
-        done();
-      });
+    await familyReference.reload({ adapterOptions }).then(function (record) {
+      assert.strictEqual(get(record, 'name'), 'Coreleone');
     });
   });
 
-  test('reload() - uses link to reload record', function (assert) {
-    var done = assert.async();
-
+  test('reload() - uses link to reload record', async function (assert) {
     let store = this.owner.lookup('service:store');
     let adapter = store.adapterFor('application');
 
@@ -692,29 +608,22 @@ module('integration/references/belongs-to', function (hooks) {
       });
     };
 
-    var person;
-    run(function () {
-      person = store.push({
-        data: {
-          type: 'person',
-          id: '1',
-          relationships: {
-            family: {
-              links: { related: '/families/1' },
-            },
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: '1',
+        relationships: {
+          family: {
+            links: { related: '/families/1' },
           },
         },
-      });
+      },
     });
 
-    var familyReference = person.belongsTo('family');
+    let familyReference = person.belongsTo('family');
 
-    run(function () {
-      familyReference.reload({ adapterOptions }).then(function (record) {
-        assert.strictEqual(get(record, 'name'), 'Coreleone');
-
-        done();
-      });
+    await familyReference.reload({ adapterOptions }).then(function (record) {
+      assert.strictEqual(get(record, 'name'), 'Coreleone');
     });
   });
 });


### PR DESCRIPTION
I think it should be possible to call .load() on a sync belongsTo reference,
but if you do, you get an AssertionError:

Assertion Failed: You looked up the 'team' relationship on a 'person' with id 1
but some of the associated records were not loaded. Either make sure they are
all loaded together with the parent record, or specify that the relationship
is async (`belongsTo({ async: true })`)

This commit adds a breaking test to demonstrate this.

Might be worth checking sync hasMany's handling of this too.

Note: for some reason, `.reload()` works (e.g. `model.belongsTo('foo').reload()`) but not `.load()`.