### PR TITLE
[BUGFIX] Update @ember/string to the latest version to fix compatibility with ember-source 4.x

### DIFF
--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -30,7 +30,7 @@
     "@ember-data/serializer": "4.1.0-alpha.2",
     "@ember-data/store": "4.1.0-alpha.2",
     "@ember/edition-utils": "^1.2.0",
-    "@ember/string": "^1.0.0",
+    "@ember/string": "^3.0.0",
     "@glimmer/env": "^0.1.7",
     "broccoli-merge-trees": "^4.2.0",
     "ember-cli-babel": "^7.26.6",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -21,7 +21,7 @@
     "@ember-data/private-build-infra": "4.1.0-alpha.2",
     "@ember-data/store": "4.1.0-alpha.2",
     "@ember/edition-utils": "^1.2.0",
-    "@ember/string": "^1.0.0",
+    "@ember/string": "^3.0.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@ember-data/private-build-infra": "4.1.0-alpha.2",
     "@ember/edition-utils": "^1.2.0",
-    "@ember/string": "^1.0.0",
+    "@ember/string": "^3.0.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-typescript": "^4.1.0"

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -22,7 +22,7 @@
     "@ember-data/private-build-infra": "4.1.0-alpha.2",
     "@ember-data/store": "4.1.0-alpha.2",
     "@ember/edition-utils": "^1.2.0",
-    "@ember/string": "^1.0.0",
+    "@ember/string": "^3.0.0",
     "ember-cached-decorator-polyfill": "^0.1.4",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-string-utils": "^1.1.0",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@ember-data/unpublished-test-infra": "4.1.0-alpha.2",
     "@ember/optional-features": "^2.0.0",
-    "@ember/string": "^1.0.0",
+    "@ember/string": "^3.0.0",
     "@ember/test-helpers": "^2.2.5",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.0.0",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@ember-data/canary-features": "4.1.0-alpha.2",
     "@ember-data/private-build-infra": "4.1.0-alpha.2",
-    "@ember/string": "^1.0.0",
+    "@ember/string": "^3.0.0",
     "@glimmer/tracking": "^1.0.4",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-path-utils": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,12 +1116,12 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
-"@ember/string@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@ember/string/-/string-1.0.0.tgz#3a2254caedacb95e09071204d36cad49e0f8b855"
-  integrity sha512-KZ+CcIXFdyIBMztxDMgza4SdLJgIeUgTjDAoHk6M50C2u1X/BK7KWUIN7MIK2LNTOMvbib9lWwEzKboxdI4lBw==
+"@ember/string@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@ember/string/-/string-3.0.0.tgz#e3a3cc7874c9f64eadfdac644d8b1238721ce289"
+  integrity sha512-T+7QYDp8ItlQseNveK2lL6OsOO5wg7aNQ/M2RpO8cGwM80oZOnr/Y35HmMfu4ejFEc+F1LPegvu7LGfeJOicWA==
   dependencies:
-    ember-cli-babel "^7.4.0"
+    ember-cli-babel "^7.26.6"
 
 "@ember/test-helpers@^2.2.5":
   version "2.2.5"
@@ -6956,7 +6956,7 @@ ember-cli-babel@^6.0.0-beta.4:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.6, ember-cli-babel@^7.4.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
   version "7.26.6"
   resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==


### PR DESCRIPTION
The prior version used deprecated import paths that error under ember-source v4.0.

This will need to be backported to beta and released.
