### PR TITLE
Handle empty query params properly by allowing in the url

### DIFF
--- a/packages/-ember-data/tests/unit/adapters/rest-adapter/fetch-options-test.js
+++ b/packages/-ember-data/tests/unit/adapters/rest-adapter/fetch-options-test.js
@@ -200,4 +200,27 @@ module('unit/adapters/rest-adapter/fetch-options', function (hooks) {
       "'options.url' is serialized"
     );
   });
+
+  test('fetchOptions serializes empty query params to the url', function (assert) {
+    assert.expect(1);
+
+    const postData = {
+      url: 'https://emberjs.com',
+      method: 'GET',
+      data: {
+        fields: {
+          post: '',
+          comments: null,
+          author: undefined,
+        },
+      },
+    };
+
+    const postOptions = fetchOptions(postData);
+    assert.equal(
+      postOptions.url,
+      'https://emberjs.com?fields%5Bpost%5D=&fields%5Bcomments%5D=&fields%5Bauthor%5D=',
+      "'options.url' is serialized"
+    );
+  });
 });

--- a/packages/-ember-data/tests/unit/adapters/rest-adapter/fetch-options-test.js
+++ b/packages/-ember-data/tests/unit/adapters/rest-adapter/fetch-options-test.js
@@ -217,7 +217,7 @@ module('unit/adapters/rest-adapter/fetch-options', function (hooks) {
     };
 
     const postOptions = fetchOptions(postData);
-    assert.equal(
+    assert.strictEqual(
       postOptions.url,
       'https://emberjs.com?fields%5Bpost%5D=&fields%5Bcomments%5D=&fields%5Bauthor%5D=',
       "'options.url' is serialized"

--- a/packages/adapter/addon/-private/utils/serialize-query-params.ts
+++ b/packages/adapter/addon/-private/utils/serialize-query-params.ts
@@ -15,11 +15,15 @@ export function serializeQueryParams(queryParamsObject: object | string): string
 
     if (prefix) {
       if (Array.isArray(obj)) {
-        for (i = 0, len = obj.length; i < len; i++) {
-          if (RBRACKET.test(prefix)) {
-            add(s, prefix, obj[i]);
-          } else {
-            buildParams(prefix + '[' + (typeof obj[i] === 'object' ? i : '') + ']', obj[i]);
+        if (obj.length === 0) {
+          buildParams(prefix + '[]', obj[i]);
+        } else {
+          for (i = 0, len = obj.length; i < len; i++) {
+            if (RBRACKET.test(prefix)) {
+              add(s, prefix, obj[i]);
+            } else {
+              buildParams(prefix + '[' + (typeof obj[i] === 'object' ? i : '') + ']', obj[i]);
+            }
           }
         }
       } else if (isPlainObject(obj)) {
@@ -48,11 +52,7 @@ export function serializeQueryParams(queryParamsObject: object | string): string
  * Part of the `serializeQueryParams` helper function.
  */
 function add(s: Array<any>, k: string, v?: string | (() => string)) {
-  // Strip out keys with undefined value and replace null values with
-  // empty strings (mimics jQuery.ajax)
-  if (v === undefined) {
-    return;
-  } else if (v === null) {
+  if (v === null || v === undefined) {
     v = '';
   }
 


### PR DESCRIPTION
https://jsonapi.org/format/#fetching-sparse-fieldsets

> An empty value indicates that no fields should be returned.


The JSONAPI has taken a strict stance on what an empty query param should mean.  They stated it should return no fields instead of leaving it up to the implementer.  I think we should follow.

Original PR that strips falsey values: https://github.com/emberjs/data/pull/6077/files.  We need to keep the query param so that an API can know that, for example, no rows are returned if `ids=[]`.

Ref implementation in other areas: https://github.com/jeregrine/jsonapi/pull/257

close #7720 