### PR TITLE
[Bugfix] ensure `shouldCompileModules` is once again respected (#7680)

### DIFF
--- a/packages/private-build-infra/src/utilities/rollup-private-module.js
+++ b/packages/private-build-infra/src/utilities/rollup-private-module.js
@@ -68,7 +68,7 @@ module.exports = function rollupPrivateModule(tree, options) {
       output: [
         {
           file: `${packageName}/-private.js`,
-          format: 'amd',
+          format: options.babelCompiler.shouldCompileModules() ? 'amd' : 'esm',
           amd: { id: `${packageName}/-private` },
           exports: 'named',
         },


### PR DESCRIPTION
Backport of #7680
Fixes Embroider compatibility