### PR TITLE
[Bugfix] ensure `shouldCompileModules` is once again respected

### DIFF
--- a/packages/private-build-infra/src/utilities/rollup-private-module.js
+++ b/packages/private-build-infra/src/utilities/rollup-private-module.js
@@ -68,7 +68,7 @@ module.exports = function rollupPrivateModule(tree, options) {
       output: [
         {
           file: `${packageName}/-private.js`,
-          format: 'esm',
+          format: options.babelCompiler.shouldCompileModules() ? 'amd' : 'esm',
           amd: { id: `${packageName}/-private` },
           exports: 'named',
         },

--- a/packages/private-build-infra/src/utilities/rollup-private-module.js
+++ b/packages/private-build-infra/src/utilities/rollup-private-module.js
@@ -68,7 +68,7 @@ module.exports = function rollupPrivateModule(tree, options) {
       output: [
         {
           file: `${packageName}/-private.js`,
-          format: 'amd',
+          format: 'esm',
           amd: { id: `${packageName}/-private` },
           exports: 'named',
         },


### PR DESCRIPTION
Fix for - > https://github.com/embroider-build/embroider/issues/946

This appears to fix the problem locally (builds work in `ember new foo` & `ember new foo-embroider --embroider` builds

This effects 3.27.1 -> current canary and most likely needs the following backports:

* 3.28
* 3.27
* beta branch