### PR TITLE
Failing test: findRecord should not cache if includes differ

### DIFF
--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -494,6 +494,56 @@ module('integration/store - findRecord', function (hooks) {
     assert.strictEqual(car1, car2, 'we receive the same car back');
   });
 
+  test('store#findRecord does not cache the inflight requests when includes differ', async function (assert) {
+    assert.expect(2);
+
+    let calls = 0;
+    let resolveHandler;
+    let result = {
+      data: {
+        type: 'car',
+        id: '1',
+        attributes: {
+          make: 'BMC',
+          model: 'Mini',
+        },
+      },
+    };
+
+    const testAdapter = DS.JSONAPIAdapter.extend({
+      shouldReloadRecord(store, type, id, snapshot) {
+        assert.ok(false, 'shouldReloadRecord should not be called when { reload: true }');
+      },
+      async findRecord() {
+        calls++;
+
+        return new Promise((resolve) => {
+          resolveHandler = resolve;
+        });
+      },
+    });
+
+    this.owner.register('adapter:application', testAdapter);
+    this.owner.register('serializer:application', JSONAPISerializer.extend());
+    let firstPromise, secondPromise;
+
+    run(() => {
+      firstPromise = store.findRecord('car', '1', { include: 'driver' });
+    });
+
+    run(() => {
+      secondPromise = store.findRecord('car', '1', { include: 'engine' });
+    });
+
+    assert.strictEqual(calls, 2, 'We made two calls to findRecord');
+
+    resolveHandler(result);
+    let car1 = await firstPromise;
+    let car2 = await secondPromise;
+
+    assert.strictEqual(car1, car2, 'we receive the same car back');
+  });
+
   test('store#findRecord { backgroundReload: false } returns cached record and does not reload in the background', async function (assert) {
     assert.expect(2);
 


### PR DESCRIPTION
In 3.28, it seems that #7651 made a change to always return an existing inflight `findRecord` for a given model - even if the request itself would have been different (such as by using different `include` options).

This PR adds a test asserting that the `findRecord` caching (asserted by the previous test) should not apply if the `include` arguments differ.