### PR TITLE
typofix `fetchRecord` -> `findRecord`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Ember Data Changelog
 
+## Release v3.28.0-beta.2 (Jul 30, 2021)
+
+#### :bug: Bug Fix
+- [#7643](https://github.com/emberjs/data/pull/7643) @ember-data/model: Simplify @cached transpilation (#7599) ([@igorT](https://github.com/igorT))
+
+#### Committers: 1
+- Igor Terzic ([@igorT](https://github.com/igorT))
+
 ## Release v3.28.0-beta.1 (May 27, 2021)
 
 #### :rocket: Enhancement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,27 @@
 # Ember Data Changelog
 
-## Release v3.28.0-beta.3 (Aug 09, 2021)
+## Release 3.28.0 (Aug 20, 2021)
 
 #### :bug: Bug Fix
-- [#7651](https://github.com/emberjs/data/pull/7651) Return inflight requests for findRecord when CUSTOM_MODEL_CLASS is on (#7651) ([@igorT](https://github.com/igorT))
-- [#7652](https://github.com/emberjs/data/pull/7652) Fir for CUSTOM_MODEL_CLASS and deprecate passing non ember data records to unloadRecord and deleteRecord (#7652) ([@igorT](https://github.com/igorT))
-
-#### Committers: 1
-- Igor Terzic ([@igorT](https://github.com/igorT))
-
-
-## Release v3.28.0-beta.2 (Jul 30, 2021)
-
-#### :bug: Bug Fix
-- [#7643](https://github.com/emberjs/data/pull/7643) @ember-data/model: Simplify @cached transpilation (#7599) ([@igorT](https://github.com/igorT))
-
-#### Committers: 1
-- Igor Terzic ([@igorT](https://github.com/igorT))
-
-## Release v3.28.0-beta.1 (May 27, 2021)
 
 #### :rocket: Enhancement
 
 - [#7258](https://github.com/emberjs/data/pull/7258) feat: record.destroyRecord should also unload the record ([@snewcomer](https://github.com/snewcomer))
-- [#7510](https://github.com/emberjs/data/pull/7510) feat: activate all feature flags related to custom model classes ([@runspired](https://github.com/runspired))
+- [#7510](https://github.com/emberjs/data/pull/7510) feat: activate all feature flags related to CUSTOM_MODEL_CLASSES ([@runspired](https://github.com/runspired))
 
 #### :zap: Performance
 
 - [#7505](https://github.com/emberjs/data/pull/7505) Perf: Refactor PromiseManyArray and prep for RFC#745 ([@runspired](https://github.com/runspired))
 - [#7516](https://github.com/emberjs/data/pull/7516) Perf: eliminate retainedManyArrayCache ([@runspired](https://github.com/runspired))
+- [#7454](https://github.com/emberjs/data/pull/7454) [PERF] Class Fields Use Optimization & Made OrderedSet Faster (Again) (#7454)
+- [#7491](https://github.com/emberjs/data/pull/7491) relationship refactor part-1 (#7491)
+- [#7493](https://github.com/emberjs/data/pull/7493) Relationship Refactor (part 2): The graph should coordinate state updates (#7493)
 
 #### :bug: Bug Fix
 
+- [#7651](https://github.com/emberjs/data/pull/7651) Return inflight requests for findRecord when CUSTOM_MODEL_CLASS is on (#7651) ([@igorT](https://github.com/igorT))
+- [#7652](https://github.com/emberjs/data/pull/7652) Fix for CUSTOM_MODEL_CLASS and deprecate passing non ember data records to unloadRecord and deleteRecord (#7652) ([@igorT](https://github.com/igorT))
+- [#7643](https://github.com/emberjs/data/pull/7643) @ember-data/model: Simplify @cached transpilation (#7599) ([@igorT](https://github.com/igorT))
 - [#7554](https://github.com/emberjs/data/pull/7554) [BUGFIX] reset previously failed linked async belongs-to now works ([@sly7-7](https://github.com/sly7-7))
 - [#7532](https://github.com/emberjs/data/pull/7532) fix: belongsTo should not attempt load if inverse in payload provided its data (#7049) ([@sly7-7](https://github.com/sly7-7))
 - [#7550](https://github.com/emberjs/data/pull/7550) fix: add asserts and assert tests for belongsTo/hasMany/findRecord empty responses ([@runspired](https://github.com/runspired))
@@ -39,11 +29,19 @@
 - [#7545](https://github.com/emberjs/data/pull/7545) [BUGFIX Model] assert when 'content' is used as a property on a record ([@zinyando](https://github.com/zinyando))
 - [#7531](https://github.com/emberjs/data/pull/7531) fix: Closes [#7053](https://github.com/emberjs/data/issues/7053) issue preventing debug adapter removal from prod builds using the ember-data package ([@sly7-7](https://github.com/sly7-7))
 - [#7527](https://github.com/emberjs/data/pull/7527) [BUGFIX] rollup step should deactivate ember modules polyfill >= 3.27 ([@runspired](https://github.com/runspired))
+- [#7425](https://github.com/emberjs/data/pull/7425) Pass lid from relationship data to get record data (#7425)
+- [#7448](https://github.com/emberjs/data/pull/7448) Bugfix: coalesceFindRequests should work with non native Adapter classes (#7448)
+- [#7463](https://github.com/emberjs/data/pull/7463) chore: cleanup Implicit relationships (#7463)
+- [#7453](https://github.com/emberjs/data/pull/7453) [CHORE] burndown of InternalModel methods that can be eliminated safely (#7453)
+- [#7226](https://github.com/emberjs/data/pull/7226) refactor: Native Model (#7226)
+- [#7470](https://github.com/emberjs/data/pull/7470) chore: convert relationships to use identifiers (#7470)
 
 #### :memo: Documentation
 
 - [#7549](https://github.com/emberjs/data/pull/7549) [DOC] Fixes JSONAPISerializer serialize documentation ([@skaterdav85](https://github.com/skaterdav85))
 - [#7535](https://github.com/emberjs/data/pull/7535) fix adapter doc example ([@sly7-7](https://github.com/sly7-7))
+- [#7447](https://github.com/emberjs/data/pull/7447) Document adapterOptions on REST adapter (#7447)
+
 
 #### Committers: 9
 
@@ -56,19 +54,6 @@
 - Scott Newcomer ([@snewcomer](https://github.com/snewcomer))
 - Steven Pham ([@spham92](https://github.com/spham92))
 - Igor Terzic ([@igorT](https://github.com/igorT))
-
-## Release 3.28.0-beta.0 (May 8, 2021)
-
-- [#7447](https://github.com/emberjs/data/pull/7447) Document adapterOptions on REST adapter (#7447)
-- [#7425](https://github.com/emberjs/data/pull/7425) Pass lid from relationship data to get record data (#7425)
-- [#7448](https://github.com/emberjs/data/pull/7448) Bugfix: coalesceFindRequests should work with non native Adapter classes (#7448)
-- [#7454](https://github.com/emberjs/data/pull/7454) [PERF] Class Fields Use Optimization & Made OrderedSet Faster (Again) (#7454)
-- [#7463](https://github.com/emberjs/data/pull/7463) chore: cleanup Implicit relationships (#7463)
-- [#7453](https://github.com/emberjs/data/pull/7453) [CHORE] burndown of InternalModel methods that can be eliminated safely (#7453)
-- [#7226](https://github.com/emberjs/data/pull/7226) refactor: Native Model (#7226)
-- [#7470](https://github.com/emberjs/data/pull/7470) chore: convert relationships to use identifiers (#7470)
-- [#7491](https://github.com/emberjs/data/pull/7491) relationship refactor part-1 (#7491)
-- [#7493](https://github.com/emberjs/data/pull/7493) Relationship Refactor (part 2): The graph should coordinate state updates (#7493)
 
 ## Release 3.27.1 (May 27, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Ember Data Changelog
 
+## Release v3.28.0-beta.3 (Aug 09, 2021)
+
+#### :bug: Bug Fix
+- [#7651](https://github.com/emberjs/data/pull/7651) Return inflight requests for findRecord when CUSTOM_MODEL_CLASS is on (#7651) ([@igorT](https://github.com/igorT))
+- [#7652](https://github.com/emberjs/data/pull/7652) Fir for CUSTOM_MODEL_CLASS and deprecate passing non ember data records to unloadRecord and deleteRecord (#7652) ([@igorT](https://github.com/igorT))
+
+#### Committers: 1
+- Igor Terzic ([@igorT](https://github.com/igorT))
+
+
 ## Release v3.28.0-beta.2 (Jul 30, 2021)
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Ember Data Changelog
 
+## Release 3.28.0-beta.0 (May 8, 2021)
+
+- [#7447](https://github.com/emberjs/data/pull/7447) Document adapterOptions on REST adapter (#7447)
+- [#7425](https://github.com/emberjs/data/pull/7425) Pass lid from relationship data to get record data (#7425)
+- [#7448](https://github.com/emberjs/data/pull/7448) Bugfix: coalesceFindRequests should work with non native Adapter classes (#7448)
+- [#7454](https://github.com/emberjs/data/pull/7454) [PERF] Class Fields Use Optimization & Made OrderedSet Faster (Again) (#7454)
+- [#7463](https://github.com/emberjs/data/pull/7463) chore: cleanup Implicit relationships (#7463)
+- [#7453](https://github.com/emberjs/data/pull/7453) [CHORE] burndown of InternalModel methods that can be eliminated safely (#7453)
+- [#7226](https://github.com/emberjs/data/pull/7226) refactor: Native Model (#7226)
+- [#7470](https://github.com/emberjs/data/pull/7470) chore: convert relationships to use identifiers (#7470)
+- [#7491](https://github.com/emberjs/data/pull/7491) relationship refactor part-1 (#7491)
+- [#7493](https://github.com/emberjs/data/pull/7493) Relationship Refactor (part 2): The graph should coordinate state updates (#7493)
+
 ## Release 3.27.1 (May 27, 2021)
 
 - [#7552](https://github.com/emberjs/data/pull/7552) [BUGFIX release] rollup step should deactivate ember modules polyfill >= 3.27 (#7552)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Ember Data Changelog
 
+## Release v3.28.0-beta.1 (May 27, 2021)
+
+#### :rocket: Enhancement
+
+- [#7258](https://github.com/emberjs/data/pull/7258) feat: record.destroyRecord should also unload the record ([@snewcomer](https://github.com/snewcomer))
+- [#7510](https://github.com/emberjs/data/pull/7510) feat: activate all feature flags related to custom model classes ([@runspired](https://github.com/runspired))
+
+#### :zap: Performance
+
+- [#7505](https://github.com/emberjs/data/pull/7505) Perf: Refactor PromiseManyArray and prep for RFC#745 ([@runspired](https://github.com/runspired))
+- [#7516](https://github.com/emberjs/data/pull/7516) Perf: eliminate retainedManyArrayCache ([@runspired](https://github.com/runspired))
+
+#### :bug: Bug Fix
+
+- [#7554](https://github.com/emberjs/data/pull/7554) [BUGFIX] reset previously failed linked async belongs-to now works ([@sly7-7](https://github.com/sly7-7))
+- [#7532](https://github.com/emberjs/data/pull/7532) fix: belongsTo should not attempt load if inverse in payload provided its data (#7049) ([@sly7-7](https://github.com/sly7-7))
+- [#7550](https://github.com/emberjs/data/pull/7550) fix: add asserts and assert tests for belongsTo/hasMany/findRecord empty responses ([@runspired](https://github.com/runspired))
+- [#7534](https://github.com/emberjs/data/pull/7534) fix: #7039 Ensure meta and links update when fetched relationship is empty or does not include the data key ([@sly7-7](https://github.com/sly7-7))
+- [#7545](https://github.com/emberjs/data/pull/7545) [BUGFIX Model] assert when 'content' is used as a property on a record ([@zinyando](https://github.com/zinyando))
+- [#7531](https://github.com/emberjs/data/pull/7531) fix: Closes [#7053](https://github.com/emberjs/data/issues/7053) issue preventing debug adapter removal from prod builds using the ember-data package ([@sly7-7](https://github.com/sly7-7))
+- [#7527](https://github.com/emberjs/data/pull/7527) [BUGFIX] rollup step should deactivate ember modules polyfill >= 3.27 ([@runspired](https://github.com/runspired))
+
+#### :memo: Documentation
+
+- [#7549](https://github.com/emberjs/data/pull/7549) [DOC] Fixes JSONAPISerializer serialize documentation ([@skaterdav85](https://github.com/skaterdav85))
+- [#7535](https://github.com/emberjs/data/pull/7535) fix adapter doc example ([@sly7-7](https://github.com/sly7-7))
+
+#### Committers: 9
+
+- Chris Thoburn ([@runspired](https://github.com/runspired))
+- Daniel Múnera Sánchez ([@dmuneras](https://github.com/dmuneras))
+- David Tang ([@skaterdav85](https://github.com/skaterdav85))
+- Lennex Zinyando ([@zinyando](https://github.com/zinyando))
+- Sylvain MINA ([@sly7-7](https://github.com/sly7-7))
+- Tyler ([@runnerboy22](https://github.com/runnerboy22))
+- Scott Newcomer ([@snewcomer](https://github.com/snewcomer))
+- Steven Pham ([@spham92](https://github.com/spham92))
+- Igor Terzic ([@igorT](https://github.com/igorT))
+
 ## Release 3.28.0-beta.0 (May 8, 2021)
 
 - [#7447](https://github.com/emberjs/data/pull/7447) Document adapterOptions on REST adapter (#7447)
@@ -2408,7 +2447,7 @@ serializer and do the logic yourself:
 // app/serializers/person.js
 // or App.PersonSerializer if you aren't using Ember CLI
 export default DS.RESTSerializer.extend({
-  normalize: function(type, hash, prop) {
+  normalize: function (type, hash, prop) {
     hash = this._super(type, hash, prop);
     if (!hash.hasOwnProperty('firstName')) {
       hash.firstName = null;
@@ -2427,9 +2466,9 @@ Or if you want to restore the old behavior for all of your models:
 // app/serializers/application.js
 // or App.ApplicationSerializer
 export default DS.RESTSerializer.extend({
-  normalize: function(type, hash, prop) {
+  normalize: function (type, hash, prop) {
     hash = this._super(type, hash, prop);
-    type.eachAttribute(function(key) {
+    type.eachAttribute(function (key) {
       if (!hash.hasOwnProperty(key)) {
         hash[key] = null;
       }
@@ -2528,7 +2567,7 @@ model's attributes. This means that the following code:
 
 ```javascript
 var Post = DS.Model.extend({
-  doSomethingWhenDataChanges: function() {
+  doSomethingWhenDataChanges: function () {
     // do the work
   }.property('data'),
 });
@@ -2541,7 +2580,7 @@ would with any `Ember.Object`:
 var Post = DS.Model.extend({
   name: DS.attr(),
   date: DS.attr(),
-  doSomethingWhenDataChanges: function() {
+  doSomethingWhenDataChanges: function () {
     // do the work
   }.property('name', 'date'),
 });

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.28.0-beta.1"
+  "version": "3.28.0-beta.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.28.0-beta.3"
+  "version": "3.28.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.28.0-beta.2"
+  "version": "3.28.0-beta.3"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.28.0-beta.0"
+  "version": "3.28.0-beta.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.29.0-alpha.4"
+  "version": "3.28.0-beta.0"
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.23.0",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
       "changelog:breaking": ":boom: Breaking Change",
       "changelog:feat": ":rocket: Enhancement",
       "changelog:bugfix": ":bug: Bug Fix",
+      "changelog:perf:": ":zap: Performance",
       "changelog:cleanup": ":shower: Deprecation Removal",
       "changelog:deprecation": ":evergreen_tree: New Deprecation",
       "changelog:doc": ":memo: Documentation",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "description": "A data layer for your Ember applications.",
   "repository": "git://github.com/emberjs/data.git",
   "directories": {
@@ -22,13 +22,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.3",
-    "@ember-data/debug": "3.28.0-beta.3",
-    "@ember-data/model": "3.28.0-beta.3",
-    "@ember-data/private-build-infra": "3.28.0-beta.3",
-    "@ember-data/record-data": "3.28.0-beta.3",
-    "@ember-data/serializer": "3.28.0-beta.3",
-    "@ember-data/store": "3.28.0-beta.3",
+    "@ember-data/adapter": "3.28.0",
+    "@ember-data/debug": "3.28.0",
+    "@ember-data/model": "3.28.0",
+    "@ember-data/private-build-infra": "3.28.0",
+    "@ember-data/record-data": "3.28.0",
+    "@ember-data/serializer": "3.28.0",
+    "@ember-data/store": "3.28.0",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "@glimmer/env": "^0.1.7",
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.9.6",
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@glimmer/component": "^1.0.0",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "description": "A data layer for your Ember applications.",
   "repository": "git://github.com/emberjs/data.git",
   "directories": {
@@ -22,13 +22,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.1",
-    "@ember-data/debug": "3.28.0-beta.1",
-    "@ember-data/model": "3.28.0-beta.1",
-    "@ember-data/private-build-infra": "3.28.0-beta.1",
-    "@ember-data/record-data": "3.28.0-beta.1",
-    "@ember-data/serializer": "3.28.0-beta.1",
-    "@ember-data/store": "3.28.0-beta.1",
+    "@ember-data/adapter": "3.28.0-beta.2",
+    "@ember-data/debug": "3.28.0-beta.2",
+    "@ember-data/model": "3.28.0-beta.2",
+    "@ember-data/private-build-infra": "3.28.0-beta.2",
+    "@ember-data/record-data": "3.28.0-beta.2",
+    "@ember-data/serializer": "3.28.0-beta.2",
+    "@ember-data/store": "3.28.0-beta.2",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "@glimmer/env": "^0.1.7",
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.9.6",
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@glimmer/component": "^1.0.0",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -76,7 +76,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^1.4.0",
     "json-typescript": "^1.1.0",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "description": "A data layer for your Ember applications.",
   "repository": "git://github.com/emberjs/data.git",
   "directories": {
@@ -22,13 +22,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.2",
-    "@ember-data/debug": "3.28.0-beta.2",
-    "@ember-data/model": "3.28.0-beta.2",
-    "@ember-data/private-build-infra": "3.28.0-beta.2",
-    "@ember-data/record-data": "3.28.0-beta.2",
-    "@ember-data/serializer": "3.28.0-beta.2",
-    "@ember-data/store": "3.28.0-beta.2",
+    "@ember-data/adapter": "3.28.0-beta.3",
+    "@ember-data/debug": "3.28.0-beta.3",
+    "@ember-data/model": "3.28.0-beta.3",
+    "@ember-data/private-build-infra": "3.28.0-beta.3",
+    "@ember-data/record-data": "3.28.0-beta.3",
+    "@ember-data/serializer": "3.28.0-beta.3",
+    "@ember-data/store": "3.28.0-beta.3",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "@glimmer/env": "^0.1.7",
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.9.6",
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@glimmer/component": "^1.0.0",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "description": "A data layer for your Ember applications.",
   "repository": "git://github.com/emberjs/data.git",
   "directories": {
@@ -22,13 +22,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.0",
-    "@ember-data/debug": "3.28.0-beta.0",
-    "@ember-data/model": "3.28.0-beta.0",
-    "@ember-data/private-build-infra": "3.28.0-beta.0",
-    "@ember-data/record-data": "3.28.0-beta.0",
-    "@ember-data/serializer": "3.28.0-beta.0",
-    "@ember-data/store": "3.28.0-beta.0",
+    "@ember-data/adapter": "3.28.0-beta.1",
+    "@ember-data/debug": "3.28.0-beta.1",
+    "@ember-data/model": "3.28.0-beta.1",
+    "@ember-data/private-build-infra": "3.28.0-beta.1",
+    "@ember-data/record-data": "3.28.0-beta.1",
+    "@ember-data/serializer": "3.28.0-beta.1",
+    "@ember-data/store": "3.28.0-beta.1",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "@glimmer/env": "^0.1.7",
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.9.6",
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@glimmer/component": "^1.0.0",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "description": "A data layer for your Ember applications.",
   "repository": "git://github.com/emberjs/data.git",
   "directories": {
@@ -22,13 +22,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ember-data/adapter": "3.29.0-alpha.4",
-    "@ember-data/debug": "3.29.0-alpha.4",
-    "@ember-data/model": "3.29.0-alpha.4",
-    "@ember-data/private-build-infra": "3.29.0-alpha.4",
-    "@ember-data/record-data": "3.29.0-alpha.4",
-    "@ember-data/serializer": "3.29.0-alpha.4",
-    "@ember-data/store": "3.29.0-alpha.4",
+    "@ember-data/adapter": "3.28.0-beta.0",
+    "@ember-data/debug": "3.28.0-beta.0",
+    "@ember-data/model": "3.28.0-beta.0",
+    "@ember-data/private-build-infra": "3.28.0-beta.0",
+    "@ember-data/record-data": "3.28.0-beta.0",
+    "@ember-data/serializer": "3.28.0-beta.0",
+    "@ember-data/store": "3.28.0-beta.0",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "@glimmer/env": "^0.1.7",
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.9.6",
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@glimmer/component": "^1.0.0",

--- a/packages/-ember-data/tests/integration/records/unload-test.js
+++ b/packages/-ember-data/tests/integration/records/unload-test.js
@@ -9,6 +9,7 @@ import { all, resolve } from 'rsvp';
 import { setupTest } from 'ember-qunit';
 
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { recordDataFor } from '@ember-data/store/-private';
@@ -2511,4 +2512,22 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     return run(() => store.findRecord('person', 1, { backgroundReload: true }).then((person) => person.unloadRecord()));
   });
+
+  if (CUSTOM_MODEL_CLASS) {
+    test('unloading a non store managed record is deprecated', function (assert) {
+      let didUnload = false;
+      let randomRecord = {
+        unloadRecord() {
+          didUnload = true;
+        },
+      };
+      assert.expectDeprecation(
+        () => {
+          store.unloadRecord(randomRecord);
+        },
+        { id: 'ember-data:unload-record-non-store' }
+      );
+      assert.ok(didUnload, 'Did unload a non store record');
+    });
+  }
 });

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -9,6 +9,7 @@ import DS from 'ember-data';
 import { setupTest } from 'ember-qunit';
 
 import RESTAdapter from '@ember-data/adapter/rest';
+import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import RESTSerializer from '@ember-data/serializer/rest';
 import deepCopy from '@ember-data/unpublished-test-infra/test-support/deep-copy';
@@ -1049,6 +1050,25 @@ module('integration/store - deleteRecord', function (hooks) {
     store.deleteRecord(person);
     assert.ok(person.isDeleted, 'expect person to be isDeleted');
   });
+
+  if (CUSTOM_MODEL_CLASS) {
+    test('deleting a non store managed record is deprecated', function (assert) {
+      let store = this.owner.lookup('service:store');
+      let didDelete = false;
+      let randomRecord = {
+        deleteRecord() {
+          didDelete = true;
+        },
+      };
+      assert.expectDeprecation(
+        () => {
+          store.deleteRecord(randomRecord);
+        },
+        { id: 'ember-data:delete-record-non-store' }
+      );
+      assert.ok(didDelete, 'Did delete a non store record');
+    });
+  }
 
   test('Store should accept a null value for `data`', function (assert) {
     assert.expect(0);

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -444,6 +444,56 @@ module('integration/store - findRecord', function (hooks) {
     assert.strictEqual(car.get('model'), 'Princess', 'cached record ignored, record reloaded via server');
   });
 
+  test('store#findRecord caches the inflight requests', async function (assert) {
+    assert.expect(2);
+
+    let calls = 0;
+    let resolveHandler;
+    let result = {
+      data: {
+        type: 'car',
+        id: '1',
+        attributes: {
+          make: 'BMC',
+          model: 'Mini',
+        },
+      },
+    };
+
+    const testAdapter = DS.JSONAPIAdapter.extend({
+      shouldReloadRecord(store, type, id, snapshot) {
+        assert.ok(false, 'shouldReloadRecord should not be called when { reload: true }');
+      },
+      async findRecord() {
+        calls++;
+
+        return new Promise((resolve) => {
+          resolveHandler = resolve;
+        });
+      },
+    });
+
+    this.owner.register('adapter:application', testAdapter);
+    this.owner.register('serializer:application', JSONAPISerializer.extend());
+    let firstPromise, secondPromise;
+
+    run(() => {
+      firstPromise = store.findRecord('car', '1');
+    });
+
+    run(() => {
+      secondPromise = store.findRecord('car', '1');
+    });
+
+    assert.strictEqual(calls, 1, 'We made one call to findRecord');
+
+    resolveHandler(result);
+    let car1 = await firstPromise;
+    let car2 = await secondPromise;
+
+    assert.strictEqual(car1, car2, 'we receive the same car back');
+  });
+
   test('store#findRecord { backgroundReload: false } returns cached record and does not reload in the background', async function (assert) {
     assert.expect(2);
 

--- a/packages/adapter/addon/index.ts
+++ b/packages/adapter/addon/index.ts
@@ -620,7 +620,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
   }
 
   /**
-    By default the store will try to coalesce all `fetchRecord` calls within the same runloop
+    By default the store will try to coalesce all `findRecord` calls within the same runloop
     into as few requests as possible by calling groupRecordsForFindMany and passing it into a findMany call.
     You can opt out of this behaviour by either not implementing the findMany hook or by setting
     coalesceFindRequests to false.

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -45,7 +45,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/adapter",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,8 +18,8 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.2",
-    "@ember-data/store": "3.28.0-beta.2",
+    "@ember-data/private-build-infra": "3.28.0-beta.3",
+    "@ember-data/store": "3.28.0-beta.3",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cli-babel": "^7.26.6",
@@ -27,7 +27,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/adapter",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,8 +18,8 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.1",
-    "@ember-data/store": "3.28.0-beta.1",
+    "@ember-data/private-build-infra": "3.28.0-beta.2",
+    "@ember-data/store": "3.28.0-beta.2",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cli-babel": "^7.26.6",
@@ -27,7 +27,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/adapter",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,8 +18,8 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.3",
-    "@ember-data/store": "3.28.0-beta.3",
+    "@ember-data/private-build-infra": "3.28.0",
+    "@ember-data/store": "3.28.0",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cli-babel": "^7.26.6",
@@ -27,7 +27,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/adapter",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,8 +18,8 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.0",
-    "@ember-data/store": "3.28.0-beta.0",
+    "@ember-data/private-build-infra": "3.28.0-beta.1",
+    "@ember-data/store": "3.28.0-beta.1",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cli-babel": "^7.26.6",
@@ -27,7 +27,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/adapter",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,8 +18,8 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.29.0-alpha.4",
-    "@ember-data/store": "3.29.0-alpha.4",
+    "@ember-data/private-build-infra": "3.28.0-beta.0",
+    "@ember-data/store": "3.28.0-beta.0",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cli-babel": "^7.26.6",
@@ -27,7 +27,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/canary-features/package.json
+++ b/packages/canary-features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/canary-features",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "description": "Canary features",
   "keywords": [
     "ember-addon"

--- a/packages/canary-features/package.json
+++ b/packages/canary-features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/canary-features",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "description": "Canary features",
   "keywords": [
     "ember-addon"

--- a/packages/canary-features/package.json
+++ b/packages/canary-features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/canary-features",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "description": "Canary features",
   "keywords": [
     "ember-addon"

--- a/packages/canary-features/package.json
+++ b/packages/canary-features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/canary-features",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "description": "Canary features",
   "keywords": [
     "ember-addon"

--- a/packages/canary-features/package.json
+++ b/packages/canary-features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/canary-features",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "description": "Canary features",
   "keywords": [
     "ember-addon"

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/debug",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "description": "Provides developer ergonomics and dev-mode enhancements for apps built with ember-data",
   "keywords": [
     "ember-addon"
@@ -17,7 +17,7 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.1",
+    "@ember-data/private-build-infra": "3.28.0-beta.2",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cli-babel": "^7.26.6",
@@ -25,7 +25,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/debug",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "description": "Provides developer ergonomics and dev-mode enhancements for apps built with ember-data",
   "keywords": [
     "ember-addon"
@@ -17,7 +17,7 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.2",
+    "@ember-data/private-build-infra": "3.28.0-beta.3",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cli-babel": "^7.26.6",
@@ -25,7 +25,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -43,7 +43,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/debug",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "description": "Provides developer ergonomics and dev-mode enhancements for apps built with ember-data",
   "keywords": [
     "ember-addon"
@@ -17,7 +17,7 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.3",
+    "@ember-data/private-build-infra": "3.28.0",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cli-babel": "^7.26.6",
@@ -25,7 +25,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/debug",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "description": "Provides developer ergonomics and dev-mode enhancements for apps built with ember-data",
   "keywords": [
     "ember-addon"
@@ -17,7 +17,7 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.0",
+    "@ember-data/private-build-infra": "3.28.0-beta.1",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cli-babel": "^7.26.6",
@@ -25,7 +25,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/debug",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "description": "Provides developer ergonomics and dev-mode enhancements for apps built with ember-data",
   "keywords": [
     "ember-addon"
@@ -17,7 +17,7 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.29.0-alpha.4",
+    "@ember-data/private-build-infra": "3.28.0-beta.0",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cli-babel": "^7.26.6",
@@ -25,7 +25,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/model",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,9 +18,9 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.1",
-    "@ember-data/private-build-infra": "3.28.0-beta.1",
-    "@ember-data/store": "3.28.0-beta.1",
+    "@ember-data/canary-features": "3.28.0-beta.2",
+    "@ember-data/private-build-infra": "3.28.0-beta.2",
+    "@ember-data/store": "3.28.0-beta.2",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cached-decorator-polyfill": "^0.1.4",
@@ -32,7 +32,7 @@
     "inflection": "~1.13.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/model",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,9 +18,9 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.3",
-    "@ember-data/private-build-infra": "3.28.0-beta.3",
-    "@ember-data/store": "3.28.0-beta.3",
+    "@ember-data/canary-features": "3.28.0",
+    "@ember-data/private-build-infra": "3.28.0",
+    "@ember-data/store": "3.28.0",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cached-decorator-polyfill": "^0.1.4",
@@ -32,7 +32,7 @@
     "inflection": "~1.13.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -50,7 +50,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/model",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,9 +18,9 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.2",
-    "@ember-data/private-build-infra": "3.28.0-beta.2",
-    "@ember-data/store": "3.28.0-beta.2",
+    "@ember-data/canary-features": "3.28.0-beta.3",
+    "@ember-data/private-build-infra": "3.28.0-beta.3",
+    "@ember-data/store": "3.28.0-beta.3",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cached-decorator-polyfill": "^0.1.4",
@@ -32,7 +32,7 @@
     "inflection": "~1.13.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -23,7 +23,7 @@
     "@ember-data/store": "3.28.0-beta.1",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
-    "ember-cached-decorator-polyfill": "^0.1.3",
+    "ember-cached-decorator-polyfill": "^0.1.4",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-test-info": "^1.0.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/model",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,9 +18,9 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.0",
-    "@ember-data/private-build-infra": "3.28.0-beta.0",
-    "@ember-data/store": "3.28.0-beta.0",
+    "@ember-data/canary-features": "3.28.0-beta.1",
+    "@ember-data/private-build-infra": "3.28.0-beta.1",
+    "@ember-data/store": "3.28.0-beta.1",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cached-decorator-polyfill": "^0.1.3",
@@ -32,11 +32,11 @@
     "inflection": "~1.13.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
-    "ember-auto-import": "^2.0.0",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^2.0.0",
     "ember-cli": "~3.26.1",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/model",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,9 +18,9 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.29.0-alpha.4",
-    "@ember-data/private-build-infra": "3.29.0-alpha.4",
-    "@ember-data/store": "3.29.0-alpha.4",
+    "@ember-data/canary-features": "3.28.0-beta.0",
+    "@ember-data/private-build-infra": "3.28.0-beta.0",
+    "@ember-data/store": "3.28.0-beta.0",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^1.0.0",
     "ember-cached-decorator-polyfill": "^0.1.3",
@@ -32,7 +32,7 @@
     "inflection": "~1.13.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "ember-auto-import": "^2.0.0",

--- a/packages/private-build-infra/package.json
+++ b/packages/private-build-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/private-build-infra",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [
     "ember-addon"
@@ -15,7 +15,7 @@
   "scripts": {},
   "dependencies": {
     "@babel/plugin-transform-block-scoping": "^7.8.3",
-    "@ember-data/canary-features": "3.28.0-beta.3",
+    "@ember-data/canary-features": "3.28.0",
     "@ember/edition-utils": "^1.2.0",
     "babel-plugin-debug-macros": "^0.3.3",
     "babel-plugin-filter-imports": "^4.0.0",

--- a/packages/private-build-infra/package.json
+++ b/packages/private-build-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/private-build-infra",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [
     "ember-addon"
@@ -15,7 +15,7 @@
   "scripts": {},
   "dependencies": {
     "@babel/plugin-transform-block-scoping": "^7.8.3",
-    "@ember-data/canary-features": "3.28.0-beta.2",
+    "@ember-data/canary-features": "3.28.0-beta.3",
     "@ember/edition-utils": "^1.2.0",
     "babel-plugin-debug-macros": "^0.3.3",
     "babel-plugin-filter-imports": "^4.0.0",

--- a/packages/private-build-infra/package.json
+++ b/packages/private-build-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/private-build-infra",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [
     "ember-addon"
@@ -15,7 +15,7 @@
   "scripts": {},
   "dependencies": {
     "@babel/plugin-transform-block-scoping": "^7.8.3",
-    "@ember-data/canary-features": "3.28.0-beta.1",
+    "@ember-data/canary-features": "3.28.0-beta.2",
     "@ember/edition-utils": "^1.2.0",
     "babel-plugin-debug-macros": "^0.3.3",
     "babel-plugin-filter-imports": "^4.0.0",

--- a/packages/private-build-infra/package.json
+++ b/packages/private-build-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/private-build-infra",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [
     "ember-addon"
@@ -15,7 +15,7 @@
   "scripts": {},
   "dependencies": {
     "@babel/plugin-transform-block-scoping": "^7.8.3",
-    "@ember-data/canary-features": "3.28.0-beta.0",
+    "@ember-data/canary-features": "3.28.0-beta.1",
     "@ember/edition-utils": "^1.2.0",
     "babel-plugin-debug-macros": "^0.3.3",
     "babel-plugin-filter-imports": "^4.0.0",

--- a/packages/private-build-infra/package.json
+++ b/packages/private-build-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/private-build-infra",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [
     "ember-addon"
@@ -15,7 +15,7 @@
   "scripts": {},
   "dependencies": {
     "@babel/plugin-transform-block-scoping": "^7.8.3",
-    "@ember-data/canary-features": "3.29.0-alpha.4",
+    "@ember-data/canary-features": "3.28.0-beta.0",
     "@ember/edition-utils": "^1.2.0",
     "babel-plugin-debug-macros": "^0.3.3",
     "babel-plugin-filter-imports": "^4.0.0",

--- a/packages/private-build-infra/src/addon-build-config-for-data-package.js
+++ b/packages/private-build-infra/src/addon-build-config-for-data-package.js
@@ -174,19 +174,10 @@ function addonBuildConfigForDataPackage(PackageName) {
       let checker = new VersionChecker(this.project);
       let emberVersion = checker.for('ember-source');
 
-      const babelOptions = Object.assign({}, this.options.babel);
-
-      // we only want to add this to the options passed to the babel transpiler for the rolled up files
-      // other files get it from the inherited app config
-      if (this.pkg.dependencies['ember-cached-decorator-polyfill']) {
-        babelOptions.plugins = babelOptions.plugins.slice();
-        babelOptions.plugins.push([require.resolve('ember-cached-decorator-polyfill/lib/transpile-modules.js')]); // eslint-disable-line
-      }
-
       let privateTree = rollupPrivateModule(tree, {
         packageName: PackageName,
         babelCompiler: babel,
-        babelOptions,
+        babelOptions: this.options.babel,
         emberVersion: emberVersion,
         emberCliBabelOptions: host.options && host.options['ember-cli-babel'] ? host.options['ember-cli-babel'] : {},
         onWarn: this._suppressUneededRollupWarnings.bind(this),

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/record-data",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "description": "Provides the default RecordData implementation for ember-data",
   "keywords": [
     "ember-addon"
@@ -20,17 +20,17 @@
     "test:try-one": "ember try:one --config-path='../-ember-data/config/ember-try.js'"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.1",
-    "@ember-data/private-build-infra": "3.28.0-beta.1",
-    "@ember-data/store": "3.28.0-beta.1",
+    "@ember-data/canary-features": "3.28.0-beta.2",
+    "@ember-data/private-build-infra": "3.28.0-beta.2",
+    "@ember-data/store": "3.28.0-beta.2",
     "@ember/edition-utils": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/model": "3.28.0-beta.1",
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/model": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -50,7 +50,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/record-data",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "description": "Provides the default RecordData implementation for ember-data",
   "keywords": [
     "ember-addon"
@@ -20,17 +20,17 @@
     "test:try-one": "ember try:one --config-path='../-ember-data/config/ember-try.js'"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.3",
-    "@ember-data/private-build-infra": "3.28.0-beta.3",
-    "@ember-data/store": "3.28.0-beta.3",
+    "@ember-data/canary-features": "3.28.0",
+    "@ember-data/private-build-infra": "3.28.0",
+    "@ember-data/store": "3.28.0",
     "@ember/edition-utils": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/model": "3.28.0-beta.3",
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/model": "3.28.0",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/record-data",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "description": "Provides the default RecordData implementation for ember-data",
   "keywords": [
     "ember-addon"
@@ -20,17 +20,17 @@
     "test:try-one": "ember try:one --config-path='../-ember-data/config/ember-try.js'"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.2",
-    "@ember-data/private-build-infra": "3.28.0-beta.2",
-    "@ember-data/store": "3.28.0-beta.2",
+    "@ember-data/canary-features": "3.28.0-beta.3",
+    "@ember-data/private-build-infra": "3.28.0-beta.3",
+    "@ember-data/store": "3.28.0-beta.3",
     "@ember/edition-utils": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/model": "3.28.0-beta.2",
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/model": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/record-data",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "description": "Provides the default RecordData implementation for ember-data",
   "keywords": [
     "ember-addon"
@@ -20,21 +20,21 @@
     "test:try-one": "ember try:one --config-path='../-ember-data/config/ember-try.js'"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.0",
-    "@ember-data/private-build-infra": "3.28.0-beta.0",
-    "@ember-data/store": "3.28.0-beta.0",
+    "@ember-data/canary-features": "3.28.0-beta.1",
+    "@ember-data/private-build-infra": "3.28.0-beta.1",
+    "@ember-data/store": "3.28.0-beta.1",
     "@ember/edition-utils": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/model": "3.28.0-beta.0",
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/model": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
-    "ember-auto-import": "^2.0.0",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^2.0.0",
     "ember-cli": "~3.26.1",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
     "ember-cli-dependency-checker": "^3.2.0",
@@ -55,8 +55,8 @@
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",
     "qunit": "^2.15.0",
-    "qunit-dom": "^1.6.0",
     "qunit-console-grouper": "^0.3.0",
+    "qunit-dom": "^1.6.0",
     "silent-error": "^1.1.1",
     "webpack": "^5.37.1"
   },

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/record-data",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "description": "Provides the default RecordData implementation for ember-data",
   "keywords": [
     "ember-addon"
@@ -20,17 +20,17 @@
     "test:try-one": "ember try:one --config-path='../-ember-data/config/ember-try.js'"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.29.0-alpha.4",
-    "@ember-data/private-build-infra": "3.29.0-alpha.4",
-    "@ember-data/store": "3.29.0-alpha.4",
+    "@ember-data/canary-features": "3.28.0-beta.0",
+    "@ember-data/private-build-infra": "3.28.0-beta.0",
+    "@ember-data/store": "3.28.0-beta.0",
     "@ember/edition-utils": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/model": "3.29.0-alpha.4",
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/model": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "ember-auto-import": "^2.0.0",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -44,7 +44,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/serializer",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,14 +18,14 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.2",
-    "@ember-data/store": "3.28.0-beta.2",
+    "@ember-data/private-build-infra": "3.28.0-beta.3",
+    "@ember-data/store": "3.28.0-beta.3",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^1.0.0",
     "@ember/test-helpers": "^2.2.5",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/serializer",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,14 +18,14 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.3",
-    "@ember-data/store": "3.28.0-beta.3",
+    "@ember-data/private-build-infra": "3.28.0",
+    "@ember-data/store": "3.28.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^1.0.0",
     "@ember/test-helpers": "^2.2.5",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/serializer",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,14 +18,14 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.1",
-    "@ember-data/store": "3.28.0-beta.1",
+    "@ember-data/private-build-infra": "3.28.0-beta.2",
+    "@ember-data/store": "3.28.0-beta.2",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^1.0.0",
     "@ember/test-helpers": "^2.2.5",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/serializer",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,19 +18,19 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.0",
-    "@ember-data/store": "3.28.0-beta.0",
+    "@ember-data/private-build-infra": "3.28.0-beta.1",
+    "@ember-data/store": "3.28.0-beta.1",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^1.0.0",
     "@ember/test-helpers": "^2.2.5",
-    "ember-auto-import": "^2.0.0",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^2.0.0",
     "ember-cli": "~3.26.1",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/serializer",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,14 +18,14 @@
     "test:node": "mocha"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.29.0-alpha.4",
-    "@ember-data/store": "3.29.0-alpha.4",
+    "@ember-data/private-build-infra": "3.28.0-beta.0",
+    "@ember-data/store": "3.28.0-beta.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^1.0.0",
     "@ember/test-helpers": "^2.2.5",

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -57,7 +57,12 @@ import { RecordReference } from './references';
 import { RequestPromise } from './request-cache';
 import { _bind, _guard, _objectIsAlive, guardDestroyedStore } from './store/common';
 import { _find, _findAll, _findBelongsTo, _findHasMany, _findMany, _query, _queryRecord } from './store/finders';
-import { internalModelFactoryFor, recordIdentifierFor, setRecordIdentifier } from './store/internal-model-factory';
+import {
+  internalModelFactoryFor,
+  peekRecordIdentifier,
+  recordIdentifierFor,
+  setRecordIdentifier,
+} from './store/internal-model-factory';
 import RecordDataStoreWrapper from './store/record-data-store-wrapper';
 import { normalizeResponseHelper } from './store/serializer-response';
 
@@ -710,10 +715,27 @@ abstract class CoreStore extends Service {
     }
     this._backburner.join(() => {
       if (CUSTOM_MODEL_CLASS) {
-        let identifier = recordIdentifierFor(record);
-        let internalModel = internalModelFactoryFor(this).peek(identifier);
-        if (internalModel) {
-          internalModel.deleteRecord();
+        let identifier = peekRecordIdentifier(record);
+        if (identifier) {
+          let internalModel = internalModelFactoryFor(this).peek(identifier);
+          if (internalModel) {
+            internalModel.deleteRecord();
+          }
+        } else {
+          deprecate(
+            `You passed a non ember-data managed record ${record} to store.deleteRecord. Ember Data store is not meant to manage non store records. This is not supported and will be removed`,
+            false,
+            {
+              id: 'ember-data:delete-record-non-store',
+              until: '4.0',
+              for: '@ember-data/store',
+              since: {
+                available: '3.28',
+                enabled: '3.28',
+              },
+            }
+          );
+          record.deleteRecord();
         }
       } else {
         record.deleteRecord();
@@ -742,10 +764,27 @@ abstract class CoreStore extends Service {
       assertDestroyingStore(this, 'unloadRecord');
     }
     if (CUSTOM_MODEL_CLASS) {
-      let identifier = recordIdentifierFor(record);
-      let internalModel = internalModelFactoryFor(this).peek(identifier);
-      if (internalModel) {
-        internalModel.unloadRecord();
+      let identifier = peekRecordIdentifier(record);
+      if (identifier) {
+        let internalModel = internalModelFactoryFor(this).peek(identifier);
+        if (internalModel) {
+          internalModel.unloadRecord();
+        }
+      } else {
+        deprecate(
+          `You passed a non ember-data managed record ${record} to store.unloadRecord. Ember Data store is not meant to manage non store records. This is not supported and will be removed`,
+          false,
+          {
+            id: 'ember-data:unload-record-non-store',
+            until: '4.0',
+            for: '@ember-data/store',
+            since: {
+              available: '3.28',
+              enabled: '3.28',
+            },
+          }
+        );
+        record.unloadRecord();
       }
     } else {
       record.unloadRecord();

--- a/packages/store/addon/-private/system/fetch-manager.ts
+++ b/packages/store/addon/-private/system/fetch-manager.ts
@@ -11,10 +11,12 @@ import { default as RSVP, Promise } from 'rsvp';
 import { symbol } from '../utils/symbol';
 import coerceId from './coerce-id';
 import { errorsArrayToHash } from './errors-utils';
-import RequestCache from './request-cache';
+import RequestCache, { RequestPromise } from './request-cache';
 import Snapshot from './snapshot';
 import { _bind, _guard, _objectIsAlive, guardDestroyedStore } from './store/common';
 import { normalizeResponseHelper } from './store/serializer-response';
+
+type StableRecordIdentifier = import('../ts-interfaces/identifier').StableRecordIdentifier;
 
 type CoreStore = import('./core-store').default;
 type FindRecordQuery = import('../ts-interfaces/fetch-manager').FindRecordQuery;
@@ -503,6 +505,16 @@ export default class FetchManager {
       for (let i = 0; i < totalItems; i++) {
         this._fetchRecord(pendingFetchItems[i]);
       }
+    }
+  }
+
+  getPendingFetch(identifier: StableRecordIdentifier) {
+    let pendingRequests = this.requestCache
+      .getPendingRequestsForRecord(identifier)
+      .filter((req) => req.type === 'query');
+
+    if (pendingRequests.length > 0) {
+      return pendingRequests[0][RequestPromise];
     }
   }
 

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/store",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -17,8 +17,8 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.1",
-    "@ember-data/private-build-infra": "3.28.0-beta.1",
+    "@ember-data/canary-features": "3.28.0-beta.2",
+    "@ember-data/private-build-infra": "3.28.0-beta.2",
     "@ember/string": "^1.0.0",
     "@glimmer/tracking": "^1.0.4",
     "ember-cli-babel": "^7.26.6",
@@ -26,7 +26,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@types/ember": "^3.16.5",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -45,7 +45,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^1.4.0",
     "loader.js": "^4.7.0",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/store",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -17,8 +17,8 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.2",
-    "@ember-data/private-build-infra": "3.28.0-beta.2",
+    "@ember-data/canary-features": "3.28.0-beta.3",
+    "@ember-data/private-build-infra": "3.28.0-beta.3",
     "@ember/string": "^1.0.0",
     "@glimmer/tracking": "^1.0.4",
     "ember-cli-babel": "^7.26.6",
@@ -26,7 +26,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@types/ember": "^3.16.5",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/store",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -17,8 +17,8 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.3",
-    "@ember-data/private-build-infra": "3.28.0-beta.3",
+    "@ember-data/canary-features": "3.28.0",
+    "@ember-data/private-build-infra": "3.28.0",
     "@ember/string": "^1.0.0",
     "@glimmer/tracking": "^1.0.4",
     "ember-cli-babel": "^7.26.6",
@@ -26,7 +26,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@types/ember": "^3.16.5",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/store",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -17,8 +17,8 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.28.0-beta.0",
-    "@ember-data/private-build-infra": "3.28.0-beta.0",
+    "@ember-data/canary-features": "3.28.0-beta.1",
+    "@ember-data/private-build-infra": "3.28.0-beta.1",
     "@ember/string": "^1.0.0",
     "@glimmer/tracking": "^1.0.4",
     "ember-cli-babel": "^7.26.6",
@@ -26,7 +26,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@types/ember": "^3.16.5",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/store",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -17,8 +17,8 @@
     "start": "ember serve"
   },
   "dependencies": {
-    "@ember-data/canary-features": "3.29.0-alpha.4",
-    "@ember-data/private-build-infra": "3.29.0-alpha.4",
+    "@ember-data/canary-features": "3.28.0-beta.0",
+    "@ember-data/private-build-infra": "3.28.0-beta.0",
     "@ember/string": "^1.0.0",
     "@glimmer/tracking": "^1.0.4",
     "ember-cli-babel": "^7.26.6",
@@ -26,7 +26,7 @@
     "ember-cli-typescript": "^4.1.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@types/ember": "^3.16.5",

--- a/packages/unpublished-adapter-encapsulation-test-app/package.json
+++ b/packages/unpublished-adapter-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapter-encapsulation-test-app",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test  --test-port=0"
   },
   "dependencies": {
-    "@ember-data/debug": "3.28.0-beta.2",
-    "@ember-data/model": "3.28.0-beta.2",
-    "@ember-data/record-data": "3.28.0-beta.2",
-    "@ember-data/serializer": "3.28.0-beta.2",
-    "@ember-data/store": "3.28.0-beta.2",
+    "@ember-data/debug": "3.28.0-beta.3",
+    "@ember-data/model": "3.28.0-beta.3",
+    "@ember-data/record-data": "3.28.0-beta.3",
+    "@ember-data/serializer": "3.28.0-beta.3",
+    "@ember-data/store": "3.28.0-beta.3",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-adapter-encapsulation-test-app/package.json
+++ b/packages/unpublished-adapter-encapsulation-test-app/package.json
@@ -43,7 +43,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "eslint": "^7.23.0",
     "eslint-plugin-ember": "^10.3.0",
     "eslint-plugin-node": "^11.1.0",

--- a/packages/unpublished-adapter-encapsulation-test-app/package.json
+++ b/packages/unpublished-adapter-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapter-encapsulation-test-app",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test  --test-port=0"
   },
   "dependencies": {
-    "@ember-data/debug": "3.28.0-beta.1",
-    "@ember-data/model": "3.28.0-beta.1",
-    "@ember-data/record-data": "3.28.0-beta.1",
-    "@ember-data/serializer": "3.28.0-beta.1",
-    "@ember-data/store": "3.28.0-beta.1",
+    "@ember-data/debug": "3.28.0-beta.2",
+    "@ember-data/model": "3.28.0-beta.2",
+    "@ember-data/record-data": "3.28.0-beta.2",
+    "@ember-data/serializer": "3.28.0-beta.2",
+    "@ember-data/store": "3.28.0-beta.2",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-adapter-encapsulation-test-app/package.json
+++ b/packages/unpublished-adapter-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapter-encapsulation-test-app",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test  --test-port=0"
   },
   "dependencies": {
-    "@ember-data/debug": "3.28.0-beta.3",
-    "@ember-data/model": "3.28.0-beta.3",
-    "@ember-data/record-data": "3.28.0-beta.3",
-    "@ember-data/serializer": "3.28.0-beta.3",
-    "@ember-data/store": "3.28.0-beta.3",
+    "@ember-data/debug": "3.28.0",
+    "@ember-data/model": "3.28.0",
+    "@ember-data/record-data": "3.28.0",
+    "@ember-data/serializer": "3.28.0",
+    "@ember-data/store": "3.28.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-adapter-encapsulation-test-app/package.json
+++ b/packages/unpublished-adapter-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapter-encapsulation-test-app",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test  --test-port=0"
   },
   "dependencies": {
-    "@ember-data/debug": "3.28.0-beta.0",
-    "@ember-data/model": "3.28.0-beta.0",
-    "@ember-data/record-data": "3.28.0-beta.0",
-    "@ember-data/serializer": "3.28.0-beta.0",
-    "@ember-data/store": "3.28.0-beta.0",
+    "@ember-data/debug": "3.28.0-beta.1",
+    "@ember-data/model": "3.28.0-beta.1",
+    "@ember-data/record-data": "3.28.0-beta.1",
+    "@ember-data/serializer": "3.28.0-beta.1",
+    "@ember-data/store": "3.28.0-beta.1",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-adapter-encapsulation-test-app/package.json
+++ b/packages/unpublished-adapter-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapter-encapsulation-test-app",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test  --test-port=0"
   },
   "dependencies": {
-    "@ember-data/debug": "3.29.0-alpha.4",
-    "@ember-data/model": "3.29.0-alpha.4",
-    "@ember-data/record-data": "3.29.0-alpha.4",
-    "@ember-data/serializer": "3.29.0-alpha.4",
-    "@ember-data/store": "3.29.0-alpha.4",
+    "@ember-data/debug": "3.28.0-beta.0",
+    "@ember-data/model": "3.28.0-beta.0",
+    "@ember-data/record-data": "3.28.0-beta.0",
+    "@ember-data/serializer": "3.28.0-beta.0",
+    "@ember-data/store": "3.28.0-beta.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-debug-encapsulation-test-app/package.json
+++ b/packages/unpublished-debug-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-encapsulation-test-app",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,14 +18,14 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.2",
-    "@ember-data/model": "3.28.0-beta.2",
-    "@ember-data/serializer": "3.28.0-beta.2",
-    "@ember-data/store": "3.28.0-beta.2",
+    "@ember-data/adapter": "3.28.0-beta.3",
+    "@ember-data/model": "3.28.0-beta.3",
+    "@ember-data/serializer": "3.28.0-beta.3",
+    "@ember-data/store": "3.28.0-beta.3",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-debug-encapsulation-test-app/package.json
+++ b/packages/unpublished-debug-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-encapsulation-test-app",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,14 +18,14 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.1",
-    "@ember-data/model": "3.28.0-beta.1",
-    "@ember-data/serializer": "3.28.0-beta.1",
-    "@ember-data/store": "3.28.0-beta.1",
+    "@ember-data/adapter": "3.28.0-beta.2",
+    "@ember-data/model": "3.28.0-beta.2",
+    "@ember-data/serializer": "3.28.0-beta.2",
+    "@ember-data/store": "3.28.0-beta.2",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-debug-encapsulation-test-app/package.json
+++ b/packages/unpublished-debug-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-encapsulation-test-app",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,14 +18,14 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.3",
-    "@ember-data/model": "3.28.0-beta.3",
-    "@ember-data/serializer": "3.28.0-beta.3",
-    "@ember-data/store": "3.28.0-beta.3",
+    "@ember-data/adapter": "3.28.0",
+    "@ember-data/model": "3.28.0",
+    "@ember-data/serializer": "3.28.0",
+    "@ember-data/store": "3.28.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-debug-encapsulation-test-app/package.json
+++ b/packages/unpublished-debug-encapsulation-test-app/package.json
@@ -42,7 +42,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "eslint": "^7.23.0",
     "eslint-plugin-ember": "^10.3.0",
     "eslint-plugin-node": "^11.1.0",

--- a/packages/unpublished-debug-encapsulation-test-app/package.json
+++ b/packages/unpublished-debug-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-encapsulation-test-app",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,14 +18,14 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.29.0-alpha.4",
-    "@ember-data/model": "3.29.0-alpha.4",
-    "@ember-data/serializer": "3.29.0-alpha.4",
-    "@ember-data/store": "3.29.0-alpha.4",
+    "@ember-data/adapter": "3.28.0-beta.0",
+    "@ember-data/model": "3.28.0-beta.0",
+    "@ember-data/serializer": "3.28.0-beta.0",
+    "@ember-data/store": "3.28.0-beta.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-debug-encapsulation-test-app/package.json
+++ b/packages/unpublished-debug-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-encapsulation-test-app",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,14 +18,14 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.0",
-    "@ember-data/model": "3.28.0-beta.0",
-    "@ember-data/serializer": "3.28.0-beta.0",
-    "@ember-data/store": "3.28.0-beta.0",
+    "@ember-data/adapter": "3.28.0-beta.1",
+    "@ember-data/model": "3.28.0-beta.1",
+    "@ember-data/serializer": "3.28.0-beta.1",
+    "@ember-data/store": "3.28.0-beta.1",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-eslint-rules/package.json
+++ b/packages/unpublished-eslint-rules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-ember-data",
   "main": "./src/index.js",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "private": true,
   "volta": {
     "node": "14.17.0",

--- a/packages/unpublished-eslint-rules/package.json
+++ b/packages/unpublished-eslint-rules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-ember-data",
   "main": "./src/index.js",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "private": true,
   "volta": {
     "node": "14.17.0",

--- a/packages/unpublished-eslint-rules/package.json
+++ b/packages/unpublished-eslint-rules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-ember-data",
   "main": "./src/index.js",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "private": true,
   "volta": {
     "node": "14.17.0",

--- a/packages/unpublished-eslint-rules/package.json
+++ b/packages/unpublished-eslint-rules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-ember-data",
   "main": "./src/index.js",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "private": true,
   "volta": {
     "node": "14.17.0",

--- a/packages/unpublished-eslint-rules/package.json
+++ b/packages/unpublished-eslint-rules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-ember-data",
   "main": "./src/index.js",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "private": true,
   "volta": {
     "node": "14.17.0",

--- a/packages/unpublished-fastboot-test-app/package.json
+++ b/packages/unpublished-fastboot-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastboot-test-app",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "private": true,
   "description": "Small description for fastboot-test-app goes here",
   "repository": "",
@@ -19,11 +19,11 @@
     "test:scenario": "ember try:one"
   },
   "dependencies": {
-    "ember-data": "3.28.0-beta.2",
+    "ember-data": "3.28.0-beta.3",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@types/ember": "^3.16.5",

--- a/packages/unpublished-fastboot-test-app/package.json
+++ b/packages/unpublished-fastboot-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastboot-test-app",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "private": true,
   "description": "Small description for fastboot-test-app goes here",
   "repository": "",
@@ -19,11 +19,11 @@
     "test:scenario": "ember try:one"
   },
   "dependencies": {
-    "ember-data": "3.28.0-beta.3",
+    "ember-data": "3.28.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@types/ember": "^3.16.5",

--- a/packages/unpublished-fastboot-test-app/package.json
+++ b/packages/unpublished-fastboot-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastboot-test-app",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "private": true,
   "description": "Small description for fastboot-test-app goes here",
   "repository": "",
@@ -19,11 +19,11 @@
     "test:scenario": "ember try:one"
   },
   "dependencies": {
-    "ember-data": "3.28.0-beta.1",
+    "ember-data": "3.28.0-beta.2",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@types/ember": "^3.16.5",

--- a/packages/unpublished-fastboot-test-app/package.json
+++ b/packages/unpublished-fastboot-test-app/package.json
@@ -52,7 +52,7 @@
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
     "ember-simple-tree": "^0.8.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.23.0",
     "eslint-plugin-ember": "^10.3.0",

--- a/packages/unpublished-fastboot-test-app/package.json
+++ b/packages/unpublished-fastboot-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastboot-test-app",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "private": true,
   "description": "Small description for fastboot-test-app goes here",
   "repository": "",
@@ -19,11 +19,11 @@
     "test:scenario": "ember try:one"
   },
   "dependencies": {
-    "ember-data": "3.28.0-beta.0",
+    "ember-data": "3.28.0-beta.1",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@types/ember": "^3.16.5",
@@ -40,7 +40,6 @@
     "ember-cli-babel": "^7.26.6",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-fastboot": "^3.2.0-beta.2",
-    "fastboot": "^3.1.2",
     "ember-cli-fastboot-testing": "^0.5.0",
     "ember-cli-htmlbars": "^5.1.2",
     "ember-cli-inject-live-reload": "^2.0.2",
@@ -58,6 +57,7 @@
     "eslint": "^7.23.0",
     "eslint-plugin-ember": "^10.3.0",
     "eslint-plugin-node": "^11.1.0",
+    "fastboot": "^3.1.2",
     "loader.js": "^4.7.0",
     "qunit": "^2.15.0",
     "qunit-dom": "^1.6.0",

--- a/packages/unpublished-fastboot-test-app/package.json
+++ b/packages/unpublished-fastboot-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastboot-test-app",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "private": true,
   "description": "Small description for fastboot-test-app goes here",
   "repository": "",
@@ -19,11 +19,11 @@
     "test:scenario": "ember try:one"
   },
   "dependencies": {
-    "ember-data": "3.29.0-alpha.4",
+    "ember-data": "3.28.0-beta.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "@types/ember": "^3.16.5",

--- a/packages/unpublished-model-encapsulation-test-app/package.json
+++ b/packages/unpublished-model-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-encapsulation-test-app",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.3",
-    "@ember-data/canary-features": "3.28.0-beta.3",
-    "@ember-data/private-build-infra": "3.28.0-beta.3",
-    "@ember-data/serializer": "3.28.0-beta.3",
-    "@ember-data/store": "3.28.0-beta.3",
+    "@ember-data/adapter": "3.28.0",
+    "@ember-data/canary-features": "3.28.0",
+    "@ember-data/private-build-infra": "3.28.0",
+    "@ember-data/serializer": "3.28.0",
+    "@ember-data/store": "3.28.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-model-encapsulation-test-app/package.json
+++ b/packages/unpublished-model-encapsulation-test-app/package.json
@@ -43,7 +43,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "eslint": "^7.23.0",
     "eslint-plugin-ember": "^10.3.0",
     "eslint-plugin-node": "^11.1.0",

--- a/packages/unpublished-model-encapsulation-test-app/package.json
+++ b/packages/unpublished-model-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-encapsulation-test-app",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.1",
-    "@ember-data/canary-features": "3.28.0-beta.1",
-    "@ember-data/private-build-infra": "3.28.0-beta.1",
-    "@ember-data/serializer": "3.28.0-beta.1",
-    "@ember-data/store": "3.28.0-beta.1",
+    "@ember-data/adapter": "3.28.0-beta.2",
+    "@ember-data/canary-features": "3.28.0-beta.2",
+    "@ember-data/private-build-infra": "3.28.0-beta.2",
+    "@ember-data/serializer": "3.28.0-beta.2",
+    "@ember-data/store": "3.28.0-beta.2",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-model-encapsulation-test-app/package.json
+++ b/packages/unpublished-model-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-encapsulation-test-app",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.2",
-    "@ember-data/canary-features": "3.28.0-beta.2",
-    "@ember-data/private-build-infra": "3.28.0-beta.2",
-    "@ember-data/serializer": "3.28.0-beta.2",
-    "@ember-data/store": "3.28.0-beta.2",
+    "@ember-data/adapter": "3.28.0-beta.3",
+    "@ember-data/canary-features": "3.28.0-beta.3",
+    "@ember-data/private-build-infra": "3.28.0-beta.3",
+    "@ember-data/serializer": "3.28.0-beta.3",
+    "@ember-data/store": "3.28.0-beta.3",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-model-encapsulation-test-app/package.json
+++ b/packages/unpublished-model-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-encapsulation-test-app",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.29.0-alpha.4",
-    "@ember-data/canary-features": "3.29.0-alpha.4",
-    "@ember-data/private-build-infra": "3.29.0-alpha.4",
-    "@ember-data/serializer": "3.29.0-alpha.4",
-    "@ember-data/store": "3.29.0-alpha.4",
+    "@ember-data/adapter": "3.28.0-beta.0",
+    "@ember-data/canary-features": "3.28.0-beta.0",
+    "@ember-data/private-build-infra": "3.28.0-beta.0",
+    "@ember-data/serializer": "3.28.0-beta.0",
+    "@ember-data/store": "3.28.0-beta.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-model-encapsulation-test-app/package.json
+++ b/packages/unpublished-model-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-encapsulation-test-app",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.0",
-    "@ember-data/canary-features": "3.28.0-beta.0",
-    "@ember-data/private-build-infra": "3.28.0-beta.0",
-    "@ember-data/serializer": "3.28.0-beta.0",
-    "@ember-data/store": "3.28.0-beta.0",
+    "@ember-data/adapter": "3.28.0-beta.1",
+    "@ember-data/canary-features": "3.28.0-beta.1",
+    "@ember-data/private-build-infra": "3.28.0-beta.1",
+    "@ember-data/serializer": "3.28.0-beta.1",
+    "@ember-data/store": "3.28.0-beta.1",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-record-data-encapsulation-test-app/package.json
+++ b/packages/unpublished-record-data-encapsulation-test-app/package.json
@@ -43,7 +43,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "eslint": "^7.23.0",
     "eslint-plugin-ember": "^10.3.0",
     "eslint-plugin-node": "^11.1.0",

--- a/packages/unpublished-record-data-encapsulation-test-app/package.json
+++ b/packages/unpublished-record-data-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "record-data-encapsulation-test-app",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.3",
-    "@ember-data/debug": "3.28.0-beta.3",
-    "@ember-data/model": "3.28.0-beta.3",
-    "@ember-data/serializer": "3.28.0-beta.3",
-    "@ember-data/store": "3.28.0-beta.3",
+    "@ember-data/adapter": "3.28.0",
+    "@ember-data/debug": "3.28.0",
+    "@ember-data/model": "3.28.0",
+    "@ember-data/serializer": "3.28.0",
+    "@ember-data/store": "3.28.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-record-data-encapsulation-test-app/package.json
+++ b/packages/unpublished-record-data-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "record-data-encapsulation-test-app",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.2",
-    "@ember-data/debug": "3.28.0-beta.2",
-    "@ember-data/model": "3.28.0-beta.2",
-    "@ember-data/serializer": "3.28.0-beta.2",
-    "@ember-data/store": "3.28.0-beta.2",
+    "@ember-data/adapter": "3.28.0-beta.3",
+    "@ember-data/debug": "3.28.0-beta.3",
+    "@ember-data/model": "3.28.0-beta.3",
+    "@ember-data/serializer": "3.28.0-beta.3",
+    "@ember-data/store": "3.28.0-beta.3",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-record-data-encapsulation-test-app/package.json
+++ b/packages/unpublished-record-data-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "record-data-encapsulation-test-app",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.1",
-    "@ember-data/debug": "3.28.0-beta.1",
-    "@ember-data/model": "3.28.0-beta.1",
-    "@ember-data/serializer": "3.28.0-beta.1",
-    "@ember-data/store": "3.28.0-beta.1",
+    "@ember-data/adapter": "3.28.0-beta.2",
+    "@ember-data/debug": "3.28.0-beta.2",
+    "@ember-data/model": "3.28.0-beta.2",
+    "@ember-data/serializer": "3.28.0-beta.2",
+    "@ember-data/store": "3.28.0-beta.2",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-record-data-encapsulation-test-app/package.json
+++ b/packages/unpublished-record-data-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "record-data-encapsulation-test-app",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.29.0-alpha.4",
-    "@ember-data/debug": "3.29.0-alpha.4",
-    "@ember-data/model": "3.29.0-alpha.4",
-    "@ember-data/serializer": "3.29.0-alpha.4",
-    "@ember-data/store": "3.29.0-alpha.4",
+    "@ember-data/adapter": "3.28.0-beta.0",
+    "@ember-data/debug": "3.28.0-beta.0",
+    "@ember-data/model": "3.28.0-beta.0",
+    "@ember-data/serializer": "3.28.0-beta.0",
+    "@ember-data/store": "3.28.0-beta.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-record-data-encapsulation-test-app/package.json
+++ b/packages/unpublished-record-data-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "record-data-encapsulation-test-app",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,15 +18,15 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.0",
-    "@ember-data/debug": "3.28.0-beta.0",
-    "@ember-data/model": "3.28.0-beta.0",
-    "@ember-data/serializer": "3.28.0-beta.0",
-    "@ember-data/store": "3.28.0-beta.0",
+    "@ember-data/adapter": "3.28.0-beta.1",
+    "@ember-data/debug": "3.28.0-beta.1",
+    "@ember-data/model": "3.28.0-beta.1",
+    "@ember-data/serializer": "3.28.0-beta.1",
+    "@ember-data/store": "3.28.0-beta.1",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-relationship-performance-test-app/package.json
+++ b/packages/unpublished-relationship-performance-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relationship-performance-test-app",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "private": true,
   "description": "Small description for relationship-performance-test-app goes here",
   "repository": "",
@@ -18,10 +18,10 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "ember-data": "3.28.0-beta.2"
+    "ember-data": "3.28.0-beta.3"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-relationship-performance-test-app/package.json
+++ b/packages/unpublished-relationship-performance-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relationship-performance-test-app",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "private": true,
   "description": "Small description for relationship-performance-test-app goes here",
   "repository": "",
@@ -18,10 +18,10 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "ember-data": "3.28.0-beta.3"
+    "ember-data": "3.28.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-relationship-performance-test-app/package.json
+++ b/packages/unpublished-relationship-performance-test-app/package.json
@@ -38,7 +38,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "eslint": "^7.23.0",
     "eslint-plugin-ember": "^10.3.0",
     "eslint-plugin-node": "^11.1.0",

--- a/packages/unpublished-relationship-performance-test-app/package.json
+++ b/packages/unpublished-relationship-performance-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relationship-performance-test-app",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "private": true,
   "description": "Small description for relationship-performance-test-app goes here",
   "repository": "",
@@ -18,10 +18,10 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "ember-data": "3.28.0-beta.1"
+    "ember-data": "3.28.0-beta.2"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-relationship-performance-test-app/package.json
+++ b/packages/unpublished-relationship-performance-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relationship-performance-test-app",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "private": true,
   "description": "Small description for relationship-performance-test-app goes here",
   "repository": "",
@@ -18,10 +18,10 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "ember-data": "3.28.0-beta.0"
+    "ember-data": "3.28.0-beta.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-relationship-performance-test-app/package.json
+++ b/packages/unpublished-relationship-performance-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relationship-performance-test-app",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "private": true,
   "description": "Small description for relationship-performance-test-app goes here",
   "repository": "",
@@ -18,10 +18,10 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "ember-data": "3.29.0-alpha.4"
+    "ember-data": "3.28.0-beta.0"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-serializer-encapsulation-test-app/package.json
+++ b/packages/unpublished-serializer-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serializer-encapsulation-test-app",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,14 +18,14 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.1",
-    "@ember-data/model": "3.28.0-beta.1",
-    "@ember-data/record-data": "3.28.0-beta.1",
-    "@ember-data/store": "3.28.0-beta.1",
+    "@ember-data/adapter": "3.28.0-beta.2",
+    "@ember-data/model": "3.28.0-beta.2",
+    "@ember-data/record-data": "3.28.0-beta.2",
+    "@ember-data/store": "3.28.0-beta.2",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-serializer-encapsulation-test-app/package.json
+++ b/packages/unpublished-serializer-encapsulation-test-app/package.json
@@ -42,7 +42,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "eslint": "^7.23.0",
     "eslint-plugin-ember": "^10.3.0",
     "eslint-plugin-node": "^11.1.0",

--- a/packages/unpublished-serializer-encapsulation-test-app/package.json
+++ b/packages/unpublished-serializer-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serializer-encapsulation-test-app",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,14 +18,14 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.3",
-    "@ember-data/model": "3.28.0-beta.3",
-    "@ember-data/record-data": "3.28.0-beta.3",
-    "@ember-data/store": "3.28.0-beta.3",
+    "@ember-data/adapter": "3.28.0",
+    "@ember-data/model": "3.28.0",
+    "@ember-data/record-data": "3.28.0",
+    "@ember-data/store": "3.28.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
+    "@ember-data/unpublished-test-infra": "3.28.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-serializer-encapsulation-test-app/package.json
+++ b/packages/unpublished-serializer-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serializer-encapsulation-test-app",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,14 +18,14 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.2",
-    "@ember-data/model": "3.28.0-beta.2",
-    "@ember-data/record-data": "3.28.0-beta.2",
-    "@ember-data/store": "3.28.0-beta.2",
+    "@ember-data/adapter": "3.28.0-beta.3",
+    "@ember-data/model": "3.28.0-beta.3",
+    "@ember-data/record-data": "3.28.0-beta.3",
+    "@ember-data/store": "3.28.0-beta.3",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.2",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-serializer-encapsulation-test-app/package.json
+++ b/packages/unpublished-serializer-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serializer-encapsulation-test-app",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,14 +18,14 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.29.0-alpha.4",
-    "@ember-data/model": "3.29.0-alpha.4",
-    "@ember-data/record-data": "3.29.0-alpha.4",
-    "@ember-data/store": "3.29.0-alpha.4",
+    "@ember-data/adapter": "3.28.0-beta.0",
+    "@ember-data/model": "3.28.0-beta.0",
+    "@ember-data/record-data": "3.28.0-beta.0",
+    "@ember-data/store": "3.28.0-beta.0",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.29.0-alpha.4",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-serializer-encapsulation-test-app/package.json
+++ b/packages/unpublished-serializer-encapsulation-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serializer-encapsulation-test-app",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "private": true,
   "description": "Small description for encapsulation-test-app goes here",
   "repository": "",
@@ -18,14 +18,14 @@
     "test": "ember test --test-port=0"
   },
   "dependencies": {
-    "@ember-data/adapter": "3.28.0-beta.0",
-    "@ember-data/model": "3.28.0-beta.0",
-    "@ember-data/record-data": "3.28.0-beta.0",
-    "@ember-data/store": "3.28.0-beta.0",
+    "@ember-data/adapter": "3.28.0-beta.1",
+    "@ember-data/model": "3.28.0-beta.1",
+    "@ember-data/record-data": "3.28.0-beta.1",
+    "@ember-data/store": "3.28.0-beta.1",
     "ember-inflector": "^4.0.1"
   },
   "devDependencies": {
-    "@ember-data/unpublished-test-infra": "3.28.0-beta.0",
+    "@ember-data/unpublished-test-infra": "3.28.0-beta.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/unpublished-test-infra",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "private": true,
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.2",
+    "@ember-data/private-build-infra": "3.28.0-beta.3",
     "@ember/edition-utils": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-blueprint-test-helpers": "^0.19.2",

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/unpublished-test-infra",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "private": true,
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.3",
+    "@ember-data/private-build-infra": "3.28.0",
     "@ember/edition-utils": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-blueprint-test-helpers": "^0.19.2",

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -42,7 +42,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.0",
-    "ember-source": "~3.27.1",
+    "ember-source": "~3.28.0",
     "loader.js": "^4.7.0",
     "qunit": "^2.15.0",
     "qunit-dom": "^1.6.0",

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/unpublished-test-infra",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "private": true,
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.1",
+    "@ember-data/private-build-infra": "3.28.0-beta.2",
     "@ember/edition-utils": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-blueprint-test-helpers": "^0.19.2",

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/unpublished-test-infra",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "private": true,
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.28.0-beta.0",
+    "@ember-data/private-build-infra": "3.28.0-beta.1",
     "@ember/edition-utils": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-blueprint-test-helpers": "^0.19.2",

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember-data/unpublished-test-infra",
-  "version": "3.29.0-alpha.4",
+  "version": "3.28.0-beta.0",
   "private": true,
   "description": "The default blueprint for ember-data private packages.",
   "keywords": [
@@ -17,7 +17,7 @@
     "test": "ember test"
   },
   "dependencies": {
-    "@ember-data/private-build-infra": "3.29.0-alpha.4",
+    "@ember-data/private-build-infra": "3.28.0-beta.0",
     "@ember/edition-utils": "^1.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-blueprint-test-helpers": "^0.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6768,10 +6768,10 @@ ember-cache-primitive-polyfill@^1.0.1:
     ember-compatibility-helpers "^1.2.1"
     silent-error "^1.1.1"
 
-ember-cached-decorator-polyfill@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.npmjs.org/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-0.1.3.tgz#9da71cacad87330e8bf090f922984cb827588a60"
-  integrity sha512-I3AJ3sJkPoJdSOnXw8E1ww8h9Ly62djVugLySrQhNerOnTSGmbSx/iAXtojFfepo7q29HfUlFcM7DSFp5shQ7g==
+ember-cached-decorator-polyfill@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-0.1.4.tgz#f1e2c65cc78d0d9c4ac0e047e643af477eb85ace"
+  integrity sha512-JOK7kBCWsTVCzmCefK4nr9BACDJk0owt9oIUaVt6Q0UtQ4XeAHmoK5kQ/YtDcxQF1ZevHQFdGhsTR3JLaHNJgA==
   dependencies:
     "@glimmer/tracking" "^1.0.4"
     ember-cache-primitive-polyfill "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1262,10 +1262,10 @@
   resolved "https://registry.npmjs.org/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
   integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
 
-"@glimmer/vm-babel-plugins@0.78.2":
-  version "0.78.2"
-  resolved "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.78.2.tgz#b530a19f54da385c7099a22cf348e9062d186838"
-  integrity sha512-GSEf16h6OCtKx7PsSvD21cLXZuVc6swW2rSOAvfLeZco1DEWMRgYTwkCkColydKZcQ3gvwbPBeYwTC2K6tlnjg==
+"@glimmer/vm-babel-plugins@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.80.0.tgz#e9a6b496501eed367b94c928dc48a954830af3b5"
+  integrity sha512-ZW6+L+FzjDZngGj87zn3MRRA/MrchC7Con33mCcI36v8u48maheB351uhQe+fBVU300IfyzNMvAdwdVKS5VIFw==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
 
@@ -7417,20 +7417,21 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@~3.27.1:
-  version "3.27.1"
-  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.27.1.tgz#7348d4ff66ce1baf8e25efb2bc70df39b52e88b8"
-  integrity sha512-gBYsWz6eCFWSvdQvteal7LpXmCfUn64cKpZ3OIYeJGuXgl6akg34mCsYltUPdybAxRJzDkJeksTF9WnqqbXmMw==
+ember-source@~3.28.0:
+  version "3.28.0"
+  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.28.0.tgz#aee9e712d80d7c39d2cc34b958d6e6e00c5dd40e"
+  integrity sha512-7cjzZlJE1Fun3+ygM5f7ubJviyHUU1LGHWyodQfbua6wkvieU2GYV0QNTUJQHe0JEAUr+Jm7x4/FuNIYB/dvpA==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"
     "@babel/plugin-transform-object-assign" "^7.8.3"
     "@ember/edition-utils" "^1.2.0"
-    "@glimmer/vm-babel-plugins" "0.78.2"
+    "@glimmer/vm-babel-plugins" "0.80.0"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
     broccoli-concat "^4.2.4"
     broccoli-debug "^0.6.4"
+    broccoli-file-creator "^2.1.1"
     broccoli-funnel "^2.0.2"
     broccoli-merge-trees "^4.2.0"
     chalk "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7818,7 +7818,7 @@ eslint-module-utils@^2.6.1:
     pkg-dir "^2.0.0"
 
 "eslint-plugin-ember-data@link:./packages/unpublished-eslint-rules":
-  version "3.29.0-alpha.4"
+  version "3.28.0-beta.0"
 
 eslint-plugin-ember@^10.3.0, eslint-plugin-ember@^10.4.1:
   version "10.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2606,14 +2606,6 @@
     "@typescript-eslint/typescript-estree" "4.25.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz#38088216f0eaf235fa30ed8cabf6948ec734f359"
-  integrity sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==
-  dependencies:
-    "@typescript-eslint/types" "4.24.0"
-    "@typescript-eslint/visitor-keys" "4.24.0"
-
 "@typescript-eslint/scope-manager@4.25.0":
   version "4.25.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.25.0.tgz#9d86a5bcc46ef40acd03d85ad4e908e5aab8d4ca"
@@ -2622,28 +2614,10 @@
     "@typescript-eslint/types" "4.25.0"
     "@typescript-eslint/visitor-keys" "4.25.0"
 
-"@typescript-eslint/types@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.24.0.tgz#6d0cca2048cbda4e265e0c4db9c2a62aaad8228c"
-  integrity sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==
-
 "@typescript-eslint/types@4.25.0":
   version "4.25.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.25.0.tgz#0e444a5c5e3c22d7ffa5e16e0e60510b3de5af87"
   integrity sha512-+CNINNvl00OkW6wEsi32wU5MhHti2J25TJsJJqgQmJu3B3dYDBcmOxcE5w9cgoM13TrdE/5ND2HoEnBohasxRQ==
-
-"@typescript-eslint/typescript-estree@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.24.0.tgz#b49249679a98014d8b03e8d4b70864b950e3c90f"
-  integrity sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==
-  dependencies:
-    "@typescript-eslint/types" "4.24.0"
-    "@typescript-eslint/visitor-keys" "4.24.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.25.0":
   version "4.25.0"
@@ -2657,14 +2631,6 @@
     is-glob "^4.0.1"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.24.0.tgz#a8fafdc76cad4e04a681a945fbbac4e35e98e297"
-  integrity sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==
-  dependencies:
-    "@typescript-eslint/types" "4.24.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.25.0":
   version "4.25.0"
@@ -7818,7 +7784,8 @@ eslint-module-utils@^2.6.1:
     pkg-dir "^2.0.0"
 
 "eslint-plugin-ember-data@link:./packages/unpublished-eslint-rules":
-  version "3.28.0-beta.0"
+  version "0.0.0"
+  uid ""
 
 eslint-plugin-ember@^10.3.0, eslint-plugin-ember@^10.4.1:
   version "10.4.2"


### PR DESCRIPTION
Description for `coalesceFindRequests` indicates that it will attempt to coalesce `fetchRecord` calls, but the relevant public API concept is `findRecord`. If using the term `fetchRecord` here is referencing the internal [`_fetchRecord`](https://github.com/emberjs/data/blob/9889ebbd4eec162dba17bb00126ee71e49d04bce/packages/store/addon/-private/system/core-store.ts#L1362) it may be more clear to say something like
```
 By default the store will try to coalesce all `findRecord` and async relationship calls within the same runloop
```
because of `get` and `belongsTo` calls being affected, but just changing to `findRecord` here is probably fine. Either way it is a bit confusing to have `fetchRecord` here since it hints at a framework concept that does not have any definition in the public API.

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
