### PR TITLE
Switch from QUnit `assert.equal()` to `assert.strictEqual()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "eslint-plugin-mocha": "^9.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-qunit": "^6.1.0",
+    "eslint-plugin-qunit": "^7.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "execa": "^5.0.0",
     "fromentries": "^1.2.0",

--- a/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/belongs-to-test.js
@@ -272,7 +272,7 @@ module('async belongs-to rendering tests', function (hooks) {
         1,
         `Expected only one implicit relationship, found ${implicitKeys.join(', ')}`
       );
-      assert.equal(petOwnerImplicit.canonicalMembers.size, 1);
+      assert.strictEqual(petOwnerImplicit.canonicalMembers.size, 1);
 
       const tweety = store.push({
         data: {
@@ -287,13 +287,13 @@ module('async belongs-to rendering tests', function (hooks) {
         },
       });
 
-      assert.equal(petOwnerImplicit.canonicalMembers.size, 2);
+      assert.strictEqual(petOwnerImplicit.canonicalMembers.size, 2);
 
       let petOwner = await goofy.get('petOwner');
-      assert.equal(petOwner.get('name'), 'Pete', 'We have the expected owner for goofy');
+      assert.strictEqual(petOwner.get('name'), 'Pete', 'We have the expected owner for goofy');
 
       petOwner = await tweety.get('petOwner');
-      assert.equal(petOwner.get('name'), 'Pete', 'We have the expected owner for tweety');
+      assert.strictEqual(petOwner.get('name'), 'Pete', 'We have the expected owner for tweety');
 
       await goofy.destroyRecord();
       assert.ok(goofy.isDeleted, 'goofy is deleted after calling destroyRecord');
@@ -301,7 +301,7 @@ module('async belongs-to rendering tests', function (hooks) {
       await tweety.destroyRecord();
       assert.ok(tweety.isDeleted, 'tweety is deleted after calling destroyRecord');
 
-      assert.equal(petOwnerImplicit.canonicalMembers.size, 0);
+      assert.strictEqual(petOwnerImplicit.canonicalMembers.size, 0);
 
       const jerry = store.push({
         data: {
@@ -317,9 +317,9 @@ module('async belongs-to rendering tests', function (hooks) {
       });
 
       petOwner = await jerry.get('petOwner');
-      assert.equal(petOwner.get('name'), 'Pete');
+      assert.strictEqual(petOwner.get('name'), 'Pete');
 
-      assert.equal(petOwnerImplicit.canonicalMembers.size, 1);
+      assert.strictEqual(petOwnerImplicit.canonicalMembers.size, 1);
 
       await settled();
     });
@@ -371,7 +371,7 @@ module('async belongs-to rendering tests', function (hooks) {
       `);
       await settled();
 
-      assert.equal(this.element.textContent.trim(), '');
+      assert.strictEqual(this.element.textContent.trim(), '');
       assert.ok(shen.get('bestHuman') === null, 'precond - Shen has no best human');
       assert.ok(pirate.get('bestHuman') === null, 'precond - pirate has no best human');
       assert.ok(bestDog === null, 'precond - Chris has no best dog');
@@ -381,7 +381,7 @@ module('async belongs-to rendering tests', function (hooks) {
       bestDog = await chris.get('bestDog');
       await settled();
 
-      assert.equal(this.element.textContent.trim(), 'Shen');
+      assert.strictEqual(this.element.textContent.trim(), 'Shen');
       assert.ok(shen.get('bestHuman') === chris, "scene 1 - Chris is Shen's best human");
       assert.ok(pirate.get('bestHuman') === null, 'scene 1 - pirate has no best human');
       assert.ok(bestDog === shen, "scene 1 - Shen is Chris's best dog");
@@ -391,7 +391,7 @@ module('async belongs-to rendering tests', function (hooks) {
       bestDog = await chris.get('bestDog');
       await settled();
 
-      assert.equal(this.element.textContent.trim(), 'Pirate');
+      assert.strictEqual(this.element.textContent.trim(), 'Pirate');
       assert.ok(shen.get('bestHuman') === null, "scene 2 - Chris is no longer Shen's best human");
       assert.ok(pirate.get('bestHuman') === chris, 'scene 2 - pirate now has Chris as best human');
       assert.ok(bestDog === pirate, "scene 2 - Pirate is now Chris's best dog");
@@ -401,7 +401,7 @@ module('async belongs-to rendering tests', function (hooks) {
       bestDog = await chris.get('bestDog');
       await settled();
 
-      assert.equal(this.element.textContent.trim(), '');
+      assert.strictEqual(this.element.textContent.trim(), '');
       assert.ok(shen.get('bestHuman') === null, "scene 3 - Chris remains no longer Shen's best human");
       assert.ok(pirate.get('bestHuman') === null, 'scene 3 - pirate no longer has Chris as best human');
       assert.ok(bestDog === null, 'scene 3 - Chris has no best dog');
@@ -424,7 +424,7 @@ module('async belongs-to rendering tests', function (hooks) {
       <p>{{this.sedona.parent.name}}</p>
       `);
 
-      assert.equal(this.element.textContent.trim(), 'Kevin has two children and one parent');
+      assert.strictEqual(this.element.textContent.trim(), 'Kevin has two children and one parent');
     });
 
     test('We can delete an async belongs-to', async function (assert) {
@@ -450,7 +450,7 @@ module('async belongs-to rendering tests', function (hooks) {
       await settled();
 
       assert.ok(newParent === null, 'We no longer have a parent');
-      assert.equal(
+      assert.strictEqual(
         this.element.textContent.trim(),
         '',
         "We no longer render our parent's name because we no longer have a parent"
@@ -472,13 +472,13 @@ module('async belongs-to rendering tests', function (hooks) {
       <p>{{this.sedona.parent.name}}</p>
       `);
 
-      assert.equal(this.element.textContent.trim(), 'Kevin has two children and one parent');
+      assert.strictEqual(this.element.textContent.trim(), 'Kevin has two children and one parent');
 
       this.set('sedona', null);
-      assert.equal(this.element.textContent.trim(), '');
+      assert.strictEqual(this.element.textContent.trim(), '');
 
       this.set('sedona', sedona);
-      assert.equal(this.element.textContent.trim(), 'Kevin has two children and one parent');
+      assert.strictEqual(this.element.textContent.trim(), 'Kevin has two children and one parent');
     });
 
     test('Rendering an async belongs-to whose fetch fails does not trigger a new request', async function (assert) {
@@ -498,7 +498,7 @@ module('async belongs-to rendering tests', function (hooks) {
         if (!hasFired) {
           hasFired = true;
           assert.ok(true, 'Children promise did reject');
-          assert.equal(
+          assert.strictEqual(
             e.message,
             'hard error while finding <person>5:has-parent-no-children',
             'Rejection has the correct message'
@@ -513,7 +513,7 @@ module('async belongs-to rendering tests', function (hooks) {
       <p>{{this.sedona.parent.name}}</p>
       `);
 
-      assert.equal(this.element.textContent.trim(), '', 'we have no parent');
+      assert.strictEqual(this.element.textContent.trim(), '', 'we have no parent');
 
       const relationship = sedona.belongsTo('parent').belongsToRelationship;
       const { state, definition } = relationship;
@@ -561,20 +561,20 @@ module('async belongs-to rendering tests', function (hooks) {
         await sedona.get('parent');
         assert.ok(false, `should have rejected`);
       } catch (e) {
-        assert.equal(e.message, error, `should have rejected with '${error}'`);
+        assert.strictEqual(e.message, error, `should have rejected with '${error}'`);
       }
 
       await render(hbs`
       <p>{{this.sedona.parent.name}}</p>
       `);
 
-      assert.equal(this.element.textContent.trim(), '', 'we have no parent');
+      assert.strictEqual(this.element.textContent.trim(), '', 'we have no parent');
 
       try {
         await sedona.get('parent');
         assert.ok(false, `should have rejected`);
       } catch (e) {
-        assert.equal(e.message, error, `should have rejected with '${error}'`);
+        assert.strictEqual(e.message, error, `should have rejected with '${error}'`);
       }
     });
   });
@@ -603,14 +603,14 @@ module('async belongs-to rendering tests', function (hooks) {
     const newParent = store.createRecord('person', { name: 'New Person' });
     sedona.set('parent', newParent);
     await settled();
-    assert.equal(
+    assert.strictEqual(
       this.element.textContent.trim(),
       'New Person',
       'after resetting to a new record, shows new content on page'
     );
     newParent.unloadRecord();
     await settled();
-    assert.equal(this.element.textContent.trim(), '', 'after unloading the record it shows no content on page');
+    assert.strictEqual(this.element.textContent.trim(), '', 'after unloading the record it shows no content on page');
     try {
       await sedona.belongsTo('parent').reload();
       assert.ok(false, 'we should have thrown an error');

--- a/packages/-ember-data/tests/acceptance/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/has-many-test.js
@@ -267,7 +267,7 @@ module('async has-many rendering tests', function (hooks) {
       this.set('parent', null);
 
       items = findAll('li');
-      assert.equal(items.length, 0, 'We have no items');
+      assert.strictEqual(items.length, 0, 'We have no items');
 
       this.set('parent', parent);
 
@@ -294,7 +294,7 @@ module('async has-many rendering tests', function (hooks) {
       let originalOnError = Ember.onerror;
       Ember.onerror = function (e) {
         assert.ok(true, 'Children promise did reject');
-        assert.equal(
+        assert.strictEqual(
           e.message,
           'hard error while finding <person>5:has-parent-no-children',
           'Rejection has the correct message'
@@ -382,7 +382,7 @@ module('async has-many rendering tests', function (hooks) {
       this.set('parent', null);
 
       items = findAll('li');
-      assert.equal(items.length, 0, 'We have no items');
+      assert.strictEqual(items.length, 0, 'We have no items');
 
       this.set('parent', parent);
 
@@ -410,7 +410,7 @@ module('async has-many rendering tests', function (hooks) {
       let originalOnError = Ember.onerror;
       Ember.onerror = function (e) {
         assert.ok(true, 'Children promise did reject');
-        assert.equal(
+        assert.strictEqual(
           e.message,
           'hard error while finding link ./person/3:has-2-children-and-parent/children',
           'Rejection has the correct message'
@@ -527,7 +527,7 @@ module('async has-many rendering tests', function (hooks) {
       this.set('parent', null);
 
       items = findAll('li');
-      assert.equal(items.length, 0, 'We have no items');
+      assert.strictEqual(items.length, 0, 'We have no items');
 
       this.set('parent', parent);
 

--- a/packages/-ember-data/tests/integration/adapter/build-url-mixin-test.js
+++ b/packages/-ember-data/tests/integration/adapter/build-url-mixin-test.js
@@ -58,7 +58,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
 
     await store.findRecord('post', 1);
 
-    assert.equal(passedUrl, 'http://example.com/api/v1/posts/1');
+    assert.strictEqual(passedUrl, 'http://example.com/api/v1/posts/1');
   });
 
   test('buildURL - with relative paths in links', async function (assert) {
@@ -85,7 +85,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     ajaxResponse({ comments: [{ id: '1' }] });
 
     await post.comments;
-    assert.equal(passedUrl, 'http://example.com/api/v1/posts/1/comments');
+    assert.strictEqual(passedUrl, 'http://example.com/api/v1/posts/1/comments');
   });
 
   test('buildURL - with absolute paths in links', async function (assert) {
@@ -112,7 +112,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
 
     ajaxResponse({ comments: [{ id: '1' }] });
     await post.comments;
-    assert.equal(passedUrl, 'http://example.com/api/v1/posts/1/comments');
+    assert.strictEqual(passedUrl, 'http://example.com/api/v1/posts/1/comments');
   });
 
   test('buildURL - with absolute paths in links and protocol relative host', async function (assert) {
@@ -139,7 +139,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     ajaxResponse({ comments: [{ id: '1' }] });
 
     await post.comments;
-    assert.equal(passedUrl, '//example.com/api/v1/posts/1/comments');
+    assert.strictEqual(passedUrl, '//example.com/api/v1/posts/1/comments');
   });
 
   test('buildURL - with absolute paths in links and host is /', async function (assert) {
@@ -166,7 +166,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     ajaxResponse({ comments: [{ id: '1' }] });
 
     await post.comments;
-    assert.equal(passedUrl, '/api/v1/posts/1/comments', 'host stripped out properly');
+    assert.strictEqual(passedUrl, '/api/v1/posts/1/comments', 'host stripped out properly');
   });
 
   test('buildURL - with full URLs in links', async function (assert) {
@@ -200,7 +200,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     ajaxResponse({ comments: [{ id: '1' }] });
 
     await post.comments;
-    assert.equal(passedUrl, 'http://example.com/api/v1/posts/1/comments');
+    assert.strictEqual(passedUrl, 'http://example.com/api/v1/posts/1/comments');
   });
 
   test('buildURL - with camelized names', async function (assert) {
@@ -214,7 +214,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     ajaxResponse({ superUsers: [{ id: '1' }] });
 
     await store.findRecord('super-user', '1');
-    assert.equal(passedUrl, '/super_users/1');
+    assert.strictEqual(passedUrl, '/super_users/1');
   });
 
   test('buildURL - buildURL takes a record from find', async function (assert) {
@@ -245,7 +245,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
 
     await store.findRecord('comment', '1', { preload: { post } });
 
-    assert.equal(passedUrl, '/posts/2/comments/1');
+    assert.strictEqual(passedUrl, '/posts/2/comments/1');
   });
 
   test('buildURL - buildURL takes the records from findMany', async function (assert) {
@@ -287,7 +287,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     });
 
     await post.comments;
-    assert.equal(passedUrl, '/posts/2/comments/');
+    assert.strictEqual(passedUrl, '/posts/2/comments/');
   });
 
   test('buildURL - buildURL takes a record from create', async function (assert) {
@@ -318,7 +318,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     let comment = store.createRecord('comment');
     comment.set('post', post);
     await comment.save();
-    assert.equal(passedUrl, '/posts/2/comments/');
+    assert.strictEqual(passedUrl, '/posts/2/comments/');
   });
 
   test('buildURL - buildURL takes a record from create to query a resolved async belongsTo relationship', async function (assert) {
@@ -355,7 +355,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
 
     await comment.save();
 
-    assert.equal(passedUrl, '/posts/2/comments/');
+    assert.strictEqual(passedUrl, '/posts/2/comments/');
   });
 
   test('buildURL - buildURL takes a record from update', async function (assert) {
@@ -392,7 +392,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     comment.set('post', post);
 
     await comment.save();
-    assert.equal(passedUrl, '/posts/2/comments/1');
+    assert.strictEqual(passedUrl, '/posts/2/comments/1');
   });
 
   test('buildURL - buildURL takes a record from delete', async function (assert) {
@@ -431,7 +431,7 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     comment.deleteRecord();
 
     await comment.save();
-    assert.equal(passedUrl, 'posts/2/comments/1');
+    assert.strictEqual(passedUrl, 'posts/2/comments/1');
   });
 
   test('buildURL - with absolute namespace', async function (assert) {
@@ -454,6 +454,6 @@ module('integration/adapter/build-url-mixin - BuildURLMixin with RESTAdapter', f
     ajaxResponse({ posts: [{ id: '1' }] });
 
     await store.findRecord('post', '1');
-    assert.equal(passedUrl, '/api/v1/posts/1');
+    assert.strictEqual(passedUrl, '/api/v1/posts/1');
   });
 });

--- a/packages/-ember-data/tests/integration/adapter/find-all-test.js
+++ b/packages/-ember-data/tests/integration/adapter/find-all-test.js
@@ -64,8 +64,8 @@ module('integration/adapter/find-all - Finding All Records of a Type', function 
     };
 
     let allRecords = await store.findAll('person');
-    assert.equal(get(allRecords, 'length'), 1, "the record array's length is 1 after a record is loaded into it");
-    assert.equal(
+    assert.strictEqual(get(allRecords, 'length'), 1, "the record array's length is 1 after a record is loaded into it");
+    assert.strictEqual(
       allRecords.objectAt(0).get('name'),
       'Braaaahm Dale',
       'the first item in the record array is Braaaahm Dale'
@@ -110,8 +110,12 @@ module('integration/adapter/find-all - Finding All Records of a Type', function 
       assert.ok(true, 'The rejection should get here');
       return store.findAll('person');
     });
-    assert.equal(get(all, 'length'), 1, "the record array's length is 1 after a record is loaded into it");
-    assert.equal(all.objectAt(0).get('name'), 'Braaaahm Dale', 'the first item in the record array is Braaaahm Dale');
+    assert.strictEqual(get(all, 'length'), 1, "the record array's length is 1 after a record is loaded into it");
+    assert.strictEqual(
+      all.objectAt(0).get('name'),
+      'Braaaahm Dale',
+      'the first item in the record array is Braaaahm Dale'
+    );
   });
 
   test('When all records for a type are requested, records that are already loaded should be returned immediately.', async function (assert) {
@@ -133,13 +137,13 @@ module('integration/adapter/find-all - Finding All Records of a Type', function 
 
     let allRecords = store.peekAll('person');
 
-    assert.equal(get(allRecords, 'length'), 2, "the record array's length is 2");
-    assert.equal(
+    assert.strictEqual(get(allRecords, 'length'), 2, "the record array's length is 2");
+    assert.strictEqual(
       allRecords.objectAt(0).get('name'),
       'Jeremy Ashkenas',
       'the first item in the record array is Jeremy Ashkenas'
     );
-    assert.equal(
+    assert.strictEqual(
       allRecords.objectAt(1).get('name'),
       'Alex MacCaw',
       'the second item in the record array is Alex MacCaw'
@@ -151,7 +155,7 @@ module('integration/adapter/find-all - Finding All Records of a Type', function 
 
     let allRecords = store.peekAll('person');
 
-    assert.equal(
+    assert.strictEqual(
       get(allRecords, 'length'),
       0,
       "precond - the record array's length is zero before any records are loaded"
@@ -162,8 +166,8 @@ module('integration/adapter/find-all - Finding All Records of a Type', function 
 
     await settled();
 
-    assert.equal(get(allRecords, 'length'), 1, "the record array's length is 1");
-    assert.equal(
+    assert.strictEqual(get(allRecords, 'length'), 1, "the record array's length is 1");
+    assert.strictEqual(
       allRecords.objectAt(0).get('name'),
       'Carsten Nielsen',
       'the first item in the record array is Carsten Nielsen'
@@ -195,11 +199,11 @@ module('integration/adapter/find-all - Finding All Records of a Type', function 
     });
 
     let persons = store.peekAll('person');
-    assert.equal(persons.get('length'), 1);
+    assert.strictEqual(persons.get('length'), 1);
 
     let promise = store.findAll('person').then((persons) => {
       assert.false(persons.get('isUpdating'));
-      assert.equal(persons.get('length'), 2);
+      assert.strictEqual(persons.get('length'), 2);
       return persons;
     });
 
@@ -229,11 +233,11 @@ module('integration/adapter/find-all - Finding All Records of a Type', function 
     });
 
     let persons = store.peekAll('person');
-    assert.equal(persons.get('length'), 1);
+    assert.strictEqual(persons.get('length'), 1);
 
     persons = await store.findAll('person');
     assert.true(persons.get('isUpdating'));
-    assert.equal(persons.get('length'), 1, 'persons are updated in the background');
+    assert.strictEqual(persons.get('length'), 1, 'persons are updated in the background');
 
     assert.true(persons.get('isUpdating'));
 
@@ -244,7 +248,7 @@ module('integration/adapter/find-all - Finding All Records of a Type', function 
     await findAllDeferred.promise;
 
     assert.false(persons.get('isUpdating'));
-    assert.equal(persons.get('length'), 2);
+    assert.strictEqual(persons.get('length'), 2);
   });
 
   test('isUpdating is false if records are not fetched in the background', async function (assert) {
@@ -266,7 +270,7 @@ module('integration/adapter/find-all - Finding All Records of a Type', function 
     });
 
     let persons = store.peekAll('person');
-    assert.equal(persons.get('length'), 1);
+    assert.strictEqual(persons.get('length'), 1);
 
     persons = await store.findAll('person');
     assert.false(persons.get('isUpdating'));

--- a/packages/-ember-data/tests/integration/adapter/find-test.js
+++ b/packages/-ember-data/tests/integration/adapter/find-test.js
@@ -48,8 +48,8 @@ module('integration/adapter/find - Finding Records', function (hooks) {
       'adapter:person',
       Adapter.extend({
         findRecord(_, type) {
-          assert.equal(type, Person, 'the find method is called with the correct type');
-          assert.equal(count, 0, 'the find method is only called once');
+          assert.strictEqual(type, Person, 'the find method is called with the correct type');
+          assert.strictEqual(count, 0, 'the find method is only called once');
 
           count++;
           return {

--- a/packages/-ember-data/tests/integration/adapter/handle-response-test.js
+++ b/packages/-ember-data/tests/integration/adapter/handle-response-test.js
@@ -66,7 +66,7 @@ module('integration/adapter/handle-response', function (hooks) {
 
     await this.store.findAll('person');
 
-    assert.equal(handleResponseCalled, 1, 'handle response is called');
+    assert.strictEqual(handleResponseCalled, 1, 'handle response is called');
   });
 
   test('handleResponse is called with empty array response', async function (assert) {
@@ -92,7 +92,7 @@ module('integration/adapter/handle-response', function (hooks) {
 
     await this.store.findAll('person');
 
-    assert.equal(handleResponseCalled, 1, 'handle response is called');
+    assert.strictEqual(handleResponseCalled, 1, 'handle response is called');
   });
 
   test('handleResponse is called on empty string response', async function (assert) {
@@ -119,7 +119,7 @@ module('integration/adapter/handle-response', function (hooks) {
       assert.ok(true, 'promise rejected');
     }
 
-    assert.equal(handleResponseCalled, 1, 'handle response is called');
+    assert.strictEqual(handleResponseCalled, 1, 'handle response is called');
   });
 
   test('handleResponse is not called on invalid response', async function (assert) {
@@ -146,7 +146,7 @@ module('integration/adapter/handle-response', function (hooks) {
       assert.ok(true, 'promise rejected');
     }
 
-    assert.equal(handleResponseCalled, 0, 'handle response is not called');
+    assert.strictEqual(handleResponseCalled, 0, 'handle response is not called');
   });
 
   test('handleResponse is called on empty string response with 400 status', async function (assert) {
@@ -173,7 +173,7 @@ module('integration/adapter/handle-response', function (hooks) {
       assert.ok(true, 'promise rejected');
     }
 
-    assert.equal(handleResponseCalled, 1, 'handle response is called');
+    assert.strictEqual(handleResponseCalled, 1, 'handle response is called');
   });
 
   test('handleResponse is called with correct parameters on string response with 422 status', async function (assert) {
@@ -203,6 +203,6 @@ module('integration/adapter/handle-response', function (hooks) {
       assert.ok(true, 'promise rejected');
     }
 
-    assert.equal(handleResponseCalled, 1, 'handle response is called');
+    assert.strictEqual(handleResponseCalled, 1, 'handle response is called');
   });
 });

--- a/packages/-ember-data/tests/integration/adapter/json-api-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/json-api-adapter-test.js
@@ -112,9 +112,9 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let post = await store.findRecord('post', '1');
 
-    assert.equal(passedUrl[0], '/posts/1', 'Builds URL correctly');
-    assert.equal(post.get('id'), '1', 'Stores record with correct id');
-    assert.equal(post.get('title'), 'Ember.js rocks', 'Title for record is correct');
+    assert.strictEqual(passedUrl[0], '/posts/1', 'Builds URL correctly');
+    assert.strictEqual(post.get('id'), '1', 'Stores record with correct id');
+    assert.strictEqual(post.get('title'), 'Ember.js rocks', 'Title for record is correct');
   });
 
   test('find all records with sideloaded relationships', async function (assert) {
@@ -183,31 +183,31 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let posts = await store.findAll('post');
 
-    assert.equal(passedUrl[0], '/posts');
+    assert.strictEqual(passedUrl[0], '/posts');
 
-    assert.equal(posts.get('length'), 2, 'Returns two post records');
-    assert.equal(posts.get('firstObject.title'), 'Ember.js rocks', 'The title for the first post is correct');
-    assert.equal(posts.get('lastObject.title'), 'Tomster rules', 'The title for the second post is correct');
+    assert.strictEqual(posts.get('length'), 2, 'Returns two post records');
+    assert.strictEqual(posts.get('firstObject.title'), 'Ember.js rocks', 'The title for the first post is correct');
+    assert.strictEqual(posts.get('lastObject.title'), 'Tomster rules', 'The title for the second post is correct');
 
-    assert.equal(
+    assert.strictEqual(
       posts.get('firstObject.author.firstName'),
       'Yehuda',
       'The author for the first post is loaded and has the correct first name'
     );
-    assert.equal(
+    assert.strictEqual(
       posts.get('lastObject.author.lastName'),
       'Katz',
       'The author for the last post is loaded and has the correct last name'
     );
 
-    assert.equal(posts.get('firstObject.comments.length'), 0, 'First post doesnt have comments');
+    assert.strictEqual(posts.get('firstObject.comments.length'), 0, 'First post doesnt have comments');
 
-    assert.equal(
+    assert.strictEqual(
       posts.get('lastObject.comments.firstObject.text'),
       'This is the first comment',
       'Loads first comment for second post'
     );
-    assert.equal(
+    assert.strictEqual(
       posts.get('lastObject.comments.lastObject.text'),
       'This is the second comment',
       'Loads second comment for second post'
@@ -233,11 +233,11 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let posts = await store.query('post', { filter: { id: 1 } });
 
-    assert.equal(passedUrl[0], '/posts', 'Builds correct URL');
+    assert.strictEqual(passedUrl[0], '/posts', 'Builds correct URL');
     assert.deepEqual(passedHash[0], { data: { filter: { id: 1 } } }, 'Sends correct params to adapter');
 
-    assert.equal(posts.get('length'), 1, 'Returns the correct number of records');
-    assert.equal(posts.get('firstObject.title'), 'Ember.js rocks', 'Sets correct title to record');
+    assert.strictEqual(posts.get('length'), 1, 'Returns the correct number of records');
+    assert.strictEqual(posts.get('firstObject.title'), 'Ember.js rocks', 'Sets correct title to record');
   });
 
   test('queryRecord - primary data being a single record', async function (assert) {
@@ -255,8 +255,8 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let post = await store.queryRecord('post', {});
 
-    assert.equal(passedUrl[0], '/posts', 'Builds correc URL');
-    assert.equal(post.get('title'), 'Ember.js rocks', 'Sets correct title to record');
+    assert.strictEqual(passedUrl[0], '/posts', 'Builds correc URL');
+    assert.strictEqual(post.get('title'), 'Ember.js rocks', 'Sets correct title to record');
   });
 
   test('queryRecord - primary data being null', async function (assert) {
@@ -268,7 +268,7 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let post = await store.queryRecord('post', {});
 
-    assert.equal(passedUrl[0], '/posts', 'Builds correct URL');
+    assert.strictEqual(passedUrl[0], '/posts', 'Builds correct URL');
     assert.strictEqual(post, null, 'Returns null when adapter response is null');
   });
 
@@ -323,18 +323,22 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let post = await store.findRecord('post', '1');
 
-    assert.equal(passedUrl[0], '/posts/1', 'The primary record post:1 was fetched by the correct url');
+    assert.strictEqual(passedUrl[0], '/posts/1', 'The primary record post:1 was fetched by the correct url');
 
-    assert.equal(post.id, '1', 'Stores record using the correct id');
-    assert.equal(post.title, 'Ember.js rocks', 'Sets correct title to record');
+    assert.strictEqual(post.id, '1', 'Stores record using the correct id');
+    assert.strictEqual(post.title, 'Ember.js rocks', 'Sets correct title to record');
 
     let author = await post.get('author');
 
-    assert.equal(passedUrl[1], 'http://example.com/user/2', 'The relationship user:2 was fetched by the correct url');
+    assert.strictEqual(
+      passedUrl[1],
+      'http://example.com/user/2',
+      'The relationship user:2 was fetched by the correct url'
+    );
 
-    assert.equal(author.id, '2', 'Record has correct id');
-    assert.equal(author.firstName, 'Yehuda', 'Sets correct firstName to record');
-    assert.equal(author.lastName, 'Katz', 'Sets correct lastName to record');
+    assert.strictEqual(author.id, '2', 'Record has correct id');
+    assert.strictEqual(author.firstName, 'Yehuda', 'Sets correct firstName to record');
+    assert.strictEqual(author.lastName, 'Katz', 'Sets correct lastName to record');
   });
 
   test('find a single record with belongsTo link as object { data }', async function (assert) {
@@ -369,17 +373,17 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let post = await store.findRecord('post', '1');
 
-    assert.equal(passedUrl[0], '/posts/1', 'The primary record post:1 was fetched by the correct url');
+    assert.strictEqual(passedUrl[0], '/posts/1', 'The primary record post:1 was fetched by the correct url');
 
-    assert.equal(post.id, '1', 'Stores record using the correct id');
-    assert.equal(post.title, 'Ember.js rocks', 'Sets correct title to record');
+    assert.strictEqual(post.id, '1', 'Stores record using the correct id');
+    assert.strictEqual(post.title, 'Ember.js rocks', 'Sets correct title to record');
 
     let author = await post.get('author');
 
-    assert.equal(passedUrl[1], '/users/2', 'The relationship user:2 was fetched by the correct url');
-    assert.equal(author.id, '2', 'Record has correct id');
-    assert.equal(author.firstName, 'Yehuda', 'Sets correct firstName to record');
-    assert.equal(author.lastName, 'Katz', 'Sets correct lastName to record');
+    assert.strictEqual(passedUrl[1], '/users/2', 'The relationship user:2 was fetched by the correct url');
+    assert.strictEqual(author.id, '2', 'Record has correct id');
+    assert.strictEqual(author.firstName, 'Yehuda', 'Sets correct firstName to record');
+    assert.strictEqual(author.lastName, 'Katz', 'Sets correct lastName to record');
   });
 
   test('find a single record with belongsTo link as object { data } (polymorphic)', async function (assert) {
@@ -415,22 +419,22 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let user = await store.findRecord('user', '1');
 
-    assert.equal(passedUrl[0], '/users/1', 'The primary record user:1 was fetched by the correct url');
+    assert.strictEqual(passedUrl[0], '/users/1', 'The primary record user:1 was fetched by the correct url');
 
-    assert.equal(user.id, '1', 'Record has correct id');
-    assert.equal(user.firstName, 'Yehuda', 'Sets correct firstName to record');
-    assert.equal(user.lastName, 'Katz', 'Sets correct lastName to record');
+    assert.strictEqual(user.id, '1', 'Record has correct id');
+    assert.strictEqual(user.firstName, 'Yehuda', 'Sets correct firstName to record');
+    assert.strictEqual(user.lastName, 'Katz', 'Sets correct lastName to record');
 
     let company = await user.get('company');
 
-    assert.equal(
+    assert.strictEqual(
       passedUrl[1],
       '/development-shops/2',
       'The relationship development-shops:2 was fetched by the correct url'
     );
 
-    assert.equal(company.id, '2', 'Record has correct id');
-    assert.equal(company.name, 'Tilde', 'Sets correct name to record');
+    assert.strictEqual(company.id, '2', 'Record has correct id');
+    assert.strictEqual(company.name, 'Tilde', 'Sets correct name to record');
     assert.true(company.coffee, 'Sets correct value for coffee attribute');
   });
 
@@ -466,18 +470,18 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let post = await store.findRecord('post', '1');
 
-    assert.equal(passedUrl[0], '/posts/1', 'The primary record post:1 was fetched by the correct url');
+    assert.strictEqual(passedUrl[0], '/posts/1', 'The primary record post:1 was fetched by the correct url');
 
-    assert.equal(post.id, '1', 'Record has correct id');
-    assert.equal(post.title, 'Ember.js rocks', 'Title is set correctly');
+    assert.strictEqual(post.id, '1', 'Record has correct id');
+    assert.strictEqual(post.title, 'Ember.js rocks', 'Title is set correctly');
 
     let author = await post.get('author');
 
-    assert.equal(passedUrl.length, 1);
+    assert.strictEqual(passedUrl.length, 1);
 
-    assert.equal(author.id, '2', 'Record has correct id');
-    assert.equal(author.firstName, 'Yehuda', 'Record firstName is correct');
-    assert.equal(author.lastName, 'Katz', 'Record lastName is correct');
+    assert.strictEqual(author.id, '2', 'Record has correct id');
+    assert.strictEqual(author.firstName, 'Yehuda', 'Record firstName is correct');
+    assert.strictEqual(author.lastName, 'Katz', 'Record lastName is correct');
   });
 
   test('find a single record with hasMany link as object { related }', async function (assert) {
@@ -522,16 +526,20 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let post = await store.findRecord('post', '1');
 
-    assert.equal(passedUrl[0], '/posts/1');
-    assert.equal(post.id, '1');
-    assert.equal(post.title, 'Ember.js rocks');
+    assert.strictEqual(passedUrl[0], '/posts/1');
+    assert.strictEqual(post.id, '1');
+    assert.strictEqual(post.title, 'Ember.js rocks');
 
     let comments = await post.get('comments');
 
-    assert.equal(passedUrl[1], 'http://example.com/post/1/comments', 'The related records comments using correct url');
-    assert.equal(comments.length, 2, 'Loads the correct number of comments from response');
-    assert.equal(comments.get('firstObject.text'), 'This is the first comment', 'First comment text is correct');
-    assert.equal(comments.get('lastObject.text'), 'This is the second comment', 'Second comment text is correct');
+    assert.strictEqual(
+      passedUrl[1],
+      'http://example.com/post/1/comments',
+      'The related records comments using correct url'
+    );
+    assert.strictEqual(comments.length, 2, 'Loads the correct number of comments from response');
+    assert.strictEqual(comments.get('firstObject.text'), 'This is the first comment', 'First comment text is correct');
+    assert.strictEqual(comments.get('lastObject.text'), 'This is the second comment', 'Second comment text is correct');
   });
 
   test('find a single record with hasMany link as object { data }', async function (assert) {
@@ -577,17 +585,17 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let post = await store.findRecord('post', '1');
 
-    assert.equal(passedUrl[0], '/posts/1', 'The primary record post:1 was fetched by the correct url');
-    assert.equal(post.id, '1', 'Record id is correct');
-    assert.equal(post.title, 'Ember.js rocks', 'Record title is correct');
+    assert.strictEqual(passedUrl[0], '/posts/1', 'The primary record post:1 was fetched by the correct url');
+    assert.strictEqual(post.id, '1', 'Record id is correct');
+    assert.strictEqual(post.title, 'Ember.js rocks', 'Record title is correct');
 
     let comments = await post.get('comments');
 
-    assert.equal(passedUrl[1], '/comments/2', 'Builds correct URL to fetch related record');
-    assert.equal(passedUrl[2], '/comments/3', 'Builds correct URL to fetch related record');
-    assert.equal(comments.length, 2);
-    assert.equal(comments.get('firstObject.text'), 'This is the first comment', 'First comment text is correct');
-    assert.equal(comments.get('lastObject.text'), 'This is the second comment', 'Second comment text is correct');
+    assert.strictEqual(passedUrl[1], '/comments/2', 'Builds correct URL to fetch related record');
+    assert.strictEqual(passedUrl[2], '/comments/3', 'Builds correct URL to fetch related record');
+    assert.strictEqual(comments.length, 2);
+    assert.strictEqual(comments.get('firstObject.text'), 'This is the first comment', 'First comment text is correct');
+    assert.strictEqual(comments.get('lastObject.text'), 'This is the second comment', 'Second comment text is correct');
   });
 
   test('find a single record with hasMany link as object { data } (polymorphic)', async function (assert) {
@@ -634,20 +642,20 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let user = await store.findRecord('user', '1');
 
-    assert.equal(passedUrl[0], '/users/1', 'The primary record users:1 was fetched by the correct url');
+    assert.strictEqual(passedUrl[0], '/users/1', 'The primary record users:1 was fetched by the correct url');
 
-    assert.equal(user.id, '1', 'Record id is correct');
-    assert.equal(user.firstName, 'Yehuda', 'Record firstName is loaded');
-    assert.equal(user.lastName, 'Katz', 'Record lastName is loaded');
+    assert.strictEqual(user.id, '1', 'Record id is correct');
+    assert.strictEqual(user.firstName, 'Yehuda', 'Record firstName is loaded');
+    assert.strictEqual(user.lastName, 'Katz', 'Record lastName is loaded');
 
     let handles = await user.get('handles');
 
-    assert.equal(passedUrl[1], '/github-handles/2', 'Builds correct URL to fetch related record');
-    assert.equal(passedUrl[2], '/twitter-handles/3', 'Builds correct URL to fetch related record');
+    assert.strictEqual(passedUrl[1], '/github-handles/2', 'Builds correct URL to fetch related record');
+    assert.strictEqual(passedUrl[2], '/twitter-handles/3', 'Builds correct URL to fetch related record');
 
-    assert.equal(handles.get('length'), 2);
-    assert.equal(handles.get('firstObject.username'), 'wycats', 'First handle username is correct');
-    assert.equal(handles.get('lastObject.nickname'), '@wycats', 'Second handle nickname is correct');
+    assert.strictEqual(handles.get('length'), 2);
+    assert.strictEqual(handles.get('firstObject.username'), 'wycats', 'First handle username is correct');
+    assert.strictEqual(handles.get('lastObject.nickname'), '@wycats', 'Second handle nickname is correct');
   });
 
   test('find a single record with sideloaded hasMany link as object { data }', async function (assert) {
@@ -691,17 +699,17 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let post = await store.findRecord('post', '1');
 
-    assert.equal(passedUrl[0], '/posts/1', 'The primary record post:1 was fetched by the correct url');
-    assert.equal(post.id, '1', 'Record id is loaded');
-    assert.equal(post.title, 'Ember.js rocks', 'Record title is loaded');
+    assert.strictEqual(passedUrl[0], '/posts/1', 'The primary record post:1 was fetched by the correct url');
+    assert.strictEqual(post.id, '1', 'Record id is loaded');
+    assert.strictEqual(post.title, 'Ember.js rocks', 'Record title is loaded');
 
     let comments = await post.get('comments');
 
-    assert.equal(passedUrl.length, 1, 'Do not call extra end points because related records are included');
+    assert.strictEqual(passedUrl.length, 1, 'Do not call extra end points because related records are included');
 
-    assert.equal(comments.get('length'), 2, 'Loads related records');
-    assert.equal(comments.get('firstObject.text'), 'This is the first comment', 'First comment text is correct');
-    assert.equal(comments.get('lastObject.text'), 'This is the second comment', 'Second comment text is correct');
+    assert.strictEqual(comments.get('length'), 2, 'Loads related records');
+    assert.strictEqual(comments.get('firstObject.text'), 'This is the first comment', 'First comment text is correct');
+    assert.strictEqual(comments.get('lastObject.text'), 'This is the second comment', 'Second comment text is correct');
   });
 
   test('find a single record with sideloaded hasMany link as object { data } (polymorphic)', async function (assert) {
@@ -746,19 +754,19 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let user = await store.findRecord('user', '1');
 
-    assert.equal(passedUrl[0], '/users/1');
+    assert.strictEqual(passedUrl[0], '/users/1');
 
-    assert.equal(user.get('id'), '1');
-    assert.equal(user.get('firstName'), 'Yehuda');
-    assert.equal(user.get('lastName'), 'Katz');
+    assert.strictEqual(user.get('id'), '1');
+    assert.strictEqual(user.get('firstName'), 'Yehuda');
+    assert.strictEqual(user.get('lastName'), 'Katz');
 
     let handles = await user.get('handles');
 
-    assert.equal(passedUrl.length, 1, 'Do not call extra end points because related records are included');
+    assert.strictEqual(passedUrl.length, 1, 'Do not call extra end points because related records are included');
 
-    assert.equal(handles.get('length'), 2);
-    assert.equal(handles.get('firstObject.username'), 'wycats');
-    assert.equal(handles.get('lastObject.nickname'), '@wycats');
+    assert.strictEqual(handles.get('length'), 2);
+    assert.strictEqual(handles.get('firstObject.username'), 'wycats');
+    assert.strictEqual(handles.get('lastObject.nickname'), '@wycats');
   });
 
   test('create record', async function (assert) {
@@ -805,8 +813,8 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     await user.save();
 
-    assert.equal(passedUrl[0], '/users');
-    assert.equal(passedVerb[0], 'POST');
+    assert.strictEqual(passedUrl[0], '/users');
+    assert.strictEqual(passedVerb[0], 'POST');
 
     // TODO @runspired seems mega-bad that we expect an extra `data` key
     assert.deepEqual(passedHash[0], {
@@ -879,8 +887,8 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     await user.save();
 
-    assert.equal(passedUrl[0], '/users/1');
-    assert.equal(passedVerb[0], 'PATCH');
+    assert.strictEqual(passedUrl[0], '/users/1');
+    assert.strictEqual(passedVerb[0], 'PATCH');
     // TODO @runspired seems mega-bad that we expect an extra `data` key
     assert.deepEqual(passedHash[0], {
       data: {
@@ -962,8 +970,8 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     await user.save();
 
-    assert.equal(passedUrl[0], '/users/1');
-    assert.equal(passedVerb[0], 'PATCH');
+    assert.strictEqual(passedUrl[0], '/users/1');
+    assert.strictEqual(passedVerb[0], 'PATCH');
     // TODO @runspired seems mega-bad that we expect an extra `data` key
     assert.deepEqual(passedHash[0], {
       data: {
@@ -1014,11 +1022,11 @@ module('integration/adapter/json-api-adapter - JSONAPIAdapter', function (hooks)
 
     let post = await store.findRecord('post', '1');
 
-    assert.equal(passedUrl[0], '/posts/1');
+    assert.strictEqual(passedUrl[0], '/posts/1');
 
     let author = await post.get('author');
 
-    assert.equal(passedUrl[1], 'http://example.com/post/1/author');
+    assert.strictEqual(passedUrl[1], 'http://example.com/post/1/author');
     assert.strictEqual(author, null);
   });
 });

--- a/packages/-ember-data/tests/integration/adapter/queries-test.js
+++ b/packages/-ember-data/tests/integration/adapter/queries-test.js
@@ -51,7 +51,7 @@ module('integration/adapter/queries - Queries', function (hooks) {
     let adapter = store.adapterFor('application');
 
     adapter.query = function (store, type, query, recordArray) {
-      assert.equal(type, Person, 'the query method is called with the correct type');
+      assert.strictEqual(type, Person, 'the query method is called with the correct type');
 
       return EmberPromise.resolve({
         data: [
@@ -75,11 +75,11 @@ module('integration/adapter/queries - Queries', function (hooks) {
 
     let queryResults = await store.query('person', { page: 1 });
 
-    assert.equal(queryResults.length, 2, 'the record array has a length of 2 after the results are loaded');
+    assert.strictEqual(queryResults.length, 2, 'the record array has a length of 2 after the results are loaded');
     assert.true(queryResults.isLoaded, "the record array's `isLoaded` property should be true");
 
-    assert.equal(queryResults.objectAt(0).name, 'Peter Wagenet', "the first record is 'Peter Wagenet'");
-    assert.equal(queryResults.objectAt(1).name, 'Brohuda Katz', "the second record is 'Brohuda Katz'");
+    assert.strictEqual(queryResults.objectAt(0).name, 'Peter Wagenet', "the first record is 'Peter Wagenet'");
+    assert.strictEqual(queryResults.objectAt(1).name, 'Brohuda Katz', "the second record is 'Brohuda Katz'");
   });
 
   test('a query can be updated via `update()`', async function (assert) {
@@ -98,8 +98,8 @@ module('integration/adapter/queries - Queries', function (hooks) {
 
     let personsQuery = await store.query('person', {});
 
-    assert.equal(personsQuery.length, 1, 'There is one person');
-    assert.equal(personsQuery.firstObject.id, 'first', 'the right person is present');
+    assert.strictEqual(personsQuery.length, 1, 'There is one person');
+    assert.strictEqual(personsQuery.firstObject.id, 'first', 'the right person is present');
     assert.false(personsQuery.isUpdating, 'RecordArray is not updating');
 
     let resolveQueryPromise;
@@ -125,8 +125,8 @@ module('integration/adapter/queries - Queries', function (hooks) {
     await settled();
 
     assert.false(personsQuery.isUpdating, 'RecordArray is not updating anymore');
-    assert.equal(personsQuery.length, 1, 'There is still one person after update resolves');
-    assert.equal(personsQuery.firstObject.id, 'second', 'Now it is a different person');
+    assert.strictEqual(personsQuery.length, 1, 'There is still one person after update resolves');
+    assert.strictEqual(personsQuery.firstObject.id, 'second', 'Now it is a different person');
   });
 
   testInDebug(
@@ -140,7 +140,7 @@ module('integration/adapter/queries - Queries', function (hooks) {
       let adapter = store.adapterFor('application');
 
       adapter.query = function (store, type, query, recordArray) {
-        assert.equal(type, Person, 'the query method is called with the correct type');
+        assert.strictEqual(type, Person, 'the query method is called with the correct type');
 
         return resolve({
           data: { id: 1, type: 'person', attributes: { name: 'Peter Wagenet' } },

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -147,12 +147,12 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     post.set('name', 'The Parley Letter');
     await post.save();
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'PUT');
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'PUT');
     assert.deepEqual(passedHash.data, { post: { name: 'The Parley Letter' } });
 
     assert.false(post.get('hasDirtyAttributes'), "the post isn't dirty anymore");
-    assert.equal(post.get('name'), 'The Parley Letter', 'the post was updated');
+    assert.strictEqual(post.get('name'), 'The Parley Letter', 'the post was updated');
   });
 
   test('updateRecord - passes the requestType to buildURL', async function (assert) {
@@ -176,7 +176,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     post.set('name', 'The Parley Letter');
     await post.save();
-    assert.equal(passedUrl, '/posts/1/updateRecord');
+    assert.strictEqual(passedUrl, '/posts/1/updateRecord');
   });
 
   test('updateRecord - a payload with updates applies the updates', async function (assert) {
@@ -196,12 +196,12 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     post.set('name', 'The Parley Letter');
     await post.save();
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'PUT');
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'PUT');
     assert.deepEqual(passedHash.data, { post: { name: 'The Parley Letter' } });
 
     assert.false(post.get('hasDirtyAttributes'), "the post isn't dirty anymore");
-    assert.equal(post.get('name'), 'Dat Parley Letter', 'the post was updated');
+    assert.strictEqual(post.get('name'), 'Dat Parley Letter', 'the post was updated');
   });
 
   test('updateRecord - a payload with updates applies the updates (with legacy singular name)', async function (assert) {
@@ -221,12 +221,12 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     post.set('name', 'The Parley Letter');
     await post.save();
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'PUT');
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'PUT');
     assert.deepEqual(passedHash.data, { post: { name: 'The Parley Letter' } });
 
     assert.false(post.get('hasDirtyAttributes'), "the post isn't dirty anymore");
-    assert.equal(post.get('name'), 'Dat Parley Letter', 'the post was updated');
+    assert.strictEqual(post.get('name'), 'Dat Parley Letter', 'the post was updated');
   });
 
   test('updateRecord - a payload with sideloaded updates pushes the updates', async function (assert) {
@@ -238,16 +238,16 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     post = store.createRecord('post', { name: 'The Parley Letter' });
     await post.save();
-    assert.equal(passedUrl, '/posts');
-    assert.equal(passedVerb, 'POST');
+    assert.strictEqual(passedUrl, '/posts');
+    assert.strictEqual(passedVerb, 'POST');
     assert.deepEqual(passedHash.data, { post: { name: 'The Parley Letter' } });
 
-    assert.equal(post.get('id'), '1', 'the post has the updated ID');
+    assert.strictEqual(post.get('id'), '1', 'the post has the updated ID');
     assert.false(post.get('hasDirtyAttributes'), "the post isn't dirty anymore");
-    assert.equal(post.get('name'), 'Dat Parley Letter', 'the post was updated');
+    assert.strictEqual(post.get('name'), 'Dat Parley Letter', 'the post was updated');
 
     let comment = store.peekRecord('comment', 1);
-    assert.equal(comment.get('name'), 'FIRST', 'The comment was sideloaded');
+    assert.strictEqual(comment.get('name'), 'FIRST', 'The comment was sideloaded');
   });
 
   test('updateRecord - a payload with sideloaded updates pushes the updates', async function (assert) {
@@ -270,15 +270,15 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     post.set('name', 'The Parley Letter');
     await post.save();
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'PUT');
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'PUT');
     assert.deepEqual(passedHash.data, { post: { name: 'The Parley Letter' } });
 
     assert.false(post.get('hasDirtyAttributes'), "the post isn't dirty anymore");
-    assert.equal(post.get('name'), 'Dat Parley Letter', 'the post was updated');
+    assert.strictEqual(post.get('name'), 'Dat Parley Letter', 'the post was updated');
 
     let comment = store.peekRecord('comment', 1);
-    assert.equal(comment.get('name'), 'FIRST', 'The comment was sideloaded');
+    assert.strictEqual(comment.get('name'), 'FIRST', 'The comment was sideloaded');
   });
 
   test("updateRecord - a serializer's primary key and attributes are consulted when building the payload", async function (assert) {
@@ -362,8 +362,8 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     comments.pushObject(newComment);
 
     await post.save();
-    assert.equal(post.get('comments.length'), 1, 'the post has the correct number of comments');
-    assert.equal(post.get('comments.firstObject.name'), 'Yes. Yes it is.', 'the post has the correct comment');
+    assert.strictEqual(post.get('comments.length'), 1, 'the post has the correct number of comments');
+    assert.strictEqual(post.get('comments.firstObject.name'), 'Yes. Yes it is.', 'the post has the correct comment');
   });
 
   test('updateRecord - hasMany relationships faithfully reflect removal from response', async function (assert) {
@@ -406,12 +406,12 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     let post = await store.peekRecord('post', 1);
-    assert.equal(post.get('comments.length'), 1, 'the post has one comment');
+    assert.strictEqual(post.get('comments.length'), 1, 'the post has one comment');
     post.set('name', 'Everyone uses Rails');
 
     post = await post.save();
 
-    assert.equal(post.get('comments.length'), 0, 'the post has the no comments');
+    assert.strictEqual(post.get('comments.length'), 0, 'the post has the no comments');
   });
 
   test('updateRecord - hasMany relationships set locally will be removed with empty response', async function (assert) {
@@ -453,11 +453,11 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     let comment = await store.peekRecord('comment', 1);
     let comments = post.comments;
     comments.pushObject(comment);
-    assert.equal(post.get('comments.length'), 1, 'the post has one comment');
+    assert.strictEqual(post.get('comments.length'), 1, 'the post has one comment');
 
     post = await post.save();
 
-    assert.equal(post.get('comments.length'), 0, 'the post has the no comments');
+    assert.strictEqual(post.get('comments.length'), 0, 'the post has the no comments');
   });
 
   test('deleteRecord - an empty payload is a basic success', async function (assert) {
@@ -478,8 +478,8 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     post.deleteRecord();
     await post.save();
 
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'DELETE');
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'DELETE');
     assert.strictEqual(passedHash, undefined);
 
     assert.false(post.get('hasDirtyAttributes'), "the post isn't dirty anymore");
@@ -508,7 +508,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     post.deleteRecord();
     await post.save();
 
-    assert.equal(passedUrl, '/posts/1/deleteRecord');
+    assert.strictEqual(passedUrl, '/posts/1/deleteRecord');
   });
 
   test('deleteRecord - a payload with sideloaded updates pushes the updates', async function (assert) {
@@ -529,15 +529,15 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     post.deleteRecord();
     await post.save();
 
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'DELETE');
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'DELETE');
     assert.strictEqual(passedHash, undefined);
 
     assert.false(post.get('hasDirtyAttributes'), "the post isn't dirty anymore");
     assert.true(post.get('isDeleted'), 'the post is now deleted');
 
     let comment = store.peekRecord('comment', 1);
-    assert.equal(comment.get('name'), 'FIRST', 'The comment was sideloaded');
+    assert.strictEqual(comment.get('name'), 'FIRST', 'The comment was sideloaded');
   });
 
   test('deleteRecord - a payload with sidloaded updates pushes the updates when the original record is omitted', async function (assert) {
@@ -558,15 +558,15 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     post.deleteRecord();
     await post.save();
 
-    assert.equal(passedUrl, '/posts/1');
-    assert.equal(passedVerb, 'DELETE');
+    assert.strictEqual(passedUrl, '/posts/1');
+    assert.strictEqual(passedVerb, 'DELETE');
     assert.strictEqual(passedHash, undefined);
 
     assert.false(post.get('hasDirtyAttributes'), "the original post isn't dirty anymore");
     assert.true(post.get('isDeleted'), 'the original post is now deleted');
 
     let newPost = store.peekRecord('post', 2);
-    assert.equal(newPost.get('name'), 'The Parley Letter', 'The new post was added to the store');
+    assert.strictEqual(newPost.get('name'), 'The Parley Letter', 'The new post was added to the store');
   });
 
   test('deleteRecord - deleting a newly created record should not throw an error', async function (assert) {
@@ -578,9 +578,9 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     assert.true(post.get('isDeleted'), 'the post is now deleted');
     assert.false(post.get('isError'), 'the post is not an error');
-    assert.equal(passedUrl, null, 'There is no ajax call to delete a record that has never been saved.');
-    assert.equal(passedVerb, null, 'There is no ajax call to delete a record that has never been saved.');
-    assert.equal(passedHash, null, 'There is no ajax call to delete a record that has never been saved.');
+    assert.strictEqual(passedUrl, null, 'There is no ajax call to delete a record that has never been saved.');
+    assert.strictEqual(passedVerb, null, 'There is no ajax call to delete a record that has never been saved.');
+    assert.strictEqual(passedHash, null, 'There is no ajax call to delete a record that has never been saved.');
 
     assert.true(internalModel.currentState.isEmpty, 'the post is now deleted');
   });
@@ -594,8 +594,8 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     let posts = await store.findAll('post');
-    assert.equal(passedUrl, '/posts');
-    assert.equal(passedVerb, 'GET');
+    assert.strictEqual(passedUrl, '/posts');
+    assert.strictEqual(passedVerb, 'GET');
     assert.deepEqual(passedHash.data, {});
 
     let post1 = store.peekRecord('post', 1);
@@ -605,7 +605,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     assert.deepEqual(post2.getProperties('id', 'name'), { id: '2', name: 'The Parley Letter' }, 'Post 2 is loaded');
 
-    assert.equal(posts.get('length'), 2, 'The posts are in the array');
+    assert.strictEqual(posts.get('length'), 2, 'The posts are in the array');
     assert.true(posts.get('isLoaded'), 'The RecordArray is loaded');
     assert.deepEqual(posts.toArray(), [post1, post2], 'The correct records are in the array');
   });
@@ -614,7 +614,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     assert.expect(2);
     let adapterOptionsStub = { stub: true };
     adapter.buildURL = function (type, id, snapshot, requestType) {
-      assert.equal(snapshot.adapterOptions, adapterOptionsStub);
+      assert.strictEqual(snapshot.adapterOptions, adapterOptionsStub);
       return '/' + requestType + '/posts';
     };
 
@@ -626,7 +626,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     await store.findAll('post', { adapterOptions: adapterOptionsStub });
-    assert.equal(passedUrl, '/findAll/posts');
+    assert.strictEqual(passedUrl, '/findAll/posts');
   });
 
   test('findAll - passed `include` as a query parameter to ajax', async function (assert) {
@@ -676,7 +676,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     assert.deepEqual(post1.getProperties('id', 'name'), { id: '1', name: 'Rails is omakase' }, 'Post 1 is loaded');
     assert.deepEqual(post2.getProperties('id', 'name'), { id: '2', name: 'The Parley Letter' }, 'Post 2 is loaded');
 
-    assert.equal(posts.get('length'), 2, 'The posts are in the array');
+    assert.strictEqual(posts.get('length'), 2, 'The posts are in the array');
     assert.true(posts.get('isLoaded'), 'The RecordArray is loaded');
     assert.deepEqual(posts.toArray(), [post1, post2], 'The correct records are in the array');
   });
@@ -704,7 +704,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     await store.query('post', { params: 1, in: 2, wrong: 3, order: 4 });
-    assert.equal(passedUrl, '/query/posts');
+    assert.strictEqual(passedUrl, '/query/posts');
   });
 
   test('query - if `sortQueryParams` is falsey, query params are not sorted at all', async function (assert) {
@@ -753,7 +753,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     let posts = await store.query('post', { page: 2 });
-    assert.equal(posts.get('meta.offset'), 5, 'Reponse metadata can be accessed with recordArray.meta');
+    assert.strictEqual(posts.get('meta.offset'), 5, 'Reponse metadata can be accessed with recordArray.meta');
   });
 
   test("query - each record array can have it's own meta object", async function (assert) {
@@ -763,15 +763,15 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     let posts = await store.query('post', { page: 2 });
-    assert.equal(posts.get('meta.offset'), 5, 'Reponse metadata can be accessed with recordArray.meta');
+    assert.strictEqual(posts.get('meta.offset'), 5, 'Reponse metadata can be accessed with recordArray.meta');
     ajaxResponse({
       meta: { offset: 1 },
       posts: [{ id: 1, name: 'Rails is very expensive sushi' }],
     });
 
     let newPosts = await store.query('post', { page: 1 });
-    assert.equal(newPosts.get('meta.offset'), 1, 'new array has correct metadata');
-    assert.equal(posts.get('meta.offset'), 5, 'metadata on the old array hasnt been clobbered');
+    assert.strictEqual(newPosts.get('meta.offset'), 1, 'new array has correct metadata');
+    assert.strictEqual(posts.get('meta.offset'), 5, 'metadata on the old array hasnt been clobbered');
   });
 
   test('query - returning an array populates the array', async function (assert) {
@@ -783,8 +783,8 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     let posts = await store.query('post', { page: 1 });
-    assert.equal(passedUrl, '/posts');
-    assert.equal(passedVerb, 'GET');
+    assert.strictEqual(passedUrl, '/posts');
+    assert.strictEqual(passedVerb, 'GET');
     assert.deepEqual(passedHash.data, { page: 1 });
 
     let post1 = store.peekRecord('post', 1);
@@ -793,7 +793,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     assert.deepEqual(post1.getProperties('id', 'name'), { id: '1', name: 'Rails is omakase' }, 'Post 1 is loaded');
     assert.deepEqual(post2.getProperties('id', 'name'), { id: '2', name: 'The Parley Letter' }, 'Post 2 is loaded');
 
-    assert.equal(posts.get('length'), 2, 'The posts are in the array');
+    assert.strictEqual(posts.get('length'), 2, 'The posts are in the array');
     assert.true(posts.get('isLoaded'), 'The RecordArray is loaded');
     assert.deepEqual(posts.toArray(), [post1, post2], 'The correct records are in the array');
   });
@@ -837,7 +837,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     assert.deepEqual(post2.getProperties('id', 'name'), { id: '2', name: 'The Parley Letter' }, 'Post 2 is loaded');
 
-    assert.equal(posts.get('length'), 2, 'The posts are in the array');
+    assert.strictEqual(posts.get('length'), 2, 'The posts are in the array');
     assert.true(posts.get('isLoaded'), 'The RecordArray is loaded');
     assert.deepEqual(posts.toArray(), [post1, post2], 'The correct records are in the array');
   });
@@ -984,7 +984,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     await post.get('comments');
-    assert.equal(passedUrl, '/comments');
+    assert.strictEqual(passedUrl, '/comments');
     assert.deepEqual(passedHash, { data: { ids: ['1', '2', '3'] } });
   });
 
@@ -1025,7 +1025,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     await post.get('comments');
-    assert.equal(passedUrl, '/findMany/comment');
+    assert.strictEqual(passedUrl, '/findMany/comment');
   });
 
   test('findMany - findMany does not coalesce by default', async function (assert) {
@@ -1061,7 +1061,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     await post.get('comments');
-    assert.equal(passedUrl, '/comments/3');
+    assert.strictEqual(passedUrl, '/comments/3');
     assert.deepEqual(passedHash.data, {});
   });
 
@@ -1262,8 +1262,8 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     let comments = await post.get('comments');
-    assert.equal(passedUrl, '/posts/1/comments');
-    assert.equal(passedVerb, 'GET');
+    assert.strictEqual(passedUrl, '/posts/1/comments');
+    assert.strictEqual(passedVerb, 'GET');
     assert.strictEqual(passedHash, undefined);
 
     let comment1 = store.peekRecord('comment', 1);
@@ -1288,7 +1288,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     adapter.shouldBackgroundReloadRecord = () => false;
     adapter.buildURL = function (type, id, snapshot, requestType) {
       assert.ok(snapshot instanceof DS.Snapshot);
-      assert.equal(requestType, 'findHasMany');
+      assert.strictEqual(requestType, 'findHasMany');
     };
 
     Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
@@ -1437,7 +1437,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     adapter.shouldBackgroundReloadRecord = () => false;
     adapter.buildURL = function (type, id, snapshot, requestType) {
       assert.ok(snapshot instanceof DS.Snapshot);
-      assert.equal(requestType, 'findBelongsTo');
+      assert.strictEqual(requestType, 'findBelongsTo');
     };
 
     Comment.reopen({ post: DS.belongsTo('post', { async: true }) });
@@ -1497,7 +1497,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
         try {
           await post.get('comments');
         } catch (e) {
-          assert.equal(
+          assert.strictEqual(
             e.message,
             `Expected: '<comment:2>' to be present in the adapter provided payload, but it was not found.`
           );
@@ -1520,7 +1520,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     };
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(id, '1');
+      assert.strictEqual(id, '1');
       return resolve({ comments: { id: 1 } });
     };
 
@@ -1564,7 +1564,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     };
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(id, '1');
+      assert.strictEqual(id, '1');
       return resolve({ comments: { id: 1 } });
     };
 
@@ -1672,8 +1672,8 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     let post = await store.findRecord('post', 1);
-    assert.equal(post.get('authorName'), '@d2h');
-    assert.equal(post.get('author.name'), 'D2H');
+    assert.strictEqual(post.get('authorName'), '@d2h');
+    assert.strictEqual(post.get('author.name'), 'D2H');
     assert.deepEqual(post.get('comments').mapBy('body'), ['Rails is unagi', 'What is omakase?']);
   });
 
@@ -1897,7 +1897,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
       await store.findRecord('post', '1');
     } catch (err) {
       assert.ok(err instanceof DS.AbortError, 'reason should be an instance of DS.AbortError');
-      assert.equal(err.errors.length, 1, 'AbortError includes errors with request/response details');
+      assert.strictEqual(err.errors.length, 1, 'AbortError includes errors with request/response details');
       let expectedError = {
         title: 'Adapter Error',
         detail: 'Request failed: GET /posts/1',
@@ -1931,7 +1931,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
       try {
         await store.findRecord('post', '1');
       } catch (err) {
-        assert.equal(err, errorThrown);
+        assert.strictEqual(err, errorThrown);
         assert.ok(err, 'promise rejected');
       }
     });
@@ -1955,7 +1955,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
       try {
         await store.findRecord('post', '1');
       } catch (err) {
-        assert.equal(err.errors[0].detail, errorThrown);
+        assert.strictEqual(err.errors[0].detail, errorThrown);
         assert.ok(err, 'promise rejected');
       }
     });
@@ -2020,7 +2020,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     try {
       await store.findRecord('post', '1');
     } catch (err) {
-      assert.equal(
+      assert.strictEqual(
         err.message,
         'Ember Data Request GET /posts/1 returned a 500\nPayload (text/plain)\nAn error message, perhaps generated from a backend server!'
       );
@@ -2036,7 +2036,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     try {
       await store.findRecord('post', '1');
     } catch (err) {
-      assert.equal(
+      assert.strictEqual(
         err.message,
         'Ember Data Request GET /posts/1 returned a 500\nPayload (text/html)\n[Omitted Lengthy HTML]'
       );
@@ -2065,7 +2065,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     });
 
     let posts = await store.findAll('post');
-    assert.equal(get(posts, 'length'), 3);
+    assert.strictEqual(get(posts, 'length'), 3);
     posts.forEach((post) => assert.ok(post instanceof DS.Model));
   });
 
@@ -2097,9 +2097,9 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     let comments = store.peekAll('comment');
 
-    assert.equal(get(comments, 'length'), 2, 'comments.length is correct');
-    assert.equal(get(comments, 'firstObject.name'), 'First comment', 'comments.firstObject.name is correct');
-    assert.equal(get(comments, 'lastObject.name'), 'Second comment', 'comments.lastObject.name is correct');
+    assert.strictEqual(get(comments, 'length'), 2, 'comments.length is correct');
+    assert.strictEqual(get(comments, 'firstObject.name'), 'First comment', 'comments.firstObject.name is correct');
+    assert.strictEqual(get(comments, 'lastObject.name'), 'Second comment', 'comments.lastObject.name is correct');
   });
 
   testInDebug(
@@ -2114,7 +2114,7 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
       let post = store.createRecord('post');
       return post.save().then(
         () => {
-          assert.equal(true, false, 'should not have fulfilled');
+          assert.strictEqual(true, false, 'should not have fulfilled');
         },
         (reason) => {
           if (!hasJQuery) {

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter/create-record-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter/create-record-test.js
@@ -192,8 +192,8 @@ module('integration/adapter/rest_adapter - REST Adapter - createRecord', functio
     await comment.save();
 
     assert.false(comment.get('hasDirtyAttributes'), "the post isn't dirty anymore");
-    assert.equal(comment.get('name'), 'Dat Parley Letter', 'the post was updated');
-    assert.equal(comment.get('post'), post, 'the post is still set');
+    assert.strictEqual(comment.get('name'), 'Dat Parley Letter', 'the post was updated');
+    assert.strictEqual(comment.get('post'), post, 'the post is still set');
   });
 
   test("createRecord - a serializer's primary key and attributes are consulted when building the payload", async function (assert) {

--- a/packages/-ember-data/tests/integration/adapter/rest-adapter/find-record-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter/find-record-test.js
@@ -112,20 +112,20 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
       }
       const { passedUrl, passedVerb, passedHash } = ajaxCallback();
 
-      assert.equal(passedUrl, '/posts/1');
-      assert.equal(passedVerb, 'GET');
+      assert.strictEqual(passedUrl, '/posts/1');
+      assert.strictEqual(passedVerb, 'GET');
       assert.deepEqual(passedHash.data, {});
 
-      assert.equal(post.get('id'), '1');
-      assert.equal(post.get('name'), 'Rails is omakase');
+      assert.strictEqual(post.get('id'), '1');
+      assert.strictEqual(post.get('name'), 'Rails is omakase');
 
       // stress tests
       let peekPost = store.peekRecord(findRecordArgs);
       assert.strictEqual(peekPost, post, 'peekRecord returns same post');
 
       let recordReference = store.getReference(findRecordArgs);
-      assert.equal(recordReference.remoteType(), 'identity');
-      assert.equal(recordReference.type, 'post');
+      assert.strictEqual(recordReference.remoteType(), 'identity');
+      assert.strictEqual(recordReference.type, 'post');
       assert.strictEqual(recordReference.id(), '1');
     });
   });
@@ -151,9 +151,9 @@ module('integration/adapter/rest_adapter - REST Adapter - findRecord', function 
     assert.strictEqual(peekPost, foundPost, 'peekRecord returns same post');
 
     let recordReference = store.getReference(identifier);
-    assert.equal(recordReference.remoteType(), 'identity');
-    assert.equal(recordReference.type, 'post');
-    assert.equal(recordReference.id(), null);
+    assert.strictEqual(recordReference.remoteType(), 'identity');
+    assert.strictEqual(recordReference.type, 'post');
+    assert.strictEqual(recordReference.id(), null);
   });
 
   // Error Identifier Tests

--- a/packages/-ember-data/tests/integration/adapter/store-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/store-adapter-test.js
@@ -68,7 +68,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
 
     const people = await store.query('person', { q: 'bla' });
     const people2 = await store.query('person', { q: 'bla2' });
-    assert.equal(people2.get('length'), 2, 'return the elements');
+    assert.strictEqual(people2.get('length'), 2, 'return the elements');
     assert.ok(people2.get('isLoaded'), 'array is loaded');
 
     const person = people.objectAt(0);
@@ -86,12 +86,12 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     let count = 1;
     adapter.shouldBackgroundReloadRecord = () => false;
     adapter.createRecord = function (store, type, snapshot) {
-      assert.equal(type, Person, 'the type is correct');
+      assert.strictEqual(type, Person, 'the type is correct');
 
       if (count === 1) {
-        assert.equal(snapshot.attr('name'), 'Tom Dale');
+        assert.strictEqual(snapshot.attr('name'), 'Tom Dale');
       } else if (count === 2) {
-        assert.equal(snapshot.attr('name'), 'Yehuda Katz');
+        assert.strictEqual(snapshot.attr('name'), 'Yehuda Katz');
       } else {
         assert.ok(false, 'should not have invoked more than 2 times');
       }
@@ -126,8 +126,8 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
 
       assert.asyncEqual(tom, store.findRecord('person', 1), 'Once an ID is in, findRecord returns the same object');
       assert.asyncEqual(yehuda, store.findRecord('person', 2), 'Once an ID is in, findRecord returns the same object');
-      assert.equal(get(tom, 'updatedAt'), 'now', 'The new information is received');
-      assert.equal(get(yehuda, 'updatedAt'), 'now', 'The new information is received');
+      assert.strictEqual(get(tom, 'updatedAt'), 'now', 'The new information is received');
+      assert.strictEqual(get(yehuda, 'updatedAt'), 'now', 'The new information is received');
     });
   });
 
@@ -139,12 +139,12 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     let count = 0;
     adapter.shouldBackgroundReloadRecord = () => false;
     adapter.updateRecord = function (store, type, snapshot) {
-      assert.equal(type, Person, 'the type is correct');
+      assert.strictEqual(type, Person, 'the type is correct');
 
       if (count === 0) {
-        assert.equal(snapshot.attr('name'), 'Tom Dale');
+        assert.strictEqual(snapshot.attr('name'), 'Tom Dale');
       } else if (count === 1) {
-        assert.equal(snapshot.attr('name'), 'Yehuda Katz');
+        assert.strictEqual(snapshot.attr('name'), 'Yehuda Katz');
       } else {
         assert.ok(false, 'should not get here');
       }
@@ -215,16 +215,16 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     let count = 0;
     adapter.shouldBackgroundReloadRecord = () => false;
     adapter.updateRecord = function (store, type, snapshot) {
-      assert.equal(type, Person, 'the type is correct');
+      assert.strictEqual(type, Person, 'the type is correct');
 
       count++;
       if (count === 1) {
-        assert.equal(snapshot.attr('name'), 'Tom Dale');
+        assert.strictEqual(snapshot.attr('name'), 'Tom Dale');
         return resolve({
           data: { id: 1, type: 'person', attributes: { name: 'Tom Dale', 'updated-at': 'now' } },
         });
       } else if (count === 2) {
-        assert.equal(snapshot.attr('name'), 'Yehuda Katz');
+        assert.strictEqual(snapshot.attr('name'), 'Yehuda Katz');
         return resolve({
           data: {
             id: 2,
@@ -281,10 +281,10 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
         let yehuda = records.yehuda;
 
         assert.false(get(tom, 'hasDirtyAttributes'), 'the record should not be dirty');
-        assert.equal(get(tom, 'updatedAt'), 'now', 'the hash was updated');
+        assert.strictEqual(get(tom, 'updatedAt'), 'now', 'the hash was updated');
 
         assert.false(get(yehuda, 'hasDirtyAttributes'), 'the record should not be dirty');
-        assert.equal(get(yehuda, 'updatedAt'), 'now!', 'the hash was updated');
+        assert.strictEqual(get(yehuda, 'updatedAt'), 'now!', 'the hash was updated');
       });
   });
 
@@ -298,12 +298,12 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     let count = 0;
     adapter.shouldBackgroundReloadRecord = () => false;
     adapter.deleteRecord = function (store, type, snapshot) {
-      assert.equal(type, Person, 'the type is correct');
+      assert.strictEqual(type, Person, 'the type is correct');
 
       if (count === 0) {
-        assert.equal(snapshot.attr('name'), 'Tom Dale');
+        assert.strictEqual(snapshot.attr('name'), 'Tom Dale');
       } else if (count === 1) {
-        assert.equal(snapshot.attr('name'), 'Yehuda Katz');
+        assert.strictEqual(snapshot.attr('name'), 'Yehuda Katz');
       } else {
         assert.ok(false, 'should not get here');
       }
@@ -361,12 +361,12 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
 
     adapter.shouldBackgroundReloadRecord = () => false;
     adapter.deleteRecord = function (store, type, snapshot) {
-      assert.equal(type, Person, 'the type is correct');
+      assert.strictEqual(type, Person, 'the type is correct');
 
       if (count === 0) {
-        assert.equal(snapshot.attr('name'), 'Tom Dale');
+        assert.strictEqual(snapshot.attr('name'), 'Tom Dale');
       } else if (count === 1) {
-        assert.equal(snapshot.attr('name'), 'Yehuda Katz');
+        assert.strictEqual(snapshot.attr('name'), 'Yehuda Katz');
       } else {
         assert.ok(false, 'should not get here');
       }
@@ -420,8 +420,8 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     adapter.shouldBackgroundReloadRecord = () => false;
     adapter.deleteRecord = function (store, type, snapshot) {
       count++;
-      assert.equal(snapshot.id, 'deleted-record', 'should pass correct record to deleteRecord');
-      assert.equal(count, 1, 'should only call deleteRecord method of adapter once');
+      assert.strictEqual(snapshot.id, 'deleted-record', 'should pass correct record to deleteRecord');
+      assert.strictEqual(count, 1, 'should only call deleteRecord method of adapter once');
 
       return resolve();
     };
@@ -486,13 +486,13 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
       assert.ok(false, 'We should throw during save');
     } catch (e) {
       assert.true(tom.isError, 'Tom is now errored');
-      assert.equal(tom.adapterError, error, 'error object is exposed');
+      assert.strictEqual(tom.adapterError, error, 'error object is exposed');
 
       // this time it succeeds
       await tom.save();
 
       assert.false(tom.isError, 'Tom is not errored anymore');
-      assert.equal(tom.adapterError, null, 'error object is discarded');
+      assert.strictEqual(tom.adapterError, null, 'error object is discarded');
     }
   });
 
@@ -502,7 +502,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     let Person = store.modelFor('person');
 
     adapter.createRecord = function (store, type, snapshot) {
-      assert.equal(type, Person, 'the type is correct');
+      assert.strictEqual(type, Person, 'the type is correct');
 
       if (snapshot.attr('name').indexOf('Bro') === -1) {
         return reject(
@@ -615,7 +615,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
 
     let saveCount = 0;
     adapter.createRecord = function (store, type, snapshot) {
-      assert.equal(type, Person, 'the type is correct');
+      assert.strictEqual(type, Person, 'the type is correct');
       saveCount++;
 
       if (snapshot.attr('name').indexOf('Bro') === -1) {
@@ -643,7 +643,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     return yehuda
       .save()
       .catch((reason) => {
-        assert.equal(saveCount, 1, 'The record has been saved once');
+        assert.strictEqual(saveCount, 1, 'The record has been saved once');
         assert.ok(
           reason.message.match('The adapter rejected the commit because it was invalid'),
           'It should fail due to being invalid'
@@ -655,7 +655,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
         return yehuda.save();
       })
       .catch((reason) => {
-        assert.equal(saveCount, 2, 'The record has been saved twice');
+        assert.strictEqual(saveCount, 2, 'The record has been saved twice');
         assert.ok(
           reason.message.match('The adapter rejected the commit because it was invalid'),
           'It should fail due to being invalid'
@@ -668,7 +668,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
         return yehuda.save();
       })
       .then((person) => {
-        assert.equal(saveCount, 3, 'The record has been saved thrice');
+        assert.strictEqual(saveCount, 3, 'The record has been saved thrice');
         assert.true(get(yehuda, 'isValid'), 'record is valid');
         assert.false(get(yehuda, 'hasDirtyAttributes'), 'record is not dirty');
         assert.true(get(yehuda, 'errors.isEmpty'), 'record has no errors');
@@ -689,7 +689,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
 
     return person.save().catch(() => {
       assert.ok(get(person, 'isError'), 'the record is in the error state');
-      assert.equal(get(person, 'adapterError'), error, 'error object is exposed');
+      assert.strictEqual(get(person, 'adapterError'), error, 'error object is exposed');
     });
   });
 
@@ -700,7 +700,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
 
     adapter.shouldBackgroundReloadRecord = () => false;
     adapter.updateRecord = function (store, type, snapshot) {
-      assert.equal(type, Person, 'the type is correct');
+      assert.strictEqual(type, Person, 'the type is correct');
 
       if (snapshot.attr('name').indexOf('Bro') === -1) {
         return reject(
@@ -736,7 +736,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     return store
       .findRecord('person', 1)
       .then((person) => {
-        assert.equal(person, yehuda, 'The same object is passed through');
+        assert.strictEqual(person, yehuda, 'The same object is passed through');
 
         assert.true(get(yehuda, 'isValid'), 'precond - the record is valid');
         set(yehuda, 'name', 'Yehuda Katz');
@@ -804,7 +804,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     return store
       .findRecord('person', 1)
       .then((person) => {
-        assert.equal(person, yehuda, 'The same object is passed through');
+        assert.strictEqual(person, yehuda, 'The same object is passed through');
 
         assert.true(get(yehuda, 'isValid'), 'precond - the record is valid');
         set(yehuda, 'name', 'Yehuda Katz');
@@ -850,7 +850,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     let saveCount = 0;
     adapter.shouldBackgroundReloadRecord = () => false;
     adapter.updateRecord = function (store, type, snapshot) {
-      assert.equal(type, Person, 'the type is correct');
+      assert.strictEqual(type, Person, 'the type is correct');
       saveCount++;
       if (snapshot.attr('name').indexOf('Bro') === -1) {
         return reject(
@@ -885,7 +885,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     return store
       .findRecord('person', 1)
       .then((person) => {
-        assert.equal(person, yehuda, 'The same object is passed through');
+        assert.strictEqual(person, yehuda, 'The same object is passed through');
 
         assert.true(get(yehuda, 'isValid'), 'precond - the record is valid');
         set(yehuda, 'name', 'Yehuda Katz');
@@ -896,7 +896,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
         return yehuda.save();
       })
       .catch((reason) => {
-        assert.equal(saveCount, 1, 'The record has been saved once');
+        assert.strictEqual(saveCount, 1, 'The record has been saved once');
         assert.ok(
           reason.message.match('The adapter rejected the commit because it was invalid'),
           'It should fail due to being invalid'
@@ -906,7 +906,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
         return yehuda.save();
       })
       .catch((reason) => {
-        assert.equal(saveCount, 2, 'The record has been saved twice');
+        assert.strictEqual(saveCount, 2, 'The record has been saved twice');
         assert.ok(
           reason.message.match('The adapter rejected the commit because it was invalid'),
           'It should fail due to being invalid'
@@ -917,7 +917,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
         return yehuda.save();
       })
       .then((person) => {
-        assert.equal(saveCount, 3, 'The record has been saved thrice');
+        assert.strictEqual(saveCount, 3, 'The record has been saved thrice');
         assert.true(get(yehuda, 'isValid'), 'record is valid');
         assert.false(get(yehuda, 'hasDirtyAttributes'), 'record is not dirty');
         assert.true(get(yehuda, 'errors.isEmpty'), 'record has no errors');
@@ -951,13 +951,13 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     store
       .findRecord('person', 1)
       .then((record) => {
-        assert.equal(record, person, 'The person was resolved');
+        assert.strictEqual(record, person, 'The person was resolved');
         person.set('name', 'Jonathan Doe');
         return person.save();
       })
       .catch((reason) => {
         assert.ok(get(person, 'isError'), 'the record is in the error state');
-        assert.equal(get(person, 'adapterError'), error, 'error object is exposed');
+        assert.strictEqual(get(person, 'adapterError'), error, 'error object is exposed');
       });
   });
 
@@ -969,7 +969,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     let Person = store.modelFor('person');
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(type, Person, 'the type is correct');
+      assert.strictEqual(type, Person, 'the type is correct');
       return resolve({ data: { id: 1, type: 'person' } });
     };
 
@@ -1102,7 +1102,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
         return dogs;
       })
       .then((dogs) => {
-        assert.equal(dogs.get('length'), 1, 'The dogs are loaded');
+        assert.strictEqual(dogs.get('length'), 1, 'The dogs are loaded');
         store.push({
           data: {
             type: 'person',
@@ -1123,7 +1123,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
         return tom.get('dogs');
       })
       .then((dogs) => {
-        assert.equal(dogs.get('length'), 1, 'The same dogs are loaded');
+        assert.strictEqual(dogs.get('length'), 1, 'The same dogs are loaded');
       });
   });
 
@@ -1480,7 +1480,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     let adapter = store.adapterFor('application');
 
     adapter.findRecord = (store, type, id, snapshot) => {
-      assert.equal(snapshot.include, 'books', 'include passed to adapter.findRecord');
+      assert.strictEqual(snapshot.include, 'books', 'include passed to adapter.findRecord');
       return resolve({ data: { id: 1, type: 'person' } });
     };
 
@@ -1509,7 +1509,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
     let adapter = store.adapterFor('application');
 
     adapter.findAll = function (store, type, sinceToken, arraySnapshot) {
-      assert.equal(arraySnapshot.include, 'books', 'include passed to adapter.findAll');
+      assert.strictEqual(arraySnapshot.include, 'books', 'include passed to adapter.findAll');
       return resolve({ data: [{ id: 1, type: 'person' }] });
     };
 
@@ -1563,7 +1563,7 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
         return post.get('comments');
       })
       .then((comments) => {
-        assert.equal(comments.get('length'), 3);
+        assert.strictEqual(comments.get('length'), 3);
       });
   });
 

--- a/packages/-ember-data/tests/integration/backwards-compat/non-dasherized-lookups-test.js
+++ b/packages/-ember-data/tests/integration/backwards-compat/non-dasherized-lookups-test.js
@@ -49,7 +49,7 @@ module(
 
       run(() => {
         store.findRecord('postNote', 1).then((postNote) => {
-          assert.equal(get(postNote, 'name'), 'Ember Data', 'record found');
+          assert.strictEqual(get(postNote, 'name'), 'Ember Data', 'record found');
         });
       });
     });
@@ -73,7 +73,7 @@ module(
 
       run(() => {
         store.findRecord('post_note', 1).then((postNote) => {
-          assert.equal(get(postNote, 'name'), 'Ember Data', 'record found');
+          assert.strictEqual(get(postNote, 'name'), 'Ember Data', 'record found');
         });
       });
     });
@@ -146,7 +146,7 @@ module(
 
       run(() => {
         store.findRecord('post-note', 1).then((postNote) => {
-          assert.equal(get(postNote, 'notePost.name'), 'Inverse', 'inverse record found');
+          assert.strictEqual(get(postNote, 'notePost.name'), 'Inverse', 'inverse record found');
         });
       });
     });

--- a/packages/-ember-data/tests/integration/client-id-generation-test.js
+++ b/packages/-ember-data/tests/integration/client-id-generation-test.js
@@ -59,7 +59,7 @@ module('integration - Client Id Generation', function (hooks) {
       let type = modelClass.modelName;
 
       if (type === 'comment') {
-        assert.equal(snapshot.id, 'id-1', "Comment passed to `createRecord` has 'id-1' assigned");
+        assert.strictEqual(snapshot.id, 'id-1', "Comment passed to `createRecord` has 'id-1' assigned");
         return resolve({
           data: {
             type,
@@ -67,7 +67,7 @@ module('integration - Client Id Generation', function (hooks) {
           },
         });
       } else {
-        assert.equal(snapshot.id, 'id-2', "Post passed to `createRecord` has 'id-2' assigned");
+        assert.strictEqual(snapshot.id, 'id-2', "Post passed to `createRecord` has 'id-2' assigned");
         return resolve({
           data: {
             type,
@@ -80,8 +80,8 @@ module('integration - Client Id Generation', function (hooks) {
     let comment = store.createRecord('comment');
     let post = store.createRecord('post');
 
-    assert.equal(get(comment, 'id'), 'id-1', "comment is assigned id 'id-1'");
-    assert.equal(get(post, 'id'), 'id-2', "post is assigned id 'id-2'");
+    assert.strictEqual(get(comment, 'id'), 'id-1', "comment is assigned id 'id-1'");
+    assert.strictEqual(get(post, 'id'), 'id-2', "post is assigned id 'id-2'");
 
     // Despite client-generated IDs, calling save() on the store should still
     // invoke the adapter's `createRecord` method.
@@ -102,15 +102,15 @@ module('integration - Client Id Generation', function (hooks) {
     };
 
     adapter.createRecord = function (store, type, record) {
-      assert.equal(typeof get(record, 'id'), 'object', 'correct type');
+      assert.strictEqual(typeof get(record, 'id'), 'object', 'correct type');
       return resolve({ data: { id: id++, type: type.modelName } });
     };
 
     let comment = store.createRecord('misc');
     let post = store.createRecord('misc');
 
-    assert.equal(get(comment, 'id'), null, "comment is assigned id 'null'");
-    assert.equal(get(post, 'id'), null, "post is assigned id 'null'");
+    assert.strictEqual(get(comment, 'id'), null, "comment is assigned id 'null'");
+    assert.strictEqual(get(post, 'id'), null, "post is assigned id 'null'");
 
     // Despite client-generated IDs, calling commit() on the store should still
     // invoke the adapter's `createRecord` method.

--- a/packages/-ember-data/tests/integration/debug-adapter-test.js
+++ b/packages/-ember-data/tests/integration/debug-adapter-test.js
@@ -44,14 +44,14 @@ if (has('@ember-data/debug')) {
       let debugAdapter = owner.lookup('data-adapter:main');
 
       function added(types) {
-        assert.equal(types.length, 1, 'added one type');
-        assert.equal(types[0].name, 'post', 'the type is post');
-        assert.equal(types[0].count, 0, 'we added zero posts');
+        assert.strictEqual(types.length, 1, 'added one type');
+        assert.strictEqual(types[0].name, 'post', 'the type is post');
+        assert.strictEqual(types[0].count, 0, 'we added zero posts');
         assert.strictEqual(types[0].object, store.modelFor('post'), 'we received the ModelClass for post');
       }
 
       function updated(types) {
-        assert.equal(types[0].count, 1, 'We updated one record');
+        assert.strictEqual(types[0].count, 1, 'We updated one record');
       }
 
       debugAdapter.watchModelTypes(added, updated);
@@ -106,7 +106,7 @@ if (has('@ember-data/debug')) {
 
       debugAdapter.watchRecords('post', recordsAdded, recordsUpdated, recordsRemoved);
 
-      assert.equal(get(addedRecords, 'length'), 1, 'We initially have 1 post');
+      assert.strictEqual(get(addedRecords, 'length'), 1, 'We initially have 1 post');
       let record = addedRecords[0];
       assert.deepEqual(record.columnValues, { id: '1', title: 'Clean Post' }, 'The initial post has the right values');
       assert.deepEqual(
@@ -124,7 +124,7 @@ if (has('@ember-data/debug')) {
       // await updated callback
       await settled();
 
-      assert.equal(get(updatedRecords, 'length'), 1, 'We updated 1 post');
+      assert.strictEqual(get(updatedRecords, 'length'), 1, 'We updated 1 post');
       record = updatedRecords[0];
       assert.deepEqual(
         record.columnValues,
@@ -146,7 +146,7 @@ if (has('@ember-data/debug')) {
 
       await settled();
 
-      assert.equal(get(addedRecords, 'length'), 1, 'We are notified when we add a newly created post');
+      assert.strictEqual(get(addedRecords, 'length'), 1, 'We are notified when we add a newly created post');
       record = addedRecords[0];
       assert.deepEqual(
         record && record.columnValues,
@@ -174,11 +174,15 @@ if (has('@ember-data/debug')) {
       await settled();
 
       if (gte('3.26.0')) {
-        assert.equal(removedRecords.length, 1, 'We are notified of the total posts removed');
-        assert.equal(removedRecords[0][0].object, post, 'The removed post is correct');
+        assert.strictEqual(removedRecords.length, 1, 'We are notified of the total posts removed');
+        assert.strictEqual(removedRecords[0][0].object, post, 'The removed post is correct');
       } else {
-        assert.equal(removedRecords[0], 1, 'We are notified of the start index of a removal when we remove posts');
-        assert.equal(removedRecords[1], 1, 'We are notified of the total posts removed');
+        assert.strictEqual(
+          removedRecords[0],
+          1,
+          'We are notified of the start index of a removal when we remove posts'
+        );
+        assert.strictEqual(removedRecords[1], 1, 'We are notified of the total posts removed');
       }
     });
 
@@ -195,9 +199,9 @@ if (has('@ember-data/debug')) {
 
       const columns = debugAdapter.columnsForType(Person);
 
-      assert.equal(columns[0].desc, 'Id');
-      assert.equal(columns[1].desc, 'Title');
-      assert.equal(columns[2].desc, 'First or last name');
+      assert.strictEqual(columns[0].desc, 'Id');
+      assert.strictEqual(columns[1].desc, 'Title');
+      assert.strictEqual(columns[2].desc, 'First or last name');
     });
   });
 }

--- a/packages/-ember-data/tests/integration/identifiers/cache-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/cache-test.ts
@@ -92,8 +92,8 @@ module('Integration | Identifiers - cache', function (hooks) {
       };
       const identifier = cache.createIdentifierForNewRecord(runspiredHash);
 
-      assert.equal(identifier.id, '1', 'identifier has id');
-      assert.equal(identifier.type, 'person', 'identifier has type');
+      assert.strictEqual(identifier.id, '1', 'identifier has id');
+      assert.strictEqual(identifier.type, 'person', 'identifier has type');
       assert.ok(identifier.lid, 'identifier has lid');
     });
   });
@@ -111,8 +111,8 @@ module('Integration | Identifiers - cache', function (hooks) {
 
       let mergedIdentifier = cache.updateRecordIdentifier(identifier, { type: 'person', id: '1' });
 
-      assert.equal(mergedIdentifier.id, identifier.id, 'merged identifier has same id');
-      assert.equal(mergedIdentifier.type, identifier.type, 'merged identifier has same type');
+      assert.strictEqual(mergedIdentifier.id, identifier.id, 'merged identifier has same id');
+      assert.strictEqual(mergedIdentifier.type, identifier.type, 'merged identifier has same type');
     });
 
     test('returns new identifier with different id', async function (assert) {
@@ -127,8 +127,8 @@ module('Integration | Identifiers - cache', function (hooks) {
 
       let mergedIdentifier = cache.updateRecordIdentifier(identifier, { type: 'person', id: '2' });
 
-      assert.equal(mergedIdentifier.id, '2', 'merged identifier has new id');
-      assert.equal(mergedIdentifier.type, 'person', 'merged identifier has same type');
+      assert.strictEqual(mergedIdentifier.id, '2', 'merged identifier has new id');
+      assert.strictEqual(mergedIdentifier.type, 'person', 'merged identifier has same type');
     });
 
     testInDebug('cannot create an existing identifier', async function (assert) {
@@ -157,8 +157,8 @@ module('Integration | Identifiers - cache', function (hooks) {
 
       let mergedIdentifier = cache.updateRecordIdentifier(identifier, { type: 'person', id: null });
 
-      assert.equal(mergedIdentifier.id, null, 'merged identifier has null id');
-      assert.equal(mergedIdentifier.type, identifier.type, 'merged identifier has same type');
+      assert.strictEqual(mergedIdentifier.id, null, 'merged identifier has null id');
+      assert.strictEqual(mergedIdentifier.type, identifier.type, 'merged identifier has same type');
     });
   });
 });

--- a/packages/-ember-data/tests/integration/identifiers/lid-reflection-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/lid-reflection-test.ts
@@ -219,7 +219,7 @@ module('Integration | Identifiers - lid reflection', function (hooks) {
     await cake.save();
 
     assert.deepEqual(cake.hasMany('ingredients').ids(), ['2']);
-    assert.equal(cake.ingredients.objectAt(0).name, 'Cheese');
+    assert.strictEqual(cake.ingredients.objectAt(0).name, 'Cheese');
   });
 
   test('belongsTo() has correct state after .save() on a newly created record with sideposted child record when lid is provided in the response payload', async function (assert) {
@@ -291,6 +291,6 @@ module('Integration | Identifiers - lid reflection', function (hooks) {
     await cake.save();
 
     assert.deepEqual(cake.belongsTo('topping').id(), '2');
-    assert.equal(cake.topping.name, 'Cheese');
+    assert.strictEqual(cake.topping.name, 'Cheese');
   });
 });

--- a/packages/-ember-data/tests/integration/injection-test.js
+++ b/packages/-ember-data/tests/integration/injection-test.js
@@ -29,6 +29,6 @@ module('integration/injection factoryFor enabled', function (hooks) {
 
     assert.strictEqual(modelClass, Model, 'expected the factory itself to be returned');
 
-    assert.equal(modelClass.modelName, 'super-villain', 'expected the factory itself to be returned');
+    assert.strictEqual(modelClass.modelName, 'super-villain', 'expected the factory itself to be returned');
   });
 });

--- a/packages/-ember-data/tests/integration/inverse-test.js
+++ b/packages/-ember-data/tests/integration/inverse-test.js
@@ -172,7 +172,7 @@ module('integration/inverse_test - inverseFor', function (hooks) {
     owner.register('model:job', Job);
 
     let user = store.modelFor('user');
-    assert.equal(user.inverseFor('job', store), null, 'There is no inverse');
+    assert.strictEqual(user.inverseFor('job', store), null, 'There is no inverse');
   });
 
   testInDebug('Errors out if you define 2 inverses to the same model', function (assert) {
@@ -254,7 +254,7 @@ module('integration/inverse_test - inverseFor', function (hooks) {
       assert.ok(false, 'Find is not called anymore');
     };
 
-    assert.equal(inverseForUser, job.inverseFor('user', store), 'Inverse cached succesfully');
+    assert.strictEqual(inverseForUser, job.inverseFor('user', store), 'Inverse cached succesfully');
   });
 
   testInDebug('Errors out if you do not define an inverse for a reflexive relationship', function (assert) {

--- a/packages/-ember-data/tests/integration/lifecycle-hooks-test.js
+++ b/packages/-ember-data/tests/integration/lifecycle-hooks-test.js
@@ -43,9 +43,9 @@ module('integration/lifecycle_hooks - Lifecycle Hooks', function (hooks) {
       let person = store.createRecord('person', { name: 'Yehuda Katz' });
 
       person.on('didCreate', function () {
-        assert.equal(this, person, 'this is bound to the record');
-        assert.equal(this.get('id'), '99', 'the ID has been assigned');
-        assert.equal(this.get('name'), 'Yehuda Katz', 'the attribute has been assigned');
+        assert.strictEqual(this, person, 'this is bound to the record');
+        assert.strictEqual(this.get('id'), '99', 'the ID has been assigned');
+        assert.strictEqual(this.get('name'), 'Yehuda Katz', 'the attribute has been assigned');
         done();
       });
 
@@ -70,9 +70,9 @@ module('integration/lifecycle_hooks - Lifecycle Hooks', function (hooks) {
       let person = store.createRecord('person', { id: 99, name: 'Yehuda Katz' });
 
       person.on('didCreate', function () {
-        assert.equal(this, person, 'this is bound to the record');
-        assert.equal(this.get('id'), '99', 'the ID has been assigned');
-        assert.equal(this.get('name'), 'Yehuda Katz', 'the attribute has been assigned');
+        assert.strictEqual(this, person, 'this is bound to the record');
+        assert.strictEqual(this.get('id'), '99', 'the ID has been assigned');
+        assert.strictEqual(this.get('name'), 'Yehuda Katz', 'the attribute has been assigned');
       });
 
       await person.save();

--- a/packages/-ember-data/tests/integration/multiple-stores-test.js
+++ b/packages/-ember-data/tests/integration/multiple-stores-test.js
@@ -57,15 +57,15 @@ module('integration/multiple_stores - Multiple Stores Tests', function (hooks) {
 
     let homePlanet = await andromedaStore.findRecord('home-planet', '1');
 
-    assert.equal(homePlanet.name, 'Earth');
+    assert.strictEqual(homePlanet.name, 'Earth');
 
     homePlanet = await cartwheelStore.findRecord('home-planet', '1');
 
-    assert.equal(homePlanet.name, 'Mars');
+    assert.strictEqual(homePlanet.name, 'Mars');
 
     homePlanet = await cigarStore.findRecord('home-planet', '1');
 
-    assert.equal(homePlanet.name, 'Saturn');
+    assert.strictEqual(homePlanet.name, 'Saturn');
   });
 
   test('embedded records should be created in multiple stores', function (assert) {
@@ -169,12 +169,12 @@ module('integration/multiple_stores - Multiple Stores Tests', function (hooks) {
     const andromedaSerializer = andromedaStore.serializerFor('home-planet');
     const cigarSerializer = cigarStore.serializerFor('home-planet');
 
-    assert.equal(
+    assert.strictEqual(
       andromedaSerializer.store,
       andromedaStore,
       "andromedaSerializer's store prop should be andromedaStore"
     );
-    assert.equal(cigarSerializer.store, cigarStore, "cigarSerializer's store prop should be cigarStore");
+    assert.strictEqual(cigarSerializer.store, cigarStore, "cigarSerializer's store prop should be cigarStore");
     assert.notEqual(andromedaSerializer, cigarSerializer, 'andromedaStore and cigarStore should be unique instances');
   });
 
@@ -187,8 +187,8 @@ module('integration/multiple_stores - Multiple Stores Tests', function (hooks) {
     const andromedaAdapter = andromedaStore.adapterFor('home-planet');
     const cigarAdapter = cigarStore.adapterFor('home-planet');
 
-    assert.equal(andromedaAdapter.store, andromedaStore);
-    assert.equal(cigarAdapter.store, cigarStore);
+    assert.strictEqual(andromedaAdapter.store, andromedaStore);
+    assert.strictEqual(cigarAdapter.store, cigarStore);
     assert.notEqual(andromedaAdapter, cigarAdapter);
   });
 });

--- a/packages/-ember-data/tests/integration/peek-all-test.js
+++ b/packages/-ember-data/tests/integration/peek-all-test.js
@@ -45,7 +45,7 @@ module('integration/peek-all - DS.Store#peekAll()', function (hooks) {
     });
 
     let all = store.peekAll('person');
-    assert.equal(get(all, 'length'), 2);
+    assert.strictEqual(get(all, 'length'), 2);
 
     store.push({
       data: [
@@ -61,15 +61,15 @@ module('integration/peek-all - DS.Store#peekAll()', function (hooks) {
 
     await settled();
 
-    assert.equal(get(all, 'length'), 3);
+    assert.strictEqual(get(all, 'length'), 3);
   });
 
   test('Calling store.peekAll() multiple times should update immediately', async function (assert) {
     assert.expect(3);
 
-    assert.equal(get(store.peekAll('person'), 'length'), 0, 'should initially be empty');
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 0, 'should initially be empty');
     store.createRecord('person', { name: 'Tomster' });
-    assert.equal(get(store.peekAll('person'), 'length'), 1, 'should contain one person');
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 1, 'should contain one person');
     store.push({
       data: {
         type: 'person',
@@ -79,13 +79,13 @@ module('integration/peek-all - DS.Store#peekAll()', function (hooks) {
         },
       },
     });
-    assert.equal(get(store.peekAll('person'), 'length'), 2, 'should contain two people');
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 2, 'should contain two people');
   });
 
   test('Calling store.peekAll() after creating a record should return correct data', async function (assert) {
     assert.expect(1);
 
     store.createRecord('person', { name: 'Tomster' });
-    assert.equal(get(store.peekAll('person'), 'length'), 1, 'should contain one person');
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 1, 'should contain one person');
   });
 });

--- a/packages/-ember-data/tests/integration/polymorphic-belongs-to-test.js
+++ b/packages/-ember-data/tests/integration/polymorphic-belongs-to-test.js
@@ -63,7 +63,7 @@ module('integration/polymorphic-belongs-to - Polymorphic BelongsTo', function (h
 
     store.push(payload);
     let book = store.peekRecord('book', 1);
-    assert.equal(book.get('author.id'), 1);
+    assert.strictEqual(book.get('author.id'), '1');
 
     let payloadThatResetsBelongToRelationship = {
       data: {
@@ -125,7 +125,7 @@ module('integration/polymorphic-belongs-to - Polymorphic BelongsTo', function (h
     return book
       .get('author')
       .then((author) => {
-        assert.equal(author.get('id'), 1);
+        assert.strictEqual(author.get('id'), '1');
         store.push(payloadThatResetsBelongToRelationship);
         return book.get('author');
       })

--- a/packages/-ember-data/tests/integration/record-array-manager-test.js
+++ b/packages/-ember-data/tests/integration/record-array-manager-test.js
@@ -98,9 +98,9 @@ module('integration/record_array_manager', function (hooks) {
     let adapterPopulatedSummary = tap(adapterPopulated, 'willDestroy');
     let internalPersonModel = person._internalModel;
 
-    assert.equal(allSummary.called.length, 0, 'initial: no calls to all.willDestroy');
-    assert.equal(adapterPopulatedSummary.called.length, 0, 'initial: no calls to adapterPopulated.willDestroy');
-    assert.equal(
+    assert.strictEqual(allSummary.called.length, 0, 'initial: no calls to all.willDestroy');
+    assert.strictEqual(adapterPopulatedSummary.called.length, 0, 'initial: no calls to adapterPopulated.willDestroy');
+    assert.strictEqual(
       manager.getRecordArraysForIdentifier(internalPersonModel.identifier).size,
       1,
       'initial: expected the person to be a member of 1 recordArrays'
@@ -110,24 +110,24 @@ module('integration/record_array_manager', function (hooks) {
     all.destroy();
     await settled();
 
-    assert.equal(
+    assert.strictEqual(
       manager.getRecordArraysForIdentifier(internalPersonModel.identifier).size,
       0,
       'expected the person to be a member of no recordArrays'
     );
-    assert.equal(allSummary.called.length, 1, 'all.willDestroy called once');
+    assert.strictEqual(allSummary.called.length, 1, 'all.willDestroy called once');
     assert.false('person' in manager._liveRecordArrays, 'no longer have a live array for person');
 
     manager.destroy();
     await settled();
 
-    assert.equal(
+    assert.strictEqual(
       manager.getRecordArraysForIdentifier(internalPersonModel.identifier).size,
       0,
       'expected the person to be a member of no recordArrays'
     );
-    assert.equal(allSummary.called.length, 1, 'all.willDestroy still only called once');
-    assert.equal(adapterPopulatedSummary.called.length, 1, 'adapterPopulated.willDestroy called once');
+    assert.strictEqual(allSummary.called.length, 1, 'all.willDestroy still only called once');
+    assert.strictEqual(adapterPopulatedSummary.called.length, 1, 'adapterPopulated.willDestroy called once');
   });
 
   test('batch liveRecordArray changes', async function (assert) {
@@ -136,13 +136,13 @@ module('integration/record_array_manager', function (hooks) {
 
     cars.arrayContentWillChange = function (startIndex, removeCount, addedCount) {
       arrayContentWillChangeCount++;
-      assert.equal(startIndex, 0, 'expected 0 startIndex');
-      assert.equal(removeCount, 0, 'expected 0 removed');
-      assert.equal(addedCount, 2, 'expected 2 added');
+      assert.strictEqual(startIndex, 0, 'expected 0 startIndex');
+      assert.strictEqual(removeCount, 0, 'expected 0 removed');
+      assert.strictEqual(addedCount, 2, 'expected 2 added');
     };
 
     assert.deepEqual(cars.toArray(), []);
-    assert.equal(arrayContentWillChangeCount, 0, 'expected NO arrayChangeEvents yet');
+    assert.strictEqual(arrayContentWillChangeCount, 0, 'expected NO arrayChangeEvents yet');
 
     store.push({
       data: [
@@ -166,19 +166,19 @@ module('integration/record_array_manager', function (hooks) {
     });
     await settled();
 
-    assert.equal(arrayContentWillChangeCount, 1, 'expected ONE array change event');
+    assert.strictEqual(arrayContentWillChangeCount, 1, 'expected ONE array change event');
 
     assert.deepEqual(cars.toArray(), [store.peekRecord('car', 1), store.peekRecord('car', 2)]);
 
     store.peekRecord('car', 1).set('model', 'Mini');
 
-    assert.equal(arrayContentWillChangeCount, 1, 'expected ONE array change event');
+    assert.strictEqual(arrayContentWillChangeCount, 1, 'expected ONE array change event');
 
     cars.arrayContentWillChange = function (startIndex, removeCount, addedCount) {
       arrayContentWillChangeCount++;
-      assert.equal(startIndex, 2, 'expected a start index of TWO');
-      assert.equal(removeCount, 0, 'expected no removes');
-      assert.equal(addedCount, 1, 'expected ONE add');
+      assert.strictEqual(startIndex, 2, 'expected a start index of TWO');
+      assert.strictEqual(removeCount, 0, 'expected no removes');
+      assert.strictEqual(addedCount, 1, 'expected ONE add');
     };
 
     arrayContentWillChangeCount = 0;
@@ -197,7 +197,7 @@ module('integration/record_array_manager', function (hooks) {
     });
     await settled();
 
-    assert.equal(arrayContentWillChangeCount, 0, 'expected NO array change events');
+    assert.strictEqual(arrayContentWillChangeCount, 0, 'expected NO array change events');
 
     store.push({
       data: [
@@ -213,7 +213,7 @@ module('integration/record_array_manager', function (hooks) {
     });
     await settled();
 
-    assert.equal(arrayContentWillChangeCount, 1, 'expected ONE array change event');
+    assert.strictEqual(arrayContentWillChangeCount, 1, 'expected ONE array change event');
     // reset function so it doesn't execute after test finishes and store is torn down
     cars.arrayContentWillChange = function () {};
   });
@@ -237,15 +237,15 @@ module('integration/record_array_manager', function (hooks) {
     adapterPopulated.destroy();
     await settled();
 
-    assert.equal(manager._adapterPopulatedRecordArrays.length, 0);
+    assert.strictEqual(manager._adapterPopulatedRecordArrays.length, 0);
   });
 
   test('createRecordArray', function (assert) {
     let recordArray = manager.createRecordArray('foo');
 
-    assert.equal(recordArray.modelName, 'foo');
+    assert.strictEqual(recordArray.modelName, 'foo');
     assert.true(recordArray.isLoaded);
-    assert.equal(recordArray.manager, manager);
+    assert.strictEqual(recordArray.manager, manager);
     assert.deepEqual(recordArray.get('content'), []);
     assert.deepEqual(recordArray.toArray(), []);
   });
@@ -265,15 +265,15 @@ module('integration/record_array_manager', function (hooks) {
 
     let recordArray = manager.createRecordArray('foo', content);
 
-    assert.equal(recordArray.modelName, 'foo', 'has modelName');
+    assert.strictEqual(recordArray.modelName, 'foo', 'has modelName');
     assert.true(recordArray.isLoaded, 'isLoaded is true');
-    assert.equal(recordArray.manager, manager, 'recordArray has manager');
+    assert.strictEqual(recordArray.manager, manager, 'recordArray has manager');
     assert.deepEqual(recordArray.get('content'), [recordIdentifierFor(record)], 'recordArray has content');
     assert.deepEqual(recordArray.toArray(), [record], 'toArray works');
   });
 
   test('liveRecordArrayFor always return the same array for a given type', function (assert) {
-    assert.equal(manager.liveRecordArrayFor('foo'), manager.liveRecordArrayFor('foo'));
+    assert.strictEqual(manager.liveRecordArrayFor('foo'), manager.liveRecordArrayFor('foo'));
   });
 
   test('liveRecordArrayFor create with content', function (assert) {
@@ -284,9 +284,9 @@ module('integration/record_array_manager', function (hooks) {
 
     manager.createRecordArray = function (modelName, internalModels) {
       createRecordArrayCalled++;
-      assert.equal(modelName, 'car');
-      assert.equal(internalModels.length, 1);
-      assert.equal(internalModels[0].id, 1);
+      assert.strictEqual(modelName, 'car');
+      assert.strictEqual(internalModels.length, 1);
+      assert.strictEqual(internalModels[0].id, '1');
       return superCreateRecordArray.apply(this, arguments);
     };
 
@@ -301,10 +301,10 @@ module('integration/record_array_manager', function (hooks) {
       },
     });
 
-    assert.equal(createRecordArrayCalled, 0, 'no record array has been created yet');
+    assert.strictEqual(createRecordArrayCalled, 0, 'no record array has been created yet');
     manager.liveRecordArrayFor('car');
-    assert.equal(createRecordArrayCalled, 1, 'one record array is created');
+    assert.strictEqual(createRecordArrayCalled, 1, 'one record array is created');
     manager.liveRecordArrayFor('car');
-    assert.equal(createRecordArrayCalled, 1, 'no new record array is created');
+    assert.strictEqual(createRecordArrayCalled, 1, 'no new record array is created');
   });
 });

--- a/packages/-ember-data/tests/integration/record-array-test.js
+++ b/packages/-ember-data/tests/integration/record-array-test.js
@@ -119,7 +119,7 @@ module('unit/record-array - RecordArray', function (hooks) {
 
     await settled();
 
-    assert.equal(get(recordArray, 'lastObject.name'), 'wycats');
+    assert.strictEqual(get(recordArray, 'lastObject.name'), 'wycats');
 
     store.push({
       data: {
@@ -133,7 +133,7 @@ module('unit/record-array - RecordArray', function (hooks) {
 
     await settled();
 
-    assert.equal(get(recordArray, 'lastObject.name'), 'brohuda');
+    assert.strictEqual(get(recordArray, 'lastObject.name'), 'brohuda');
   });
 
   test('acts as a live query (normalized names)', async function (assert) {
@@ -194,7 +194,7 @@ module('unit/record-array - RecordArray', function (hooks) {
 
     await settled();
 
-    assert.equal(recordArray.get('length'), 0, 'Has no more records');
+    assert.strictEqual(recordArray.get('length'), 0, 'Has no more records');
     store.push({
       data: {
         type: 'person',
@@ -207,8 +207,8 @@ module('unit/record-array - RecordArray', function (hooks) {
 
     await settled();
 
-    assert.equal(recordArray.get('length'), 0, 'Has not been updated');
-    assert.equal(recordArray.get('content'), undefined, 'Has not been updated');
+    assert.strictEqual(recordArray.get('length'), 0, 'length has not been updated');
+    assert.strictEqual(recordArray.get('content'), null, 'content has not been updated');
   });
 
   test('a loaded record is removed from a record array when it is deleted', async function (assert) {
@@ -263,16 +263,16 @@ module('unit/record-array - RecordArray', function (hooks) {
     recordArray.addObject(scumbag);
 
     assert.ok(scumbag.get('tag') === tag, "precond - the scumbag's tag has been set");
-    assert.equal(get(recordArray, 'length'), 1, 'precond - record array has one item');
-    assert.equal(get(recordArray.objectAt(0), 'name'), 'Scumbag Dale', 'item at index 0 is record with id 1');
+    assert.strictEqual(get(recordArray, 'length'), 1, 'precond - record array has one item');
+    assert.strictEqual(get(recordArray.objectAt(0), 'name'), 'Scumbag Dale', 'item at index 0 is record with id 1');
 
     scumbag.deleteRecord();
 
-    assert.equal(get(recordArray, 'length'), 1, 'record is still in the record array until it is saved');
+    assert.strictEqual(get(recordArray, 'length'), 1, 'record is still in the record array until it is saved');
 
     await scumbag.save();
 
-    assert.equal(get(recordArray, 'length'), 0, 'record is removed from the array when it is saved');
+    assert.strictEqual(get(recordArray, 'length'), 0, 'record is removed from the array when it is saved');
   });
 
   test("a loaded record is not removed from a record array when it is deleted even if the belongsTo side isn't defined", async function (assert) {
@@ -325,8 +325,8 @@ module('unit/record-array - RecordArray', function (hooks) {
 
     scumbag.deleteRecord();
 
-    assert.equal(tag.get('people.length'), 1, 'record is not removed from the record array');
-    assert.equal(tag.get('people').objectAt(0), scumbag, 'tag still has the scumbag');
+    assert.strictEqual(tag.get('people.length'), 1, 'record is not removed from the record array');
+    assert.strictEqual(tag.get('people').objectAt(0), scumbag, 'tag still has the scumbag');
   });
 
   test("a loaded record is not removed from both the record array and from the belongs to, even if the belongsTo side isn't defined", async function (assert) {
@@ -373,13 +373,13 @@ module('unit/record-array - RecordArray', function (hooks) {
     let tag = store.peekRecord('tag', 1);
     let tool = store.peekRecord('tool', 1);
 
-    assert.equal(tag.get('people.length'), 1, 'record is in the record array');
-    assert.equal(tool.get('person'), scumbag, 'the tool belongs to the record');
+    assert.strictEqual(tag.get('people.length'), 1, 'record is in the record array');
+    assert.strictEqual(tool.get('person'), scumbag, 'the tool belongs to the record');
 
     scumbag.deleteRecord();
 
-    assert.equal(tag.get('people.length'), 1, 'record is stil in the record array');
-    assert.equal(tool.get('person'), scumbag, 'the tool still belongs to the record');
+    assert.strictEqual(tag.get('people.length'), 1, 'record is stil in the record array');
+    assert.strictEqual(tool.get('person'), scumbag, 'the tool still belongs to the record');
   });
 
   // GitHub Issue #168
@@ -390,7 +390,7 @@ module('unit/record-array - RecordArray', function (hooks) {
     });
 
     await settled();
-    assert.equal(get(recordArray, 'length'), 1, 'precond - record array already has the first created item');
+    assert.strictEqual(get(recordArray, 'length'), 1, 'precond - record array already has the first created item');
 
     store.createRecord('person', { name: 'p1' });
     store.createRecord('person', { name: 'p2' });
@@ -398,12 +398,12 @@ module('unit/record-array - RecordArray', function (hooks) {
 
     await settled();
 
-    assert.equal(get(recordArray, 'length'), 4, 'precond - record array has the created item');
-    assert.equal(recordArray.objectAt(0), scumbag, 'item at index 0 is record with id 1');
+    assert.strictEqual(get(recordArray, 'length'), 4, 'precond - record array has the created item');
+    assert.strictEqual(recordArray.objectAt(0), scumbag, 'item at index 0 is record with id 1');
 
     scumbag.deleteRecord();
 
-    assert.equal(get(recordArray, 'length'), 3, 'record array no longer has the created item');
+    assert.strictEqual(get(recordArray, 'length'), 3, 'record array no longer has the created item');
   });
 
   test("a record array returns undefined when asking for a member outside of its content Array's range", async function (assert) {
@@ -468,9 +468,9 @@ module('unit/record-array - RecordArray', function (hooks) {
 
     let recordArray = store.peekAll('person');
 
-    assert.equal(get(recordArray.objectAt(2), 'id'), '3', 'should retrieve correct record at index 2');
-    assert.equal(get(recordArray.objectAt(1), 'id'), '2', 'should retrieve correct record at index 1');
-    assert.equal(get(recordArray.objectAt(0), 'id'), '1', 'should retrieve correct record at index 0');
+    assert.strictEqual(get(recordArray.objectAt(2), 'id'), '3', 'should retrieve correct record at index 2');
+    assert.strictEqual(get(recordArray.objectAt(1), 'id'), '2', 'should retrieve correct record at index 1');
+    assert.strictEqual(get(recordArray.objectAt(0), 'id'), '1', 'should retrieve correct record at index 0');
   });
 
   test("an AdapterPopulatedRecordArray knows if it's loaded or not", async function (assert) {

--- a/packages/-ember-data/tests/integration/record-arrays/adapter-populated-record-array-test.js
+++ b/packages/-ember-data/tests/integration/record-arrays/adapter-populated-record-array-test.js
@@ -72,13 +72,13 @@ module('integration/record-arrays/adapter_populated_record_array - AdapterPopula
       payload
     );
 
-    assert.equal(recordArray.get('length'), 3, 'expected recordArray to contain exactly 3 records');
+    assert.strictEqual(recordArray.get('length'), 3, 'expected recordArray to contain exactly 3 records');
 
     recordArray.get('firstObject').destroyRecord();
 
     await settled();
 
-    assert.equal(recordArray.get('length'), 2, 'expected recordArray to contain exactly 2 records');
+    assert.strictEqual(recordArray.get('length'), 2, 'expected recordArray to contain exactly 2 records');
   });
 
   test('stores the metadata off the payload', async function (assert) {
@@ -119,7 +119,7 @@ module('integration/record-arrays/adapter_populated_record_array - AdapterPopula
       results.map((r) => recordIdentifierFor(r)),
       payload
     );
-    assert.equal(recordArray.get('meta.foo'), 'bar', 'expected meta.foo to be bar from payload');
+    assert.strictEqual(recordArray.get('meta.foo'), 'bar', 'expected meta.foo to be bar from payload');
   });
 
   test('stores the links off the payload', async function (assert) {
@@ -161,7 +161,7 @@ module('integration/record-arrays/adapter_populated_record_array - AdapterPopula
       payload
     );
 
-    assert.equal(
+    assert.strictEqual(
       recordArray.get('links.first'),
       '/foo?page=1',
       'expected links.first to be "/foo?page=1" from payload'
@@ -196,14 +196,14 @@ module('integration/record-arrays/adapter_populated_record_array - AdapterPopula
 
     adapter.query = function (store, type, query) {
       // Due to #6232, we now expect 5 arguments regardless of arity
-      assert.equal(arguments.length, 5, 'expect 5 arguments in query');
+      assert.strictEqual(arguments.length, 5, 'expect 5 arguments in query');
       return payload;
     };
 
     await store.query('person', {});
 
     adapter.query = function (store, type, query, recordArray) {
-      assert.equal(arguments.length, 5);
+      assert.strictEqual(arguments.length, 5);
       return payload;
     };
     store.query('person', {});
@@ -225,33 +225,33 @@ module('integration/record-arrays/adapter_populated_record_array - AdapterPopula
     let superCreateAdapterPopulatedRecordArray = store.recordArrayManager.createAdapterPopulatedRecordArray;
 
     store.recordArrayManager.createStore = function (modelName, query, internalModels, _payload) {
-      assert.equal(arguments.length === 4);
+      assert.strictEqual(arguments.length === 4);
 
-      assert.equal(modelName, 'person');
-      assert.equal(query, actualQuery);
-      assert.equal(_payload, payload);
-      assert.equal(internalModels.length, 2);
+      assert.strictEqual(modelName, 'person');
+      assert.strictEqual(query, actualQuery);
+      assert.strictEqual(_payload, payload);
+      assert.strictEqual(internalModels.length, 2);
       return superCreateAdapterPopulatedRecordArray.apply(this, arguments);
     };
 
     adapter.query = function (store, type, query) {
       // Due to #6232, we now expect 5 arguments regardless of arity
-      assert.equal(arguments.length, 5);
+      assert.strictEqual(arguments.length, 5);
       return payload;
     };
 
     await store.query('person', actualQuery);
 
     adapter.query = function (store, type, query, _recordArray) {
-      assert.equal(arguments.length, 5);
+      assert.strictEqual(arguments.length, 5);
       return payload;
     };
 
     store.recordArrayManager.createStore = function (modelName, query) {
-      assert.equal(arguments.length === 2);
+      assert.strictEqual(arguments.length === 2);
 
-      assert.equal(modelName, 'person');
-      assert.equal(query, actualQuery);
+      assert.strictEqual(modelName, 'person');
+      assert.strictEqual(query, actualQuery);
       return superCreateAdapterPopulatedRecordArray.apply(this, arguments);
     };
 
@@ -320,24 +320,24 @@ module('integration/record-arrays/adapter_populated_record_array - AdapterPopula
     queryArr = await store.query('person', { slice: 1 });
     findArray = await store.findAll('person');
 
-    assert.equal(queryArr.get('length'), 0, 'No records for this query');
+    assert.strictEqual(queryArr.get('length'), 0, 'No records for this query');
     assert.false(queryArr.get('isUpdating'), 'Record array isUpdating state updated');
-    assert.equal(findArray.get('length'), 1, 'All records are included in collection array');
+    assert.strictEqual(findArray.get('length'), 1, 'All records are included in collection array');
 
     // a new element gets pushed in record array
     array.push({ id: '2', type: 'person', attributes: { name: 'Scumbag Katz' } });
     await queryArr.update();
 
-    assert.equal(queryArr.get('length'), 1, 'The new record is returned and added in adapter populated array');
+    assert.strictEqual(queryArr.get('length'), 1, 'The new record is returned and added in adapter populated array');
     assert.false(queryArr.get('isUpdating'), 'Record array isUpdating state updated');
-    assert.equal(findArray.get('length'), 2, 'find returns 2 records');
+    assert.strictEqual(findArray.get('length'), 2, 'find returns 2 records');
 
     // element gets removed
     array.pop(0);
     await queryArr.update();
 
-    assert.equal(queryArr.get('length'), 0, 'Record removed from array');
+    assert.strictEqual(queryArr.get('length'), 0, 'Record removed from array');
     // record not removed from the model collection
-    assert.equal(findArray.get('length'), 2, 'Record still remains in collection array');
+    assert.strictEqual(findArray.get('length'), 2, 'Record still remains in collection array');
   });
 });

--- a/packages/-ember-data/tests/integration/record-arrays/peeked-records-test.js
+++ b/packages/-ember-data/tests/integration/record-arrays/peeked-records-test.js
@@ -214,11 +214,11 @@ module('integration/peeked-records', function (hooks) {
         'RecordArray state after unloadAll has not changed yet'
       );
 
-      assert.equal(get(peekedRecordArray, 'length'), 2, 'Array length is unchanged before the next peek');
+      assert.strictEqual(get(peekedRecordArray, 'length'), 2, 'Array length is unchanged before the next peek');
 
       store.peekAll('person');
 
-      assert.equal(get(peekedRecordArray, 'length'), 0, 'We no longer have any array content');
+      assert.strictEqual(get(peekedRecordArray, 'length'), 0, 'We no longer have any array content');
 
       assert.watchedPropertyCounts(
         watcher,
@@ -271,11 +271,11 @@ module('integration/peeked-records', function (hooks) {
     );
 
     unload();
-    assert.equal(get(peekedRecordArray, 'length'), 0, 'We no longer have any array content');
+    assert.strictEqual(get(peekedRecordArray, 'length'), 0, 'We no longer have any array content');
     assert.watchedPropertyCounts(watcher, { length: 2, '[]': 2 }, 'RecordArray state has signaled the unload');
 
     push();
-    assert.equal(get(peekedRecordArray, 'length'), 2, 'We have array content');
+    assert.strictEqual(get(peekedRecordArray, 'length'), 2, 'We have array content');
     assert.watchedPropertyCounts(watcher, { length: 3, '[]': 3 }, 'RecordArray state now has records again');
   });
 
@@ -320,11 +320,11 @@ module('integration/peeked-records', function (hooks) {
     );
 
     unload();
-    assert.equal(get(peekedRecordArray, 'length'), 0, 'We no longer have any array content');
+    assert.strictEqual(get(peekedRecordArray, 'length'), 0, 'We no longer have any array content');
     assert.watchedPropertyCounts(watcher, { length: 2, '[]': 2 }, 'RecordArray state has signaled the unload');
 
     _push();
-    assert.equal(get(peekedRecordArray, 'length'), 2, 'We have array content');
+    assert.strictEqual(get(peekedRecordArray, 'length'), 2, 'We have array content');
     assert.watchedPropertyCounts(watcher, { length: 3, '[]': 3 }, 'RecordArray state now has records again');
   });
 });

--- a/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
@@ -144,8 +144,8 @@ module('integration/record-data - Custom RecordData Errors', function (hooks) {
 
     class LifecycleRecordData extends TestRecordData {
       commitWasRejected(recordIdentifier, errors) {
-        assert.equal(errors[0].detail, 'is a generally unsavoury character', 'received the error');
-        assert.equal(errors[0].source.pointer, '/data/attributes/name', 'pointer is correct');
+        assert.strictEqual(errors[0].detail, 'is a generally unsavoury character', 'received the error');
+        assert.strictEqual(errors[0].source.pointer, '/data/attributes/name', 'pointer is correct');
       }
     }
 
@@ -203,7 +203,7 @@ module('integration/record-data - Custom RecordData Errors', function (hooks) {
 
     class LifecycleRecordData extends TestRecordData {
       commitWasRejected(recordIdentifier, errors) {
-        assert.equal(errors, undefined, 'Did not pass adapter errors');
+        assert.strictEqual(errors, undefined, 'Did not pass adapter errors');
       }
     }
 
@@ -281,12 +281,12 @@ module('integration/record-data - Custom RecordData Errors', function (hooks) {
     });
     let person = store.peekRecord('person', '1');
     let nameError = person.get('errors').errorsFor('name').get('firstObject');
-    assert.equal(nameError.attribute, 'name', 'error shows up on name');
+    assert.strictEqual(nameError.attribute, 'name', 'error shows up on name');
     assert.false(person.get('isValid'), 'person is not valid');
     errorsToReturn = [];
     storeWrapper.notifyErrorsChange('person', '1');
     assert.true(person.get('isValid'), 'person is valid');
-    assert.equal(person.get('errors').errorsFor('name').length, 0, 'no errors on name');
+    assert.strictEqual(person.get('errors').errorsFor('name').length, 0, 'no errors on name');
     errorsToReturn = [
       {
         title: 'Invalid Attribute',
@@ -298,9 +298,9 @@ module('integration/record-data - Custom RecordData Errors', function (hooks) {
     ];
     storeWrapper.notifyErrorsChange('person', '1');
     assert.false(person.get('isValid'), 'person is valid');
-    assert.equal(person.get('errors').errorsFor('name').length, 0, 'no errors on name');
+    assert.strictEqual(person.get('errors').errorsFor('name').length, 0, 'no errors on name');
     let lastNameError = person.get('errors').errorsFor('lastName').get('firstObject');
-    assert.equal(lastNameError.attribute, 'lastName', 'error shows up on lastName');
+    assert.strictEqual(lastNameError.attribute, 'lastName', 'error shows up on lastName');
   });
 
   test('Record data which does not implement getErrors still works correctly with the default DS.Model', async function (assert) {
@@ -317,8 +317,8 @@ module('integration/record-data - Custom RecordData Errors', function (hooks) {
 
     class LifecycleRecordData extends TestRecordData {
       commitWasRejected(recordIdentifier, errors) {
-        assert.equal(errors[0].detail, 'is a generally unsavoury character', 'received the error');
-        assert.equal(errors[0].source.pointer, '/data/attributes/name', 'pointer is correct');
+        assert.strictEqual(errors[0].detail, 'is a generally unsavoury character', 'received the error');
+        assert.strictEqual(errors[0].source.pointer, '/data/attributes/name', 'pointer is correct');
       }
     }
 
@@ -364,6 +364,6 @@ module('integration/record-data - Custom RecordData Errors', function (hooks) {
 
     assert.false(person.get('isValid'), 'rejecting the save invalidates the person');
     let nameError = person.get('errors').errorsFor('name').get('firstObject');
-    assert.equal(nameError.attribute, 'name', 'error shows up on name');
+    assert.strictEqual(nameError.attribute, 'name', 'error shows up on name');
   });
 });

--- a/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
@@ -286,11 +286,11 @@ module('integration/record-data - Record Data State', function (hooks) {
     assert.false(person.get('isDeleted'), 'calling deleteRecord does not automatically set isDeleted flag to true');
     assert.true(calledSetIsDeleted, 'called setIsDeleted');
 
-    assert.equal(people.get('length'), 1, 'live array starting length is 1');
+    assert.strictEqual(people.get('length'), 1, 'live array starting length is 1');
     isDeletionCommitted = true;
     Ember.run(() => {
       storeWrapper.notifyStateChange('person', '1', null, 'isDeletionCommitted');
     });
-    assert.equal(people.get('length'), 0, 'commiting a deletion updates the live array');
+    assert.strictEqual(people.get('length'), 0, 'commiting a deletion updates the live array');
   });
 });

--- a/packages/-ember-data/tests/integration/record-data/record-data-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-test.ts
@@ -168,7 +168,7 @@ module('integration/record-data - Custom RecordData Implementations', function (
     });
 
     let all = store.peekAll('person');
-    assert.equal(get(all, 'length'), 2);
+    assert.strictEqual(get(all, 'length'), 2);
 
     store.push({
       data: [
@@ -184,7 +184,7 @@ module('integration/record-data - Custom RecordData Implementations', function (
 
     await settled();
 
-    assert.equal(get(all, 'length'), 3);
+    assert.strictEqual(get(all, 'length'), 3);
   });
 
   test('Record Data push, create and save lifecycle', async function (assert) {
@@ -272,30 +272,30 @@ module('integration/record-data - Custom RecordData Implementations', function (
     store.push({
       data: [personHash],
     });
-    assert.equal(calledPush, 1, 'Called pushData');
+    assert.strictEqual(calledPush, 1, 'Called pushData');
 
     let person = store.peekRecord('person', '1');
     person.save();
-    assert.equal(calledWillCommit, 1, 'Called willCommit');
+    assert.strictEqual(calledWillCommit, 1, 'Called willCommit');
 
     await settled();
-    assert.equal(calledDidCommit, 1, 'Called didCommit');
+    assert.strictEqual(calledDidCommit, 1, 'Called didCommit');
 
     person.save();
-    assert.equal(calledWillCommit, 2, 'Called willCommit');
+    assert.strictEqual(calledWillCommit, 2, 'Called willCommit');
 
     await settled();
-    assert.equal(calledDidCommit, 1, 'Did not call didCommit again');
-    assert.equal(calledWasRejected, 1, 'Called commitWasRejected');
+    assert.strictEqual(calledDidCommit, 1, 'Did not call didCommit again');
+    assert.strictEqual(calledWasRejected, 1, 'Called commitWasRejected');
 
     person.rollbackAttributes();
-    assert.equal(calledRollbackAttributes, 1, 'Called rollbackAttributes');
+    assert.strictEqual(calledRollbackAttributes, 1, 'Called rollbackAttributes');
 
     person.unloadRecord();
-    assert.equal(calledUnloadRecord, 1, 'Called unloadRecord');
+    assert.strictEqual(calledUnloadRecord, 1, 'Called unloadRecord');
 
     await settled();
-    assert.equal(calledClientDidCreate, 0, 'Did not called clientDidCreate');
+    assert.strictEqual(calledClientDidCreate, 0, 'Did not called clientDidCreate');
 
     calledPush = 0;
     calledClientDidCreate = 0;
@@ -306,26 +306,26 @@ module('integration/record-data - Custom RecordData Implementations', function (
     calledDidCommit = 0;
 
     let clientPerson = store.createRecord('person', { id: 2 });
-    assert.equal(calledClientDidCreate, 1, 'Called clientDidCreate');
+    assert.strictEqual(calledClientDidCreate, 1, 'Called clientDidCreate');
 
     clientPerson.save();
-    assert.equal(calledWillCommit, 1, 'Called willCommit');
+    assert.strictEqual(calledWillCommit, 1, 'Called willCommit');
 
     await settled();
-    assert.equal(calledDidCommit, 1, 'Called didCommit');
+    assert.strictEqual(calledDidCommit, 1, 'Called didCommit');
 
     clientPerson.save();
-    assert.equal(calledWillCommit, 2, 'Called willCommit');
+    assert.strictEqual(calledWillCommit, 2, 'Called willCommit');
 
     await settled();
-    assert.equal(calledWasRejected, 1, 'Called commitWasRejected');
-    assert.equal(calledDidCommit, 1, 'Did not call didCommit again');
+    assert.strictEqual(calledWasRejected, 1, 'Called commitWasRejected');
+    assert.strictEqual(calledDidCommit, 1, 'Did not call didCommit again');
 
     clientPerson.unloadRecord();
-    assert.equal(calledUnloadRecord, 1, 'Called unloadRecord');
+    assert.strictEqual(calledUnloadRecord, 1, 'Called unloadRecord');
 
     await settled();
-    assert.equal(calledPush, 0, 'Did not call pushData');
+    assert.strictEqual(calledPush, 0, 'Did not call pushData');
   });
 
   test('Record Data attribute settting', async function (assert) {
@@ -352,18 +352,18 @@ module('integration/record-data - Custom RecordData Implementations', function (
       }
 
       setDirtyAttribute(key: string, value: any) {
-        assert.equal(key, 'name', 'key passed to setDirtyAttribute');
-        assert.equal(value, 'new value', 'value passed to setDirtyAttribute');
+        assert.strictEqual(key, 'name', 'key passed to setDirtyAttribute');
+        assert.strictEqual(value, 'new value', 'value passed to setDirtyAttribute');
       }
 
       getAttr(key: string): string {
         calledGet++;
-        assert.equal(key, 'name', 'key passed to getAttr');
+        assert.strictEqual(key, 'name', 'key passed to getAttr');
         return 'new attribute';
       }
 
       hasAttr(key: string): boolean {
-        assert.equal(key, 'name', 'key passed to hasAttr');
+        assert.strictEqual(key, 'name', 'key passed to hasAttr');
         return true;
       }
 
@@ -387,15 +387,15 @@ module('integration/record-data - Custom RecordData Implementations', function (
     });
 
     let person = store.peekRecord('person', '1');
-    assert.equal(person.get('name'), 'new attribute');
-    assert.equal(calledGet, 1, 'called getAttr for initial get');
+    assert.strictEqual(person.get('name'), 'new attribute');
+    assert.strictEqual(calledGet, 1, 'called getAttr for initial get');
     person.set('name', 'new value');
-    assert.equal(calledGet, 2, 'called getAttr during set');
-    assert.equal(person.get('name'), 'new value');
-    assert.equal(calledGet, 2, 'did not call getAttr after set');
+    assert.strictEqual(calledGet, 2, 'called getAttr during set');
+    assert.strictEqual(person.get('name'), 'new value');
+    assert.strictEqual(calledGet, 2, 'did not call getAttr after set');
     person.notifyPropertyChange('name');
-    assert.equal(person.get('name'), 'new attribute');
-    assert.equal(calledGet, 3, 'called getAttr after notifyPropertyChange');
+    assert.strictEqual(person.get('name'), 'new attribute');
+    assert.strictEqual(calledGet, 3, 'called getAttr after notifyPropertyChange');
     assert.deepEqual(
       person.changedAttributes(),
       { name: ['old', 'new'] },
@@ -416,14 +416,14 @@ module('integration/record-data - Custom RecordData Implementations', function (
       }
 
       getBelongsTo(key: string) {
-        assert.equal(key, 'landlord', 'Passed correct key to getBelongsTo');
+        assert.strictEqual(key, 'landlord', 'Passed correct key to getBelongsTo');
         return belongsToReturnValue;
       }
 
       // Use correct interface once imports have been fix
       setDirtyBelongsTo(key: string, recordData: any) {
-        assert.equal(key, 'landlord', 'Passed correct key to setBelongsTo');
-        assert.equal(recordData.id, '2', 'Passed correct RD to setBelongsTo');
+        assert.strictEqual(key, 'landlord', 'Passed correct key to setBelongsTo');
+        assert.strictEqual(recordData.id, '2', 'Passed correct RD to setBelongsTo');
       }
     }
 
@@ -451,10 +451,10 @@ module('integration/record-data - Custom RecordData Implementations', function (
 
     let house = store.peekRecord('house', '1');
     let runspired = store.peekRecord('person', '2');
-    assert.equal(house.get('landlord.name'), 'David', 'belongsTo get correctly looked up');
+    assert.strictEqual(house.get('landlord.name'), 'David', 'belongsTo get correctly looked up');
 
     house.set('landlord', runspired);
-    assert.equal(house.get('landlord.name'), 'David', 'belongsTo does not change if RD did not notify');
+    assert.strictEqual(house.get('landlord.name'), 'David', 'belongsTo does not change if RD did not notify');
   });
 
   test('Record Data custom belongsTo', async function (assert) {
@@ -470,7 +470,7 @@ module('integration/record-data - Custom RecordData Implementations', function (
       }
 
       getBelongsTo(key: string) {
-        assert.equal(key, 'landlord', 'Passed correct key to getBelongsTo');
+        assert.strictEqual(key, 'landlord', 'Passed correct key to getBelongsTo');
         return belongsToReturnValue;
       }
 
@@ -503,13 +503,13 @@ module('integration/record-data - Custom RecordData Implementations', function (
     });
 
     let house = store.peekRecord('house', '1');
-    assert.equal(house.get('landlord.name'), 'David', 'belongsTo get correctly looked up');
+    assert.strictEqual(house.get('landlord.name'), 'David', 'belongsTo get correctly looked up');
 
     let runspired = store.peekRecord('person', '2');
     house.set('landlord', runspired);
 
     // This is intentionally !== runspired to test the custom RD implementation
-    assert.equal(house.get('landlord.name'), 'Igor', 'RecordData sets the custom belongsTo value');
+    assert.strictEqual(house.get('landlord.name'), 'Igor', 'RecordData sets the custom belongsTo value');
   });
 
   test('Record Data controls hasMany notifications', async function (assert) {
@@ -538,8 +538,8 @@ module('integration/record-data - Custom RecordData Implementations', function (
         if (calledAddToHasMany === 1) {
           return;
         }
-        assert.equal(key, 'tenants', 'Passed correct key to addToHasMany');
-        assert.equal(recordDatas[0].id, '2', 'Passed correct RD to addToHasMany');
+        assert.strictEqual(key, 'tenants', 'Passed correct key to addToHasMany');
+        assert.strictEqual(recordDatas[0].id, '2', 'Passed correct RD to addToHasMany');
         calledAddToHasMany++;
       }
 
@@ -548,14 +548,14 @@ module('integration/record-data - Custom RecordData Implementations', function (
         if (calledRemoveFromHasMany === 1) {
           return;
         }
-        assert.equal(key, 'tenants', 'Passed correct key to removeFromHasMany');
-        assert.equal(recordDatas[0].id, '1', 'Passed correct RD to removeFromHasMany');
+        assert.strictEqual(key, 'tenants', 'Passed correct key to removeFromHasMany');
+        assert.strictEqual(recordDatas[0].id, '1', 'Passed correct RD to removeFromHasMany');
         calledRemoveFromHasMany++;
       }
 
       setDirtyHasMany(key: string, recordDatas: any[]) {
-        assert.equal(key, 'tenants', 'Passed correct key to addToHasMany');
-        assert.equal(recordDatas[0].id, '3', 'Passed correct RD to addToHasMany');
+        assert.strictEqual(key, 'tenants', 'Passed correct key to addToHasMany');
+        assert.strictEqual(recordDatas[0].id, '3', 'Passed correct RD to addToHasMany');
       }
     }
 
@@ -623,8 +623,8 @@ module('integration/record-data - Custom RecordData Implementations', function (
         if (calledAddToHasMany === 1) {
           return;
         }
-        assert.equal(key, 'tenants', 'Passed correct key to addToHasMany');
-        assert.equal(recordDatas[0].id, '2', 'Passed correct RD to addToHasMany');
+        assert.strictEqual(key, 'tenants', 'Passed correct key to addToHasMany');
+        assert.strictEqual(recordDatas[0].id, '2', 'Passed correct RD to addToHasMany');
         calledAddToHasMany++;
 
         hasManyReturnValue = {
@@ -641,16 +641,16 @@ module('integration/record-data - Custom RecordData Implementations', function (
         if (calledRemoveFromHasMany === 1) {
           return;
         }
-        assert.equal(key, 'tenants', 'Passed correct key to removeFromHasMany');
-        assert.equal(recordDatas[0].id, '2', 'Passed correct RD to removeFromHasMany');
+        assert.strictEqual(key, 'tenants', 'Passed correct key to removeFromHasMany');
+        assert.strictEqual(recordDatas[0].id, '2', 'Passed correct RD to removeFromHasMany');
         calledRemoveFromHasMany++;
         hasManyReturnValue = { data: [{ id: '1', type: 'person' }] };
         this._storeWrapper.notifyHasManyChange('house', '1', null, 'tenants');
       }
 
       setDirtyHasMany(key: string, recordDatas: any[]) {
-        assert.equal(key, 'tenants', 'Passed correct key to addToHasMany');
-        assert.equal(recordDatas[0].id, '3', 'Passed correct RD to addToHasMany');
+        assert.strictEqual(key, 'tenants', 'Passed correct key to addToHasMany');
+        assert.strictEqual(recordDatas[0].id, '3', 'Passed correct RD to addToHasMany');
         hasManyReturnValue = {
           data: [
             { id: '1', type: 'person' },

--- a/packages/-ember-data/tests/integration/record-data/store-wrapper-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/store-wrapper-test.ts
@@ -189,8 +189,12 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
         // Retrive only public values from the result
         // This should go away once we put private things in symbols/weakmaps
         assert.deepEqual(houseRelationships, result, 'can lookup relationship definitions');
-        assert.equal(storeWrapper.inverseForRelationship('house', 'car'), 'garage', 'can lookup inverses on self');
-        assert.equal(
+        assert.strictEqual(
+          storeWrapper.inverseForRelationship('house', 'car'),
+          'garage',
+          'can lookup inverses on self'
+        );
+        assert.strictEqual(
           storeWrapper.inverseForRelationship('car', 'garage'),
           'car',
           'can lookup inverses on other models'
@@ -235,14 +239,14 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
         this.id = id;
 
         if (count === 1) {
-          assert.equal(
+          assert.strictEqual(
             storeWrapper.recordDataFor('house', 2).id,
-            2,
+            '2',
             'Can lookup another RecordData that has been loaded'
           );
-          assert.equal(
+          assert.strictEqual(
             storeWrapper.recordDataFor('person', 1).id,
-            1,
+            '1',
             'Can lookup another RecordData which hasnt been loaded'
           );
         }
@@ -266,7 +270,7 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
       data: [houseHash, houseHash2],
     });
 
-    assert.equal(count, 2, 'two TestRecordDatas have been created');
+    assert.strictEqual(count, 2, 'two TestRecordDatas have been created');
   });
 
   test('recordDataFor - create new', async function (assert) {
@@ -326,7 +330,7 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
       'The internalModel for a RecordData created via Wrapper.recordDataFor(type) is in the "new" state'
     );
 
-    assert.equal(count, 2, 'two TestRecordDatas have been created');
+    assert.strictEqual(count, 2, 'two TestRecordDatas have been created');
   });
 
   test('setRecordId', async function (assert) {
@@ -358,8 +362,8 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
 
     let house = store.createRecord('house');
     // TODO there is a bug when setting id while creating the Record instance, preventing the id property lookup to work
-    // assert.equal(house.get('id'), '17', 'setRecordId correctly set the id');
-    assert.equal(
+    // assert.strictEqual(house.get('id'), '17', 'setRecordId correctly set the id');
+    assert.strictEqual(
       store.peekRecord('house', 17),
       house,
       'can lookup the record from the identify map based on the new id'
@@ -376,7 +380,7 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
         if (!id) {
           assert.true(storeWrapper.isRecordInUse('house', '1'), 'house 1 is in use');
           // TODO isRecordInUse should coorce to false rather than null
-          assert.equal(storeWrapper.isRecordInUse('house', '2'), null, 'house 2 is not in use');
+          assert.strictEqual(storeWrapper.isRecordInUse('house', '2'), null, 'house 2 is not in use');
         }
       }
     }

--- a/packages/-ember-data/tests/integration/record-data/unloading-record-data-test.js
+++ b/packages/-ember-data/tests/integration/record-data/unloading-record-data-test.js
@@ -152,7 +152,7 @@ module('RecordData Compatibility', function (hooks) {
     let pets = chris.get('pets');
     let shen = pets.objectAt(0);
 
-    assert.equal(shen.get('name'), 'Shen', 'We found Shen');
+    assert.strictEqual(shen.get('name'), 'Shen', 'We found Shen');
     assert.ok(recordDataFor(chris) instanceof RecordData, 'We used the default record-data for person');
     assert.ok(recordDataFor(shen) instanceof CustomRecordData, 'We used the custom record-data for pets');
 
@@ -210,7 +210,7 @@ module('RecordData Compatibility', function (hooks) {
     let pets = chris.get('pets');
     let shen = pets.objectAt(0);
 
-    assert.equal(shen.get('name'), 'Shen', 'We found Shen');
+    assert.strictEqual(shen.get('name'), 'Shen', 'We found Shen');
 
     try {
       run(() => shen.unloadRecord());
@@ -240,7 +240,11 @@ module('RecordData Compatibility', function (hooks) {
         }
 
         findRecord() {
-          assert.equal(recordDataInstances, 0, 'no instance created from findRecord before adapter promise resolves');
+          assert.strictEqual(
+            recordDataInstances,
+            0,
+            'no instance created from findRecord before adapter promise resolves'
+          );
 
           return resolve({
             data: {
@@ -267,10 +271,10 @@ module('RecordData Compatibility', function (hooks) {
       }
     );
 
-    assert.equal(recordDataInstances, 0, 'initially no instances');
+    assert.strictEqual(recordDataInstances, 0, 'initially no instances');
 
     await store.findRecord('pet', '1');
 
-    assert.equal(recordDataInstances, 1, 'record data created after promise fulfills');
+    assert.strictEqual(recordDataInstances, 1, 'record data created after promise fulfills');
   });
 });

--- a/packages/-ember-data/tests/integration/records/collection-save-test.js
+++ b/packages/-ember-data/tests/integration/records/collection-save-test.js
@@ -97,7 +97,7 @@ module('integration/records/collection_save - Save Collection of Records', funct
         .then((post) => {
           // the ID here is '2' because the second post saves on the first attempt,
           // while the first post saves on the second attempt
-          assert.equal(posts.get('firstObject.id'), '2', 'The post ID made it through');
+          assert.strictEqual(posts.get('firstObject.id'), '2', 'The post ID made it through');
         });
     });
   });

--- a/packages/-ember-data/tests/integration/records/delete-record-test.js
+++ b/packages/-ember-data/tests/integration/records/delete-record-test.js
@@ -58,15 +58,15 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
     let all = store.peekAll('person');
 
     // pre-condition
-    assert.equal(all.get('length'), 2, 'pre-condition: 2 records in array');
+    assert.strictEqual(all.get('length'), 2, 'pre-condition: 2 records in array');
 
     run(adam, 'deleteRecord');
 
-    assert.equal(all.get('length'), 2, '2 records in array after deleteRecord');
+    assert.strictEqual(all.get('length'), 2, '2 records in array after deleteRecord');
 
     run(adam, 'save');
 
-    assert.equal(all.get('length'), 1, '1 record in array after deleteRecord and save');
+    assert.strictEqual(all.get('length'), 1, '1 record in array after deleteRecord and save');
   });
 
   test('deleting a record that is part of a hasMany removes it from the hasMany recordArray', async function (assert) {
@@ -121,12 +121,12 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
     let person = store.peekRecord('person', '1');
 
     // Sanity Check we are in the correct state.
-    assert.equal(group.get('people.length'), 2, 'expected 2 related records before delete');
-    assert.equal(person.get('name'), 'Adam Sunderland', 'expected related records to be loaded');
+    assert.strictEqual(group.get('people.length'), 2, 'expected 2 related records before delete');
+    assert.strictEqual(person.get('name'), 'Adam Sunderland', 'expected related records to be loaded');
 
     await person.destroyRecord();
 
-    assert.equal(group.get('people.length'), 1, 'expected 1 related records after delete');
+    assert.strictEqual(group.get('people.length'), 1, 'expected 1 related records after delete');
   });
 
   test('records can be deleted during record array enumeration', async function (assert) {
@@ -160,7 +160,7 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
     var all = store.peekAll('person');
 
     // pre-condition
-    assert.equal(all.get('length'), 2, 'expected 2 records');
+    assert.strictEqual(all.get('length'), 2, 'expected 2 records');
 
     run(function () {
       all.forEach(function (record) {
@@ -168,8 +168,8 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
       });
     });
 
-    assert.equal(all.get('length'), 0, 'expected 0 records');
-    assert.equal(all.objectAt(0), null, "can't get any records");
+    assert.strictEqual(all.get('length'), 0, 'expected 0 records');
+    assert.strictEqual(all.objectAt(0), undefined, "can't get any records");
   });
 
   test('Deleting an invalid newly created record should remove it from the store', async function (assert) {
@@ -195,19 +195,19 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
     await record.save().catch(() => {});
 
     // Preconditions
-    assert.equal(
+    assert.strictEqual(
       record.currentState.stateName,
       'root.loaded.created.invalid',
       'records should start in the created.invalid state'
     );
-    assert.equal(get(store.peekAll('person'), 'length'), 1, 'The new person should be in the store');
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 1, 'The new person should be in the store');
 
     let internalModel = record._internalModel;
 
     record.deleteRecord();
 
-    assert.equal(internalModel.currentState.stateName, 'root.empty', 'new person state is empty');
-    assert.equal(get(store.peekAll('person'), 'length'), 0, 'The new person should be removed from the store');
+    assert.strictEqual(internalModel.currentState.stateName, 'root.empty', 'new person state is empty');
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 0, 'The new person should be removed from the store');
   });
 
   test('Destroying an invalid newly created record should remove it from the store', async function (assert) {
@@ -237,19 +237,19 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
     await record.save().catch(() => {});
 
     // Preconditions
-    assert.equal(
+    assert.strictEqual(
       get(record, 'currentState.stateName'),
       'root.loaded.created.invalid',
       'records should start in the created.invalid state'
     );
-    assert.equal(get(store.peekAll('person'), 'length'), 1, 'The new person should be in the store');
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 1, 'The new person should be in the store');
 
     let internalModel = record._internalModel;
 
     await record.destroyRecord();
 
-    assert.equal(internalModel.currentState.stateName, 'root.empty', 'new person state is empty');
-    assert.equal(get(store.peekAll('person'), 'length'), 0, 'The new person should be removed from the store');
+    assert.strictEqual(internalModel.currentState.stateName, 'root.empty', 'new person state is empty');
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 0, 'The new person should be removed from the store');
   });
 
   test('Will resolve destroy and save in same loop', async function (assert) {
@@ -297,7 +297,7 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
 
     let record = store.createRecord('person', { name: 'pablobm' });
 
-    assert.equal(get(store.peekAll('person'), 'length'), 1, 'The new person should be in the store');
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 1, 'The new person should be in the store');
 
     let internalModel = record._internalModel;
 
@@ -305,8 +305,12 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
 
     // it is uncertain that `root.empty` vs `root.deleted.saved` afterwards is correct
     //   but this is the expected result of `unloadRecord`. We may want a `root.deleted.saved.unloaded` state?
-    assert.equal(internalModel.currentState.stateName, 'root.empty', 'We reached the correct persisted saved state');
-    assert.equal(get(store.peekAll('person'), 'length'), 0, 'The new person should be removed from the store');
+    assert.strictEqual(
+      internalModel.currentState.stateName,
+      'root.empty',
+      'We reached the correct persisted saved state'
+    );
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 0, 'The new person should be removed from the store');
 
     // let cache = store._identityMap._map.person._models;
 
@@ -332,7 +336,7 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
 
     let record = store.createRecord('person', { name: 'pablobm' });
 
-    assert.equal(get(store.peekAll('person'), 'length'), 1, 'The new person should be in the store');
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 1, 'The new person should be in the store');
 
     let internalModel = record._internalModel;
 
@@ -341,8 +345,12 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
 
     // it is uncertain that `root.empty` vs `root.deleted.saved` afterwards is correct
     //   but this is the expected result of `unloadRecord`. We may want a `root.deleted.saved.unloaded` state?
-    assert.equal(internalModel.currentState.stateName, 'root.empty', 'We reached the correct persisted saved state');
-    assert.equal(get(store.peekAll('person'), 'length'), 0, 'The new person should be removed from the store');
+    assert.strictEqual(
+      internalModel.currentState.stateName,
+      'root.empty',
+      'We reached the correct persisted saved state'
+    );
+    assert.strictEqual(get(store.peekAll('person'), 'length'), 0, 'The new person should be removed from the store');
 
     // let cache = store._identityMap._map.person._models;
 
@@ -435,22 +443,22 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
 
     // Sanity Check
     assert.ok(group, 'expected group to be found');
-    assert.equal(group.get('company.name'), 'Inc.', 'group belongs to our company');
-    assert.equal(group.get('employees.length'), 1, 'expected 1 related record before delete');
+    assert.strictEqual(group.get('company.name'), 'Inc.', 'group belongs to our company');
+    assert.strictEqual(group.get('employees.length'), 1, 'expected 1 related record before delete');
     employee = group.get('employees').objectAt(0);
-    assert.equal(employee.get('name'), 'Adam Sunderland', 'expected related records to be loaded');
+    assert.strictEqual(employee.get('name'), 'Adam Sunderland', 'expected related records to be loaded');
 
     await group.destroyRecord();
     await employee.destroyRecord();
 
-    assert.equal(store.peekAll('employee').get('length'), 0, 'no employee record loaded');
-    assert.equal(store.peekAll('group').get('length'), 0, 'no group record loaded');
+    assert.strictEqual(store.peekAll('employee').get('length'), 0, 'no employee record loaded');
+    assert.strictEqual(store.peekAll('group').get('length'), 0, 'no group record loaded');
 
     // Server pushes the same group and employee once more after they have been destroyed client-side. (The company is a long-lived record)
     store.push(jsonEmployee);
     store.push(jsonGroup);
 
     group = store.peekRecord('group', '1');
-    assert.equal(group.get('employees.length'), 1, 'expected 1 related record after delete and restore');
+    assert.strictEqual(group.get('employees.length'), 1, 'expected 1 related record after delete and restore');
   });
 });

--- a/packages/-ember-data/tests/integration/records/error-test.js
+++ b/packages/-ember-data/tests/integration/records/error-test.js
@@ -42,7 +42,7 @@ module('integration/records/error', function (hooks) {
       lastName: null,
     });
 
-    assert.equal(
+    assert.strictEqual(
       person._internalModel.currentState.stateName,
       'root.loaded.updated.uncommitted',
       'Model state is root.loaded.updated.uncommitted'
@@ -50,7 +50,7 @@ module('integration/records/error', function (hooks) {
 
     person.errors.add('firstName', 'is invalid');
 
-    assert.equal(
+    assert.strictEqual(
       person._internalModel.currentState.stateName,
       'root.loaded.updated.invalid',
       'Model state is updated to root.loaded.updated.invalid after an error is manually added'
@@ -91,7 +91,7 @@ module('integration/records/error', function (hooks) {
       lastName: null,
     });
 
-    assert.equal(
+    assert.strictEqual(
       person._internalModel.currentState.stateName,
       'root.loaded.created.uncommitted',
       'Model state is root.loaded.updated.uncommitted'
@@ -99,7 +99,7 @@ module('integration/records/error', function (hooks) {
 
     person.errors.add('firstName', 'is invalid');
 
-    assert.equal(
+    assert.strictEqual(
       person._internalModel.currentState.stateName,
       'root.loaded.created.invalid',
       'Model state is updated to root.loaded.updated.invalid after an error is manually added'
@@ -136,11 +136,11 @@ module('integration/records/error', function (hooks) {
 
     person.set('firstName', null);
 
-    assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.uncommitted');
+    assert.strictEqual(person._internalModel.currentState.stateName, 'root.loaded.created.uncommitted');
 
     person.errors.add('firstName', 'is invalid');
 
-    assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.invalid');
+    assert.strictEqual(person._internalModel.currentState.stateName, 'root.loaded.created.invalid');
 
     person.errors.remove('firstName');
 
@@ -170,16 +170,16 @@ module('integration/records/error', function (hooks) {
 
     person.set('firstName', null);
 
-    assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.uncommitted');
+    assert.strictEqual(person._internalModel.currentState.stateName, 'root.loaded.created.uncommitted');
 
     person.errors.add('firstName', 'is invalid');
 
-    assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.invalid');
+    assert.strictEqual(person._internalModel.currentState.stateName, 'root.loaded.created.invalid');
 
     person.errors.remove('firstName');
     person.errors.add('firstName', 'is invalid');
 
-    assert.equal(person._internalModel.currentState.stateName, 'root.loaded.created.invalid');
+    assert.strictEqual(person._internalModel.currentState.stateName, 'root.loaded.created.invalid');
 
     assert.deepEqual(person.errors.toArray(), [{ attribute: 'firstName', message: 'is invalid' }]);
   });
@@ -221,7 +221,7 @@ module('integration/records/error', function (hooks) {
     } catch (_error) {
       let errors = person.errors;
 
-      assert.equal(errors.length, 2, 'Adds two errors to the model');
+      assert.strictEqual(errors.length, 2, 'Adds two errors to the model');
       assert.true(errors.has('firstName'), 'firstName is included in the errors object');
       assert.true(errors.has('lastName'), 'lastName is included in the errors object');
 
@@ -230,7 +230,7 @@ module('integration/records/error', function (hooks) {
         lastName: 'updated',
       });
 
-      assert.equal(errors.length, 0, 'Clears errors after the attributes are updated');
+      assert.strictEqual(errors.length, 0, 'Clears errors after the attributes are updated');
     }
   });
 });

--- a/packages/-ember-data/tests/integration/records/load-test.js
+++ b/packages/-ember-data/tests/integration/records/load-test.js
@@ -147,21 +147,25 @@ module('integration/load - Loading Records', function (hooks) {
     let internalModel = store._internalModelForId('person', '1');
 
     // test that our initial state is correct
-    assert.equal(internalModel.currentState.isEmpty, true, 'We begin in the empty state');
-    assert.equal(internalModel.currentState.isLoading, false, 'We have not triggered a load');
+    assert.strictEqual(internalModel.currentState.isEmpty, true, 'We begin in the empty state');
+    assert.strictEqual(internalModel.currentState.isLoading, false, 'We have not triggered a load');
 
     let recordPromise = store.findRecord('person', '1');
 
     // test that during the initial load our state is correct
     assert.todo.equal(internalModel.currentState.isEmpty, true, 'awaiting first fetch: We remain in the empty state');
-    assert.equal(internalModel.currentState.isLoading, true, 'awaiting first fetch: We have now triggered a load');
+    assert.strictEqual(
+      internalModel.currentState.isLoading,
+      true,
+      'awaiting first fetch: We have now triggered a load'
+    );
 
     let record = await recordPromise;
 
     // test that after the initial load our state is correct
-    assert.equal(internalModel.currentState.isEmpty, false, 'after first fetch: We are no longer empty');
-    assert.equal(internalModel.currentState.isLoading, false, 'after first fetch: We have loaded');
-    assert.equal(record.isReloading, false, 'after first fetch: We are not reloading');
+    assert.strictEqual(internalModel.currentState.isEmpty, false, 'after first fetch: We are no longer empty');
+    assert.strictEqual(internalModel.currentState.isLoading, false, 'after first fetch: We have loaded');
+    assert.strictEqual(record.isReloading, false, 'after first fetch: We are not reloading');
 
     let bestFriend = await record.get('bestFriend');
     let trueBestFriend = await bestFriend.get('bestFriend');
@@ -177,37 +181,37 @@ module('integration/load - Loading Records', function (hooks) {
     recordPromise = record.reload();
 
     // test that during a reload our state is correct
-    assert.equal(internalModel.currentState.isEmpty, false, 'awaiting reload: We remain non-empty');
-    assert.equal(internalModel.currentState.isLoading, false, 'awaiting reload: We are not loading again');
-    assert.equal(record.isReloading, true, 'awaiting reload: We are reloading');
+    assert.strictEqual(internalModel.currentState.isEmpty, false, 'awaiting reload: We remain non-empty');
+    assert.strictEqual(internalModel.currentState.isLoading, false, 'awaiting reload: We are not loading again');
+    assert.strictEqual(record.isReloading, true, 'awaiting reload: We are reloading');
 
     await recordPromise;
 
     // test that after a reload our state is correct
-    assert.equal(internalModel.currentState.isEmpty, false, 'after reload: We remain non-empty');
-    assert.equal(internalModel.currentState.isLoading, false, 'after reload: We have loaded');
-    assert.equal(record.isReloading, false, 'after reload:: We are not reloading');
+    assert.strictEqual(internalModel.currentState.isEmpty, false, 'after reload: We remain non-empty');
+    assert.strictEqual(internalModel.currentState.isLoading, false, 'after reload: We have loaded');
+    assert.strictEqual(record.isReloading, false, 'after reload:: We are not reloading');
 
     run(() => record.unloadRecord());
 
     // test that after an unload our state is correct
-    assert.equal(internalModel.currentState.isEmpty, true, 'after unload: We are empty again');
-    assert.equal(internalModel.currentState.isLoading, false, 'after unload: We are not loading');
-    assert.equal(record.isReloading, false, 'after unload:: We are not reloading');
+    assert.strictEqual(internalModel.currentState.isEmpty, true, 'after unload: We are empty again');
+    assert.strictEqual(internalModel.currentState.isLoading, false, 'after unload: We are not loading');
+    assert.strictEqual(record.isReloading, false, 'after unload:: We are not reloading');
 
     recordPromise = store.findRecord('person', '1');
 
     // test that during a reload-due-to-unload our state is correct
     //   This requires a retainer (the async bestFriend relationship)
     assert.todo.equal(internalModel.currentState.isEmpty, true, 'awaiting second find: We remain empty');
-    assert.equal(internalModel.currentState.isLoading, true, 'awaiting second find: We are loading again');
-    assert.equal(record.isReloading, false, 'awaiting second find: We are not reloading');
+    assert.strictEqual(internalModel.currentState.isLoading, true, 'awaiting second find: We are loading again');
+    assert.strictEqual(record.isReloading, false, 'awaiting second find: We are not reloading');
 
     await recordPromise;
 
     // test that after the reload-due-to-unload our state is correct
-    assert.equal(internalModel.currentState.isEmpty, false, 'after second find: We are no longer empty');
-    assert.equal(internalModel.currentState.isLoading, false, 'after second find: We have loaded');
-    assert.equal(record.isReloading, false, 'after second find: We are not reloading');
+    assert.strictEqual(internalModel.currentState.isEmpty, false, 'after second find: We are no longer empty');
+    assert.strictEqual(internalModel.currentState.isLoading, false, 'after second find: We have loaded');
+    assert.strictEqual(record.isReloading, false, 'after second find: We are not reloading');
   });
 });

--- a/packages/-ember-data/tests/integration/records/relationship-changes-test.js
+++ b/packages/-ember-data/tests/integration/records/relationship-changes-test.js
@@ -210,7 +210,7 @@ module('integration/records/relationship-changes - Relationship changes', functi
 
     run(() => {
       let cpResult = get(obj, 'siblings').toArray();
-      assert.equal(cpResult.length, 1, 'siblings cp should have recalculated');
+      assert.strictEqual(cpResult.length, 1, 'siblings cp should have recalculated');
       obj.destroy();
     });
   });
@@ -264,7 +264,7 @@ module('integration/records/relationship-changes - Relationship changes', functi
 
     run(() => {
       let cpResult = get(obj, 'firstSibling');
-      assert.equal(get(cpResult, 'id'), 1, 'siblings cp should have recalculated');
+      assert.strictEqual(get(cpResult, 'id'), '1', 'siblings cp should have recalculated');
       obj.destroy();
     });
   });
@@ -491,7 +491,7 @@ module('integration/records/relationship-changes - Relationship changes', functi
     });
 
     run(() => {
-      assert.equal(observerCount, 0, 'siblings observer should not be triggered');
+      assert.strictEqual(observerCount, 0, 'siblings observer should not be triggered');
     });
 
     person.removeObserver('siblings.[]', observerMethod);
@@ -508,16 +508,16 @@ module('integration/records/relationship-changes - Relationship changes', functi
         let observer = {
           arrayWillChange(array, start, removing, adding) {
             willChangeCount++;
-            assert.equal(start, 1, 'willChange.start');
-            assert.equal(removing, 0, 'willChange.removing');
-            assert.equal(adding, 1, 'willChange.adding');
+            assert.strictEqual(start, 1, 'willChange.start');
+            assert.strictEqual(removing, 0, 'willChange.removing');
+            assert.strictEqual(adding, 1, 'willChange.adding');
           },
 
           arrayDidChange(array, start, removed, added) {
             didChangeCount++;
-            assert.equal(start, 1, 'didChange.start');
-            assert.equal(removed, 0, 'didChange.removed');
-            assert.equal(added, 1, 'didChange.added');
+            assert.strictEqual(start, 1, 'didChange.start');
+            assert.strictEqual(removed, 0, 'didChange.removed');
+            assert.strictEqual(added, 1, 'didChange.added');
           },
         };
 
@@ -564,8 +564,8 @@ module('integration/records/relationship-changes - Relationship changes', functi
           included: [sibling2],
         });
 
-        assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-        assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+        assert.strictEqual(willChangeCount, 1, 'willChange observer should be triggered once');
+        assert.strictEqual(didChangeCount, 1, 'didChange observer should be triggered once');
 
         siblings.removeArrayObserver(observer);
       },
@@ -611,16 +611,16 @@ module('integration/records/relationship-changes - Relationship changes', functi
         let observer = {
           arrayWillChange(array, start, removing, adding) {
             willChangeCount++;
-            assert.equal(start, 1);
-            assert.equal(removing, 1);
-            assert.equal(adding, 0);
+            assert.strictEqual(start, 1);
+            assert.strictEqual(removing, 1);
+            assert.strictEqual(adding, 0);
           },
 
           arrayDidChange(array, start, removed, added) {
             didChangeCount++;
-            assert.equal(start, 1);
-            assert.equal(removed, 1);
-            assert.equal(added, 0);
+            assert.strictEqual(start, 1);
+            assert.strictEqual(removed, 1);
+            assert.strictEqual(added, 0);
           },
         };
 
@@ -640,8 +640,8 @@ module('integration/records/relationship-changes - Relationship changes', functi
           included: [],
         });
 
-        assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-        assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+        assert.strictEqual(willChangeCount, 1, 'willChange observer should be triggered once');
+        assert.strictEqual(didChangeCount, 1, 'didChange observer should be triggered once');
 
         siblings.removeArrayObserver(observer);
       },
@@ -680,16 +680,16 @@ module('integration/records/relationship-changes - Relationship changes', functi
         let observer = {
           arrayWillChange(array, start, removing, adding) {
             willChangeCount++;
-            assert.equal(start, 0, 'change will start at the beginning');
-            assert.equal(removing, 0, 'we have no removals');
-            assert.equal(adding, 1, 'we have one insertion');
+            assert.strictEqual(start, 0, 'change will start at the beginning');
+            assert.strictEqual(removing, 0, 'we have no removals');
+            assert.strictEqual(adding, 1, 'we have one insertion');
           },
 
           arrayDidChange(array, start, removed, added) {
             didChangeCount++;
-            assert.equal(start, 0, 'change did start at the beginning');
-            assert.equal(removed, 0, 'change had no removals');
-            assert.equal(added, 1, 'change had one insertion');
+            assert.strictEqual(start, 0, 'change did start at the beginning');
+            assert.strictEqual(removed, 0, 'change had no removals');
+            assert.strictEqual(added, 1, 'change had one insertion');
           },
         };
 
@@ -719,8 +719,8 @@ module('integration/records/relationship-changes - Relationship changes', functi
           included: [sibling1],
         });
 
-        assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-        assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+        assert.strictEqual(willChangeCount, 1, 'willChange observer should be triggered once');
+        assert.strictEqual(didChangeCount, 1, 'didChange observer should be triggered once');
         assert.deepEqual(
           siblings.map((i) => i.id),
           ['1', '2'],
@@ -763,15 +763,15 @@ module('integration/records/relationship-changes - Relationship changes', functi
         let observer = {
           arrayWillChange(array, start, removing, adding) {
             willChangeCount++;
-            assert.equal(start, 1);
-            assert.equal(removing, 0);
-            assert.equal(adding, 1);
+            assert.strictEqual(start, 1);
+            assert.strictEqual(removing, 0);
+            assert.strictEqual(adding, 1);
           },
           arrayDidChange(array, start, removed, added) {
             didChangeCount++;
-            assert.equal(start, 1);
-            assert.equal(removed, 0);
-            assert.equal(added, 1);
+            assert.strictEqual(start, 1);
+            assert.strictEqual(removed, 0);
+            assert.strictEqual(added, 1);
           },
         };
 
@@ -802,8 +802,8 @@ module('integration/records/relationship-changes - Relationship changes', functi
           });
         });
 
-        assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-        assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+        assert.strictEqual(willChangeCount, 1, 'willChange observer should be triggered once');
+        assert.strictEqual(didChangeCount, 1, 'didChange observer should be triggered once');
 
         siblings.removeArrayObserver(observer);
       },
@@ -842,16 +842,16 @@ module('integration/records/relationship-changes - Relationship changes', functi
         let observer = {
           arrayWillChange(array, start, removing, adding) {
             willChangeCount++;
-            assert.equal(start, 1);
-            assert.equal(removing, 1);
-            assert.equal(adding, 2);
+            assert.strictEqual(start, 1);
+            assert.strictEqual(removing, 1);
+            assert.strictEqual(adding, 2);
           },
 
           arrayDidChange(array, start, removed, added) {
             didChangeCount++;
-            assert.equal(start, 1);
-            assert.equal(removed, 1);
-            assert.equal(added, 2);
+            assert.strictEqual(start, 1);
+            assert.strictEqual(removed, 1);
+            assert.strictEqual(added, 2);
           },
         };
 
@@ -880,8 +880,8 @@ module('integration/records/relationship-changes - Relationship changes', functi
           });
         });
 
-        assert.equal(willChangeCount, 1, 'willChange observer should be triggered once');
-        assert.equal(didChangeCount, 1, 'didChange observer should be triggered once');
+        assert.strictEqual(willChangeCount, 1, 'willChange observer should be triggered once');
+        assert.strictEqual(didChangeCount, 1, 'didChange observer should be triggered once');
 
         siblings.removeArrayObserver(observer);
       },
@@ -933,7 +933,7 @@ module('integration/records/relationship-changes - Relationship changes', functi
       });
     });
 
-    assert.equal(observerCount, 1, 'author observer should be triggered once');
+    assert.strictEqual(observerCount, 1, 'author observer should be triggered once');
   });
 
   test('Calling push with same belongsTo relationship does not trigger observer', function (assert) {
@@ -972,6 +972,6 @@ module('integration/records/relationship-changes - Relationship changes', functi
       });
     });
 
-    assert.equal(observerCount, 0, 'author observer should not be triggered');
+    assert.strictEqual(observerCount, 0, 'author observer should not be triggered');
   });
 });

--- a/packages/-ember-data/tests/integration/records/reload-test.js
+++ b/packages/-ember-data/tests/integration/records/reload-test.js
@@ -60,7 +60,11 @@ module('integration/reload - Reloading Records', function (hooks) {
             count++;
             return resolve({ data: { id: id, type: 'person', attributes: { name: 'Tom Dale' } } });
           } else if (count === 1) {
-            assert.equal(snapshot.adapterOptions, reloadOptions.adapterOptions, 'We passed adapterOptions via reload');
+            assert.strictEqual(
+              snapshot.adapterOptions,
+              reloadOptions.adapterOptions,
+              'We passed adapterOptions via reload'
+            );
             count++;
             return resolve({
               data: { id: id, type: 'person', attributes: { name: 'Braaaahm Dale' } },
@@ -74,7 +78,7 @@ module('integration/reload - Reloading Records', function (hooks) {
 
     let person = await store.findRecord('person', '1');
 
-    assert.equal(get(person, 'name'), 'Tom Dale', 'The person is loaded with the right name');
+    assert.strictEqual(get(person, 'name'), 'Tom Dale', 'The person is loaded with the right name');
     assert.true(get(person, 'isLoaded'), 'The person is now loaded');
 
     let promise = person.reload(reloadOptions);
@@ -84,7 +88,7 @@ module('integration/reload - Reloading Records', function (hooks) {
     await promise;
 
     assert.false(get(person, 'isReloading'), 'The person is no longer reloading');
-    assert.equal(get(person, 'name'), 'Braaaahm Dale', 'The person is now updated with the right name');
+    assert.strictEqual(get(person, 'name'), 'Braaaahm Dale', 'The person is now updated with the right name');
 
     // ensure we won't call adapter.findRecord again
     await store.findRecord('person', '1');
@@ -131,10 +135,10 @@ module('integration/reload - Reloading Records', function (hooks) {
 
     let person = await tom.reload();
 
-    assert.equal(person, tom, 'The resolved value is the record');
+    assert.strictEqual(person, tom, 'The resolved value is the record');
     assert.false(tom.get('isError'), 'Tom is no longer errored');
     assert.false(tom.get('isReloading'), 'Tom is no longer reloading');
-    assert.equal(tom.get('name'), 'Thomas Dale', 'the updates apply');
+    assert.strictEqual(tom.get('name'), 'Thomas Dale', 'the updates apply');
   });
 
   test('When a record is loaded a second time, isLoaded stays true', async function (assert) {
@@ -241,14 +245,14 @@ module('integration/reload - Reloading Records', function (hooks) {
     let person = await store.findRecord('person', '1');
 
     tom = person;
-    assert.equal(person.get('name'), 'Tom', 'precond');
+    assert.strictEqual(person.get('name'), 'Tom', 'precond');
 
     let tags = await person.get('tags');
 
     assert.deepEqual(tags.mapBy('name'), ['hipster', 'hair']);
 
     person = await tom.reload();
-    assert.equal(person.get('name'), 'Tom', 'precond');
+    assert.strictEqual(person.get('name'), 'Tom', 'precond');
 
     tags = await person.get('tags');
 

--- a/packages/-ember-data/tests/integration/records/rematerialize-test.js
+++ b/packages/-ember-data/tests/integration/records/rematerialize-test.js
@@ -82,7 +82,7 @@ module('integration/unload - Rematerializing Unloaded Records', function (hooks)
     });
 
     let person = store.peekRecord('person', 1);
-    assert.equal(person.get('cars.length'), 1, 'The inital length of cars is correct');
+    assert.strictEqual(person.get('cars.length'), 1, 'The inital length of cars is correct');
 
     assert.true(store.hasRecordForId('person', 1), 'The person is in the store');
     assert.true(
@@ -116,8 +116,8 @@ module('integration/unload - Rematerializing Unloaded Records', function (hooks)
     });
 
     let rematerializedPerson = bob.get('person');
-    assert.equal(rematerializedPerson.get('id'), '1');
-    assert.equal(rematerializedPerson.get('name'), 'Adam Sunderland');
+    assert.strictEqual(rematerializedPerson.get('id'), '1');
+    assert.strictEqual(rematerializedPerson.get('name'), 'Adam Sunderland');
     // the person is rematerialized; the previous person is *not* re-used
     assert.notEqual(rematerializedPerson, adam, 'the person is rematerialized, not recycled');
   });
@@ -222,10 +222,10 @@ module('integration/unload - Rematerializing Unloaded Records', function (hooks)
     assert.true(store._internalModelsFor('boat').has('@ember-data:lid-boat-1'), 'The boat internalModel is loaded');
 
     let boats = await adam.get('boats');
-    assert.equal(boats.get('length'), 2, 'Before unloading boats.length is correct');
+    assert.strictEqual(boats.get('length'), 2, 'Before unloading boats.length is correct');
 
     boaty.unloadRecord();
-    assert.equal(boats.get('length'), 1, 'after unloading boats.length is correct');
+    assert.strictEqual(boats.get('length'), 1, 'after unloading boats.length is correct');
 
     // assert our new cache state
     assert.false(store.hasRecordForId('boat', '1'), 'The boat is unloaded');
@@ -236,9 +236,9 @@ module('integration/unload - Rematerializing Unloaded Records', function (hooks)
     let rematerializedBoaty = boats.objectAt(1);
 
     assert.ok(!!rematerializedBoaty, 'We have a boat!');
-    assert.equal(adam.get('boats.length'), 2, 'boats.length correct after rematerialization');
-    assert.equal(rematerializedBoaty.get('id'), '1', 'Rematerialized boat has the right id');
-    assert.equal(rematerializedBoaty.get('name'), 'Boaty McBoatface', 'Rematerialized boat has the right name');
+    assert.strictEqual(adam.get('boats.length'), 2, 'boats.length correct after rematerialization');
+    assert.strictEqual(rematerializedBoaty.get('id'), '1', 'Rematerialized boat has the right id');
+    assert.strictEqual(rematerializedBoaty.get('name'), 'Boaty McBoatface', 'Rematerialized boat has the right name');
     assert.ok(rematerializedBoaty !== boaty, 'the boat is rematerialized, not recycled');
 
     assert.true(store.hasRecordForId('boat', '1'), 'The boat is loaded');

--- a/packages/-ember-data/tests/integration/records/save-test.js
+++ b/packages/-ember-data/tests/integration/records/save-test.js
@@ -44,8 +44,8 @@ module('integration/records/save - Save Record', function (hooks) {
       deferred.resolve({ data: { id: 123, type: 'post' } });
       saved.then(function (model) {
         assert.ok(true, 'save operation was resolved');
-        assert.equal(saved.get('id'), 123);
-        assert.equal(model, post, 'resolves with the model');
+        assert.strictEqual(saved.get('id'), '123');
+        assert.strictEqual(model, post, 'resolves with the model');
       });
     });
   });
@@ -97,7 +97,7 @@ module('integration/records/save - Save Record', function (hooks) {
           }
         )
         .then(function (post) {
-          assert.equal(post.get('id'), '123', 'The post ID made it through');
+          assert.strictEqual(post.get('id'), '123', 'The post ID made it through');
         });
     });
   });
@@ -116,11 +116,11 @@ module('integration/records/save - Save Record', function (hooks) {
     run(function () {
       post.save().then(null, function () {
         assert.ok(post.get('isError'));
-        assert.equal(post.get('currentState.stateName'), 'root.loaded.created.uncommitted');
+        assert.strictEqual(post.get('currentState.stateName'), 'root.loaded.created.uncommitted');
 
         post.save().then(null, function () {
           assert.ok(post.get('isError'));
-          assert.equal(post.get('currentState.stateName'), 'root.loaded.created.uncommitted');
+          assert.strictEqual(post.get('currentState.stateName'), 'root.loaded.created.uncommitted');
         });
       });
     });

--- a/packages/-ember-data/tests/integration/records/unload-test.js
+++ b/packages/-ember-data/tests/integration/records/unload-test.js
@@ -182,15 +182,15 @@ module('integration/unload - Unloading Records', function (hooks) {
       adam = store.peekRecord('person', 1);
     });
 
-    assert.equal(store.peekAll('person').get('length'), 1, 'one person record loaded');
-    assert.equal(store._internalModelsFor('person').length, 1, 'one person internalModel loaded');
+    assert.strictEqual(store.peekAll('person').get('length'), 1, 'one person record loaded');
+    assert.strictEqual(store._internalModelsFor('person').length, 1, 'one person internalModel loaded');
 
     run(function () {
       adam.unloadRecord();
     });
 
-    assert.equal(store.peekAll('person').get('length'), 0, 'no person records');
-    assert.equal(store._internalModelsFor('person').length, 0, 'no person internalModels');
+    assert.strictEqual(store.peekAll('person').get('length'), 0, 'no person records');
+    assert.strictEqual(store._internalModelsFor('person').length, 0, 'no person internalModels');
   });
 
   test('can unload all records for a given type', function (assert) {
@@ -237,20 +237,20 @@ module('integration/unload - Unloading Records', function (hooks) {
       bob = store.peekRecord('car', 1);
     });
 
-    assert.equal(store.peekAll('person').get('length'), 2, 'two person records loaded');
-    assert.equal(store._internalModelsFor('person').length, 2, 'two person internalModels loaded');
-    assert.equal(store.peekAll('car').get('length'), 1, 'one car record loaded');
-    assert.equal(store._internalModelsFor('car').length, 1, 'one car internalModel loaded');
+    assert.strictEqual(store.peekAll('person').get('length'), 2, 'two person records loaded');
+    assert.strictEqual(store._internalModelsFor('person').length, 2, 'two person internalModels loaded');
+    assert.strictEqual(store.peekAll('car').get('length'), 1, 'one car record loaded');
+    assert.strictEqual(store._internalModelsFor('car').length, 1, 'one car internalModel loaded');
 
     run(function () {
       car.get('person');
       store.unloadAll('person');
     });
 
-    assert.equal(store.peekAll('person').get('length'), 0);
-    assert.equal(store.peekAll('car').get('length'), 1);
-    assert.equal(store._internalModelsFor('person').length, 0, 'zero person internalModels loaded');
-    assert.equal(store._internalModelsFor('car').length, 1, 'one car internalModel loaded');
+    assert.strictEqual(store.peekAll('person').get('length'), 0);
+    assert.strictEqual(store.peekAll('car').get('length'), 1);
+    assert.strictEqual(store._internalModelsFor('person').length, 0, 'zero person internalModels loaded');
+    assert.strictEqual(store._internalModelsFor('car').length, 1, 'one car internalModel loaded');
 
     run(function () {
       store.push({
@@ -280,8 +280,8 @@ module('integration/unload - Unloading Records', function (hooks) {
    because the `person` relationship is never materialized, it's state was
    not cleared on unload, and thus the client-side delete never happened as intended.
   */
-    // assert.equal(person.get('id'), '1', 'Inverse can load relationship after the record is unloaded');
-    // assert.equal(person.get('name'), 'Richard II', 'Inverse can load relationship after the record is unloaded');
+    // assert.strictEqual(person.get('id'), '1', 'Inverse can load relationship after the record is unloaded');
+    // assert.strictEqual(person.get('name'), 'Richard II', 'Inverse can load relationship after the record is unloaded');
   });
 
   test('can unload all records', function (assert) {
@@ -327,19 +327,19 @@ module('integration/unload - Unloading Records', function (hooks) {
       bob = store.peekRecord('car', 1);
     });
 
-    assert.equal(store.peekAll('person').get('length'), 2, 'two person records loaded');
-    assert.equal(store._internalModelsFor('person').length, 2, 'two person internalModels loaded');
-    assert.equal(store.peekAll('car').get('length'), 1, 'one car record loaded');
-    assert.equal(store._internalModelsFor('car').length, 1, 'one car internalModel loaded');
+    assert.strictEqual(store.peekAll('person').get('length'), 2, 'two person records loaded');
+    assert.strictEqual(store._internalModelsFor('person').length, 2, 'two person internalModels loaded');
+    assert.strictEqual(store.peekAll('car').get('length'), 1, 'one car record loaded');
+    assert.strictEqual(store._internalModelsFor('car').length, 1, 'one car internalModel loaded');
 
     run(function () {
       store.unloadAll();
     });
 
-    assert.equal(store.peekAll('person').get('length'), 0);
-    assert.equal(store.peekAll('car').get('length'), 0);
-    assert.equal(store._internalModelsFor('person').length, 0, 'zero person internalModels loaded');
-    assert.equal(store._internalModelsFor('car').length, 0, 'zero car internalModels loaded');
+    assert.strictEqual(store.peekAll('person').get('length'), 0);
+    assert.strictEqual(store.peekAll('car').get('length'), 0);
+    assert.strictEqual(store._internalModelsFor('person').length, 0, 'zero person internalModels loaded');
+    assert.strictEqual(store._internalModelsFor('car').length, 0, 'zero car internalModels loaded');
   });
 
   test('removes findAllCache after unloading all records', function (assert) {
@@ -368,16 +368,16 @@ module('integration/unload - Unloading Records', function (hooks) {
       let bob = store.peekRecord('person', 2);
     });
 
-    assert.equal(store.peekAll('person').get('length'), 2, 'two person records loaded');
-    assert.equal(store._internalModelsFor('person').length, 2, 'two person internalModels loaded');
+    assert.strictEqual(store.peekAll('person').get('length'), 2, 'two person records loaded');
+    assert.strictEqual(store._internalModelsFor('person').length, 2, 'two person internalModels loaded');
 
     run(function () {
       store.peekAll('person');
       store.unloadAll('person');
     });
 
-    assert.equal(store.peekAll('person').get('length'), 0, 'zero person records loaded');
-    assert.equal(store._internalModelsFor('person').length, 0, 'zero person internalModels loaded');
+    assert.strictEqual(store.peekAll('person').get('length'), 0, 'zero person records loaded');
+    assert.strictEqual(store._internalModelsFor('person').length, 0, 'zero person internalModels loaded');
   });
 
   test('unloading all records also updates record array from peekAll()', function (assert) {
@@ -405,12 +405,12 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
     let all = store.peekAll('person');
 
-    assert.equal(all.get('length'), 2);
+    assert.strictEqual(all.get('length'), 2);
 
     run(function () {
       store.unloadAll('person');
     });
-    assert.equal(all.get('length'), 0);
+    assert.strictEqual(all.get('length'), 0);
   });
 
   function makeBoatOneForPersonOne() {
@@ -454,8 +454,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     let knownBoats = store._internalModelsFor('boat');
 
     // ensure we loaded the people and boats
-    assert.equal(knownPeople.models.length, 1, 'one person record is loaded');
-    assert.equal(knownBoats.models.length, 1, 'one boat record is loaded');
+    assert.strictEqual(knownPeople.models.length, 1, 'one person record is loaded');
+    assert.strictEqual(knownBoats.models.length, 1, 'one boat record is loaded');
     assert.true(store.hasRecordForId('person', '1'));
     assert.true(store.hasRecordForId('boat', '1'));
 
@@ -463,8 +463,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     let peopleBoats = await person.get('boats');
     let boatPerson = await boat.get('person');
 
-    assert.equal(relationshipState.canonicalState.length, 1, 'canonical member size should be 1');
-    assert.equal(relationshipState.members.size, 1, 'members size should be 1');
+    assert.strictEqual(relationshipState.canonicalState.length, 1, 'canonical member size should be 1');
+    assert.strictEqual(relationshipState.members.size, 1, 'members size should be 1');
     assert.ok(get(peopleBoats, 'length') === 1, 'Our person has a boat');
     assert.ok(peopleBoats.objectAt(0) === boat, 'Our person has the right boat');
     assert.ok(boatPerson === person, 'Our boat has the right person');
@@ -474,10 +474,10 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     // ensure that our new state is correct
-    assert.equal(knownPeople.models.length, 1, 'one person record is loaded');
-    assert.equal(knownBoats.models.length, 0, 'no boat records are loaded');
-    assert.equal(relationshipState.canonicalState.length, 1, 'canonical member size should still be 1');
-    assert.equal(relationshipState.members.size, 1, 'members size should still be 1');
+    assert.strictEqual(knownPeople.models.length, 1, 'one person record is loaded');
+    assert.strictEqual(knownBoats.models.length, 0, 'no boat records are loaded');
+    assert.strictEqual(relationshipState.canonicalState.length, 1, 'canonical member size should still be 1');
+    assert.strictEqual(relationshipState.members.size, 1, 'members size should still be 1');
     assert.ok(get(peopleBoats, 'length') === 0, 'Our person thinks they have no boats');
 
     run(() =>
@@ -531,8 +531,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     let knownBoats = store._internalModelsFor('boat');
 
     // ensure we loaded the people and boats
-    assert.equal(knownPeople.models.length, 1, 'one person record is loaded');
-    assert.equal(knownBoats.models.length, 1, 'one boat record is loaded');
+    assert.strictEqual(knownPeople.models.length, 1, 'one person record is loaded');
+    assert.strictEqual(knownBoats.models.length, 1, 'one boat record is loaded');
     assert.true(store.hasRecordForId('person', '1'));
     assert.true(store.hasRecordForId('boat', '1'));
 
@@ -540,8 +540,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     let peopleBoats = run(() => person.get('boats.content'));
     let boatPerson = run(() => boat.get('person.content'));
 
-    assert.equal(relationshipState.canonicalState.length, 1, 'canonical member size should be 1');
-    assert.equal(relationshipState.members.size, 1, 'members size should be 1');
+    assert.strictEqual(relationshipState.canonicalState.length, 1, 'canonical member size should be 1');
+    assert.strictEqual(relationshipState.members.size, 1, 'members size should be 1');
     assert.ok(get(peopleBoats, 'length') === 1, 'Our person has a boat');
     assert.ok(peopleBoats.objectAt(0) === boat, 'Our person has the right boat');
     assert.ok(boatPerson === person, 'Our boat has the right person');
@@ -551,10 +551,10 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     // ensure that our new state is correct
-    assert.equal(knownPeople.models.length, 1, 'one person record is loaded');
-    assert.equal(knownBoats.models.length, 0, 'no boat records are loaded');
-    assert.equal(relationshipState.canonicalState.length, 1, 'canonical member size should still be 1');
-    assert.equal(relationshipState.members.size, 1, 'members size should still be 1');
+    assert.strictEqual(knownPeople.models.length, 1, 'one person record is loaded');
+    assert.strictEqual(knownBoats.models.length, 0, 'no boat records are loaded');
+    assert.strictEqual(relationshipState.canonicalState.length, 1, 'canonical member size should still be 1');
+    assert.strictEqual(relationshipState.members.size, 1, 'members size should still be 1');
     assert.ok(get(peopleBoats, 'length') === 0, 'Our person thinks they have no boats');
 
     run(() => person.get('boats'));
@@ -731,8 +731,8 @@ module('integration/unload - Unloading Records', function (hooks) {
       });
     });
 
-    assert.equal(store._internalModelsFor('person').models.length, 1, 'one person record is loaded');
-    assert.equal(store._internalModelsFor('boat').models.length, 2, 'two boat records are loaded');
+    assert.strictEqual(store._internalModelsFor('person').models.length, 1, 'one person record is loaded');
+    assert.strictEqual(store._internalModelsFor('boat').models.length, 2, 'two boat records are loaded');
     assert.true(store.hasRecordForId('person', 1));
     assert.true(store.hasRecordForId('boat', 1));
     assert.true(store.hasRecordForId('boat', 2));
@@ -771,11 +771,11 @@ module('integration/unload - Unloading Records', function (hooks) {
           store.peekRecord('boat', 2).unloadRecord();
         });
 
-        assert.equal(store._internalModelsFor('person').models.length, 0);
-        assert.equal(store._internalModelsFor('boat').models.length, 0);
+        assert.strictEqual(store._internalModelsFor('person').models.length, 0);
+        assert.strictEqual(store._internalModelsFor('boat').models.length, 0);
 
-        assert.equal(checkOrphanCalls, 3, 'each internalModel checks for cleanup');
-        assert.equal(cleanupOrphanCalls, 3, 'each model data tries to cleanup');
+        assert.strictEqual(checkOrphanCalls, 3, 'each internalModel checks for cleanup');
+        assert.strictEqual(cleanupOrphanCalls, 3, 'each model data tries to cleanup');
       });
   });
 
@@ -823,7 +823,7 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     const internalModel = record._internalModel;
-    assert.equal(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded initially');
+    assert.strictEqual(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded initially');
 
     run(function () {
       store.unloadRecord(record);
@@ -831,12 +831,12 @@ module('integration/unload - Unloading Records', function (hooks) {
       assert.false(internalModel.isDestroyed, 'the internal model is not destroyed');
       assert.true(internalModel._isDematerializing, 'the internal model is dematerializing');
       internalModel.cancelDestroy();
-      assert.equal(internalModel.currentState.stateName, 'root.empty', 'We are unloaded after unloadRecord');
+      assert.strictEqual(internalModel.currentState.stateName, 'root.empty', 'We are unloaded after unloadRecord');
     });
 
     assert.false(internalModel.isDestroyed, 'the internal model was not destroyed');
     assert.false(internalModel._isDematerializing, 'the internal model is no longer dematerializing');
-    assert.equal(internalModel.currentState.stateName, 'root.empty', 'We are still unloaded after unloadRecord');
+    assert.strictEqual(internalModel.currentState.stateName, 'root.empty', 'We are still unloaded after unloadRecord');
   });
 
   test('after unloading a record, the record can be fetched again immediately', function (assert) {
@@ -887,16 +887,16 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     const internalModel = record._internalModel;
-    assert.equal(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded initially');
+    assert.strictEqual(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded initially');
 
     // we test that we can sync call unloadRecord followed by findRecord
     return run(() => {
       store.unloadRecord(record);
       assert.true(record.isDestroying, 'the record is destroying');
-      assert.equal(internalModel.currentState.stateName, 'root.empty', 'We are unloaded after unloadRecord');
+      assert.strictEqual(internalModel.currentState.stateName, 'root.empty', 'We are unloaded after unloadRecord');
       return store.findRecord('person', '1').then((newRecord) => {
         assert.ok(internalModel === newRecord._internalModel, 'the old internalModel is reused');
-        assert.equal(
+        assert.strictEqual(
           newRecord._internalModel.currentState.stateName,
           'root.loaded.saved',
           'We are loaded after findRecord'
@@ -958,23 +958,23 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     const internalModel = record._internalModel;
-    assert.equal(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded initially');
+    assert.strictEqual(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded initially');
 
     // we test that we can sync call unloadRecord followed by findRecord
     return run(() => {
-      assert.equal(record.get('cars.firstObject.make'), 'jeep');
+      assert.strictEqual(record.get('cars.firstObject.make'), 'jeep');
       store.unloadRecord(record);
       assert.true(record.isDestroying, 'the record is destroying');
-      assert.equal(
+      assert.strictEqual(
         internalModel.currentState.stateName,
         'root.empty',
         'Expected the previous internal model tobe unloaded'
       );
 
       return store.findRecord('person', '1').then((record) => {
-        assert.equal(record.get('cars.length'), 0, 'Expected relationship to be cleared by the new push');
+        assert.strictEqual(record.get('cars.length'), 0, 'Expected relationship to be cleared by the new push');
         assert.ok(internalModel === record._internalModel, 'the old internalModel is reused');
-        assert.equal(
+        assert.strictEqual(
           record._internalModel.currentState.stateName,
           'root.loaded.saved',
           'Expected the NEW internal model to be loaded'
@@ -1024,16 +1024,16 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     const internalModel = record._internalModel;
     const bike = store.peekRecord('bike', '1');
-    assert.equal(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded initially');
+    assert.strictEqual(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded initially');
 
-    assert.equal(record.get('bike.name'), 'mr bike');
+    assert.strictEqual(record.get('bike.name'), 'mr bike');
 
     // we test that we can sync call unloadRecord followed by findRecord
     let wait = run(() => {
       store.unloadRecord(record);
       assert.true(record.isDestroying, 'the record is destroying');
       assert.false(record.isDestroyed, 'the record is NOT YET destroyed');
-      assert.equal(internalModel.currentState.stateName, 'root.empty', 'We are unloaded after unloadRecord');
+      assert.strictEqual(internalModel.currentState.stateName, 'root.empty', 'We are unloaded after unloadRecord');
 
       let wait = store.findRecord('person', '1').then((newRecord) => {
         assert.false(record.isDestroyed, 'the record is NOT YET destroyed');
@@ -1078,12 +1078,12 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     let internalModel = record._internalModel;
-    assert.equal(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded initially');
+    assert.strictEqual(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded initially');
 
     run(function () {
       store.unloadRecord(record);
       assert.true(record.isDestroying, 'the record is destroying');
-      assert.equal(internalModel.currentState.stateName, 'root.empty', 'We are unloaded after unloadRecord');
+      assert.strictEqual(internalModel.currentState.stateName, 'root.empty', 'We are unloaded after unloadRecord');
     });
 
     run(function () {
@@ -1093,7 +1093,7 @@ module('integration/unload - Unloading Records', function (hooks) {
     record = store.peekRecord('person', '1');
     internalModel = record._internalModel;
 
-    assert.equal(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded after findRecord');
+    assert.strictEqual(internalModel.currentState.stateName, 'root.loaded.saved', 'We are loaded after findRecord');
   });
 
   test('after unloading a record, the record can be saved again immediately', function (assert) {
@@ -1157,16 +1157,16 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     let adam = store.peekRecord('person', 1);
-    assert.equal(adam.get('cars.length'), 0, 'cars hasMany starts off empty');
+    assert.strictEqual(adam.get('cars.length'), 0, 'cars hasMany starts off empty');
 
     run(() => pushCar());
-    assert.equal(adam.get('cars.length'), 1, 'pushing car setups inverse relationship');
+    assert.strictEqual(adam.get('cars.length'), 1, 'pushing car setups inverse relationship');
 
     run(() => adam.get('cars.firstObject').unloadRecord());
-    assert.equal(adam.get('cars.length'), 0, 'unloading car cleaned up hasMany');
+    assert.strictEqual(adam.get('cars.length'), 0, 'unloading car cleaned up hasMany');
 
     run(() => pushCar());
-    assert.equal(adam.get('cars.length'), 1, 'pushing car again setups inverse relationship');
+    assert.strictEqual(adam.get('cars.length'), 1, 'pushing car again setups inverse relationship');
   });
 
   test('1:1 sync unload', function (assert) {
@@ -1196,12 +1196,12 @@ module('integration/unload - Unloading Records', function (hooks) {
     let person = store.peekRecord('person', 1);
     let house = store.peekRecord('house', 2);
 
-    assert.equal(person.get('house.id'), 2, 'initially relationship established lhs');
-    assert.equal(house.get('person.id'), 1, 'initially relationship established rhs');
+    assert.strictEqual(person.get('house.id'), '2', 'initially relationship established lhs');
+    assert.strictEqual(house.get('person.id'), '1', 'initially relationship established rhs');
 
     run(() => house.unloadRecord());
 
-    assert.equal(person.get('house'), null, 'unloading acts as a delete for sync relationships');
+    assert.strictEqual(person.get('house'), null, 'unloading acts as a delete for sync relationships');
     assert.false(store.hasRecordForId('house', 2), 'unloaded record gone from store');
 
     house = run(() =>
@@ -1214,8 +1214,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     );
 
     assert.true(store.hasRecordForId('house', 2), 'unloaded record can be restored');
-    assert.equal(person.get('house'), null, 'restoring unloaded record does not restore relationship');
-    assert.equal(house.get('person'), null, 'restoring unloaded record does not restore relationship');
+    assert.strictEqual(person.get('house'), null, 'restoring unloaded record does not restore relationship');
+    assert.strictEqual(house.get('person'), null, 'restoring unloaded record does not restore relationship');
 
     run(() =>
       store.push({
@@ -1234,8 +1234,8 @@ module('integration/unload - Unloading Records', function (hooks) {
       })
     );
 
-    assert.equal(person.get('house.id'), 2, 'after unloading, relationship can be restored');
-    assert.equal(house.get('person.id'), 1, 'after unloading, relationship can be restored');
+    assert.strictEqual(person.get('house.id'), '2', 'after unloading, relationship can be restored');
+    assert.strictEqual(house.get('person.id'), '1', 'after unloading, relationship can be restored');
   });
 
   test('1:many sync unload 1 side', function (assert) {
@@ -1279,15 +1279,15 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     assert.false(cars.isDestroyed, 'ManyArray not destroyed');
     assert.deepEqual(person.get('cars').mapBy('id'), ['2', '3'], 'initialy relationship established lhs');
-    assert.equal(car2.get('person.id'), 1, 'initially relationship established rhs');
-    assert.equal(car3.get('person.id'), 1, 'initially relationship established rhs');
+    assert.strictEqual(car2.get('person.id'), '1', 'initially relationship established rhs');
+    assert.strictEqual(car3.get('person.id'), '1', 'initially relationship established rhs');
 
     run(() => person.unloadRecord());
 
     assert.false(store.hasRecordForId('person', 1), 'unloaded record gone from store');
 
-    assert.equal(car2.get('person'), null, 'unloading acts as delete for sync relationships');
-    assert.equal(car3.get('person'), null, 'unloading acts as delete for sync relationships');
+    assert.strictEqual(car2.get('person'), null, 'unloading acts as delete for sync relationships');
+    assert.strictEqual(car3.get('person'), null, 'unloading acts as delete for sync relationships');
     assert.true(cars.isDestroyed, 'ManyArray destroyed');
 
     person = run(() =>
@@ -1301,8 +1301,8 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     assert.true(store.hasRecordForId('person', 1), 'unloaded record can be restored');
     assert.deepEqual(person.get('cars').mapBy('id'), [], 'restoring unloaded record does not restore relationship');
-    assert.equal(car2.get('person'), null, 'restoring unloaded record does not restore relationship');
-    assert.equal(car3.get('person'), null, 'restoring unloaded record does not restore relationship');
+    assert.strictEqual(car2.get('person'), null, 'restoring unloaded record does not restore relationship');
+    assert.strictEqual(car3.get('person'), null, 'restoring unloaded record does not restore relationship');
 
     run(() =>
       store.push({
@@ -1327,8 +1327,8 @@ module('integration/unload - Unloading Records', function (hooks) {
       })
     );
 
-    assert.equal(car2.get('person.id'), '1', 'after unloading, relationship can be restored');
-    assert.equal(car3.get('person.id'), '1', 'after unloading, relationship can be restored');
+    assert.strictEqual(car2.get('person.id'), '1', 'after unloading, relationship can be restored');
+    assert.strictEqual(car3.get('person.id'), '1', 'after unloading, relationship can be restored');
     assert.deepEqual(person.get('cars').mapBy('id'), ['2', '3'], 'after unloading, relationship can be restored');
   });
 
@@ -1373,8 +1373,8 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     assert.false(cars.isDestroyed, 'ManyArray not destroyed');
     assert.deepEqual(person.get('cars').mapBy('id'), ['2', '3'], 'initialy relationship established lhs');
-    assert.equal(car2.get('person.id'), 1, 'initially relationship established rhs');
-    assert.equal(car3.get('person.id'), 1, 'initially relationship established rhs');
+    assert.strictEqual(car2.get('person.id'), '1', 'initially relationship established rhs');
+    assert.strictEqual(car3.get('person.id'), '1', 'initially relationship established rhs');
 
     run(() => car2.unloadRecord());
 
@@ -1382,7 +1382,7 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     assert.false(cars.isDestroyed, 'ManyArray not destroyed');
     assert.deepEqual(person.get('cars').mapBy('id'), ['3'], 'unload sync relationship acts as delete');
-    assert.equal(car3.get('person.id'), '1', 'unloading one of a sync hasMany does not affect the rest');
+    assert.strictEqual(car3.get('person.id'), '1', 'unloading one of a sync hasMany does not affect the rest');
 
     car2 = run(() =>
       store.push({
@@ -1395,7 +1395,7 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     assert.true(store.hasRecordForId('car', 2), 'unloaded record can be restored');
     assert.deepEqual(person.get('cars').mapBy('id'), ['3'], 'restoring unloaded record does not restore relationship');
-    assert.equal(car2.get('person'), null, 'restoring unloaded record does not restore relationship');
+    assert.strictEqual(car2.get('person'), null, 'restoring unloaded record does not restore relationship');
 
     run(() =>
       store.push({
@@ -1420,7 +1420,7 @@ module('integration/unload - Unloading Records', function (hooks) {
       })
     );
 
-    assert.equal(car2.get('person.id'), '1', 'after unloading, relationship can be restored');
+    assert.strictEqual(car2.get('person.id'), '1', 'after unloading, relationship can be restored');
     assert.deepEqual(person.get('cars').mapBy('id'), ['2', '3'], 'after unloading, relationship can be restored');
   });
 
@@ -1562,8 +1562,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     let findRecordCalls = 0;
 
     adapter.findRecord = (store, type, id) => {
-      assert.equal(type, Mortgage, 'findRecord(_, type) is correct');
-      assert.equal(id, '2', 'findRecord(_, _, id) is correct');
+      assert.strictEqual(type, Mortgage, 'findRecord(_, type) is correct');
+      assert.strictEqual(id, '2', 'findRecord(_, _, id) is correct');
       ++findRecordCalls;
 
       return {
@@ -1600,21 +1600,21 @@ module('integration/unload - Unloading Records', function (hooks) {
           return mortgage.get('person');
         })
         .then(() => {
-          assert.equal(mortgage.belongsTo('person').id(), '1', 'initially relationship established lhs');
-          assert.equal(person.belongsTo('mortgage').id(), '2', 'initially relationship established rhs');
+          assert.strictEqual(mortgage.belongsTo('person').id(), '1', 'initially relationship established lhs');
+          assert.strictEqual(person.belongsTo('mortgage').id(), '2', 'initially relationship established rhs');
 
           run(() => mortgage.unloadRecord());
 
-          assert.equal(person.belongsTo('mortgage').id(), '2', 'unload async is not treated as delete');
+          assert.strictEqual(person.belongsTo('mortgage').id(), '2', 'unload async is not treated as delete');
 
           return person.get('mortgage');
         })
         .then((refetchedMortgage) => {
           assert.notEqual(mortgage, refetchedMortgage, 'the previously loaded record is not reused');
 
-          assert.equal(person.belongsTo('mortgage').id(), '2', 'unload async is not treated as delete');
-          assert.equal(refetchedMortgage.belongsTo('person').id(), '1', 'unload async is not treated as delete');
-          assert.equal(findRecordCalls, 2);
+          assert.strictEqual(person.belongsTo('mortgage').id(), '2', 'unload async is not treated as delete');
+          assert.strictEqual(refetchedMortgage.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+          assert.strictEqual(findRecordCalls, 2);
         })
     );
   });
@@ -1626,7 +1626,7 @@ module('integration/unload - Unloading Records', function (hooks) {
     adapter.coalesceFindRequests = true;
 
     adapter.findRecord = (store, type, id) => {
-      assert.equal(type, Person, 'findRecord(_, type) is correct');
+      assert.strictEqual(type, Person, 'findRecord(_, type) is correct');
       assert.deepEqual(id, '1', 'findRecord(_, _, id) is correct');
       ++findRecordCalls;
 
@@ -1639,7 +1639,7 @@ module('integration/unload - Unloading Records', function (hooks) {
     };
 
     adapter.findMany = (store, type, ids) => {
-      assert.equal(type + '', Boat + '', 'findMany(_, type) is correct');
+      assert.strictEqual(type + '', Boat + '', 'findMany(_, type) is correct');
       assert.deepEqual(ids, ['2', '3'], 'findMany(_, _, ids) is correct');
       ++findManyCalls;
 
@@ -1691,16 +1691,16 @@ module('integration/unload - Unloading Records', function (hooks) {
         })
         .then(() => {
           assert.deepEqual(person.hasMany('boats').ids(), ['2', '3'], 'initially relationship established lhs');
-          assert.equal(boat2.belongsTo('person').id(), '1', 'initially relationship established rhs');
-          assert.equal(boat3.belongsTo('person').id(), '1', 'initially relationship established rhs');
+          assert.strictEqual(boat2.belongsTo('person').id(), '1', 'initially relationship established rhs');
+          assert.strictEqual(boat3.belongsTo('person').id(), '1', 'initially relationship established rhs');
 
           assert.false(boats.isDestroyed, 'ManyArray is not destroyed');
 
           run(() => person.unloadRecord());
 
           assert.false(boats.isDestroyed, 'ManyArray is not destroyed when 1 side is unloaded');
-          assert.equal(boat2.belongsTo('person').id(), '1', 'unload async is not treated as delete');
-          assert.equal(boat3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+          assert.strictEqual(boat2.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+          assert.strictEqual(boat3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
 
           return boat2.get('person');
         })
@@ -1708,11 +1708,11 @@ module('integration/unload - Unloading Records', function (hooks) {
           assert.notEqual(person, refetchedPerson, 'the previously loaded record is not reused');
 
           assert.deepEqual(person.hasMany('boats').ids(), ['2', '3'], 'unload async is not treated as delete');
-          assert.equal(boat2.belongsTo('person').id(), '1', 'unload async is not treated as delete');
-          assert.equal(boat3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+          assert.strictEqual(boat2.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+          assert.strictEqual(boat3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
 
-          assert.equal(findManyCalls, 1, 'findMany called as expected');
-          assert.equal(findRecordCalls, 1, 'findRecord called as expected');
+          assert.strictEqual(findManyCalls, 1, 'findMany called as expected');
+          assert.strictEqual(findRecordCalls, 1, 'findRecord called as expected');
         })
     );
   });
@@ -1723,7 +1723,7 @@ module('integration/unload - Unloading Records', function (hooks) {
     adapter.coalesceFindRequests = true;
 
     adapter.findMany = (store, type, ids) => {
-      assert.equal(type + '', Boat + '', 'findMany(_, type) is correct');
+      assert.strictEqual(type + '', Boat + '', 'findMany(_, type) is correct');
       assert.deepEqual(ids, ['2', '3'], 'findMany(_, _, ids) is correct');
       ++findManyCalls;
 
@@ -1767,8 +1767,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     await all([boat2.person, boat3.person]);
 
     assert.deepEqual(person.hasMany('boats').ids(), ['2', '3'], 'initially relationship established lhs');
-    assert.equal(boat2.belongsTo('person').id(), '1', 'initially relationship established rhs');
-    assert.equal(boat3.belongsTo('person').id(), '1', 'initially relationship established rhs');
+    assert.strictEqual(boat2.belongsTo('person').id(), '1', 'initially relationship established rhs');
+    assert.strictEqual(boat3.belongsTo('person').id(), '1', 'initially relationship established rhs');
     assert.deepEqual(boats.mapBy('id'), ['2', '3'], 'many array is initially set up correctly');
 
     boat2.unloadRecord();
@@ -1779,16 +1779,16 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     assert.deepEqual(boats.mapBy('id'), [], 'unload async removes from previous many array');
     assert.deepEqual(person.hasMany('boats').ids(), ['2', '3'], 'unload async is not treated as delete');
-    assert.equal(boat3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+    assert.strictEqual(boat3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
 
     const refetchedBoats = await person.boats;
 
     assert.true(refetchedBoats === boats, 'we have the same ManyArray');
     assert.deepEqual(refetchedBoats.mapBy('id'), ['2', '3'], 'boats refetched');
     assert.deepEqual(person.hasMany('boats').ids(), ['2', '3'], 'unload async is not treated as delete');
-    assert.equal(boat3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+    assert.strictEqual(boat3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
 
-    assert.equal(findManyCalls, 2, 'findMany called as expected');
+    assert.strictEqual(findManyCalls, 2, 'findMany called as expected');
   });
 
   test('many:many async unload', async function (assert) {
@@ -1797,7 +1797,7 @@ module('integration/unload - Unloading Records', function (hooks) {
     adapter.coalesceFindRequests = true;
 
     adapter.findMany = (store, type, ids) => {
-      assert.equal(type + '', Person + '', 'findMany(_, type) is correct');
+      assert.strictEqual(type + '', Person + '', 'findMany(_, type) is correct');
       assert.deepEqual(ids, ['3', '4'], 'findMany(_, _, ids) is correct');
       ++findManyCalls;
 
@@ -1890,7 +1890,7 @@ module('integration/unload - Unloading Records', function (hooks) {
       'unload async is not treated as delete'
     );
 
-    assert.equal(findManyCalls, 2, 'findMany called as expected');
+    assert.strictEqual(findManyCalls, 2, 'findMany called as expected');
   });
 
   test('1 sync : 1 async unload sync side', function (assert) {
@@ -1921,12 +1921,12 @@ module('integration/unload - Unloading Records', function (hooks) {
     let book = store.peekRecord('book', 2);
 
     return book.get('person').then(() => {
-      assert.equal(person.get('favoriteBook.id'), 2, 'initially relationship established lhs');
-      assert.equal(book.belongsTo('person').id(), 1, 'initially relationship established rhs');
+      assert.strictEqual(person.get('favoriteBook.id'), '2', 'initially relationship established lhs');
+      assert.strictEqual(book.belongsTo('person').id(), '1', 'initially relationship established rhs');
 
       run(() => book.unloadRecord());
 
-      assert.equal(person.get('book'), null, 'unloading acts as a delete for sync relationships');
+      assert.strictEqual(person.get('book'), undefined, 'unloading acts as a delete for sync relationships');
       assert.false(store.hasRecordForId('book', 2), 'unloaded record gone from store');
 
       book = run(() =>
@@ -1939,8 +1939,12 @@ module('integration/unload - Unloading Records', function (hooks) {
       );
 
       assert.true(store.hasRecordForId('book', 2), 'unloaded record can be restored');
-      assert.equal(person.get('book'), null, 'restoring unloaded record does not restore relationship');
-      assert.equal(book.belongsTo('person').id(), null, 'restoring unloaded record does not restore relationship');
+      assert.strictEqual(person.get('book'), undefined, 'restoring unloaded record does not restore relationship');
+      assert.strictEqual(
+        book.belongsTo('person').id(),
+        null,
+        'restoring unloaded record does not restore relationship'
+      );
 
       run(() =>
         store.push({
@@ -1959,8 +1963,8 @@ module('integration/unload - Unloading Records', function (hooks) {
         })
       );
 
-      assert.equal(person.get('favoriteBook.id'), 2, 'after unloading, relationship can be restored');
-      assert.equal(book.get('person.id'), 1, 'after unloading, relationship can be restored');
+      assert.strictEqual(person.get('favoriteBook.id'), '2', 'after unloading, relationship can be restored');
+      assert.strictEqual(book.get('person.id'), '1', 'after unloading, relationship can be restored');
     });
   });
 
@@ -1968,8 +1972,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     let findRecordCalls = 0;
 
     adapter.findRecord = (store, type, id) => {
-      assert.equal(type, Person, 'findRecord(_, type) is correct');
-      assert.equal(id, '1', 'findRecord(_, _, id) is correct');
+      assert.strictEqual(type, Person, 'findRecord(_, type) is correct');
+      assert.strictEqual(id, '1', 'findRecord(_, _, id) is correct');
       ++findRecordCalls;
 
       return {
@@ -2010,21 +2014,21 @@ module('integration/unload - Unloading Records', function (hooks) {
       book
         .get('person')
         .then(() => {
-          assert.equal(person.get('favoriteBook.id'), 2, 'initially relationship established lhs');
-          assert.equal(book.belongsTo('person').id(), 1, 'initially relationship established rhs');
+          assert.strictEqual(person.get('favoriteBook.id'), '2', 'initially relationship established lhs');
+          assert.strictEqual(book.belongsTo('person').id(), '1', 'initially relationship established rhs');
 
           run(() => person.unloadRecord());
 
-          assert.equal(book.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+          assert.strictEqual(book.belongsTo('person').id(), '1', 'unload async is not treated as delete');
 
           return book.get('person');
         })
         .then((refetchedPerson) => {
           assert.notEqual(person, refetchedPerson, 'the previously loaded record is not reused');
 
-          assert.equal(book.belongsTo('person').id(), '1', 'unload async is not treated as delete');
-          assert.equal(refetchedPerson.get('favoriteBook.id'), '2', 'unload async is not treated as delete');
-          assert.equal(findRecordCalls, 1);
+          assert.strictEqual(book.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+          assert.strictEqual(refetchedPerson.get('favoriteBook.id'), '2', 'unload async is not treated as delete');
+          assert.strictEqual(findRecordCalls, 1);
         })
     );
   });
@@ -2070,8 +2074,8 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     assert.false(spoons.isDestroyed, 'ManyArray not destroyed');
     assert.deepEqual(person.get('favoriteSpoons').mapBy('id'), ['2', '3'], 'initialy relationship established lhs');
-    assert.equal(spoon2.belongsTo('person').id(), '1', 'initially relationship established rhs');
-    assert.equal(spoon3.belongsTo('person').id(), '1', 'initially relationship established rhs');
+    assert.strictEqual(spoon2.belongsTo('person').id(), '1', 'initially relationship established rhs');
+    assert.strictEqual(spoon3.belongsTo('person').id(), '1', 'initially relationship established rhs');
 
     run(() => spoon2.unloadRecord());
 
@@ -2079,7 +2083,11 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     assert.false(spoons.isDestroyed, 'ManyArray not destroyed');
     assert.deepEqual(person.get('favoriteSpoons').mapBy('id'), ['3'], 'unload sync relationship acts as delete');
-    assert.equal(spoon3.belongsTo('person').id(), '1', 'unloading one of a sync hasMany does not affect the rest');
+    assert.strictEqual(
+      spoon3.belongsTo('person').id(),
+      '1',
+      'unloading one of a sync hasMany does not affect the rest'
+    );
 
     spoon2 = run(() =>
       store.push({
@@ -2096,7 +2104,11 @@ module('integration/unload - Unloading Records', function (hooks) {
       ['3'],
       'restoring unloaded record does not restore relationship'
     );
-    assert.equal(spoon2.belongsTo('person').id(), null, 'restoring unloaded record does not restore relationship');
+    assert.strictEqual(
+      spoon2.belongsTo('person').id(),
+      null,
+      'restoring unloaded record does not restore relationship'
+    );
 
     run(() =>
       store.push({
@@ -2121,7 +2133,7 @@ module('integration/unload - Unloading Records', function (hooks) {
       })
     );
 
-    assert.equal(spoon2.belongsTo('person').id(), '1', 'after unloading, relationship can be restored');
+    assert.strictEqual(spoon2.belongsTo('person').id(), '1', 'after unloading, relationship can be restored');
     assert.deepEqual(
       person.get('favoriteSpoons').mapBy('id'),
       ['2', '3'],
@@ -2135,7 +2147,7 @@ module('integration/unload - Unloading Records', function (hooks) {
     adapter.coalesceFindRequests = true;
 
     adapter.findRecord = (store, type, id) => {
-      assert.equal(type, Person, 'findRecord(_, type) is correct');
+      assert.strictEqual(type, Person, 'findRecord(_, type) is correct');
       assert.deepEqual(id, '1', 'findRecord(_, _, id) is correct');
       ++findRecordCalls;
 
@@ -2185,26 +2197,26 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     return run(() => {
       assert.deepEqual(person.get('favoriteSpoons').mapBy('id'), ['2', '3'], 'initially relationship established lhs');
-      assert.equal(spoon2.belongsTo('person').id(), '1', 'initially relationship established rhs');
-      assert.equal(spoon3.belongsTo('person').id(), '1', 'initially relationship established rhs');
+      assert.strictEqual(spoon2.belongsTo('person').id(), '1', 'initially relationship established rhs');
+      assert.strictEqual(spoon3.belongsTo('person').id(), '1', 'initially relationship established rhs');
 
       assert.false(spoons.isDestroyed, 'ManyArray is not destroyed');
 
       run(() => person.unloadRecord());
 
       assert.false(spoons.isDestroyed, 'ManyArray is not destroyed when 1 side is unloaded');
-      assert.equal(spoon2.belongsTo('person').id(), '1', 'unload async is not treated as delete');
-      assert.equal(spoon3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+      assert.strictEqual(spoon2.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+      assert.strictEqual(spoon3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
 
       return spoon2.get('person');
     }).then((refetchedPerson) => {
       assert.notEqual(person, refetchedPerson, 'the previously loaded record is not reused');
 
       assert.deepEqual(person.get('favoriteSpoons').mapBy('id'), ['2', '3'], 'unload async is not treated as delete');
-      assert.equal(spoon2.belongsTo('person').id(), '1', 'unload async is not treated as delete');
-      assert.equal(spoon3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+      assert.strictEqual(spoon2.belongsTo('person').id(), '1', 'unload async is not treated as delete');
+      assert.strictEqual(spoon3.belongsTo('person').id(), '1', 'unload async is not treated as delete');
 
-      assert.equal(findRecordCalls, 1, 'findRecord called as expected');
+      assert.strictEqual(findRecordCalls, 1, 'findRecord called as expected');
     });
   });
 
@@ -2214,7 +2226,7 @@ module('integration/unload - Unloading Records', function (hooks) {
     adapter.coalesceFindRequests = true;
 
     adapter.findMany = (store, type, ids) => {
-      assert.equal(type + '', Show + '', 'findMany(_, type) is correct');
+      assert.strictEqual(type + '', Show + '', 'findMany(_, type) is correct');
       assert.deepEqual(ids, ['2', '3'], 'findMany(_, _, ids) is correct');
       ++findManyCalls;
 
@@ -2257,8 +2269,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     const [show2, show3] = shows.toArray();
 
     assert.deepEqual(person.hasMany('favoriteShows').ids(), ['2', '3'], 'initially relationship established lhs');
-    assert.equal(show2.get('person.id'), '1', 'initially relationship established rhs');
-    assert.equal(show3.get('person.id'), '1', 'initially relationship established rhs');
+    assert.strictEqual(show2.get('person.id'), '1', 'initially relationship established rhs');
+    assert.strictEqual(show3.get('person.id'), '1', 'initially relationship established rhs');
     assert.deepEqual(shows.mapBy('id'), ['2', '3'], 'many array is initially set up correctly');
 
     show2.unloadRecord();
@@ -2276,7 +2288,7 @@ module('integration/unload - Unloading Records', function (hooks) {
     assert.deepEqual(refetchedShows.mapBy('id'), ['2', '3'], 'shows refetched');
     assert.deepEqual(person.hasMany('favoriteShows').ids(), ['2', '3'], 'unload async is not treated as delete');
 
-    assert.equal(findManyCalls, 2, 'findMany called as expected');
+    assert.strictEqual(findManyCalls, 2, 'findMany called as expected');
   });
 
   test('1 sync : many async unload sync side', function (assert) {
@@ -2285,7 +2297,7 @@ module('integration/unload - Unloading Records', function (hooks) {
     adapter.coalesceFindRequests = true;
 
     adapter.findMany = (store, type, ids) => {
-      assert.equal(type + '', Show + '', 'findMany(_, type) is correct');
+      assert.strictEqual(type + '', Show + '', 'findMany(_, type) is correct');
       assert.deepEqual(ids, ['2', '3'], 'findMany(_, _, ids) is correct');
       ++findManyCalls;
 
@@ -2336,8 +2348,8 @@ module('integration/unload - Unloading Records', function (hooks) {
           [show2, show3] = shows.toArray();
 
           assert.deepEqual(person.hasMany('favoriteShows').ids(), ['2', '3'], 'initially relationship established lhs');
-          assert.equal(show2.get('person.id'), '1', 'initially relationship established rhs');
-          assert.equal(show3.get('person.id'), '1', 'initially relationship established rhs');
+          assert.strictEqual(show2.get('person.id'), '1', 'initially relationship established rhs');
+          assert.strictEqual(show3.get('person.id'), '1', 'initially relationship established rhs');
           assert.deepEqual(shows.mapBy('id'), ['2', '3'], 'many array is initially set up correctly');
 
           run(() => person.unloadRecord());
@@ -2345,8 +2357,8 @@ module('integration/unload - Unloading Records', function (hooks) {
           assert.false(store.hasRecordForId('person', 1), 'unloaded record gone from store');
 
           assert.true(shows.isDestroyed, 'previous manyarray immediately destroyed');
-          assert.equal(show2.get('person.id'), null, 'unloading acts as delete for sync relationships');
-          assert.equal(show3.get('person.id'), null, 'unloading acts as delete for sync relationships');
+          assert.strictEqual(show2.get('person.id'), undefined, 'unloading acts as delete for sync relationships');
+          assert.strictEqual(show3.get('person.id'), undefined, 'unloading acts as delete for sync relationships');
 
           person = run(() =>
             store.push({
@@ -2363,8 +2375,16 @@ module('integration/unload - Unloading Records', function (hooks) {
             [],
             'restoring unloaded record does not restore relationship'
           );
-          assert.equal(show2.get('person.id'), null, 'restoring unloaded record does not restore relationship');
-          assert.equal(show3.get('person.id'), null, 'restoring unloaded record does not restore relationship');
+          assert.strictEqual(
+            show2.get('person.id'),
+            undefined,
+            'restoring unloaded record does not restore relationship'
+          );
+          assert.strictEqual(
+            show3.get('person.id'),
+            undefined,
+            'restoring unloaded record does not restore relationship'
+          );
 
           run(() =>
             store.push({
@@ -2397,7 +2417,7 @@ module('integration/unload - Unloading Records', function (hooks) {
           assert.notEqual(refetchedShows, shows, 'ManyArray not reused');
           assert.deepEqual(refetchedShows.mapBy('id'), ['2', '3'], 'unload async not treated as a delete');
 
-          assert.equal(findManyCalls, 1, 'findMany calls as expected');
+          assert.strictEqual(findManyCalls, 1, 'findMany calls as expected');
         })
     );
   });
@@ -2411,8 +2431,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     };
 
     adapter.findHasMany = (store, snapshot, link) => {
-      assert.equal(snapshot.modelName, 'person', 'findHasMany(_, snapshot) is correct');
-      assert.equal(link, 'boats', 'findHasMany(_, _, link) is correct');
+      assert.strictEqual(snapshot.modelName, 'person', 'findHasMany(_, snapshot) is correct');
+      assert.strictEqual(link, 'boats', 'findHasMany(_, _, link) is correct');
 
       let relationships = {
         person: {
@@ -2468,8 +2488,8 @@ module('integration/unload - Unloading Records', function (hooks) {
         })
         .then(() => {
           assert.deepEqual(person.hasMany('boats').ids(), ['2', '3'], 'initially relationship established rhs');
-          assert.equal(boat2.belongsTo('person').id(), '1', 'initially relationship established rhs');
-          assert.equal(boat3.belongsTo('person').id(), '1', 'initially relationship established rhs');
+          assert.strictEqual(boat2.belongsTo('person').id(), '1', 'initially relationship established rhs');
+          assert.strictEqual(boat3.belongsTo('person').id(), '1', 'initially relationship established rhs');
 
           isUnloaded = true;
           run(() => {
@@ -2483,14 +2503,14 @@ module('integration/unload - Unloading Records', function (hooks) {
           return run(() => person.get('boats'));
         })
         .then((newBoats) => {
-          assert.equal(newBoats.length, 1, 'new ManyArray has only 1 boat after unload');
+          assert.strictEqual(newBoats.length, 1, 'new ManyArray has only 1 boat after unload');
         })
     );
   });
 
   test('fetching records cancels unloading', function (assert) {
     adapter.findRecord = (store, type, id) => {
-      assert.equal(type, Person, 'findRecord(_, type) is correct');
+      assert.strictEqual(type, Person, 'findRecord(_, type) is correct');
       assert.deepEqual(id, '1', 'findRecord(_, _, id) is correct');
 
       return {

--- a/packages/-ember-data/tests/integration/references/belongs-to-test.js
+++ b/packages/-ember-data/tests/integration/references/belongs-to-test.js
@@ -94,9 +94,9 @@ module('integration/references/belongs-to', function (hooks) {
 
     var familyReference = person.belongsTo('family');
 
-    assert.equal(familyReference.remoteType(), 'id');
-    assert.equal(familyReference.type, 'family');
-    assert.equal(familyReference.id(), 1);
+    assert.strictEqual(familyReference.remoteType(), 'id');
+    assert.strictEqual(familyReference.type, 'family');
+    assert.strictEqual(familyReference.id(), '1');
   });
 
   test('record#belongsTo for a linked reference', function (assert) {
@@ -119,9 +119,9 @@ module('integration/references/belongs-to', function (hooks) {
 
     var familyReference = person.belongsTo('family');
 
-    assert.equal(familyReference.remoteType(), 'link');
-    assert.equal(familyReference.type, 'family');
-    assert.equal(familyReference.link(), '/families/1');
+    assert.strictEqual(familyReference.remoteType(), 'link');
+    assert.strictEqual(familyReference.type, 'family');
+    assert.strictEqual(familyReference.link(), '/families/1');
   });
 
   test('BelongsToReference#parent is a reference to the parent where the relationship is defined', function (assert) {
@@ -212,7 +212,7 @@ module('integration/references/belongs-to', function (hooks) {
 
       familyReference.push(data).then(function (record) {
         assert.ok(Family.detectInstance(record), 'push resolves with the referenced record');
-        assert.equal(get(record, 'name'), 'Coreleone', 'name is set');
+        assert.strictEqual(get(record, 'name'), 'Coreleone', 'name is set');
 
         done();
       });
@@ -252,8 +252,8 @@ module('integration/references/belongs-to', function (hooks) {
     }, /Pushing a record into a BelongsToReference is deprecated/);
 
     assert.ok(Family.detectInstance(record), 'push resolves with the referenced record');
-    assert.equal(get(record, 'name'), 'Coreleone', 'name is set');
-    assert.equal(record, family);
+    assert.strictEqual(get(record, 'name'), 'Coreleone', 'name is set');
+    assert.strictEqual(record, family);
   });
 
   test('push(promise)', function (assert) {
@@ -298,7 +298,7 @@ module('integration/references/belongs-to', function (hooks) {
     run(function () {
       push.then(function (record) {
         assert.ok(Family.detectInstance(record), 'push resolves with the record');
-        assert.equal(get(record, 'name'), 'Coreleone', 'name is updated');
+        assert.strictEqual(get(record, 'name'), 'Coreleone', 'name is updated');
 
         done();
       });
@@ -360,7 +360,7 @@ module('integration/references/belongs-to', function (hooks) {
       family = await familyReference.push(mafiaFamily);
     }, /Pushing a record into a BelongsToReference is deprecated/);
 
-    assert.equal(family, mafiaFamily);
+    assert.strictEqual(family, mafiaFamily);
   });
 
   test('value() is null when reference is not yet loaded', function (assert) {
@@ -410,7 +410,7 @@ module('integration/references/belongs-to', function (hooks) {
     });
 
     var familyReference = person.belongsTo('family');
-    assert.equal(familyReference.value(), family);
+    assert.strictEqual(familyReference.value(), family);
   });
 
   test('value() returns the referenced record when loaded even if links are present', function (assert) {
@@ -445,7 +445,7 @@ module('integration/references/belongs-to', function (hooks) {
     });
 
     var familyReference = person.belongsTo('family');
-    assert.equal(familyReference.value(), family);
+    assert.strictEqual(familyReference.value(), family);
   });
 
   test('load() fetches the record', function (assert) {
@@ -457,7 +457,7 @@ module('integration/references/belongs-to', function (hooks) {
     const adapterOptions = { thing: 'one' };
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
       return resolve({
         data: {
           id: 1,
@@ -486,7 +486,7 @@ module('integration/references/belongs-to', function (hooks) {
 
     run(function () {
       familyReference.load({ adapterOptions }).then(function (record) {
-        assert.equal(get(record, 'name'), 'Coreleone');
+        assert.strictEqual(get(record, 'name'), 'Coreleone');
 
         done();
       });
@@ -502,8 +502,8 @@ module('integration/references/belongs-to', function (hooks) {
     const adapterOptions = { thing: 'one' };
 
     adapter.findBelongsTo = function (store, snapshot, link) {
-      assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
-      assert.equal(link, '/families/1');
+      assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(link, '/families/1');
 
       return resolve({
         data: {
@@ -530,11 +530,11 @@ module('integration/references/belongs-to', function (hooks) {
     });
 
     var familyReference = person.belongsTo('family');
-    assert.equal(familyReference.remoteType(), 'link');
+    assert.strictEqual(familyReference.remoteType(), 'link');
 
     run(function () {
       familyReference.load({ adapterOptions }).then(function (record) {
-        assert.equal(get(record, 'name'), 'Coreleone');
+        assert.strictEqual(get(record, 'name'), 'Coreleone');
 
         done();
       });
@@ -548,8 +548,8 @@ module('integration/references/belongs-to', function (hooks) {
     const adapterOptions = { thing: 'one' };
 
     adapter.findBelongsTo = function (store, snapshot, link) {
-      assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
-      assert.equal(link, '/families/1', 'link was passed correctly');
+      assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(link, '/families/1', 'link was passed correctly');
 
       return resolve({
         data: null,
@@ -570,11 +570,11 @@ module('integration/references/belongs-to', function (hooks) {
     });
 
     const familyReference = person.belongsTo('family');
-    assert.equal(familyReference.remoteType(), 'link');
+    assert.strictEqual(familyReference.remoteType(), 'link');
 
     const record = await familyReference.load({ adapterOptions });
     const meta = familyReference.meta();
-    assert.equal(record, null, 'we have no record');
+    assert.strictEqual(record, null, 'we have no record');
     assert.deepEqual(meta, { it: 'works' }, 'meta is available');
   });
 
@@ -588,10 +588,10 @@ module('integration/references/belongs-to', function (hooks) {
 
     var count = 0;
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
 
       count++;
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
 
       return resolve({
         data: {
@@ -621,7 +621,7 @@ module('integration/references/belongs-to', function (hooks) {
 
     run(function () {
       familyReference.reload({ adapterOptions }).then(function (record) {
-        assert.equal(get(record, 'name'), 'Coreleone');
+        assert.strictEqual(get(record, 'name'), 'Coreleone');
 
         done();
       });
@@ -638,10 +638,10 @@ module('integration/references/belongs-to', function (hooks) {
 
     var count = 0;
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
 
       count++;
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
 
       return resolve({
         data: {
@@ -677,7 +677,7 @@ module('integration/references/belongs-to', function (hooks) {
 
     run(function () {
       familyReference.reload({ adapterOptions }).then(function (record) {
-        assert.equal(get(record, 'name'), 'Coreleone');
+        assert.strictEqual(get(record, 'name'), 'Coreleone');
 
         done();
       });
@@ -693,9 +693,9 @@ module('integration/references/belongs-to', function (hooks) {
     const adapterOptions = { thing: 'one' };
 
     adapter.findBelongsTo = function (store, snapshot, link) {
-      assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
 
-      assert.equal(link, '/families/1');
+      assert.strictEqual(link, '/families/1');
 
       return resolve({
         data: {
@@ -725,7 +725,7 @@ module('integration/references/belongs-to', function (hooks) {
 
     run(function () {
       familyReference.reload({ adapterOptions }).then(function (record) {
-        assert.equal(get(record, 'name'), 'Coreleone');
+        assert.strictEqual(get(record, 'name'), 'Coreleone');
 
         done();
       });

--- a/packages/-ember-data/tests/integration/references/has-many-test.js
+++ b/packages/-ember-data/tests/integration/references/has-many-test.js
@@ -105,8 +105,8 @@ module('integration/references/has-many', function (hooks) {
 
     var personsReference = family.hasMany('persons');
 
-    assert.equal(personsReference.remoteType(), 'ids');
-    assert.equal(personsReference.type, 'person');
+    assert.strictEqual(personsReference.remoteType(), 'ids');
+    assert.strictEqual(personsReference.type, 'person');
     assert.deepEqual(personsReference.ids(), ['1', '2']);
   });
 
@@ -130,9 +130,9 @@ module('integration/references/has-many', function (hooks) {
 
     var personsReference = family.hasMany('persons');
 
-    assert.equal(personsReference.remoteType(), 'link');
-    assert.equal(personsReference.type, 'person');
-    assert.equal(personsReference.link(), '/families/1/persons');
+    assert.strictEqual(personsReference.remoteType(), 'link');
+    assert.strictEqual(personsReference.type, 'person');
+    assert.strictEqual(personsReference.link(), '/families/1/persons');
   });
 
   test('HasManyReference#parent is a reference to the parent where the relationship is defined', function (assert) {
@@ -319,9 +319,9 @@ module('integration/references/has-many', function (hooks) {
 
       personsReference.push(data).then(function (records) {
         assert.ok(records instanceof DS.ManyArray, 'push resolves with the referenced records');
-        assert.equal(get(records, 'length'), 2);
-        assert.equal(records.objectAt(0).get('name'), 'Vito');
-        assert.equal(records.objectAt(1).get('name'), 'Michael');
+        assert.strictEqual(get(records, 'length'), 2);
+        assert.strictEqual(records.objectAt(0).get('name'), 'Vito');
+        assert.strictEqual(records.objectAt(1).get('name'), 'Michael');
 
         done();
       });
@@ -353,8 +353,8 @@ module('integration/references/has-many', function (hooks) {
 
       personsReference.push(data).then(function (records) {
         assert.ok(records instanceof DS.ManyArray, 'push resolves with the referenced records');
-        assert.equal(get(records, 'length'), 1);
-        assert.equal(records.objectAt(0).get('name'), 'Vito');
+        assert.strictEqual(get(records, 'length'), 1);
+        assert.strictEqual(records.objectAt(0).get('name'), 'Vito');
 
         done();
       });
@@ -420,9 +420,9 @@ module('integration/references/has-many', function (hooks) {
 
       personsReference.push(payload).then(function (records) {
         assert.ok(records instanceof DS.ManyArray, 'push resolves with the referenced records');
-        assert.equal(get(records, 'length'), 2);
-        assert.equal(records.objectAt(0).get('name'), 'Vito');
-        assert.equal(records.objectAt(1).get('name'), 'Michael');
+        assert.strictEqual(get(records, 'length'), 2);
+        assert.strictEqual(records.objectAt(0).get('name'), 'Vito');
+        assert.strictEqual(records.objectAt(1).get('name'), 'Michael');
 
         done();
       });
@@ -472,9 +472,9 @@ module('integration/references/has-many', function (hooks) {
     run(function () {
       push.then(function (records) {
         assert.ok(records instanceof DS.ManyArray, 'push resolves with the referenced records');
-        assert.equal(get(records, 'length'), 2);
-        assert.equal(records.objectAt(0).get('name'), 'Vito');
-        assert.equal(records.objectAt(1).get('name'), 'Michael');
+        assert.strictEqual(get(records, 'length'), 2);
+        assert.strictEqual(records.objectAt(0).get('name'), 'Vito');
+        assert.strictEqual(records.objectAt(1).get('name'), 'Michael');
 
         done();
       });
@@ -532,7 +532,7 @@ module('integration/references/has-many', function (hooks) {
     run(function () {
       var personsReference = family.hasMany('persons');
       var records = personsReference.value();
-      assert.equal(get(records, 'length'), 2);
+      assert.strictEqual(get(records, 'length'), 2);
       assert.true(records.isEvery('isLoaded'));
     });
   });
@@ -558,7 +558,7 @@ module('integration/references/has-many', function (hooks) {
     run(function () {
       var personsReference = family.hasMany('persons');
       var records = personsReference.value();
-      assert.equal(get(records, 'length'), 0);
+      assert.strictEqual(get(records, 'length'), 0);
     });
   });
 
@@ -596,7 +596,7 @@ module('integration/references/has-many', function (hooks) {
     const adapterOptions = { thing: 'one' };
 
     adapter.findMany = function (store, type, id, snapshots) {
-      assert.equal(snapshots[0].adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(snapshots[0].adapterOptions, adapterOptions, 'adapterOptions are passed in');
       return resolve({
         data: [
           { id: 1, type: 'person', attributes: { name: 'Vito' } },
@@ -628,9 +628,9 @@ module('integration/references/has-many', function (hooks) {
     run(function () {
       personsReference.load({ adapterOptions }).then(function (records) {
         assert.ok(records instanceof DS.ManyArray, 'push resolves with the referenced records');
-        assert.equal(get(records, 'length'), 2);
-        assert.equal(records.objectAt(0).get('name'), 'Vito');
-        assert.equal(records.objectAt(1).get('name'), 'Michael');
+        assert.strictEqual(get(records, 'length'), 2);
+        assert.strictEqual(records.objectAt(0).get('name'), 'Vito');
+        assert.strictEqual(records.objectAt(1).get('name'), 'Michael');
 
         done();
       });
@@ -646,8 +646,8 @@ module('integration/references/has-many', function (hooks) {
     const adapterOptions = { thing: 'one' };
 
     adapter.findHasMany = function (store, snapshot, link) {
-      assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
-      assert.equal(link, '/families/1/persons');
+      assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(link, '/families/1/persons');
 
       return resolve({
         data: [
@@ -673,14 +673,14 @@ module('integration/references/has-many', function (hooks) {
     });
 
     var personsReference = family.hasMany('persons');
-    assert.equal(personsReference.remoteType(), 'link');
+    assert.strictEqual(personsReference.remoteType(), 'link');
 
     run(function () {
       personsReference.load({ adapterOptions }).then(function (records) {
         assert.ok(records instanceof DS.ManyArray, 'push resolves with the referenced records');
-        assert.equal(get(records, 'length'), 2);
-        assert.equal(records.objectAt(0).get('name'), 'Vito');
-        assert.equal(records.objectAt(1).get('name'), 'Michael');
+        assert.strictEqual(get(records, 'length'), 2);
+        assert.strictEqual(records.objectAt(0).get('name'), 'Vito');
+        assert.strictEqual(records.objectAt(1).get('name'), 'Michael');
 
         done();
       });
@@ -694,8 +694,8 @@ module('integration/references/has-many', function (hooks) {
     const adapterOptions = { thing: 'one' };
 
     adapter.findHasMany = function (store, snapshot, link) {
-      assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
-      assert.equal(link, '/families/1/persons');
+      assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(link, '/families/1/persons');
 
       return resolve({ data: [] });
     };
@@ -716,13 +716,13 @@ module('integration/references/has-many', function (hooks) {
     });
 
     let personsReference = family.hasMany('persons');
-    assert.equal(personsReference.remoteType(), 'link');
+    assert.strictEqual(personsReference.remoteType(), 'link');
 
     return run(() => {
       return personsReference.load({ adapterOptions }).then((records) => {
         assert.ok(records instanceof DS.ManyArray, 'push resolves with the referenced records');
-        assert.equal(get(records, 'length'), 0);
-        assert.equal(get(personsReference.value(), 'length'), 0);
+        assert.strictEqual(get(records, 'length'), 0);
+        assert.strictEqual(get(personsReference.value(), 'length'), 0);
       });
     });
   });
@@ -738,7 +738,7 @@ module('integration/references/has-many', function (hooks) {
 
     adapter.findMany = function (store, type, id) {
       count++;
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
 
       return deferred.promise;
     };
@@ -766,7 +766,7 @@ module('integration/references/has-many', function (hooks) {
     run(function () {
       personsReference.load();
       personsReference.load().then(function (records) {
-        assert.equal(get(records, 'length'), 2);
+        assert.strictEqual(get(records, 'length'), 2);
       });
     });
 
@@ -781,7 +781,7 @@ module('integration/references/has-many', function (hooks) {
 
     run(function () {
       personsReference.load().then(function (records) {
-        assert.equal(get(records, 'length'), 2);
+        assert.strictEqual(get(records, 'length'), 2);
 
         done();
       });
@@ -797,7 +797,7 @@ module('integration/references/has-many', function (hooks) {
     const adapterOptions = { thing: 'one' };
 
     adapter.findMany = function (store, type, id, snapshots) {
-      assert.equal(snapshots[0].adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(snapshots[0].adapterOptions, adapterOptions, 'adapterOptions are passed in');
       return resolve({
         data: [
           { id: 1, type: 'person', attributes: { name: 'Vito Coreleone' } },
@@ -831,9 +831,9 @@ module('integration/references/has-many', function (hooks) {
     run(function () {
       personsReference.reload({ adapterOptions }).then(function (records) {
         assert.ok(records instanceof DS.ManyArray, 'push resolves with the referenced records');
-        assert.equal(get(records, 'length'), 2);
-        assert.equal(records.objectAt(0).get('name'), 'Vito Coreleone');
-        assert.equal(records.objectAt(1).get('name'), 'Michael Coreleone');
+        assert.strictEqual(get(records, 'length'), 2);
+        assert.strictEqual(records.objectAt(0).get('name'), 'Vito Coreleone');
+        assert.strictEqual(records.objectAt(1).get('name'), 'Michael Coreleone');
 
         done();
       });
@@ -850,9 +850,9 @@ module('integration/references/has-many', function (hooks) {
 
     var count = 0;
     adapter.findHasMany = function (store, snapshot, link) {
-      assert.equal(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
+      assert.strictEqual(snapshot.adapterOptions, adapterOptions, 'adapterOptions are passed in');
       count++;
-      assert.equal(link, '/families/1/persons');
+      assert.strictEqual(link, '/families/1/persons');
 
       if (count === 1) {
         return resolve({
@@ -887,7 +887,7 @@ module('integration/references/has-many', function (hooks) {
     });
 
     var personsReference = family.hasMany('persons');
-    assert.equal(personsReference.remoteType(), 'link');
+    assert.strictEqual(personsReference.remoteType(), 'link');
 
     run(function () {
       personsReference
@@ -897,9 +897,9 @@ module('integration/references/has-many', function (hooks) {
         })
         .then(function (records) {
           assert.ok(records instanceof DS.ManyArray, 'push resolves with the referenced records');
-          assert.equal(get(records, 'length'), 2);
-          assert.equal(records.objectAt(0).get('name'), 'Vito Coreleone');
-          assert.equal(records.objectAt(1).get('name'), 'Michael Coreleone');
+          assert.strictEqual(get(records, 'length'), 2);
+          assert.strictEqual(records.objectAt(0).get('name'), 'Vito Coreleone');
+          assert.strictEqual(records.objectAt(1).get('name'), 'Michael Coreleone');
 
           done();
         });
@@ -992,10 +992,10 @@ module('integration/references/has-many', function (hooks) {
     });
 
     let persons = family.hasMany('persons').value();
-    assert.equal(persons.length, 2);
+    assert.strictEqual(persons.length, 2);
     persons.forEach((person) => {
       let pets = person.hasMany('pets').value();
-      assert.equal(pets.length, 2);
+      assert.strictEqual(pets.length, 2);
     });
   });
 
@@ -1090,10 +1090,10 @@ module('integration/references/has-many', function (hooks) {
 
     let family = await store.findRecord('family', '1');
     let persons = family.hasMany('persons').value();
-    assert.equal(persons.length, 2);
+    assert.strictEqual(persons.length, 2);
     persons.forEach((person) => {
       let pets = person.hasMany('pets').value();
-      assert.equal(pets.length, 2);
+      assert.strictEqual(pets.length, 2);
     });
   });
 });

--- a/packages/-ember-data/tests/integration/references/record-test.js
+++ b/packages/-ember-data/tests/integration/references/record-test.js
@@ -27,18 +27,18 @@ module('integration/references/record', function (hooks) {
     let store = this.owner.lookup('service:store');
     let recordReference = store.getReference('person', 1);
 
-    assert.equal(recordReference.remoteType(), 'identity');
-    assert.equal(recordReference.type, 'person');
-    assert.equal(recordReference.id(), 1);
+    assert.strictEqual(recordReference.remoteType(), 'identity');
+    assert.strictEqual(recordReference.type, 'person');
+    assert.strictEqual(recordReference.id(), '1');
   });
 
   test('a RecordReference can be retrieved via store.getReference(identifier) without local state', function (assert) {
     let store = this.owner.lookup('service:store');
     let recordReference = store.getReference({ type: 'person', id: '1' });
 
-    assert.equal(recordReference.remoteType(), 'identity');
-    assert.equal(recordReference.type, 'person');
-    assert.equal(recordReference.id(), '1');
+    assert.strictEqual(recordReference.remoteType(), 'identity');
+    assert.strictEqual(recordReference.type, 'person');
+    assert.strictEqual(recordReference.id(), '1');
   });
 
   [
@@ -73,10 +73,10 @@ module('integration/references/record', function (hooks) {
 
       let recordReference = store.getReference(getReferenceArgs);
 
-      assert.equal(recordReference.remoteType(), 'identity');
-      assert.equal(recordReference.type, 'person');
+      assert.strictEqual(recordReference.remoteType(), 'identity');
+      assert.strictEqual(recordReference.type, 'person');
       if (isCreate || !withId) {
-        assert.equal(recordReference.id(), null);
+        assert.strictEqual(recordReference.id(), null);
       } else {
         assert.strictEqual(recordReference.id(), '1');
       }
@@ -103,7 +103,7 @@ module('integration/references/record', function (hooks) {
 
     let record = await pushed;
     assert.ok(record instanceof Person, 'push resolves with the record');
-    assert.equal(get(record, 'name'), 'le name');
+    assert.strictEqual(get(record, 'name'), 'le name');
   });
 
   test('push(promise)', async function (assert) {
@@ -129,7 +129,7 @@ module('integration/references/record', function (hooks) {
 
     let record = await pushed;
     assert.ok(record instanceof Person, 'push resolves with the record');
-    assert.equal(get(record, 'name'), 'le name', 'name is updated');
+    assert.strictEqual(get(record, 'name'), 'le name', 'name is updated');
   });
 
   test('value() returns null when not yet loaded', function (assert) {
@@ -149,7 +149,7 @@ module('integration/references/record', function (hooks) {
     });
 
     let recordReference = store.getReference('person', 1);
-    assert.equal(recordReference.value(), person);
+    assert.strictEqual(recordReference.value(), person);
   });
 
   test('load() fetches the record', async function (assert) {
@@ -171,7 +171,7 @@ module('integration/references/record', function (hooks) {
     let recordReference = store.getReference('person', 1);
 
     let record = await recordReference.load();
-    assert.equal(get(record, 'name'), 'Vito');
+    assert.strictEqual(get(record, 'name'), 'Vito');
   });
 
   test('load() only a single find is triggered', async function (assert) {
@@ -189,7 +189,7 @@ module('integration/references/record', function (hooks) {
     };
     adapter.findRecord = function (store, type, id) {
       count++;
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
 
       return deferred.promise;
     };
@@ -198,7 +198,7 @@ module('integration/references/record', function (hooks) {
 
     recordReference.load();
     let record = await recordReference.load();
-    assert.equal(get(record, 'name'), 'Vito');
+    assert.strictEqual(get(record, 'name'), 'Vito');
 
     deferred.resolve({
       data: {
@@ -211,7 +211,7 @@ module('integration/references/record', function (hooks) {
     });
 
     record = await recordReference.load();
-    assert.equal(get(record, 'name'), 'Vito');
+    assert.strictEqual(get(record, 'name'), 'Vito');
   });
 
   test('reload() loads the record if not yet loaded', async function (assert) {
@@ -221,7 +221,7 @@ module('integration/references/record', function (hooks) {
     let count = 0;
     adapter.findRecord = function (store, type, id) {
       count++;
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
 
       return resolve({
         data: {
@@ -237,7 +237,7 @@ module('integration/references/record', function (hooks) {
     let recordReference = store.getReference('person', 1);
 
     let record = await recordReference.reload();
-    assert.equal(get(record, 'name'), 'Vito Coreleone');
+    assert.strictEqual(get(record, 'name'), 'Vito Coreleone');
   });
 
   test('reload() fetches the record', async function (assert) {
@@ -269,6 +269,6 @@ module('integration/references/record', function (hooks) {
     let recordReference = store.getReference('person', 1);
 
     let record = await recordReference.reload();
-    assert.equal(get(record, 'name'), 'Vito Coreleone');
+    assert.strictEqual(get(record, 'name'), 'Vito Coreleone');
   });
 });

--- a/packages/-ember-data/tests/integration/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/integration/relationships/belongs-to-test.js
@@ -144,7 +144,7 @@ module('integration/relationship/belongs-to BelongsTo Relationships (new-style)'
       'adapter:pet',
       JSONAPIAdapter.extend({
         findRecord() {
-          assert.equal(++petFindRecordCalls, 1, 'We call findRecord only once for our pet');
+          assert.strictEqual(++petFindRecordCalls, 1, 'We call findRecord only once for our pet');
           return resolve({
             data: {
               type: 'pet',
@@ -168,7 +168,7 @@ module('integration/relationship/belongs-to BelongsTo Relationships (new-style)'
       'adapter:person',
       JSONAPIAdapter.extend({
         findRecord() {
-          assert.equal(++personFindRecordCalls, 1, 'We call findRecord only once for our person');
+          assert.strictEqual(++personFindRecordCalls, 1, 'We call findRecord only once for our person');
           return resolve({
             data: {
               type: 'person',
@@ -396,7 +396,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
 
     const app = store.peekRecord('app', '1');
     const team = store.peekRecord('team', '1');
-    assert.equal(app.get('team.id'), team.get('id'), 'sets team correctly on app');
+    assert.strictEqual(app.get('team.id'), team.get('id'), 'sets team correctly on app');
     assert.deepEqual(team.get('apps').toArray().mapBy('id'), ['1'], 'sets apps correctly on team');
 
     adapter.shouldBackgroundReloadRecord = () => false;
@@ -420,7 +420,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
     return run(() => {
       app.set('name', 'Hello');
       return app.save().then(() => {
-        assert.equal(app.get('team.id'), null, 'team removed from app relationship');
+        assert.strictEqual(app.get('team.id'), undefined, 'team removed from app relationship');
         assert.deepEqual(team.get('apps').toArray().mapBy('id'), [], 'app removed from team apps relationship');
       });
     });
@@ -655,7 +655,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
         message: store.findRecord('post', 1),
         comment: store.findRecord('comment', 2),
       }).then((records) => {
-        assert.equal(records.comment.get('message'), records.message);
+        assert.strictEqual(records.comment.get('message'), records.message);
       });
     });
   });
@@ -698,8 +698,8 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
 
       return store.findRecord('comment', 2).then((comment) => {
         let serialized = comment.serialize({ includeId: true });
-        assert.equal(serialized.data.relationships.message.data.id, 1);
-        assert.equal(serialized.data.relationships.message.data.type, 'posts');
+        assert.strictEqual(serialized.data.relationships.message.data.id, '1');
+        assert.strictEqual(serialized.data.relationships.message.data.type, 'posts');
       });
     });
   });
@@ -742,9 +742,9 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
     };
 
     adapter.findBelongsTo = function (store, snapshot, link, relationship) {
-      assert.equal(relationship.type, 'group');
-      assert.equal(relationship.key, 'group');
-      assert.equal(link, '/people/1/group');
+      assert.strictEqual(relationship.type, 'group');
+      assert.strictEqual(relationship.key, 'group');
+      assert.strictEqual(link, '/people/1/group');
 
       return resolve({
         data: {
@@ -911,7 +911,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
       let person = store.createRecord('person', {
         group: groupPromise,
       });
-      assert.equal(person.get('group.content'), group);
+      assert.strictEqual(person.get('group.content'), group);
     });
   });
 
@@ -926,7 +926,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
 
       igor.set('favouriteMessage', post);
 
-      assert.equal(igor.get('favouriteMessage.title'), "Igor's unimaginative blog post");
+      assert.strictEqual(igor.get('favouriteMessage.title'), "Igor's unimaginative blog post");
     });
   });
 
@@ -1016,7 +1016,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
 
     adapter.deleteRecord = function (store, type, snapshot) {
       assert.ok(snapshot.record instanceof type);
-      assert.equal(snapshot.id, 1, 'should first comment');
+      assert.strictEqual(snapshot.id, '1', 'should first comment');
       return {
         data: {
           id: snapshot.record.id,
@@ -1075,7 +1075,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
 
     adapter.deleteRecord = function (store, type, snapshot) {
       assert.ok(snapshot.record instanceof type);
-      assert.equal(snapshot.id, 1, 'should first post');
+      assert.strictEqual(snapshot.id, '1', 'should first post');
       return {
         data: {
           id: '1',
@@ -1166,7 +1166,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
       author.rollbackAttributes();
 
       return book.get('author').then((fetchedAuthor) => {
-        assert.equal(fetchedAuthor, author, 'Book has an author after rollback attributes');
+        assert.strictEqual(fetchedAuthor, author, 'Book has an author after rollback attributes');
       });
     });
   });
@@ -1210,7 +1210,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
       author.rollbackAttributes();
     });
 
-    assert.equal(book.get('author'), author, 'Book has an author after rollback attributes');
+    assert.strictEqual(book.get('author'), author, 'Book has an author after rollback attributes');
   });
 
   testInDebug('Passing a model as type to belongsTo should not work', function (assert) {
@@ -1462,7 +1462,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
     let adapter = store.adapterFor('application');
 
     adapter.findBelongsTo = function (store, snapshot, url, relationship) {
-      assert.equal(url, 'author', 'url is correct');
+      assert.strictEqual(url, 'author', 'url is correct');
       assert.ok(true, "The adapter's findBelongsTo method should be called");
       return resolve({
         data: {
@@ -1489,7 +1489,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
       });
 
       return book.get('author').then((author) => {
-        assert.equal(author.get('name'), 'This is author', 'author name is correct');
+        assert.strictEqual(author.get('name'), 'This is author', 'author name is correct');
       });
     });
   });
@@ -1536,7 +1536,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
 
     const author = await book.get('author');
 
-    assert.equal(author.get('name'), 'This is author', 'author name is correct');
+    assert.strictEqual(author.get('name'), 'This is author', 'author name is correct');
   });
 
   test('Relationship data should take precedence over related link when local record data is available', function (assert) {
@@ -1584,7 +1584,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
       });
 
       return book.get('author').then((author) => {
-        assert.equal(author.get('name'), 'This is author', 'author name is correct');
+        assert.strictEqual(author.get('name'), 'This is author', 'author name is correct');
       });
     });
   });
@@ -1600,7 +1600,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
     let adapter = store.adapterFor('application');
 
     adapter.findBelongsTo = function (store, snapshot, url, relationship) {
-      assert.equal(url, 'author-new-link', 'url is correct');
+      assert.strictEqual(url, 'author-new-link', 'url is correct');
       assert.ok(true, "The adapter's findBelongsTo method should be called");
       return resolve({
         data: {
@@ -1646,7 +1646,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
       });
 
       book.get('author').then((author) => {
-        assert.equal(author.get('name'), 'This is author', 'author name is correct');
+        assert.strictEqual(author.get('name'), 'This is author', 'author name is correct');
       });
     });
   });
@@ -1662,7 +1662,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
     let adapter = store.adapterFor('application');
 
     adapter.findBelongsTo = function (store, snapshot, url, relationship) {
-      assert.equal(url, 'author-updated-link', 'url is correct');
+      assert.strictEqual(url, 'author-updated-link', 'url is correct');
       assert.ok(true, "The adapter's findBelongsTo method should be called");
       return resolve({
         data: {
@@ -1707,7 +1707,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
       return book
         .get('author')
         .then((author) => {
-          assert.equal(author.get('name'), 'This is author', 'author name is correct');
+          assert.strictEqual(author.get('name'), 'This is author', 'author name is correct');
         })
         .then(() => {
           store.push({
@@ -1725,7 +1725,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
           });
 
           return book.get('author').then((author) => {
-            assert.equal(author.get('name'), 'This is updated author', 'author name is correct');
+            assert.strictEqual(author.get('name'), 'This is updated author', 'author name is correct');
           });
         });
     });
@@ -1777,7 +1777,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
       return book
         .get('author')
         .then((author) => {
-          assert.equal(author.get('name'), 'This is author', 'author name is correct');
+          assert.strictEqual(author.get('name'), 'This is author', 'author name is correct');
         })
         .then(() => {
           store.push({
@@ -1795,7 +1795,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
           });
 
           return book.get('author').then((author) => {
-            assert.equal(author.get('name'), 'This is author', 'author name is correct');
+            assert.strictEqual(author.get('name'), 'This is author', 'author name is correct');
           });
         });
     });
@@ -1844,7 +1844,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
           return chapter.get('book');
         })
         .then((book) => {
-          assert.equal(book.get('name'), 'book title');
+          assert.strictEqual(book.get('name'), 'book title');
 
           adapter.findBelongsTo = function () {
             return resolve({
@@ -1859,7 +1859,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
           return chapter.belongsTo('book').reload();
         })
         .then((book) => {
-          assert.equal(book.get('name'), 'updated book title');
+          assert.strictEqual(book.get('name'), 'updated book title');
         });
     });
   });
@@ -1908,13 +1908,13 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
 
     return run(() => {
       let book = chapter.get('book');
-      assert.equal(book.get('name'), 'book title');
+      assert.strictEqual(book.get('name'), 'book title');
 
       return chapter
         .belongsTo('book')
         .reload()
         .then(function (book) {
-          assert.equal(book.get('name'), 'updated book title');
+          assert.strictEqual(book.get('name'), 'updated book title');
         });
     });
   });
@@ -1956,7 +1956,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
       return chapter
         .get('book')
         .then((book) => {
-          assert.equal(book.get('name'), 'book title');
+          assert.strictEqual(book.get('name'), 'book title');
 
           adapter.findRecord = function () {
             return resolve({
@@ -1971,7 +1971,7 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
           return chapter.belongsTo('book').reload();
         })
         .then((book) => {
-          assert.equal(book.get('name'), 'updated book title');
+          assert.strictEqual(book.get('name'), 'updated book title');
         });
     });
   });
@@ -2031,6 +2031,6 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
       chapter.get('book');
     });
 
-    assert.equal(count, 0);
+    assert.strictEqual(count, 0);
   });
 });

--- a/packages/-ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/has-many-test.js
@@ -321,7 +321,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       ['3', '4', '5', '7'],
       `user's contacts should have expected contacts`
     );
-    assert.equal(contacts, user.get('contacts'));
+    assert.strictEqual(contacts, user.get('contacts'));
 
     assert.ok(!user.contacts.initialState || !user.contacts.initialState.find((model) => model.id === '2'));
 
@@ -334,7 +334,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       ['3', '4', '5', '7', '8'],
       `user's contacts should have expected contacts`
     );
-    assert.equal(contacts, user.get('contacts'));
+    assert.strictEqual(contacts, user.get('contacts'));
   });
 
   test('hasMany + canonical vs currentState + unloadRecord', function (assert) {
@@ -423,7 +423,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       ['3', '4', '5', '7'],
       `user's contacts should have expected contacts`
     );
-    assert.equal(contacts, user.get('contacts'));
+    assert.strictEqual(contacts, user.get('contacts'));
 
     run(() => {
       contacts.addObject(store.createRecord('user', { id: 8 }));
@@ -434,7 +434,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       ['3', '4', '5', '7', '8'],
       `user's contacts should have expected contacts`
     );
-    assert.equal(contacts, user.get('contacts'));
+    assert.strictEqual(contacts, user.get('contacts'));
   });
 
   test('adapter.findMany only gets unique IDs even if duplicate IDs are present in the hasMany relationship', function (assert) {
@@ -459,7 +459,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     };
 
     adapter.findMany = function (store, type, ids, snapshots) {
-      assert.equal(type, Chapter, 'type passed to adapter.findMany is correct');
+      assert.strictEqual(type, Chapter, 'type passed to adapter.findMany is correct');
       assert.deepEqual(ids, ['2', '3'], 'ids passed to adapter.findMany are unique');
 
       return resolve({
@@ -502,8 +502,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     // When the store asks the adapter for the record with ID 1,
     // provide some fake data.
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(type, Post, 'find type was Post');
-      assert.equal(id, '1', 'find id was 1');
+      assert.strictEqual(type, Post, 'find type was Post');
+      assert.strictEqual(id, '1', 'find id was 1');
 
       return resolve({
         data: {
@@ -526,8 +526,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     };
 
     adapter.findHasMany = function (store, snapshot, link, relationship) {
-      assert.equal(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
-      assert.equal(relationship.type, 'comment', 'relationship was passed correctly');
+      assert.strictEqual(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
+      assert.strictEqual(relationship.type, 'comment', 'relationship was passed correctly');
 
       return resolve({
         data: [
@@ -545,8 +545,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
         })
         .then((comments) => {
           assert.true(comments.get('isLoaded'), 'comments are loaded');
-          assert.equal(comments.get('length'), 2, 'comments have 2 length');
-          assert.equal(comments.objectAt(0).get('body'), 'First', 'comment loaded successfully');
+          assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
+          assert.strictEqual(comments.objectAt(0).get('body'), 'First', 'comment loaded successfully');
         });
     });
   });
@@ -587,7 +587,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     let count = 0;
     adapter.findHasMany = function (store, snapshot, link, relationship) {
       count++;
-      assert.equal(count, 1, 'findHasMany has only been called once');
+      assert.strictEqual(count, 1, 'findHasMany has only been called once');
       return new EmberPromise((resolve, reject) => {
         setTimeout(() => {
           let value = {
@@ -621,7 +621,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     return all([promise1, promise2]).then(() => {
-      assert.equal(promise1.get('promise'), promise2.get('promise'), 'Same promise is returned both times');
+      assert.strictEqual(promise1.get('promise'), promise2.get('promise'), 'Same promise is returned both times');
     });
   });
 
@@ -724,13 +724,13 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       return post
         .get('comments')
         .then((comments) => {
-          assert.equal(comments.get('length'), 1, 'initially we have one comment');
+          assert.strictEqual(comments.get('length'), 1, 'initially we have one comment');
 
           return post.save();
         })
         .then(() => post.get('comments'))
         .then((comments) => {
-          assert.equal(comments.get('length'), 1, 'after saving, we still have one comment');
+          assert.strictEqual(comments.get('length'), 1, 'after saving, we still have one comment');
         });
     });
   });
@@ -774,12 +774,12 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       return post
         .get('comments')
         .then((comments) => {
-          assert.equal(comments.get('length'), 1);
+          assert.strictEqual(comments.get('length'), 1);
           return post.save();
         })
         .then(() => post.get('comments'))
         .then((comments) => {
-          assert.equal(comments.get('length'), 2);
+          assert.strictEqual(comments.get('length'), 2);
         });
     });
   });
@@ -810,7 +810,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       return post
         .get('comments')
         .then((comments) => {
-          assert.equal(comments.get('length'), 1);
+          assert.strictEqual(comments.get('length'), 1);
           assert.true(localComment.get('isNew'));
 
           return post.save();
@@ -842,7 +842,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
         })
         .then(() => post.get('comments'))
         .then((comments) => {
-          assert.equal(comments.get('length'), 1);
+          assert.strictEqual(comments.get('length'), 1);
           assert.true(localComment.get('isNew'));
         });
     });
@@ -859,8 +859,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(type, Post, 'find type was Post');
-      assert.equal(id, '1', 'find id was 1');
+      assert.strictEqual(type, Post, 'find type was Post');
+      assert.strictEqual(id, '1', 'find id was 1');
 
       return resolve({
         data: {
@@ -876,9 +876,9 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     };
 
     adapter.findHasMany = function (store, snapshot, link, relationship) {
-      assert.equal(relationship.type, 'comment', 'findHasMany relationship type was Comment');
-      assert.equal(relationship.key, 'comments', 'findHasMany relationship key was comments');
-      assert.equal(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
+      assert.strictEqual(relationship.type, 'comment', 'findHasMany relationship type was Comment');
+      assert.strictEqual(relationship.key, 'comments', 'findHasMany relationship key was comments');
+      assert.strictEqual(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
 
       return resolve({
         data: [
@@ -895,12 +895,12 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
         })
         .then(function (comments) {
           assert.true(comments.get('isLoaded'), 'comments are loaded');
-          assert.equal(comments.get('length'), 2, 'comments have 2 length');
+          assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
 
           adapter.findHasMany = function (store, snapshot, link, relationship) {
-            assert.equal(relationship.type, 'comment', 'findHasMany relationship type was Comment');
-            assert.equal(relationship.key, 'comments', 'findHasMany relationship key was comments');
-            assert.equal(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
+            assert.strictEqual(relationship.type, 'comment', 'findHasMany relationship type was Comment');
+            assert.strictEqual(relationship.key, 'comments', 'findHasMany relationship key was comments');
+            assert.strictEqual(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
 
             return resolve({
               data: [
@@ -914,7 +914,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           return comments.reload();
         })
         .then(function (newComments) {
-          assert.equal(newComments.get('length'), 3, 'reloaded comments have 3 length');
+          assert.strictEqual(newComments.get('length'), 3, 'reloaded comments have 3 length');
         });
     });
   });
@@ -930,8 +930,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(type, Post, 'find type was Post');
-      assert.equal(id, '1', 'find id was 1');
+      assert.strictEqual(type, Post, 'find type was Post');
+      assert.strictEqual(id, '1', 'find id was 1');
 
       return resolve({
         data: {
@@ -974,7 +974,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
         .then(function (post) {
           let comments = post.get('comments');
           assert.true(comments.get('isLoaded'), 'comments are loaded');
-          assert.equal(comments.get('length'), 2, 'comments have a length of 2');
+          assert.strictEqual(comments.get('length'), 2, 'comments have a length of 2');
 
           adapter.findMany = function (store, type, ids, snapshots) {
             return resolve({
@@ -988,7 +988,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           return comments.reload();
         })
         .then(function (newComments) {
-          assert.equal(newComments.get('firstObject.body'), 'FirstUpdated', 'Record body was correctly updated');
+          assert.strictEqual(newComments.get('firstObject.body'), 'FirstUpdated', 'Record body was correctly updated');
         });
     });
   });
@@ -1004,8 +1004,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(type, Post, 'find type was Post');
-      assert.equal(id, '1', 'find id was 1');
+      assert.strictEqual(type, Post, 'find type was Post');
+      assert.strictEqual(id, '1', 'find id was 1');
 
       return resolve({
         data: {
@@ -1040,7 +1040,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
         })
         .then(function (comments) {
           assert.true(comments.get('isLoaded'), 'comments are loaded');
-          assert.equal(comments.get('length'), 2, 'comments have 2 length');
+          assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
 
           adapter.findMany = function (store, type, ids, snapshots) {
             return resolve({
@@ -1054,7 +1054,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           return comments.reload();
         })
         .then(function (newComments) {
-          assert.equal(newComments.get('firstObject.body'), 'FirstUpdated', 'Record body was correctly updated');
+          assert.strictEqual(newComments.get('firstObject.body'), 'FirstUpdated', 'Record body was correctly updated');
         });
     });
   });
@@ -1125,7 +1125,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
     assert.true(reloadedManyArray.get('isLoaded'), 'the third reload worked, comments are loaded again');
     assert.ok(reloadedManyArray === manyArray, 'the many array stays the same');
-    assert.equal(loadingCount, 4, 'We only fired 4 requests');
+    assert.strictEqual(loadingCount, 4, 'We only fired 4 requests');
   });
 
   test('A hasMany relationship can be directly reloaded if it was fetched via links', function (assert) {
@@ -1140,8 +1140,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     adapter.findRecord = function (store, type, id) {
-      assert.equal(type, Post, 'find type was Post');
-      assert.equal(id, '1', 'find id was 1');
+      assert.strictEqual(type, Post, 'find type was Post');
+      assert.strictEqual(id, '1', 'find id was 1');
 
       return resolve({
         data: {
@@ -1157,7 +1157,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     };
 
     adapter.findHasMany = function (store, record, link, relationship) {
-      assert.equal(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
+      assert.strictEqual(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
 
       return resolve({
         data: [
@@ -1173,8 +1173,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           .reload()
           .then(function (comments) {
             assert.true(comments.get('isLoaded'), 'comments are loaded');
-            assert.equal(comments.get('length'), 2, 'comments have 2 length');
-            assert.equal(comments.get('firstObject.body'), 'FirstUpdated', 'Record body was correctly updated');
+            assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
+            assert.strictEqual(comments.get('firstObject.body'), 'FirstUpdated', 'Record body was correctly updated');
           });
       });
     });
@@ -1220,7 +1220,11 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       store.findRecord('post', 1).then(function (post) {
         post.get('comments').then(function (comments) {
           all([comments.reload(), comments.reload(), comments.reload()]).then(function (comments) {
-            assert.equal(count, 2, 'One request for the original access and only one request for the mulitple reloads');
+            assert.strictEqual(
+              count,
+              2,
+              'One request for the original access and only one request for the mulitple reloads'
+            );
             done();
           });
         });
@@ -1238,8 +1242,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(type, Post, 'find type was Post');
-      assert.equal(id, '1', 'find id was 1');
+      assert.strictEqual(type, Post, 'find type was Post');
+      assert.strictEqual(id, '1', 'find id was 1');
 
       return resolve({
         data: {
@@ -1273,8 +1277,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           .reload()
           .then(function (comments) {
             assert.true(comments.get('isLoaded'), 'comments are loaded');
-            assert.equal(comments.get('length'), 2, 'comments have 2 length');
-            assert.equal(comments.get('firstObject.body'), 'FirstUpdated', 'Record body was correctly updated');
+            assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
+            assert.strictEqual(comments.get('firstObject.body'), 'FirstUpdated', 'Record body was correctly updated');
           });
       });
     });
@@ -1324,7 +1328,11 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       store.findRecord('post', 1).then(function (post) {
         post.get('comments').then(function (comments) {
           all([comments.reload(), comments.reload(), comments.reload()]).then(function (comments) {
-            assert.equal(count, 2, 'One request for the original access and only one request for the mulitple reloads');
+            assert.strictEqual(
+              count,
+              2,
+              'One request for the original access and only one request for the mulitple reloads'
+            );
             done();
           });
         });
@@ -1372,11 +1380,11 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     run(function () {
       post.get('comments').then(function (comments) {
         assert.true(comments.get('isLoaded'), 'comments are loaded');
-        assert.equal(comments.get('length'), 2, 'comments have 2 length');
+        assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
 
         let newComment = post.get('comments').createRecord({ body: 'Third' });
-        assert.equal(newComment.get('body'), 'Third', 'new comment is returned');
-        assert.equal(comments.get('length'), 3, 'comments have 3 length, including new record');
+        assert.strictEqual(newComment.get('body'), 'Third', 'new comment is returned');
+        assert.strictEqual(comments.get('length'), 3, 'comments have 3 length, including new record');
       });
     });
   });
@@ -1434,7 +1442,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
         comments.trigger('on-event');
       });
 
-      assert.equal(comments.has('on-event'), true);
+      assert.strictEqual(comments.has('on-event'), true);
       const cb = function () {
         assert.ok(false, 'We should not trigger this event');
       };
@@ -1442,19 +1450,19 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       comments.on('off-event', cb);
       comments.off('off-event', cb);
 
-      assert.equal(comments.has('off-event'), false);
+      assert.strictEqual(comments.has('off-event'), false);
 
       comments.one('one-event', function () {
         assert.ok(true);
       });
 
-      assert.equal(comments.has('one-event'), true);
+      assert.strictEqual(comments.has('one-event'), true);
 
       run(function () {
         comments.trigger('one-event');
       });
 
-      assert.equal(comments.has('one-event'), false);
+      assert.strictEqual(comments.has('one-event'), false);
     }
   );
 
@@ -1469,7 +1477,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     adapter.findHasMany = function (store, snapshot, link, relationship) {
-      assert.equal(relationship.type, 'comment', 'relationship was passed correctly');
+      assert.strictEqual(relationship.type, 'comment', 'relationship was passed correctly');
 
       if (link === '/first') {
         return resolve({
@@ -1509,8 +1517,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
     const comments = await post.get('comments');
     assert.true(comments.get('isLoaded'), 'comments are loaded');
-    assert.equal(comments.get('length'), 2, 'comments have 2 length');
-    assert.equal(comments.objectAt(0).get('body'), 'First', 'comment 1 successfully loaded');
+    assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
+    assert.strictEqual(comments.objectAt(0).get('body'), 'First', 'comment 1 successfully loaded');
     store.push({
       data: {
         type: 'post',
@@ -1576,7 +1584,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     run(function () {
       store.findRecord('user', 1).then(function (user) {
         let messages = user.get('messages');
-        assert.equal(messages.get('length'), 2, 'The messages are correctly loaded');
+        assert.strictEqual(messages.get('length'), 2, 'The messages are correctly loaded');
       });
     });
   });
@@ -1622,7 +1630,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           return user.get('messages');
         })
         .then(function (messages) {
-          assert.equal(messages.get('length'), 2, 'The messages are correctly loaded');
+          assert.strictEqual(messages.get('length'), 2, 'The messages are correctly loaded');
         });
     });
   });
@@ -1640,7 +1648,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
       igor.get('messages').addObject(comment);
 
-      assert.equal(igor.get('messages.firstObject.body'), 'Well I thought the title was fine');
+      assert.strictEqual(igor.get('messages.firstObject.body'), 'Well I thought the title was fine');
     });
   });
 
@@ -1695,7 +1703,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       ],
     });
     const contacts = await user.contacts;
-    assert.equal(contacts.get('length'), 1, 'The contacts relationship is correctly set up');
+    assert.strictEqual(contacts.get('length'), 1, 'The contacts relationship is correctly set up');
   });
 
   test('Type can be inferred from the key of an async hasMany relationship', function (assert) {
@@ -1748,7 +1756,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           return user.get('contacts');
         })
         .then(function (contacts) {
-          assert.equal(contacts.get('length'), 1, 'The contacts relationship is correctly set up');
+          assert.strictEqual(contacts.get('length'), 1, 'The contacts relationship is correctly set up');
         });
     });
   });
@@ -1800,7 +1808,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           return user.get('contacts');
         })
         .then(function (contacts) {
-          assert.equal(contacts.get('length'), 2, 'The contacts relationship is correctly set up');
+          assert.strictEqual(contacts.get('length'), 2, 'The contacts relationship is correctly set up');
         });
     });
   });
@@ -1823,8 +1831,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       contact: email,
     });
 
-    assert.equal(post.get('contact'), email, 'The polymorphic belongsTo is set up correctly');
-    assert.equal(get(email, 'posts.length'), 1, 'The inverse has many is set up correctly on the email side.');
+    assert.strictEqual(post.get('contact'), email, 'The polymorphic belongsTo is set up correctly');
+    assert.strictEqual(get(email, 'posts.length'), 1, 'The inverse has many is set up correctly on the email side.');
   });
 
   testInDebug('Only records of the same type can be added to a monomorphic hasMany relationship', function (assert) {
@@ -1931,7 +1939,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           .then(function (records) {
             records.messages.pushObject(records.post);
             records.messages.pushObject(records.comment);
-            assert.equal(records.messages.get('length'), 2, 'The messages are correctly added');
+            assert.strictEqual(records.messages.get('length'), 2, 'The messages are correctly added');
 
             assert.expectAssertion(function () {
               records.messages.pushObject(records.anotherUser);
@@ -1970,13 +1978,13 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
     const messages = await user.messages;
 
-    assert.equal(messages.get('length'), 1, 'The user has 1 message');
+    assert.strictEqual(messages.get('length'), 1, 'The user has 1 message');
 
     let removedObject = messages.popObject();
 
-    assert.equal(removedObject, comment, 'The message is correctly removed');
-    assert.equal(messages.get('length'), 0, 'The user does not have any messages');
-    assert.equal(messages.objectAt(0), null, "Null messages can't be fetched");
+    assert.strictEqual(removedObject, comment, 'The message is correctly removed');
+    assert.strictEqual(messages.get('length'), 0, 'The user does not have any messages');
+    assert.strictEqual(messages.objectAt(0), undefined, "Null messages can't be fetched");
   });
 
   test('When a record is created on the client, its hasMany arrays should be in a loaded state', function (assert) {
@@ -1991,7 +1999,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       comments = get(post, 'comments');
     });
 
-    assert.equal(get(comments, 'length'), 0, 'The comments should be an empty array');
+    assert.strictEqual(get(comments, 'length'), 0, 'The comments should be an empty array');
 
     assert.ok(get(comments, 'isLoaded'), 'The comments should have isLoaded flag');
   });
@@ -2012,7 +2020,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     run(function () {
       get(post, 'comments').then(function (comments) {
         assert.ok(true, 'Comments array successfully resolves');
-        assert.equal(get(comments, 'length'), 0, 'The comments should be an empty array');
+        assert.strictEqual(get(comments, 'length'), 0, 'The comments should be an empty array');
         assert.ok(get(comments, 'isLoaded'), 'The comments should have isLoaded flag');
       });
     });
@@ -2046,7 +2054,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       post.set('comments', store.peekAll('comment'));
     });
 
-    assert.equal(get(post, 'comments.length'), 2, 'we can set HM relationship');
+    assert.strictEqual(get(post, 'comments.length'), 2, 'we can set HM relationship');
   });
 
   test('We can set records ASYNC HM relationship', function (assert) {
@@ -2083,7 +2091,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     return post.get('comments').then((comments) => {
-      assert.equal(comments.get('length'), 2, 'we can set async HM relationship');
+      assert.strictEqual(comments.get('length'), 2, 'we can set async HM relationship');
     });
   });
 
@@ -2104,7 +2112,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       post.get('comments').pushObject(comment);
       return post.save();
     }).then(() => {
-      assert.equal(get(post, 'comments.length'), 1, "The unsaved comment should be in the post's comments array");
+      assert.strictEqual(get(post, 'comments.length'), 1, "The unsaved comment should be in the post's comments array");
     });
   });
 
@@ -2167,7 +2175,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
           assert.deepEqual(post, commentPost, 'expect the new comments post, to be the correct post');
           assert.ok(postComments, 'comments should exist');
-          assert.equal(postCommentsLength, 2, "comment's post should have a internalModel back to comment");
+          assert.strictEqual(postCommentsLength, 2, "comment's post should have a internalModel back to comment");
           assert.ok(postComments && postComments.indexOf(firstComment) !== -1, 'expect to contain first comment');
           assert.ok(postComments && postComments.indexOf(comment) !== -1, 'expected to contain the new comment');
         });
@@ -2220,8 +2228,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
     let fetchedComments = await post.get('comments');
 
-    assert.equal(fetchedComments.get('length'), 2, 'comments fetched successfully');
-    assert.equal(fetchedComments.objectAt(0).get('body'), 'first', 'first comment loaded successfully');
+    assert.strictEqual(fetchedComments.get('length'), 2, 'comments fetched successfully');
+    assert.strictEqual(fetchedComments.objectAt(0).get('body'), 'first', 'first comment loaded successfully');
 
     store.push({
       data: {
@@ -2241,8 +2249,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
     let newlyFetchedComments = await post.get('comments');
 
-    assert.equal(newlyFetchedComments.get('length'), 3, 'all three comments fetched successfully');
-    assert.equal(newlyFetchedComments.objectAt(2).get('body'), 'third', 'third comment loaded successfully');
+    assert.strictEqual(newlyFetchedComments.get('length'), 3, 'all three comments fetched successfully');
+    assert.strictEqual(newlyFetchedComments.objectAt(2).get('body'), 'third', 'third comment loaded successfully');
   });
 
   testInDebug('A sync hasMany errors out if there are unloaded records in it', function (assert) {
@@ -2295,12 +2303,12 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       const comment = comments.objectAt(0);
       comments.removeObject(comment);
       store.unloadRecord(comment);
-      assert.equal(comments.get('length'), 0);
+      assert.strictEqual(comments.get('length'), 0);
       return post;
     });
 
     // Explicitly re-get comments
-    assert.equal(run(post, 'get', 'comments.length'), 0);
+    assert.strictEqual(run(post, 'get', 'comments.length'), 0);
   });
 
   test('If reordered hasMany data has been pushed to the store, the many array reflects the ordering change - sync', function (assert) {
@@ -2498,7 +2506,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
     return run(() => {
       return book.get('chapters').then((fetchedChapters) => {
-        assert.equal(fetchedChapters.objectAt(0), chapter, 'Book has a chapter after rollback attributes');
+        assert.strictEqual(fetchedChapters.objectAt(0), chapter, 'Book has a chapter after rollback attributes');
       });
     });
   });
@@ -2542,7 +2550,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     run(() => {
-      assert.equal(book.get('chapters.firstObject'), chapter, 'Book has a chapter after rollback attributes');
+      assert.strictEqual(book.get('chapters.firstObject'), chapter, 'Book has a chapter after rollback attributes');
     });
   });
 
@@ -2590,7 +2598,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
     return run(() => {
       return page.get('chapter').then((fetchedChapter) => {
-        assert.equal(fetchedChapter, chapter, 'Page has a chapter after rollback attributes');
+        assert.strictEqual(fetchedChapter, chapter, 'Page has a chapter after rollback attributes');
       });
     });
   });
@@ -2633,7 +2641,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     run(() => {
-      assert.equal(page.get('chapter'), chapter, 'Page has a chapter after rollback attributes');
+      assert.strictEqual(page.get('chapter'), chapter, 'Page has a chapter after rollback attributes');
     });
   });
 
@@ -2687,12 +2695,12 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           chapter.get('pages').addArrayObserver(this, {
             willChange(pages, index, removeCount, addCount) {
               if (observe) {
-                assert.equal(pages.objectAt(index), page2, 'page2 is passed to willChange');
+                assert.strictEqual(pages.objectAt(index), page2, 'page2 is passed to willChange');
               }
             },
             didChange(pages, index, removeCount, addCount) {
               if (observe) {
-                assert.equal(removeCount, 1, 'removeCount is correct');
+                assert.strictEqual(removeCount, 1, 'removeCount is correct');
               }
             },
           });
@@ -2755,12 +2763,12 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           chapter.get('pages').addArrayObserver(this, {
             willChange(pages, index, removeCount, addCount) {
               if (observe) {
-                assert.equal(addCount, 1, 'addCount is correct');
+                assert.strictEqual(addCount, 1, 'addCount is correct');
               }
             },
             didChange(pages, index, removeCount, addCount) {
               if (observe) {
-                assert.equal(pages.objectAt(index), page2, 'page2 is passed to didChange');
+                assert.strictEqual(pages.objectAt(index), page2, 'page2 is passed to didChange');
               }
             },
           });
@@ -3002,7 +3010,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     return run(() => {
       return store.findRecord('post', 1).then((post) => {
         let comments = post.get('comments');
-        assert.equal(comments.get('length'), 3, 'Initial comments count');
+        assert.strictEqual(comments.get('length'), 3, 'Initial comments count');
 
         // Add comment #4
         let comment = store.createRecord('comment');
@@ -3012,7 +3020,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           .save()
           .then(() => {
             let comments = post.get('comments');
-            assert.equal(comments.get('length'), 4, 'Comments count after first add');
+            assert.strictEqual(comments.get('length'), 4, 'Comments count after first add');
 
             // Delete comment #4
             return comments.get('lastObject').destroyRecord();
@@ -3021,7 +3029,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
             let comments = post.get('comments');
             let length = comments.get('length');
 
-            assert.equal(length, 3, 'Comments count after destroy');
+            assert.strictEqual(length, 3, 'Comments count after destroy');
 
             // Add another comment #4
             let comment = store.createRecord('comment');
@@ -3030,7 +3038,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
           })
           .then(() => {
             let comments = post.get('comments');
-            assert.equal(comments.get('length'), 4, 'Comments count after second add');
+            assert.strictEqual(comments.get('length'), 4, 'Comments count after second add');
           });
       });
     });
@@ -3268,7 +3276,11 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     run(() => {
-      assert.equal(getRelationshipStateForRecord(book, 'chapters').meta.where, 'the lefkada sea', 'meta is there');
+      assert.strictEqual(
+        getRelationshipStateForRecord(book, 'chapters').meta.where,
+        'the lefkada sea',
+        'meta is there'
+      );
     });
   });
 
@@ -3314,7 +3326,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     return run(() => {
       return book.get('chapters').then((chapters) => {
         let meta = chapters.get('meta');
-        assert.equal(get(meta, 'foo'), 'bar', 'metadata is available');
+        assert.strictEqual(get(meta, 'foo'), 'bar', 'metadata is available');
       });
     });
   });
@@ -3388,11 +3400,11 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     return run(() => {
       return book1.get('chapters').then((chapters) => {
         let meta = chapters.get('meta');
-        assert.equal(get(meta, 'foo'), 'bar', 'metadata should available');
+        assert.strictEqual(get(meta, 'foo'), 'bar', 'metadata should available');
 
         return book2.get('chapters').then((chapters) => {
           let meta = chapters.get('meta');
-          assert.equal(meta, undefined, 'metadata should not be available');
+          assert.strictEqual(meta, null, 'metadata should not be available');
         });
       });
     });
@@ -3423,7 +3435,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     };
 
     adapter.findHasMany = function (store, snapshot, url, relationship) {
-      assert.equal(url, 'get-comments', 'url is correct');
+      assert.strictEqual(url, 'get-comments', 'url is correct');
       assert.ok(true, "The adapter's findHasMany method should be called");
       return resolve({
         data: [
@@ -3454,7 +3466,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       });
 
       return post.get('comments').then((comments) => {
-        assert.equal(comments.get('firstObject.body'), 'This is comment', 'comment body is correct');
+        assert.strictEqual(comments.get('firstObject.body'), 'This is comment', 'comment body is correct');
       });
     });
   });
@@ -3484,7 +3496,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     };
 
     adapter.findHasMany = function (store, snapshot, url, relationship) {
-      assert.equal(url, 'get-comments', 'url is correct');
+      assert.strictEqual(url, 'get-comments', 'url is correct');
       assert.ok(true, "The adapter's findHasMany method should be called");
       return resolve({
         data: [
@@ -3516,7 +3528,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       });
 
       return post.get('comments').then((comments) => {
-        assert.equal(comments.get('firstObject.body'), 'This is comment', 'comment body is correct');
+        assert.strictEqual(comments.get('firstObject.body'), 'This is comment', 'comment body is correct');
       });
     });
   });
@@ -3575,7 +3587,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       });
 
       return post.get('comments').then((comments) => {
-        assert.equal(comments.get('firstObject.body'), 'This is comment', 'comment body is correct');
+        assert.strictEqual(comments.get('firstObject.body'), 'This is comment', 'comment body is correct');
       });
     });
   });
@@ -3605,7 +3617,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     };
 
     adapter.findHasMany = function (store, snapshot, url, relationship) {
-      assert.equal(url, 'get-comments', 'url is correct');
+      assert.strictEqual(url, 'get-comments', 'url is correct');
       assert.ok(true, "The adapter's findHasMany method should be called");
       return resolve({
         data: [
@@ -3653,7 +3665,11 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       });
 
       return post.get('comments').then((comments) => {
-        assert.equal(comments.get('firstObject.body'), 'This is comment fetched by link', 'comment body is correct');
+        assert.strictEqual(
+          comments.get('firstObject.body'),
+          'This is comment fetched by link',
+          'comment body is correct'
+        );
       });
     });
   });
@@ -3669,7 +3685,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
     });
 
     adapter.findHasMany = function (store, snapshot, url, relationship) {
-      assert.equal(url, 'comments-updated-link', 'url is correct');
+      assert.strictEqual(url, 'comments-updated-link', 'url is correct');
       assert.ok(true, "The adapter's findHasMany method should be called");
       return resolve({
         data: [{ id: 1, type: 'comment', attributes: { body: 'This is updated comment' } }],
@@ -3711,7 +3727,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       });
 
       return post.get('comments').then((comments) => {
-        assert.equal(comments.get('firstObject.body'), 'This is updated comment', 'comment body is correct');
+        assert.strictEqual(comments.get('firstObject.body'), 'This is updated comment', 'comment body is correct');
       });
     });
   });
@@ -3753,7 +3769,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       let comments = post.get('comments');
       comments.createRecord();
       return comments.then((comments) => {
-        assert.equal(comments.get('length'), 3, 'comments have 3 length, including new record');
+        assert.strictEqual(comments.get('length'), 3, 'comments have 3 length, including new record');
       });
     });
   });
@@ -3873,8 +3889,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       user = store.peekRecord('user', 'user-1');
       message = store.peekRecord('message', 'message-1');
 
-      assert.equal(get(user, 'messages.firstObject.id'), 'message-1');
-      assert.equal(get(message, 'user.id'), 'user-1');
+      assert.strictEqual(get(user, 'messages.firstObject.id'), 'message-1');
+      assert.strictEqual(get(message, 'user.id'), 'user-1');
     });
 
     run(() => {
@@ -3902,8 +3918,8 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
       user = store.peekRecord('user', 'user-1');
 
-      assert.equal(get(user, 'messages.firstObject.id'), 'message-1', 'user points to message');
-      assert.equal(get(message, 'user.id'), 'user-1', 'message points to user');
+      assert.strictEqual(get(user, 'messages.firstObject.id'), 'message-1', 'user points to message');
+      assert.strictEqual(get(message, 'user.id'), 'user-1', 'message points to user');
     });
   });
 
@@ -3949,7 +3965,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       user = store.peekRecord('user', 'user-1');
       message = store.peekRecord('message', 'message-1');
 
-      assert.equal(get(user, 'messages.length'), 2);
+      assert.strictEqual(get(user, 'messages.length'), 2);
     });
 
     run(() => message.destroyRecord());
@@ -4009,7 +4025,7 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       book.get('chapters');
     });
 
-    assert.equal(count, 0);
+    assert.strictEqual(count, 0);
   });
 
   test('A hasMany relationship with a link will trigger the link request even if a inverse related object is pushed to the store', function (assert) {
@@ -4065,9 +4081,9 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
 
       let hasManyCounter = 0;
       adapter.findHasMany = function (store, snapshot, link, relationship) {
-        assert.equal(relationship.type, 'comment', 'findHasMany relationship type was Comment');
-        assert.equal(relationship.key, 'comments', 'findHasMany relationship key was comments');
-        assert.equal(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
+        assert.strictEqual(relationship.type, 'comment', 'findHasMany relationship type was Comment');
+        assert.strictEqual(relationship.key, 'comments', 'findHasMany relationship key was comments');
+        assert.strictEqual(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
         hasManyCounter++;
 
         return resolve({
@@ -4081,16 +4097,16 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       const post = store.peekRecord('post', postID);
       post.get('comments').then(function (comments) {
         assert.true(comments.get('isLoaded'), 'comments are loaded');
-        assert.equal(hasManyCounter, 1, 'link was requested');
-        assert.equal(comments.get('length'), 2, 'comments have 2 length');
+        assert.strictEqual(hasManyCounter, 1, 'link was requested');
+        assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
 
         post
           .hasMany('comments')
           .reload()
           .then(function (comments) {
             assert.true(comments.get('isLoaded'), 'comments are loaded');
-            assert.equal(hasManyCounter, 2, 'link was requested');
-            assert.equal(comments.get('length'), 2, 'comments have 2 length');
+            assert.strictEqual(hasManyCounter, 2, 'link was requested');
+            assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
           });
       });
     });

--- a/packages/-ember-data/tests/integration/relationships/inverse-relationship-load-test.js
+++ b/packages/-ember-data/tests/integration/relationships/inverse-relationship-load-test.js
@@ -93,24 +93,24 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
     let dog1 = dogs.get('firstObject');
     let dogPerson1 = await dog1.get('person');
-    assert.equal(
+    assert.strictEqual(
       dogPerson1.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     let dogPerson2 = await dogs.objectAt(1).get('person');
-    assert.equal(
+    assert.strictEqual(
       dogPerson2.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many (left hand async, right hand sync) - findHasMany/implicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -179,24 +179,24 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
     let dog1 = dogs.get('firstObject');
     let dogPerson1 = await dog1.get('person');
-    assert.equal(
+    assert.strictEqual(
       dogPerson1.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     let dogPerson2 = await dogs.objectAt(1).get('person');
-    assert.equal(
+    assert.strictEqual(
       dogPerson2.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many - findHasMany/explicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -266,24 +266,24 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
     let dog1 = dogs.get('firstObject');
     let dogPerson1 = await dog1.get('pal');
-    assert.equal(
+    assert.strictEqual(
       dogPerson1.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     let dogPerson2 = await dogs.objectAt(1).get('pal');
-    assert.equal(
+    assert.strictEqual(
       dogPerson2.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many (left hand async, right hand sync) - findHasMany/explicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -354,24 +354,24 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
     let dog1 = dogs.get('firstObject');
     let dogPerson1 = await dog1.get('pal');
-    assert.equal(
+    assert.strictEqual(
       dogPerson1.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     let dogPerson2 = await dogs.objectAt(1).get('pal');
-    assert.equal(
+    assert.strictEqual(
       dogPerson2.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many - findHasMany/null inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -445,13 +445,13 @@ module('inverse relationship load test', function (hooks) {
 
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty);
-    assert.equal(dogs.get('length'), 2);
+    assert.strictEqual(dogs.get('length'), 2);
     assert.deepEqual(dogs.mapBy('id'), ['1', '2']);
 
     let dog1 = dogs.get('firstObject');
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), '1');
-    assert.equal(dogs.get('firstObject.id'), '2');
+    assert.strictEqual(dogs.get('length'), 1);
+    assert.strictEqual(dogs.get('firstObject.id'), '2');
   });
 
   test('one-to-one - findBelongsTo/implicit inverse - ensures inverse relationship is set up when payload does not return parent relationship info', async function (assert) {
@@ -514,16 +514,16 @@ module('inverse relationship load test', function (hooks) {
 
     let favoriteDog = await person.get('favoriteDog');
     assert.false(person.belongsTo('favoriteDog').belongsToRelationship.state.isEmpty);
-    assert.equal(favoriteDog.get('id'), '1', 'favoriteDog id is set correctly');
+    assert.strictEqual(favoriteDog.get('id'), '1', 'favoriteDog id is set correctly');
     let favoriteDogPerson = await favoriteDog.get('person');
-    assert.equal(
+    assert.strictEqual(
       favoriteDogPerson.get('id'),
       '1',
       'favoriteDog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     await favoriteDog.destroyRecord();
     favoriteDog = await person.get('favoriteDog');
-    assert.equal(favoriteDog, null);
+    assert.strictEqual(favoriteDog, null);
   });
 
   test('one-to-one (left hand async, right hand sync) - findBelongsTo/implicit inverse - ensures inverse relationship is set up when payload does not return parent relationship info', async function (assert) {
@@ -586,16 +586,16 @@ module('inverse relationship load test', function (hooks) {
 
     let favoriteDog = await person.get('favoriteDog');
     assert.false(person.belongsTo('favoriteDog').belongsToRelationship.state.isEmpty);
-    assert.equal(favoriteDog.get('id'), '1', 'favoriteDog id is set correctly');
+    assert.strictEqual(favoriteDog.get('id'), '1', 'favoriteDog id is set correctly');
     let favoriteDogPerson = await favoriteDog.get('person');
-    assert.equal(
+    assert.strictEqual(
       favoriteDogPerson.get('id'),
       '1',
       'favoriteDog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     await favoriteDog.destroyRecord();
     favoriteDog = await person.get('favoriteDog');
-    assert.equal(favoriteDog, null);
+    assert.strictEqual(favoriteDog, null);
   });
 
   test('one-to-one - findBelongsTo/explicit inverse - ensures inverse relationship is set up when payload does not return parent relationship info', async function (assert) {
@@ -658,16 +658,16 @@ module('inverse relationship load test', function (hooks) {
 
     let favoriteDog = await person.get('favoriteDog');
     assert.false(person.belongsTo('favoriteDog').belongsToRelationship.state.isEmpty);
-    assert.equal(favoriteDog.get('id'), '1', 'favoriteDog id is set correctly');
+    assert.strictEqual(favoriteDog.get('id'), '1', 'favoriteDog id is set correctly');
     let favoriteDogPerson = await favoriteDog.get('pal');
-    assert.equal(
+    assert.strictEqual(
       favoriteDogPerson.get('id'),
       '1',
       'favoriteDog.pal inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     await favoriteDog.destroyRecord();
     favoriteDog = await person.get('favoriteDog');
-    assert.equal(favoriteDog, null);
+    assert.strictEqual(favoriteDog, null);
   });
 
   test('one-to-one (left hand async, right hand sync) - findBelongsTo/explicit inverse - ensures inverse relationship is set up when payload does not return parent relationship info', async function (assert) {
@@ -730,16 +730,16 @@ module('inverse relationship load test', function (hooks) {
 
     let favoriteDog = await person.get('favoriteDog');
     assert.false(person.belongsTo('favoriteDog').belongsToRelationship.state.isEmpty);
-    assert.equal(favoriteDog.get('id'), '1', 'favoriteDog id is set correctly');
+    assert.strictEqual(favoriteDog.get('id'), '1', 'favoriteDog id is set correctly');
     let favoriteDogPerson = await favoriteDog.get('pal');
-    assert.equal(
+    assert.strictEqual(
       favoriteDogPerson.get('id'),
       '1',
       'favoriteDog.pal inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     await favoriteDog.destroyRecord();
     favoriteDog = await person.get('favoriteDog');
-    assert.equal(favoriteDog, null);
+    assert.strictEqual(favoriteDog, null);
   });
 
   test('one-to-one - findBelongsTo/null inverse - ensures inverse relationship is set up when payload does not return parent relationship info', async function (assert) {
@@ -800,10 +800,10 @@ module('inverse relationship load test', function (hooks) {
 
     let favoriteDog = await person.get('favoriteDog');
     assert.false(person.belongsTo('favoriteDog').belongsToRelationship.state.isEmpty);
-    assert.equal(favoriteDog.get('id'), '1', 'favoriteDog id is set correctly');
+    assert.strictEqual(favoriteDog.get('id'), '1', 'favoriteDog id is set correctly');
     await favoriteDog.destroyRecord();
     favoriteDog = await person.get('favoriteDog');
-    assert.equal(favoriteDog, null);
+    assert.strictEqual(favoriteDog, null);
   });
 
   test('many-to-many - findHasMany/implicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -872,19 +872,19 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty);
 
-    assert.equal(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
     let [dog1, dog2] = dogs.toArray();
     let dog1Walkers = await dog1.get('walkers');
-    assert.equal(dog1Walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
-    assert.equal(dog1Walkers.get('firstObject.id'), '1', 'dog1.walkers inverse relationship is set up correctly');
+    assert.strictEqual(dog1Walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
+    assert.strictEqual(dog1Walkers.get('firstObject.id'), '1', 'dog1.walkers inverse relationship is set up correctly');
 
     let dog2Walkers = await dog2.get('walkers');
-    assert.equal(dog2Walkers.length, 1, 'dog2.walkers inverse relationship includes correct number of records');
-    assert.equal(dog2Walkers.get('firstObject.id'), '1', 'dog2.walkers inverse relationship is set up correctly');
+    assert.strictEqual(dog2Walkers.length, 1, 'dog2.walkers inverse relationship includes correct number of records');
+    assert.strictEqual(dog2Walkers.get('firstObject.id'), '1', 'dog2.walkers inverse relationship is set up correctly');
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'person.dogs relationship was updated when record removed');
-    assert.equal(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'person.dogs relationship was updated when record removed');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
   });
 
   test('many-to-many (left hand async, right hand sync) - findHasMany/implicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -953,19 +953,19 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty);
 
-    assert.equal(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
     let [dog1, dog2] = dogs.toArray();
     let dog1Walkers = await dog1.get('walkers');
-    assert.equal(dog1Walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
-    assert.equal(dog1Walkers.get('firstObject.id'), '1', 'dog1.walkers inverse relationship is set up correctly');
+    assert.strictEqual(dog1Walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
+    assert.strictEqual(dog1Walkers.get('firstObject.id'), '1', 'dog1.walkers inverse relationship is set up correctly');
 
     let dog2Walkers = await dog2.get('walkers');
-    assert.equal(dog2Walkers.length, 1, 'dog2.walkers inverse relationship includes correct number of records');
-    assert.equal(dog2Walkers.get('firstObject.id'), '1', 'dog2.walkers inverse relationship is set up correctly');
+    assert.strictEqual(dog2Walkers.length, 1, 'dog2.walkers inverse relationship includes correct number of records');
+    assert.strictEqual(dog2Walkers.get('firstObject.id'), '1', 'dog2.walkers inverse relationship is set up correctly');
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'person.dogs relationship was updated when record removed');
-    assert.equal(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'person.dogs relationship was updated when record removed');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
   });
 
   test('many-to-many - findHasMany/explicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -1035,19 +1035,19 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty);
 
-    assert.equal(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
     let [dog1, dog2] = dogs.toArray();
     let dog1Pals = await dog1.get('pals');
-    assert.equal(dog1Pals.length, 1, 'dog1.pals inverse relationship includes correct number of records');
-    assert.equal(dog1Pals.get('firstObject.id'), '1', 'dog1.pals inverse relationship is set up correctly');
+    assert.strictEqual(dog1Pals.length, 1, 'dog1.pals inverse relationship includes correct number of records');
+    assert.strictEqual(dog1Pals.get('firstObject.id'), '1', 'dog1.pals inverse relationship is set up correctly');
 
     let dog2Pals = await dog2.get('pals');
-    assert.equal(dog2Pals.length, 1, 'dog2.pals inverse relationship includes correct number of records');
-    assert.equal(dog2Pals.get('firstObject.id'), '1', 'dog2.pals inverse relationship is set up correctly');
+    assert.strictEqual(dog2Pals.length, 1, 'dog2.pals inverse relationship includes correct number of records');
+    assert.strictEqual(dog2Pals.get('firstObject.id'), '1', 'dog2.pals inverse relationship is set up correctly');
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'person.dogs relationship was updated when record removed');
-    assert.equal(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'person.dogs relationship was updated when record removed');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
   });
 
   test('many-to-many (left hand async, right hand sync) - findHasMany/explicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -1117,19 +1117,19 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty);
 
-    assert.equal(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
     let [dog1, dog2] = dogs.toArray();
     let dog1Pals = await dog1.get('pals');
-    assert.equal(dog1Pals.length, 1, 'dog1.pals inverse relationship includes correct number of records');
-    assert.equal(dog1Pals.get('firstObject.id'), '1', 'dog1.pals inverse relationship is set up correctly');
+    assert.strictEqual(dog1Pals.length, 1, 'dog1.pals inverse relationship includes correct number of records');
+    assert.strictEqual(dog1Pals.get('firstObject.id'), '1', 'dog1.pals inverse relationship is set up correctly');
 
     let dog2Pals = await dog2.get('pals');
-    assert.equal(dog2Pals.length, 1, 'dog2.pals inverse relationship includes correct number of records');
-    assert.equal(dog2Pals.get('firstObject.id'), '1', 'dog2.pals inverse relationship is set up correctly');
+    assert.strictEqual(dog2Pals.length, 1, 'dog2.pals inverse relationship includes correct number of records');
+    assert.strictEqual(dog2Pals.get('firstObject.id'), '1', 'dog2.pals inverse relationship is set up correctly');
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'person.dogs relationship was updated when record removed');
-    assert.equal(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'person.dogs relationship was updated when record removed');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
   });
 
   test('many-to-one - findBelongsTo/implicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -1191,17 +1191,17 @@ module('inverse relationship load test', function (hooks) {
       dog.belongsTo('person').belongsToRelationship.state.isEmpty,
       'belongsTo relationship state was populated'
     );
-    assert.equal(person.get('id'), '1', 'dog.person relationship is correctly set up');
+    assert.strictEqual(person.get('id'), '1', 'dog.person relationship is correctly set up');
 
     let dogs = await person.get('dogs');
 
-    assert.equal(dogs.get('length'), 1, 'person.dogs inverse relationship includes correct number of records');
+    assert.strictEqual(dogs.get('length'), 1, 'person.dogs inverse relationship includes correct number of records');
     let [dog1] = dogs.toArray();
-    assert.equal(dog1.id, '1', 'dog1.person inverse relationship is set up correctly');
+    assert.strictEqual(dog1.id, '1', 'dog1.person inverse relationship is set up correctly');
 
     await person.destroyRecord();
     dog = await dog.get('person');
-    assert.equal(dog, null, 'record deleted removed from belongsTo relationship');
+    assert.strictEqual(dog, null, 'record deleted removed from belongsTo relationship');
   });
 
   test('many-to-one (left hand async, right hand sync) - findBelongsTo/implicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -1263,17 +1263,17 @@ module('inverse relationship load test', function (hooks) {
       dog.belongsTo('person').belongsToRelationship.state.isEmpty,
       'belongsTo relationship state was populated'
     );
-    assert.equal(person.get('id'), '1', 'dog.person relationship is correctly set up');
+    assert.strictEqual(person.get('id'), '1', 'dog.person relationship is correctly set up');
 
     let dogs = await person.get('dogs');
 
-    assert.equal(dogs.get('length'), 1, 'person.dogs inverse relationship includes correct number of records');
+    assert.strictEqual(dogs.get('length'), 1, 'person.dogs inverse relationship includes correct number of records');
     let [dog1] = dogs.toArray();
-    assert.equal(dog1.id, '1', 'dog1.person inverse relationship is set up correctly');
+    assert.strictEqual(dog1.id, '1', 'dog1.person inverse relationship is set up correctly');
 
     await person.destroyRecord();
     dog = await dog.get('person');
-    assert.equal(dog, null, 'record deleted removed from belongsTo relationship');
+    assert.strictEqual(dog, null, 'record deleted removed from belongsTo relationship');
   });
 
   test('many-to-one - findBelongsTo/explicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -1336,17 +1336,17 @@ module('inverse relationship load test', function (hooks) {
       dog.belongsTo('pal').belongsToRelationship.state.isEmpty,
       'belongsTo relationship state was populated'
     );
-    assert.equal(person.get('id'), '1', 'dog.person relationship is correctly set up');
+    assert.strictEqual(person.get('id'), '1', 'dog.person relationship is correctly set up');
 
     let dogs = await person.get('dogs');
 
-    assert.equal(dogs.get('length'), 1, 'person.dogs inverse relationship includes correct number of records');
+    assert.strictEqual(dogs.get('length'), 1, 'person.dogs inverse relationship includes correct number of records');
     let [dog1] = dogs.toArray();
-    assert.equal(dog1.id, '1', 'dog1.person inverse relationship is set up correctly');
+    assert.strictEqual(dog1.id, '1', 'dog1.person inverse relationship is set up correctly');
 
     await person.destroyRecord();
     dog = await dog.get('pal');
-    assert.equal(dog, null, 'record deleted removed from belongsTo relationship');
+    assert.strictEqual(dog, null, 'record deleted removed from belongsTo relationship');
   });
 
   test('many-to-one (left hand async, right hand sync) - findBelongsTo/explicit inverse - adds parent relationship information to the payload if it is not included/added by the serializer', async function (assert) {
@@ -1409,17 +1409,17 @@ module('inverse relationship load test', function (hooks) {
       dog.belongsTo('pal').belongsToRelationship.state.isEmpty,
       'belongsTo relationship state was populated'
     );
-    assert.equal(person.get('id'), '1', 'dog.person relationship is correctly set up');
+    assert.strictEqual(person.get('id'), '1', 'dog.person relationship is correctly set up');
 
     let dogs = await person.get('dogs');
 
-    assert.equal(dogs.get('length'), 1, 'person.dogs inverse relationship includes correct number of records');
+    assert.strictEqual(dogs.get('length'), 1, 'person.dogs inverse relationship includes correct number of records');
     let [dog1] = dogs.toArray();
-    assert.equal(dog1.id, '1', 'dog1.person inverse relationship is set up correctly');
+    assert.strictEqual(dog1.id, '1', 'dog1.person inverse relationship is set up correctly');
 
     await person.destroyRecord();
     dog = await dog.get('pal');
-    assert.equal(dog, null, 'record deleted removed from belongsTo relationship');
+    assert.strictEqual(dog, null, 'record deleted removed from belongsTo relationship');
   });
 
   testInDebug(
@@ -1508,26 +1508,26 @@ module('inverse relationship load test', function (hooks) {
         id: 'mismatched-inverse-relationship-data-from-payload',
         count: 2,
       });
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
-      assert.equal(dogs.get('length'), 2);
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
+      assert.strictEqual(dogs.get('length'), 2);
 
       let dog1 = dogs.get('firstObject');
       let dogPerson1 = await dog1.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
       let dogPerson2 = await dogs.objectAt(1).get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson2.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
 
       await dog1.destroyRecord();
-      assert.equal(dogs.get('length'), 1);
-      assert.equal(dogs.get('firstObject.id'), '2');
+      assert.strictEqual(dogs.get('length'), 1);
+      assert.strictEqual(dogs.get('firstObject.id'), '2');
     }
   );
 
@@ -1617,26 +1617,26 @@ module('inverse relationship load test', function (hooks) {
         id: 'mismatched-inverse-relationship-data-from-payload',
         count: 2,
       });
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
-      assert.equal(dogs.get('length'), 2);
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
+      assert.strictEqual(dogs.get('length'), 2);
 
       let dog1 = dogs.get('firstObject');
       let dogPerson1 = await dog1.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
       let dogPerson2 = await dogs.objectAt(1).get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson2.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
 
       await dog1.destroyRecord();
-      assert.equal(dogs.get('length'), 1);
-      assert.equal(dogs.get('firstObject.id'), '2');
+      assert.strictEqual(dogs.get('length'), 1);
+      assert.strictEqual(dogs.get('firstObject.id'), '2');
     }
   );
 
@@ -1720,26 +1720,26 @@ module('inverse relationship load test', function (hooks) {
         id: 'mismatched-inverse-relationship-data-from-payload',
         count: 2,
       });
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
-      assert.equal(dogs.get('length'), 2);
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
+      assert.strictEqual(dogs.get('length'), 2);
 
       let dog1 = dogs.get('firstObject');
       let dogPerson1 = await dog1.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
       let dogPerson2 = await dogs.objectAt(1).get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson2.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
 
       await dog1.destroyRecord();
-      assert.equal(dogs.get('length'), 1);
-      assert.equal(dogs.get('firstObject.id'), '2');
+      assert.strictEqual(dogs.get('length'), 1);
+      assert.strictEqual(dogs.get('firstObject.id'), '2');
     }
   );
 
@@ -1823,26 +1823,26 @@ module('inverse relationship load test', function (hooks) {
         id: 'mismatched-inverse-relationship-data-from-payload',
         count: 2,
       });
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
-      assert.equal(dogs.get('length'), 2);
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
+      assert.strictEqual(dogs.get('length'), 2);
 
       let dog1 = dogs.get('firstObject');
       let dogPerson1 = await dog1.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
       let dogPerson2 = await dogs.objectAt(1).get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson2.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
 
       await dog1.destroyRecord();
-      assert.equal(dogs.get('length'), 1);
-      assert.equal(dogs.get('firstObject.id'), '2');
+      assert.strictEqual(dogs.get('length'), 1);
+      assert.strictEqual(dogs.get('firstObject.id'), '2');
     }
   );
 
@@ -1919,13 +1919,17 @@ module('inverse relationship load test', function (hooks) {
       let dogFromStore = await store.peekRecord('dog', '1');
 
       // weirdly these pass
-      assert.equal(dogFromStore.belongsTo('person').id(), '1');
-      assert.equal(person.belongsTo('dog').id(), '1');
-      assert.equal(dog.id, '1', 'dog.person relationship loaded correctly');
-      assert.equal(person.belongsTo('dog').belongsToRelationship.state.isEmpty, false, 'relationship is not empty');
+      assert.strictEqual(dogFromStore.belongsTo('person').id(), '1');
+      assert.strictEqual(person.belongsTo('dog').id(), '1');
+      assert.strictEqual(dog.id, '1', 'dog.person relationship loaded correctly');
+      assert.strictEqual(
+        person.belongsTo('dog').belongsToRelationship.state.isEmpty,
+        false,
+        'relationship is not empty'
+      );
 
       let dogPerson1 = await dog.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
@@ -1933,7 +1937,7 @@ module('inverse relationship load test', function (hooks) {
 
       await dog.destroyRecord();
       dog = await person.get('dog');
-      assert.equal(dog, null, 'record was removed from belongsTo relationship');
+      assert.strictEqual(dog, null, 'record was removed from belongsTo relationship');
     }
   );
 
@@ -2010,14 +2014,18 @@ module('inverse relationship load test', function (hooks) {
       let dogFromStore = store.peekRecord('dog', '1');
 
       // weirdly these pass
-      assert.equal(dogFromStore.belongsTo('person').id(), '1');
-      assert.equal(person.belongsTo('dog').id(), '1');
-      assert.equal(dog.id, '1', 'dog.person relationship loaded correctly');
+      assert.strictEqual(dogFromStore.belongsTo('person').id(), '1');
+      assert.strictEqual(person.belongsTo('dog').id(), '1');
+      assert.strictEqual(dog.id, '1', 'dog.person relationship loaded correctly');
 
-      assert.equal(person.belongsTo('dog').belongsToRelationship.state.isEmpty, false, 'relationship is not empty');
+      assert.strictEqual(
+        person.belongsTo('dog').belongsToRelationship.state.isEmpty,
+        false,
+        'relationship is not empty'
+      );
 
       let dogPerson1 = dog.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
@@ -2025,7 +2033,7 @@ module('inverse relationship load test', function (hooks) {
 
       await dog.destroyRecord();
       dog = await person.get('dog');
-      assert.equal(dog, null, 'record was removed from belongsTo relationship');
+      assert.strictEqual(dog, null, 'record was removed from belongsTo relationship');
     }
   );
 
@@ -2099,14 +2107,18 @@ module('inverse relationship load test', function (hooks) {
       let dogFromStore = await store.peekRecord('dog', '1');
 
       // weirdly these pass
-      assert.equal(dogFromStore.belongsTo('person').id(), '1');
-      assert.equal(person.belongsTo('dog').id(), '1');
-      assert.equal(dog.id, '1', 'dog.person relationship loaded correctly');
+      assert.strictEqual(dogFromStore.belongsTo('person').id(), '1');
+      assert.strictEqual(person.belongsTo('dog').id(), '1');
+      assert.strictEqual(dog.id, '1', 'dog.person relationship loaded correctly');
 
-      assert.equal(person.belongsTo('dog').belongsToRelationship.state.isEmpty, false, 'relationship is not empty');
+      assert.strictEqual(
+        person.belongsTo('dog').belongsToRelationship.state.isEmpty,
+        false,
+        'relationship is not empty'
+      );
 
       let dogPerson1 = await dog.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
@@ -2114,7 +2126,7 @@ module('inverse relationship load test', function (hooks) {
 
       await dog.destroyRecord();
       dog = await person.get('dog');
-      assert.equal(dog, null, 'record was removed from belongsTo relationship');
+      assert.strictEqual(dog, null, 'record was removed from belongsTo relationship');
     }
   );
 
@@ -2188,14 +2200,18 @@ module('inverse relationship load test', function (hooks) {
       let dogFromStore = await store.peekRecord('dog', '1');
 
       // weirdly these pass
-      assert.equal(dogFromStore.belongsTo('person').id(), '1');
-      assert.equal(person.belongsTo('dog').id(), '1');
-      assert.equal(dog.id, '1', 'dog.person relationship loaded correctly');
+      assert.strictEqual(dogFromStore.belongsTo('person').id(), '1');
+      assert.strictEqual(person.belongsTo('dog').id(), '1');
+      assert.strictEqual(dog.id, '1', 'dog.person relationship loaded correctly');
 
-      assert.equal(person.belongsTo('dog').belongsToRelationship.state.isEmpty, false, 'relationship is not empty');
+      assert.strictEqual(
+        person.belongsTo('dog').belongsToRelationship.state.isEmpty,
+        false,
+        'relationship is not empty'
+      );
 
       let dogPerson1 = await dog.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
@@ -2203,7 +2219,7 @@ module('inverse relationship load test', function (hooks) {
 
       await dog.destroyRecord();
       dog = await person.get('dog');
-      assert.equal(dog, null, 'record was removed from belongsTo relationship');
+      assert.strictEqual(dog, null, 'record was removed from belongsTo relationship');
     }
   );
 
@@ -2280,18 +2296,18 @@ module('inverse relationship load test', function (hooks) {
       });
       let dogFromStore = await store.peekRecord('dog', '1');
 
-      assert.equal(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
+      assert.strictEqual(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
       let dogPerson1 = await dog.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false, 'relationship is not empty');
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false, 'relationship is not empty');
 
       await dog.destroyRecord();
       dog = await person.get('dog');
-      assert.equal(dog, null, 'record was removed from belongsTo relationship');
+      assert.strictEqual(dog, undefined, 'record was removed from belongsTo relationship');
     }
   );
 
@@ -2368,18 +2384,18 @@ module('inverse relationship load test', function (hooks) {
       });
       let dogFromStore = await store.peekRecord('dog', '1');
 
-      assert.equal(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
+      assert.strictEqual(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
       let dogPerson1 = await dog.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false, 'relationship is not empty');
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false, 'relationship is not empty');
 
       await dog.destroyRecord();
       dog = await person.get('dog');
-      assert.equal(dog, null, 'record was removed from belongsTo relationship');
+      assert.strictEqual(dog, undefined, 'record was removed from belongsTo relationship');
     }
   );
 
@@ -2451,18 +2467,18 @@ module('inverse relationship load test', function (hooks) {
       });
       let dogFromStore = await store.peekRecord('dog', '1');
 
-      assert.equal(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
+      assert.strictEqual(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
       let dogPerson1 = await dog.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false, 'relationship is not empty');
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false, 'relationship is not empty');
 
       await dog.destroyRecord();
       dog = await person.get('dog');
-      assert.equal(dog, null, 'record was removed from belongsTo relationship');
+      assert.strictEqual(dog, undefined, 'record was removed from belongsTo relationship');
     }
   );
 
@@ -2534,18 +2550,18 @@ module('inverse relationship load test', function (hooks) {
       });
       let dogFromStore = await store.peekRecord('dog', '1');
 
-      assert.equal(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
+      assert.strictEqual(dogFromStore.belongsTo('person').id(), '1', 'dog relationship is set up correctly');
       let dogPerson1 = await dog.get('person');
-      assert.equal(
+      assert.strictEqual(
         dogPerson1.get('id'),
         '1',
         'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
       );
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false, 'relationship is not empty');
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false, 'relationship is not empty');
 
       await dog.destroyRecord();
       dog = await person.get('dog');
-      assert.equal(dog, null, 'record was removed from belongsTo relationship');
+      assert.strictEqual(dog, undefined, 'record was removed from belongsTo relationship');
     }
   );
 
@@ -2649,20 +2665,24 @@ module('inverse relationship load test', function (hooks) {
         id: 'mismatched-inverse-relationship-data-from-payload',
         count: 2,
       });
-      assert.equal(person1.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
+      assert.strictEqual(person1.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
       let dog2 = store.peekRecord('dog', '2');
 
       for (let person of [person1, person2]) {
         const dogs = await person.get('dogs');
-        assert.equal(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
+        assert.strictEqual(
+          dogs.get('length'),
+          2,
+          'left hand side relationship is set up with correct number of records'
+        );
         assert.ok(dogs.indexOf(dog1) >= 0, 'relationship includes the parent even though it was not specified');
         assert.ok(dogs.indexOf(dog2) >= 0, 'relationship also includes records the payload specified');
 
         for (let dog of [dog1, dog2]) {
           let walkers = await dog.get('walkers');
-          assert.equal(walkers.length, 2, 'dog1.walkers inverse relationship includes correct number of records');
+          assert.strictEqual(walkers.length, 2, 'dog1.walkers inverse relationship includes correct number of records');
           assert.ok(
             walkers.indexOf(person1) >= 0,
             'dog1Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -2678,12 +2698,16 @@ module('inverse relationship load test', function (hooks) {
 
       for (let person of [person1, person2]) {
         let dogs = await person.get('dogs');
-        assert.equal(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
-        assert.equal(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
+        assert.strictEqual(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
+        assert.strictEqual(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
       }
 
       let dog2Walkers = await dog2.get('walkers');
-      assert.equal(dog2Walkers.get('length'), 2, 'dog2 still has correct number of records for hasMany relationship');
+      assert.strictEqual(
+        dog2Walkers.get('length'),
+        2,
+        'dog2 still has correct number of records for hasMany relationship'
+      );
       assert.ok(
         dog2Walkers.indexOf(person1) >= 0,
         'dog2Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -2697,18 +2721,18 @@ module('inverse relationship load test', function (hooks) {
 
       await person2.destroyRecord();
 
-      assert.equal(person1Dogs.get('length'), 1, 'person1 has correct # of dogs');
-      assert.equal(
+      assert.strictEqual(person1Dogs.get('length'), 1, 'person1 has correct # of dogs');
+      assert.strictEqual(
         person1Dogs.get('firstObject.id'),
         dog2.get('id'),
         'person1 has dog2 in its hasMany relationship; dog1 is not present because it was destroyed.'
       );
-      assert.equal(
+      assert.strictEqual(
         dog2Walkers.get('length'),
         1,
         'dog2 has correct # of records after record specified by server response is destroyed'
       );
-      assert.equal(
+      assert.strictEqual(
         dog2Walkers.get('firstObject.id'),
         person1.get('id'),
         'dog2 has person1 in its hasMany relationship; person2 is not present because it was destroyed.'
@@ -2717,7 +2741,7 @@ module('inverse relationship load test', function (hooks) {
       // finally, destroy person1, the record that loaded all this data through the relationship
 
       await person1.destroyRecord();
-      assert.equal(
+      assert.strictEqual(
         dog2Walkers.get('length'),
         0,
         'dog2 hasMany relationship is empty after all person records are destroyed'
@@ -2825,20 +2849,24 @@ module('inverse relationship load test', function (hooks) {
         id: 'mismatched-inverse-relationship-data-from-payload',
         count: 2,
       });
-      assert.equal(person1.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
+      assert.strictEqual(person1.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
       let dog2 = store.peekRecord('dog', '2');
 
       for (let person of [person1, person2]) {
         const dogs = await person.get('dogs');
-        assert.equal(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
+        assert.strictEqual(
+          dogs.get('length'),
+          2,
+          'left hand side relationship is set up with correct number of records'
+        );
         assert.ok(dogs.indexOf(dog1) >= 0, 'relationship includes the parent even though it was not specified');
         assert.ok(dogs.indexOf(dog2) >= 0, 'relationship also includes records the payload specified');
 
         for (let dog of [dog1, dog2]) {
           let walkers = await dog.get('walkers');
-          assert.equal(walkers.length, 2, 'dog1.walkers inverse relationship includes correct number of records');
+          assert.strictEqual(walkers.length, 2, 'dog1.walkers inverse relationship includes correct number of records');
           assert.ok(
             walkers.indexOf(person1) >= 0,
             'dog1Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -2854,12 +2882,16 @@ module('inverse relationship load test', function (hooks) {
 
       for (let person of [person1, person2]) {
         let dogs = await person.get('dogs');
-        assert.equal(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
-        assert.equal(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
+        assert.strictEqual(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
+        assert.strictEqual(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
       }
 
       let dog2Walkers = await dog2.get('walkers');
-      assert.equal(dog2Walkers.get('length'), 2, 'dog2 still has correct number of records for hasMany relationship');
+      assert.strictEqual(
+        dog2Walkers.get('length'),
+        2,
+        'dog2 still has correct number of records for hasMany relationship'
+      );
       assert.ok(
         dog2Walkers.indexOf(person1) >= 0,
         'dog2Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -2873,18 +2905,18 @@ module('inverse relationship load test', function (hooks) {
 
       await person2.destroyRecord();
 
-      assert.equal(person1Dogs.get('length'), 1, 'person1 has correct # of dogs');
-      assert.equal(
+      assert.strictEqual(person1Dogs.get('length'), 1, 'person1 has correct # of dogs');
+      assert.strictEqual(
         person1Dogs.get('firstObject.id'),
         dog2.get('id'),
         'person1 has dog2 in its hasMany relationship; dog1 is not present because it was destroyed.'
       );
-      assert.equal(
+      assert.strictEqual(
         dog2Walkers.get('length'),
         1,
         'dog2 has correct # of records after record specified by server response is destroyed'
       );
-      assert.equal(
+      assert.strictEqual(
         dog2Walkers.get('firstObject.id'),
         person1.get('id'),
         'dog2 has person1 in its hasMany relationship; person2 is not present because it was destroyed.'
@@ -2893,7 +2925,7 @@ module('inverse relationship load test', function (hooks) {
       // finally, destroy person1, the record that loaded all this data through the relationship
 
       await person1.destroyRecord();
-      assert.equal(
+      assert.strictEqual(
         dog2Walkers.get('length'),
         0,
         'dog2 hasMany relationship is empty after all person records are destroyed'
@@ -2982,19 +3014,19 @@ module('inverse relationship load test', function (hooks) {
         id: 'mismatched-inverse-relationship-data-from-payload',
         count: 2,
       });
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
       let dog2 = store.peekRecord('dog', '2');
 
       const dogs = await person.get('dogs');
-      assert.equal(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
+      assert.strictEqual(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
       assert.ok(dogs.indexOf(dog1) >= 0, 'relationship includes the parent even though it was not specified');
       assert.ok(dogs.indexOf(dog2) >= 0, 'relationship also includes records the payload specified');
 
       for (let dog of [dog1, dog2]) {
         let walkers = await dog.get('walkers');
-        assert.equal(walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
+        assert.strictEqual(walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
         assert.ok(
           walkers.indexOf(person) >= 0,
           'dog1Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -3003,11 +3035,15 @@ module('inverse relationship load test', function (hooks) {
 
       await dog1.destroyRecord();
 
-      assert.equal(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
-      assert.equal(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
+      assert.strictEqual(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
+      assert.strictEqual(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
 
       let dog2Walkers = await dog2.get('walkers');
-      assert.equal(dog2Walkers.get('length'), 1, 'dog2 still has correct number of records for hasMany relationship');
+      assert.strictEqual(
+        dog2Walkers.get('length'),
+        1,
+        'dog2 still has correct number of records for hasMany relationship'
+      );
       assert.ok(
         dog2Walkers.indexOf(person) >= 0,
         'dog2Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -3015,7 +3051,7 @@ module('inverse relationship load test', function (hooks) {
 
       // finally, destroy person1, the record that loaded all this data through the relationship
       await person.destroyRecord();
-      assert.equal(
+      assert.strictEqual(
         dog2Walkers.get('length'),
         0,
         'dog2 hasMany relationship is empty after all person records are destroyed'
@@ -3104,19 +3140,19 @@ module('inverse relationship load test', function (hooks) {
         id: 'mismatched-inverse-relationship-data-from-payload',
         count: 2,
       });
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
       let dog2 = store.peekRecord('dog', '2');
 
       const dogs = await person.get('dogs');
-      assert.equal(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
+      assert.strictEqual(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
       assert.ok(dogs.indexOf(dog1) >= 0, 'relationship includes the parent even though it was not specified');
       assert.ok(dogs.indexOf(dog2) >= 0, 'relationship also includes records the payload specified');
 
       for (let dog of [dog1, dog2]) {
         let walkers = await dog.get('walkers');
-        assert.equal(walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
+        assert.strictEqual(walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
         assert.ok(
           walkers.indexOf(person) >= 0,
           'dog1Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -3125,11 +3161,15 @@ module('inverse relationship load test', function (hooks) {
 
       await dog1.destroyRecord();
 
-      assert.equal(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
-      assert.equal(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
+      assert.strictEqual(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
+      assert.strictEqual(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
 
       let dog2Walkers = await dog2.get('walkers');
-      assert.equal(dog2Walkers.get('length'), 1, 'dog2 still has correct number of records for hasMany relationship');
+      assert.strictEqual(
+        dog2Walkers.get('length'),
+        1,
+        'dog2 still has correct number of records for hasMany relationship'
+      );
       assert.ok(
         dog2Walkers.indexOf(person) >= 0,
         'dog2Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -3137,7 +3177,7 @@ module('inverse relationship load test', function (hooks) {
 
       // finally, destroy person1, the record that loaded all this data through the relationship
       await person.destroyRecord();
-      assert.equal(
+      assert.strictEqual(
         dog2Walkers.get('length'),
         0,
         'dog2 hasMany relationship is empty after all person records are destroyed'
@@ -3226,18 +3266,18 @@ module('inverse relationship load test', function (hooks) {
         id: 'mismatched-inverse-relationship-data-from-payload',
         count: 2,
       });
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
       let dog2 = store.peekRecord('dog', '2');
 
-      assert.equal(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
+      assert.strictEqual(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
       assert.ok(dogs.indexOf(dog1) >= 0, 'relationship includes the parent even though it was not specified');
       assert.ok(dogs.indexOf(dog2) >= 0, 'relationship also includes records the payload specified');
 
       for (let dog of [dog1, dog2]) {
         let walkers = await dog.get('walkers');
-        assert.equal(walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
+        assert.strictEqual(walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
         assert.ok(
           walkers.indexOf(person) >= 0,
           'dog1Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -3246,11 +3286,15 @@ module('inverse relationship load test', function (hooks) {
 
       await dog1.destroyRecord();
 
-      assert.equal(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
-      assert.equal(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
+      assert.strictEqual(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
+      assert.strictEqual(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
 
       let dog2Walkers = await dog2.get('walkers');
-      assert.equal(dog2Walkers.get('length'), 1, 'dog2 still has correct number of records for hasMany relationship');
+      assert.strictEqual(
+        dog2Walkers.get('length'),
+        1,
+        'dog2 still has correct number of records for hasMany relationship'
+      );
       assert.ok(
         dog2Walkers.indexOf(person) >= 0,
         'dog2Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -3258,7 +3302,7 @@ module('inverse relationship load test', function (hooks) {
 
       // finally, destroy person1, the record that loaded all this data through the relationship
       await person.destroyRecord();
-      assert.equal(
+      assert.strictEqual(
         dog2Walkers.get('length'),
         0,
         'dog2 hasMany relationship is empty after all person records are destroyed'
@@ -3347,18 +3391,18 @@ module('inverse relationship load test', function (hooks) {
         id: 'mismatched-inverse-relationship-data-from-payload',
         count: 2,
       });
-      assert.equal(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
+      assert.strictEqual(person.hasMany('dogs').hasManyRelationship.state.isEmpty, false);
 
       let dog1 = store.peekRecord('dog', '1');
       let dog2 = store.peekRecord('dog', '2');
 
-      assert.equal(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
+      assert.strictEqual(dogs.get('length'), 2, 'left hand side relationship is set up with correct number of records');
       assert.ok(dogs.indexOf(dog1) >= 0, 'relationship includes the parent even though it was not specified');
       assert.ok(dogs.indexOf(dog2) >= 0, 'relationship also includes records the payload specified');
 
       for (let dog of [dog1, dog2]) {
         let walkers = await dog.get('walkers');
-        assert.equal(walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
+        assert.strictEqual(walkers.length, 1, 'dog1.walkers inverse relationship includes correct number of records');
         assert.ok(
           walkers.indexOf(person) >= 0,
           'dog1Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -3367,11 +3411,15 @@ module('inverse relationship load test', function (hooks) {
 
       await dog1.destroyRecord();
 
-      assert.equal(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
-      assert.equal(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
+      assert.strictEqual(dogs.get('length'), 1, 'person1.dogs relationship was updated when record removed');
+      assert.strictEqual(dogs.get('firstObject.id'), '2', 'person.dogs relationship has the correct records');
 
       let dog2Walkers = await dog2.get('walkers');
-      assert.equal(dog2Walkers.get('length'), 1, 'dog2 still has correct number of records for hasMany relationship');
+      assert.strictEqual(
+        dog2Walkers.get('length'),
+        1,
+        'dog2 still has correct number of records for hasMany relationship'
+      );
       assert.ok(
         dog2Walkers.indexOf(person) >= 0,
         'dog2Walkers includes the record that requested the relationship but was not specified in the relationships of the records in the response'
@@ -3379,7 +3427,7 @@ module('inverse relationship load test', function (hooks) {
 
       // finally, destroy person1, the record that loaded all this data through the relationship
       await person.destroyRecord();
-      assert.equal(
+      assert.strictEqual(
         dog2Walkers.get('length'),
         0,
         'dog2 hasMany relationship is empty after all person records are destroyed'
@@ -3462,24 +3510,24 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
     let dog1 = dogs.get('firstObject');
     let dogPerson1 = await dog1.get('person');
-    assert.equal(
+    assert.strictEqual(
       dogPerson1.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     let dogPerson2 = await dogs.objectAt(1).get('person');
-    assert.equal(
+    assert.strictEqual(
       dogPerson2.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many (left hand async, right hand sync) - ids/non-link/implicit inverse - ids - records loaded through ids/findRecord are linked to the parent if the response from the server does not include relationship information', async function (assert) {
@@ -3557,24 +3605,24 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
     let dog1 = dogs.get('firstObject');
     let dogPerson1 = await dog1.get('person');
-    assert.equal(
+    assert.strictEqual(
       dogPerson1.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     let dogPerson2 = await dogs.objectAt(1).get('person');
-    assert.equal(
+    assert.strictEqual(
       dogPerson2.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many - ids/non-link/explicit inverse - ids - records loaded through ids/findRecord are linked to the parent if the response from the server does not include relationship information', async function (assert) {
@@ -3653,24 +3701,24 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
     let dog1 = dogs.get('firstObject');
     let dogPerson1 = await dog1.get('pal');
-    assert.equal(
+    assert.strictEqual(
       dogPerson1.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     let dogPerson2 = await dogs.objectAt(1).get('pal');
-    assert.equal(
+    assert.strictEqual(
       dogPerson2.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many (left hand async, right hand sync) - ids/non-link/explicit inverse - ids - records loaded through ids/findRecord are linked to the parent if the response from the server does not include relationship information', async function (assert) {
@@ -3749,24 +3797,24 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
     let dog1 = dogs.get('firstObject');
     let dogPerson1 = await dog1.get('pal');
-    assert.equal(
+    assert.strictEqual(
       dogPerson1.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
     let dogPerson2 = await dogs.objectAt(1).get('pal');
-    assert.equal(
+    assert.strictEqual(
       dogPerson2.get('id'),
       '1',
       'dog.person inverse relationship is set up correctly when adapter does not include parent relationships in data.relationships'
     );
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many - ids/non-link/null inverse - ids - records loaded through ids/findRecord are linked to the parent if the response from the server does not include relationship information', async function (assert) {
@@ -3840,12 +3888,12 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
+    assert.strictEqual(dogs.get('length'), 2, 'hasMany relationship has correct number of records');
     let dog1 = dogs.get('firstObject');
 
     await dog1.destroyRecord();
-    assert.equal(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many - ids/non-link/implicit inverse - records loaded through ids/findRecord do not get associated with the parent if the server specifies another resource as the relationship value in the response', async function (assert) {
@@ -3949,10 +3997,10 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 0, 'hasMany relationship for parent is empty');
+    assert.strictEqual(dogs.get('length'), 0, 'hasMany relationship for parent is empty');
 
     let person2Dogs = await person2.get('dogs');
-    assert.equal(
+    assert.strictEqual(
       person2Dogs.get('length'),
       2,
       'hasMany relationship on specified record has correct number of associated records'
@@ -3962,13 +4010,13 @@ module('inverse relationship load test', function (hooks) {
     for (let i = 0; i < allDogs.length; i++) {
       let dog = allDogs[i];
       let dogPerson = await dog.get('person');
-      assert.equal(dogPerson.get('id'), person2.get('id'), 'right hand side has correct belongsTo value');
+      assert.strictEqual(dogPerson.get('id'), person2.get('id'), 'right hand side has correct belongsTo value');
     }
 
     let dog1 = store.peekRecord('dog', '1');
     await dog1.destroyRecord();
-    assert.equal(person2Dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(person2Dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(person2Dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(person2Dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many (left hand async, right hand sync) - ids/non-link/implicit inverse - records loaded through ids/findRecord do not get associated with the parent if the server specifies another resource as the relationship value in the response', async function (assert) {
@@ -4072,10 +4120,10 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 0, 'hasMany relationship for parent is empty');
+    assert.strictEqual(dogs.get('length'), 0, 'hasMany relationship for parent is empty');
 
     let person2Dogs = await person2.get('dogs');
-    assert.equal(
+    assert.strictEqual(
       person2Dogs.get('length'),
       2,
       'hasMany relationship on specified record has correct number of associated records'
@@ -4085,13 +4133,13 @@ module('inverse relationship load test', function (hooks) {
     for (let i = 0; i < allDogs.length; i++) {
       let dog = allDogs[i];
       let dogPerson = await dog.get('person');
-      assert.equal(dogPerson.get('id'), person2.get('id'), 'right hand side has correct belongsTo value');
+      assert.strictEqual(dogPerson.get('id'), person2.get('id'), 'right hand side has correct belongsTo value');
     }
 
     let dog1 = store.peekRecord('dog', '1');
     await dog1.destroyRecord();
-    assert.equal(person2Dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(person2Dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(person2Dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(person2Dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many - ids/non-link/implicit inverse - records loaded through ids/findRecord do not get associated with the parent if the server specifies null as the relationship value in the response', async function (assert) {
@@ -4179,19 +4227,19 @@ module('inverse relationship load test', function (hooks) {
     let personDogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(personDogs.get('length'), 0, 'hasMany relationship for parent is empty');
+    assert.strictEqual(personDogs.get('length'), 0, 'hasMany relationship for parent is empty');
 
     let allDogs = store.peekAll('dogs').toArray();
     for (let i = 0; i < allDogs.length; i++) {
       let dog = allDogs[i];
       let dogPerson = await dog.get('person');
-      assert.equal(dogPerson, null, 'right hand side has correct belongsTo value');
+      assert.strictEqual(dogPerson, null, 'right hand side has correct belongsTo value');
     }
 
     let dog1 = store.peekRecord('dog', '1');
     await dog1.destroyRecord();
 
-    assert.equal(personDogs.get('length'), 0);
+    assert.strictEqual(personDogs.get('length'), 0);
   });
 
   test('one-to-many (left hand async, right hand sync) - ids/non-link/implicit inverse - records loaded through ids/findRecord do not get associated with the parent if the server specifies null as the relationship value in the response', async function (assert) {
@@ -4279,19 +4327,19 @@ module('inverse relationship load test', function (hooks) {
     let personDogs = await person.get('dogs');
     assert.false(person.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(personDogs.get('length'), 0, 'hasMany relationship for parent is empty');
+    assert.strictEqual(personDogs.get('length'), 0, 'hasMany relationship for parent is empty');
 
     let allDogs = store.peekAll('dogs').toArray();
     for (let i = 0; i < allDogs.length; i++) {
       let dog = allDogs[i];
       let dogPerson = await dog.get('person');
-      assert.equal(dogPerson, null, 'right hand side has correct belongsTo value');
+      assert.strictEqual(dogPerson, null, 'right hand side has correct belongsTo value');
     }
 
     let dog1 = store.peekRecord('dog', '1');
     await dog1.destroyRecord();
 
-    assert.equal(personDogs.get('length'), 0);
+    assert.strictEqual(personDogs.get('length'), 0);
   });
 
   test('one-to-many - ids/non-link/explicit inverse - records loaded through ids/findRecord do not get associated with the parent if the server specifies another resource as the relationship value in the response', async function (assert) {
@@ -4395,10 +4443,10 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await pal.get('dogs');
     assert.false(pal.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 0, 'hasMany relationship for parent is empty');
+    assert.strictEqual(dogs.get('length'), 0, 'hasMany relationship for parent is empty');
 
     let pal2Dogs = await pal2.get('dogs');
-    assert.equal(
+    assert.strictEqual(
       pal2Dogs.get('length'),
       2,
       'hasMany relationship on specified record has correct number of associated records'
@@ -4408,13 +4456,13 @@ module('inverse relationship load test', function (hooks) {
     for (let i = 0; i < allDogs.length; i++) {
       let dog = allDogs[i];
       let dogPerson = await dog.get('pal');
-      assert.equal(dogPerson.get('id'), pal2.get('id'), 'right hand side has correct belongsTo value');
+      assert.strictEqual(dogPerson.get('id'), pal2.get('id'), 'right hand side has correct belongsTo value');
     }
 
     let dog1 = store.peekRecord('dog', '1');
     await dog1.destroyRecord();
-    assert.equal(pal2Dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(pal2Dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(pal2Dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(pal2Dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test('one-to-many (left hand async, right hand sync) - ids/non-link/explicit inverse - records loaded through ids/findRecord do not get associated with the parent if the server specifies another resource as the relationship value in the response', async function (assert) {
@@ -4518,10 +4566,10 @@ module('inverse relationship load test', function (hooks) {
     let dogs = await pal.get('dogs');
     assert.false(pal.hasMany('dogs').hasManyRelationship.state.isEmpty, 'relationship state was set up correctly');
 
-    assert.equal(dogs.get('length'), 0, 'hasMany relationship for parent is empty');
+    assert.strictEqual(dogs.get('length'), 0, 'hasMany relationship for parent is empty');
 
     let pal2Dogs = await pal2.get('dogs');
-    assert.equal(
+    assert.strictEqual(
       pal2Dogs.get('length'),
       2,
       'hasMany relationship on specified record has correct number of associated records'
@@ -4531,13 +4579,13 @@ module('inverse relationship load test', function (hooks) {
     for (let i = 0; i < allDogs.length; i++) {
       let dog = allDogs[i];
       let dogPerson = await dog.get('pal');
-      assert.equal(dogPerson.get('id'), pal2.get('id'), 'right hand side has correct belongsTo value');
+      assert.strictEqual(dogPerson.get('id'), pal2.get('id'), 'right hand side has correct belongsTo value');
     }
 
     let dog1 = store.peekRecord('dog', '1');
     await dog1.destroyRecord();
-    assert.equal(pal2Dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
-    assert.equal(pal2Dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
+    assert.strictEqual(pal2Dogs.get('length'), 1, 'record removed from hasMany relationship after deletion');
+    assert.strictEqual(pal2Dogs.get('firstObject.id'), '2', 'hasMany relationship has correct records');
   });
 
   test("loading belongsTo doesn't remove inverse relationship for other instances", async function (assert) {
@@ -4625,12 +4673,12 @@ module('inverse relationship load test', function (hooks) {
     let dog1 = await owner.lookup('service:store').findRecord('dog', '1');
     let dog2 = await owner.lookup('service:store').findRecord('dog', '2');
 
-    assert.equal(dog1.belongsTo('person').id(), '1');
-    assert.equal(dog2.belongsTo('person').id(), '1');
+    assert.strictEqual(dog1.belongsTo('person').id(), '1');
+    assert.strictEqual(dog2.belongsTo('person').id(), '1');
 
     await dog1.get('person');
 
-    assert.equal(dog1.belongsTo('person').id(), '1');
-    assert.equal(dog2.belongsTo('person').id(), '1');
+    assert.strictEqual(dog1.belongsTo('person').id(), '1');
+    assert.strictEqual(dog2.belongsTo('person').id(), '1');
   });
 });

--- a/packages/-ember-data/tests/integration/relationships/inverse-relationships-test.js
+++ b/packages/-ember-data/tests/integration/relationships/inverse-relationships-test.js
@@ -36,10 +36,10 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     const comment = store.createRecord('comment');
     const post = store.createRecord('post');
 
-    assert.equal(comment.get('post'), null, 'no post has been set on the comment');
+    assert.strictEqual(comment.get('post'), null, 'no post has been set on the comment');
 
     post.get('comments').pushObject(comment);
-    assert.equal(comment.get('post'), post, 'post was set on the comment');
+    assert.strictEqual(comment.get('post'), post, 'post was set on the comment');
   });
 
   test('Inverse relationships can be explicitly nullable', function (assert) {
@@ -62,9 +62,9 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     const user = store.createRecord('user');
     const post = store.createRecord('post');
 
-    assert.equal(user.inverseFor('posts').name, 'participants', 'User.posts inverse is Post.participants');
-    assert.equal(post.inverseFor('lastParticipant'), null, 'Post.lastParticipant has no inverse');
-    assert.equal(post.inverseFor('participants').name, 'posts', 'Post.participants inverse is User.posts');
+    assert.strictEqual(user.inverseFor('posts').name, 'participants', 'User.posts inverse is Post.participants');
+    assert.strictEqual(post.inverseFor('lastParticipant'), null, 'Post.lastParticipant has no inverse');
+    assert.strictEqual(post.inverseFor('participants').name, 'posts', 'Post.participants inverse is User.posts');
   });
 
   test('Null inverses are excluded from potential relationship resolutions', function (assert) {
@@ -87,9 +87,9 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     const user = store.createRecord('user');
     const post = store.createRecord('post');
 
-    assert.equal(user.inverseFor('posts').name, 'participants', 'User.posts inverse is Post.participants');
-    assert.equal(post.inverseFor('lastParticipant'), null, 'Post.lastParticipant has no inverse');
-    assert.equal(post.inverseFor('participants').name, 'posts', 'Post.participants inverse is User.posts');
+    assert.strictEqual(user.inverseFor('posts').name, 'participants', 'User.posts inverse is Post.participants');
+    assert.strictEqual(post.inverseFor('lastParticipant'), null, 'Post.lastParticipant has no inverse');
+    assert.strictEqual(post.inverseFor('participants').name, 'posts', 'Post.participants inverse is User.posts');
   });
 
   test('When a record is added to a has-many relationship, the inverse belongsTo can be set explicitly', async function (assert) {
@@ -118,17 +118,17 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     const comment = store.createRecord('comment');
     const post = store.createRecord('post');
 
-    assert.equal(comment.get('onePost'), null, 'onePost has not been set on the comment');
-    assert.equal(comment.get('twoPost'), null, 'twoPost has not been set on the comment');
-    assert.equal(comment.get('redPost'), null, 'redPost has not been set on the comment');
-    assert.equal(comment.get('bluePost'), null, 'bluePost has not been set on the comment');
+    assert.strictEqual(comment.get('onePost'), null, 'onePost has not been set on the comment');
+    assert.strictEqual(comment.get('twoPost'), null, 'twoPost has not been set on the comment');
+    assert.strictEqual(comment.get('redPost'), null, 'redPost has not been set on the comment');
+    assert.strictEqual(comment.get('bluePost'), null, 'bluePost has not been set on the comment');
 
     post.get('comments').pushObject(comment);
 
-    assert.equal(comment.get('onePost'), null, 'onePost has not been set on the comment');
-    assert.equal(comment.get('twoPost'), null, 'twoPost has not been set on the comment');
-    assert.equal(comment.get('redPost'), post, 'redPost has been set on the comment');
-    assert.equal(comment.get('bluePost'), null, 'bluePost has not been set on the comment');
+    assert.strictEqual(comment.get('onePost'), null, 'onePost has not been set on the comment');
+    assert.strictEqual(comment.get('twoPost'), null, 'twoPost has not been set on the comment');
+    assert.strictEqual(comment.get('redPost'), post, 'redPost has been set on the comment');
+    assert.strictEqual(comment.get('bluePost'), null, 'bluePost has not been set on the comment');
   });
 
   test("When a record's belongsTo relationship is set, it can specify the inverse hasMany to which the new child should be added", async function (assert) {
@@ -156,17 +156,17 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     comment = store.createRecord('comment');
     post = store.createRecord('post');
 
-    assert.equal(post.get('meComments.length'), 0, 'meComments has no posts');
-    assert.equal(post.get('youComments.length'), 0, 'youComments has no posts');
-    assert.equal(post.get('everyoneWeKnowComments.length'), 0, 'everyoneWeKnowComments has no posts');
+    assert.strictEqual(post.get('meComments.length'), 0, 'meComments has no posts');
+    assert.strictEqual(post.get('youComments.length'), 0, 'youComments has no posts');
+    assert.strictEqual(post.get('everyoneWeKnowComments.length'), 0, 'everyoneWeKnowComments has no posts');
 
     comment.set('post', post);
 
-    assert.equal(comment.get('post'), post, 'The post that was set can be retrieved');
+    assert.strictEqual(comment.get('post'), post, 'The post that was set can be retrieved');
 
-    assert.equal(post.get('meComments.length'), 0, 'meComments has no posts');
-    assert.equal(post.get('youComments.length'), 1, 'youComments had the post added');
-    assert.equal(post.get('everyoneWeKnowComments.length'), 0, 'everyoneWeKnowComments has no posts');
+    assert.strictEqual(post.get('meComments.length'), 0, 'meComments has no posts');
+    assert.strictEqual(post.get('youComments.length'), 1, 'youComments had the post added');
+    assert.strictEqual(post.get('everyoneWeKnowComments.length'), 0, 'everyoneWeKnowComments has no posts');
   });
 
   test('When setting a belongsTo, the OneToOne invariant is respected even when other records have been previously used', async function (assert) {
@@ -190,15 +190,15 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     comment.set('post', post);
     post2.set('bestComment', null);
 
-    assert.equal(comment.get('post'), post);
-    assert.equal(post.get('bestComment'), comment);
+    assert.strictEqual(comment.get('post'), post);
+    assert.strictEqual(post.get('bestComment'), comment);
     assert.strictEqual(post2.get('bestComment'), null);
 
     comment.set('post', post2);
 
-    assert.equal(comment.get('post'), post2);
+    assert.strictEqual(comment.get('post'), post2);
     assert.strictEqual(post.get('bestComment'), null);
-    assert.equal(post2.get('bestComment'), comment);
+    assert.strictEqual(post2.get('bestComment'), comment);
   });
 
   test('When setting a belongsTo, the OneToOne invariant is transitive', async function (assert) {
@@ -252,15 +252,15 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
 
     comment.set('post', post);
 
-    assert.equal(comment.get('post'), post);
-    assert.equal(post.get('bestComment'), comment);
+    assert.strictEqual(comment.get('post'), post);
+    assert.strictEqual(post.get('bestComment'), comment);
     assert.strictEqual(comment2.get('post'), null);
 
     post.set('bestComment', comment2);
 
     assert.strictEqual(comment.get('post'), null);
-    assert.equal(post.get('bestComment'), comment2);
-    assert.equal(comment2.get('post'), post);
+    assert.strictEqual(post.get('bestComment'), comment2);
+    assert.strictEqual(comment2.get('post'), post);
   });
 
   test('OneToNone relationship works', async function (assert) {
@@ -284,13 +284,13 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     const post2 = store.createRecord('post');
 
     comment.set('post', post1);
-    assert.equal(comment.get('post'), post1, 'the post is set to the first one');
+    assert.strictEqual(comment.get('post'), post1, 'the post is set to the first one');
 
     comment.set('post', post2);
-    assert.equal(comment.get('post'), post2, 'the post is set to the second one');
+    assert.strictEqual(comment.get('post'), post2, 'the post is set to the second one');
 
     comment.set('post', post1);
-    assert.equal(comment.get('post'), post1, 'the post is re-set to the first one');
+    assert.strictEqual(comment.get('post'), post1, 'the post is re-set to the first one');
   });
 
   test('When a record is added to or removed from a polymorphic has-many relationship, the inverse belongsTo can be set explicitly', async function (assert) {
@@ -322,24 +322,24 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     const post = store.createRecord('post');
     const user = store.createRecord('user');
 
-    assert.equal(post.get('oneUser'), null, 'oneUser has not been set on the user');
-    assert.equal(post.get('twoUser'), null, 'twoUser has not been set on the user');
-    assert.equal(post.get('redUser'), null, 'redUser has not been set on the user');
-    assert.equal(post.get('blueUser'), null, 'blueUser has not been set on the user');
+    assert.strictEqual(post.get('oneUser'), null, 'oneUser has not been set on the user');
+    assert.strictEqual(post.get('twoUser'), null, 'twoUser has not been set on the user');
+    assert.strictEqual(post.get('redUser'), null, 'redUser has not been set on the user');
+    assert.strictEqual(post.get('blueUser'), null, 'blueUser has not been set on the user');
 
     user.get('messages').pushObject(post);
 
-    assert.equal(post.get('oneUser'), null, 'oneUser has not been set on the user');
-    assert.equal(post.get('twoUser'), null, 'twoUser has not been set on the user');
-    assert.equal(post.get('redUser'), user, 'redUser has been set on the user');
-    assert.equal(post.get('blueUser'), null, 'blueUser has not been set on the user');
+    assert.strictEqual(post.get('oneUser'), null, 'oneUser has not been set on the user');
+    assert.strictEqual(post.get('twoUser'), null, 'twoUser has not been set on the user');
+    assert.strictEqual(post.get('redUser'), user, 'redUser has been set on the user');
+    assert.strictEqual(post.get('blueUser'), null, 'blueUser has not been set on the user');
 
     user.get('messages').popObject();
 
-    assert.equal(post.get('oneUser'), null, 'oneUser has not been set on the user');
-    assert.equal(post.get('twoUser'), null, 'twoUser has not been set on the user');
-    assert.equal(post.get('redUser'), null, 'redUser has bot been set on the user');
-    assert.equal(post.get('blueUser'), null, 'blueUser has not been set on the user');
+    assert.strictEqual(post.get('oneUser'), null, 'oneUser has not been set on the user');
+    assert.strictEqual(post.get('twoUser'), null, 'twoUser has not been set on the user');
+    assert.strictEqual(post.get('redUser'), null, 'redUser has bot been set on the user');
+    assert.strictEqual(post.get('blueUser'), null, 'blueUser has not been set on the user');
   });
 
   test("When a record's belongsTo relationship is set, it can specify the inverse polymorphic hasMany to which the new child should be added or removed", async function (assert) {
@@ -368,21 +368,21 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     const user = store.createRecord('user');
     const post = store.createRecord('post');
 
-    assert.equal(user.get('meMessages.length'), 0, 'meMessages has no posts');
-    assert.equal(user.get('youMessages.length'), 0, 'youMessages has no posts');
-    assert.equal(user.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
+    assert.strictEqual(user.get('meMessages.length'), 0, 'meMessages has no posts');
+    assert.strictEqual(user.get('youMessages.length'), 0, 'youMessages has no posts');
+    assert.strictEqual(user.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
 
     post.set('user', user);
 
-    assert.equal(user.get('meMessages.length'), 0, 'meMessages has no posts');
-    assert.equal(user.get('youMessages.length'), 1, 'youMessages had the post added');
-    assert.equal(user.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
+    assert.strictEqual(user.get('meMessages.length'), 0, 'meMessages has no posts');
+    assert.strictEqual(user.get('youMessages.length'), 1, 'youMessages had the post added');
+    assert.strictEqual(user.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
 
     post.set('user', null);
 
-    assert.equal(user.get('meMessages.length'), 0, 'meMessages has no posts');
-    assert.equal(user.get('youMessages.length'), 0, 'youMessages has no posts');
-    assert.equal(user.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
+    assert.strictEqual(user.get('meMessages.length'), 0, 'meMessages has no posts');
+    assert.strictEqual(user.get('youMessages.length'), 0, 'youMessages has no posts');
+    assert.strictEqual(user.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
   });
 
   test("When a record's polymorphic belongsTo relationship is set, it can specify the inverse hasMany to which the new child should be added", async function (assert) {
@@ -411,21 +411,21 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
     const comment = store.createRecord('comment');
     const post = store.createRecord('post');
 
-    assert.equal(post.get('meMessages.length'), 0, 'meMessages has no posts');
-    assert.equal(post.get('youMessages.length'), 0, 'youMessages has no posts');
-    assert.equal(post.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
+    assert.strictEqual(post.get('meMessages.length'), 0, 'meMessages has no posts');
+    assert.strictEqual(post.get('youMessages.length'), 0, 'youMessages has no posts');
+    assert.strictEqual(post.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
 
     comment.set('message', post);
 
-    assert.equal(post.get('meMessages.length'), 0, 'meMessages has no posts');
-    assert.equal(post.get('youMessages.length'), 1, 'youMessages had the post added');
-    assert.equal(post.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
+    assert.strictEqual(post.get('meMessages.length'), 0, 'meMessages has no posts');
+    assert.strictEqual(post.get('youMessages.length'), 1, 'youMessages had the post added');
+    assert.strictEqual(post.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
 
     comment.set('message', null);
 
-    assert.equal(post.get('meMessages.length'), 0, 'meMessages has no posts');
-    assert.equal(post.get('youMessages.length'), 0, 'youMessages has no posts');
-    assert.equal(post.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
+    assert.strictEqual(post.get('meMessages.length'), 0, 'meMessages has no posts');
+    assert.strictEqual(post.get('youMessages.length'), 0, 'youMessages has no posts');
+    assert.strictEqual(post.get('everyoneWeKnowMessages.length'), 0, 'everyoneWeKnowMessages has no posts');
   });
 
   testInDebug("Inverse relationships that don't exist throw a nice error for a hasMany", async function (assert) {
@@ -648,7 +648,7 @@ module('integration/relationships/inverse_relationships - Inverse Relationships'
 
     const comment = store.createRecord('comment');
 
-    assert.equal(comment.inverseFor('user'), null, 'Defaults to a null inverse');
+    assert.strictEqual(comment.inverseFor('user'), null, 'Defaults to a null inverse');
   });
 
   test('Unload a destroyed record should clean the relations', async function (assert) {

--- a/packages/-ember-data/tests/integration/relationships/json-api-links-test.js
+++ b/packages/-ember-data/tests/integration/relationships/json-api-links-test.js
@@ -77,8 +77,8 @@ module('integration/relationship/json-api-links | Relationship state updates', f
         assert.ok(user1, 'user should be populated');
 
         return store.findRecord('organisation', 2).then((org2FromFind) => {
-          assert.equal(user1.belongsTo('organisation').remoteType(), 'id', `user's belongsTo is based on id`);
-          assert.equal(user1.belongsTo('organisation').id(), 1, `user's belongsTo has its id populated`);
+          assert.strictEqual(user1.belongsTo('organisation').remoteType(), 'id', `user's belongsTo is based on id`);
+          assert.strictEqual(user1.belongsTo('organisation').id(), '1', `user's belongsTo has its id populated`);
 
           return user1.get('organisation').then((orgFromUser) => {
             assert.false(

--- a/packages/-ember-data/tests/integration/relationships/many-to-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/many-to-many-test.js
@@ -88,7 +88,7 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
 
     return run(() => {
       return topic.get('users').then((fetchedUsers) => {
-        assert.equal(fetchedUsers.get('length'), 1, 'User relationship was set up correctly');
+        assert.strictEqual(fetchedUsers.get('length'), 1, 'User relationship was set up correctly');
       });
     });
   });
@@ -129,7 +129,7 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
     });
 
     run(() => {
-      assert.equal(account.get('users.length'), 1, 'User relationship was set up correctly');
+      assert.strictEqual(account.get('users.length'), 1, 'User relationship was set up correctly');
     });
   });
 
@@ -170,11 +170,11 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
 
     return run(() => {
       return user.get('topics').then((fetchedTopics) => {
-        assert.equal(fetchedTopics.get('length'), 0, 'Topics were removed correctly');
-        assert.equal(fetchedTopics.objectAt(0), null, "Topics can't be fetched");
+        assert.strictEqual(fetchedTopics.get('length'), 0, 'Topics were removed correctly');
+        assert.strictEqual(fetchedTopics.objectAt(0), undefined, "Topics can't be fetched");
         return topic.get('users').then((fetchedUsers) => {
-          assert.equal(fetchedUsers.get('length'), 0, 'Users were removed correctly');
-          assert.equal(fetchedUsers.objectAt(0), null, "User can't be fetched");
+          assert.strictEqual(fetchedUsers.get('length'), 0, 'Users were removed correctly');
+          assert.strictEqual(fetchedUsers.objectAt(0), undefined, "User can't be fetched");
         });
       });
     });
@@ -230,8 +230,8 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
     });
 
     run(() => {
-      assert.equal(user.get('accounts.length'), 0, 'Accounts were removed correctly');
-      assert.equal(account.get('users.length'), 0, 'Users were removed correctly');
+      assert.strictEqual(user.get('accounts.length'), 0, 'Accounts were removed correctly');
+      assert.strictEqual(account.get('users.length'), 0, 'Users were removed correctly');
     });
   });
 
@@ -276,7 +276,7 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
       return topic.get('users').then((fetchedUsers) => {
         fetchedUsers.pushObject(user);
         return user.get('topics').then((fetchedTopics) => {
-          assert.equal(fetchedTopics.get('length'), 1, 'User relationship was set up correctly');
+          assert.strictEqual(fetchedTopics.get('length'), 1, 'User relationship was set up correctly');
         });
       });
     });
@@ -309,7 +309,7 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
     });
 
     run(() => {
-      assert.equal(account.get('users.length'), 1, 'User relationship was set up correctly');
+      assert.strictEqual(account.get('users.length'), 1, 'User relationship was set up correctly');
     });
   });
 
@@ -350,11 +350,11 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
 
     return run(() => {
       return user.get('topics').then((fetchedTopics) => {
-        assert.equal(fetchedTopics.get('length'), 1, 'Topics were setup correctly');
+        assert.strictEqual(fetchedTopics.get('length'), 1, 'Topics were setup correctly');
         fetchedTopics.removeObject(topic);
         return topic.get('users').then((fetchedUsers) => {
-          assert.equal(fetchedUsers.get('length'), 0, 'Users were removed correctly');
-          assert.equal(fetchedUsers.objectAt(0), null, "User can't be fetched");
+          assert.strictEqual(fetchedUsers.get('length'), 0, 'Users were removed correctly');
+          assert.strictEqual(fetchedUsers.objectAt(0), undefined, "User can't be fetched");
         });
       });
     });
@@ -396,10 +396,10 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
     });
 
     run(() => {
-      assert.equal(account.get('users.length'), 1, 'Users were setup correctly');
+      assert.strictEqual(account.get('users.length'), 1, 'Users were setup correctly');
       account.get('users').removeObject(user);
-      assert.equal(user.get('accounts.length'), 0, 'Accounts were removed correctly');
-      assert.equal(account.get('users.length'), 0, 'Users were removed correctly');
+      assert.strictEqual(user.get('accounts.length'), 0, 'Accounts were removed correctly');
+      assert.strictEqual(account.get('users.length'), 0, 'Users were removed correctly');
     });
   });
 
@@ -449,11 +449,11 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
 
     return run(() => {
       let users = topic.get('users').then((fetchedUsers) => {
-        assert.equal(fetchedUsers.get('length'), 1, 'Users are still there');
+        assert.strictEqual(fetchedUsers.get('length'), 1, 'Users are still there');
       });
 
       let topics = user.get('topics').then((fetchedTopics) => {
-        assert.equal(fetchedTopics.get('length'), 1, 'Topic got rollbacked into the user');
+        assert.strictEqual(fetchedTopics.get('length'), 1, 'Topic got rollbacked into the user');
       });
 
       return EmberPromise.all([users, topics]);
@@ -498,8 +498,8 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
     run(() => {
       account.deleteRecord();
       account.rollbackAttributes();
-      assert.equal(account.get('users.length'), 1, 'Users are still there');
-      assert.equal(user.get('accounts.length'), 1, 'Account got rolledback correctly into the user');
+      assert.strictEqual(account.get('users.length'), 1, 'Users are still there');
+      assert.strictEqual(user.get('accounts.length'), 1, 'Account got rolledback correctly into the user');
     });
   });
 
@@ -527,13 +527,13 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
         topic.rollbackAttributes();
 
         let users = topic.get('users').then((fetchedUsers) => {
-          assert.equal(fetchedUsers.get('length'), 0, 'Users got removed');
-          assert.equal(fetchedUsers.objectAt(0), null, "User can't be fetched");
+          assert.strictEqual(fetchedUsers.get('length'), 0, 'Users got removed');
+          assert.strictEqual(fetchedUsers.objectAt(0), undefined, "User can't be fetched");
         });
 
         let topics = user.get('topics').then((fetchedTopics) => {
-          assert.equal(fetchedTopics.get('length'), 0, 'Topics got removed');
-          assert.equal(fetchedTopics.objectAt(0), null, "Topic can't be fetched");
+          assert.strictEqual(fetchedTopics.get('length'), 0, 'Topics got removed');
+          assert.strictEqual(fetchedTopics.objectAt(0), undefined, "Topic can't be fetched");
         });
 
         return EmberPromise.all([users, topics]);
@@ -564,8 +564,8 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
       user.rollbackAttributes();
     });
 
-    assert.equal(account.get('users.length'), 0, 'Users got removed');
-    assert.equal(user.get('accounts.length'), 0, 'Accounts got rolledback correctly');
+    assert.strictEqual(account.get('users.length'), 0, 'Users got removed');
+    assert.strictEqual(user.get('accounts.length'), 0, 'Accounts got rolledback correctly');
   });
 
   todo(
@@ -660,7 +660,7 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
         ['1'],
         'Accounts were updated correctly (ui state)'
       );
-      assert.equal(state.length, 2, 'Accounts were updated correctly (server state)');
+      assert.strictEqual(state.length, 2, 'Accounts were updated correctly (server state)');
       assert.deepEqual(
         state.map((r) => r.id),
         ['1', '2'],

--- a/packages/-ember-data/tests/integration/relationships/nested-relationship-test.js
+++ b/packages/-ember-data/tests/integration/relationships/nested-relationship-test.js
@@ -135,13 +135,13 @@ module('integration/relationships/nested_relationships_test - Nested relationshi
         assert.ok(middleAger, 'MiddleAger relationship was set up correctly');
 
         let middleAgerName = get(middleAger, 'name');
-        assert.equal(middleAgerName, 'Middle Ager 1', 'MiddleAger name is there');
+        assert.strictEqual(middleAgerName, 'Middle Ager 1', 'MiddleAger name is there');
         assert.ok(middleAger.get('kids').includes(kid));
 
         return middleAger.get('elder').then((elder) => {
           assert.notEqual(elder, null, 'Elder relationship was set up correctly');
           let elderName = get(elder, 'name');
-          assert.equal(elderName, 'Elder 1', 'Elder name is there');
+          assert.strictEqual(elderName, 'Elder 1', 'Elder name is there');
         });
       });
     });

--- a/packages/-ember-data/tests/integration/relationships/one-to-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/one-to-many-test.js
@@ -82,7 +82,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
     run(function () {
       message.get('user').then(function (fetchedUser) {
-        assert.equal(fetchedUser, user, 'User relationship was set up correctly');
+        assert.strictEqual(fetchedUser, user, 'User relationship was set up correctly');
       });
     });
   });
@@ -179,7 +179,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
         },
       });
     });
-    assert.equal(account.get('user'), user, 'User relationship was set up correctly');
+    assert.strictEqual(account.get('user'), user, 'User relationship was set up correctly');
   });
 
   test('Relationship is available from the hasMany side even if only loaded from the belongsTo side - async', function (assert) {
@@ -216,7 +216,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
     run(function () {
       user.get('messages').then(function (fetchedMessages) {
-        assert.equal(fetchedMessages.objectAt(0), message, 'Messages relationship was set up correctly');
+        assert.strictEqual(fetchedMessages.objectAt(0), message, 'Messages relationship was set up correctly');
       });
     });
   });
@@ -254,7 +254,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       });
     });
     run(function () {
-      assert.equal(user.get('accounts').objectAt(0), account, 'Accounts relationship was set up correctly');
+      assert.strictEqual(user.get('accounts').objectAt(0), account, 'Accounts relationship was set up correctly');
     });
   });
 
@@ -322,7 +322,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
     run(function () {
       user.get('messages').then(function (fetchedMessages) {
-        assert.equal(get(fetchedMessages, 'length'), 1, 'Messages relationship was set up correctly');
+        assert.strictEqual(get(fetchedMessages, 'length'), 1, 'Messages relationship was set up correctly');
       });
     });
   });
@@ -379,7 +379,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
 
     run(function () {
-      assert.equal(user.get('accounts').objectAt(0), null, 'Account was sucesfully removed');
+      assert.strictEqual(user.get('accounts').objectAt(0), undefined, 'Account was sucesfully removed');
     });
   });
 
@@ -442,7 +442,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
     run(function () {
       user.get('messages').then(function (fetchedMessages) {
-        assert.equal(get(fetchedMessages, 'length'), 2, 'Messages relationship was set up correctly');
+        assert.strictEqual(get(fetchedMessages, 'length'), 2, 'Messages relationship was set up correctly');
       });
     });
   });
@@ -492,7 +492,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
 
     run(function () {
-      assert.equal(user.get('accounts').objectAt(0), account, 'Account was sucesfully removed');
+      assert.strictEqual(user.get('accounts').objectAt(0), account, 'Account was sucesfully removed');
     });
   });
 
@@ -570,11 +570,11 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
     run(function () {
       message.get('user').then(function (fetchedUser) {
-        assert.equal(fetchedUser, null, 'User was removed correctly');
+        assert.strictEqual(fetchedUser, null, 'User was removed correctly');
       });
 
       message2.get('user').then(function (fetchedUser) {
-        assert.equal(fetchedUser, user, 'User was set on the second message');
+        assert.strictEqual(fetchedUser, user, 'User was set on the second message');
       });
     });
   });
@@ -707,7 +707,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
 
     run(function () {
       message.get('user').then(function (fetchedUser) {
-        assert.equal(fetchedUser, user, 'User was not removed');
+        assert.strictEqual(fetchedUser, user, 'User was not removed');
       });
     });
   });
@@ -774,7 +774,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
 
     run(function () {
-      assert.equal(account.get('user'), user, 'User was not removed');
+      assert.strictEqual(account.get('user'), user, 'User was not removed');
     });
   });
 
@@ -830,7 +830,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       user.get('messages').then(function (fetchedMessages) {
         fetchedMessages.pushObject(message2);
         message2.get('user').then(function (fetchedUser) {
-          assert.equal(fetchedUser, user, 'user got set correctly');
+          assert.strictEqual(fetchedUser, user, 'user got set correctly');
         });
       });
     });
@@ -890,7 +890,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       user.get('accounts').pushObject(account2);
     });
 
-    assert.equal(account2.get('user'), user, 'user got set correctly');
+    assert.strictEqual(account2.get('user'), user, 'user got set correctly');
   });
 
   test('Removing from the hasMany side reflects the change on the belongsTo side - async', function (assert) {
@@ -932,7 +932,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       user.get('messages').then(function (fetchedMessages) {
         fetchedMessages.removeObject(message);
         message.get('user').then(function (fetchedUser) {
-          assert.equal(fetchedUser, null, 'user got removed correctly');
+          assert.strictEqual(fetchedUser, null, 'user got removed correctly');
         });
       });
     });
@@ -984,7 +984,7 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       user.get('accounts').removeObject(account);
     });
 
-    assert.equal(account.get('user'), null, 'user got removed correctly');
+    assert.strictEqual(account.get('user'), null, 'user got removed correctly');
   });
 
   test('Pushing to the hasMany side keeps the oneToMany invariant on the belongsTo side - async', function (assert) {
@@ -1038,11 +1038,11 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
         fetchedMessages.pushObject(message);
 
         message.get('user').then(function (fetchedUser) {
-          assert.equal(fetchedUser, user2, 'user got set correctly');
+          assert.strictEqual(fetchedUser, user2, 'user got set correctly');
         });
 
         user.get('messages').then(function (newFetchedMessages) {
-          assert.equal(get(newFetchedMessages, 'length'), 0, 'message got removed from the old messages hasMany');
+          assert.strictEqual(get(newFetchedMessages, 'length'), 0, 'message got removed from the old messages hasMany');
         });
       });
     });
@@ -1092,9 +1092,9 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       });
       user2.get('accounts').pushObject(account);
     });
-    assert.equal(account.get('user'), user2, 'user got set correctly');
-    assert.equal(user.get('accounts.length'), 0, 'the account got removed correctly');
-    assert.equal(user2.get('accounts.length'), 1, 'the account got pushed correctly');
+    assert.strictEqual(account.get('user'), user2, 'user got set correctly');
+    assert.strictEqual(user.get('accounts.length'), 0, 'the account got removed correctly');
+    assert.strictEqual(user2.get('accounts.length'), 1, 'the account got pushed correctly');
   });
 
   test('Setting the belongsTo side keeps the oneToMany invariant on the hasMany- async', function (assert) {
@@ -1154,12 +1154,12 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
 
     run(function () {
       user.get('messages').then(function (fetchedMessages) {
-        assert.equal(get(fetchedMessages, 'length'), 0, 'message got removed from the first user correctly');
+        assert.strictEqual(get(fetchedMessages, 'length'), 0, 'message got removed from the first user correctly');
       });
     });
     run(function () {
       user2.get('messages').then(function (fetchedMessages) {
-        assert.equal(get(fetchedMessages, 'length'), 1, 'message got added to the second user correctly');
+        assert.strictEqual(get(fetchedMessages, 'length'), 1, 'message got added to the second user correctly');
       });
     });
   });
@@ -1216,9 +1216,9 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       });
       account.set('user', user2);
     });
-    assert.equal(account.get('user'), user2, 'user got set correctly');
-    assert.equal(user.get('accounts.length'), 0, 'the account got removed correctly');
-    assert.equal(user2.get('accounts.length'), 1, 'the account got pushed correctly');
+    assert.strictEqual(account.get('user'), user2, 'user got set correctly');
+    assert.strictEqual(user.get('accounts.length'), 0, 'the account got removed correctly');
+    assert.strictEqual(user2.get('accounts.length'), 1, 'the account got pushed correctly');
   });
 
   test('Setting the belongsTo side to null removes the record from the hasMany side - async', function (assert) {
@@ -1268,13 +1268,13 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
     run(function () {
       user.get('messages').then(function (fetchedMessages) {
-        assert.equal(get(fetchedMessages, 'length'), 0, 'message got removed from the  user correctly');
+        assert.strictEqual(get(fetchedMessages, 'length'), 0, 'message got removed from the  user correctly');
       });
     });
 
     run(function () {
       message.get('user').then(function (fetchedUser) {
-        assert.equal(fetchedUser, null, 'user got set to null correctly');
+        assert.strictEqual(fetchedUser, null, 'user got set to null correctly');
       });
     });
   });
@@ -1323,9 +1323,9 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       account.set('user', null);
     });
 
-    assert.equal(account.get('user'), null, 'user got set to null correctly');
+    assert.strictEqual(account.get('user'), null, 'user got set to null correctly');
 
-    assert.equal(user.get('accounts.length'), 0, 'the account got removed correctly');
+    assert.strictEqual(user.get('accounts.length'), 0, 'the account got removed correctly');
   });
 
   /*
@@ -1372,10 +1372,10 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
     run(function () {
       message.get('user').then(function (fetchedUser) {
-        assert.equal(fetchedUser, user, 'Message still has the user');
+        assert.strictEqual(fetchedUser, user, 'Message still has the user');
       });
       user.get('messages').then(function (fetchedMessages) {
-        assert.equal(fetchedMessages.objectAt(0), message, 'User has the message');
+        assert.strictEqual(fetchedMessages.objectAt(0), message, 'User has the message');
       });
     });
   });
@@ -1417,8 +1417,8 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     run(function () {
       account.deleteRecord();
       account.rollbackAttributes();
-      assert.equal(user.get('accounts.length'), 1, 'Accounts are rolled back');
-      assert.equal(account.get('user'), user, 'Account still has the user');
+      assert.strictEqual(user.get('accounts.length'), 1, 'Accounts are rolled back');
+      assert.strictEqual(account.get('user'), user, 'Account still has the user');
     });
   });
 
@@ -1462,10 +1462,10 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     });
     run(function () {
       message.get('user').then(function (fetchedUser) {
-        assert.equal(fetchedUser, user, 'Message has the user again');
+        assert.strictEqual(fetchedUser, user, 'Message has the user again');
       });
       user.get('messages').then(function (fetchedMessages) {
-        assert.equal(fetchedMessages.get('length'), 1, 'User still has the messages');
+        assert.strictEqual(fetchedMessages.get('length'), 1, 'User still has the messages');
       });
     });
   });
@@ -1507,8 +1507,8 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     run(function () {
       user.deleteRecord();
       user.rollbackAttributes();
-      assert.equal(user.get('accounts.length'), 1, 'User still has the accounts');
-      assert.equal(account.get('user'), user, 'Account has the user again');
+      assert.strictEqual(user.get('accounts.length'), 1, 'User still has the accounts');
+      assert.strictEqual(account.get('user'), user, 'Account has the user again');
     });
   });
 
@@ -1537,11 +1537,11 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     run(message, 'rollbackAttributes');
     run(function () {
       message.get('user').then(function (fetchedUser) {
-        assert.equal(fetchedUser, null, 'Message does not have the user anymore');
+        assert.strictEqual(fetchedUser, null, 'Message does not have the user anymore');
       });
       user.get('messages').then(function (fetchedMessages) {
-        assert.equal(fetchedMessages.get('length'), 0, 'User does not have the message anymore');
-        assert.equal(fetchedMessages.get('firstObject'), null, "User message can't be accessed");
+        assert.strictEqual(fetchedMessages.get('length'), 0, 'User does not have the message anymore');
+        assert.strictEqual(fetchedMessages.get('firstObject'), undefined, "User message can't be accessed");
       });
     });
   });
@@ -1565,8 +1565,8 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       });
     });
     run(account, 'rollbackAttributes');
-    assert.equal(user.get('accounts.length'), 0, 'Accounts are rolled back');
-    assert.equal(account.get('user'), null, 'Account does not have the user anymore');
+    assert.strictEqual(user.get('accounts.length'), 0, 'Accounts are rolled back');
+    assert.strictEqual(account.get('user'), null, 'Account does not have the user anymore');
   });
 
   test('Rollbacking attributes of a created record works correctly when the belongsTo side has been created - async', function (assert) {
@@ -1590,11 +1590,11 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
         messages.pushObject(message);
         user.rollbackAttributes();
         message.get('user').then(function (fetchedUser) {
-          assert.equal(fetchedUser, null, 'Message does not have the user anymore');
+          assert.strictEqual(fetchedUser, null, 'Message does not have the user anymore');
         });
         user.get('messages').then(function (fetchedMessages) {
-          assert.equal(fetchedMessages.get('length'), 0, 'User does not have the message anymore');
-          assert.equal(fetchedMessages.get('firstObject'), null, "User message can't be accessed");
+          assert.strictEqual(fetchedMessages.get('length'), 0, 'User does not have the message anymore');
+          assert.strictEqual(fetchedMessages.get('firstObject'), undefined, "User message can't be accessed");
         });
       });
     });
@@ -1620,8 +1620,8 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
       user.get('accounts').pushObject(account);
     });
     run(user, 'rollbackAttributes');
-    assert.equal(user.get('accounts.length'), 0, 'User does not have the account anymore');
-    assert.equal(account.get('user'), null, 'Account does not have the user anymore');
+    assert.strictEqual(user.get('accounts.length'), 0, 'User does not have the account anymore');
+    assert.strictEqual(account.get('user'), null, 'Account does not have the user anymore');
   });
 
   test('createRecord updates inverse record array which has observers', function (assert) {
@@ -1643,17 +1643,17 @@ module('integration/relationships/one_to_many_test - OneToMany relationships', f
     };
 
     return store.findAll('user').then((users) => {
-      assert.equal(users.get('length'), 1, 'Exactly 1 user');
+      assert.strictEqual(users.get('length'), 1, 'Exactly 1 user');
 
       let user = users.get('firstObject');
-      assert.equal(user.get('messages.length'), 0, 'Record array is initially empty');
+      assert.strictEqual(user.get('messages.length'), 0, 'Record array is initially empty');
 
       // set up an observer
       user.addObserver('messages.@each.title', () => {});
       user.get('messages.firstObject');
 
       let message = store.createRecord('message', { user, title: 'EmberFest was great' });
-      assert.equal(user.get('messages.length'), 1, 'The message is added to the record array');
+      assert.strictEqual(user.get('messages.length'), 1, 'The message is added to the record array');
 
       let messageFromArray = user.get('messages.firstObject');
       assert.ok(message === messageFromArray, 'Only one message record instance should be created');

--- a/packages/-ember-data/tests/integration/relationships/one-to-one-test.js
+++ b/packages/-ember-data/tests/integration/relationships/one-to-one-test.js
@@ -76,7 +76,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
       });
 
       stanleysFriend.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, stanley, 'User relationship was set up correctly');
+        assert.strictEqual(fetchedUser, stanley, 'User relationship was set up correctly');
       });
     });
   });
@@ -113,7 +113,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
         },
       });
     });
-    assert.equal(job.get('user'), user, 'User relationship was set up correctly');
+    assert.strictEqual(job.get('user'), user, 'User relationship was set up correctly');
   });
 
   test('Fetching a belongsTo that is set to null removes the record from a relationship - async', function (assert) {
@@ -153,7 +153,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
         },
       });
       stanleysFriend.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, null, 'User relationship was removed correctly');
+        assert.strictEqual(fetchedUser, null, 'User relationship was removed correctly');
       });
     });
   });
@@ -206,7 +206,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
         },
       });
     });
-    assert.equal(job.get('user'), null, 'User relationship was removed correctly');
+    assert.strictEqual(job.get('user'), null, 'User relationship was removed correctly');
   });
 
   test('Fetching a belongsTo that is set to a different record, sets the old relationship to null - async', async function (assert) {
@@ -240,7 +240,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     let user2 = store.peekRecord('user', '2');
     let user1Friend = await user1.get('bestFriend');
 
-    assert.equal(user1Friend, user2, '<user:1>.bestFriend is <user:2>');
+    assert.strictEqual(user1Friend, user2, '<user:1>.bestFriend is <user:2>');
 
     /*
       Now we "reload" <user:2> but with a new bestFriend. While this only gives
@@ -283,14 +283,14 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     let user2bestFriend = await user2.get('bestFriend');
     let user3bestFriend = await user3.get('bestFriend');
 
-    assert.equal(user3bestFriend, user2, '<user:3>.bestFriend is <user:2>');
-    assert.equal(user2bestFriend, user3, '<user:2>.bestFriend is <user:3>');
-    assert.equal(user1bestFriend, null, '<user:1>.bestFriend is null');
+    assert.strictEqual(user3bestFriend, user2, '<user:3>.bestFriend is <user:2>');
+    assert.strictEqual(user2bestFriend, user3, '<user:2>.bestFriend is <user:3>');
+    assert.strictEqual(user1bestFriend, null, '<user:1>.bestFriend is null');
 
     let user1bestFriendState = user1.belongsTo('bestFriend').belongsToRelationship;
 
-    assert.equal(user1bestFriendState.remoteState, null, '<user:1>.job is canonically empty');
-    assert.equal(user1bestFriendState.localState, null, '<user:1>.job is locally empty');
+    assert.strictEqual(user1bestFriendState.remoteState, null, '<user:1>.job is canonically empty');
+    assert.strictEqual(user1bestFriendState.localState, null, '<user:1>.job is locally empty');
     assert.true(user1bestFriendState.state.isEmpty, 'The relationship is empty');
     assert.false(user1bestFriendState.state.isStale, 'The relationship is not stale');
     assert.false(user1bestFriendState.state.shouldForceReload, 'The relationship does not require reload');
@@ -327,7 +327,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
 
     let job1 = store.peekRecord('job', '1');
 
-    assert.equal(user1.get('job'), job1, '<user:1>.job is <job:1>');
+    assert.strictEqual(user1.get('job'), job1, '<user:1>.job is <job:1>');
 
     /*
       Now we "reload" <job:1> but with a new user. While this only gives
@@ -367,14 +367,14 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
 
     let user2 = store.peekRecord('user', '2');
 
-    assert.equal(user2.get('job'), job1, '<user:2>.job is <job:1>');
-    assert.equal(job1.get('user'), user2, '<job:1>.user is <user:2>');
-    assert.equal(user1.get('job'), null, '<user:1>.job is null');
+    assert.strictEqual(user2.get('job'), job1, '<user:2>.job is <job:1>');
+    assert.strictEqual(job1.get('user'), user2, '<job:1>.user is <user:2>');
+    assert.strictEqual(user1.get('job'), null, '<user:1>.job is null');
 
     let user1JobState = user1.belongsTo('job').belongsToRelationship;
 
-    assert.equal(user1JobState.canonicalState, null, '<user:1>.job is canonically empty');
-    assert.equal(user1JobState.currentState, null, '<user:1>.job is locally empty');
+    assert.strictEqual(user1JobState.canonicalState, undefined, '<user:1>.job is canonically empty');
+    assert.strictEqual(user1JobState.currentState, undefined, '<user:1>.job is locally empty');
     assert.true(user1JobState.state.isEmpty, 'The relationship is empty');
     assert.false(user1JobState.state.isStale, 'The relationship is not stale');
     assert.false(user1JobState.state.shouldForceReload, 'The relationship does not require reload');
@@ -412,7 +412,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     run(function () {
       stanley.set('bestFriend', stanleysFriend);
       stanleysFriend.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, stanley, 'User relationship was updated correctly');
+        assert.strictEqual(fetchedUser, stanley, 'User relationship was updated correctly');
       });
     });
   });
@@ -444,7 +444,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     run(function () {
       user.set('job', job);
     });
-    assert.equal(job.get('user'), user, 'User relationship was set up correctly');
+    assert.strictEqual(job.get('user'), user, 'User relationship was set up correctly');
   });
 
   test('Setting a BelongsTo to a promise unwraps the promise before setting- async', function (assert) {
@@ -491,10 +491,18 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     run(function () {
       newFriend.set('bestFriend', stanleysFriend.get('bestFriend'));
       stanley.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, newFriend, `Stanley's bestFriend relationship was updated correctly to newFriend`);
+        assert.strictEqual(
+          fetchedUser,
+          newFriend,
+          `Stanley's bestFriend relationship was updated correctly to newFriend`
+        );
       });
       newFriend.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, stanley, `newFriend's bestFriend relationship was updated correctly to be Stanley`);
+        assert.strictEqual(
+          fetchedUser,
+          stanley,
+          `newFriend's bestFriend relationship was updated correctly to be Stanley`
+        );
       });
     });
   });
@@ -543,7 +551,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     run(function () {
       newFriend.set('bestFriend', igor.get('bestFriend'));
       newFriend.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, null, 'User relationship was updated correctly');
+        assert.strictEqual(fetchedUser, null, 'User relationship was updated correctly');
       });
     });
   });
@@ -659,7 +667,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
       newFriend.set('bestFriend', stanley.get('bestFriend'));
       newFriend.set('bestFriend', igor.get('bestFriend'));
       newFriend.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser.get('name'), "Igor's friend", 'User relationship was updated correctly');
+        assert.strictEqual(fetchedUser.get('name'), "Igor's friend", 'User relationship was updated correctly');
       });
     });
   });
@@ -708,7 +716,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     run(function () {
       stanley.set('bestFriend', null); // :(
       stanleysFriend.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, null, 'User relationship was removed correctly');
+        assert.strictEqual(fetchedUser, null, 'User relationship was removed correctly');
       });
     });
   });
@@ -757,7 +765,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     run(function () {
       user.set('job', null);
     });
-    assert.equal(job.get('user'), null, 'User relationship was removed correctly');
+    assert.strictEqual(job.get('user'), null, 'User relationship was removed correctly');
   });
 
   test('Setting a belongsTo to a different record, sets the old relationship to null - async', function (assert) {
@@ -803,7 +811,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
       });
 
       stanleysFriend.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, stanley, 'User relationship was initally setup correctly');
+        assert.strictEqual(fetchedUser, stanley, 'User relationship was initally setup correctly');
         var stanleysNewFriend = store.push({
           data: {
             id: 3,
@@ -819,11 +827,11 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
         });
 
         stanley.get('bestFriend').then(function (fetchedNewFriend) {
-          assert.equal(fetchedNewFriend, stanleysNewFriend, 'User relationship was updated correctly');
+          assert.strictEqual(fetchedNewFriend, stanleysNewFriend, 'User relationship was updated correctly');
         });
 
         stanleysFriend.get('bestFriend').then(function (fetchedOldFriend) {
-          assert.equal(fetchedOldFriend, null, 'The old relationship was set to null correctly');
+          assert.strictEqual(fetchedOldFriend, null, 'The old relationship was set to null correctly');
         });
       });
     });
@@ -862,7 +870,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
       });
     });
 
-    assert.equal(job.get('user'), user, 'Job and user initially setup correctly');
+    assert.strictEqual(job.get('user'), user, 'Job and user initially setup correctly');
 
     run(function () {
       newBetterJob = store.push({
@@ -878,9 +886,9 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
       newBetterJob.set('user', user);
     });
 
-    assert.equal(user.get('job'), newBetterJob, 'Job updated correctly');
-    assert.equal(job.get('user'), null, 'Old relationship nulled out correctly');
-    assert.equal(newBetterJob.get('user'), user, 'New job setup correctly');
+    assert.strictEqual(user.get('job'), newBetterJob, 'Job updated correctly');
+    assert.strictEqual(job.get('user'), null, 'Old relationship nulled out correctly');
+    assert.strictEqual(newBetterJob.get('user'), user, 'New job setup correctly');
   });
 
   /*
@@ -925,10 +933,10 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     run(function () {
       stanley.rollbackAttributes();
       stanleysFriend.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, stanley, 'Stanley got rollbacked correctly');
+        assert.strictEqual(fetchedUser, stanley, 'Stanley got rollbacked correctly');
       });
       stanley.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, stanleysFriend, 'Stanleys friend did not get removed');
+        assert.strictEqual(fetchedUser, stanleysFriend, 'Stanleys friend did not get removed');
       });
     });
   });
@@ -969,8 +977,8 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
       job.deleteRecord();
       job.rollbackAttributes();
     });
-    assert.equal(user.get('job'), job, 'Job got rollbacked correctly');
-    assert.equal(job.get('user'), user, 'Job still has the user');
+    assert.strictEqual(user.get('job'), job, 'Job got rollbacked correctly');
+    assert.strictEqual(job.get('user'), user, 'Job still has the user');
   });
 
   test('Rollbacking attributes of created record removes the relationship on both sides - async', function (assert) {
@@ -993,10 +1001,10 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     run(function () {
       stanley.rollbackAttributes();
       stanleysFriend.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, null, 'Stanley got rollbacked correctly');
+        assert.strictEqual(fetchedUser, null, 'Stanley got rollbacked correctly');
       });
       stanley.get('bestFriend').then(function (fetchedUser) {
-        assert.equal(fetchedUser, null, 'Stanleys friend did got removed');
+        assert.strictEqual(fetchedUser, null, 'Stanleys friend did got removed');
       });
     });
   });
@@ -1021,7 +1029,7 @@ module('integration/relationships/one_to_one_test - OneToOne relationships', fun
     run(function () {
       job.rollbackAttributes();
     });
-    assert.equal(user.get('job'), null, 'Job got rollbacked correctly');
-    assert.equal(job.get('user'), null, 'Job does not have user anymore');
+    assert.strictEqual(user.get('job'), null, 'Job got rollbacked correctly');
+    assert.strictEqual(job.get('user'), null, 'Job does not have user anymore');
   });
 });

--- a/packages/-ember-data/tests/integration/relationships/polymorphic-mixins-belongs-to-test.js
+++ b/packages/-ember-data/tests/integration/relationships/polymorphic-mixins-belongs-to-test.js
@@ -76,9 +76,9 @@ module(
       });
       run(function () {
         user.get('bestMessage').then(function (message) {
-          assert.equal(message, video, 'The message was loaded correctly');
+          assert.strictEqual(message, video, 'The message was loaded correctly');
           message.get('user').then(function (fetchedUser) {
-            assert.equal(fetchedUser, user, 'The inverse was setup correctly');
+            assert.strictEqual(fetchedUser, user, 'The inverse was setup correctly');
           });
         });
       });
@@ -117,10 +117,10 @@ module(
       run(function () {
         user.set('bestMessage', video);
         video.get('user').then(function (fetchedUser) {
-          assert.equal(fetchedUser, user, 'user got set correctly');
+          assert.strictEqual(fetchedUser, user, 'user got set correctly');
         });
         user.get('bestMessage').then(function (message) {
-          assert.equal(message, video, 'The message was set correctly');
+          assert.strictEqual(message, video, 'The message was set correctly');
         });
       });
     });
@@ -194,10 +194,10 @@ module(
       run(function () {
         user.set('bestMessage', video);
         video.get('user').then(function (fetchedUser) {
-          assert.equal(fetchedUser, user, 'user got set correctly');
+          assert.strictEqual(fetchedUser, user, 'user got set correctly');
         });
         user.get('bestMessage').then(function (message) {
-          assert.equal(message, video, 'The message was set correctly');
+          assert.strictEqual(message, video, 'The message was set correctly');
         });
       });
     });

--- a/packages/-ember-data/tests/integration/relationships/polymorphic-mixins-has-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/polymorphic-mixins-has-many-test.js
@@ -78,12 +78,12 @@ module(
       });
       run(function () {
         user.get('messages').then(function (messages) {
-          assert.equal(messages.objectAt(0), video, 'The hasMany has loaded correctly');
+          assert.strictEqual(messages.objectAt(0), video, 'The hasMany has loaded correctly');
           messages
             .objectAt(0)
             .get('user')
             .then(function (fetchedUser) {
-              assert.equal(fetchedUser, user, 'The inverse was setup correctly');
+              assert.strictEqual(fetchedUser, user, 'The inverse was setup correctly');
             });
         });
       });
@@ -128,7 +128,7 @@ module(
         user.get('messages').then(function (fetchedMessages) {
           fetchedMessages.pushObject(video);
           video.get('user').then(function (fetchedUser) {
-            assert.equal(fetchedUser, user, 'user got set correctly');
+            assert.strictEqual(fetchedUser, user, 'user got set correctly');
           });
         });
       });
@@ -174,7 +174,7 @@ module(
         user.get('messages').then(function (fetchedMessages) {
           fetchedMessages.pushObject(video);
           video.get('user').then(function (fetchedUser) {
-            assert.equal(fetchedUser, user, 'user got set correctly');
+            assert.strictEqual(fetchedUser, user, 'user got set correctly');
           });
         });
       });
@@ -263,7 +263,7 @@ module(
         user.get('messages').then(function (fetchedMessages) {
           fetchedMessages.pushObject(video);
           video.get('user').then(function (fetchedUser) {
-            assert.equal(fetchedUser, user, 'user got set correctly');
+            assert.strictEqual(fetchedUser, user, 'user got set correctly');
           });
         });
       });

--- a/packages/-ember-data/tests/integration/relationships/reload-error-test.js
+++ b/packages/-ember-data/tests/integration/relationships/reload-error-test.js
@@ -72,7 +72,7 @@ module('Relationships | unloading new records', function (hooks) {
       await entryNode.belongsTo('parent').reload();
       assert.ok(false, 'No error thrown');
     } catch (e) {
-      assert.equal(e.message, 'Bad Request', 'We caught the correct error');
+      assert.strictEqual(e.message, 'Bad Request', 'We caught the correct error');
     }
   });
 
@@ -81,7 +81,7 @@ module('Relationships | unloading new records', function (hooks) {
       await entryNode.belongsTo('relatedGraph').reload();
       assert.ok(false, 'No error thrown');
     } catch (e) {
-      assert.equal(e.message, 'Bad Request', 'We caught the correct error');
+      assert.strictEqual(e.message, 'Bad Request', 'We caught the correct error');
     }
   });
 });

--- a/packages/-ember-data/tests/integration/request-state-service-test.ts
+++ b/packages/-ember-data/tests/integration/request-state-service-test.ts
@@ -87,8 +87,8 @@ if (REQUEST_SERVICE) {
       normalizedHash.data.lid = identifier.lid;
       let request = requestService.getPendingRequestsForRecord(identifier)[0];
 
-      assert.equal(request.state, 'pending', 'request is pending');
-      assert.equal(request.type, 'query', 'request is a query');
+      assert.strictEqual(request.state, 'pending', 'request is pending');
+      assert.strictEqual(request.type, 'query', 'request is a query');
       let requestOp = {
         op: 'findRecord',
         recordIdentifier: identifier,
@@ -114,8 +114,8 @@ if (REQUEST_SERVICE) {
       let savingPromise = person.save();
       let savingRequest = requestService.getPendingRequestsForRecord(identifier)[0];
 
-      assert.equal(savingRequest.state, 'pending', 'request is pending');
-      assert.equal(savingRequest.type, 'mutation', 'request is a mutation');
+      assert.strictEqual(savingRequest.state, 'pending', 'request is pending');
+      assert.strictEqual(savingRequest.type, 'mutation', 'request is a mutation');
       let savingRequestOp = {
         op: 'saveRecord',
         recordIdentifier: identifier,
@@ -200,8 +200,8 @@ if (REQUEST_SERVICE) {
 
       requestService.subscribeForRecord(identifier, (request) => {
         if (count === 0) {
-          assert.equal(request.state, 'pending', 'request is pending');
-          assert.equal(request.type, 'query', 'request is a query');
+          assert.strictEqual(request.state, 'pending', 'request is pending');
+          assert.strictEqual(request.type, 'query', 'request is a query');
           assert.deepEqual(request.request.data[0], requestOp, 'request op is correct');
         } else if (count === 1) {
           let requestStateResult = {
@@ -212,8 +212,8 @@ if (REQUEST_SERVICE) {
           };
           assert.deepEqual(request, requestStateResult, 'request is correct after fulfilling');
         } else if (count === 2) {
-          assert.equal(request.state, 'pending', 'request is pending');
-          assert.equal(request.type, 'mutation', 'request is a mutation');
+          assert.strictEqual(request.state, 'pending', 'request is pending');
+          assert.strictEqual(request.type, 'mutation', 'request is a mutation');
           assert.deepEqual(request.request.data[0], savingRequestOp, 'request op is correct');
         } else if (count === 3) {
           let savingRequestStateResult = {
@@ -229,7 +229,7 @@ if (REQUEST_SERVICE) {
 
       let person = await store.findRecord('person', '1');
       await person.save();
-      assert.equal(count, 4, 'callback called four times');
+      assert.strictEqual(count, 4, 'callback called four times');
     });
   });
 }

--- a/packages/-ember-data/tests/integration/serializers/json-api-serializer-test.js
+++ b/packages/-ember-data/tests/integration/serializers/json-api-serializer-test.js
@@ -105,11 +105,15 @@ module('integration/serializers/json-api-serializer - JSONAPISerializer', functi
 
       var user = store.peekRecord('user', 1);
 
-      assert.equal(get(user, 'firstName'), 'Yehuda', 'firstName is correct');
-      assert.equal(get(user, 'lastName'), 'Katz', 'lastName is correct');
-      assert.equal(get(user, 'company.name'), 'Tilde Inc.', 'company.name is correct');
-      assert.equal(get(user, 'handles.firstObject.username'), 'wycats', 'handles.firstObject.username is correct');
-      assert.equal(get(user, 'handles.lastObject.nickname'), '@wycats', 'handles.lastObject.nickname is correct');
+      assert.strictEqual(get(user, 'firstName'), 'Yehuda', 'firstName is correct');
+      assert.strictEqual(get(user, 'lastName'), 'Katz', 'lastName is correct');
+      assert.strictEqual(get(user, 'company.name'), 'Tilde Inc.', 'company.name is correct');
+      assert.strictEqual(
+        get(user, 'handles.firstObject.username'),
+        'wycats',
+        'handles.firstObject.username is correct'
+      );
+      assert.strictEqual(get(user, 'handles.lastObject.nickname'), '@wycats', 'handles.lastObject.nickname is correct');
     });
   });
 
@@ -200,7 +204,7 @@ module('integration/serializers/json-api-serializer - JSONAPISerializer', functi
     }, /Encountered a resource object with type "unknown-types", but no model was found for model name "unknown-type"/);
 
     var user = store.peekRecord('user', 1);
-    assert.equal(get(user, 'firstName'), 'Yehuda', 'firstName is correct');
+    assert.strictEqual(get(user, 'firstName'), 'Yehuda', 'firstName is correct');
   });
 
   testInDebug('Errors when pushing payload with unknown type included in relationship', function (assert) {
@@ -291,8 +295,8 @@ module('integration/serializers/json-api-serializer - JSONAPISerializer', functi
 
     var user = store.serializerFor('user').normalizeResponse(store, User, jsonHash, '1', 'findRecord');
 
-    assert.equal(user.data.attributes.firstName, 'Yehuda');
-    assert.equal(user.data.attributes.title, 'director');
+    assert.strictEqual(user.data.attributes.firstName, 'Yehuda');
+    assert.strictEqual(user.data.attributes.title, 'director');
     assert.deepEqual(user.data.relationships.company.data, { id: '2', type: 'company' });
   });
 
@@ -331,9 +335,9 @@ module('integration/serializers/json-api-serializer - JSONAPISerializer', functi
 
     var payload = store.serializerFor('user').serialize(user._createSnapshot());
 
-    assert.equal(payload.data.relationships['company_relationship_key'].data.id, '1');
-    assert.equal(payload.data.attributes['firstname_attribute_key'], 'Yehuda');
-    assert.equal(payload.data.attributes['title_attribute_key'], 'director');
+    assert.strictEqual(payload.data.relationships['company_relationship_key'].data.id, '1');
+    assert.strictEqual(payload.data.attributes['firstname_attribute_key'], 'Yehuda');
+    assert.strictEqual(payload.data.attributes['title_attribute_key'], 'director');
   });
 
   test('Serializer should respect the attrs hash when extracting attributes with not camelized keys', function (assert) {
@@ -361,7 +365,7 @@ module('integration/serializers/json-api-serializer - JSONAPISerializer', functi
 
     var project = store.serializerFor('project').normalizeResponse(store, User, jsonHash, '1', 'findRecord');
 
-    assert.equal(project.data.attributes['company-name'], 'Tilde Inc.');
+    assert.strictEqual(project.data.attributes['company-name'], 'Tilde Inc.');
   });
 
   test('Serializer should respect the attrs hash when serializing attributes with not camelized keys', function (assert) {
@@ -378,7 +382,7 @@ module('integration/serializers/json-api-serializer - JSONAPISerializer', functi
     let project = store.createRecord('project', { 'company-name': 'Tilde Inc.' });
     let payload = store.serializerFor('project').serialize(project._createSnapshot());
 
-    assert.equal(payload.data.attributes['company_name'], 'Tilde Inc.');
+    assert.strictEqual(payload.data.attributes['company_name'], 'Tilde Inc.');
   });
 
   test('options are passed to transform for serialization', function (assert) {

--- a/packages/-ember-data/tests/integration/serializers/json-serializer-test.js
+++ b/packages/-ember-data/tests/integration/serializers/json-serializer-test.js
@@ -338,7 +338,7 @@ module('integration/serializer/json - JSONSerializer', function (hooks) {
       store.serializerFor('post').normalizeResponse(store, Post, posts, null, 'findAll');
     });
 
-    assert.equal(postNormalizeCount, 2, 'two posts are normalized');
+    assert.strictEqual(postNormalizeCount, 2, 'two posts are normalized');
   });
 
   test('Serializer should respect the attrs hash when extracting records', function (assert) {
@@ -361,7 +361,7 @@ module('integration/serializer/json - JSONSerializer', function (hooks) {
     let store = this.owner.lookup('service:store');
     var post = store.serializerFor('post').normalizeResponse(store, Post, jsonHash, '1', 'findRecord');
 
-    assert.equal(post.data.attributes.title, 'Rails is omakase');
+    assert.strictEqual(post.data.attributes.title, 'Rails is omakase');
     assert.deepEqual(post.data.relationships.comments.data, [
       { id: '1', type: 'comment' },
       { id: '2', type: 'comment' },
@@ -394,7 +394,7 @@ module('integration/serializer/json - JSONSerializer', function (hooks) {
 
     var post = store.serializerFor('post').normalizeResponse(store, Post, jsonHash, '1', 'findRecord');
 
-    assert.equal(post.data.attributes.authorName, 'DHH');
+    assert.strictEqual(post.data.attributes.authorName, 'DHH');
   });
 
   test('Serializer should respect the attrs hash when serializing records', function (assert) {
@@ -430,8 +430,8 @@ module('integration/serializer/json - JSONSerializer', function (hooks) {
     });
     let payload = store.serializerFor('post').serialize(post._createSnapshot());
 
-    assert.equal(payload.title_payload_key, 'Rails is omakase');
-    assert.equal(payload.my_parent, '2');
+    assert.strictEqual(payload.title_payload_key, 'Rails is omakase');
+    assert.strictEqual(payload.my_parent, '2');
   });
 
   test('Serializer respects if embedded model has an attribute named "type" - #3726', function (assert) {
@@ -724,9 +724,9 @@ module('integration/serializer/json - JSONSerializer', function (hooks) {
     });
     let payload = store.serializerFor('post').serialize(post._createSnapshot());
 
-    assert.equal(payload.title_payload_key, 'Rails is omakase');
-    assert.equal(payload.description_payload_key, 'Omakase is delicious');
-    assert.equal(payload.overwritten_another_string_key, 'yet another string');
+    assert.strictEqual(payload.title_payload_key, 'Rails is omakase');
+    assert.strictEqual(payload.description_payload_key, 'Omakase is delicious');
+    assert.strictEqual(payload.overwritten_another_string_key, 'yet another string');
     assert.notOk(payload.base_another_string_key, 'overwritten key is not added');
   });
 
@@ -742,8 +742,8 @@ module('integration/serializer/json - JSONSerializer', function (hooks) {
     let store = this.owner.lookup('service:store');
     let post = store.serializerFor('post').normalizeResponse(store, Post, jsonHash, '1', 'findRecord');
 
-    assert.equal(post.data.id, '1');
-    assert.equal(post.data.attributes.title, 'Rails is omakase');
+    assert.strictEqual(post.data.id, '1');
+    assert.strictEqual(post.data.attributes.title, 'Rails is omakase');
   });
 
   test('Serializer should respect the primaryKey attribute when serializing records', function (assert) {
@@ -758,7 +758,7 @@ module('integration/serializer/json - JSONSerializer', function (hooks) {
     let post = store.createRecord('post', { id: '1', title: 'Rails is omakase' });
     let payload = store.serializerFor('post').serialize(post._createSnapshot(), { includeId: true });
 
-    assert.equal(payload._ID_, '1');
+    assert.strictEqual(payload._ID_, '1');
   });
 
   test('Serializer should respect keyForAttribute when extracting records', function (assert) {
@@ -775,8 +775,8 @@ module('integration/serializer/json - JSONSerializer', function (hooks) {
     let store = this.owner.lookup('service:store');
     let post = store.serializerFor('post').normalize(Post, jsonHash);
 
-    assert.equal(post.data.id, '1');
-    assert.equal(post.data.attributes.title, 'Rails is omakase');
+    assert.strictEqual(post.data.id, '1');
+    assert.strictEqual(post.data.attributes.title, 'Rails is omakase');
   });
 
   test('Serializer should respect keyForRelationship when extracting records', function (assert) {
@@ -1082,7 +1082,7 @@ module('integration/serializer/json - JSONSerializer', function (hooks) {
 
     assert.expectWarning(function () {
       var post = store.serializerFor('post').normalizeResponse(store, Post, jsonHash, '1', 'findRecord');
-      assert.equal(post.data.attributes.title, 'Rails is omakase');
+      assert.strictEqual(post.data.attributes.title, 'Rails is omakase');
     }, /There is no attribute or relationship with the name/);
   });
 
@@ -1158,7 +1158,7 @@ module('integration/serializer/json - JSONSerializer', function (hooks) {
     let store = this.owner.lookup('service:store');
     var post = this.owner.lookup('serializer:post').normalizeSingleResponse(store, Post, jsonHash);
 
-    assert.equal(post.data.attributes.title, 'Rails is omakase');
-    assert.equal(post.data.relationships.comments.links.related, 'posts/1/comments');
+    assert.strictEqual(post.data.attributes.title, 'Rails is omakase');
+    assert.strictEqual(post.data.relationships.comments.links.related, 'posts/1/comments');
   });
 });

--- a/packages/-ember-data/tests/integration/serializers/rest-serializer-test.js
+++ b/packages/-ember-data/tests/integration/serializers/rest-serializer-test.js
@@ -85,8 +85,8 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
     Inflector.inflector.uncountable('words');
     var expectedModelName = 'multi-words';
 
-    assert.equal(serializer.modelNameFromPayloadKey('multi_words'), expectedModelName);
-    assert.equal(serializer.modelNameFromPayloadKey('multi-words'), expectedModelName);
+    assert.strictEqual(serializer.modelNameFromPayloadKey('multi_words'), expectedModelName);
+    assert.strictEqual(serializer.modelNameFromPayloadKey('multi-words'), expectedModelName);
   });
 
   test('normalizeResponse should extract meta using extractMeta', function (assert) {
@@ -225,7 +225,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
       ],
       included: [],
     });
-    assert.equal(homePlanetNormalizeCount, 1, 'homePlanet is normalized once');
+    assert.strictEqual(homePlanetNormalizeCount, 1, 'homePlanet is normalized once');
   });
 
   testInDebug('normalizeResponse warning with custom modelNameFromPayloadKey', function (assert) {
@@ -267,7 +267,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
       });
     });
 
-    assert.equal(homePlanet.data.attributes.name, 'Umber');
+    assert.strictEqual(homePlanet.data.attributes.name, 'Umber');
     assert.deepEqual(homePlanet.data.relationships.superVillains.data, [{ id: '1', type: 'super-villain' }]);
   });
 
@@ -306,8 +306,8 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
       });
     });
 
-    assert.equal(homePlanets.data.length, 1);
-    assert.equal(homePlanets.data[0].attributes.name, 'Umber');
+    assert.strictEqual(homePlanets.data.length, 1);
+    assert.strictEqual(homePlanets.data[0].attributes.name, 'Umber');
     assert.deepEqual(homePlanets.data[0].relationships.superVillains.data, [{ id: '1', type: 'super-villain' }]);
   });
 
@@ -372,7 +372,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
       serializer.normalizeResponse(store, EvilMinion, jsonHash, '1', 'findRecord');
     });
 
-    assert.equal(superVillainNormalizeCount, 1, 'superVillain is normalized once');
+    assert.strictEqual(superVillainNormalizeCount, 1, 'superVillain is normalized once');
   });
 
   test('normalizeResponse returns null if payload contains null', function (assert) {
@@ -419,7 +419,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
       serializer.normalizeResponse(store, EvilMinion, jsonHash, null, 'findAll');
     });
 
-    assert.equal(superVillainNormalizeCount, 1, 'superVillain is normalized once');
+    assert.strictEqual(superVillainNormalizeCount, 1, 'superVillain is normalized once');
   });
 
   test('normalize should allow for different levels of normalization', function (assert) {
@@ -447,7 +447,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
       array = serializer.normalizeResponse(store, EvilMinion, jsonHash, null, 'findAll');
     });
 
-    assert.equal(array.data[0].relationships.superVillain.data.id, 1);
+    assert.strictEqual(array.data[0].relationships.superVillain.data.id, '1');
   });
 
   test('normalize should allow for different levels of normalization - attributes', function (assert) {
@@ -475,7 +475,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
       array = serializer.normalizeResponse(store, EvilMinion, jsonHash, null, 'findAll');
     });
 
-    assert.equal(array.data[0].attributes.name, 'Tom Dale');
+    assert.strictEqual(array.data[0].attributes.name, 'Tom Dale');
   });
 
   test('serializeIntoHash', function (assert) {
@@ -635,7 +635,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
         };
       }
 
-      assert.equal(type.modelName, 'yellow-minion');
+      assert.strictEqual(type.modelName, 'yellow-minion');
 
       return {
         yellowMinion: {
@@ -654,7 +654,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
           return deathRay.get('evilMinion');
         })
         .then((evilMinion) => {
-          assert.equal(evilMinion.get('eyes'), 3);
+          assert.strictEqual(evilMinion.get('eyes'), 3);
         });
     });
   });
@@ -695,7 +695,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
           return deathRay.get('evilMinion');
         })
         .then((evilMinion) => {
-          assert.equal(evilMinion.get('eyes'), 3);
+          assert.strictEqual(evilMinion.get('eyes'), 3);
         });
     });
   });
@@ -744,7 +744,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
         })
         .then((evilMinions) => {
           assert.ok(evilMinions.get('firstObject') instanceof YellowMinion);
-          assert.equal(evilMinions.get('firstObject.eyes'), 3);
+          assert.strictEqual(evilMinions.get('firstObject.eyes'), 3);
         });
     });
   });
@@ -876,7 +876,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
         })
         .then((basket) => {
           assert.ok(basket instanceof Basket);
-          assert.equal(basket.get('size'), 4);
+          assert.strictEqual(basket.get('size'), 4);
         });
     });
   });
@@ -907,7 +907,7 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
 
     var documentHash = store.serializerFor('super-villain').normalizeSingleResponse(store, SuperVillain, jsonHash);
 
-    assert.equal(documentHash.data.relationships.evilMinions.links.related, 'me/minions');
+    assert.strictEqual(documentHash.data.relationships.evilMinions.links.related, 'me/minions');
   });
 
   // https://github.com/emberjs/data/issues/3805
@@ -929,8 +929,8 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
     let store = this.owner.lookup('service:store');
     let document = store.serializerFor('doomsday-device').normalizeSingleResponse(store, DoomsdayDevice, payload);
 
-    assert.equal(document.data.relationships.evilMinion.data.id, 2);
-    assert.equal(document.included.length, 1);
+    assert.strictEqual(document.data.relationships.evilMinion.data.id, '2');
+    assert.strictEqual(document.included.length, 1);
     assert.deepEqual(document.included[0], {
       attributes: {},
       id: '2',
@@ -965,9 +965,9 @@ module('integration/serializer/rest - RESTSerializer', function (hooks) {
     let store = this.owner.lookup('service:store');
     let document = store.serializerFor('home-planet').normalizeSingleResponse(store, HomePlanet, payload);
 
-    assert.equal(document.data.relationships.superVillains.data.length, 1);
-    assert.equal(document.data.relationships.superVillains.data[0].id, 2);
-    assert.equal(document.included.length, 1);
+    assert.strictEqual(document.data.relationships.superVillains.data.length, 1);
+    assert.strictEqual(document.data.relationships.superVillains.data[0].id, '2');
+    assert.strictEqual(document.included.length, 1);
     assert.deepEqual(document.included[0], {
       attributes: {},
       id: '2',

--- a/packages/-ember-data/tests/integration/snapshot-test.js
+++ b/packages/-ember-data/tests/integration/snapshot-test.js
@@ -101,9 +101,9 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let post = store.peekRecord('post', 1);
     let snapshot = post._createSnapshot();
 
-    assert.equal(snapshot.id, '1', 'id is correct');
+    assert.strictEqual(snapshot.id, '1', 'id is correct');
     assert.ok(Model.detect(snapshot.type), 'type is correct');
-    assert.equal(snapshot.modelName, 'post', 'modelName is correct');
+    assert.strictEqual(snapshot.modelName, 'post', 'modelName is correct');
   });
 
   test('snapshot.type loads the class lazily', async function (assert) {
@@ -131,7 +131,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let snapshot = await postInternalModel.createSnapshot();
 
     assert.false(postClassLoaded, 'model class is not eagerly loaded');
-    assert.equal(snapshot.type, _Post, 'type is correct');
+    assert.strictEqual(snapshot.type, _Post, 'type is correct');
     assert.true(postClassLoaded, 'model class is loaded');
   });
 
@@ -139,7 +139,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     assert.expect(2);
     store.adapterFor('application').findRecord = (store, type, id, snapshot) => {
       assert.false(snapshot._internalModel.hasRecord, 'We do not have a materialized record');
-      assert.equal(snapshot.__attributes, null, 'attributes were not populated initially');
+      assert.strictEqual(snapshot.__attributes, null, 'attributes were not populated initially');
       return resolve({
         data: {
           type: 'post',
@@ -174,7 +174,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
       title: 'Hello World',
     };
 
-    assert.equal(snapshot.__attributes, null, 'attributes were not populated initially');
+    assert.strictEqual(snapshot.__attributes, null, 'attributes were not populated initially');
     snapshot.attributes();
     assert.deepEqual(snapshot.__attributes, expected, 'attributes were populated on access');
   });
@@ -217,9 +217,9 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let post = store.peekRecord('post', 1);
     let snapshot = post._createSnapshot();
 
-    assert.equal(snapshot.attr('title'), 'Hello World', 'snapshot title is correct');
+    assert.strictEqual(snapshot.attr('title'), 'Hello World', 'snapshot title is correct');
     post.set('title', 'Tomster');
-    assert.equal(snapshot.attr('title'), 'Hello World', 'snapshot title is still correct');
+    assert.strictEqual(snapshot.attr('title'), 'Hello World', 'snapshot title is still correct');
   });
 
   test('snapshot.attr() throws an error attribute not found', function (assert) {
@@ -302,7 +302,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let snapshot = comment._createSnapshot();
     let relationship = snapshot.belongsTo('post');
 
-    assert.equal(relationship, undefined, 'relationship is undefined');
+    assert.strictEqual(relationship, undefined, 'relationship is undefined');
   });
 
   test('snapshot.belongsTo() returns null if relationship is unset', function (assert) {
@@ -335,7 +335,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let snapshot = comment._createSnapshot();
     let relationship = snapshot.belongsTo('post');
 
-    assert.equal(relationship, null, 'relationship is unset');
+    assert.strictEqual(relationship, null, 'relationship is unset');
   });
 
   test('snapshot.belongsTo() returns a snapshot if relationship is set', function (assert) {
@@ -369,8 +369,8 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let relationship = snapshot.belongsTo('post');
 
     assert.ok(relationship instanceof Snapshot, 'snapshot is an instance of Snapshot');
-    assert.equal(relationship.id, '1', 'post id is correct');
-    assert.equal(relationship.attr('title'), 'Hello World', 'post title is correct');
+    assert.strictEqual(relationship.id, '1', 'post id is correct');
+    assert.strictEqual(relationship.attr('title'), 'Hello World', 'post title is correct');
   });
 
   test('snapshot.belongsTo().changedAttributes() returns an empty object if belongsTo record in not instantiated #7015', function (assert) {
@@ -443,7 +443,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let snapshot = comment._createSnapshot();
     let relationship = snapshot.belongsTo('post');
 
-    assert.equal(relationship, null, 'relationship unset after deleted');
+    assert.strictEqual(relationship, null, 'relationship unset after deleted');
   });
 
   test('snapshot.belongsTo() returns undefined if relationship is a link', function (assert) {
@@ -469,7 +469,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let snapshot = comment._createSnapshot();
     let relationship = snapshot.belongsTo('post');
 
-    assert.equal(relationship, undefined, 'relationship is undefined');
+    assert.strictEqual(relationship, undefined, 'relationship is undefined');
   });
 
   test('snapshot.belongsTo() returns null after a fetched relationship link returns null', async function (assert) {
@@ -497,9 +497,9 @@ module('integration/snapshot - Snapshot', function (hooks) {
     });
     let comment = store.peekRecord('comment', 2);
 
-    assert.equal(comment._createSnapshot().belongsTo('post'), undefined, 'relationship is undefined');
+    assert.strictEqual(comment._createSnapshot().belongsTo('post'), undefined, 'relationship is undefined');
     await comment.get('post');
-    assert.equal(comment._createSnapshot().belongsTo('post'), null, 'relationship is null');
+    assert.strictEqual(comment._createSnapshot().belongsTo('post'), undefined, 'relationship is undefined');
   });
 
   test("snapshot.belongsTo() throws error if relation doesn't exist", function (assert) {
@@ -582,10 +582,10 @@ module('integration/snapshot - Snapshot', function (hooks) {
         let belongsToRelationship = commentSnapshot.belongsTo('post');
 
         assert.ok(hasManyRelationship instanceof Array, 'hasMany relationship is an instance of Array');
-        assert.equal(hasManyRelationship.length, 1, 'hasMany relationship contains related object');
+        assert.strictEqual(hasManyRelationship.length, 1, 'hasMany relationship contains related object');
 
         assert.ok(belongsToRelationship instanceof Snapshot, 'belongsTo relationship is an instance of Snapshot');
-        assert.equal(
+        assert.strictEqual(
           belongsToRelationship.attr('title'),
           'Hello World',
           'belongsTo relationship contains related object'
@@ -628,10 +628,14 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let belongsToRelationship = commentSnapshot.belongsTo('post');
 
     assert.ok(hasManyRelationship instanceof Array, 'hasMany relationship is an instance of Array');
-    assert.equal(hasManyRelationship.length, 1, 'hasMany relationship contains related object');
+    assert.strictEqual(hasManyRelationship.length, 1, 'hasMany relationship contains related object');
 
     assert.ok(belongsToRelationship instanceof Snapshot, 'belongsTo relationship is an instance of Snapshot');
-    assert.equal(belongsToRelationship.attr('title'), 'Hello World', 'belongsTo relationship contains related object');
+    assert.strictEqual(
+      belongsToRelationship.attr('title'),
+      'Hello World',
+      'belongsTo relationship contains related object'
+    );
   });
 
   test('snapshot.belongsTo() and snapshot.hasMany() returns correctly when setting an object to a belongsTo relationship', function (assert) {
@@ -667,10 +671,14 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let belongsToRelationship = commentSnapshot.belongsTo('post');
 
     assert.ok(hasManyRelationship instanceof Array, 'hasMany relationship is an instance of Array');
-    assert.equal(hasManyRelationship.length, 1, 'hasMany relationship contains related object');
+    assert.strictEqual(hasManyRelationship.length, 1, 'hasMany relationship contains related object');
 
     assert.ok(belongsToRelationship instanceof Snapshot, 'belongsTo relationship is an instance of Snapshot');
-    assert.equal(belongsToRelationship.attr('title'), 'Hello World', 'belongsTo relationship contains related object');
+    assert.strictEqual(
+      belongsToRelationship.attr('title'),
+      'Hello World',
+      'belongsTo relationship contains related object'
+    );
   });
 
   test('snapshot.belongsTo() returns ID if option.id is set', function (assert) {
@@ -703,7 +711,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let snapshot = comment._createSnapshot();
     let relationship = snapshot.belongsTo('post', { id: true });
 
-    assert.equal(relationship, '1', 'relationship ID correctly returned');
+    assert.strictEqual(relationship, '1', 'relationship ID correctly returned');
   });
 
   test('snapshot.belongsTo() returns null if option.id is set but relationship was deleted', function (assert) {
@@ -740,7 +748,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let snapshot = comment._createSnapshot();
     let relationship = snapshot.belongsTo('post', { id: true });
 
-    assert.equal(relationship, null, 'relationship unset after deleted');
+    assert.strictEqual(relationship, null, 'relationship unset after deleted');
   });
 
   test('snapshot.hasMany() returns undefined if relationship is undefined', function (assert) {
@@ -759,7 +767,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let snapshot = post._createSnapshot();
     let relationship = snapshot.hasMany('comments');
 
-    assert.equal(relationship, undefined, 'relationship is undefined');
+    assert.strictEqual(relationship, undefined, 'relationship is undefined');
   });
 
   test('snapshot.hasMany() returns empty array if relationship is empty', function (assert) {
@@ -784,7 +792,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let relationship = snapshot.hasMany('comments');
 
     assert.ok(relationship instanceof Array, 'relationship is an instance of Array');
-    assert.equal(relationship.length, 0, 'relationship is empty');
+    assert.strictEqual(relationship.length, 0, 'relationship is empty');
   });
 
   test('snapshot.hasMany() returns array of snapshots if relationship is set', function (assert) {
@@ -828,13 +836,13 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let relationship = snapshot.hasMany('comments');
 
     assert.ok(relationship instanceof Array, 'relationship is an instance of Array');
-    assert.equal(relationship.length, 2, 'relationship has two items');
+    assert.strictEqual(relationship.length, 2, 'relationship has two items');
 
     let relationship1 = relationship[0];
 
     assert.ok(relationship1 instanceof Snapshot, 'relationship item is an instance of Snapshot');
-    assert.equal(relationship1.id, '1', 'relationship item id is correct');
-    assert.equal(relationship1.attr('body'), 'This is the first comment', 'relationship item body is correct');
+    assert.strictEqual(relationship1.id, '1', 'relationship item id is correct');
+    assert.strictEqual(relationship1.attr('body'), 'This is the first comment', 'relationship item body is correct');
   });
 
   test('snapshot.hasMany() returns empty array if relationship records are deleted', function (assert) {
@@ -884,7 +892,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let relationship = snapshot.hasMany('comments');
 
     assert.ok(relationship instanceof Array, 'relationship is an instance of Array');
-    assert.equal(relationship.length, 0, 'relationship is empty');
+    assert.strictEqual(relationship.length, 0, 'relationship is empty');
   });
 
   test('snapshot.hasMany() returns array of IDs if option.ids is set', function (assert) {
@@ -961,7 +969,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let relationship = snapshot.hasMany('comments', { ids: true });
 
     assert.ok(relationship instanceof Array, 'relationship is an instance of Array');
-    assert.equal(relationship.length, 0, 'relationship is empty');
+    assert.strictEqual(relationship.length, 0, 'relationship is empty');
   });
 
   test('snapshot.hasMany() returns undefined if relationship is a link', function (assert) {
@@ -987,7 +995,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let snapshot = post._createSnapshot();
     let relationship = snapshot.hasMany('comments');
 
-    assert.equal(relationship, undefined, 'relationship is undefined');
+    assert.strictEqual(relationship, undefined, 'relationship is undefined');
   });
 
   test('snapshot.hasMany() returns array of snapshots if relationship link has been fetched', async function (assert) {
@@ -1023,7 +1031,7 @@ module('integration/snapshot - Snapshot', function (hooks) {
       let relationship = snapshot.hasMany('comments');
 
       assert.ok(relationship instanceof Array, 'relationship is an instance of Array');
-      assert.equal(relationship.length, 1, 'relationship has one item');
+      assert.strictEqual(relationship.length, 1, 'relationship has one item');
     });
   });
 
@@ -1104,9 +1112,9 @@ module('integration/snapshot - Snapshot', function (hooks) {
     let snapshot = post._createSnapshot();
     let relationship = snapshot.hasMany('comments');
 
-    assert.equal(relationship[0].id, '3', 'order of comment 3 is correct');
-    assert.equal(relationship[1].id, '1', 'order of comment 1 is correct');
-    assert.equal(relationship[2].id, '2', 'order of comment 2 is correct');
+    assert.strictEqual(relationship[0].id, '3', 'order of comment 3 is correct');
+    assert.strictEqual(relationship[1].id, '1', 'order of comment 1 is correct');
+    assert.strictEqual(relationship[2].id, '2', 'order of comment 2 is correct');
   });
 
   test('snapshot.eachAttribute() proxies to record', function (assert) {

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -252,25 +252,29 @@ module('integration/store - destroy', function (hooks) {
 
     await store.findRecord('person', '2');
 
-    assert.equal(personWillDestroy.called.length, 0, 'expected person.willDestroy to not have been called');
-    assert.equal(carWillDestroy.called.length, 0, 'expected car.willDestroy to not have been called');
-    assert.equal(carsWillDestroy.called.length, 0, 'expected cars.willDestroy to not have been called');
-    assert.equal(
+    assert.strictEqual(personWillDestroy.called.length, 0, 'expected person.willDestroy to not have been called');
+    assert.strictEqual(carWillDestroy.called.length, 0, 'expected car.willDestroy to not have been called');
+    assert.strictEqual(carsWillDestroy.called.length, 0, 'expected cars.willDestroy to not have been called');
+    assert.strictEqual(
       adapterPopulatedPeopleWillDestroy.called.length,
       0,
       'expected adapterPopulatedPeople.willDestroy to not have been called'
     );
-    assert.equal(car.get('person'), person, "expected car's person to be the correct person");
-    assert.equal(person.get('cars.firstObject'), car, " expected persons cars's firstRecord to be the correct car");
+    assert.strictEqual(car.get('person'), person, "expected car's person to be the correct person");
+    assert.strictEqual(
+      person.get('cars.firstObject'),
+      car,
+      " expected persons cars's firstRecord to be the correct car"
+    );
 
     store.destroy();
 
     await settled();
 
-    assert.equal(personWillDestroy.called.length, 1, 'expected person to have received willDestroy once');
-    assert.equal(carWillDestroy.called.length, 1, 'expected car to have received willDestroy once');
-    assert.equal(carsWillDestroy.called.length, 1, 'expected person.cars to have received willDestroy once');
-    assert.equal(
+    assert.strictEqual(personWillDestroy.called.length, 1, 'expected person to have received willDestroy once');
+    assert.strictEqual(carWillDestroy.called.length, 1, 'expected car to have received willDestroy once');
+    assert.strictEqual(carsWillDestroy.called.length, 1, 'expected person.cars to have received willDestroy once');
+    assert.strictEqual(
       adapterPopulatedPeopleWillDestroy.called.length,
       1,
       'expected adapterPopulatedPeople to receive willDestroy once'
@@ -735,11 +739,11 @@ module('integration/store - findAll', function (hooks) {
 
     let cars = store.peekAll('car');
 
-    assert.equal(cars.length, 1, 'There is one car in the store');
+    assert.strictEqual(cars.length, 1, 'There is one car in the store');
 
     cars = await store.findAll('car');
 
-    assert.equal(cars.length, 1, 'Store resolves with the existing records');
+    assert.strictEqual(cars.length, 1, 'Store resolves with the existing records');
 
     resolvefindAll();
 
@@ -747,11 +751,11 @@ module('integration/store - findAll', function (hooks) {
 
     cars = store.peekAll('car');
 
-    assert.equal(cars.length, 2, 'There is 2 cars in the store now');
+    assert.strictEqual(cars.length, 2, 'There is 2 cars in the store now');
 
     let mini = cars.findBy('id', '1');
 
-    assert.equal(mini.model, 'New Mini', 'Existing records have been updated');
+    assert.strictEqual(mini.model, 'New Mini', 'Existing records have been updated');
   });
 
   test('store#findAll { backgroundReload: false } skips shouldBackgroundReloadAll, returns cached records & does not reload in the background', async function (assert) {
@@ -786,15 +790,15 @@ module('integration/store - findAll', function (hooks) {
 
     let cars = await store.findAll('car', { backgroundReload: false });
 
-    assert.equal(cars.length, 1, 'single cached car record is returned');
-    assert.equal(cars.firstObject.model, 'Mini', 'correct cached car record is returned');
+    assert.strictEqual(cars.length, 1, 'single cached car record is returned');
+    assert.strictEqual(cars.firstObject.model, 'Mini', 'correct cached car record is returned');
 
     await settled();
 
     cars = store.peekAll('car');
 
-    assert.equal(cars.length, 1, 'single cached car record is returned again');
-    assert.equal(cars.firstObject.model, 'Mini', 'correct cached car record is returned again');
+    assert.strictEqual(cars.length, 1, 'single cached car record is returned again');
+    assert.strictEqual(cars.firstObject.model, 'Mini', 'correct cached car record is returned again');
   });
 
   test('store#findAll { backgroundReload: true } skips shouldBackgroundReloadAll, returns cached records, & reloads in background', async function (assert) {
@@ -845,16 +849,16 @@ module('integration/store - findAll', function (hooks) {
 
     let cars = await store.findAll('car', { backgroundReload: true });
 
-    assert.equal(cars.length, 1, 'single cached car record is returned');
-    assert.equal(cars.firstObject.model, 'Mini', 'correct cached car record is returned');
+    assert.strictEqual(cars.length, 1, 'single cached car record is returned');
+    assert.strictEqual(cars.firstObject.model, 'Mini', 'correct cached car record is returned');
 
     await settled();
 
     // IE11 hack
     cars = store.peekAll('car');
-    assert.equal(cars.length, 2, 'multiple cars now in the store');
-    assert.equal(cars.firstObject.model, 'New Mini', 'existing record updated correctly');
-    assert.equal(cars.lastObject.model, 'Isetta', 'new record added to the store');
+    assert.strictEqual(cars.length, 2, 'multiple cars now in the store');
+    assert.strictEqual(cars.firstObject.model, 'New Mini', 'existing record updated correctly');
+    assert.strictEqual(cars.lastObject.model, 'Isetta', 'new record added to the store');
   });
 
   test('store#findAll { backgroundReload: false } is ignored if adapter.shouldReloadAll is true', async function (assert) {
@@ -907,14 +911,14 @@ module('integration/store - findAll', function (hooks) {
 
     let cars = store.peekAll('car');
 
-    assert.equal(cars.length, 1, 'one car in the store');
-    assert.equal(cars.firstObject.model, 'Mini', 'correct car is in the store');
+    assert.strictEqual(cars.length, 1, 'one car in the store');
+    assert.strictEqual(cars.firstObject.model, 'Mini', 'correct car is in the store');
 
     cars = await store.findAll('car', { backgroundReload: false });
 
-    assert.equal(cars.length, 2, 'multiple car records are returned');
-    assert.equal(cars.firstObject.model, 'New Mini', 'initial car record was updated');
-    assert.equal(cars.lastObject.model, 'Isetta', 'second car record was loaded');
+    assert.strictEqual(cars.length, 2, 'multiple car records are returned');
+    assert.strictEqual(cars.firstObject.model, 'New Mini', 'initial car record was updated');
+    assert.strictEqual(cars.lastObject.model, 'Isetta', 'second car record was loaded');
   });
 
   test('store#findAll should eventually return all known records even if they are not in the adapter response', async function (assert) {
@@ -972,21 +976,21 @@ module('integration/store - findAll', function (hooks) {
 
     let cars = await store.findAll('car');
 
-    assert.equal(cars.length, 2, 'It returns all cars');
+    assert.strictEqual(cars.length, 2, 'It returns all cars');
 
     let mini = cars.findBy('id', '1');
-    assert.equal(mini.model, 'Mini', 'Records have not yet been updated');
+    assert.strictEqual(mini.model, 'Mini', 'Records have not yet been updated');
 
     resolvefindAll();
 
     await settled();
 
-    assert.equal(cars.length, 2, 'There are still 2 cars in the store after ajax promise resolves');
+    assert.strictEqual(cars.length, 2, 'There are still 2 cars in the store after ajax promise resolves');
     const peeked = store.peekAll('car');
     assert.strictEqual(peeked, cars, 'findAll and peekAll result are the same');
 
     mini = cars.findBy('id', '1');
-    assert.equal(mini.model, 'New Mini', 'Existing records have been updated');
+    assert.strictEqual(mini.model, 'New Mini', 'Existing records have been updated');
   });
 
   test('Using store#fetch on an empty record calls find', async function (assert) {
@@ -1033,7 +1037,7 @@ module('integration/store - findAll', function (hooks) {
 
     car = await store.findRecord('car', '20', { reload: true });
 
-    assert.equal(car.make, 'BMCW', 'Car with id=20 is now loaded');
+    assert.strictEqual(car.make, 'BMCW', 'Car with id=20 is now loaded');
   });
 
   test('Using store#adapterFor should not throw an error when looking up the application adapter', function (assert) {
@@ -1231,7 +1235,7 @@ module('integration/store - queryRecord', function (hooks) {
     try {
       await store.findRecord('car', '1');
     } catch (error) {
-      assert.equal(error.message, 'Refusing to find record');
+      assert.strictEqual(error.message, 'Refusing to find record');
     }
   });
 
@@ -1248,7 +1252,7 @@ module('integration/store - queryRecord', function (hooks) {
     try {
       await store.findAll('car');
     } catch (error) {
-      assert.equal(error.message, 'Refusing to find all records');
+      assert.strictEqual(error.message, 'Refusing to find all records');
     }
   });
 
@@ -1265,7 +1269,7 @@ module('integration/store - queryRecord', function (hooks) {
     try {
       await store.query('car', {});
     } catch (error) {
-      assert.equal(error.message, 'Refusing to query records');
+      assert.strictEqual(error.message, 'Refusing to query records');
     }
   });
 
@@ -1282,7 +1286,7 @@ module('integration/store - queryRecord', function (hooks) {
     try {
       await store.queryRecord('car', {});
     } catch (error) {
-      assert.equal(error.message, 'Refusing to query record');
+      assert.strictEqual(error.message, 'Refusing to query record');
     }
   });
 
@@ -1301,7 +1305,7 @@ module('integration/store - queryRecord', function (hooks) {
 
       await car.save();
     } catch (error) {
-      assert.equal(error.message, 'Refusing to serialize');
+      assert.strictEqual(error.message, 'Refusing to serialize');
     }
   });
 });

--- a/packages/-ember-data/tests/integration/store/package-import-test.js
+++ b/packages/-ember-data/tests/integration/store/package-import-test.js
@@ -50,7 +50,7 @@ module('integration/store/package-import', function (hooks) {
     });
 
     let all = store.peekAll('person');
-    assert.equal(get(all, 'length'), 2);
+    assert.strictEqual(get(all, 'length'), 2);
 
     store.push({
       data: [
@@ -65,6 +65,6 @@ module('integration/store/package-import', function (hooks) {
     });
 
     await settled();
-    assert.equal(get(all, 'length'), 3);
+    assert.strictEqual(get(all, 'length'), 3);
   });
 });

--- a/packages/-ember-data/tests/integration/store/query-record-test.js
+++ b/packages/-ember-data/tests/integration/store/query-record-test.js
@@ -47,7 +47,7 @@ module('integration/store/query-record - Query one record with a query hash', fu
       'adapter:person',
       DS.Adapter.extend({
         queryRecord(store, type, query) {
-          assert.equal(type, Person, 'the query method is called with the correct type');
+          assert.strictEqual(type, Person, 'the query method is called with the correct type');
           return resolve({
             data: { id: 1, type: 'person', attributes: { name: 'Peter Wagenet' } },
           });
@@ -88,7 +88,7 @@ module('integration/store/query-record - Query one record with a query hash', fu
       'serializer:person',
       DS.JSONAPISerializer.extend({
         normalizeQueryRecordResponse(store, primaryModelClass, payload, id, requestType) {
-          assert.equal(
+          assert.strictEqual(
             payload.data.id,
             '1',
             'the normalizeQueryRecordResponse method was called with the right payload'

--- a/packages/-ember-data/tests/integration/store/query-test.js
+++ b/packages/-ember-data/tests/integration/store/query-test.js
@@ -44,6 +44,6 @@ module('integration/store/query', function (hooks) {
       defered.resolve({ data: [], meta: { foo: 'bar' } });
     });
 
-    assert.equal(result.get('meta.foo'), 'bar');
+    assert.strictEqual(result.get('meta.foo'), 'bar');
   });
 });

--- a/packages/-ember-data/tests/unit/adapter-errors-test.js
+++ b/packages/-ember-data/tests/unit/adapter-errors-test.js
@@ -13,7 +13,7 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     assert.ok(error instanceof Error);
     assert.ok(error instanceof EmberError);
     assert.ok(error.isAdapterError);
-    assert.equal(error.message, 'Adapter operation failed');
+    assert.strictEqual(error.message, 'Adapter operation failed');
   });
 
   test('DS.InvalidError', function (assert) {
@@ -22,7 +22,7 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     assert.ok(error instanceof Error);
     assert.ok(error instanceof DS.AdapterError);
     assert.ok(error.isAdapterError);
-    assert.equal(error.message, 'The adapter rejected the commit because it was invalid');
+    assert.strictEqual(error.message, 'The adapter rejected the commit because it was invalid');
   });
 
   test('DS.TimeoutError', function (assert) {
@@ -31,7 +31,7 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     assert.ok(error instanceof Error);
     assert.ok(error instanceof DS.AdapterError);
     assert.ok(error.isAdapterError);
-    assert.equal(error.message, 'The adapter operation timed out');
+    assert.strictEqual(error.message, 'The adapter operation timed out');
   });
 
   test('DS.AbortError', function (assert) {
@@ -40,7 +40,7 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     assert.ok(error instanceof Error);
     assert.ok(error instanceof DS.AdapterError);
     assert.ok(error.isAdapterError);
-    assert.equal(error.message, 'The adapter operation was aborted');
+    assert.strictEqual(error.message, 'The adapter operation was aborted');
   });
 
   test('DS.UnauthorizedError', function (assert) {
@@ -49,7 +49,7 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     assert.ok(error instanceof Error);
     assert.ok(error instanceof DS.AdapterError);
     assert.ok(error.isAdapterError);
-    assert.equal(error.message, 'The adapter operation is unauthorized');
+    assert.strictEqual(error.message, 'The adapter operation is unauthorized');
   });
 
   test('DS.ForbiddenError', function (assert) {
@@ -58,7 +58,7 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     assert.ok(error instanceof Error);
     assert.ok(error instanceof DS.AdapterError);
     assert.ok(error.isAdapterError);
-    assert.equal(error.message, 'The adapter operation is forbidden');
+    assert.strictEqual(error.message, 'The adapter operation is forbidden');
   });
 
   test('DS.NotFoundError', function (assert) {
@@ -67,7 +67,7 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     assert.ok(error instanceof Error);
     assert.ok(error instanceof DS.AdapterError);
     assert.ok(error.isAdapterError);
-    assert.equal(error.message, 'The adapter could not find the resource');
+    assert.strictEqual(error.message, 'The adapter could not find the resource');
   });
 
   test('DS.ConflictError', function (assert) {
@@ -76,7 +76,7 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     assert.ok(error instanceof Error);
     assert.ok(error instanceof DS.AdapterError);
     assert.ok(error.isAdapterError);
-    assert.equal(error.message, 'The adapter operation failed due to a conflict');
+    assert.strictEqual(error.message, 'The adapter operation failed due to a conflict');
   });
 
   test('DS.ServerError', function (assert) {
@@ -85,7 +85,7 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     assert.ok(error instanceof Error);
     assert.ok(error instanceof DS.AdapterError);
     assert.ok(error.isAdapterError);
-    assert.equal(error.message, 'The adapter operation failed due to a server error');
+    assert.strictEqual(error.message, 'The adapter operation failed due to a server error');
   });
 
   test('CustomAdapterError', function (assert) {
@@ -95,14 +95,14 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     assert.ok(error instanceof Error);
     assert.ok(error instanceof DS.AdapterError);
     assert.ok(error.isAdapterError);
-    assert.equal(error.message, 'Adapter operation failed');
+    assert.strictEqual(error.message, 'Adapter operation failed');
   });
 
   test('CustomAdapterError with default message', function (assert) {
     let CustomAdapterError = DS.AdapterError.extend({ message: 'custom error!' });
     let error = new CustomAdapterError();
 
-    assert.equal(error.message, 'custom error!');
+    assert.strictEqual(error.message, 'custom error!');
   });
 
   const errorsHash = {

--- a/packages/-ember-data/tests/unit/adapters/build-url-mixin/build-url-test.js
+++ b/packages/-ember-data/tests/unit/adapters/build-url-mixin/build-url-test.js
@@ -22,7 +22,7 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
   });
 
   test('buildURL - works with empty paths', function (assert) {
-    assert.equal(adapter.buildURL('rootModel', 1), '/1');
+    assert.strictEqual(adapter.buildURL('rootModel', 1), '/1');
   });
 
   test('buildURL - find requestType delegates to urlForFindRecord', function (assert) {
@@ -30,12 +30,12 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
     let snapshotStub = { snapshot: true };
     let originalMethod = adapter.urlForFindRecord;
     adapter.urlForFindRecord = function (id, type, snapshot) {
-      assert.equal(id, 1);
-      assert.equal(type, 'super-user');
-      assert.equal(snapshot, snapshotStub);
+      assert.strictEqual(id, 1);
+      assert.strictEqual(type, 'super-user');
+      assert.strictEqual(snapshot, snapshotStub);
       return originalMethod.apply(this, arguments);
     };
-    assert.equal(adapter.buildURL('super-user', 1, snapshotStub, 'findRecord'), '/superUsers/1');
+    assert.strictEqual(adapter.buildURL('super-user', 1, snapshotStub, 'findRecord'), '/superUsers/1');
   });
 
   test('buildURL - findAll requestType delegates to urlForFindAll', function (assert) {
@@ -43,11 +43,11 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
     let originalMethod = adapter.urlForFindAll;
     let snapshotStub = { snapshot: true };
     adapter.urlForFindAll = function (type, snapshot) {
-      assert.equal(type, 'super-user');
-      assert.equal(snapshot, snapshotStub);
+      assert.strictEqual(type, 'super-user');
+      assert.strictEqual(snapshot, snapshotStub);
       return originalMethod.apply(this, arguments);
     };
-    assert.equal(adapter.buildURL('super-user', null, snapshotStub, 'findAll'), '/superUsers');
+    assert.strictEqual(adapter.buildURL('super-user', null, snapshotStub, 'findAll'), '/superUsers');
   });
 
   test('buildURL - query requestType delegates to urlForQuery', function (assert) {
@@ -55,11 +55,11 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
     let originalMethod = adapter.urlForQuery;
     let queryStub = { limit: 10 };
     adapter.urlForQuery = function (query, type) {
-      assert.equal(query, queryStub);
-      assert.equal(type, 'super-user');
+      assert.strictEqual(query, queryStub);
+      assert.strictEqual(type, 'super-user');
       return originalMethod.apply(this, arguments);
     };
-    assert.equal(adapter.buildURL('super-user', null, null, 'query', queryStub), '/superUsers');
+    assert.strictEqual(adapter.buildURL('super-user', null, null, 'query', queryStub), '/superUsers');
   });
 
   test('buildURL - queryRecord requestType delegates to urlForQueryRecord', function (assert) {
@@ -67,11 +67,11 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
     let originalMethod = adapter.urlForQueryRecord;
     let queryStub = { companyId: 10 };
     adapter.urlForQueryRecord = function (query, type) {
-      assert.equal(query, queryStub);
-      assert.equal(type, 'super-user');
+      assert.strictEqual(query, queryStub);
+      assert.strictEqual(type, 'super-user');
       return originalMethod.apply(this, arguments);
     };
-    assert.equal(adapter.buildURL('super-user', null, null, 'queryRecord', queryStub), '/superUsers');
+    assert.strictEqual(adapter.buildURL('super-user', null, null, 'queryRecord', queryStub), '/superUsers');
   });
 
   test('buildURL - findMany requestType delegates to urlForFindMany', function (assert) {
@@ -79,11 +79,11 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
     let originalMethod = adapter.urlForFindMany;
     let idsStub = [1, 2, 3];
     adapter.urlForFindMany = function (ids, type) {
-      assert.equal(ids, idsStub);
-      assert.equal(type, 'super-user');
+      assert.strictEqual(ids, idsStub);
+      assert.strictEqual(type, 'super-user');
       return originalMethod.apply(this, arguments);
     };
-    assert.equal(adapter.buildURL('super-user', idsStub, null, 'findMany'), '/superUsers');
+    assert.strictEqual(adapter.buildURL('super-user', idsStub, null, 'findMany'), '/superUsers');
   });
 
   test('buildURL - findHasMany requestType delegates to urlForFindHasMany', function (assert) {
@@ -91,12 +91,12 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
     let originalMethod = adapter.urlForFindHasMany;
     let snapshotStub = { snapshot: true };
     adapter.urlForFindHasMany = function (id, type, snapshot) {
-      assert.equal(id, 1);
-      assert.equal(type, 'super-user');
-      assert.equal(snapshot, snapshotStub);
+      assert.strictEqual(id, 1);
+      assert.strictEqual(type, 'super-user');
+      assert.strictEqual(snapshot, snapshotStub);
       return originalMethod.apply(this, arguments);
     };
-    assert.equal(adapter.buildURL('super-user', 1, snapshotStub, 'findHasMany'), '/superUsers/1');
+    assert.strictEqual(adapter.buildURL('super-user', 1, snapshotStub, 'findHasMany'), '/superUsers/1');
   });
 
   test('buildURL - findBelongsTo requestType delegates to urlForFindBelongsTo', function (assert) {
@@ -104,12 +104,12 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
     let originalMethod = adapter.urlForFindBelongsTo;
     let snapshotStub = { snapshot: true };
     adapter.urlForFindBelongsTo = function (id, type, snapshot) {
-      assert.equal(id, 1);
-      assert.equal(type, 'super-user');
-      assert.equal(snapshot, snapshotStub);
+      assert.strictEqual(id, 1);
+      assert.strictEqual(type, 'super-user');
+      assert.strictEqual(snapshot, snapshotStub);
       return originalMethod.apply(this, arguments);
     };
-    assert.equal(adapter.buildURL('super-user', 1, snapshotStub, 'findBelongsTo'), '/superUsers/1');
+    assert.strictEqual(adapter.buildURL('super-user', 1, snapshotStub, 'findBelongsTo'), '/superUsers/1');
   });
 
   test('buildURL - createRecord requestType delegates to urlForCreateRecord', function (assert) {
@@ -117,11 +117,11 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
     let snapshotStub = { snapshot: true };
     let originalMethod = adapter.urlForCreateRecord;
     adapter.urlForCreateRecord = function (type, snapshot) {
-      assert.equal(type, 'super-user');
-      assert.equal(snapshot, snapshotStub);
+      assert.strictEqual(type, 'super-user');
+      assert.strictEqual(snapshot, snapshotStub);
       return originalMethod.apply(this, arguments);
     };
-    assert.equal(adapter.buildURL('super-user', null, snapshotStub, 'createRecord'), '/superUsers');
+    assert.strictEqual(adapter.buildURL('super-user', null, snapshotStub, 'createRecord'), '/superUsers');
   });
 
   test('buildURL - updateRecord requestType delegates to urlForUpdateRecord', function (assert) {
@@ -129,12 +129,12 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
     let snapshotStub = { snapshot: true };
     let originalMethod = adapter.urlForUpdateRecord;
     adapter.urlForUpdateRecord = function (id, type, snapshot) {
-      assert.equal(id, 1);
-      assert.equal(type, 'super-user');
-      assert.equal(snapshot, snapshotStub);
+      assert.strictEqual(id, 1);
+      assert.strictEqual(type, 'super-user');
+      assert.strictEqual(snapshot, snapshotStub);
       return originalMethod.apply(this, arguments);
     };
-    assert.equal(adapter.buildURL('super-user', 1, snapshotStub, 'updateRecord'), '/superUsers/1');
+    assert.strictEqual(adapter.buildURL('super-user', 1, snapshotStub, 'updateRecord'), '/superUsers/1');
   });
 
   test('buildURL - deleteRecord requestType delegates to urlForDeleteRecord', function (assert) {
@@ -142,16 +142,16 @@ module('unit/adapters/build-url-mixin/build-url - DS.BuildURLMixin#buildURL', fu
     let snapshotStub = { snapshot: true };
     let originalMethod = adapter.urlForDeleteRecord;
     adapter.urlForDeleteRecord = function (id, type, snapshot) {
-      assert.equal(id, 1);
-      assert.equal(type, 'super-user');
-      assert.equal(snapshot, snapshotStub);
+      assert.strictEqual(id, 1);
+      assert.strictEqual(type, 'super-user');
+      assert.strictEqual(snapshot, snapshotStub);
       return originalMethod.apply(this, arguments);
     };
-    assert.equal(adapter.buildURL('super-user', 1, snapshotStub, 'deleteRecord'), '/superUsers/1');
+    assert.strictEqual(adapter.buildURL('super-user', 1, snapshotStub, 'deleteRecord'), '/superUsers/1');
   });
 
   test('buildURL - unknown requestType', function (assert) {
-    assert.equal(adapter.buildURL('super-user', 1, null, 'unknown'), '/superUsers/1');
-    assert.equal(adapter.buildURL('super-user', null, null, 'unknown'), '/superUsers');
+    assert.strictEqual(adapter.buildURL('super-user', 1, null, 'unknown'), '/superUsers/1');
+    assert.strictEqual(adapter.buildURL('super-user', null, null, 'unknown'), '/superUsers');
   });
 });

--- a/packages/-ember-data/tests/unit/adapters/build-url-mixin/path-for-type-test.js
+++ b/packages/-ember-data/tests/unit/adapters/build-url-mixin/path-for-type-test.js
@@ -23,16 +23,16 @@ module('unit/adapters/build-url-mixin/path-for-type - DS.BuildURLMixin#pathForTy
 
   test('pathForType - works with camelized types', function (assert) {
     let adapter = this.owner.lookup('adapter:application');
-    assert.equal(adapter.pathForType('superUser'), 'superUsers');
+    assert.strictEqual(adapter.pathForType('superUser'), 'superUsers');
   });
 
   test('pathForType - works with dasherized types', function (assert) {
     let adapter = this.owner.lookup('adapter:application');
-    assert.equal(adapter.pathForType('super-user'), 'superUsers');
+    assert.strictEqual(adapter.pathForType('super-user'), 'superUsers');
   });
 
   test('pathForType - works with underscored types', function (assert) {
     let adapter = this.owner.lookup('adapter:application');
-    assert.equal(adapter.pathForType('super_user'), 'superUsers');
+    assert.strictEqual(adapter.pathForType('super_user'), 'superUsers');
   });
 });

--- a/packages/-ember-data/tests/unit/adapters/rest-adapter/ajax-options-test.js
+++ b/packages/-ember-data/tests/unit/adapters/rest-adapter/ajax-options-test.js
@@ -39,10 +39,10 @@ module('unit/adapters/rest-adapter/ajax-options - building requests', function (
 
     adapter.ajax = function (url, method) {
       if (count === 0) {
-        assert.equal(url, '/people/1', 'should create the correct url');
+        assert.strictEqual(url, '/people/1', 'should create the correct url');
       }
       if (count === 1) {
-        assert.equal(url, '/places/1', 'should create the correct url');
+        assert.strictEqual(url, '/places/1', 'should create the correct url');
       }
       count++;
       return resolve();
@@ -60,7 +60,7 @@ module('unit/adapters/rest-adapter/ajax-options - building requests', function (
     let adapter = store.adapterFor('application');
 
     adapter.ajax = function (url, method) {
-      assert.equal(url, '/people/..%2Fplace%2F1', 'should create the correct url');
+      assert.strictEqual(url, '/people/..%2Fplace%2F1', 'should create the correct url');
       return resolve();
     };
 
@@ -240,7 +240,7 @@ module('unit/adapters/rest-adapter/ajax-options - building requests', function (
         error: noop,
       });
 
-      assert.equal(typeof fetchPlacePromise.then, 'function', '_fetchRequest does not return a promise');
+      assert.strictEqual(typeof fetchPlacePromise.then, 'function', '_fetchRequest does not return a promise');
 
       return fetchPlacePromise;
     });
@@ -292,7 +292,7 @@ module('unit/adapters/rest-adapter/ajax-options - building requests', function (
       let type = 'POST';
       let ajaxOptions = adapter.ajaxOptions(url, type, { data: { type: 'post' } });
 
-      assert.equal(ajaxOptions.contentType, 'application/json; charset=utf-8', 'contentType is set with POST');
+      assert.strictEqual(ajaxOptions.contentType, 'application/json; charset=utf-8', 'contentType is set with POST');
     });
 
     test('ajaxOptions() Content-Type is set with ajax POST with data if useFetch', function (assert) {
@@ -309,7 +309,7 @@ module('unit/adapters/rest-adapter/ajax-options - building requests', function (
       let type = 'POST';
       let ajaxOptions = adapter.ajaxOptions(url, type, { data: { type: 'post' } });
 
-      assert.equal(
+      assert.strictEqual(
         ajaxOptions.headers['content-type'],
         'application/json; charset=utf-8',
         'contentType is set with POST'

--- a/packages/-ember-data/tests/unit/adapters/rest-adapter/detailed-message-test.js
+++ b/packages/-ember-data/tests/unit/adapters/rest-adapter/detailed-message-test.js
@@ -28,7 +28,7 @@ module('unit/adapters/rest_adapter/detailed_message_test - RESTAdapter#generated
       }
     );
 
-    assert.equal(
+    assert.strictEqual(
       friendlyMessage,
       [
         'Ember Data Request GET /teapots/testing returned a 418',
@@ -46,7 +46,7 @@ module('unit/adapters/rest_adapter/detailed_message_test - RESTAdapter#generated
       method: 'GET',
     });
 
-    assert.equal(
+    assert.strictEqual(
       friendlyMessage,
       [
         'Ember Data Request GET /teapots/testing returned a 418',

--- a/packages/-ember-data/tests/unit/adapters/rest-adapter/fetch-options-test.js
+++ b/packages/-ember-data/tests/unit/adapters/rest-adapter/fetch-options-test.js
@@ -36,17 +36,17 @@ module('unit/adapters/rest-adapter/fetch-options', function (hooks) {
 
     // Tests POST method.
     let options = fetchOptions(baseOptions);
-    assert.equal(options.body, JSON.stringify(baseOptions.data), 'POST request body correctly set');
+    assert.strictEqual(options.body, JSON.stringify(baseOptions.data), 'POST request body correctly set');
 
     // Tests PUT method.
     baseOptions.method = 'PUT';
     options = fetchOptions(baseOptions);
-    assert.equal(options.body, JSON.stringify(baseOptions.data), 'PUT request body correctly set');
+    assert.strictEqual(options.body, JSON.stringify(baseOptions.data), 'PUT request body correctly set');
 
     // Tests DELETE method.
     baseOptions.method = 'DELETE';
     options = fetchOptions(baseOptions);
-    assert.equal(options.body, JSON.stringify(baseOptions.data), 'DELETE request has the correct body');
+    assert.strictEqual(options.body, JSON.stringify(baseOptions.data), 'DELETE request has the correct body');
   });
 
   test("fetchOptions sets the request body correctly when the method is POST and 'data' is a string", function (assert) {
@@ -61,7 +61,7 @@ module('unit/adapters/rest-adapter/fetch-options', function (hooks) {
     };
 
     let options = fetchOptions(optionsWithStringData);
-    assert.equal(options.body, stringifiedData);
+    assert.strictEqual(options.body, stringifiedData);
   });
 
   test('fetchOptions does not set a request body when the method is GET or HEAD', function (assert) {
@@ -107,7 +107,11 @@ module('unit/adapters/rest-adapter/fetch-options', function (hooks) {
     };
 
     const getOptions = fetchOptions(getData);
-    assert.equal(getOptions.url.indexOf('?'), -1, 'A question mark is not added if there are no query params to add');
+    assert.strictEqual(
+      getOptions.url.indexOf('?'),
+      -1,
+      'A question mark is not added if there are no query params to add'
+    );
 
     const postData = {
       url: 'https://emberjs.com',
@@ -116,7 +120,7 @@ module('unit/adapters/rest-adapter/fetch-options', function (hooks) {
     };
 
     const postOptions = fetchOptions(postData);
-    assert.equal(postOptions.body, '{}', "'options.body' is an empty object");
+    assert.strictEqual(postOptions.body, '{}', "'options.body' is an empty object");
   });
 
   test("fetchOptions sets the request body correctly when 'data' is FormData", function (assert) {
@@ -144,7 +148,7 @@ module('unit/adapters/rest-adapter/fetch-options', function (hooks) {
     };
 
     const postOptions = fetchOptions(postData);
-    assert.equal(postOptions.body, stringBody, "'options.body' is the String passed in");
+    assert.strictEqual(postOptions.body, stringBody, "'options.body' is the String passed in");
   });
 
   test("fetchOptions sets credentials when 'credentials' is empty", function (assert) {
@@ -157,7 +161,7 @@ module('unit/adapters/rest-adapter/fetch-options', function (hooks) {
     };
 
     const postOptions = fetchOptions(postData);
-    assert.equal(postOptions.credentials, 'same-origin', "'options.credentials' is 'same-origin'");
+    assert.strictEqual(postOptions.credentials, 'same-origin', "'options.credentials' is 'same-origin'");
   });
 
   test("fetchOptions sets credentials when 'credentials' is not empty", function (assert) {
@@ -172,7 +176,7 @@ module('unit/adapters/rest-adapter/fetch-options', function (hooks) {
     };
 
     const postOptions = fetchOptions(postData);
-    assert.equal(postOptions.credentials, credentials, "'options.credentials' is 'include'");
+    assert.strictEqual(postOptions.credentials, credentials, "'options.credentials' is 'include'");
   });
 
   test('fetchOptions serializes query params to the url', function (assert) {
@@ -190,7 +194,7 @@ module('unit/adapters/rest-adapter/fetch-options', function (hooks) {
     };
 
     const postOptions = fetchOptions(postData);
-    assert.equal(
+    assert.strictEqual(
       postOptions.url,
       'https://emberjs.com?fields%5Bpost%5D=title%2Cemail&fields%5Bcomments%5D=body',
       "'options.url' is serialized"

--- a/packages/-ember-data/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
+++ b/packages/-ember-data/tests/unit/adapters/rest-adapter/group-records-for-find-many-test.js
@@ -80,8 +80,8 @@ module(
         wait.push(store.findRecord('testRecord', 'my-id:2'));
       });
 
-      assert.equal(requests.length, 1);
-      assert.equal(requests[0].url, '/testRecords');
+      assert.strictEqual(requests.length, 1);
+      assert.strictEqual(requests[0].url, '/testRecords');
       assert.deepEqual(requests[0].ids, ['my-id:1', 'my-id:2']);
 
       return EmberPromise.all(wait);
@@ -93,7 +93,7 @@ module(
       let snapshot = record._internalModel.createSnapshot();
       let strippedUrl = adapter._stripIDFromURL(store, snapshot);
 
-      assert.equal(strippedUrl, '/testRecords/');
+      assert.strictEqual(strippedUrl, '/testRecords/');
     });
   }
 );

--- a/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -95,13 +95,13 @@ if (CUSTOM_MODEL_CLASS) {
           identifier = id;
           notificationManager.subscribe(identifier, (passedId, key) => {
             notificationCount++;
-            assert.equal(passedId, identifier, 'passed the identifier to the callback');
+            assert.strictEqual(passedId, identifier, 'passed the identifier to the callback');
             if (notificationCount === 1) {
-              assert.equal(key, 'state', 'passed the key');
+              assert.strictEqual(key, 'state', 'passed the key');
             } else if (notificationCount === 2) {
-              assert.equal(key, 'errors', 'passed the key');
+              assert.strictEqual(key, 'errors', 'passed the key');
             } else if (notificationCount === 3) {
-              assert.equal(key, 'relationships', 'passed the key');
+              assert.strictEqual(key, 'relationships', 'passed the key');
             }
           });
           return { hi: 'igor' };
@@ -116,7 +116,7 @@ if (CUSTOM_MODEL_CLASS) {
       recordData.storeWrapper.notifyErrorsChange(identifier.type, identifier.id, identifier.lid, 'key');
       await settled();
 
-      assert.equal(notificationCount, 3, 'called notification callback');
+      assert.strictEqual(notificationCount, 3, 'called notification callback');
     });
 
     test('record creation and teardown', function (assert) {
@@ -124,19 +124,19 @@ if (CUSTOM_MODEL_CLASS) {
       let returnValue;
       let CreationStore = CustomStore.extend({
         instantiateRecord(identifier, createRecordArgs, recordDataFor, notificationManager) {
-          assert.equal(identifier.type, 'person', 'Identifier type passed in correctly');
+          assert.strictEqual(identifier.type, 'person', 'Identifier type passed in correctly');
           assert.deepEqual(createRecordArgs, { otherProp: 'unk' }, 'createRecordArg passed in');
           returnValue = {};
           return returnValue;
         },
         teardownRecord(record) {
-          assert.equal(record, person, 'Passed in person to teardown');
+          assert.strictEqual(record, person, 'Passed in person to teardown');
         },
       });
       this.owner.register('service:store', CreationStore);
       store = this.owner.lookup('service:store');
       let person = store.createRecord('person', { name: 'chris', otherProp: 'unk' });
-      assert.equal(returnValue, person, 'createRecord returns the instantiated record');
+      assert.strictEqual(returnValue, person, 'createRecord returns the instantiated record');
       assert.deepEqual(returnValue, person, 'record instantiating does not modify the returned value');
     });
 
@@ -146,7 +146,7 @@ if (CUSTOM_MODEL_CLASS) {
       let CreationStore = CustomStore.extend({
         instantiateRecord(identifier, createRecordArgs, recordDataFor, notificationManager) {
           rd = recordDataFor(identifier);
-          assert.equal(rd.getAttr('name'), 'chris', 'Can look up record data from recordDataFor');
+          assert.strictEqual(rd.getAttr('name'), 'chris', 'Can look up record data from recordDataFor');
           return {};
         },
       });
@@ -185,14 +185,14 @@ if (CUSTOM_MODEL_CLASS) {
             let count = 0;
             snapshot.eachAttribute((attr, attrDef) => {
               if (count === 0) {
-                assert.equal(attr, 'name', 'attribute key is correct');
+                assert.strictEqual(attr, 'name', 'attribute key is correct');
                 assert.deepEqual(
                   attrDef,
                   { kind: 'attribute', type: 'string', options: {}, name: 'name' },
                   'attribute def matches schem'
                 );
               } else if (count === 1) {
-                assert.equal(attr, 'age', 'attribute key is correct');
+                assert.strictEqual(attr, 'age', 'attribute key is correct');
                 assert.deepEqual(
                   attrDef,
                   { kind: 'attribute', type: 'number', options: {}, name: 'age' },
@@ -204,7 +204,7 @@ if (CUSTOM_MODEL_CLASS) {
             count = 0;
             snapshot.eachRelationship((rel, relDef) => {
               if (count === 0) {
-                assert.equal(rel, 'boats', 'relationship key is correct');
+                assert.strictEqual(rel, 'boats', 'relationship key is correct');
                 assert.deepEqual(
                   relDef,
                   {
@@ -219,7 +219,7 @@ if (CUSTOM_MODEL_CLASS) {
                   'relationships def matches schem'
                 );
               } else if (count === 1) {
-                assert.equal(rel, 'house', 'relationship key is correct');
+                assert.strictEqual(rel, 'house', 'relationship key is correct');
                 assert.deepEqual(
                   relDef,
                   { type: 'house', kind: 'belongsTo', options: { inverse: null }, key: 'house', name: 'house' },
@@ -237,9 +237,9 @@ if (CUSTOM_MODEL_CLASS) {
       let schema: SchemaDefinitionService = {
         attributesDefinitionFor(identifier: string | RecordIdentifier): AttributesSchema {
           if (typeof identifier === 'string') {
-            assert.equal(identifier, 'person', 'type passed in to the schema hooks');
+            assert.strictEqual(identifier, 'person', 'type passed in to the schema hooks');
           } else {
-            assert.equal(identifier.type, 'person', 'type passed in to the schema hooks');
+            assert.strictEqual(identifier.type, 'person', 'type passed in to the schema hooks');
           }
           return {
             name: {
@@ -258,9 +258,9 @@ if (CUSTOM_MODEL_CLASS) {
         },
         relationshipsDefinitionFor(identifier: string | RecordIdentifier): RelationshipsSchema {
           if (typeof identifier === 'string') {
-            assert.equal(identifier, 'person', 'type passed in to the schema hooks');
+            assert.strictEqual(identifier, 'person', 'type passed in to the schema hooks');
           } else {
-            assert.equal(identifier.type, 'person', 'type passed in to the schema hooks');
+            assert.strictEqual(identifier.type, 'person', 'type passed in to the schema hooks');
           }
           return {
             boats: {
@@ -306,9 +306,9 @@ if (CUSTOM_MODEL_CLASS) {
         },
         doesTypeExist(modelName: string) {
           if (count === 0) {
-            assert.equal(modelName, 'person', 'type passed in to the schema hooks');
+            assert.strictEqual(modelName, 'person', 'type passed in to the schema hooks');
           } else if (count === 1) {
-            assert.equal(modelName, 'boat', 'type passed in to the schema hooks');
+            assert.strictEqual(modelName, 'boat', 'type passed in to the schema hooks');
           }
           count++;
           return modelName === 'person';
@@ -334,7 +334,7 @@ if (CUSTOM_MODEL_CLASS) {
       store = this.owner.lookup('service:store');
       let person = store.createRecord('person', { name: 'chris' });
       let promisePerson = await store.saveRecord(person);
-      assert.equal(person, promisePerson, 'save promise resolves with the same record');
+      assert.strictEqual(person, promisePerson, 'save promise resolves with the same record');
     });
 
     test('store.deleteRecord', async function (assert) {
@@ -355,13 +355,13 @@ if (CUSTOM_MODEL_CLASS) {
           rd = recordDataFor(identifier);
           assert.false(rd.isDeleted!(), 'we are not deleted when we start');
           notificationManager.subscribe(identifier, (passedId, key) => {
-            assert.equal(key, 'state', 'state change to deleted has been notified');
+            assert.strictEqual(key, 'state', 'state change to deleted has been notified');
             assert.true(recordDataFor(identifier).isDeleted(), 'we have been marked as deleted');
           });
           return {};
         },
         teardownRecord(record) {
-          assert.equal(record, person, 'Passed in person to teardown');
+          assert.strictEqual(record, person, 'Passed in person to teardown');
         },
       });
       this.owner.register('service:store', CreationStore);
@@ -533,9 +533,9 @@ if (CUSTOM_MODEL_CLASS) {
       });
       let identifier = recordIdentifierFor(person);
       let relationship = store.relationshipReferenceFor({ type: 'person', id: '7', lid: identifier.lid }, 'house');
-      assert.equal(relationship.id(), '1', 'house relationship id found');
-      assert.equal(relationship.type, 'house', 'house relationship type found');
-      assert.equal(relationship.parent.id(), '7', 'house relationship parent found');
+      assert.strictEqual(relationship.id(), '1', 'house relationship id found');
+      assert.strictEqual(relationship.type, 'house', 'house relationship type found');
+      assert.strictEqual(relationship.parent.id(), '7', 'house relationship parent found');
     });
 
     test('relationshipReferenceFor hasMany', async function (assert) {
@@ -613,8 +613,8 @@ if (CUSTOM_MODEL_CLASS) {
       let identifier = recordIdentifierFor(person);
       let relationship = store.relationshipReferenceFor({ type: 'person', id: '7', lid: identifier.lid }, 'house');
       assert.deepEqual(relationship.ids(), ['1', '2'], 'relationship found');
-      assert.equal(relationship.type, 'house', 'house relationship type found');
-      assert.equal(relationship.parent.id(), '7', 'house relationship parent found');
+      assert.strictEqual(relationship.type, 'house', 'house relationship type found');
+      assert.strictEqual(relationship.parent.id(), '7', 'house relationship parent found');
     });
   });
 }

--- a/packages/-ember-data/tests/unit/debug-test.js
+++ b/packages/-ember-data/tests/unit/debug-test.js
@@ -36,12 +36,12 @@ if (has('@ember-data/debug')) {
 
       let propertyInfo = record._debugInfo().propertyInfo;
 
-      assert.equal(propertyInfo.groups.length, 4);
-      assert.equal(propertyInfo.groups[0].name, 'Attributes');
+      assert.strictEqual(propertyInfo.groups.length, 4);
+      assert.strictEqual(propertyInfo.groups[0].name, 'Attributes');
       assert.deepEqual(propertyInfo.groups[0].properties, ['id', 'name', 'isDrugAddict']);
-      assert.equal(propertyInfo.groups[1].name, 'belongsTo');
+      assert.strictEqual(propertyInfo.groups[1].name, 'belongsTo');
       assert.deepEqual(propertyInfo.groups[1].properties, ['maritalStatus']);
-      assert.equal(propertyInfo.groups[2].name, 'hasMany');
+      assert.strictEqual(propertyInfo.groups[2].name, 'hasMany');
       assert.deepEqual(propertyInfo.groups[2].properties, ['posts']);
     });
 

--- a/packages/-ember-data/tests/unit/diff-array-test.js
+++ b/packages/-ember-data/tests/unit/diff-array-test.js
@@ -19,469 +19,469 @@ module('unit/diff-array Diff Array tests', function () {
   test('diff array returns no change given two empty arrays', function (assert) {
     const result = diffArray([], []);
     assert.strictEqual(result.firstChangeIndex, null);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns no change given two identical arrays length 1', function (assert) {
     const result = diffArray([a], [a]);
     assert.strictEqual(result.firstChangeIndex, null);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns no change given two identical arrays length 3', function (assert) {
     const result = diffArray([a, b, c], [a, b, c]);
     assert.strictEqual(result.firstChangeIndex, null);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given one appended item with old length 0', function (assert) {
     const result = diffArray([], [a]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given one appended item with old length 1', function (assert) {
     const result = diffArray([a], [a, b]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given one appended item with old length 2', function (assert) {
     const result = diffArray([a, b], [a, b, c]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given 3 appended items with old length 0', function (assert) {
     const result = diffArray([], [a, b, c]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given 3 appended items with old length 1', function (assert) {
     const result = diffArray([a], [a, b, c, d]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given 3 appended items with old length 2', function (assert) {
     const result = diffArray([a, b], [a, b, c, d, e]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given one item removed from end with old length 1', function (assert) {
     const result = diffArray([a], []);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given one item removed from end with old length 2', function (assert) {
     const result = diffArray([a, b], [a]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given one item removed from end with old length 3', function (assert) {
     const result = diffArray([a, b, c], [a, b]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given 3 items removed from end with old length 3', function (assert) {
     const result = diffArray([a, b, c], []);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given 3 items removed from end with old length 4', function (assert) {
     const result = diffArray([a, b, c, d], [a]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given 3 items removed from end with old length 5', function (assert) {
     const result = diffArray([a, b, c, d, e], [a, b]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given one item removed from beginning with old length 2', function (assert) {
     const result = diffArray([a, b], [b]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given one item removed from beginning with old length 3', function (assert) {
     const result = diffArray([a, b, c], [b, c]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given 3 items removed from beginning with old length 4', function (assert) {
     const result = diffArray([a, b, c, d], [d]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given 3 items removed from beginning with old length 5', function (assert) {
     const result = diffArray([a, b, c, d, e], [d, e]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given one item removed from middle with old length 3', function (assert) {
     const result = diffArray([a, b, c], [a, c]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given one item removed from middle with old length 5', function (assert) {
     const result = diffArray([a, b, c, d, e], [a, b, d, e]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given 3 items removed from middle with old length 5', function (assert) {
     const result = diffArray([a, b, c, d, e], [a, e]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given 3 items removed from middle with old length 7', function (assert) {
     const result = diffArray([a, b, c, d, e, f, g], [a, b, f, g]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 0);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 0);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given one item added to middle with old length 2', function (assert) {
     const result = diffArray([a, c], [a, b, c]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given one item added to middle with old length 4', function (assert) {
     const result = diffArray([a, b, d, e], [a, b, c, d, e]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given 3 items added to middle with old length 2', function (assert) {
     const result = diffArray([a, e], [a, b, c, d, e]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given 3 items added to middle with old length 4', function (assert) {
     const result = diffArray([a, b, f, g], [a, b, c, d, e, f, g]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 0);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 0);
   });
 
   test('diff array returns correctly given complete replacement with length 1', function (assert) {
     const result = diffArray([a], [b]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given complete replacement with length 3', function (assert) {
     const result = diffArray([a, b, c], [x, y, z]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given complete replacement with longer length', function (assert) {
     const result = diffArray([a, b], [x, y, z]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 2);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 2);
   });
 
   test('diff array returns correctly given one item replaced in middle with old length 3', function (assert) {
     const result = diffArray([a, b, c], [a, x, c]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given one item replaced in middle with old length 5', function (assert) {
     const result = diffArray([a, b, c, d, e], [a, b, x, d, e]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given 3 items replaced in middle with old length 5', function (assert) {
     const result = diffArray([a, b, c, d, e], [a, x, y, z, e]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given 3 items replaced in middle with old length 7', function (assert) {
     const result = diffArray([a, b, c, d, e, f, g], [a, b, x, y, z, f, g]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given one item replaced at beginning with old length 2', function (assert) {
     const result = diffArray([a, b], [x, b]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given one item replaced at beginning with old length 3', function (assert) {
     const result = diffArray([a, b, c], [x, b, c]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given 3 items replaced at beginning with old length 4', function (assert) {
     const result = diffArray([a, b, c, d], [x, y, z, d]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given 3 items replaced at beginning with old length 6', function (assert) {
     const result = diffArray([a, b, c, d, e, f], [x, y, z, d, e, f]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given one item replaced at end with old length 2', function (assert) {
     const result = diffArray([a, b], [a, x]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given one item replaced at end with old length 3', function (assert) {
     const result = diffArray([a, b, c], [a, b, x]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given 3 items replaced at end with old length 4', function (assert) {
     const result = diffArray([a, b, c, d], [a, x, y, z]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given 3 items replaced at end with old length 6', function (assert) {
     const result = diffArray([a, b, c, d, e, f], [a, b, c, x, y, z]);
-    assert.equal(result.firstChangeIndex, 3);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 3);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given one item replaced with two in middle with old length 3', function (assert) {
     const result = diffArray([a, b, c], [a, x, y, c]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 2);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 2);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given one item replaced with two in middle with old length 5', function (assert) {
     const result = diffArray([a, b, c, d, e], [a, b, x, y, d, e]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 2);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 2);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given 3 items replaced with 4 in middle with old length 5', function (assert) {
     const result = diffArray([a, b, c, d, e], [a, w, x, y, z, e]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 4);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 4);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given 3 items replaced with 4 in middle with old length 7', function (assert) {
     const result = diffArray([a, b, c, d, e, f, g], [a, b, w, x, y, z, f, g]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 4);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 4);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given one item replaced with two at beginning with old length 2', function (assert) {
     const result = diffArray([a, b], [x, y, b]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 2);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 2);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given one item replaced with two at beginning with old length 3', function (assert) {
     const result = diffArray([a, b, c], [x, y, b, c]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 2);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 2);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given 3 items replaced with 4 at beginning with old length 4', function (assert) {
     const result = diffArray([a, b, c, d], [w, x, y, z, d]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 4);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 4);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given 3 items replaced with 4 at beginning with old length 6', function (assert) {
     const result = diffArray([a, b, c, d, e, f], [w, x, y, z, d, e, f]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 4);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 4);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given one item replaced with two at end with old length 2', function (assert) {
     const result = diffArray([a, b], [a, x, y]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 2);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 2);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given one item replaced with two at end with old length 3', function (assert) {
     const result = diffArray([a, b, c], [a, b, x, y]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 2);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 2);
+    assert.strictEqual(result.removedCount, 1);
   });
 
   test('diff array returns correctly given 3 items replaced with 4 at end with old length 4', function (assert) {
     const result = diffArray([a, b, c, d], [a, w, x, y, z]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 4);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 4);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given 3 items replaced with 4 at end with old length 6', function (assert) {
     const result = diffArray([a, b, c, d, e, f], [a, b, c, w, x, y, z]);
-    assert.equal(result.firstChangeIndex, 3);
-    assert.equal(result.addedCount, 4);
-    assert.equal(result.removedCount, 3);
+    assert.strictEqual(result.firstChangeIndex, 3);
+    assert.strictEqual(result.addedCount, 4);
+    assert.strictEqual(result.removedCount, 3);
   });
 
   test('diff array returns correctly given two items replaced with one in middle with old length 4', function (assert) {
     const result = diffArray([a, b, c, d], [a, x, d]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 2);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 2);
   });
 
   test('diff array returns correctly given two items replaced with one in middle with old length 6', function (assert) {
     const result = diffArray([a, b, c, d, e, f], [a, b, x, e, f]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 2);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 2);
   });
 
   test('diff array returns correctly given 4 items replaced with 3 in middle with old length 6', function (assert) {
     const result = diffArray([a, b, c, d, e, f], [a, x, y, z, f]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 4);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 4);
   });
 
   test('diff array returns correctly given 4 items replaced with 3 in middle with old length 8', function (assert) {
     const result = diffArray([a, b, c, d, e, f, g, h], [a, b, x, y, z, g, h]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 4);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 4);
   });
 
   test('diff array returns correctly given two items replaced with one at beginning with old length 3', function (assert) {
     const result = diffArray([a, b, c], [x, c]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 2);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 2);
   });
 
   test('diff array returns correctly given two items replaced with one at beginning with old length 4', function (assert) {
     const result = diffArray([a, b, c, d], [x, c, d]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 2);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 2);
   });
 
   test('diff array returns correctly given 4 items replaced with 3 at beginning with old length 5', function (assert) {
     const result = diffArray([a, b, c, d, e], [x, y, z, e]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 4);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 4);
   });
 
   test('diff array returns correctly given 4 items replaced with 3 at beginning with old length 6', function (assert) {
     const result = diffArray([a, b, c, d, e, f], [x, y, z, e, f]);
-    assert.equal(result.firstChangeIndex, 0);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 4);
+    assert.strictEqual(result.firstChangeIndex, 0);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 4);
   });
 
   test('diff array returns correctly given two items replaced with one at end with old length 3', function (assert) {
     const result = diffArray([a, b, c], [a, x]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 2);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 2);
   });
 
   test('diff array returns correctly given two items replaced with one at end with old length 4', function (assert) {
     const result = diffArray([a, b, c, d], [a, b, x]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 1);
-    assert.equal(result.removedCount, 2);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 1);
+    assert.strictEqual(result.removedCount, 2);
   });
 
   test('diff array returns correctly given 4 items replaced with 3 at end with old length 5', function (assert) {
     const result = diffArray([a, b, c, d, e], [a, x, y, z]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 4);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 4);
   });
 
   test('diff array returns correctly given 4 items replaced with 3 at end with old length 6', function (assert) {
     const result = diffArray([a, b, c, d, e, f], [a, b, x, y, z]);
-    assert.equal(result.firstChangeIndex, 2);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 4);
+    assert.strictEqual(result.firstChangeIndex, 2);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 4);
   });
 
   test('diff array returns correctly given non-contiguous insertion', function (assert) {
     const result = diffArray([a, c, e], [a, b, c, d, e]);
-    assert.equal(result.firstChangeIndex, 1);
-    assert.equal(result.addedCount, 3);
-    assert.equal(result.removedCount, 1);
+    assert.strictEqual(result.firstChangeIndex, 1);
+    assert.strictEqual(result.addedCount, 3);
+    assert.strictEqual(result.removedCount, 1);
   });
 });

--- a/packages/-ember-data/tests/unit/many-array-test.js
+++ b/packages/-ember-data/tests/unit/many-array-test.js
@@ -130,9 +130,9 @@ module('unit/many_array - DS.ManyArray', function (hooks) {
     };
 
     TestManyArray.arrayContentDidChange = function (startIdx, removeAmt, addAmt) {
-      assert.equal(startIdx, willChangeStartIdx, 'WillChange and DidChange startIdx should match');
-      assert.equal(removeAmt, willChangeRemoveAmt, 'WillChange and DidChange removeAmt should match');
-      assert.equal(addAmt, willChangeAddAmt, 'WillChange and DidChange addAmt should match');
+      assert.strictEqual(startIdx, willChangeStartIdx, 'WillChange and DidChange startIdx should match');
+      assert.strictEqual(removeAmt, willChangeRemoveAmt, 'WillChange and DidChange removeAmt should match');
+      assert.strictEqual(addAmt, willChangeAddAmt, 'WillChange and DidChange addAmt should match');
 
       return originalArrayContentDidChange.apply(this, arguments);
     };

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -67,7 +67,7 @@ module('unit/model - Model', function (hooks) {
         },
       });
 
-      assert.equal(
+      assert.strictEqual(
         get(record, 'currentState.stateName'),
         'root.deleted.uncommitted',
         'record accepts pushedData is in root.deleted.uncommitted state'
@@ -178,7 +178,7 @@ module('unit/model - Model', function (hooks) {
         },
       });
 
-      assert.equal(
+      assert.strictEqual(
         get(record, 'currentState.stateName'),
         'root.loaded.saved',
         'records pushed into the store start in the loaded state'
@@ -197,7 +197,7 @@ module('unit/model - Model', function (hooks) {
 
       let record = await store.findRecord('person', '1');
 
-      assert.equal(get(record, 'id'), 1, 'reports id as id by default');
+      assert.strictEqual(get(record, 'id'), '1', 'reports id as id by default');
     });
 
     test("a record's id is included in its toString representation", async function (assert) {
@@ -208,7 +208,7 @@ module('unit/model - Model', function (hooks) {
         },
       });
 
-      assert.equal(
+      assert.strictEqual(
         person.toString(),
         `<dummy@model:${person.constructor.modelName}::${guidFor(person)}:1>`,
         'reports id in toString'
@@ -266,7 +266,7 @@ module('unit/model - Model', function (hooks) {
 
         let record = await store.findRecord('person', 'watch');
 
-        assert.equal(get(record, 'id'), 'watch', 'record is successfully created and could be found by its id');
+        assert.strictEqual(get(record, 'id'), 'watch', 'record is successfully created and could be found by its id');
       } finally {
         if (!hasWatchMethod) {
           delete Object.prototype.watch;
@@ -310,7 +310,7 @@ module('unit/model - Model', function (hooks) {
     test('setting the id during createRecord should correctly update the id', async function (assert) {
       let person = store.createRecord('person', { id: 'john' });
 
-      assert.equal(person.get('id'), 'john', 'new id should be correctly set.');
+      assert.strictEqual(person.get('id'), 'john', 'new id should be correctly set.');
 
       let record = store.peekRecord('person', 'john');
 
@@ -320,11 +320,11 @@ module('unit/model - Model', function (hooks) {
     test('setting the id after createRecord should correctly update the id', async function (assert) {
       let person = store.createRecord('person');
 
-      assert.equal(person.get('id'), null, 'initial created model id should be null');
+      assert.strictEqual(person.get('id'), null, 'initial created model id should be null');
 
       person.set('id', 'john');
 
-      assert.equal(person.get('id'), 'john', 'new id should be correctly set.');
+      assert.strictEqual(person.get('id'), 'john', 'new id should be correctly set.');
 
       let record = store.peekRecord('person', 'john');
 
@@ -334,7 +334,7 @@ module('unit/model - Model', function (hooks) {
     testInDebug('mutating the id after createRecord but before save works', async function (assert) {
       let person = store.createRecord('person', { id: 'chris' });
 
-      assert.equal(person.get('id'), 'chris', 'initial created model id should be null');
+      assert.strictEqual(person.get('id'), 'chris', 'initial created model id should be null');
 
       try {
         person.set('id', 'john');
@@ -362,16 +362,16 @@ module('unit/model - Model', function (hooks) {
       let person = store.createRecord('odd-person');
       let oddId = person.get('idComputed');
 
-      assert.equal(oddId, null, 'initial computed get is null');
+      assert.strictEqual(oddId, null, 'initial computed get is null');
       // test .get access of id
-      assert.equal(person.get('id'), null, 'initial created model id should be null');
+      assert.strictEqual(person.get('id'), null, 'initial created model id should be null');
 
       store.setRecordId('odd-person', 'john', person._internalModel.clientId);
 
       oddId = person.get('idComputed');
-      assert.equal(oddId, 'john', 'computed get is correct');
+      assert.strictEqual(oddId, 'john', 'computed get is correct');
       // test direct access of id
-      assert.equal(person.id, 'john', 'new id should be correctly set.');
+      assert.strictEqual(person.id, 'john', 'new id should be correctly set.');
     });
 
     test('ID mutation (complicated)', async function (assert) {
@@ -391,24 +391,24 @@ module('unit/model - Model', function (hooks) {
 
       let person = store.createRecord('odd-person');
       assert.strictEqual(person.get('idComputed'), 'not-the-id:0');
-      assert.equal(idChange, 0, 'we have had no changes initially');
+      assert.strictEqual(idChange, 0, 'we have had no changes initially');
 
       let personId = person.get('id');
       assert.strictEqual(personId, null, 'initial created model id should be null');
-      assert.equal(idChange, 0, 'we should still have no id changes');
+      assert.strictEqual(idChange, 0, 'we should still have no id changes');
 
       // simulate an update from the store or RecordData that doesn't
       // go through the internalModelFactory
       person._internalModel.setId('john');
-      assert.equal(idChange, 1, 'we should have one change after updating id');
+      assert.strictEqual(idChange, 1, 'we should have one change after updating id');
       let recordData = recordDataFor(person);
-      assert.equal(
+      assert.strictEqual(
         recordData.getResourceIdentifier().id,
         'john',
         'new id should be set on the identifier on record data.'
       );
-      assert.equal(recordData.id, 'john', 'new id should be correctly set on the record data itself.');
-      assert.equal(person.get('id'), 'john', 'new id should be correctly set.');
+      assert.strictEqual(recordData.id, 'john', 'new id should be correctly set on the record data itself.');
+      assert.strictEqual(person.get('id'), 'john', 'new id should be correctly set.');
     });
 
     test('an ID of 0 is allowed', async function (assert) {
@@ -426,7 +426,7 @@ module('unit/model - Model', function (hooks) {
       // we can locate it in the identity map
       let record = store.peekRecord('person', 0);
 
-      assert.equal(record.get('name'), 'Tom Dale', 'found record with id 0');
+      assert.strictEqual(record.get('name'), 'Tom Dale', 'found record with id 0');
     });
   });
 
@@ -446,8 +446,8 @@ module('unit/model - Model', function (hooks) {
       let nativeTag = store.createRecord('native-tag', { name: 'test native' });
       let legacyTag = store.createRecord('legacy-tag', { name: 'test legacy' });
 
-      assert.equal(get(nativeTag, 'name'), 'test native', 'the value is persisted');
-      assert.equal(get(legacyTag, 'name'), 'test legacy', 'the value is persisted');
+      assert.strictEqual(get(nativeTag, 'name'), 'test native', 'the value is persisted');
+      assert.strictEqual(get(legacyTag, 'name'), 'test legacy', 'the value is persisted');
     });
 
     test('a Model can have a defaultValue without an attribute type', async function (assert) {
@@ -465,8 +465,8 @@ module('unit/model - Model', function (hooks) {
       let nativeTag = store.createRecord('native-tag');
       let legacyTag = store.createRecord('legacy-tag');
 
-      assert.equal(get(nativeTag, 'name'), 'unknown native tag', 'the default value is found');
-      assert.equal(get(legacyTag, 'name'), 'unknown legacy tag', 'the default value is found');
+      assert.strictEqual(get(nativeTag, 'name'), 'unknown native tag', 'the default value is found');
+      assert.strictEqual(get(legacyTag, 'name'), 'unknown legacy tag', 'the default value is found');
     });
 
     test('a defaultValue for an attribute can be a function', async function (assert) {
@@ -481,7 +481,7 @@ module('unit/model - Model', function (hooks) {
       this.owner.register('model:tag', Tag);
 
       let tag = store.createRecord('tag');
-      assert.equal(get(tag, 'createdAt'), 'le default value', 'the defaultValue function is evaluated');
+      assert.strictEqual(get(tag, 'createdAt'), 'le default value', 'the defaultValue function is evaluated');
     });
 
     test('a defaultValue function gets the record, options, and key', async function (assert) {
@@ -490,7 +490,7 @@ module('unit/model - Model', function (hooks) {
         @attr('string', {
           defaultValue(record, options, key) {
             assert.deepEqual(record, tag, 'the record is passed in properly');
-            assert.equal(key, 'createdAt', 'the attribute being defaulted is passed in properly');
+            assert.strictEqual(key, 'createdAt', 'the attribute being defaulted is passed in properly');
             return 'le default value';
           },
         })
@@ -649,13 +649,13 @@ module('unit/model - Model', function (hooks) {
 
         await settled();
 
-        assert.equal(count, 1, 'the event was triggered');
+        assert.strictEqual(count, 1, 'the event was triggered');
 
         record.trigger('event!');
 
         await settled();
 
-        assert.equal(count, 2, 'the event was triggered');
+        assert.strictEqual(count, 2, 'the event was triggered');
       }
     );
 
@@ -679,7 +679,7 @@ module('unit/model - Model', function (hooks) {
 
         await settled();
 
-        assert.equal(count, 1, 'the corresponding method was called');
+        assert.strictEqual(count, 1, 'the corresponding method was called');
       }
     );
 
@@ -702,8 +702,8 @@ module('unit/model - Model', function (hooks) {
 
         await settled();
 
-        assert.equal(eventMethodArgs[0], 1);
-        assert.equal(eventMethodArgs[1], 2);
+        assert.strictEqual(eventMethodArgs[0], 1);
+        assert.strictEqual(eventMethodArgs[1], 2);
       }
     );
 
@@ -836,7 +836,7 @@ module('unit/model - Model', function (hooks) {
 
       let person = await store.findRecord('person', 1);
 
-      assert.equal(get(person, 'currentState.stateName'), 'root.loaded.saved', 'model is in loaded state');
+      assert.strictEqual(get(person, 'currentState.stateName'), 'root.loaded.saved', 'model is in loaded state');
       assert.true(get(person, 'isLoaded'), 'model is loaded');
     });
 
@@ -857,11 +857,15 @@ module('unit/model - Model', function (hooks) {
 
       assert.false(person.isNew, 'push should put move the record into the loaded state');
       if (CUSTOM_MODEL_CLASS) {
-        assert.equal(person.currentState.stateName, 'root.loaded.saved', 'model is in loaded state');
+        assert.strictEqual(person.currentState.stateName, 'root.loaded.saved', 'model is in loaded state');
       } else {
         // TODO either this is a bug or being able to push a record with the same ID as a client created one is a bug
         //   probably the bug is the former
-        assert.equal(person.currentState.stateName, 'root.loaded.updated.uncommitted', 'model is in loaded state');
+        assert.strictEqual(
+          person.currentState.stateName,
+          'root.loaded.updated.uncommitted',
+          'model is in loaded state'
+        );
       }
     });
 
@@ -889,13 +893,13 @@ module('unit/model - Model', function (hooks) {
       this.owner.register('model:native-person', OddNativePerson);
       this.owner.register('model:legacy-person', OddLegacyPerson);
 
-      assert.equal(nameDidChange, 0, 'observer should not trigger on create');
+      assert.strictEqual(nameDidChange, 0, 'observer should not trigger on create');
       let person = store.createRecord('legacy-person');
-      assert.equal(nameDidChange, 0, 'observer should not trigger on create');
-      assert.equal(person.get('name'), 'my-name-set-in-init');
+      assert.strictEqual(nameDidChange, 0, 'observer should not trigger on create');
+      assert.strictEqual(person.get('name'), 'my-name-set-in-init');
 
       person = store.createRecord('native-person');
-      assert.equal(person.get('name'), 'my-name-set-in-init');
+      assert.strictEqual(person.get('name'), 'my-name-set-in-init');
     });
 
     test('accessing attributes during init should not throw an error', async function (assert) {
@@ -995,7 +999,7 @@ module('unit/model - Model', function (hooks) {
       });
 
       set(person, 'name', 'Brohuda Katz');
-      assert.equal(get(person, 'name'), 'Brohuda Katz', 'setting took hold');
+      assert.strictEqual(get(person, 'name'), 'Brohuda Katz', 'setting took hold');
     });
 
     test(`clearing the value when a Model's defaultValue was in use works`, async function (assert) {
@@ -1007,10 +1011,10 @@ module('unit/model - Model', function (hooks) {
       this.owner.register('model:tag', Tag);
 
       let tag = store.createRecord('tag');
-      assert.equal(get(tag, 'name'), 'unknown', 'the default value is found');
+      assert.strictEqual(get(tag, 'name'), 'unknown', 'the default value is found');
 
       set(tag, 'name', null);
-      assert.equal(get(tag, 'name'), null, `null doesn't shadow defaultValue`);
+      assert.strictEqual(get(tag, 'name'), null, `null doesn't shadow defaultValue`);
     });
 
     test(`a Model can define 'setUnknownProperty'`, async function (assert) {
@@ -1037,22 +1041,22 @@ module('unit/model - Model', function (hooks) {
       this.owner.register('model:legacy-tag', LegacyTag);
 
       let legacyTag = store.createRecord('legacy-tag', { name: 'old' });
-      assert.equal(get(legacyTag, 'name'), 'old', 'precond - name is correct');
+      assert.strictEqual(get(legacyTag, 'name'), 'old', 'precond - name is correct');
 
       set(legacyTag, 'name', 'edited');
-      assert.equal(get(legacyTag, 'name'), 'edited', 'setUnknownProperty was not triggered');
+      assert.strictEqual(get(legacyTag, 'name'), 'edited', 'setUnknownProperty was not triggered');
 
       set(legacyTag, 'title', 'new');
-      assert.equal(get(legacyTag, 'name'), 'new', 'setUnknownProperty was triggered');
+      assert.strictEqual(get(legacyTag, 'name'), 'new', 'setUnknownProperty was triggered');
 
       let nativeTag = store.createRecord('native-tag', { name: 'old' });
-      assert.equal(get(nativeTag, 'name'), 'old', 'precond - name is correct');
+      assert.strictEqual(get(nativeTag, 'name'), 'old', 'precond - name is correct');
 
       set(nativeTag, 'name', 'edited');
-      assert.equal(get(nativeTag, 'name'), 'edited', 'setUnknownProperty was not triggered');
+      assert.strictEqual(get(nativeTag, 'name'), 'edited', 'setUnknownProperty was not triggered');
 
       set(nativeTag, 'title', 'new');
-      assert.equal(get(nativeTag, 'name'), 'new', 'setUnknownProperty was triggered');
+      assert.strictEqual(get(nativeTag, 'name'), 'new', 'setUnknownProperty was triggered');
     });
 
     test('setting a property to undefined on a newly created record should not impact the current state', async function (assert) {
@@ -1066,15 +1070,15 @@ module('unit/model - Model', function (hooks) {
 
       set(tag, 'name', 'testing');
 
-      assert.equal(get(tag, 'currentState.stateName'), 'root.loaded.created.uncommitted');
+      assert.strictEqual(get(tag, 'currentState.stateName'), 'root.loaded.created.uncommitted');
 
       set(tag, 'name', undefined);
 
-      assert.equal(get(tag, 'currentState.stateName'), 'root.loaded.created.uncommitted');
+      assert.strictEqual(get(tag, 'currentState.stateName'), 'root.loaded.created.uncommitted');
 
       tag = store.createRecord('tag', { name: undefined });
 
-      assert.equal(get(tag, 'currentState.stateName'), 'root.loaded.created.uncommitted');
+      assert.strictEqual(get(tag, 'currentState.stateName'), 'root.loaded.created.uncommitted');
     });
 
     test('setting a property back to its original value removes the property from the `_attributes` hash', async function (assert) {
@@ -1089,15 +1093,19 @@ module('unit/model - Model', function (hooks) {
       });
 
       let recordData = recordDataFor(person);
-      assert.equal(recordData._attributes.name, undefined, 'the `_attributes` hash is clean');
+      assert.strictEqual(recordData._attributes.name, undefined, 'the `_attributes` hash is clean');
 
       set(person, 'name', 'Niceguy Dale');
 
-      assert.equal(recordData._attributes.name, 'Niceguy Dale', 'the `_attributes` hash contains the changed value');
+      assert.strictEqual(
+        recordData._attributes.name,
+        'Niceguy Dale',
+        'the `_attributes` hash contains the changed value'
+      );
 
       set(person, 'name', 'Scumbag Dale');
 
-      assert.equal(recordData._attributes.name, undefined, 'the `_attributes` hash is reset');
+      assert.strictEqual(recordData._attributes.name, undefined, 'the `_attributes` hash is reset');
     });
   });
 
@@ -1107,10 +1115,10 @@ module('unit/model - Model', function (hooks) {
       set(record, 'name', 'bar');
       set(record, 'anotherNotAnAttr', 'my other value');
 
-      assert.equal(get(record, 'notAnAttr'), 'my value', 'property was set on the record');
-      assert.equal(get(record, 'anotherNotAnAttr'), 'my other value', 'property was set on the record');
+      assert.strictEqual(get(record, 'notAnAttr'), 'my value', 'property was set on the record');
+      assert.strictEqual(get(record, 'anotherNotAnAttr'), 'my other value', 'property was set on the record');
       assert.false(get(record, 'isDrugAddict'), 'property was set on the record');
-      assert.equal(get(record, 'name'), 'bar', 'property was set on the record');
+      assert.strictEqual(get(record, 'name'), 'bar', 'property was set on the record');
     });
 
     test('setting a property on a record that has not changed does not cause it to become dirty', async function (assert) {
@@ -1183,13 +1191,13 @@ module('unit/model - Model', function (hooks) {
 
       let saving = person.save();
 
-      assert.equal(person.get('name'), 'Thomas');
+      assert.strictEqual(person.get('name'), 'Thomas');
 
       person.set('name', 'Tomathy');
-      assert.equal(person.get('name'), 'Tomathy');
+      assert.strictEqual(person.get('name'), 'Tomathy');
 
       person.set('name', 'Thomas');
-      assert.equal(person.get('name'), 'Thomas');
+      assert.strictEqual(person.get('name'), 'Thomas');
 
       await saving;
 
@@ -1375,7 +1383,7 @@ module('unit/model - Model', function (hooks) {
         },
       });
 
-      assert.equal(Object.keys(mascot.changedAttributes()).length, 0, 'there are no initial changes');
+      assert.strictEqual(Object.keys(mascot.changedAttributes()).length, 0, 'there are no initial changes');
 
       mascot.set('name', 'Tomster'); // new value
       mascot.set('likes', 'Ember.js'); // changed value
@@ -1388,7 +1396,11 @@ module('unit/model - Model', function (hooks) {
 
       mascot.rollbackAttributes();
 
-      assert.equal(Object.keys(mascot.changedAttributes()).length, 0, 'after rollback attributes there are no changes');
+      assert.strictEqual(
+        Object.keys(mascot.changedAttributes()).length,
+        0,
+        'after rollback attributes there are no changes'
+      );
     });
 
     test('changedAttributes() works while the record is being saved', async function (assert) {

--- a/packages/-ember-data/tests/unit/model/errors-test.js
+++ b/packages/-ember-data/tests/unit/model/errors-test.js
@@ -38,13 +38,13 @@ module('unit/model/errors', function (hooks) {
     errors.add('firstName', 'error');
     errors.trigger = assert.unexpectedSend;
     assert.ok(errors.has('firstName'), 'it has firstName errors');
-    assert.equal(errors.get('length'), 1, 'it has 1 error');
+    assert.strictEqual(errors.get('length'), 1, 'it has 1 error');
     errors.add('firstName', ['error1', 'error2']);
-    assert.equal(errors.get('length'), 3, 'it has 3 errors');
+    assert.strictEqual(errors.get('length'), 3, 'it has 3 errors');
     assert.ok(!errors.get('isEmpty'), 'it is not empty');
     errors.add('lastName', 'error');
     errors.add('lastName', 'error');
-    assert.equal(errors.get('length'), 4, 'it has 4 errors');
+    assert.strictEqual(errors.get('length'), 4, 'it has 4 errors');
   });
 
   testInDebug('get error', function (assert) {
@@ -76,7 +76,7 @@ module('unit/model/errors', function (hooks) {
     errors.remove('firstName');
     errors.trigger = assert.unexpectedSend;
     assert.ok(!errors.has('firstName'), 'it has no firstName errors');
-    assert.equal(errors.get('length'), 0, 'it has 0 error');
+    assert.strictEqual(errors.get('length'), 0, 'it has 0 error');
     assert.ok(errors.get('isEmpty'), 'it is empty');
     errors.remove('firstName');
   });
@@ -86,9 +86,9 @@ module('unit/model/errors', function (hooks) {
     errors.add('firstName', 'error');
     errors.add('lastName', 'error');
     errors.trigger = assert.unexpectedSend;
-    assert.equal(errors.get('length'), 2, 'it has 2 error');
+    assert.strictEqual(errors.get('length'), 2, 'it has 2 error');
     errors.remove('firstName');
-    assert.equal(errors.get('length'), 1, 'it has 1 error');
+    assert.strictEqual(errors.get('length'), 1, 'it has 1 error');
     errors.trigger = assert.becameValid;
     errors.remove('lastName');
     assert.ok(errors.get('isEmpty'), 'it is empty');
@@ -97,12 +97,12 @@ module('unit/model/errors', function (hooks) {
   testInDebug('clear errors', function (assert) {
     errors.trigger = assert.becameInvalid;
     errors.add('firstName', ['error', 'error1']);
-    assert.equal(errors.get('length'), 2, 'it has 2 errors');
+    assert.strictEqual(errors.get('length'), 2, 'it has 2 errors');
     errors.trigger = assert.becameValid;
     errors.clear();
     errors.trigger = assert.unexpectedSend;
     assert.ok(!errors.has('firstName'), 'it has no firstName errors');
-    assert.equal(errors.get('length'), 0, 'it has 0 error');
+    assert.strictEqual(errors.get('length'), 0, 'it has 0 error');
     errors.clear();
   });
 });

--- a/packages/-ember-data/tests/unit/model/init-properties-test.js
+++ b/packages/-ember-data/tests/unit/model/init-properties-test.js
@@ -268,8 +268,8 @@ module('unit/model - init properties', function (hooks) {
     const Post = Model.extend({
       title: attr(),
       setUnknownProperty: function (key, value) {
-        assert.equal(key, 'randomProp', 'Passed the correct key to setUknownProperty');
-        assert.equal(value, 'An unknown prop', 'Passed the correct value to setUknownProperty');
+        assert.strictEqual(key, 'randomProp', 'Passed the correct key to setUknownProperty');
+        assert.strictEqual(value, 'An unknown prop', 'Passed the correct value to setUknownProperty');
       },
     });
 

--- a/packages/-ember-data/tests/unit/model/lifecycle-callbacks-test.js
+++ b/packages/-ember-data/tests/unit/model/lifecycle-callbacks-test.js
@@ -45,8 +45,8 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
 
       return run(() => {
         return store.findRecord('person', 1).then((person) => {
-          assert.equal(person.get('id'), '1', `The person's ID is available`);
-          assert.equal(person.get('name'), 'Foo', `The person's properties are availablez`);
+          assert.strictEqual(person.get('id'), '1', `The person's ID is available`);
+          assert.strictEqual(person.get('name'), 'Foo', `The person's properties are availablez`);
         });
       });
     }
@@ -75,12 +75,12 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
 
       run(() => {
         store._pushInternalModel({ id: 1, type: 'person' });
-        assert.equal(didLoadCalled, 0, 'didLoad was not called');
+        assert.strictEqual(didLoadCalled, 0, 'didLoad was not called');
       });
 
       run(() => store.peekRecord('person', 1));
 
-      assert.equal(didLoadCalled, 1, 'didLoad was called');
+      assert.strictEqual(didLoadCalled, 1, 'didLoad was called');
     }
   );
 
@@ -101,8 +101,8 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
 
         didUpdate() {
           callCount++;
-          assert.equal(get(this, 'isSaving'), false, 'record should be saving');
-          assert.equal(get(this, 'hasDirtyAttributes'), false, 'record should not be dirty');
+          assert.strictEqual(get(this, 'isSaving'), false, 'record should be saving');
+          assert.strictEqual(get(this, 'hasDirtyAttributes'), false, 'record should not be dirty');
         },
       });
 
@@ -112,7 +112,7 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
         },
 
         updateRecord(store, type, snapshot) {
-          assert.equal(callCount, 0, 'didUpdate callback was not called until didSaveRecord is called');
+          assert.strictEqual(callCount, 0, 'didUpdate callback was not called until didSaveRecord is called');
           return resolve();
         },
       });
@@ -123,7 +123,7 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
 
       let asyncPerson = run(() => this.owner.lookup('service:store').findRecord('person', 1));
 
-      assert.equal(callCount, 0, 'precond - didUpdate callback was not called yet');
+      assert.strictEqual(callCount, 0, 'precond - didUpdate callback was not called yet');
 
       return run(() => {
         return asyncPerson
@@ -134,7 +134,7 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
             });
           })
           .then(() => {
-            assert.equal(callCount, 1, 'didUpdate called after update');
+            assert.strictEqual(callCount, 1, 'didUpdate called after update');
           });
       });
     }
@@ -154,14 +154,14 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
       const Person = Model.extend({
         didCreate() {
           callCount++;
-          assert.equal(get(this, 'isSaving'), false, 'record should not be saving');
-          assert.equal(get(this, 'hasDirtyAttributes'), false, 'record should not be dirty');
+          assert.strictEqual(get(this, 'isSaving'), false, 'record should not be saving');
+          assert.strictEqual(get(this, 'hasDirtyAttributes'), false, 'record should not be dirty');
         },
       });
 
       const ApplicationAdapter = Adapter.extend({
         createRecord(store, type, snapshot) {
-          assert.equal(callCount, 0, 'didCreate callback was not called until didSaveRecord is called');
+          assert.strictEqual(callCount, 0, 'didCreate callback was not called until didSaveRecord is called');
           return resolve();
         },
       });
@@ -170,7 +170,7 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
       this.owner.register('adapter:application', ApplicationAdapter);
       this.owner.register('serializer:application', JSONAPISerializer.extend());
 
-      assert.equal(callCount, 0, 'precond - didCreate callback was not called yet');
+      assert.strictEqual(callCount, 0, 'precond - didCreate callback was not called yet');
 
       let person = this.owner.lookup('service:store').createRecord('person', {
         id: 69,
@@ -179,7 +179,7 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
 
       return run(() => {
         return person.save().then(() => {
-          assert.equal(callCount, 1, 'didCreate called after commit');
+          assert.strictEqual(callCount, 1, 'didCreate called after commit');
         });
       });
     }
@@ -203,8 +203,8 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
         didDelete() {
           callCount++;
 
-          assert.equal(get(this, 'isSaving'), false, 'record should not be saving');
-          assert.equal(get(this, 'hasDirtyAttributes'), false, 'record should not be dirty');
+          assert.strictEqual(get(this, 'isSaving'), false, 'record should not be saving');
+          assert.strictEqual(get(this, 'hasDirtyAttributes'), false, 'record should not be dirty');
         },
       });
 
@@ -214,7 +214,7 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
         },
 
         deleteRecord(store, type, snapshot) {
-          assert.equal(callCount, 0, 'didDelete callback was not called until didSaveRecord is called');
+          assert.strictEqual(callCount, 0, 'didDelete callback was not called until didSaveRecord is called');
 
           return resolve();
         },
@@ -226,7 +226,7 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
 
       let asyncPerson = run(() => this.owner.lookup('service:store').findRecord('person', 1));
 
-      assert.equal(callCount, 0, 'precond - didDelete callback was not called yet');
+      assert.strictEqual(callCount, 0, 'precond - didDelete callback was not called yet');
 
       return run(() => {
         return asyncPerson
@@ -237,7 +237,7 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
             });
           })
           .then(() => {
-            assert.equal(callCount, 1, 'didDelete called after delete');
+            assert.strictEqual(callCount, 1, 'didDelete called after delete');
           });
       });
     }
@@ -260,8 +260,8 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
 
         didDelete() {
           callCount++;
-          assert.equal(this.isSaving, false, 'record should not be saving');
-          assert.equal(this.hasDirtyAttributes, false, 'record should not be dirty');
+          assert.strictEqual(this.isSaving, false, 'record should not be saving');
+          assert.strictEqual(this.hasDirtyAttributes, false, 'record should not be dirty');
         },
       });
 
@@ -271,11 +271,11 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
         name: 'Tomster',
       });
 
-      assert.equal(callCount, 0, 'precond - didDelete callback was not called yet');
+      assert.strictEqual(callCount, 0, 'precond - didDelete callback was not called yet');
 
       run(() => person.deleteRecord());
 
-      assert.equal(callCount, 1, 'didDelete called after delete');
+      assert.strictEqual(callCount, 1, 'didDelete called after delete');
     }
   );
 
@@ -297,8 +297,8 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
         becameInvalid() {
           callCount++;
 
-          assert.equal(get(this, 'isSaving'), false, 'record should not be saving');
-          assert.equal(get(this, 'hasDirtyAttributes'), true, 'record should be dirty');
+          assert.strictEqual(get(this, 'isSaving'), false, 'record should not be saving');
+          assert.strictEqual(get(this, 'hasDirtyAttributes'), true, 'record should be dirty');
         },
       });
 
@@ -308,7 +308,7 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
         },
 
         updateRecord(store, type, snapshot) {
-          assert.equal(callCount, 0, 'becameInvalid callback was not called until recordWasInvalid is called');
+          assert.strictEqual(callCount, 0, 'becameInvalid callback was not called until recordWasInvalid is called');
 
           return reject(
             new InvalidError([
@@ -329,7 +329,7 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
       this.owner.register('serializer:application', JSONAPISerializer.extend());
 
       let asyncPerson = run(() => this.owner.lookup('service:store').findRecord('person', 1));
-      assert.equal(callCount, 0, 'precond - becameInvalid callback was not called yet');
+      assert.strictEqual(callCount, 0, 'precond - becameInvalid callback was not called yet');
 
       // Make sure that the error handler has a chance to attach before
       // save fails.
@@ -340,9 +340,9 @@ module('unit/model/lifecycle_callbacks - Lifecycle Callbacks', function (hooks) 
             return person.save().catch((reason) => {
               assert.ok(reason.isAdapterError, 'reason should have been an adapter error');
 
-              assert.equal(reason.errors.length, 1, 'reason should have one error');
-              assert.equal(reason.errors[0].title, 'Invalid Attribute');
-              assert.equal(callCount, 1, 'becameInvalid called after invalidating');
+              assert.strictEqual(reason.errors.length, 1, 'reason should have one error');
+              assert.strictEqual(reason.errors[0].title, 'Invalid Attribute');
+              assert.strictEqual(callCount, 1, 'becameInvalid called after invalidating');
             });
           });
         });

--- a/packages/-ember-data/tests/unit/model/merge-test.js
+++ b/packages/-ember-data/tests/unit/model/merge-test.js
@@ -42,13 +42,13 @@ module('unit/model/merge - Merging', function (hooks) {
     return run(() => {
       let save = person.save();
 
-      assert.equal(person.get('name'), 'Tom Dale');
+      assert.strictEqual(person.get('name'), 'Tom Dale');
 
       person.set('name', 'Thomas Dale');
 
       return save.then((person) => {
         assert.true(person.get('hasDirtyAttributes'), 'The person is still dirty');
-        assert.equal(person.get('name'), 'Thomas Dale', 'The changes made still apply');
+        assert.strictEqual(person.get('name'), 'Thomas Dale', 'The changes made still apply');
       });
     });
   });
@@ -58,7 +58,7 @@ module('unit/model/merge - Merging', function (hooks) {
 
     const ApplicationAdapter = Adapter.extend({
       updateRecord(store, type, snapshot) {
-        assert.equal(snapshot.attr('name'), 'Thomas Dale');
+        assert.strictEqual(snapshot.attr('name'), 'Thomas Dale');
 
         return resolve();
       },
@@ -83,15 +83,15 @@ module('unit/model/merge - Merging', function (hooks) {
     return run(() => {
       let promise = person.save();
 
-      assert.equal(person.get('name'), 'Thomas Dale');
+      assert.strictEqual(person.get('name'), 'Thomas Dale');
 
       person.set('name', 'Tomasz Dale');
 
-      assert.equal(person.get('name'), 'Tomasz Dale', 'the local changes applied on top');
+      assert.strictEqual(person.get('name'), 'Tomasz Dale', 'the local changes applied on top');
 
       return promise.then((person) => {
         assert.true(person.get('hasDirtyAttributes'), 'The person is still dirty');
-        assert.equal(person.get('name'), 'Tomasz Dale', 'The local changes apply');
+        assert.strictEqual(person.get('name'), 'Tomasz Dale', 'The local changes apply');
       });
     });
   });
@@ -134,7 +134,7 @@ module('unit/model/merge - Merging', function (hooks) {
     return run(() => {
       var promise = person.save();
 
-      assert.equal(person.get('name'), 'Thomas Dale');
+      assert.strictEqual(person.get('name'), 'Thomas Dale');
 
       person.set('name', 'Tomasz Dale');
 
@@ -149,13 +149,17 @@ module('unit/model/merge - Merging', function (hooks) {
         },
       });
 
-      assert.equal(person.get('name'), 'Tomasz Dale', 'the local changes applied on top');
-      assert.equal(person.get('city'), 'PDX', 'the pushed change is available');
+      assert.strictEqual(person.get('name'), 'Tomasz Dale', 'the local changes applied on top');
+      assert.strictEqual(person.get('city'), 'PDX', 'the pushed change is available');
 
       return promise.then((person) => {
         assert.true(person.get('hasDirtyAttributes'), 'The person is still dirty');
-        assert.equal(person.get('name'), 'Tomasz Dale', 'The local changes apply');
-        assert.equal(person.get('city'), 'Portland', 'The updates from the server apply on top of the previous pushes');
+        assert.strictEqual(person.get('name'), 'Tomasz Dale', 'The local changes apply');
+        assert.strictEqual(
+          person.get('city'),
+          'Portland',
+          'The updates from the server apply on top of the previous pushes'
+        );
       });
     });
   });
@@ -178,8 +182,8 @@ module('unit/model/merge - Merging', function (hooks) {
     });
 
     assert.true(person.get('hasDirtyAttributes'), 'the person is currently dirty');
-    assert.equal(person.get('name'), 'Tomasz Dale', 'the update was effective');
-    assert.equal(person.get('city'), 'San Francisco', 'the original data applies');
+    assert.strictEqual(person.get('name'), 'Tomasz Dale', 'the update was effective');
+    assert.strictEqual(person.get('city'), 'San Francisco', 'the original data applies');
 
     run(() => {
       this.store.push({
@@ -195,8 +199,8 @@ module('unit/model/merge - Merging', function (hooks) {
     });
 
     assert.true(person.get('hasDirtyAttributes'), 'the local changes are reapplied');
-    assert.equal(person.get('name'), 'Tomasz Dale', 'the local changes are reapplied');
-    assert.equal(person.get('city'), 'Portland', 'if there are no local changes, the new data applied');
+    assert.strictEqual(person.get('name'), 'Tomasz Dale', 'the local changes are reapplied');
+    assert.strictEqual(person.get('city'), 'Portland', 'if there are no local changes, the new data applied');
   });
 
   test('When a record is invalid, pushes are overridden by local changes', async function (assert) {
@@ -233,8 +237,8 @@ module('unit/model/merge - Merging', function (hooks) {
     }
     assert.false(person.get('isValid'), 'the person is currently invalid');
     assert.true(person.get('hasDirtyAttributes'), 'the person is currently dirty');
-    assert.equal(person.get('name'), 'Brondan McLoughlin', 'the update was effective');
-    assert.equal(person.get('city'), 'Boston', 'the original data applies');
+    assert.strictEqual(person.get('name'), 'Brondan McLoughlin', 'the update was effective');
+    assert.strictEqual(person.get('city'), 'Boston', 'the original data applies');
 
     run(() => {
       this.store.push({
@@ -251,8 +255,8 @@ module('unit/model/merge - Merging', function (hooks) {
 
     assert.true(person.get('hasDirtyAttributes'), 'the local changes are reapplied');
     assert.false(person.get('isValid'), 'record is still invalid');
-    assert.equal(person.get('name'), 'Brondan McLoughlin', 'the local changes are reapplied');
-    assert.equal(person.get('city'), 'Prague', 'if there are no local changes, the new data applied');
+    assert.strictEqual(person.get('name'), 'Brondan McLoughlin', 'the local changes are reapplied');
+    assert.strictEqual(person.get('city'), 'Prague', 'if there are no local changes, the new data applied');
   });
 
   test('A record with no changes can still be saved', function (assert) {
@@ -280,7 +284,7 @@ module('unit/model/merge - Merging', function (hooks) {
 
     return run(() => {
       return person.save().then((foo) => {
-        assert.equal(person.get('name'), 'Thomas Dale', 'the updates occurred');
+        assert.strictEqual(person.get('name'), 'Thomas Dale', 'the updates occurred');
       });
     });
   });
@@ -316,8 +320,8 @@ module('unit/model/merge - Merging', function (hooks) {
     return run(() => {
       return person.reload().then(() => {
         assert.true(person.get('hasDirtyAttributes'), 'the person is dirty');
-        assert.equal(person.get('name'), 'Tomasz Dale', 'the local changes remain');
-        assert.equal(person.get('city'), 'Portland', 'the new changes apply');
+        assert.strictEqual(person.get('name'), 'Tomasz Dale', 'the local changes remain');
+        assert.strictEqual(person.get('city'), 'Portland', 'the new changes apply');
       });
     });
   });

--- a/packages/-ember-data/tests/unit/model/relationships-test.js
+++ b/packages/-ember-data/tests/unit/model/relationships-test.js
@@ -97,7 +97,7 @@ module('[@ember-data/model] unit - relationships', function (hooks) {
 
     const relationship = relationships.get('user-profile')[0];
 
-    assert.equal(relationship.meta.name, 'userProfile', 'relationship name has not been changed');
+    assert.strictEqual(relationship.meta.name, 'userProfile', 'relationship name has not been changed');
   });
 
   test('normalizing hasMany relationship names', function (assert) {
@@ -126,7 +126,7 @@ module('[@ember-data/model] unit - relationships', function (hooks) {
 
     const relationship = relationships.get('stream-item')[0];
 
-    assert.equal(relationship.meta.name, 'streamItems', 'relationship name has not been changed');
+    assert.strictEqual(relationship.meta.name, 'streamItems', 'relationship name has not been changed');
   });
 
   if (gte('3.10.0')) {
@@ -156,7 +156,7 @@ module('[@ember-data/model] unit - relationships', function (hooks) {
 
       const relationship = relationships.get('stream-item')[0];
 
-      assert.equal(relationship.meta.name, 'streamItems', 'relationship name has not been changed');
+      assert.strictEqual(relationship.meta.name, 'streamItems', 'relationship name has not been changed');
     });
   }
 });

--- a/packages/-ember-data/tests/unit/model/relationships/belongs-to-test.js
+++ b/packages/-ember-data/tests/unit/model/relationships/belongs-to-test.js
@@ -83,10 +83,10 @@ module('unit/model/relationships - belongsTo', function (hooks) {
 
     return run(() => {
       return store.findRecord('person', 1).then((person) => {
-        assert.equal(get(person, 'name'), 'Tom Dale', 'precond - retrieves person record from store');
+        assert.strictEqual(get(person, 'name'), 'Tom Dale', 'precond - retrieves person record from store');
 
         assert.true(get(person, 'tag') instanceof Tag, 'the tag property should return a tag');
-        assert.equal(get(person, 'tag.name'), 'friendly', 'the tag shuld have name');
+        assert.strictEqual(get(person, 'tag.name'), 'friendly', 'the tag shuld have name');
 
         assert.strictEqual(get(person, 'tag'), get(person, 'tag'), 'the returned object is always the same');
         assert.asyncEqual(
@@ -157,7 +157,7 @@ module('unit/model/relationships - belongsTo', function (hooks) {
 
       person.addObserver('tag', tagDidChange);
 
-      assert.equal(person.get('tag.name'), 'whatever', 'relationship is correct');
+      assert.strictEqual(person.get('tag.name'), 'whatever', 'relationship is correct');
 
       // This needs to be removed so it is not triggered when test context is torn down
       person.removeObserver('tag', tagDidChange);
@@ -184,7 +184,7 @@ module('unit/model/relationships - belongsTo', function (hooks) {
 
     adapter.findRecord = function (store, type, id, snapshot) {
       if (type === Person) {
-        assert.equal(id, 1, 'id should be 1');
+        assert.strictEqual(id, '1', 'id should be 1');
 
         return {
           data: {
@@ -195,7 +195,7 @@ module('unit/model/relationships - belongsTo', function (hooks) {
           },
         };
       } else if (type === Tag) {
-        assert.equal(id, 2, 'id should be 2');
+        assert.strictEqual(id, '2', 'id should be 2');
 
         return { data: { id: 2, type: 'tag', attributes: { name: 'friendly' } } };
       }
@@ -205,14 +205,14 @@ module('unit/model/relationships - belongsTo', function (hooks) {
       return store
         .findRecord('person', 1)
         .then((person) => {
-          assert.equal(get(person, 'name'), 'Tom Dale', 'The person is now populated');
+          assert.strictEqual(get(person, 'name'), 'Tom Dale', 'The person is now populated');
 
           return run(() => {
             return get(person, 'tag');
           });
         })
         .then((tag) => {
-          assert.equal(get(tag, 'name'), 'friendly', 'Tom Dale is now friendly');
+          assert.strictEqual(get(tag, 'name'), 'friendly', 'Tom Dale is now friendly');
           assert.true(get(tag, 'isLoaded'), 'Tom Dale is now loaded');
         });
     });
@@ -272,7 +272,7 @@ module('unit/model/relationships - belongsTo', function (hooks) {
     };
 
     adapter.findRecord = function (store, type, id) {
-      assert.equal(type.modelName, 'tag', 'modelName is tag');
+      assert.strictEqual(type.modelName, 'tag', 'modelName is tag');
 
       if (id === '3') {
         return Promise.resolve({
@@ -296,10 +296,10 @@ module('unit/model/relationships - belongsTo', function (hooks) {
     let persons = [store.peekRecord('person', '1'), store.peekRecord('person', '2')];
     let [tag1, tag2] = await Promise.all(persons.map((person) => get(person, 'tag')));
 
-    assert.equal(get(tag1, 'name'), 'friendly', 'Tom Dale is now friendly');
+    assert.strictEqual(get(tag1, 'name'), 'friendly', 'Tom Dale is now friendly');
     assert.true(get(tag1, 'isLoaded'), "Tom Dale's tag is now loaded");
 
-    assert.equal(get(tag2, 'name'), 'nice', 'Bob Dylan is now nice');
+    assert.strictEqual(get(tag2, 'name'), 'nice', 'Bob Dylan is now nice');
     assert.true(get(tag2, 'isLoaded'), "Bob Dylan's tag is now loaded");
   });
 
@@ -353,7 +353,7 @@ module('unit/model/relationships - belongsTo', function (hooks) {
     });
 
     adapter.findMany = function (store, type, ids, snapshots) {
-      assert.equal(type.modelName, 'tag', 'modelName is tag');
+      assert.strictEqual(type.modelName, 'tag', 'modelName is tag');
       assert.deepEqual(ids, ['3', '4'], 'it coalesces the find requests correctly');
 
       return Promise.resolve({
@@ -379,10 +379,10 @@ module('unit/model/relationships - belongsTo', function (hooks) {
     let persons = [store.peekRecord('person', '1'), store.peekRecord('person', '2')];
     let [tag1, tag2] = await Promise.all(persons.map((person) => get(person, 'tag')));
 
-    assert.equal(get(tag1, 'name'), 'friendly', 'Tom Dale is now friendly');
+    assert.strictEqual(get(tag1, 'name'), 'friendly', 'Tom Dale is now friendly');
     assert.true(get(tag1, 'isLoaded'), "Tom Dale's tag is now loaded");
 
-    assert.equal(get(tag2, 'name'), 'nice', 'Bob Dylan is now nice');
+    assert.strictEqual(get(tag2, 'name'), 'nice', 'Bob Dylan is now nice');
     assert.true(get(tag2, 'isLoaded'), "Bob Dylan's tag is now loaded");
   });
 
@@ -431,11 +431,11 @@ module('unit/model/relationships - belongsTo', function (hooks) {
 
     return run(() => {
       let person = store.peekRecord('person', 1);
-      assert.equal(get(person, 'name'), 'Tom Dale', 'The person is now populated');
+      assert.strictEqual(get(person, 'name'), 'Tom Dale', 'The person is now populated');
       return run(() => {
         return get(person, 'tag');
       }).then((tag) => {
-        assert.equal(get(tag, 'name'), 'friendly', 'Tom Dale is now friendly');
+        assert.strictEqual(get(tag, 'name'), 'friendly', 'Tom Dale is now friendly');
         assert.true(get(tag, 'isLoaded'), 'Tom Dale is now loaded');
       });
     });
@@ -471,13 +471,13 @@ module('unit/model/relationships - belongsTo', function (hooks) {
       ],
     });
 
-    assert.equal(tag1.label, 'A', 'tag1 is loaded');
-    assert.equal(tag2.label, 'B', 'tag2 is loaded');
-    assert.equal(user.tag.id, '1', 'user starts with tag1 as tag');
+    assert.strictEqual(tag1.label, 'A', 'tag1 is loaded');
+    assert.strictEqual(tag2.label, 'B', 'tag2 is loaded');
+    assert.strictEqual(user.tag.id, '1', 'user starts with tag1 as tag');
 
     user.set('tag', tag2);
 
-    assert.equal(user.tag.id, '2', 'user tag updated to tag2');
+    assert.strictEqual(user.tag.id, '2', 'user tag updated to tag2');
 
     adapter.updateRecord = function () {
       return {
@@ -497,7 +497,7 @@ module('unit/model/relationships - belongsTo', function (hooks) {
     };
 
     await user.save();
-    assert.equal(user.tag.id, '1', 'expected new server state to be applied');
+    assert.strictEqual(user.tag.id, '1', 'expected new server state to be applied');
   });
 
   test('calling createRecord and passing in an undefined value for a relationship should be treated as if null', function (assert) {
@@ -550,7 +550,7 @@ module('unit/model/relationships - belongsTo', function (hooks) {
     adapter.shouldBackgroundReloadRecord = () => false;
 
     adapter.findMany = function (store, type, ids, snapshots) {
-      assert.equal(snapshots[0].belongsTo('person').id, '1');
+      assert.strictEqual(snapshots[0].belongsTo('person').id, '1');
       return {
         data: [
           { id: 5, type: 'occupation', attributes: { description: 'fifth' } },
@@ -586,14 +586,14 @@ module('unit/model/relationships - belongsTo', function (hooks) {
         .findRecord('person', 1)
         .then((person) => {
           assert.true(get(person, 'isLoaded'), 'isLoaded should be true');
-          assert.equal(get(person, 'name'), 'Tom Dale', 'the person is still Tom Dale');
+          assert.strictEqual(get(person, 'name'), 'Tom Dale', 'the person is still Tom Dale');
 
           return get(person, 'occupations');
         })
         .then((occupations) => {
-          assert.equal(get(occupations, 'length'), 2, 'the list of occupations should have the correct length');
+          assert.strictEqual(get(occupations, 'length'), 2, 'the list of occupations should have the correct length');
 
-          assert.equal(get(occupations.objectAt(0), 'description'), 'fifth', 'the occupation is the fifth');
+          assert.strictEqual(get(occupations.objectAt(0), 'description'), 'fifth', 'the occupation is the fifth');
           assert.true(get(occupations.objectAt(0), 'isLoaded'), 'the occupation is now loaded');
         });
     });
@@ -619,7 +619,7 @@ module('unit/model/relationships - belongsTo', function (hooks) {
     let adapter = store.adapterFor('application');
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(snapshot.belongsTo('person').id, '1');
+      assert.strictEqual(snapshot.belongsTo('person').id, '1');
       return { data: { id: 5, type: 'occupation', attributes: { description: 'fifth' } } };
     };
 
@@ -706,10 +706,10 @@ module('unit/model/relationships - belongsTo', function (hooks) {
 
     return run(() => {
       return store.findRecord('person', 1).then((person) => {
-        assert.equal(get(person, 'name'), 'Tom Dale', 'precond - retrieves person record from store');
+        assert.strictEqual(get(person, 'name'), 'Tom Dale', 'precond - retrieves person record from store');
 
         assert.true(get(person, 'tag') instanceof Tag, 'the tag property should return a tag');
-        assert.equal(get(person, 'tag.name'), 'friendly', 'the tag should have name');
+        assert.strictEqual(get(person, 'tag.name'), 'friendly', 'the tag should have name');
 
         assert.strictEqual(get(person, 'tag'), get(person, 'tag'), 'the returned object is always the same');
         assert.asyncEqual(

--- a/packages/-ember-data/tests/unit/model/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/unit/model/relationships/has-many-test.js
@@ -124,11 +124,11 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
       return store
         .findRecord('person', 1)
         .then((person) => {
-          assert.equal(get(person, 'name'), 'Tom Dale', 'precond - retrieves person record from store');
+          assert.strictEqual(get(person, 'name'), 'Tom Dale', 'precond - retrieves person record from store');
 
           let tags = get(person, 'tags');
-          assert.equal(get(tags, 'length'), 1, 'the list of tags should have the correct length');
-          assert.equal(get(tags.objectAt(0), 'name'), 'friendly', 'the first tag should be a Tag');
+          assert.strictEqual(get(tags, 'length'), 1, 'the list of tags should have the correct length');
+          assert.strictEqual(get(tags.objectAt(0), 'name'), 'friendly', 'the first tag should be a Tag');
 
           run(() => {
             store.push({
@@ -150,15 +150,15 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
             });
           });
 
-          assert.equal(tags, get(person, 'tags'), 'a relationship returns the same object every time');
-          assert.equal(get(get(person, 'tags'), 'length'), 2, 'the length is updated after new data is loaded');
+          assert.strictEqual(tags, get(person, 'tags'), 'a relationship returns the same object every time');
+          assert.strictEqual(get(get(person, 'tags'), 'length'), 2, 'the length is updated after new data is loaded');
 
           assert.strictEqual(
             get(person, 'tags').objectAt(0),
             get(person, 'tags').objectAt(0),
             'the returned object is always the same'
           );
-          assert.equal(
+          assert.strictEqual(
             get(person, 'tags').objectAt(0),
             store.peekRecord('tag', 5),
             'relationship objects are the same as objects retrieved directly'
@@ -179,7 +179,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
           return store.findRecord('person', 3);
         })
         .then((kselden) => {
-          assert.equal(
+          assert.strictEqual(
             get(get(kselden, 'tags'), 'length'),
             0,
             'a relationship that has not been supplied returns an empty array'
@@ -204,11 +204,11 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
           return store.findRecord('person', 4);
         })
         .then((cyvid) => {
-          assert.equal(get(cyvid, 'name'), 'Cyvid Hamluck', 'precond - retrieves person record from store');
+          assert.strictEqual(get(cyvid, 'name'), 'Cyvid Hamluck', 'precond - retrieves person record from store');
 
           let pets = get(cyvid, 'pets');
-          assert.equal(get(pets, 'length'), 1, 'the list of pets should have the correct length');
-          assert.equal(get(pets.objectAt(0), 'name'), 'fluffy', 'the first pet should be correct');
+          assert.strictEqual(get(pets, 'length'), 1, 'the list of pets should have the correct length');
+          assert.strictEqual(get(pets.objectAt(0), 'name'), 'fluffy', 'the first pet should be correct');
 
           run(() => {
             store.push({
@@ -230,8 +230,8 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
             });
           });
 
-          assert.equal(pets, get(cyvid, 'pets'), 'a relationship returns the same object every time');
-          assert.equal(get(get(cyvid, 'pets'), 'length'), 2, 'the length is updated after new data is loaded');
+          assert.strictEqual(pets, get(cyvid, 'pets'), 'a relationship returns the same object every time');
+          assert.strictEqual(get(get(cyvid, 'pets'), 'length'), 2, 'the length is updated after new data is loaded');
         });
     });
   });
@@ -299,7 +299,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
         assert.ok(false, 'observer is not called');
       });
 
-      assert.equal(tag.get('people').mapBy('name'), 'David J. Hamilton', 'relationship is correct');
+      assert.deepEqual(tag.get('people').mapBy('name'), ['David J. Hamilton'], 'relationship is correct');
     });
   });
 
@@ -344,7 +344,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     return run(() => {
       let tag = store.peekRecord('tag', 1);
 
-      assert.equal(tag.get('people.length'), 0, 'relationship is correct');
+      assert.strictEqual(tag.get('people.length'), 0, 'relationship is correct');
     });
   });
 
@@ -429,8 +429,8 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
       let tag = store.peekRecord('tag', 1);
       let person = store.peekRecord('person', 1);
 
-      assert.equal(person.get('tag'), null, 'relationship is empty');
-      assert.equal(tag.get('people.length'), 0, 'relationship is correct');
+      assert.strictEqual(person.get('tag'), null, 'relationship is empty');
+      assert.strictEqual(tag.get('people.length'), 0, 'relationship is correct');
     });
   });
 
@@ -510,7 +510,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     run(() => {
       let tag = store.peekRecord('tag', 1);
-      assert.equal(tag.get('people.length'), 1, 'relationship does not contain duplicates');
+      assert.strictEqual(tag.get('people.length'), 1, 'relationship does not contain duplicates');
     });
   });
 
@@ -642,11 +642,11 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     run(() => {
       let tag = store.peekRecord('tag', 1);
-      assert.equal(tag.get('people.length'), 2, 'relationship does contain all data');
+      assert.strictEqual(tag.get('people.length'), 2, 'relationship does contain all data');
       let person1 = store.peekRecord('person', 1);
-      assert.equal(person1.get('tags.length'), 2, 'relationship does contain all data');
+      assert.strictEqual(person1.get('tags.length'), 2, 'relationship does contain all data');
       let person2 = store.peekRecord('person', 2);
-      assert.equal(person2.get('tags.length'), 2, 'relationship does contain all data');
+      assert.strictEqual(person2.get('tags.length'), 2, 'relationship does contain all data');
     });
   });
 
@@ -715,7 +715,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
       let person = store.peekRecord('person', 1);
       let tag = store.peekRecord('tag', 1);
 
-      assert.equal(person.get('tag'), tag, 'relationship is not empty');
+      assert.strictEqual(person.get('tag'), tag, 'relationship is not empty');
     });
 
     run(() => {
@@ -740,8 +740,8 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
       let person = store.peekRecord('person', 1);
       let tag = store.peekRecord('tag', 1);
 
-      assert.equal(person.get('tag'), null, 'relationship is now empty');
-      assert.equal(tag.get('people.length'), 0, 'relationship is correct');
+      assert.strictEqual(person.get('tag'), null, 'relationship is now empty');
+      assert.strictEqual(tag.get('people.length'), 0, 'relationship is correct');
     });
   });
 
@@ -898,7 +898,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
         .then(function (person) {
           wycats = person;
 
-          assert.equal(get(wycats, 'name'), 'Yehuda Katz', 'precond - retrieves person record from store');
+          assert.strictEqual(get(wycats, 'name'), 'Yehuda Katz', 'precond - retrieves person record from store');
 
           return hash({
             wycats,
@@ -906,15 +906,15 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
           });
         })
         .then((records) => {
-          assert.equal(get(records.tags, 'length'), 1, 'the list of tags should have the correct length');
-          assert.equal(get(records.tags.objectAt(0), 'name'), 'oohlala', 'the first tag should be a Tag');
+          assert.strictEqual(get(records.tags, 'length'), 1, 'the list of tags should have the correct length');
+          assert.strictEqual(get(records.tags.objectAt(0), 'name'), 'oohlala', 'the first tag should be a Tag');
 
           assert.strictEqual(
             records.tags.objectAt(0),
             records.tags.objectAt(0),
             'the returned object is always the same'
           );
-          assert.equal(
+          assert.strictEqual(
             records.tags.objectAt(0),
             store.peekRecord('tag', 12),
             'relationship objects are the same as objects retrieved directly'
@@ -941,7 +941,11 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     let store = this.owner.lookup('service:store');
 
-    assert.equal(store.modelFor('person').typeForRelationship('tags', store), Tag, 'returns the relationship type');
+    assert.strictEqual(
+      store.modelFor('person').typeForRelationship('tags', store),
+      Tag,
+      'returns the relationship type'
+    );
   });
 
   test('should be able to retrieve the type for a hasMany relationship specified using a string from its metadata', function (assert) {
@@ -956,7 +960,11 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     let store = this.owner.lookup('service:store');
 
-    assert.equal(store.modelFor('person').typeForRelationship('tags', store), Tag, 'returns the relationship type');
+    assert.strictEqual(
+      store.modelFor('person').typeForRelationship('tags', store),
+      Tag,
+      'returns the relationship type'
+    );
   });
 
   test('should be able to retrieve the type for a belongsTo relationship without specifying a type from its metadata', function (assert) {
@@ -971,7 +979,11 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     let store = this.owner.lookup('service:store');
 
-    assert.equal(store.modelFor('person').typeForRelationship('tag', store), Tag, 'returns the relationship type');
+    assert.strictEqual(
+      store.modelFor('person').typeForRelationship('tag', store),
+      Tag,
+      'returns the relationship type'
+    );
   });
 
   test('should be able to retrieve the type for a belongsTo relationship specified using a string from its metadata', function (assert) {
@@ -988,7 +1000,11 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     let store = this.owner.lookup('service:store');
 
-    assert.equal(store.modelFor('person').typeForRelationship('tags', store), Tag, 'returns the relationship type');
+    assert.strictEqual(
+      store.modelFor('person').typeForRelationship('tags', store),
+      Tag,
+      'returns the relationship type'
+    );
   });
 
   test('relationships work when declared with a string path', function (assert) {
@@ -1056,8 +1072,8 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     return run(() => {
       return store.findRecord('person', 1).then((person) => {
-        assert.equal(get(person, 'name'), 'Tom Dale', 'precond - retrieves person record from store');
-        assert.equal(get(person, 'tags.length'), 2, 'the list of tags should have the correct length');
+        assert.strictEqual(get(person, 'name'), 'Tom Dale', 'precond - retrieves person record from store');
+        assert.strictEqual(get(person, 'tags.length'), 2, 'the list of tags should have the correct length');
       });
     });
   });
@@ -1083,7 +1099,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     adapter.coalesceFindRequests = true;
     adapter.findMany = function (store, type, ids, snapshots) {
-      assert.equal(type, Tag, 'type should be Tag');
+      assert.strictEqual(type, Tag, 'type should be Tag');
       assert.deepEqual(ids, ['5', '2'], 'ids should be 5 and 2');
 
       return {
@@ -1095,8 +1111,8 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     };
 
     adapter.findRecord = function (store, type, id, snapshot) {
-      assert.equal(type, Person, 'type should be Person');
-      assert.equal(id, 1, 'id should be 1');
+      assert.strictEqual(type, Person, 'type should be Person');
+      assert.strictEqual(id, '1', 'id should be 1');
 
       return {
         data: {
@@ -1119,13 +1135,13 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
       return store
         .findRecord('person', 1)
         .then((person) => {
-          assert.equal(get(person, 'name'), 'Tom Dale', 'The person is now populated');
+          assert.strictEqual(get(person, 'name'), 'Tom Dale', 'The person is now populated');
 
           return run(() => person.get('tags'));
         })
         .then((tags) => {
-          assert.equal(get(tags, 'length'), 2, 'the tags object still exists');
-          assert.equal(get(tags.objectAt(0), 'name'), 'friendly', 'Tom Dale is now friendly');
+          assert.strictEqual(get(tags, 'length'), 2, 'the tags object still exists');
+          assert.strictEqual(get(tags.objectAt(0), 'name'), 'friendly', 'Tom Dale is now friendly');
           assert.true(get(tags.objectAt(0), 'isLoaded'), 'Tom Dale is now loaded');
         });
     });
@@ -1182,12 +1198,12 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
       return store.findRecord('person', 1).then((person) => {
         let tag = get(person, 'tags').objectAt(0);
 
-        assert.equal(get(tag, 'name'), 'ember', 'precond - relationships work');
+        assert.strictEqual(get(tag, 'name'), 'ember', 'precond - relationships work');
 
         tag = store.createRecord('tag', { name: 'js' });
         get(person, 'tags').pushObject(tag);
 
-        assert.equal(get(person, 'tags').objectAt(1), tag, 'newly added relationship works');
+        assert.strictEqual(get(person, 'tags').objectAt(1), tag, 'newly added relationship works');
       });
     });
   });
@@ -1263,7 +1279,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     const rambo = store.peekRecord('pet', '2');
     const rebel = store.peekRecord('pet', '3');
 
-    assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+    assert.strictEqual(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
     assert.deepEqual(
       pets.map((p) => get(p, 'id')),
       ['1'],
@@ -1363,7 +1379,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     const shen = pets.objectAt(0);
     const rebel = store.peekRecord('pet', '3');
 
-    assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+    assert.strictEqual(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
     assert.deepEqual(
       pets.map((p) => get(p, 'id')),
       ['1'],
@@ -1481,7 +1497,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     const shen = pets.objectAt(0);
     const rebel = store.peekRecord('pet', '3');
 
-    assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+    assert.strictEqual(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
     assert.deepEqual(
       pets.map((p) => get(p, 'id')),
       ['1', '3'],
@@ -1602,13 +1618,13 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
         const rambo = store.peekRecord('pet', '2');
         const rebel = store.peekRecord('pet', '3');
 
-        assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+        assert.strictEqual(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
         assert.deepEqual(
           pets.map((p) => get(p, 'id')),
           ['1'],
           'precond - relationship has the correct pet to start'
         );
-        assert.equal(get(petsProxy, 'length'), 1, 'precond - proxy has only one pet to start');
+        assert.strictEqual(get(petsProxy, 'length'), 1, 'precond - proxy has only one pet to start');
 
         pets.pushObjects([rambo, rebel]);
 
@@ -1617,7 +1633,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
           ['1', '2', '3'],
           'precond2 - relationship now has the correct three pets'
         );
-        assert.equal(get(petsProxy, 'length'), 3, 'precond2 - proxy now reflects three pets');
+        assert.strictEqual(get(petsProxy, 'length'), 3, 'precond2 - proxy now reflects three pets');
 
         return shen.destroyRecord({}).then(() => {
           shen.unloadRecord();
@@ -1627,7 +1643,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
             ['2', '3'],
             'relationship now has the correct two pets'
           );
-          assert.equal(get(petsProxy, 'length'), 2, 'proxy now reflects two pets');
+          assert.strictEqual(get(petsProxy, 'length'), 2, 'proxy now reflects two pets');
         });
       });
     });
@@ -1695,21 +1711,21 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     const rambo = store.peekRecord('dog', '2');
 
     assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
-    assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
+    assert.strictEqual(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
 
     run(() => {
       person.set('dog', rambo);
     });
 
     dog = person.get('dog');
-    assert.equal(dog, rambo, 'precond2 - relationship was updated');
+    assert.strictEqual(dog, rambo, 'precond2 - relationship was updated');
 
     return run(() => {
       return shen.destroyRecord({}).then(() => {
         shen.unloadRecord();
 
         dog = person.get('dog');
-        assert.equal(dog, rambo, 'The currentState of the belongsTo was preserved after the delete');
+        assert.strictEqual(dog, rambo, 'The currentState of the belongsTo was preserved after the delete');
       });
     });
   });
@@ -1777,7 +1793,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
       return person.get('dog').then((dog) => {
         assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
-        assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
+        assert.strictEqual(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
 
         person.set('dog', rambo);
 
@@ -1857,21 +1873,21 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     const rambo = store.peekRecord('dog', '2');
 
     assert.ok(dog === shen, 'precond - the belongsTo points to the correct dog');
-    assert.equal(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
+    assert.strictEqual(get(dog, 'name'), 'Shenanigans', 'precond - relationships work');
 
     run(() => {
       person.set('dog', rambo);
     });
 
     dog = person.get('dog');
-    assert.equal(dog, rambo, 'precond2 - relationship was updated');
+    assert.strictEqual(dog, rambo, 'precond2 - relationship was updated');
 
     return run(() => {
       return rambo.destroyRecord({}).then(() => {
         rambo.unloadRecord();
 
         dog = person.get('dog');
-        assert.equal(dog, null, 'The current state of the belongsTo was clearer');
+        assert.strictEqual(dog, null, 'The current state of the belongsTo was clearer');
       });
     });
   });
@@ -1930,16 +1946,16 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     let person = store.peekRecord('person', 1);
     let cars = person.get('cars');
 
-    assert.equal(cars.get('length'), 2);
+    assert.strictEqual(cars.get('length'), 2);
 
     run(() => {
       cars.get('firstObject').unloadRecord();
-      assert.equal(cars.get('length'), 1); // unload now..
-      assert.equal(person.get('cars.length'), 1); // unload now..
+      assert.strictEqual(cars.get('length'), 1); // unload now..
+      assert.strictEqual(person.get('cars.length'), 1); // unload now..
     });
 
-    assert.equal(cars.get('length'), 1); // unload now..
-    assert.equal(person.get('cars.length'), 1); // unload now..
+    assert.strictEqual(cars.get('length'), 1); // unload now..
+    assert.strictEqual(person.get('cars.length'), 1); // unload now..
   });
 
   /*
@@ -2040,7 +2056,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     const shen = store.peekRecord('pet', '1');
     const rebel = store.peekRecord('pet', '3');
 
-    assert.equal(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
+    assert.strictEqual(get(shen, 'name'), 'Shenanigans', 'precond - relationships work');
     assert.deepEqual(
       pets.map((p) => get(p, 'id')),
       ['1', '2'],
@@ -2144,8 +2160,8 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
       tom.get('tags').setObjects(sylvain.get('tags'));
     });
 
-    assert.equal(tom.get('tags.length'), 1);
-    assert.equal(tom.get('tags.firstObject'), store.peekRecord('tag', 2));
+    assert.strictEqual(tom.get('tags.length'), 1);
+    assert.strictEqual(tom.get('tags.firstObject'), store.peekRecord('tag', 2));
   });
 
   test('Replacing `has-many` with non-array will throw assertion', function (assert) {
@@ -2260,11 +2276,11 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
       return store.findRecord('person', 1).then((person) => {
         let tag = get(person, 'tags').objectAt(0);
 
-        assert.equal(get(tag, 'name'), 'ember', 'precond - relationships work');
+        assert.strictEqual(get(tag, 'name'), 'ember', 'precond - relationships work');
 
         run(() => get(person, 'tags').removeObject(tag));
 
-        assert.equal(get(person, 'tags.length'), 0, 'object is removed from the relationship');
+        assert.strictEqual(get(person, 'tags.length'), 0, 'object is removed from the relationship');
       });
     });
   });
@@ -2296,18 +2312,18 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
       tags.removeObject(tag2);
     });
 
-    assert.equal(tags.objectAt(0), tag1);
-    assert.equal(tags.objectAt(1), tag3);
-    assert.equal(get(person, 'tags.length'), 2, 'object is removed from the relationship');
+    assert.strictEqual(tags.objectAt(0), tag1);
+    assert.strictEqual(tags.objectAt(1), tag3);
+    assert.strictEqual(get(person, 'tags.length'), 2, 'object is removed from the relationship');
 
     run(() => {
       tags.insertAt(0, tag2);
     });
 
-    assert.equal(get(person, 'tags.length'), 3, 'object is added back to the relationship');
-    assert.equal(tags.objectAt(0), tag2);
-    assert.equal(tags.objectAt(1), tag1);
-    assert.equal(tags.objectAt(2), tag3);
+    assert.strictEqual(get(person, 'tags.length'), 3, 'object is added back to the relationship');
+    assert.strictEqual(tags.objectAt(0), tag2);
+    assert.strictEqual(tags.objectAt(1), tag1);
+    assert.strictEqual(tags.objectAt(2), tag3);
   });
 
   test('hasMany is async by default', function (assert) {
@@ -2349,12 +2365,12 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     let people = tag.get('people');
     let peopleCached = tag.get('people');
 
-    assert.equal(people, peopleCached);
+    assert.strictEqual(people, peopleCached);
 
     tag.notifyPropertyChange('people');
     let notifiedPeople = tag.get('people');
 
-    assert.equal(people, notifiedPeople);
+    assert.strictEqual(people, notifiedPeople);
 
     return EmberPromise.all([people]);
   });
@@ -2418,13 +2434,13 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     //assert.ok(!hasManyRelationship._manyArray);
 
-    assert.equal(peopleDidChange, 0, 'expect people hasMany to not emit a change event (before access)');
+    assert.strictEqual(peopleDidChange, 0, 'expect people hasMany to not emit a change event (before access)');
     tag.people; // access async relationship
-    assert.equal(peopleDidChange, 0, 'expect people hasMany to not emit a change event (sync after access)');
+    assert.strictEqual(peopleDidChange, 0, 'expect people hasMany to not emit a change event (sync after access)');
 
     await settled();
 
-    assert.equal(
+    assert.strictEqual(
       peopleDidChange,
       0,
       'expect people hasMany to not emit a change event (after access, but after the current run loop)'
@@ -2433,7 +2449,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     let person = store.createRecord('person');
 
-    assert.equal(peopleDidChange, 0, 'expect people hasMany to not emit a change event (before access)');
+    assert.strictEqual(peopleDidChange, 0, 'expect people hasMany to not emit a change event (before access)');
     const people = await tag.people;
     people.addObject(person);
     assert.strictEqual(peopleDidChange, 1, 'expect people hasMany to have changed exactly once');
@@ -2459,7 +2475,7 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
     let adapter = store.adapterFor('application');
 
     adapter.findHasMany = function (store, snapshot, url, relationship) {
-      assert.equal(relationship.key, 'tags', 'relationship should be tags');
+      assert.strictEqual(relationship.key, 'tags', 'relationship should be tags');
 
       return {
         data: [
@@ -2502,15 +2518,15 @@ module('unit/model/relationships - DS.hasMany', function (hooks) {
 
     return run(() => {
       return store.findRecord('person', 1).then((person) => {
-        assert.equal(get(person, 'name'), 'Watson', 'The person is now loaded');
+        assert.strictEqual(get(person, 'name'), 'Watson', 'The person is now loaded');
 
         // when I remove this findRecord the test passes
         return store.findRecord('tag', 2).then((tag) => {
-          assert.equal(get(tag, 'name'), 'second', 'The tag is now loaded');
+          assert.strictEqual(get(tag, 'name'), 'second', 'The tag is now loaded');
 
           return run(() =>
             person.get('tags').then((tags) => {
-              assert.equal(get(tags, 'length'), 3, 'the tags are all loaded');
+              assert.strictEqual(get(tags, 'length'), 3, 'the tags are all loaded');
             })
           );
         });

--- a/packages/-ember-data/tests/unit/model/relationships/record-array-test.js
+++ b/packages/-ember-data/tests/unit/model/relationships/record-array-test.js
@@ -53,7 +53,7 @@ module('unit/model/relationships - RecordArray', function (hooks) {
     });
 
     let tag = tags.objectAt(0);
-    assert.equal(get(tag, 'name'), 'friendly', `precond - we're working with the right tags`);
+    assert.strictEqual(get(tag, 'name'), 'friendly', `precond - we're working with the right tags`);
 
     set(
       tags,
@@ -67,7 +67,7 @@ module('unit/model/relationships - RecordArray', function (hooks) {
     );
 
     tag = tags.objectAt(0);
-    assert.equal(get(tag, 'name'), 'smarmy', 'the lookup was updated');
+    assert.strictEqual(get(tag, 'name'), 'smarmy', 'the lookup was updated');
   });
 
   test('can create child record from a hasMany relationship', async function (assert) {
@@ -104,8 +104,8 @@ module('unit/model/relationships - RecordArray', function (hooks) {
     let person = await store.findRecord('person', 1);
     person.get('tags').createRecord({ name: 'cool' });
 
-    assert.equal(get(person, 'name'), 'Tom Dale', 'precond - retrieves person record from store');
-    assert.equal(get(person, 'tags.length'), 1, 'tag is added to the parent record');
-    assert.equal(get(person, 'tags').objectAt(0).get('name'), 'cool', 'tag values are passed along');
+    assert.strictEqual(get(person, 'name'), 'Tom Dale', 'precond - retrieves person record from store');
+    assert.strictEqual(get(person, 'tags.length'), 1, 'tag is added to the parent record');
+    assert.strictEqual(get(person, 'tags').objectAt(0).get('name'), 'cool', 'tag values are passed along');
   });
 });

--- a/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
+++ b/packages/-ember-data/tests/unit/model/rollback-attributes-test.js
@@ -66,18 +66,18 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
         return person;
       });
 
-      assert.equal(person.get('firstName'), 'Thomas', 'PreCond: we mutated firstName');
+      assert.strictEqual(person.get('firstName'), 'Thomas', 'PreCond: we mutated firstName');
       if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-        assert.equal(person.get('rolledBackCount'), 0, 'PreCond: we have not yet rolled back');
+        assert.strictEqual(person.get('rolledBackCount'), 0, 'PreCond: we have not yet rolled back');
       }
 
       run(() => person.rollbackAttributes());
 
-      assert.equal(person.get('firstName'), 'Tom', 'We rolled back firstName');
+      assert.strictEqual(person.get('firstName'), 'Tom', 'We rolled back firstName');
       assert.false(person.get('hasDirtyAttributes'), 'We expect the record to be clean');
 
       if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-        assert.equal(person.get('rolledBackCount'), 1, 'We rolled back once');
+        assert.strictEqual(person.get('rolledBackCount'), 1, 'We rolled back once');
       }
     });
 
@@ -101,9 +101,9 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
         return person;
       });
 
-      assert.equal(person.get('firstName'), 'Thomas');
+      assert.strictEqual(person.get('firstName'), 'Thomas');
       if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-        assert.equal(person.get('rolledBackCount'), 0);
+        assert.strictEqual(person.get('rolledBackCount'), 0);
       }
 
       run(() => person.rollbackAttributes());
@@ -112,7 +112,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
       assert.false(person.get('hasDirtyAttributes'));
 
       if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-        assert.equal(person.get('rolledBackCount'), 1);
+        assert.strictEqual(person.get('rolledBackCount'), 1);
       }
     });
 
@@ -146,24 +146,24 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
       return run(() => {
         let saving = person.save();
 
-        assert.equal(person.get('firstName'), 'Thomas');
+        assert.strictEqual(person.get('firstName'), 'Thomas');
 
         person.set('lastName', 'Dolly');
 
-        assert.equal(person.get('lastName'), 'Dolly');
+        assert.strictEqual(person.get('lastName'), 'Dolly');
         if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-          assert.equal(person.get('rolledBackCount'), 0);
+          assert.strictEqual(person.get('rolledBackCount'), 0);
         }
 
         person.rollbackAttributes();
 
-        assert.equal(person.get('firstName'), 'Thomas');
-        assert.equal(person.get('lastName'), 'Dale');
+        assert.strictEqual(person.get('firstName'), 'Thomas');
+        assert.strictEqual(person.get('lastName'), 'Dale');
         assert.true(person.get('isSaving'));
 
         return saving.then(() => {
           if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-            assert.equal(person.get('rolledBackCount'), 1);
+            assert.strictEqual(person.get('rolledBackCount'), 1);
           }
           assert.false(person.get('hasDirtyAttributes'), 'The person is now clean');
         });
@@ -203,17 +203,17 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
           assert.true(person.get('isError'));
           assert.deepEqual(person.changedAttributes().firstName, ['Tom', 'Thomas']);
           if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-            assert.equal(person.get('rolledBackCount'), 0);
+            assert.strictEqual(person.get('rolledBackCount'), 0);
           }
           run(function () {
             person.rollbackAttributes();
           });
 
-          assert.equal(person.get('firstName'), 'Tom');
+          assert.strictEqual(person.get('firstName'), 'Tom');
           assert.false(person.get('isError'));
-          assert.equal(Object.keys(person.changedAttributes()).length, 0);
+          assert.strictEqual(Object.keys(person.changedAttributes()).length, 0);
           if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-            assert.equal(person.get('rolledBackCount'), 1);
+            assert.strictEqual(person.get('rolledBackCount'), 1);
           }
         });
       });
@@ -246,8 +246,8 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
 
       run(() => person.deleteRecord());
 
-      assert.equal(people.get('length'), 1, 'a deleted record appears in record array until it is saved');
-      assert.equal(people.objectAt(0), person, 'a deleted record appears in record array until it is saved');
+      assert.strictEqual(people.get('length'), 1, 'a deleted record appears in record array until it is saved');
+      assert.strictEqual(people.objectAt(0), person, 'a deleted record appears in record array until it is saved');
 
       return run(() => {
         return person
@@ -256,7 +256,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
             assert.true(person.get('isError'));
             assert.true(person.get('isDeleted'));
             if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-              assert.equal(person.get('rolledBackCount'), 0);
+              assert.strictEqual(person.get('rolledBackCount'), 0);
             }
 
             run(() => person.rollbackAttributes());
@@ -265,11 +265,11 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
             assert.false(person.get('isError'));
             assert.false(person.get('hasDirtyAttributes'), 'must be not dirty');
             if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-              assert.equal(person.get('rolledBackCount'), 1);
+              assert.strictEqual(person.get('rolledBackCount'), 1);
             }
           })
           .then(() => {
-            assert.equal(
+            assert.strictEqual(
               people.get('length'),
               1,
               'the underlying record array is updated accordingly in an asynchronous way'
@@ -285,7 +285,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
       assert.true(person.get('isNew'), 'must be new');
       assert.true(person.get('hasDirtyAttributes'), 'must be dirty');
       if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-        assert.equal(person.get('rolledBackCount'), 0);
+        assert.strictEqual(person.get('rolledBackCount'), 0);
       }
 
       run(person, 'rollbackAttributes');
@@ -294,7 +294,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
       assert.false(person.get('hasDirtyAttributes'), 'must not be dirty');
       assert.true(person.get('isDeleted'), 'must be deleted');
       if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-        assert.equal(person.get('rolledBackCount'), 1);
+        assert.strictEqual(person.get('rolledBackCount'), 1);
       }
     });
 
@@ -323,7 +323,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
 
       return run(() => {
         return person.save().catch((reason) => {
-          assert.equal(error, reason);
+          assert.strictEqual(error, reason);
           assert.false(person.get('isValid'));
 
           run(() => person.rollbackAttributes());
@@ -332,7 +332,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
           assert.false(person.get('hasDirtyAttributes'), 'must not be dirty');
           assert.true(person.get('isDeleted'), 'must be deleted');
           if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-            assert.equal(person.get('rolledBackCount'), 1);
+            assert.strictEqual(person.get('rolledBackCount'), 1);
           }
         });
       });
@@ -367,13 +367,13 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
       });
 
       return run(() => {
-        assert.equal(person.get('firstName'), 'updated name', 'precondition: firstName is changed');
+        assert.strictEqual(person.get('firstName'), 'updated name', 'precondition: firstName is changed');
 
         return person
           .save()
           .catch(() => {
             assert.true(person.get('hasDirtyAttributes'), 'has dirty attributes');
-            assert.equal(person.get('firstName'), 'updated name', 'firstName is still changed');
+            assert.strictEqual(person.get('firstName'), 'updated name', 'firstName is still changed');
 
             return person.save();
           })
@@ -381,13 +381,13 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
             run(() => person.rollbackAttributes());
 
             assert.false(person.get('hasDirtyAttributes'), 'has no dirty attributes');
-            assert.equal(
+            assert.strictEqual(
               person.get('firstName'),
               'original name',
               'after rollbackAttributes() firstName has the original value'
             );
             if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-              assert.equal(person.get('rolledBackCount'), 1);
+              assert.strictEqual(person.get('rolledBackCount'), 1);
             }
           });
       });
@@ -410,14 +410,14 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
         person.deleteRecord();
       });
 
-      assert.equal(people.get('length'), 1, 'a deleted record appears in the record array until it is saved');
-      assert.equal(people.objectAt(0), person, 'a deleted record appears in the record array until it is saved');
+      assert.strictEqual(people.get('length'), 1, 'a deleted record appears in the record array until it is saved');
+      assert.strictEqual(people.objectAt(0), person, 'a deleted record appears in the record array until it is saved');
 
       assert.true(person.get('isDeleted'), 'must be deleted');
 
       run(() => person.rollbackAttributes());
 
-      assert.equal(people.get('length'), 1, 'the rollbacked record should appear again in the record array');
+      assert.strictEqual(people.get('length'), 1, 'the rollbacked record should appear again in the record array');
       assert.false(person.get('isDeleted'), 'must not be deleted');
       assert.false(person.get('hasDirtyAttributes'), 'must not be dirty');
     });
@@ -481,17 +481,17 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
         assert.ok(true, 'saving');
         await dog.save();
       } catch (reason) {
-        assert.equal(reason, thrownAdapterError, 'We threw the expected error during save');
+        assert.strictEqual(reason, thrownAdapterError, 'We threw the expected error during save');
 
         dog.rollbackAttributes();
         await settled();
 
         assert.false(dog.get('hasDirtyAttributes'), 'must not be dirty');
-        assert.equal(dog.get('name'), 'Pluto', 'Name is rolled back');
+        assert.strictEqual(dog.get('name'), 'Pluto', 'Name is rolled back');
         assert.notOk(dog.get('errors.name'), 'We have no errors for name anymore');
         assert.ok(dog.get('isValid'), 'We are now in a valid state');
         if (DEPRECATE_RECORD_LIFECYCLE_EVENT_METHODS) {
-          assert.equal(dog.get('rolledBackCount'), 1, 'we only rolled back once');
+          assert.strictEqual(dog.get('rolledBackCount'), 1, 'we only rolled back once');
         }
       }
 
@@ -542,23 +542,23 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
     try {
       await dog.save();
     } catch (reason) {
-      assert.equal(reason, thrownAdapterError);
-      assert.equal(dog.get('name'), 'is a dwarf planet');
-      assert.equal(dog.get('breed'), 'planet');
+      assert.strictEqual(reason, thrownAdapterError);
+      assert.strictEqual(dog.get('name'), 'is a dwarf planet');
+      assert.strictEqual(dog.get('breed'), 'planet');
       assert.ok(isPresent(dog.get('errors.name')));
-      assert.equal(dog.get('errors.name.length'), 1);
+      assert.strictEqual(dog.get('errors.name.length'), 1);
 
       dog.set('name', 'Seymour Asses');
       await settled();
 
-      assert.equal(dog.get('name'), 'Seymour Asses');
-      assert.equal(dog.get('breed'), 'planet');
+      assert.strictEqual(dog.get('name'), 'Seymour Asses');
+      assert.strictEqual(dog.get('breed'), 'planet');
 
       dog.rollbackAttributes();
       await settled();
 
-      assert.equal(dog.get('name'), 'Pluto');
-      assert.equal(dog.get('breed'), 'Disney');
+      assert.strictEqual(dog.get('name'), 'Pluto');
+      assert.strictEqual(dog.get('breed'), 'Disney');
       assert.false(dog.get('hasDirtyAttributes'), 'must not be dirty');
       assert.notOk(dog.get('errors.name'));
       assert.ok(dog.get('isValid'));
@@ -604,7 +604,7 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
 
     return run(() => {
       return dog.destroyRecord().catch((reason) => {
-        assert.equal(reason, error);
+        assert.strictEqual(reason, error);
 
         assert.false(dog.get('isError'), 'must not be error');
         assert.true(dog.get('isDeleted'), 'must be deleted');

--- a/packages/-ember-data/tests/unit/promise-proxies-test.js
+++ b/packages/-ember-data/tests/unit/promise-proxies-test.js
@@ -63,7 +63,7 @@ module('PromiseManyArray', function () {
     assert.false(array.isFulfilled, 'should NOT be fulfilled');
 
     assert.ok(reloaded instanceof DS.PromiseManyArray);
-    assert.equal(reloaded, array);
+    assert.strictEqual(reloaded, array);
 
     let value = await reloaded;
     assert.false(array.isRejected, 'should NOT be rejected');
@@ -71,7 +71,7 @@ module('PromiseManyArray', function () {
     assert.true(array.isSettled, 'should be settled');
     assert.true(array.isFulfilled, 'should be fulfilled');
 
-    assert.equal(content, value);
+    assert.strictEqual(content, value);
   });
 
   test('.set to new promise should be like reload', async function (assert) {
@@ -111,7 +111,7 @@ module('PromiseManyArray', function () {
     assert.true(array.isSettled, 'should be settled');
     assert.true(array.isFulfilled, 'should be fulfilled');
 
-    assert.equal(content, value);
+    assert.strictEqual(content, value);
   });
 });
 
@@ -177,6 +177,6 @@ module('unit/PromiseBelongsTo', function (hooks) {
     assert.expectAssertion(() => {
       belongsToProxy.get('meta');
     }, 'You attempted to access meta on the promise for the async belongsTo relationship ' + `child:child'.` + '\nUse `record.belongsTo(relationshipName).meta()` instead.');
-    assert.equal(parent.belongsTo('child').meta(), meta);
+    assert.strictEqual(parent.belongsTo('child').meta(), meta);
   });
 });

--- a/packages/-ember-data/tests/unit/record-arrays/adapter-populated-record-array-test.js
+++ b/packages/-ember-data/tests/unit/record-arrays/adapter-populated-record-array-test.js
@@ -26,7 +26,7 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
     let recordArray = AdapterPopulatedRecordArray.create({ modelName: 'recordType' });
 
     assert.false(recordArray.get('isLoaded'), 'expected isLoaded to be false');
-    assert.equal(recordArray.get('modelName'), 'recordType', 'has modelName');
+    assert.strictEqual(recordArray.get('modelName'), 'recordType', 'has modelName');
     assert.deepEqual(recordArray.get('content'), [], 'has no content');
     assert.strictEqual(recordArray.get('query'), null, 'no query');
     assert.strictEqual(recordArray.get('store'), null, 'no store');
@@ -47,10 +47,10 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
     });
     assert.true(recordArray.get('isLoaded'));
     assert.false(recordArray.get('isUpdating'));
-    assert.equal(recordArray.get('modelName'), 'apple');
+    assert.strictEqual(recordArray.get('modelName'), 'apple');
     assert.deepEqual(recordArray.get('content'), content);
-    assert.equal(recordArray.get('store'), store);
-    assert.equal(recordArray.get('query'), 'some-query');
+    assert.strictEqual(recordArray.get('store'), store);
+    assert.strictEqual(recordArray.get('query'), 'some-query');
     assert.strictEqual(recordArray.get('links'), 'foo');
   });
 
@@ -73,9 +73,9 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
     const store = {
       _query(modelName, query, array) {
         queryCalled++;
-        assert.equal(modelName, 'recordType');
-        assert.equal(query, 'some-query');
-        assert.equal(array, recordArray);
+        assert.strictEqual(modelName, 'recordType');
+        assert.strictEqual(query, 'some-query');
+        assert.strictEqual(array, recordArray);
 
         return deferred.promise;
       },
@@ -89,18 +89,18 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
 
     assert.false(recordArray.get('isUpdating'), 'should not yet be updating');
 
-    assert.equal(queryCalled, 0);
+    assert.strictEqual(queryCalled, 0);
 
     let updateResult = recordArray.update();
 
-    assert.equal(queryCalled, 1);
+    assert.strictEqual(queryCalled, 1);
 
     deferred.resolve('return value');
 
     assert.true(recordArray.get('isUpdating'), 'should be updating');
 
     return updateResult.then((result) => {
-      assert.equal(result, 'return value');
+      assert.strictEqual(result, 'return value');
       assert.false(recordArray.get('isUpdating'), 'should no longer be updating');
     });
   });
@@ -110,7 +110,7 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
     let didAddRecord = 0;
     function add(array) {
       didAddRecord++;
-      assert.equal(array, recordArray);
+      assert.strictEqual(array, recordArray);
     }
 
     this.owner.register('model:tag', Tag);
@@ -148,7 +148,7 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
     let identifier1 = recordIdentifierFor(record1);
     let identifier2 = recordIdentifierFor(record2);
 
-    assert.equal(didAddRecord, 0, 'no records should have been added yet');
+    assert.strictEqual(didAddRecord, 0, 'no records should have been added yet');
 
     let didLoad = 0;
     if (DEPRECATE_EVENTED_API_USAGE) {
@@ -165,22 +165,22 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
       meta,
     });
 
-    assert.equal(result, undefined, '_setIdentifiers should have no return value');
+    assert.strictEqual(result, undefined, '_setIdentifiers should have no return value');
 
-    assert.equal(didAddRecord, 2, 'two records should have been added');
+    assert.strictEqual(didAddRecord, 2, 'two records should have been added');
 
     assert.deepEqual(recordArray.toArray(), [record1, record2], 'should now contain the loaded records by identifier');
 
     if (DEPRECATE_EVENTED_API_USAGE) {
-      assert.equal(didLoad, 0, 'didLoad event should not have fired');
+      assert.strictEqual(didLoad, 0, 'didLoad event should not have fired');
     }
-    assert.equal(recordArray.get('links').foo, 1, 'has links');
-    assert.equal(recordArray.get('meta').bar, 2, 'has meta');
+    assert.strictEqual(recordArray.get('links').foo, 1, 'has links');
+    assert.strictEqual(recordArray.get('meta').bar, 2, 'has meta');
 
     await settled();
 
     if (DEPRECATE_EVENTED_API_USAGE) {
-      assert.equal(didLoad, 1, 'didLoad event should have fired once');
+      assert.strictEqual(didLoad, 1, 'didLoad event should have fired once');
     }
     assert.expectDeprecation({
       id: 'ember-data:evented-api-usage',
@@ -199,11 +199,11 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
 
     function add(array) {
       didAddRecord++;
-      assert.equal(array, recordArray);
+      assert.strictEqual(array, recordArray);
     }
 
     function del(array) {
-      assert.equal(array, recordArray);
+      assert.strictEqual(array, recordArray);
     }
 
     const set = new Set();
@@ -243,14 +243,14 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
 
     recordArray._setIdentifiers([recordIdentifierFor(record1), recordIdentifierFor(record2)], {});
 
-    assert.equal(didAddRecord, 2, 'expected 2 didAddRecords');
+    assert.strictEqual(didAddRecord, 2, 'expected 2 didAddRecords');
     assert.deepEqual(
       recordArray.map((x) => x.name),
       ['Scumbag Dale', 'Scumbag Katz']
     );
 
-    assert.equal(arrayDidChange, 0, 'array should not yet have emitted a change event');
-    assert.equal(contentDidChange, 0, 'recordArray.content should not have changed');
+    assert.strictEqual(arrayDidChange, 0, 'array should not yet have emitted a change event');
+    assert.strictEqual(contentDidChange, 0, 'recordArray.content should not have changed');
 
     recordArray.addObserver('content', function () {
       contentDidChange++;
@@ -260,17 +260,17 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
       arrayDidChange++;
 
       // first time invoked
-      assert.equal(array, recordArray, 'should be same record array as above');
-      assert.equal(startIdx, 0, 'expected startIdx');
-      assert.equal(removeAmt, 2, 'expected removeAmt');
-      assert.equal(addAmt, 2, 'expected addAmt');
+      assert.strictEqual(array, recordArray, 'should be same record array as above');
+      assert.strictEqual(startIdx, 0, 'expected startIdx');
+      assert.strictEqual(removeAmt, 2, 'expected removeAmt');
+      assert.strictEqual(addAmt, 2, 'expected addAmt');
     });
 
     assert.true(recordArray.get('isLoaded'), 'should be considered loaded');
     assert.false(recordArray.get('isUpdating'), 'should not yet be updating');
 
-    assert.equal(arrayDidChange, 0);
-    assert.equal(contentDidChange, 0, 'recordArray.content should not have changed');
+    assert.strictEqual(arrayDidChange, 0);
+    assert.strictEqual(contentDidChange, 0, 'recordArray.content should not have changed');
 
     arrayDidChange = 0;
     contentDidChange = 0;
@@ -297,12 +297,12 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
 
     recordArray._setIdentifiers([recordIdentifierFor(record3), recordIdentifierFor(record4)], {});
 
-    assert.equal(didAddRecord, 2, 'expected 2 didAddRecords');
+    assert.strictEqual(didAddRecord, 2, 'expected 2 didAddRecords');
     assert.true(recordArray.get('isLoaded'), 'should be considered loaded');
     assert.false(recordArray.get('isUpdating'), 'should no longer be updating');
 
-    assert.equal(arrayDidChange, 1, 'record array should have omitted ONE change event');
-    assert.equal(contentDidChange, 0, 'recordArray.content should not have changed');
+    assert.strictEqual(arrayDidChange, 1, 'record array should have omitted ONE change event');
+    assert.strictEqual(contentDidChange, 0, 'recordArray.content should not have changed');
 
     assert.deepEqual(
       recordArray.map((x) => x.name),
@@ -316,18 +316,18 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
     recordArray.one('@array:change', function (array, startIdx, removeAmt, addAmt) {
       arrayDidChange++;
 
-      assert.equal(array, recordArray, 'should be same recordArray as above');
-      assert.equal(startIdx, 0, 'expected startIdx');
-      assert.equal(removeAmt, 2, 'expected removeAmt');
-      assert.equal(addAmt, 1, 'expected addAmt');
+      assert.strictEqual(array, recordArray, 'should be same recordArray as above');
+      assert.strictEqual(startIdx, 0, 'expected startIdx');
+      assert.strictEqual(removeAmt, 2, 'expected removeAmt');
+      assert.strictEqual(addAmt, 1, 'expected addAmt');
     });
 
     // re-query
     assert.true(recordArray.get('isLoaded'), 'should be considered loaded');
     assert.false(recordArray.get('isUpdating'), 'should not yet be updating');
 
-    assert.equal(arrayDidChange, 0, 'record array should not yet have omitted a change event');
-    assert.equal(contentDidChange, 0, 'recordArray.content should not have changed');
+    assert.strictEqual(arrayDidChange, 0, 'record array should not yet have omitted a change event');
+    assert.strictEqual(contentDidChange, 0, 'recordArray.content should not have changed');
 
     let model5 = {
       type: 'tag',
@@ -343,13 +343,13 @@ module('unit/record-arrays/adapter-populated-record-array - DS.AdapterPopulatedR
 
     recordArray._setIdentifiers([recordIdentifierFor(record5)], {});
 
-    assert.equal(didAddRecord, 1, 'expected 0 didAddRecord');
+    assert.strictEqual(didAddRecord, 1, 'expected 0 didAddRecord');
 
     assert.true(recordArray.get('isLoaded'), 'should be considered loaded');
     assert.false(recordArray.get('isUpdating'), 'should not longer be updating');
 
-    assert.equal(arrayDidChange, 1, 'record array should have emitted one change event');
-    assert.equal(contentDidChange, 0, 'recordArray.content should not have changed');
+    assert.strictEqual(arrayDidChange, 1, 'record array should have emitted one change event');
+    assert.strictEqual(contentDidChange, 0, 'recordArray.content should not have changed');
 
     assert.deepEqual(
       recordArray.map((x) => x.name),

--- a/packages/-ember-data/tests/unit/record-arrays/record-array-test.js
+++ b/packages/-ember-data/tests/unit/record-arrays/record-array-test.js
@@ -26,8 +26,8 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
 
     assert.false(get(recordArray, 'isLoaded'), 'record is not loaded');
     assert.false(get(recordArray, 'isUpdating'), 'record is not updating');
-    assert.equal(get(recordArray, 'modelName'), 'recordType', 'has modelName');
-    assert.equal(get(recordArray, 'content'), undefined, 'content is not defined');
+    assert.strictEqual(get(recordArray, 'modelName'), 'recordType', 'has modelName');
+    assert.strictEqual(get(recordArray, 'content'), null, 'content is not defined');
     assert.strictEqual(get(recordArray, 'store'), null, 'no store with recordArray');
   });
 
@@ -43,9 +43,9 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     });
     assert.true(get(recordArray, 'isLoaded'));
     assert.false(get(recordArray, 'isUpdating')); // cannot set as default value:
-    assert.equal(get(recordArray, 'modelName'), 'apple');
+    assert.strictEqual(get(recordArray, 'modelName'), 'apple');
     assert.deepEqual(get(recordArray, 'content'), content);
-    assert.equal(get(recordArray, 'store'), store);
+    assert.strictEqual(get(recordArray, 'store'), store);
   });
 
   test('#replace() throws error', async function (assert) {
@@ -87,10 +87,10 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
       store,
     });
 
-    assert.equal(get(recordArray, 'length'), 3);
-    assert.equal(recordArray.objectAtContent(0).id, '1');
-    assert.equal(recordArray.objectAtContent(1).id, '3');
-    assert.equal(recordArray.objectAtContent(2).id, '5');
+    assert.strictEqual(get(recordArray, 'length'), 3);
+    assert.strictEqual(recordArray.objectAtContent(0).id, '1');
+    assert.strictEqual(recordArray.objectAtContent(1).id, '3');
+    assert.strictEqual(recordArray.objectAtContent(2).id, '5');
     assert.strictEqual(recordArray.objectAtContent(3), undefined);
   });
 
@@ -101,7 +101,7 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     const store = {
       findAll(modelName, options) {
         findAllCalled++;
-        assert.equal(modelName, 'recordType');
+        assert.strictEqual(modelName, 'recordType');
         assert.true(options.reload, 'options should contain reload: true');
         return deferred.promise;
       },
@@ -114,18 +114,18 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
 
     assert.false(get(recordArray, 'isUpdating'), 'should not yet be updating');
 
-    assert.equal(findAllCalled, 0);
+    assert.strictEqual(findAllCalled, 0);
 
     let updateResult = recordArray.update();
 
-    assert.equal(findAllCalled, 1);
+    assert.strictEqual(findAllCalled, 1);
 
     deferred.resolve('return value');
 
     assert.true(get(recordArray, 'isUpdating'), 'should be updating');
 
     return updateResult.then((result) => {
-      assert.equal(result, 'return value');
+      assert.strictEqual(result, 'return value');
       assert.false(get(recordArray, 'isUpdating'), 'should no longer be updating');
     });
   });
@@ -146,24 +146,24 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     });
 
     assert.false(get(recordArray, 'isUpdating'), 'should not be updating');
-    assert.equal(findAllCalled, 0);
+    assert.strictEqual(findAllCalled, 0);
 
     let updateResult1 = recordArray.update();
 
-    assert.equal(findAllCalled, 1);
+    assert.strictEqual(findAllCalled, 1);
 
     let updateResult2 = recordArray.update();
 
-    assert.equal(findAllCalled, 1);
+    assert.strictEqual(findAllCalled, 1);
 
-    assert.equal(updateResult1, updateResult2);
+    assert.strictEqual(updateResult1, updateResult2);
 
     deferred.resolve('return value');
 
     assert.true(get(recordArray, 'isUpdating'), 'should be updating');
 
     return updateResult1.then((result) => {
-      assert.equal(result, 'return value');
+      assert.strictEqual(result, 'return value');
       assert.false(get(recordArray, 'isUpdating'), 'should no longer be updating');
     });
   });
@@ -196,7 +196,11 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
       },
     };
 
-    assert.equal(recordArray._pushIdentifiers([model1.identifier]), undefined, '_pushIdentifiers has no return value');
+    assert.strictEqual(
+      recordArray._pushIdentifiers([model1.identifier]),
+      undefined,
+      '_pushIdentifiers has no return value'
+    );
     assert.deepEqual(recordArray.get('content'), [model1.identifier], 'now contains model1');
 
     recordArray._pushIdentifiers([model1.identifier]);
@@ -246,8 +250,8 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
       },
     };
 
-    assert.equal(recordArray.get('content').length, 0);
-    assert.equal(
+    assert.strictEqual(recordArray.get('content').length, 0);
+    assert.strictEqual(
       recordArray._removeIdentifiers([model1.identifier]),
       undefined,
       '_removeIdentifiers has no return value'
@@ -261,13 +265,13 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
       [model1.identifier, model2.identifier],
       'now contains model1, model2,'
     );
-    assert.equal(
+    assert.strictEqual(
       recordArray._removeIdentifiers([model1.identifier]),
       undefined,
       '_removeIdentifiers has no return value'
     );
     assert.deepEqual(recordArray.get('content'), [model2.identifier], 'now only contains model2');
-    assert.equal(
+    assert.strictEqual(
       recordArray._removeIdentifiers([model2.identifier]),
       undefined,
       '_removeIdentifiers has no return value'
@@ -276,14 +280,14 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
 
     recordArray._pushIdentifiers([model1.identifier, model2.identifier, model3.identifier]);
 
-    assert.equal(
+    assert.strictEqual(
       recordArray._removeIdentifiers([model1.identifier, model3.identifier]),
       undefined,
       '_removeIdentifiers has no return value'
     );
 
     assert.deepEqual(recordArray.get('content'), [model2.identifier], 'now contains model2');
-    assert.equal(
+    assert.strictEqual(
       recordArray._removeIdentifiers([model2.identifier]),
       undefined,
       '_removeIdentifiers has no return value'
@@ -328,16 +332,16 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     let model1Saved = 0;
     let model2Saved = 0;
 
-    assert.equal(model1Saved, 0, 'save not yet called');
-    assert.equal(model2Saved, 0, 'save not yet called');
+    assert.strictEqual(model1Saved, 0, 'save not yet called');
+    assert.strictEqual(model2Saved, 0, 'save not yet called');
 
     let result = recordArray.save();
 
-    assert.equal(model1Saved, 1, 'save was called for model1');
-    assert.equal(model2Saved, 1, 'save was called for mode2');
+    assert.strictEqual(model1Saved, 1, 'save was called for model1');
+    assert.strictEqual(model2Saved, 1, 'save was called for mode2');
 
     const r = await result;
-    assert.equal(r.id, result.id, 'save promise should fulfill with the original recordArray');
+    assert.strictEqual(r.id, result.id, 'save promise should fulfill with the original recordArray');
   });
 
   test('#destroy', async function (assert) {
@@ -357,7 +361,7 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     const set = new Set();
     set.delete = (array) => {
       didDissociatieFromOwnRecords++;
-      assert.equal(array, recordArray);
+      assert.strictEqual(array, recordArray);
     };
 
     let recordArray = RecordArray.create({
@@ -369,7 +373,7 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
         },
         unregisterRecordArray(_recordArray) {
           didUnregisterRecordArray++;
-          assert.equal(recordArray, _recordArray);
+          assert.strictEqual(recordArray, _recordArray);
         },
       },
     });
@@ -377,9 +381,13 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     assert.false(get(recordArray, 'isDestroyed'), 'should not be destroyed');
     assert.false(get(recordArray, 'isDestroying'), 'should not be destroying');
 
-    assert.equal(get(recordArray, 'length'), 1, 'before destroy, length should be 1');
-    assert.equal(didUnregisterRecordArray, 0, 'before destroy, we should not yet have unregisterd the record array');
-    assert.equal(
+    assert.strictEqual(get(recordArray, 'length'), 1, 'before destroy, length should be 1');
+    assert.strictEqual(
+      didUnregisterRecordArray,
+      0,
+      'before destroy, we should not yet have unregisterd the record array'
+    );
+    assert.strictEqual(
       didDissociatieFromOwnRecords,
       0,
       'before destroy, we should not yet have dissociated from own record array'
@@ -387,11 +395,15 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     recordArray.destroy();
     await settled();
 
-    assert.equal(didUnregisterRecordArray, 1, 'after destroy we should have unregistered the record array');
-    assert.equal(didDissociatieFromOwnRecords, 1, 'after destroy, we should have dissociated from own record array');
+    assert.strictEqual(didUnregisterRecordArray, 1, 'after destroy we should have unregistered the record array');
+    assert.strictEqual(
+      didDissociatieFromOwnRecords,
+      1,
+      'after destroy, we should have dissociated from own record array'
+    );
 
     assert.strictEqual(get(recordArray, 'content'), null);
-    assert.equal(get(recordArray, 'length'), 0, 'after destroy we should have no length');
+    assert.strictEqual(get(recordArray, 'length'), 0, 'after destroy we should have no length');
     assert.true(get(recordArray, 'isDestroyed'), 'should be destroyed');
   });
 
@@ -420,14 +432,14 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     let snapshot = recordArray._createSnapshot();
     let [snapshot1, snapshot2] = snapshot.snapshots();
 
-    assert.equal(
+    assert.strictEqual(
       snapshot1.id,
-      model1.id,
+      String(model1.id),
       'record array snapshot should contain the first internalModel.createSnapshot result'
     );
-    assert.equal(
+    assert.strictEqual(
       snapshot2.id,
-      model2.id,
+      String(model2.id),
       'record array snapshot should contain the second internalModel.createSnapshot result'
     );
   });
@@ -451,7 +463,7 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     const set = new Set();
     set.delete = (array) => {
       didDissociatieFromOwnRecords++;
-      assert.equal(array, recordArray);
+      assert.strictEqual(array, recordArray);
     };
     // end TODO:
 
@@ -463,7 +475,7 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
         },
         unregisterRecordArray(_recordArray) {
           didUnregisterRecordArray++;
-          assert.equal(recordArray, _recordArray);
+          assert.strictEqual(recordArray, _recordArray);
         },
       },
       store,
@@ -472,9 +484,13 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     assert.false(get(recordArray, 'isDestroyed'), 'should not be destroyed');
     assert.false(get(recordArray, 'isDestroying'), 'should not be destroying');
 
-    assert.equal(get(recordArray, 'length'), 1, 'before destroy, length should be 1');
-    assert.equal(didUnregisterRecordArray, 0, 'before destroy, we should not yet have unregisterd the record array');
-    assert.equal(
+    assert.strictEqual(get(recordArray, 'length'), 1, 'before destroy, length should be 1');
+    assert.strictEqual(
+      didUnregisterRecordArray,
+      0,
+      'before destroy, we should not yet have unregisterd the record array'
+    );
+    assert.strictEqual(
       didDissociatieFromOwnRecords,
       0,
       'before destroy, we should not yet have dissociated from own record array'
@@ -482,12 +498,16 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     recordArray.destroy();
     await settled();
 
-    assert.equal(didUnregisterRecordArray, 1, 'after destroy we should have unregistered the record array');
-    assert.equal(didDissociatieFromOwnRecords, 1, 'after destroy, we should have dissociated from own record array');
+    assert.strictEqual(didUnregisterRecordArray, 1, 'after destroy we should have unregistered the record array');
+    assert.strictEqual(
+      didDissociatieFromOwnRecords,
+      1,
+      'after destroy, we should have dissociated from own record array'
+    );
     recordArray.destroy();
 
     assert.strictEqual(get(recordArray, 'content'), null);
-    assert.equal(get(recordArray, 'length'), 0, 'after destroy we should have no length');
+    assert.strictEqual(get(recordArray, 'length'), 0, 'after destroy we should have no length');
     assert.true(get(recordArray, 'isDestroyed'), 'should be destroyed');
   });
 });

--- a/packages/-ember-data/tests/unit/store/adapter-interop-test.js
+++ b/packages/-ember-data/tests/unit/store/adapter-interop-test.js
@@ -64,10 +64,14 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
     const ApplicationAdapter = Adapter.extend({
       findRecord(store, type, id, snapshot) {
         assert.ok(true, 'Adapter#find was called');
-        assert.equal(store, currentStore, 'Adapter#find was called with the right store');
-        assert.equal(type, store.modelFor('test'), 'Adapter#find was called with the type passed into Store#find');
-        assert.equal(id, 1, 'Adapter#find was called with the id passed into Store#find');
-        assert.equal(snapshot.id, '1', 'Adapter#find was called with the record created from Store#find');
+        assert.strictEqual(store, currentStore, 'Adapter#find was called with the right store');
+        assert.strictEqual(
+          type,
+          store.modelFor('test'),
+          'Adapter#find was called with the type passed into Store#find'
+        );
+        assert.strictEqual(id, '1', 'Adapter#find was called with the id passed into Store#find');
+        assert.strictEqual(snapshot.id, '1', 'Adapter#find was called with the record created from Store#find');
 
         return resolve({
           data: {
@@ -137,7 +141,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
       findMany(store, type, ids, snapshots) {
         snapshots.forEach((snapshot) => {
-          assert.equal(
+          assert.strictEqual(
             snapshot.include,
             includedResourcesForIds[snapshot.id],
             `Snapshot #${snapshot.id} retains the 'include' adapter option in #findMany`
@@ -151,7 +155,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
       },
 
       findRecord(store, type, id, snapshot) {
-        assert.equal(
+        assert.strictEqual(
           snapshot.include,
           includedResourcesForIds[snapshot.id],
           `Snapshot #${snapshot.id} retains the 'include' adapter option in #findRecord`
@@ -207,7 +211,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     const ApplicationAdapter = Adapter.extend({
       findRecord(store, type, id, snapshot) {
-        assert.equal(typeof id, 'string', 'id has been normalized to a string');
+        assert.strictEqual(typeof id, 'string', 'id has been normalized to a string');
         return resolve({ data: { id, type: 'test', attributes: { name: 'Scumbag Sylvain' } } });
       },
     });
@@ -222,7 +226,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
       return store
         .findRecord('test', 1)
         .then((object) => {
-          assert.equal(typeof object.get('id'), 'string', 'id was coerced to a string');
+          assert.strictEqual(typeof object.get('id'), 'string', 'id was coerced to a string');
           run(() => {
             store.push({
               data: {
@@ -239,7 +243,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
         })
         .then((object) => {
           assert.ok(object, 'object was found');
-          assert.equal(
+          assert.strictEqual(
             typeof object.get('id'),
             'string',
             'id is a string despite being supplied and searched for as a number'
@@ -280,7 +284,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
       return store.findRecord('person', 1).then((tom) => {
         assert.false(get(tom, 'hasDirtyAttributes'), 'precond - record is not dirty');
-        assert.equal(get(tom, 'name'), 'Tom Dale', 'returns the correct name');
+        assert.strictEqual(get(tom, 'name'), 'Tom Dale', 'returns the correct name');
 
         store.push({
           data: {
@@ -291,7 +295,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
             },
           },
         });
-        assert.equal(get(tom, 'name'), 'Captain Underpants', 'updated record with new date');
+        assert.strictEqual(get(tom, 'name'), 'Captain Underpants', 'updated record with new date');
       });
     });
   });
@@ -307,8 +311,8 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     const ApplicationAdapter = Adapter.extend({
       query(store, type, query) {
-        assert.equal(type, store.modelFor('person'), 'The type was Person');
-        assert.equal(query, passedQuery, 'The query was passed in');
+        assert.strictEqual(type, store.modelFor('person'), 'The type was Person');
+        assert.strictEqual(query, passedQuery, 'The query was passed in');
         return resolve({ data: [] });
       },
     });
@@ -351,7 +355,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     run(() => store.query('person', passedQuery));
 
-    assert.equal(callCount, 1, 'normalizeQueryResponse was called');
+    assert.strictEqual(callCount, 1, 'normalizeQueryResponse was called');
   });
 
   test('peekAll(type) returns a record array of all records of a specific type', function (assert) {
@@ -378,8 +382,8 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     let results = store.peekAll('person');
 
-    assert.equal(get(results, 'length'), 1, 'record array should have the original object');
-    assert.equal(get(results.objectAt(0), 'name'), 'Tom Dale', 'record has the correct information');
+    assert.strictEqual(get(results, 'length'), 1, 'record array should have the original object');
+    assert.strictEqual(get(results.objectAt(0), 'name'), 'Tom Dale', 'record has the correct information');
 
     run(() => {
       store.push({
@@ -393,8 +397,8 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
       });
     });
 
-    assert.equal(get(results, 'length'), 2, 'record array should have the new object');
-    assert.equal(get(results.objectAt(1), 'name'), 'Yehuda Katz', 'record has the correct information');
+    assert.strictEqual(get(results, 'length'), 2, 'record array should have the new object');
+    assert.strictEqual(get(results.objectAt(1), 'name'), 'Yehuda Katz', 'record has the correct information');
 
     assert.strictEqual(results, store.peekAll('person'), 'subsequent calls to peekAll return the same recordArray)');
   });
@@ -414,7 +418,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     run(() => set(person, 'name', 'Braaahm Dale'));
 
-    assert.equal(get(person, 'name'), 'Braaahm Dale', 'Even if no hash is supplied, `set` still worked');
+    assert.strictEqual(get(person, 'name'), 'Braaahm Dale', 'Even if no hash is supplied, `set` still worked');
   });
 
   testInDebug(
@@ -456,7 +460,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
     assert.true(get(person, 'isNew'), 'A newly created record is new');
     assert.true(get(person, 'hasDirtyAttributes'), 'A newly created record is dirty');
 
-    assert.equal(get(person, 'name'), 'Brohuda Katz', 'The initial data hash is provided');
+    assert.strictEqual(get(person, 'name'), 'Brohuda Katz', 'The initial data hash is provided');
   });
 
   test('if an id is supplied in the initial data hash, it can be looked up using `store.find`', function (assert) {
@@ -493,7 +497,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     const ApplicationAdapter = Adapter.extend({
       findRecord(store, type, id, snapshot) {
-        assert.equal(snapshot.attr('name'), 'Test', 'Preloaded attribtue set');
+        assert.strictEqual(snapshot.attr('name'), 'Test', 'Preloaded attribtue set');
         return { data: { id: '1', type: 'test', attributes: { name: 'Test' } } };
       },
     });
@@ -512,7 +516,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     const ApplicationAdapter = Adapter.extend({
       findRecord(store, type, id, snapshot) {
-        assert.equal(snapshot.belongsTo('friend').attr('name'), 'Tom', 'Preloaded belongsTo set');
+        assert.strictEqual(snapshot.belongsTo('friend').attr('name'), 'Tom', 'Preloaded belongsTo set');
         return { data: { id, type: 'person' } };
       },
     });
@@ -570,7 +574,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
           .peekRecord('person', 1)
           .get('friend')
           .then((friend) => {
-            assert.equal(friend.get('id'), '2', 'Preloaded belongsTo set');
+            assert.strictEqual(friend.get('id'), '2', 'Preloaded belongsTo set');
           });
       });
     });
@@ -581,7 +585,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     const ApplicationAdapter = Adapter.extend({
       findRecord(store, type, id, snapshot) {
-        assert.equal(snapshot.hasMany('friends')[0].attr('name'), 'Tom', 'Preloaded hasMany set');
+        assert.strictEqual(snapshot.hasMany('friends')[0].attr('name'), 'Tom', 'Preloaded hasMany set');
         return { data: { id, type: 'person' } };
       },
     });
@@ -618,7 +622,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     const ApplicationAdapter = Adapter.extend({
       findRecord(store, type, id, snapshot) {
-        assert.equal(snapshot.hasMany('friends')[0].id, '2', 'Preloaded hasMany set');
+        assert.strictEqual(snapshot.hasMany('friends')[0].id, '2', 'Preloaded hasMany set');
         return { data: { id, type: 'person' } };
       },
     });
@@ -647,7 +651,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     const ApplicationAdapter = Adapter.extend({
       findRecord(store, type, id, snapshot) {
-        assert.equal(snapshot.hasMany('friends').length, 0, 'Preloaded hasMany set');
+        assert.strictEqual(snapshot.hasMany('friends').length, 0, 'Preloaded hasMany set');
         return { data: { id, type: 'person' } };
       },
     });
@@ -673,7 +677,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     const ApplicationAdapter = Adapter.extend({
       findRecord(store, type, id, snapshot) {
-        assert.equal(snapshot.hasMany('friends').length, 0, 'Preloaded hasMany set');
+        assert.strictEqual(snapshot.hasMany('friends').length, 0, 'Preloaded hasMany set');
         return { data: { id, type: 'person' } };
       },
     });
@@ -722,7 +726,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
     return run(() => {
       return all([tom.save(), yehuda.save()]).then(() => {
         people.forEach((person, index) => {
-          assert.equal(person.get('id'), index + 1, `The record's id should be correct.`);
+          assert.strictEqual(person.get('id'), String(index + 1), `The record's id should be correct.`);
         });
       });
     });
@@ -792,7 +796,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
       return store._scheduleFetchMany(internalModels).then(() => {
         let unloadedRecords = A(internalModels.map((r) => r.getRecord())).filterBy('isEmpty');
 
-        assert.equal(get(unloadedRecords, 'length'), 0, 'All unloaded records should be loaded');
+        assert.strictEqual(get(unloadedRecords, 'length'), 0, 'All unloaded records should be loaded');
       });
     });
   });
@@ -806,7 +810,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
       },
 
       findRecord(store, type, id, snapshot) {
-        assert.equal(id, '10', 'The first group is passed to find');
+        assert.strictEqual(id, '10', 'The first group is passed to find');
         return { data: { id, type: 'test' } };
       },
 
@@ -1002,7 +1006,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
         wait.push(
           store.findRecord('test', 'igor').catch((e) => {
             igorDidReject = true;
-            assert.equal(
+            assert.strictEqual(
               e.message,
               `Expected: '<test:igor>' to be present in the adapter provided payload, but it was not found.`
             );
@@ -1105,7 +1109,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
       });
 
       return store.findRecord('person', 1).then((record) => {
-        assert.equal(record.get('name'), 'Tom');
+        assert.strictEqual(record.get('name'), 'Tom');
       });
     });
   });
@@ -1145,7 +1149,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
       });
 
       return store.findRecord('person', 1).then((record) => {
-        assert.equal(record.get('name'), 'Tom');
+        assert.strictEqual(record.get('name'), 'Tom');
       });
     });
   });
@@ -1217,7 +1221,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
       });
     });
 
-    assert.equal(store.peekRecord('person', 1).get('name'), 'Tom');
+    assert.strictEqual(store.peekRecord('person', 1).get('name'), 'Tom');
 
     return done;
   });
@@ -1273,7 +1277,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     return run(() => {
       return store.findAll('person').then((records) => {
-        assert.equal(records.get('firstObject.name'), 'Tom');
+        assert.strictEqual(records.get('firstObject.name'), 'Tom');
       });
     });
   });
@@ -1306,7 +1310,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
 
     return run(() => {
       return store.findAll('person').then((records) => {
-        assert.equal(records.get('firstObject.name'), 'Tom');
+        assert.strictEqual(records.get('firstObject.name'), 'Tom');
       });
     });
   });
@@ -1376,7 +1380,7 @@ module('unit/store/adapter-interop - Store working with a Adapter', function (ho
       });
     });
 
-    assert.equal(store.peekRecord('person', 1).get('name'), 'Tom');
+    assert.strictEqual(store.peekRecord('person', 1).get('name'), 'Tom');
 
     return done;
   });

--- a/packages/-ember-data/tests/unit/store/async-leak-test.js
+++ b/packages/-ember-data/tests/unit/store/async-leak-test.js
@@ -101,7 +101,7 @@ module('unit/store async-waiter and leak detection', function (hooks) {
 
     await findRecordWasInvokedPromise;
 
-    assert.equal(store._trackedAsyncRequests.length, 1, 'We return true even though a request is pending');
+    assert.strictEqual(store._trackedAsyncRequests.length, 1, 'We return true even though a request is pending');
     assert.true(waiter(), 'We return true even though a request is pending');
 
     await request;
@@ -208,7 +208,7 @@ module('unit/store async-waiter and leak detection', function (hooks) {
 
     // make the waiter complete
     run(() => next());
-    assert.equal(store._trackedAsyncRequests.length, 0, 'Our pending request is cleaned up');
+    assert.strictEqual(store._trackedAsyncRequests.length, 0, 'Our pending request is cleaned up');
     assert.true(waiter(), 'We return true because the waiter is cleared');
   });
 
@@ -238,12 +238,12 @@ module('unit/store async-waiter and leak detection', function (hooks) {
     store.findRecord('person', '1');
     let waiter = store.__asyncWaiter;
 
-    assert.equal(store._trackedAsyncRequests.length, 0, 'We have no requests yet');
+    assert.strictEqual(store._trackedAsyncRequests.length, 0, 'We have no requests yet');
     assert.true(waiter(), 'We return true when no requests have been initiated yet (pending queue flush is async)');
 
     await stepPromise;
 
-    assert.equal(store._trackedAsyncRequests.length, 1, 'We have a pending request');
+    assert.strictEqual(store._trackedAsyncRequests.length, 1, 'We have a pending request');
     assert.true(waiter(), 'We return true because the waiter is turned off');
     assert.expectWarning(() => {
       run(() => {
@@ -255,7 +255,7 @@ module('unit/store async-waiter and leak detection', function (hooks) {
 
     // make the waiter complete
     run(() => next());
-    assert.equal(store._trackedAsyncRequests.length, 0, 'Our pending request is cleaned up');
+    assert.strictEqual(store._trackedAsyncRequests.length, 0, 'Our pending request is cleaned up');
     assert.true(waiter(), 'We return true because the waiter is cleared');
   });
 
@@ -287,7 +287,7 @@ module('unit/store async-waiter and leak detection', function (hooks) {
     await stepPromise;
 
     assert.false(waiter(), 'We return false to keep waiting while requests are pending');
-    assert.equal(
+    assert.strictEqual(
       store._trackedAsyncRequests[0].trace,
       'set `store.generateStackTracesForTrackedRequests = true;` to get a detailed trace for where this request originated',
       'We provide a useful default message in place of a trace'
@@ -310,7 +310,7 @@ module('unit/store async-waiter and leak detection', function (hooks) {
       we should do something similar to capture where the fetch was scheduled
       from.
      */
-    assert.equal(
+    assert.strictEqual(
       store._trackedAsyncRequests[0].trace.message,
       "EmberData TrackedRequest: DS: Handle Adapter#findRecord of 'person' with id: '2'",
       'We captured a trace'

--- a/packages/-ember-data/tests/unit/store/create-record-test.js
+++ b/packages/-ember-data/tests/unit/store/create-record-test.js
@@ -114,13 +114,13 @@ module('unit/store/createRecord - Store creating records', function (hooks) {
       storage = store.createRecord('storage', { name: 'Great store', records: records });
     });
 
-    assert.equal(storage.get('name'), 'Great store', 'The attribute is well defined');
-    assert.equal(
+    assert.strictEqual(storage.get('name'), 'Great store', 'The attribute is well defined');
+    assert.strictEqual(
       storage.get('records').findBy('id', '1'),
       A(records).findBy('id', '1'),
       'Defined relationships are allowed in createRecord'
     );
-    assert.equal(
+    assert.strictEqual(
       storage.get('records').findBy('id', '2'),
       A(records).findBy('id', '2'),
       'Defined relationships are allowed in createRecord'
@@ -142,7 +142,7 @@ module('unit/store/createRecord - Store with models by dash', function (hooks) {
     let attributes = { foo: 'bar' };
     let record = store.createRecord('some-thing', attributes);
 
-    assert.equal(record.get('foo'), attributes.foo, 'The record is created');
-    assert.equal(store.modelFor('some-thing').modelName, 'some-thing');
+    assert.strictEqual(record.get('foo'), attributes.foo, 'The record is created');
+    assert.strictEqual(store.modelFor('some-thing').modelName, 'some-thing');
   });
 });

--- a/packages/-ember-data/tests/unit/store/model-for-test.js
+++ b/packages/-ember-data/tests/unit/store/model-for-test.js
@@ -20,8 +20,8 @@ module('unit/store/model_for - DS.Store#modelFor', function (hooks) {
 
     registry.normalize = (key) => dasherize(camelize(key));
 
-    assert.equal(registry.normalize('some.post'), 'some-post', 'precond - container camelizes');
-    assert.equal(store.modelFor('blog.post').modelName, 'blog.post', 'modelName is normalized to dasherized');
+    assert.strictEqual(registry.normalize('some.post'), 'some-post', 'precond - container camelizes');
+    assert.strictEqual(store.modelFor('blog.post').modelName, 'blog.post', 'modelName is normalized to dasherized');
   });
 
   test('when fetching factory from string and dashing normalizer, sets a normalized key as modelName', function (assert) {
@@ -30,8 +30,8 @@ module('unit/store/model_for - DS.Store#modelFor', function (hooks) {
 
     registry.normalize = (key) => dasherize(camelize(key));
 
-    assert.equal(registry.normalize('some.post'), 'some-post', 'precond - container dasherizes');
-    assert.equal(store.modelFor('blog.post').modelName, 'blog.post', 'modelName is normalized to dasherized');
+    assert.strictEqual(registry.normalize('some.post'), 'some-post', 'precond - container dasherizes');
+    assert.strictEqual(store.modelFor('blog.post').modelName, 'blog.post', 'modelName is normalized to dasherized');
   });
 
   test(`when fetching something that doesn't exist, throws error`, function (assert) {

--- a/packages/-ember-data/tests/unit/store/peek-record-test.js
+++ b/packages/-ember-data/tests/unit/store/peek-record-test.js
@@ -24,7 +24,11 @@ module('unit/store/peekRecord - Store peekRecord', function (hooks) {
         id: '1',
       },
     });
-    assert.equal(person, store.peekRecord('person', 1), 'peekRecord only return the corresponding record in the store');
+    assert.strictEqual(
+      person,
+      store.peekRecord('person', 1),
+      'peekRecord only return the corresponding record in the store'
+    );
   });
 
   test('peekRecord should return the record with identifier as argument', function (assert) {
@@ -36,7 +40,7 @@ module('unit/store/peekRecord - Store peekRecord', function (hooks) {
         id: '1',
       },
     });
-    assert.equal(
+    assert.strictEqual(
       person,
       store.peekRecord({ type: 'person', id: 1 }),
       'peekRecord only return the corresponding record in the store'
@@ -46,7 +50,7 @@ module('unit/store/peekRecord - Store peekRecord', function (hooks) {
   test('peekRecord should return null if the record is not in the store ', function (assert) {
     let store = this.owner.lookup('service:store');
 
-    assert.equal(
+    assert.strictEqual(
       null,
       store.peekRecord('person', 1),
       'peekRecord returns null if the corresponding record is not in the store'

--- a/packages/-ember-data/tests/unit/store/push-test.js
+++ b/packages/-ember-data/tests/unit/store/push-test.js
@@ -57,14 +57,14 @@ module('unit/store/push - DS.Store#push', function (hooks) {
       });
     });
 
-    assert.equal(person.get('firstName'), 'original first name');
-    assert.equal(person.get('currentState.stateName'), 'root.loaded.saved');
+    assert.strictEqual(person.get('firstName'), 'original first name');
+    assert.strictEqual(person.get('currentState.stateName'), 'root.loaded.saved');
 
     run(() => person.set('firstName', 'updated first name'));
 
-    assert.equal(person.get('firstName'), 'updated first name');
+    assert.strictEqual(person.get('firstName'), 'updated first name');
     assert.strictEqual(person.get('lastName'), undefined);
-    assert.equal(person.get('currentState.stateName'), 'root.loaded.updated.uncommitted');
+    assert.strictEqual(person.get('currentState.stateName'), 'root.loaded.updated.uncommitted');
     assert.deepEqual(person.changedAttributes().firstName, ['original first name', 'updated first name']);
 
     run(() => {
@@ -79,8 +79,8 @@ module('unit/store/push - DS.Store#push', function (hooks) {
       });
     });
 
-    assert.equal(person.get('firstName'), 'updated first name');
-    assert.equal(person.get('currentState.stateName'), 'root.loaded.saved');
+    assert.strictEqual(person.get('firstName'), 'updated first name');
+    assert.strictEqual(person.get('currentState.stateName'), 'root.loaded.saved');
     assert.notOk(person.changedAttributes().firstName);
   });
 
@@ -104,7 +104,7 @@ module('unit/store/push - DS.Store#push', function (hooks) {
       });
 
       return store.findRecord('person', 'wat').then((foundPerson) => {
-        assert.equal(
+        assert.strictEqual(
           foundPerson,
           person,
           'record returned via load() is the same as the record returned from findRecord()'
@@ -221,7 +221,7 @@ module('unit/store/push - DS.Store#push', function (hooks) {
       });
 
       return store.findRecord('person', 'wat').then((foundPerson) => {
-        assert.equal(
+        assert.strictEqual(
           foundPerson,
           person,
           'record returned via load() is the same as the record returned from findRecord()'
@@ -259,8 +259,8 @@ module('unit/store/push - DS.Store#push', function (hooks) {
       );
     });
 
-    assert.equal(person.get('firstName'), 'Jacquie', 'you can push raw JSON into the store');
-    assert.equal(person.get('lastName'), 'Jackson', 'existing fields are untouched');
+    assert.strictEqual(person.get('firstName'), 'Jacquie', 'you can push raw JSON into the store');
+    assert.strictEqual(person.get('lastName'), 'Jackson', 'existing fields are untouched');
   });
 
   test('Calling push with a normalized hash containing IDs of related records returns a record', function (assert) {
@@ -359,7 +359,7 @@ module('unit/store/push - DS.Store#push', function (hooks) {
 
     let post = store.peekRecord('post', 1);
 
-    assert.equal(post.get('postTitle'), 'Ember rocks', 'you can push raw JSON into the store');
+    assert.strictEqual(post.get('postTitle'), 'Ember rocks', 'you can push raw JSON into the store');
 
     run(() => {
       store.pushPayload('post', {
@@ -372,7 +372,7 @@ module('unit/store/push - DS.Store#push', function (hooks) {
       });
     });
 
-    assert.equal(post.get('postTitle'), 'Ember rocks (updated)', 'You can update data in the store');
+    assert.strictEqual(post.get('postTitle'), 'Ember rocks (updated)', 'You can update data in the store');
   });
 
   test('Calling pushPayload allows pushing singular payload properties', function (assert) {
@@ -387,7 +387,7 @@ module('unit/store/push - DS.Store#push', function (hooks) {
 
     let post = store.peekRecord('post', 1);
 
-    assert.equal(post.get('postTitle'), 'Ember rocks', 'you can push raw JSON into the store');
+    assert.strictEqual(post.get('postTitle'), 'Ember rocks', 'you can push raw JSON into the store');
 
     run(() => {
       store.pushPayload('post', {
@@ -398,7 +398,7 @@ module('unit/store/push - DS.Store#push', function (hooks) {
       });
     });
 
-    assert.equal(post.get('postTitle'), 'Ember rocks (updated)', 'You can update data in the store');
+    assert.strictEqual(post.get('postTitle'), 'Ember rocks (updated)', 'You can update data in the store');
   });
 
   test(`Calling pushPayload should use the type's serializer for normalizing`, function (assert) {
@@ -443,11 +443,11 @@ module('unit/store/push - DS.Store#push', function (hooks) {
 
     let post = store.peekRecord('post', 1);
 
-    assert.equal(post.get('postTitle'), 'Ember rocks', 'you can push raw JSON into the store');
+    assert.strictEqual(post.get('postTitle'), 'Ember rocks', 'you can push raw JSON into the store');
 
     let person = store.peekRecord('person', 2);
 
-    assert.equal(person.get('firstName'), 'Yehuda', 'you can push raw JSON into the store');
+    assert.strictEqual(person.get('firstName'), 'Yehuda', 'you can push raw JSON into the store');
   });
 
   test(`Calling pushPayload without a type uses application serializer's pushPayload method`, function (assert) {
@@ -512,11 +512,11 @@ module('unit/store/push - DS.Store#push', function (hooks) {
 
     var post = store.peekRecord('post', 1);
 
-    assert.equal(post.get('postTitle'), 'Ember rocks', 'you can push raw JSON into the store');
+    assert.strictEqual(post.get('postTitle'), 'Ember rocks', 'you can push raw JSON into the store');
 
     var person = store.peekRecord('person', 2);
 
-    assert.equal(person.get('firstName'), 'Yehuda', 'you can push raw JSON into the store');
+    assert.strictEqual(person.get('firstName'), 'Yehuda', 'you can push raw JSON into the store');
   });
 
   test('Calling pushPayload allows partial updates with raw JSON', function (assert) {
@@ -536,8 +536,8 @@ module('unit/store/push - DS.Store#push', function (hooks) {
 
     let person = store.peekRecord('person', 1);
 
-    assert.equal(person.get('firstName'), 'Robert', 'you can push raw JSON into the store');
-    assert.equal(person.get('lastName'), 'Jackson', 'you can push raw JSON into the store');
+    assert.strictEqual(person.get('firstName'), 'Robert', 'you can push raw JSON into the store');
+    assert.strictEqual(person.get('lastName'), 'Jackson', 'you can push raw JSON into the store');
 
     run(() => {
       store.pushPayload('person', {
@@ -550,8 +550,8 @@ module('unit/store/push - DS.Store#push', function (hooks) {
       });
     });
 
-    assert.equal(person.get('firstName'), 'Jacquie', 'you can push raw JSON into the store');
-    assert.equal(person.get('lastName'), 'Jackson', 'existing fields are untouched');
+    assert.strictEqual(person.get('firstName'), 'Jacquie', 'you can push raw JSON into the store');
+    assert.strictEqual(person.get('lastName'), 'Jackson', 'existing fields are untouched');
   });
 
   testInDebug(
@@ -618,8 +618,8 @@ module('unit/store/push - DS.Store#push', function (hooks) {
       let robert = store.peekRecord('person', '1');
 
       var friends = robert.friends;
-      assert.equal(friends.firstObject.id, '2', 'first object is unchanged');
-      assert.equal(friends.lastObject.id, '3', 'last object is unchanged');
+      assert.strictEqual(friends.firstObject.id, '2', 'first object is unchanged');
+      assert.strictEqual(friends.lastObject.id, '3', 'last object is unchanged');
     }
   );
 
@@ -722,8 +722,8 @@ module('unit/store/push - DS.Store#push', function (hooks) {
 
       let person = store.peekRecord('person', 1);
 
-      assert.equal(person.get('phoneNumbers.length'), 1);
-      assert.equal(person.get('phoneNumbers.firstObject.number'), '1-800-DATA');
+      assert.strictEqual(person.get('phoneNumbers.length'), 1);
+      assert.strictEqual(person.get('phoneNumbers.firstObject.number'), '1-800-DATA');
 
       // GET /persons/1
       assert.expectNoWarning(() => {
@@ -742,8 +742,8 @@ module('unit/store/push - DS.Store#push', function (hooks) {
         });
       });
 
-      assert.equal(person.get('phoneNumbers.length'), 1);
-      assert.equal(person.get('phoneNumbers.firstObject.number'), '1-800-DATA');
+      assert.strictEqual(person.get('phoneNumbers.length'), 1);
+      assert.strictEqual(person.get('phoneNumbers.firstObject.number'), '1-800-DATA');
     }
   );
 
@@ -784,7 +784,7 @@ module('unit/store/push - DS.Store#push', function (hooks) {
 
     let person = store.peekRecord('person', 1);
 
-    assert.equal(person.get('firstName'), 'Tan', 'you can use links containing an object');
+    assert.strictEqual(person.get('firstName'), 'Tan', 'you can use links containing an object');
   });
 
   test('Calling push with a link containing the value null', function (assert) {
@@ -809,7 +809,7 @@ module('unit/store/push - DS.Store#push', function (hooks) {
 
     let person = store.peekRecord('person', 1);
 
-    assert.equal(person.get('firstName'), 'Tan', 'you can use links that contain null as a value');
+    assert.strictEqual(person.get('firstName'), 'Tan', 'you can use links that contain null as a value');
   });
 
   testInDebug('calling push with hasMany relationship the value must be an array', function (assert) {
@@ -1046,10 +1046,10 @@ module('unit/store/push - DS.Store#push with JSON-API', function (hooks) {
     });
 
     let tom = store.peekRecord('person', 1);
-    assert.equal(tom.get('name'), 'Tom Dale', 'Tom should be in the store');
+    assert.strictEqual(tom.get('name'), 'Tom Dale', 'Tom should be in the store');
 
     let tomster = store.peekRecord('person', 2);
-    assert.equal(tomster.get('name'), 'Tomster', 'Tomster should be in the store');
+    assert.strictEqual(tomster.get('name'), 'Tomster', 'Tomster should be in the store');
   });
 
   test('Should support pushing included models into the store', function (assert) {
@@ -1098,9 +1098,9 @@ module('unit/store/push - DS.Store#push with JSON-API', function (hooks) {
     });
 
     let tomster = store.peekRecord('person', 1);
-    assert.equal(tomster.get('name'), 'Tomster', 'Tomster should be in the store');
+    assert.strictEqual(tomster.get('name'), 'Tomster', 'Tomster should be in the store');
 
     let car = store.peekRecord('car', 1);
-    assert.equal(car.get('model'), 'Neon', "Tomster's car should be in the store");
+    assert.strictEqual(car.get('model'), 'Neon', "Tomster's car should be in the store");
   });
 });

--- a/packages/-ember-data/tests/unit/store/unload-test.js
+++ b/packages/-ember-data/tests/unit/store/unload-test.js
@@ -65,7 +65,7 @@ module('unit/store/unload - Store unloading records', function (hooks) {
       record.set('title', 'toto2');
       record._internalModel.send('willCommit');
 
-      assert.equal(get(record, 'hasDirtyAttributes'), true, 'record is dirty');
+      assert.strictEqual(get(record, 'hasDirtyAttributes'), true, 'record is dirty');
 
       assert.expectAssertion(
         function () {
@@ -97,7 +97,7 @@ module('unit/store/unload - Store unloading records', function (hooks) {
       });
 
       return store.findRecord('record', 1).then((record) => {
-        assert.equal(get(record, 'id'), 1, 'found record with id 1');
+        assert.strictEqual(get(record, 'id'), '1', 'found record with id 1');
 
         run(() => store.unloadRecord(record));
 
@@ -232,7 +232,7 @@ module('Store - unload record with relationships', function (hooks) {
         return store.findRecord('product', 1);
       })
       .then((product) => {
-        assert.equal(
+        assert.strictEqual(
           product.get('description'),
           'cuisinart',
           "The record was unloaded and the adapter's `findRecord` was called"

--- a/packages/-ember-data/tests/unit/system/relationships/polymorphic-relationship-payloads-test.js
+++ b/packages/-ember-data/tests/unit/system/relationships/polymorphic-relationship-payloads-test.js
@@ -312,8 +312,8 @@ module('unit/system/relationships/relationship-payloads-manager (polymorphic)', 
     const finalBigResult = bigPerson.get('hats').toArray();
     const finalSmallResult = smallPerson.get('hats').toArray();
 
-    assert.equal(finalBigResult.length, 4, 'We got all our hats!');
-    assert.equal(finalSmallResult.length, 2, 'We got all our hats!');
+    assert.strictEqual(finalBigResult.length, 4, 'We got all our hats!');
+    assert.strictEqual(finalSmallResult.length, 2, 'We got all our hats!');
   });
 
   test('handles relationships where both sides are polymorphic reflexive', function (assert) {

--- a/packages/-ember-data/tests/unit/system/snapshot-record-array-test.js
+++ b/packages/-ember-data/tests/unit/system/snapshot-record-array-test.js
@@ -16,11 +16,11 @@ module('Unit - snapshot-record-array', function () {
 
     let snapshot = new SnapshotRecordArray(array, meta, options);
 
-    assert.equal(snapshot.length, 2);
-    assert.equal(snapshot.meta, meta);
-    assert.equal(snapshot.type, 'some type');
-    assert.equal(snapshot.adapterOptions, 'some options');
-    assert.equal(snapshot.include, 'include me');
+    assert.strictEqual(snapshot.length, 2);
+    assert.strictEqual(snapshot.meta, meta);
+    assert.strictEqual(snapshot.type, 'some type');
+    assert.strictEqual(snapshot.adapterOptions, 'some options');
+    assert.strictEqual(snapshot.include, 'include me');
   });
 
   test('#snapshot', function (assert) {
@@ -42,11 +42,11 @@ module('Unit - snapshot-record-array', function () {
 
     let snapshot = new SnapshotRecordArray(array, meta, options);
 
-    assert.equal(didTakeSnapshot, 0, 'no shapshot shouldn yet be taken');
-    assert.equal(snapshot.snapshots(), snapshotTaken, 'should be correct snapshot');
-    assert.equal(didTakeSnapshot, 1, 'one snapshot should have been taken');
-    assert.equal(snapshot.snapshots(), snapshotTaken, 'should return the exact same snapshot');
-    assert.equal(didTakeSnapshot, 1, 'still only one snapshot should have been taken');
+    assert.strictEqual(didTakeSnapshot, 0, 'no shapshot shouldn yet be taken');
+    assert.strictEqual(snapshot.snapshots(), snapshotTaken, 'should be correct snapshot');
+    assert.strictEqual(didTakeSnapshot, 1, 'one snapshot should have been taken');
+    assert.strictEqual(snapshot.snapshots(), snapshotTaken, 'should return the exact same snapshot');
+    assert.strictEqual(didTakeSnapshot, 1, 'still only one snapshot should have been taken');
   });
 
   test('SnapshotRecordArray.type loads the class lazily', function (assert) {
@@ -69,7 +69,7 @@ module('Unit - snapshot-record-array', function () {
     let snapshot = new SnapshotRecordArray(array, meta, options);
 
     assert.false(typeLoaded, 'model class is not eager loaded');
-    assert.equal(snapshot.type, 'some type');
+    assert.strictEqual(snapshot.type, 'some type');
     assert.true(typeLoaded, 'model class is loaded');
   });
 });

--- a/packages/-ember-data/tests/unit/transform/date-test.js
+++ b/packages/-ember-data/tests/unit/transform/date-test.js
@@ -15,17 +15,17 @@ module('unit/transform - DateTransform', function (hooks) {
     assert.strictEqual(transform.serialize(undefined), null);
     assert.strictEqual(transform.serialize(new Date('invalid')), null);
 
-    assert.equal(transform.serialize(date), dateString);
+    assert.strictEqual(transform.serialize(date), dateString);
   });
 
   test('#deserialize', async function (assert) {
     const transform = this.owner.lookup('transform:date');
 
     // from String
-    assert.equal(transform.deserialize(dateString).toISOString(), dateString);
+    assert.strictEqual(transform.deserialize(dateString).toISOString(), dateString);
 
     // from Number
-    assert.equal(transform.deserialize(dateInMillis).valueOf(), dateInMillis);
+    assert.strictEqual(transform.deserialize(dateInMillis).valueOf(), dateInMillis);
 
     // from other
     assert.strictEqual(transform.deserialize({}), null);

--- a/packages/-ember-data/tests/unit/transform/number-test.js
+++ b/packages/-ember-data/tests/unit/transform/number-test.js
@@ -10,9 +10,9 @@ module('unit/transform - NumberTransform', function (hooks) {
 
     assert.strictEqual(transform.serialize(null), null);
     assert.strictEqual(transform.serialize(undefined), null);
-    assert.equal(transform.serialize('1.1'), 1.1);
-    assert.equal(transform.serialize(1.1), 1.1);
-    assert.equal(transform.serialize(new Number(1.1)), 1.1);
+    assert.strictEqual(transform.serialize('1.1'), 1.1);
+    assert.strictEqual(transform.serialize(1.1), 1.1);
+    assert.strictEqual(transform.serialize(new Number(1.1)), 1.1);
     assert.strictEqual(transform.serialize(NaN), null);
     assert.strictEqual(transform.serialize(Infinity), null);
     assert.strictEqual(transform.serialize(-Infinity), null);
@@ -23,9 +23,9 @@ module('unit/transform - NumberTransform', function (hooks) {
 
     assert.strictEqual(transform.deserialize(null), null);
     assert.strictEqual(transform.deserialize(undefined), null);
-    assert.equal(transform.deserialize('1.1'), 1.1);
-    assert.equal(transform.deserialize(1.1), 1.1);
-    assert.equal(transform.deserialize(new Number(1.1)), 1.1);
+    assert.strictEqual(transform.deserialize('1.1'), 1.1);
+    assert.strictEqual(transform.deserialize(1.1), 1.1);
+    assert.strictEqual(transform.deserialize(new Number(1.1)), 1.1);
     assert.strictEqual(transform.deserialize(NaN), null);
     assert.strictEqual(transform.deserialize(Infinity), null);
     assert.strictEqual(transform.deserialize(-Infinity), null);

--- a/packages/-ember-data/tests/unit/transform/string-test.js
+++ b/packages/-ember-data/tests/unit/transform/string-test.js
@@ -11,8 +11,8 @@ module('unit/transform - StringTransform', function (hooks) {
     assert.strictEqual(transform.serialize(null), null);
     assert.strictEqual(transform.serialize(undefined), null);
 
-    assert.equal(transform.serialize('foo'), 'foo');
-    assert.equal(transform.serialize(1), '1');
+    assert.strictEqual(transform.serialize('foo'), 'foo');
+    assert.strictEqual(transform.serialize(1), '1');
   });
 
   test('#deserialize', async function (assert) {
@@ -21,7 +21,7 @@ module('unit/transform - StringTransform', function (hooks) {
     assert.strictEqual(transform.deserialize(null), null);
     assert.strictEqual(transform.deserialize(undefined), null);
 
-    assert.equal(transform.deserialize('foo'), 'foo');
-    assert.equal(transform.deserialize(1), '1');
+    assert.strictEqual(transform.deserialize('foo'), 'foo');
+    assert.strictEqual(transform.deserialize(1), '1');
   });
 });

--- a/packages/-ember-data/tests/unit/utils/parse-response-headers-test.js
+++ b/packages/-ember-data/tests/unit/utils/parse-response-headers-test.js
@@ -21,9 +21,9 @@ module('unit/adapters/parse-response-headers', function () {
 
     let headers = parseResponseHeaders(headersString);
 
-    assert.equal(headers['content-encoding'], 'gzip', 'parses basic header pair');
-    assert.equal(headers['content-type'], 'application/json; charset=utf-8', 'parses header with complex value');
-    assert.equal(headers['date'], 'Fri, 05 Feb 2016 21:47:56 GMT', 'parses header with date value');
+    assert.strictEqual(headers['content-encoding'], 'gzip', 'parses basic header pair');
+    assert.strictEqual(headers['content-type'], 'application/json; charset=utf-8', 'parses header with complex value');
+    assert.strictEqual(headers['date'], 'Fri, 05 Feb 2016 21:47:56 GMT', 'parses header with date value');
   });
 
   test('field-name parsing', function (assert) {
@@ -35,13 +35,17 @@ module('unit/adapters/parse-response-headers', function () {
 
     let headers = parseResponseHeaders(headersString);
 
-    assert.equal(headers['name-with-leading-whitespace'], 'some value', 'strips leading whitespace from field-name');
-    assert.equal(
+    assert.strictEqual(
+      headers['name-with-leading-whitespace'],
+      'some value',
+      'strips leading whitespace from field-name'
+    );
+    assert.strictEqual(
       headers['name-with-whitespace-before-colon'],
       'another value',
       'strips whitespace before colon from field-name'
     );
-    assert.equal(headers['uppercase-name'], 'yet another value', 'lowercases the field-name');
+    assert.strictEqual(headers['uppercase-name'], 'yet another value', 'lowercases the field-name');
   });
 
   test('field-value parsing', function (assert) {
@@ -54,18 +58,26 @@ module('unit/adapters/parse-response-headers', function () {
 
     let headers = parseResponseHeaders(headersString);
 
-    assert.equal(
+    assert.strictEqual(
       headers['value-with-leading-space'],
       'value with leading whitespace',
       'strips leading whitespace in field-value'
     );
-    assert.equal(
+    assert.strictEqual(
       headers['value-without-leading-space'],
       'value without leading whitespace',
       'works without leaading whitespace in field-value'
     );
-    assert.equal(headers['value-with-colon'], 'value with: a colon', 'has correct value when value contains a colon');
-    assert.equal(headers['value-with-trailing-whitespace'], 'banana', 'strips trailing whitespace from field-value');
+    assert.strictEqual(
+      headers['value-with-colon'],
+      'value with: a colon',
+      'has correct value when value contains a colon'
+    );
+    assert.strictEqual(
+      headers['value-with-trailing-whitespace'],
+      'banana',
+      'strips trailing whitespace from field-value'
+    );
   });
   ('\r\nfoo: bar');
 
@@ -78,7 +90,7 @@ module('unit/adapters/parse-response-headers', function () {
 
     assert.deepEqual(headers['content-encoding'], 'gzip', 'parses basic header pair');
     assert.deepEqual(headers['apple'], 'pie', 'parses basic header pair');
-    assert.equal(Object.keys(headers).length, 3, 'only has the three valid headers');
+    assert.strictEqual(Object.keys(headers).length, 3, 'only has the three valid headers');
   });
 
   test('tollerate extra new-lines', function (assert) {
@@ -86,7 +98,7 @@ module('unit/adapters/parse-response-headers', function () {
     let headers = parseResponseHeaders(headersString);
 
     assert.deepEqual(headers['foo'], 'bar', 'parses basic header pair');
-    assert.equal(Object.keys(headers).length, 1, 'only has the one valid header');
+    assert.strictEqual(Object.keys(headers).length, 1, 'only has the one valid header');
   });
 
   test('works with only line feeds', function (assert) {
@@ -98,8 +110,8 @@ module('unit/adapters/parse-response-headers', function () {
 
     let headers = parseResponseHeaders(headersString);
 
-    assert.equal(headers['Content-Encoding'], 'gzip', 'parses basic header pair');
-    assert.equal(headers['content-type'], 'application/json; charset=utf-8', 'parses header with complex value');
-    assert.equal(headers['date'], 'Fri, 05 Feb 2016 21:47:56 GMT', 'parses header with date value');
+    assert.strictEqual(headers['Content-Encoding'], 'gzip', 'parses basic header pair');
+    assert.strictEqual(headers['content-type'], 'application/json; charset=utf-8', 'parses header with complex value');
+    assert.strictEqual(headers['date'], 'Fri, 05 Feb 2016 21:47:56 GMT', 'parses header with date value');
   });
 });

--- a/packages/unpublished-adapter-encapsulation-test-app/tests/integration/belongs-to-test.js
+++ b/packages/unpublished-adapter-encapsulation-test-app/tests/integration/belongs-to-test.js
@@ -156,14 +156,14 @@ module('integration/belongs-to - Belongs To Tests', function (hooks) {
       findBelongsTo(passedStore, snapshot, url, relationship) {
         findBelongsToCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findBelongsTo');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findBelongsTo');
 
         let expectedURL = initialRecord.data.relationships.post.links.related;
-        assert.equal(url, expectedURL, 'url is passed to findBelongsTo');
-        assert.equal(relationship.meta.key, 'post', 'relationship is passed to findBelongsTo');
+        assert.strictEqual(url, expectedURL, 'url is passed to findBelongsTo');
+        assert.strictEqual(relationship.meta.key, 'post', 'relationship is passed to findBelongsTo');
 
-        assert.equal(snapshot.modelName, 'comment', 'snapshot is passed to findBelongsTo with correct modelName');
-        assert.equal(snapshot.id, '3', 'snapshot is passed to findBelongsTo with correct id');
+        assert.strictEqual(snapshot.modelName, 'comment', 'snapshot is passed to findBelongsTo with correct modelName');
+        assert.strictEqual(snapshot.id, '3', 'snapshot is passed to findBelongsTo with correct id');
 
         return resolve(expectedResultCopy);
       }
@@ -175,8 +175,8 @@ module('integration/belongs-to - Belongs To Tests', function (hooks) {
 
     let post = await comment.get('post');
 
-    assert.equal(findRecordCalled, 0, 'findRecord is not called');
-    assert.equal(findBelongsToCalled, 1, 'findBelongsTo is called once');
+    assert.strictEqual(findRecordCalled, 0, 'findRecord is not called');
+    assert.strictEqual(findBelongsToCalled, 1, 'findBelongsTo is called once');
     assert.deepEqual(post.serialize(), expectedResult, 'findBelongsTo returns expected result');
   });
 
@@ -269,12 +269,12 @@ module('integration/belongs-to - Belongs To Tests', function (hooks) {
       findRecord(passedStore, type, id, snapshot) {
         findRecordCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findRecord');
-        assert.equal(type, Post, 'model is passed to findRecord');
-        assert.equal(id, '2', 'id is passed to findRecord');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findRecord');
+        assert.strictEqual(type, Post, 'model is passed to findRecord');
+        assert.strictEqual(id, '2', 'id is passed to findRecord');
 
-        assert.equal(snapshot.modelName, 'post', 'snapshot is passed to findRecord with correct modelName');
-        assert.equal(snapshot.id, '2', 'snapshot is passed to findRecord with correct id');
+        assert.strictEqual(snapshot.modelName, 'post', 'snapshot is passed to findRecord with correct modelName');
+        assert.strictEqual(snapshot.id, '2', 'snapshot is passed to findRecord with correct id');
 
         return resolve(expectedResultCopy);
       }
@@ -290,8 +290,8 @@ module('integration/belongs-to - Belongs To Tests', function (hooks) {
 
     let post = await comment.get('post');
 
-    assert.equal(findRecordCalled, 1, 'findRecord is called once');
-    assert.equal(findBelongsToCalled, 0, 'findBelongsTo is not called');
+    assert.strictEqual(findRecordCalled, 1, 'findRecord is called once');
+    assert.strictEqual(findBelongsToCalled, 0, 'findBelongsTo is not called');
     assert.deepEqual(post.serialize(), expectedResult, 'findRecord returns expected result');
   });
 
@@ -348,12 +348,12 @@ module('integration/belongs-to - Belongs To Tests', function (hooks) {
       findRecord(passedStore, type, id, snapshot) {
         findRecordCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findRecord');
-        assert.equal(type, Post, 'model is passed to findRecord');
-        assert.equal(id, '2', 'id is passed to findRecord');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findRecord');
+        assert.strictEqual(type, Post, 'model is passed to findRecord');
+        assert.strictEqual(id, '2', 'id is passed to findRecord');
 
-        assert.equal(snapshot.modelName, 'post', 'snapshot is passed to findRecord with correct modelName');
-        assert.equal(snapshot.id, '2', 'snapshot is passed to findRecord with correct id');
+        assert.strictEqual(snapshot.modelName, 'post', 'snapshot is passed to findRecord with correct modelName');
+        assert.strictEqual(snapshot.id, '2', 'snapshot is passed to findRecord with correct id');
 
         return resolve(expectedResultCopy);
       }
@@ -365,7 +365,7 @@ module('integration/belongs-to - Belongs To Tests', function (hooks) {
 
     let post = await comment.get('post');
 
-    assert.equal(findRecordCalled, 1, 'findRecord is called once');
+    assert.strictEqual(findRecordCalled, 1, 'findRecord is called once');
     assert.deepEqual(post.serialize(), expectedResult, 'findRecord returns expected result');
   });
 
@@ -430,14 +430,14 @@ module('integration/belongs-to - Belongs To Tests', function (hooks) {
       findBelongsTo(passedStore, snapshot, url, relationship) {
         findBelongsToCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findBelongsTo');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findBelongsTo');
 
         let expectedURL = initialRecord.data.relationships.post.links.related;
-        assert.equal(url, expectedURL, 'url is passed to findBelongsTo');
-        assert.equal(relationship.meta.key, 'post', 'relationship is passed to findBelongsTo');
+        assert.strictEqual(url, expectedURL, 'url is passed to findBelongsTo');
+        assert.strictEqual(relationship.meta.key, 'post', 'relationship is passed to findBelongsTo');
 
-        assert.equal(snapshot.modelName, 'comment', 'snapshot is passed to findBelongsTo with correct modelName');
-        assert.equal(snapshot.id, '3', 'snapshot is passed to findBelongsTo with correct id');
+        assert.strictEqual(snapshot.modelName, 'comment', 'snapshot is passed to findBelongsTo with correct modelName');
+        assert.strictEqual(snapshot.id, '3', 'snapshot is passed to findBelongsTo with correct id');
 
         return resolve(expectedResultCopy);
       }
@@ -449,8 +449,8 @@ module('integration/belongs-to - Belongs To Tests', function (hooks) {
 
     let post = await comment.get('post');
 
-    assert.equal(findRecordCalled, 0, 'findRecord is not called');
-    assert.equal(findBelongsToCalled, 1, 'findBelongsTo is called once');
+    assert.strictEqual(findRecordCalled, 0, 'findRecord is not called');
+    assert.strictEqual(findBelongsToCalled, 1, 'findBelongsTo is called once');
     assert.deepEqual(post.serialize(), expectedResult, 'findBelongsTo returns expected result');
   });
 
@@ -507,12 +507,12 @@ module('integration/belongs-to - Belongs To Tests', function (hooks) {
       findRecord(passedStore, type, id, snapshot) {
         findRecordCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findRecord');
-        assert.equal(type, Post, 'model is passed to findRecord');
-        assert.equal(id, '2', 'id is passed to findRecord');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findRecord');
+        assert.strictEqual(type, Post, 'model is passed to findRecord');
+        assert.strictEqual(id, '2', 'id is passed to findRecord');
 
-        assert.equal(snapshot.modelName, 'post', 'snapshot is passed to findRecord with correct modelName');
-        assert.equal(snapshot.id, '2', 'snapshot is passed to findRecord with correct id');
+        assert.strictEqual(snapshot.modelName, 'post', 'snapshot is passed to findRecord with correct modelName');
+        assert.strictEqual(snapshot.id, '2', 'snapshot is passed to findRecord with correct id');
 
         return resolve(expectedResultCopy);
       }
@@ -524,7 +524,7 @@ module('integration/belongs-to - Belongs To Tests', function (hooks) {
 
     let post = await comment.get('post');
 
-    assert.equal(findRecordCalled, 1, 'findRecord is called once');
+    assert.strictEqual(findRecordCalled, 1, 'findRecord is called once');
     assert.deepEqual(post.serialize(), expectedResult, 'findRecord returns expected result');
   });
 });

--- a/packages/unpublished-adapter-encapsulation-test-app/tests/integration/coalescing-test.js
+++ b/packages/unpublished-adapter-encapsulation-test-app/tests/integration/coalescing-test.js
@@ -80,14 +80,14 @@ module('integration/coalescing - Coalescing Tests', function (hooks) {
       coalesceFindRequests = true;
 
       findRecord(passedStore, type, id, snapshot) {
-        assert.equal(passedStore, store, 'instance of store is passed to findRecord');
-        assert.equal(type, Person, 'model is passed to findRecord');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findRecord');
+        assert.strictEqual(type, Person, 'model is passed to findRecord');
 
         let expectedId = expectedResultsCopy[findRecordCalled].data.id;
-        assert.equal(id, expectedId, 'id is passed to findRecord');
+        assert.strictEqual(id, expectedId, 'id is passed to findRecord');
 
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to findRecord with correct modelName');
-        assert.equal(snapshot.id, expectedId, 'snapshot is passed to findRecord with correct id');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to findRecord with correct modelName');
+        assert.strictEqual(snapshot.id, expectedId, 'snapshot is passed to findRecord with correct id');
 
         return resolve(expectedResultsCopy[findRecordCalled++]);
       }
@@ -100,7 +100,7 @@ module('integration/coalescing - Coalescing Tests', function (hooks) {
 
     let serializedRecords = records.map((record) => record.serialize());
 
-    assert.equal(findRecordCalled, 2, 'findRecord is called twice');
+    assert.strictEqual(findRecordCalled, 2, 'findRecord is called twice');
     assert.deepEqual(serializedRecords, expectedResults, 'each findRecord returns expected result');
   });
 
@@ -148,15 +148,15 @@ module('integration/coalescing - Coalescing Tests', function (hooks) {
       findMany(passedStore, type, ids, snapshots) {
         findManyCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findMany');
-        assert.equal(type, Person, 'model is passed to findMany');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findMany');
+        assert.strictEqual(type, Person, 'model is passed to findMany');
 
         let expectedIds = expectedResultsCopy.data.map((record) => record.id);
         assert.deepEqual(ids, expectedIds, 'ids are passed to findMany');
 
         snapshots.forEach((snapshot, index) => {
-          assert.equal(snapshot.modelName, 'person', 'snapshot is passed to findMany with correct modelName');
-          assert.equal(snapshot.id, expectedIds[index], 'snapshot is passed to findMany with correct id');
+          assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to findMany with correct modelName');
+          assert.strictEqual(snapshot.id, expectedIds[index], 'snapshot is passed to findMany with correct id');
         });
 
         return resolve(expectedResultsCopy);
@@ -176,9 +176,9 @@ module('integration/coalescing - Coalescing Tests', function (hooks) {
     let serializedRecords = records.toArray().map((record) => record.serialize());
     expectedResults = expectedResults.data.map((result) => ({ data: result }));
 
-    assert.equal(findRecordCalled, 0, 'findRecord is not called');
-    assert.equal(findManyCalled, 1, 'findMany is called once');
-    assert.equal(groupRecordsForFindManyCalled, 1, 'groupRecordsForFindMany is called once');
+    assert.strictEqual(findRecordCalled, 0, 'findRecord is not called');
+    assert.strictEqual(findManyCalled, 1, 'findMany is called once');
+    assert.strictEqual(groupRecordsForFindManyCalled, 1, 'groupRecordsForFindMany is called once');
     assert.deepEqual(serializedRecords, expectedResults, 'each findRecord returns expected result');
   });
 
@@ -221,15 +221,15 @@ module('integration/coalescing - Coalescing Tests', function (hooks) {
       findMany(passedStore, type, ids, snapshots) {
         findManyCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findMany');
-        assert.equal(type, Person, 'model is passed to findMany');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findMany');
+        assert.strictEqual(type, Person, 'model is passed to findMany');
 
         let expectedIds = expectedResultsCopy.data.map((record) => record.id);
         assert.deepEqual(ids, expectedIds, 'ids are passed to findMany');
 
         snapshots.forEach((snapshot, index) => {
-          assert.equal(snapshot.modelName, 'person', 'snapshot is passed to findMany with correct modelName');
-          assert.equal(snapshot.id, expectedIds[index], 'snapshot is passed to findMany with correct id');
+          assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to findMany with correct modelName');
+          assert.strictEqual(snapshot.id, expectedIds[index], 'snapshot is passed to findMany with correct id');
         });
 
         return resolve(expectedResultsCopy);
@@ -244,8 +244,8 @@ module('integration/coalescing - Coalescing Tests', function (hooks) {
     let serializedRecords = records.toArray().map((record) => record.serialize());
     expectedResults = expectedResults.data.map((result) => ({ data: result }));
 
-    assert.equal(findRecordCalled, 0, 'findRecord is not called');
-    assert.equal(findManyCalled, 1, 'findMany is called once');
+    assert.strictEqual(findRecordCalled, 0, 'findRecord is not called');
+    assert.strictEqual(findManyCalled, 1, 'findMany is called once');
     assert.deepEqual(serializedRecords, expectedResults, 'each findRecord returns expected result');
   });
 
@@ -289,14 +289,14 @@ module('integration/coalescing - Coalescing Tests', function (hooks) {
       coalesceFindRequests = false;
 
       findRecord(passedStore, type, id, snapshot) {
-        assert.equal(passedStore, store, 'instance of store is passed to findRecord');
-        assert.equal(type, Person, 'model is passed to findRecord');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findRecord');
+        assert.strictEqual(type, Person, 'model is passed to findRecord');
 
         let expectedId = expectedResultsCopy[findRecordCalled].data.id;
-        assert.equal(id, expectedId, 'id is passed to findRecord');
+        assert.strictEqual(id, expectedId, 'id is passed to findRecord');
 
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to findRecord with correct modelName');
-        assert.equal(snapshot.id, expectedId, 'snapshot is passed to findRecord with correct id');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to findRecord with correct modelName');
+        assert.strictEqual(snapshot.id, expectedId, 'snapshot is passed to findRecord with correct id');
 
         return resolve(expectedResultsCopy[findRecordCalled++]);
       }
@@ -318,9 +318,9 @@ module('integration/coalescing - Coalescing Tests', function (hooks) {
 
     let serializedRecords = records.map((record) => record.serialize());
 
-    assert.equal(findRecordCalled, 2, 'findRecord is called twice');
-    assert.equal(findManyCalled, 0, 'findMany is not called');
-    assert.equal(groupRecordsForFindManyCalled, 0, 'groupRecordsForFindMany is not called');
+    assert.strictEqual(findRecordCalled, 2, 'findRecord is called twice');
+    assert.strictEqual(findManyCalled, 0, 'findMany is not called');
+    assert.strictEqual(groupRecordsForFindManyCalled, 0, 'groupRecordsForFindMany is not called');
     assert.deepEqual(serializedRecords, expectedResults, 'each findRecord returns expected result');
   });
 });

--- a/packages/unpublished-adapter-encapsulation-test-app/tests/integration/generate-id-test.js
+++ b/packages/unpublished-adapter-encapsulation-test-app/tests/integration/generate-id-test.js
@@ -62,12 +62,12 @@ module('integration/generate-id - GenerateIdForRecord Tests', function (hooks) {
 
     let record = store.createRecord('person', expectedProps);
 
-    assert.equal(record.id, 'manually generated id 1', 'manually generated id used');
+    assert.strictEqual(record.id, 'manually generated id 1', 'manually generated id used');
 
     let recordFromPeekRecord = store.peekRecord('person', record.id);
 
     assert.strictEqual(record, recordFromPeekRecord, 'peekRecord returns the same record');
-    assert.equal(generateIdForRecordCalled, 1, 'generateIdForRecord is called once');
+    assert.strictEqual(generateIdForRecordCalled, 1, 'generateIdForRecord is called once');
     assert.deepEqual(record.serialize(), {
       data: {
         id: 'manually generated id 1',

--- a/packages/unpublished-adapter-encapsulation-test-app/tests/integration/has-many-test.js
+++ b/packages/unpublished-adapter-encapsulation-test-app/tests/integration/has-many-test.js
@@ -176,14 +176,14 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       findHasMany(passedStore, snapshot, url, relationship) {
         findHasManyCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findHasMany');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findHasMany');
 
         let expectedURL = initialRecord.data.relationships.comments.links.related;
-        assert.equal(url, expectedURL, 'url is passed to findHasMany');
-        assert.equal(relationship.meta.key, 'comments', 'relationship is passed to findHasMany');
+        assert.strictEqual(url, expectedURL, 'url is passed to findHasMany');
+        assert.strictEqual(relationship.meta.key, 'comments', 'relationship is passed to findHasMany');
 
-        assert.equal(snapshot.modelName, 'post', 'snapshot is passed to findHasMany with correct modelName');
-        assert.equal(snapshot.id, '2', 'snapshot is passed to findHasMany with correct id');
+        assert.strictEqual(snapshot.modelName, 'post', 'snapshot is passed to findHasMany with correct modelName');
+        assert.strictEqual(snapshot.id, '2', 'snapshot is passed to findHasMany with correct id');
 
         return resolve(expectedResultCopy);
       }
@@ -198,9 +198,9 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       data: comments.toArray().map((comment) => comment.serialize().data),
     };
 
-    assert.equal(findRecordCalled, 0, 'findRecord is not called');
-    assert.equal(findManyCalled, 0, 'findMany is not called');
-    assert.equal(findHasManyCalled, 1, 'findHasMany is called once');
+    assert.strictEqual(findRecordCalled, 0, 'findRecord is not called');
+    assert.strictEqual(findManyCalled, 0, 'findMany is not called');
+    assert.strictEqual(findHasManyCalled, 1, 'findHasMany is called once');
     assert.deepEqual(serializedComments, expectedResult, 'findHasMany returns expected result');
   });
 
@@ -280,12 +280,12 @@ module('integration/has-many - Has Many Tests', function (hooks) {
         let index = findRecordCalled++;
         let expectedId = initialRecord.data.relationships.comments.data[index].id;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findRecord');
-        assert.equal(type, Comment, 'model is passed to findRecord');
-        assert.equal(id, expectedId, 'id is passed to findRecord');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findRecord');
+        assert.strictEqual(type, Comment, 'model is passed to findRecord');
+        assert.strictEqual(id, expectedId, 'id is passed to findRecord');
 
-        assert.equal(snapshot.modelName, 'comment', 'snapshot is passed to findRecord with correct modelName');
-        assert.equal(snapshot.id, expectedId, 'snapshot is passed to findRecord with correct id');
+        assert.strictEqual(snapshot.modelName, 'comment', 'snapshot is passed to findRecord with correct modelName');
+        assert.strictEqual(snapshot.id, expectedId, 'snapshot is passed to findRecord with correct id');
 
         return resolve({ data: expectedResultCopy.data[index] });
       }
@@ -307,9 +307,9 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       data: comments.toArray().map((comment) => comment.serialize().data),
     };
 
-    assert.equal(findRecordCalled, 2, 'findRecord is called twice');
-    assert.equal(findManyCalled, 0, 'findMany is not called');
-    assert.equal(findHasManyCalled, 0, 'findHasMany is not called');
+    assert.strictEqual(findRecordCalled, 2, 'findRecord is called twice');
+    assert.strictEqual(findManyCalled, 0, 'findMany is not called');
+    assert.strictEqual(findHasManyCalled, 0, 'findHasMany is not called');
     assert.deepEqual(serializedComments, expectedResult, 'get returns expected result');
   });
 
@@ -356,12 +356,12 @@ module('integration/has-many - Has Many Tests', function (hooks) {
         let index = findRecordCalled++;
         let expectedId = initialRecord.data.relationships.comments.data[index].id;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findRecord');
-        assert.equal(type, Comment, 'model is passed to findRecord');
-        assert.equal(id, expectedId, 'id is passed to findRecord');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findRecord');
+        assert.strictEqual(type, Comment, 'model is passed to findRecord');
+        assert.strictEqual(id, expectedId, 'id is passed to findRecord');
 
-        assert.equal(snapshot.modelName, 'comment', 'snapshot is passed to findRecord with correct modelName');
-        assert.equal(snapshot.id, expectedId, 'snapshot is passed to findRecord with correct id');
+        assert.strictEqual(snapshot.modelName, 'comment', 'snapshot is passed to findRecord with correct modelName');
+        assert.strictEqual(snapshot.id, expectedId, 'snapshot is passed to findRecord with correct id');
 
         return resolve({ data: expectedResultCopy.data[index] });
       }
@@ -379,8 +379,8 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       data: comments.toArray().map((comment) => comment.serialize().data),
     };
 
-    assert.equal(findRecordCalled, 2, 'findRecord is called twice');
-    assert.equal(findManyCalled, 0, 'findMany is not called');
+    assert.strictEqual(findRecordCalled, 2, 'findRecord is called twice');
+    assert.strictEqual(findManyCalled, 0, 'findMany is not called');
     assert.deepEqual(serializedComments, expectedResult, 'get returns expected result');
   });
 
@@ -439,15 +439,15 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       findMany(passedStore, type, ids, snapshots) {
         findManyCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findMany');
-        assert.equal(type, Comment, 'model is passed to findMany');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findMany');
+        assert.strictEqual(type, Comment, 'model is passed to findMany');
 
         let expectedIds = expectedResultCopy.data.map((record) => record.id);
         assert.deepEqual(ids, expectedIds, 'ids are passed to findMany');
 
         snapshots.forEach((snapshot, index) => {
-          assert.equal(snapshot.modelName, 'comment', 'snapshot is passed to findMany with correct modelName');
-          assert.equal(snapshot.id, expectedIds[index], 'snapshot is passed to findMany with correct id');
+          assert.strictEqual(snapshot.modelName, 'comment', 'snapshot is passed to findMany with correct modelName');
+          assert.strictEqual(snapshot.id, expectedIds[index], 'snapshot is passed to findMany with correct id');
         });
 
         return resolve(expectedResultCopy);
@@ -462,9 +462,9 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       data: comments.toArray().map((comment) => comment.serialize().data),
     };
 
-    assert.equal(findRecordCalled, 0, 'findRecord is not called');
-    assert.equal(findManyCalled, 1, 'findMany is called once');
-    assert.equal(findHasManyCalled, 0, 'findHasMany is not called');
+    assert.strictEqual(findRecordCalled, 0, 'findRecord is not called');
+    assert.strictEqual(findManyCalled, 1, 'findMany is called once');
+    assert.strictEqual(findHasManyCalled, 0, 'findHasMany is not called');
     assert.deepEqual(serializedComments, expectedResult, 'get returns expected result');
   });
 
@@ -518,15 +518,15 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       findMany(passedStore, type, ids, snapshots) {
         findManyCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findMany');
-        assert.equal(type, Comment, 'model is passed to findMany');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findMany');
+        assert.strictEqual(type, Comment, 'model is passed to findMany');
 
         let expectedIds = expectedResultCopy.data.map((record) => record.id);
         assert.deepEqual(ids, expectedIds, 'ids are passed to findMany');
 
         snapshots.forEach((snapshot, index) => {
-          assert.equal(snapshot.modelName, 'comment', 'snapshot is passed to findMany with correct modelName');
-          assert.equal(snapshot.id, expectedIds[index], 'snapshot is passed to findMany with correct id');
+          assert.strictEqual(snapshot.modelName, 'comment', 'snapshot is passed to findMany with correct modelName');
+          assert.strictEqual(snapshot.id, expectedIds[index], 'snapshot is passed to findMany with correct id');
         });
 
         return resolve(expectedResultCopy);
@@ -541,8 +541,8 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       data: comments.toArray().map((comment) => comment.serialize().data),
     };
 
-    assert.equal(findRecordCalled, 0, 'findRecord is not called');
-    assert.equal(findManyCalled, 1, 'findMany is called once');
+    assert.strictEqual(findRecordCalled, 0, 'findRecord is not called');
+    assert.strictEqual(findManyCalled, 1, 'findMany is called once');
     assert.deepEqual(serializedComments, expectedResult, 'get returns expected result');
   });
 
@@ -598,14 +598,14 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       findHasMany(passedStore, snapshot, url, relationship) {
         findHasManyCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findHasMany');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findHasMany');
 
         let expectedURL = initialRecord.data.relationships.comments.links.related;
-        assert.equal(url, expectedURL, 'url is passed to findHasMany');
-        assert.equal(relationship.meta.key, 'comments', 'relationship is passed to findHasMany');
+        assert.strictEqual(url, expectedURL, 'url is passed to findHasMany');
+        assert.strictEqual(relationship.meta.key, 'comments', 'relationship is passed to findHasMany');
 
-        assert.equal(snapshot.modelName, 'post', 'snapshot is passed to findHasMany with correct modelName');
-        assert.equal(snapshot.id, '2', 'snapshot is passed to findHasMany with correct id');
+        assert.strictEqual(snapshot.modelName, 'post', 'snapshot is passed to findHasMany with correct modelName');
+        assert.strictEqual(snapshot.id, '2', 'snapshot is passed to findHasMany with correct id');
 
         return resolve(expectedResultCopy);
       }
@@ -620,9 +620,9 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       data: comments.toArray().map((comment) => comment.serialize().data),
     };
 
-    assert.equal(findRecordCalled, 0, 'findRecord is not called');
-    assert.equal(findManyCalled, 0, 'findMany is not called');
-    assert.equal(findHasManyCalled, 1, 'findHasMany is called once');
+    assert.strictEqual(findRecordCalled, 0, 'findRecord is not called');
+    assert.strictEqual(findManyCalled, 0, 'findMany is not called');
+    assert.strictEqual(findHasManyCalled, 1, 'findHasMany is called once');
     assert.deepEqual(serializedComments, expectedResult, 'findHasMany returns expected result');
   });
 
@@ -679,15 +679,15 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       findMany(passedStore, type, ids, snapshots) {
         findManyCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findMany');
-        assert.equal(type, Comment, 'model is passed to findMany');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findMany');
+        assert.strictEqual(type, Comment, 'model is passed to findMany');
 
         let expectedIds = expectedResultCopy.data.map((record) => record.id);
         assert.deepEqual(ids, expectedIds, 'ids are passed to findMany');
 
         snapshots.forEach((snapshot, index) => {
-          assert.equal(snapshot.modelName, 'comment', 'snapshot is passed to findMany with correct modelName');
-          assert.equal(snapshot.id, expectedIds[index], 'snapshot is passed to findMany with correct id');
+          assert.strictEqual(snapshot.modelName, 'comment', 'snapshot is passed to findMany with correct modelName');
+          assert.strictEqual(snapshot.id, expectedIds[index], 'snapshot is passed to findMany with correct id');
         });
 
         return resolve(expectedResultCopy);
@@ -702,8 +702,8 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       data: comments.toArray().map((comment) => comment.serialize().data),
     };
 
-    assert.equal(findRecordCalled, 0, 'findRecord is not called');
-    assert.equal(findManyCalled, 1, 'findMany is called once');
+    assert.strictEqual(findRecordCalled, 0, 'findRecord is not called');
+    assert.strictEqual(findManyCalled, 1, 'findMany is called once');
     assert.deepEqual(serializedComments, expectedResult, 'get returns expected result');
   });
 
@@ -750,12 +750,12 @@ module('integration/has-many - Has Many Tests', function (hooks) {
         let index = findRecordCalled++;
         let expectedId = initialRecord.data.relationships.comments.data[index].id;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findRecord');
-        assert.equal(type, Comment, 'model is passed to findRecord');
-        assert.equal(id, expectedId, 'id is passed to findRecord');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findRecord');
+        assert.strictEqual(type, Comment, 'model is passed to findRecord');
+        assert.strictEqual(id, expectedId, 'id is passed to findRecord');
 
-        assert.equal(snapshot.modelName, 'comment', 'snapshot is passed to findRecord with correct modelName');
-        assert.equal(snapshot.id, expectedId, 'snapshot is passed to findRecord with correct id');
+        assert.strictEqual(snapshot.modelName, 'comment', 'snapshot is passed to findRecord with correct modelName');
+        assert.strictEqual(snapshot.id, expectedId, 'snapshot is passed to findRecord with correct id');
 
         return resolve({ data: expectedResultCopy.data[index] });
       }
@@ -773,8 +773,8 @@ module('integration/has-many - Has Many Tests', function (hooks) {
       data: comments.toArray().map((comment) => comment.serialize().data),
     };
 
-    assert.equal(findRecordCalled, 2, 'findRecord is called twice');
-    assert.equal(findManyCalled, 0, 'findMany is not called');
+    assert.strictEqual(findRecordCalled, 2, 'findRecord is called twice');
+    assert.strictEqual(findManyCalled, 0, 'findMany is not called');
     assert.deepEqual(serializedComments, expectedResult, 'get returns expected result');
   });
 });

--- a/packages/unpublished-adapter-encapsulation-test-app/tests/integration/mutations-test.js
+++ b/packages/unpublished-adapter-encapsulation-test-app/tests/integration/mutations-test.js
@@ -62,11 +62,11 @@ module('integration/mutations - Mutations Tests', function (hooks) {
         let data = snapshot.serialize();
         let id = snapshot.id;
 
-        assert.equal(passedStore, store, 'instance of store is passed to deleteRecord');
-        assert.equal(type, Person, 'model is passed to deleteRecord');
-        assert.equal(id, '12', 'id is passed to deleteRecord through snapshot');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to deleteRecord');
+        assert.strictEqual(type, Person, 'model is passed to deleteRecord');
+        assert.strictEqual(id, '12', 'id is passed to deleteRecord through snapshot');
 
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
         assert.deepEqual(data, expectedData, 'snapshot is passed to deleteRecord with correct data');
       }
     }
@@ -78,7 +78,7 @@ module('integration/mutations - Mutations Tests', function (hooks) {
     record.deleteRecord();
     await record.save();
 
-    assert.equal(deleteRecordCalled, 1, 'deleteRecord is called once');
+    assert.strictEqual(deleteRecordCalled, 1, 'deleteRecord is called once');
   });
 
   test('store.deleteRecord calls adapter.deleteRecord if a newly created record is persisted, then deleted and then saved', async function (assert) {
@@ -103,11 +103,11 @@ module('integration/mutations - Mutations Tests', function (hooks) {
         let data = snapshot.serialize();
         let id = snapshot.id;
 
-        assert.equal(passedStore, store, 'instance of store is passed to deleteRecord');
-        assert.equal(type, Person, 'model is passed to deleteRecord');
-        assert.equal(id, '12', 'id is passed to deleteRecord through snapshot');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to deleteRecord');
+        assert.strictEqual(type, Person, 'model is passed to deleteRecord');
+        assert.strictEqual(id, '12', 'id is passed to deleteRecord through snapshot');
 
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
         assert.deepEqual(data, expectedData, 'snapshot is passed to deleteRecord with correct data');
 
         return resolve(data);
@@ -119,11 +119,11 @@ module('integration/mutations - Mutations Tests', function (hooks) {
         let data = snapshot.serialize();
         let id = snapshot.id;
 
-        assert.equal(passedStore, store, 'instance of store is passed to deleteRecord');
-        assert.equal(type, Person, 'model is passed to deleteRecord');
-        assert.equal(id, '12', 'id is passed to deleteRecord through snapshot');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to deleteRecord');
+        assert.strictEqual(type, Person, 'model is passed to deleteRecord');
+        assert.strictEqual(id, '12', 'id is passed to deleteRecord through snapshot');
 
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
         assert.deepEqual(data, expectedData, 'snapshot is passed to deleteRecord with correct data');
       }
     }
@@ -134,12 +134,12 @@ module('integration/mutations - Mutations Tests', function (hooks) {
     let record = store.createRecord('person', props);
     await record.save();
 
-    assert.equal(createRecordCalled, 1, 'createRecord is called once');
+    assert.strictEqual(createRecordCalled, 1, 'createRecord is called once');
 
     record.deleteRecord();
     await record.save();
 
-    assert.equal(deleteRecordCalled, 1, 'deleteRecord is called once');
+    assert.strictEqual(deleteRecordCalled, 1, 'deleteRecord is called once');
   });
 
   test('store.deleteRecord does not call adapter.deleteRecord if a newly created, unpersisted record is deleted and then saved', async function (assert) {
@@ -175,8 +175,8 @@ module('integration/mutations - Mutations Tests', function (hooks) {
     record.deleteRecord();
     await record.save();
 
-    assert.equal(createRecordCalled, 0, 'adapter.createRecord is not called');
-    assert.equal(deleteRecordCalled, 0, 'adapter.deleteRecord is not called');
+    assert.strictEqual(createRecordCalled, 0, 'adapter.createRecord is not called');
+    assert.strictEqual(deleteRecordCalled, 0, 'adapter.deleteRecord is not called');
   });
 
   test('record.save() calls adapter.createRecord if a newly created record unpersisted record is saved', async function (assert) {
@@ -200,11 +200,11 @@ module('integration/mutations - Mutations Tests', function (hooks) {
         let data = snapshot.serialize();
         let id = snapshot.id;
 
-        assert.equal(passedStore, store, 'instance of store is passed to deleteRecord');
-        assert.equal(type, Person, 'model is passed to deleteRecord');
-        assert.equal(id, '12', 'id is passed to deleteRecord through snapshot');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to deleteRecord');
+        assert.strictEqual(type, Person, 'model is passed to deleteRecord');
+        assert.strictEqual(id, '12', 'id is passed to deleteRecord through snapshot');
 
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
         assert.deepEqual(data, expectedData, 'snapshot is passed to deleteRecord with correct data');
 
         return resolve(data);
@@ -217,7 +217,7 @@ module('integration/mutations - Mutations Tests', function (hooks) {
     let record = store.createRecord('person', props);
     await record.save();
 
-    assert.equal(createRecordCalled, 1, 'createRecord is called once');
+    assert.strictEqual(createRecordCalled, 1, 'createRecord is called once');
   });
 
   test('record.save() calls adapter.createRecord then adapter.updateRecord if a newly created record record is saved, then saved again', async function (assert) {
@@ -242,11 +242,11 @@ module('integration/mutations - Mutations Tests', function (hooks) {
         let data = snapshot.serialize();
         let id = snapshot.id;
 
-        assert.equal(passedStore, store, 'instance of store is passed to deleteRecord');
-        assert.equal(type, Person, 'model is passed to deleteRecord');
-        assert.equal(id, '12', 'id is passed to deleteRecord through snapshot');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to deleteRecord');
+        assert.strictEqual(type, Person, 'model is passed to deleteRecord');
+        assert.strictEqual(id, '12', 'id is passed to deleteRecord through snapshot');
 
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
         assert.deepEqual(data, expectedData, 'snapshot is passed to deleteRecord with correct data');
 
         return resolve(data);
@@ -258,11 +258,11 @@ module('integration/mutations - Mutations Tests', function (hooks) {
         let data = snapshot.serialize();
         let id = snapshot.id;
 
-        assert.equal(passedStore, store, 'instance of store is passed to deleteRecord');
-        assert.equal(type, Person, 'model is passed to deleteRecord');
-        assert.equal(id, '12', 'id is passed to deleteRecord through snapshot');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to deleteRecord');
+        assert.strictEqual(type, Person, 'model is passed to deleteRecord');
+        assert.strictEqual(id, '12', 'id is passed to deleteRecord through snapshot');
 
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
         assert.deepEqual(data, expectedData, 'snapshot is passed to deleteRecord with correct data');
 
         return resolve(expectedData);
@@ -275,14 +275,14 @@ module('integration/mutations - Mutations Tests', function (hooks) {
     let record = store.createRecord('person', props);
     await record.save();
 
-    assert.equal(createRecordCalled, 1, 'createRecord is called once');
+    assert.strictEqual(createRecordCalled, 1, 'createRecord is called once');
 
     record.firstName = 'Kevin';
     expectedData.data.attributes.firstName = 'Kevin';
     await record.save();
 
-    assert.equal(createRecordCalled, 1, 'createRecord is not called again');
-    assert.equal(updateRecord, 1, 'updateRecord is called once');
+    assert.strictEqual(createRecordCalled, 1, 'createRecord is not called again');
+    assert.strictEqual(updateRecord, 1, 'updateRecord is called once');
   });
 
   test('record.save() calls adapter.updateRecord if an existing persisted record is saved', async function (assert) {
@@ -311,11 +311,11 @@ module('integration/mutations - Mutations Tests', function (hooks) {
         let data = snapshot.serialize();
         let id = snapshot.id;
 
-        assert.equal(passedStore, store, 'instance of store is passed to deleteRecord');
-        assert.equal(type, Person, 'model is passed to deleteRecord');
-        assert.equal(id, '12', 'id is passed to deleteRecord through snapshot');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to deleteRecord');
+        assert.strictEqual(type, Person, 'model is passed to deleteRecord');
+        assert.strictEqual(id, '12', 'id is passed to deleteRecord through snapshot');
 
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to deleteRecord with correct modelName');
         assert.deepEqual(data, expectedData, 'snapshot is passed to deleteRecord with correct data');
 
         return resolve(expectedData);
@@ -330,7 +330,7 @@ module('integration/mutations - Mutations Tests', function (hooks) {
     expectedData.data.attributes.firstName = 'Kevin';
     await record.save();
 
-    assert.equal(createRecordCalled, 0, 'createRecord is not called');
-    assert.equal(updateRecord, 1, 'updateRecord is called once');
+    assert.strictEqual(createRecordCalled, 0, 'createRecord is not called');
+    assert.strictEqual(updateRecord, 1, 'updateRecord is called once');
   });
 });

--- a/packages/unpublished-adapter-encapsulation-test-app/tests/integration/queries-test.js
+++ b/packages/unpublished-adapter-encapsulation-test-app/tests/integration/queries-test.js
@@ -66,12 +66,12 @@ module('integration/queries - Queries Tests', function (hooks) {
       findRecord(passedStore, type, id, snapshot) {
         findRecordCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findRecord');
-        assert.equal(type, Person, 'model is passed to findRecord');
-        assert.equal(id, '12', 'id is passed to findRecord');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findRecord');
+        assert.strictEqual(type, Person, 'model is passed to findRecord');
+        assert.strictEqual(id, '12', 'id is passed to findRecord');
 
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to findRecord with correct modelName');
-        assert.equal(snapshot.id, '12', 'snapshot is passed to findRecord with correct id');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to findRecord with correct modelName');
+        assert.strictEqual(snapshot.id, '12', 'snapshot is passed to findRecord with correct id');
 
         return resolve(expectedResultCopy);
       }
@@ -81,7 +81,7 @@ module('integration/queries - Queries Tests', function (hooks) {
 
     let record = await store.findRecord('person', '12');
 
-    assert.equal(findRecordCalled, 1, 'findRecord is called once');
+    assert.strictEqual(findRecordCalled, 1, 'findRecord is called once');
     assert.deepEqual(record.serialize(), expectedResult, 'findRecord returns expected result');
   });
 
@@ -120,11 +120,11 @@ module('integration/queries - Queries Tests', function (hooks) {
       findAll(passedStore, type, sinceToken, snapshot) {
         findAllCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to findAll');
-        assert.equal(type, Person, 'model is passed to findAll');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to findAll');
+        assert.strictEqual(type, Person, 'model is passed to findAll');
         assert.strictEqual(sinceToken, null, 'sinceToken passed to findAll is null');
-        assert.equal(snapshot.modelName, 'person', 'snapshot is passed to findAll with correct modelName');
-        assert.equal(snapshot.length, 0, 'snapshot is passed to findAll represnts empty array');
+        assert.strictEqual(snapshot.modelName, 'person', 'snapshot is passed to findAll with correct modelName');
+        assert.strictEqual(snapshot.length, 0, 'snapshot is passed to findAll represnts empty array');
 
         return resolve(expectedResultCopy);
       }
@@ -137,7 +137,7 @@ module('integration/queries - Queries Tests', function (hooks) {
     let result = manyArray.toArray().map((person) => person.serialize());
     expectedResult = expectedResult.data.map((person) => ({ data: person }));
 
-    assert.equal(findAllCalled, 1, 'findAll is called once');
+    assert.strictEqual(findAllCalled, 1, 'findAll is called once');
     assert.deepEqual(result, expectedResult, 'findAll returns expected result');
   });
 
@@ -160,8 +160,8 @@ module('integration/queries - Queries Tests', function (hooks) {
       queryRecord(passedStore, type, query, options) {
         queryRecordCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to queryRecord');
-        assert.equal(type, Person, 'model is passed to queryRecord');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to queryRecord');
+        assert.strictEqual(type, Person, 'model is passed to queryRecord');
         assert.deepEqual(query, { firstName: 'Gaurav' }, 'query is passed to queryRecord');
         assert.deepEqual(options, {}, 'options is passsed to queryRecord');
 
@@ -173,7 +173,7 @@ module('integration/queries - Queries Tests', function (hooks) {
 
     let record = await store.queryRecord('person', { firstName: 'Gaurav' });
 
-    assert.equal(queryRecordCalled, 1, 'queryRecord is called once');
+    assert.strictEqual(queryRecordCalled, 1, 'queryRecord is called once');
     assert.deepEqual(record.serialize(), expectedResult, 'queryRecord returns expected result');
   });
 
@@ -206,8 +206,8 @@ module('integration/queries - Queries Tests', function (hooks) {
       query(passedStore, type, query, recordArray, options) {
         queryCalled++;
 
-        assert.equal(passedStore, store, 'instance of store is passed to query');
-        assert.equal(type, Person, 'model is passed to query');
+        assert.strictEqual(passedStore, store, 'instance of store is passed to query');
+        assert.strictEqual(type, Person, 'model is passed to query');
         assert.deepEqual(query, { firstName: 'Chris' }, 'query is passed to query');
         assert.deepEqual(recordArray.toArray(), [], 'recordArray is passsed to query');
         assert.deepEqual(options, {}, 'options is passed to query');
@@ -223,7 +223,7 @@ module('integration/queries - Queries Tests', function (hooks) {
     let result = manyArray.toArray().map((person) => person.serialize());
     expectedResult = expectedResult.data.map((person) => ({ data: person }));
 
-    assert.equal(queryCalled, 1, 'query is called once');
+    assert.strictEqual(queryCalled, 1, 'query is called once');
     assert.deepEqual(result, expectedResult, 'query returns expected result');
   });
 });

--- a/packages/unpublished-adapter-encapsulation-test-app/tests/integration/reload-test.js
+++ b/packages/unpublished-adapter-encapsulation-test-app/tests/integration/reload-test.js
@@ -96,8 +96,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person', { reload: false });
 
-      assert.equal(this.adapter.shouldReloadAllCalled, 0, 'shouldReloadAll is not called');
-      assert.equal(this.adapter.requestsMade, 0, 'no request is made');
+      assert.strictEqual(this.adapter.shouldReloadAllCalled, 0, 'shouldReloadAll is not called');
+      assert.strictEqual(this.adapter.requestsMade, 0, 'no request is made');
     });
 
     test('adapter.shouldReloadAll is not called when store.findAll is called with a reload: true flag', async function (assert) {
@@ -108,8 +108,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person', { reload: true });
 
-      assert.equal(this.adapter.shouldReloadAllCalled, 0, 'shouldReloadAll is not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldReloadAllCalled, 0, 'shouldReloadAll is not called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('store.findAll does not error if adapter.shouldReloadAll is not defined (records are present)', async function (assert) {
@@ -130,7 +130,7 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person');
 
-      assert.equal(this.adapter.requestsMade, 0, 'no ajax request is made');
+      assert.strictEqual(this.adapter.requestsMade, 0, 'no ajax request is made');
     });
 
     test('store.findAll does not error if adapter.shouldReloadAll is not defined (records are absent)', async function (assert) {
@@ -140,7 +140,7 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person');
 
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldReloadAll is called when store.findAll is called without a reload flag (shouldReloadAll is false)', async function (assert) {
@@ -151,8 +151,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person');
 
-      assert.equal(this.adapter.shouldReloadAllCalled, 1, 'shouldReloadAll is called');
-      assert.equal(this.adapter.requestsMade, 0, 'no ajax request is made');
+      assert.strictEqual(this.adapter.shouldReloadAllCalled, 1, 'shouldReloadAll is called');
+      assert.strictEqual(this.adapter.requestsMade, 0, 'no ajax request is made');
     });
 
     test('adapter.shouldReloadAll is called when store.findAll is called without a reload flag (shouldReloadAll is false)', async function (assert) {
@@ -163,8 +163,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person');
 
-      assert.equal(this.adapter.shouldReloadAllCalled, 1, 'shouldReloadAll is called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldReloadAllCalled, 1, 'shouldReloadAll is called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
   });
 
@@ -174,8 +174,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person', { reload: true });
 
-      assert.equal(this.adapter.shouldBackgroundReloadAllCalled, 0, 'shouldBackgroundReloadAll not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldBackgroundReloadAllCalled, 0, 'shouldBackgroundReloadAll not called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadAll is not called called when store.findAll is called and adaptershouldReloadAll() returns true (but we do make request)', async function (assert) {
@@ -185,8 +185,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person');
 
-      assert.equal(this.adapter.shouldBackgroundReloadAllCalled, 0, 'shouldBackgroundReloadAll not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldBackgroundReloadAllCalled, 0, 'shouldBackgroundReloadAll not called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadAll is not called when store.findAll is called with backroundReload: true', async function (assert) {
@@ -196,8 +196,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person', { backgroundReload: true });
 
-      assert.equal(this.adapter.shouldBackgroundReloadAllCalled, 0, 'shouldBackgroundReloadAll is not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldBackgroundReloadAllCalled, 0, 'shouldBackgroundReloadAll is not called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadAll is not called when store.findAll is called with backroundReload: false', async function (assert) {
@@ -207,8 +207,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person', { backgroundReload: false });
 
-      assert.equal(this.adapter.shouldBackgroundReloadAllCalled, 0, 'shouldBackgroundReloadAll is not called');
-      assert.equal(this.adapter.requestsMade, 0, 'no ajax request is made');
+      assert.strictEqual(this.adapter.shouldBackgroundReloadAllCalled, 0, 'shouldBackgroundReloadAll is not called');
+      assert.strictEqual(this.adapter.requestsMade, 0, 'no ajax request is made');
     });
 
     test('store.findAll does not error if adapter.shouldBackgroundReloadAll is undefined and backgroundReload is not present.', async function (assert) {
@@ -218,7 +218,7 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person');
 
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadAll is called when store.findAll is called and there is no backgroundReload flag (returns true)', async function (assert) {
@@ -229,8 +229,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person');
 
-      assert.equal(this.adapter.shouldBackgroundReloadAllCalled, 1, 'shouldBackgroundReloadAll is called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldBackgroundReloadAllCalled, 1, 'shouldBackgroundReloadAll is called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadAll is called when store.findAll is called and there is no backgroundReload flag (returns false)', async function (assert) {
@@ -241,8 +241,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findAll('person');
 
-      assert.equal(this.adapter.shouldBackgroundReloadAllCalled, 1, 'shouldBackgroundReloadAll is called');
-      assert.equal(this.adapter.requestsMade, 0, 'no ajax request is made');
+      assert.strictEqual(this.adapter.shouldBackgroundReloadAllCalled, 1, 'shouldBackgroundReloadAll is called');
+      assert.strictEqual(this.adapter.requestsMade, 0, 'no ajax request is made');
     });
   });
 
@@ -270,8 +270,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.shouldReloadRecordCalled, 0, 'shouldReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldReloadRecordCalled, 0, 'shouldReloadRecord is not called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldReloadRecord is not called when store.findRecord is called for a never loaded record (but we do make request)', async function (assert) {
@@ -293,8 +293,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.shouldReloadRecordCalled, 0, 'shouldReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldReloadRecordCalled, 0, 'shouldReloadRecord is not called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldReloadRecord is not called when store.findRecord is called with a reload flag (but we do make request if reload is true)', async function (assert) {
@@ -318,8 +318,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1', { reload: true });
 
-      assert.equal(this.adapter.shouldReloadRecordCalled, 0, 'shouldReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldReloadRecordCalled, 0, 'shouldReloadRecord is not called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldReloadRecord is not called when store.findRecord is called with a reload flag (and we do not make request if reload is false)', async function (assert) {
@@ -343,8 +343,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1', { reload: false });
 
-      assert.equal(this.adapter.shouldReloadRecordCalled, 0, 'shouldReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 0, 'no ajax request is made');
+      assert.strictEqual(this.adapter.shouldReloadRecordCalled, 0, 'shouldReloadRecord is not called');
+      assert.strictEqual(this.adapter.requestsMade, 0, 'no ajax request is made');
     });
 
     test('if adapter.shouldReloadRecord is undefined, we default to false and do not make a request', async function (assert) {
@@ -368,8 +368,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.shouldReloadRecordCalled, 0, 'shouldReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 0, 'no ajax request is made');
+      assert.strictEqual(this.adapter.shouldReloadRecordCalled, 0, 'shouldReloadRecord is not called');
+      assert.strictEqual(this.adapter.requestsMade, 0, 'no ajax request is made');
     });
 
     test('adapter.shouldReloadRecord is called when store.findRecord is called without a reload flag (shouldReloadRecord returns true)', async function (assert) {
@@ -394,8 +394,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.shouldReloadRecordCalled, 1, 'shouldReloadRecord is called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldReloadRecordCalled, 1, 'shouldReloadRecord is called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldReloadRecord is called when store.findRecord is called without a reload flag (shouldReloadRecord returns false)', async function (assert) {
@@ -420,8 +420,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.shouldReloadRecordCalled, 1, 'shouldReloadRecord is called');
-      assert.equal(this.adapter.requestsMade, 0, 'no ajax request is made');
+      assert.strictEqual(this.adapter.shouldReloadRecordCalled, 1, 'shouldReloadRecord is called');
+      assert.strictEqual(this.adapter.requestsMade, 0, 'no ajax request is made');
     });
   });
 
@@ -448,8 +448,12 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.shouldBackgroundReloadRecordCalled, 0, 'shouldBackgroundReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(
+        this.adapter.shouldBackgroundReloadRecordCalled,
+        0,
+        'shouldBackgroundReloadRecord is not called'
+      );
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadRecord is not called when store.findRecord is called for a never loaded record (but we do make request)', async function (assert) {
@@ -470,8 +474,12 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.shouldBackgroundReloadRecordCalled, 0, 'shouldBackgroundReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(
+        this.adapter.shouldBackgroundReloadRecordCalled,
+        0,
+        'shouldBackgroundReloadRecord is not called'
+      );
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadRecord is not called called when store.findRecord is called with reload: true flag (but we do make request)', async function (assert) {
@@ -494,8 +502,12 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1', { reload: true });
 
-      assert.equal(this.adapter.shouldBackgroundReloadRecordCalled, 0, 'shouldBackgroundReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(
+        this.adapter.shouldBackgroundReloadRecordCalled,
+        0,
+        'shouldBackgroundReloadRecord is not called'
+      );
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadRecord is not called called when store.findRecord is called and shouldReloadRecord returns true (but we do make request)', async function (assert) {
@@ -519,8 +531,12 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.shouldBackgroundReloadRecordCalled, 0, 'shouldBackgroundReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(
+        this.adapter.shouldBackgroundReloadRecordCalled,
+        0,
+        'shouldBackgroundReloadRecord is not called'
+      );
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadRecord is not called when store.findRecord is called with backroundReload as an option (backgroundReload is true)', async function (assert) {
@@ -543,8 +559,12 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1', { backgroundReload: true });
 
-      assert.equal(this.adapter.shouldBackgroundReloadRecordCalled, 0, 'shouldBackgroundReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(
+        this.adapter.shouldBackgroundReloadRecordCalled,
+        0,
+        'shouldBackgroundReloadRecord is not called'
+      );
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadRecord is not called when store.findRecord is called with backroundReload as an option (backgroundReload is false)', async function (assert) {
@@ -567,8 +587,12 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1', { backgroundReload: false });
 
-      assert.equal(this.adapter.shouldBackgroundReloadRecordCalled, 0, 'shouldBackgroundReloadRecord is not called');
-      assert.equal(this.adapter.requestsMade, 0, 'no ajax request is made');
+      assert.strictEqual(
+        this.adapter.shouldBackgroundReloadRecordCalled,
+        0,
+        'shouldBackgroundReloadRecord is not called'
+      );
+      assert.strictEqual(this.adapter.requestsMade, 0, 'no ajax request is made');
     });
 
     test('store.findRecord does not error if adapter.shouldBackgroundReloadRecord is undefined and backgroundReload is not present.', async function (assert) {
@@ -591,7 +615,7 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadRecord is called when store.findRecord is called and there is no backgroundReload flag (adapter.shouldBackgroundReloadRecord() returns true)', async function (assert) {
@@ -615,8 +639,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.shouldBackgroundReloadRecordCalled, 1, 'shouldBackgroundReloadRecord is called');
-      assert.equal(this.adapter.requestsMade, 1, 'an ajax request is made');
+      assert.strictEqual(this.adapter.shouldBackgroundReloadRecordCalled, 1, 'shouldBackgroundReloadRecord is called');
+      assert.strictEqual(this.adapter.requestsMade, 1, 'an ajax request is made');
     });
 
     test('adapter.shouldBackgroundReloadRecord is called when store.findRecord is called and there is no backgroundReload flag (adapter.shouldBackgroundReloadRecord() returns false)', async function (assert) {
@@ -640,8 +664,8 @@ module('integration/reload - Reloading Tests', function (hooks) {
 
       await this.store.findRecord('person', '1');
 
-      assert.equal(this.adapter.shouldBackgroundReloadRecordCalled, 1, 'shouldBackgroundReloadRecord is called');
-      assert.equal(this.adapter.requestsMade, 0, 'no ajax request is made');
+      assert.strictEqual(this.adapter.shouldBackgroundReloadRecordCalled, 1, 'shouldBackgroundReloadRecord is called');
+      assert.strictEqual(this.adapter.requestsMade, 0, 'no ajax request is made');
     });
   });
 });

--- a/packages/unpublished-serializer-encapsulation-test-app/tests/integration/create-record-test.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/tests/integration/create-record-test.js
@@ -47,7 +47,7 @@ module('integration/create-record - running createRecord with minimum serializer
         serializeCalled++;
 
         assert.strictEqual(snapshot.id, '1', 'id is correct');
-        assert.equal(snapshot.modelName, 'person', 'modelName is correct');
+        assert.strictEqual(snapshot.modelName, 'person', 'modelName is correct');
         assert.deepEqual(snapshot.attributes(), { firstName: 'John', lastName: 'Smith' }, 'attributes are correct');
 
         const serializedResource = {
@@ -62,7 +62,7 @@ module('integration/create-record - running createRecord with minimum serializer
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
 
-        assert.equal(requestType, 'createRecord', 'expected method name is correct');
+        assert.strictEqual(requestType, 'createRecord', 'expected method name is correct');
         assert.deepEqual(rawPayload, {
           id: '1m',
           type: 'person',
@@ -114,8 +114,8 @@ module('integration/create-record - running createRecord with minimum serializer
 
     await person.save();
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse called once');
-    assert.equal(serializeCalled, 1, 'serialize called once');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse called once');
+    assert.strictEqual(serializeCalled, 1, 'serialize called once');
     assert.deepEqual(person.toJSON(), {
       id: '1m',
       type: 'person',
@@ -142,7 +142,7 @@ module('integration/create-record - running createRecord with minimum serializer
         serializeCalled++;
 
         assert.strictEqual(snapshot.id, '1', 'id is correct');
-        assert.equal(snapshot.modelName, 'person', 'modelName is correct');
+        assert.strictEqual(snapshot.modelName, 'person', 'modelName is correct');
         assert.deepEqual(snapshot.attributes(), { firstName: 'John', lastName: 'Smith' }, 'attributes are correct');
 
         const serializedResource = {
@@ -157,7 +157,7 @@ module('integration/create-record - running createRecord with minimum serializer
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
 
-        assert.equal(requestType, 'createRecord', 'expected method name is correct');
+        assert.strictEqual(requestType, 'createRecord', 'expected method name is correct');
         assert.deepEqual(rawPayload, {
           person: {
             id: '1m',
@@ -213,9 +213,9 @@ module('integration/create-record - running createRecord with minimum serializer
 
     await person.save();
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse called once');
-    assert.equal(serializeIntoHashCalled, 1, 'serializeIntoHash called once');
-    assert.equal(serializeCalled, 1, 'serialize called once');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse called once');
+    assert.strictEqual(serializeIntoHashCalled, 1, 'serializeIntoHash called once');
+    assert.strictEqual(serializeCalled, 1, 'serialize called once');
     assert.deepEqual(person.toJSON(), {
       id: '1m',
       type: 'person',

--- a/packages/unpublished-serializer-encapsulation-test-app/tests/integration/delete-record-test.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/tests/integration/delete-record-test.js
@@ -56,7 +56,7 @@ module('integration/delete-record - running deleteRecord with minimum serializer
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
 
-        assert.equal(requestType, 'findRecord', 'expected method name is correct');
+        assert.strictEqual(requestType, 'findRecord', 'expected method name is correct');
         assert.deepEqual(
           rawPayload,
           {
@@ -104,7 +104,7 @@ module('integration/delete-record - running deleteRecord with minimum serializer
     person.deleteRecord();
     await person.save();
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse called once');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse called once');
   });
 
   test('save after deleting record does not call normalizeResponse and serializeIntoHash if implemented', async function (assert) {
@@ -135,7 +135,7 @@ module('integration/delete-record - running deleteRecord with minimum serializer
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
 
-        assert.equal(requestType, 'findRecord', 'expected method name is correct');
+        assert.strictEqual(requestType, 'findRecord', 'expected method name is correct');
         assert.deepEqual(
           rawPayload,
           {
@@ -183,9 +183,9 @@ module('integration/delete-record - running deleteRecord with minimum serializer
     person.deleteRecord();
     await person.save();
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse called once');
-    assert.equal(serializeIntoHashCalled, 0, 'serializeIntoHash not called');
-    assert.equal(serializeCalled, 0, 'serialize not called');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse called once');
+    assert.strictEqual(serializeIntoHashCalled, 0, 'serializeIntoHash not called');
+    assert.strictEqual(serializeCalled, 0, 'serialize not called');
   });
 
   test('save after deleting record does call normalizeResponse if response provided', async function (assert) {
@@ -212,7 +212,7 @@ module('integration/delete-record - running deleteRecord with minimum serializer
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
 
-        assert.equal(requestType, this._methods.shift(), 'expected method name is correct');
+        assert.strictEqual(requestType, this._methods.shift(), 'expected method name is correct');
         assert.deepEqual(rawPayload, this._payloads.shift(), 'payload is correct');
 
         return {
@@ -249,6 +249,6 @@ module('integration/delete-record - running deleteRecord with minimum serializer
     person.deleteRecord();
     await person.save();
 
-    assert.equal(normalizeResponseCalled, 2, 'normalizeResponse called twice');
+    assert.strictEqual(normalizeResponseCalled, 2, 'normalizeResponse called twice');
   });
 });

--- a/packages/unpublished-serializer-encapsulation-test-app/tests/integration/errors-test.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/tests/integration/errors-test.js
@@ -61,9 +61,9 @@ module(
         ({ errors } = adapterError);
       }
 
-      assert.equal(errors.length, 1, 'error recorded');
-      assert.equal(errors[0].status, '404', 'error status is correct');
-      assert.equal(errors[0].detail, 'file not found', 'error detail is correct');
+      assert.strictEqual(errors.length, 1, 'error recorded');
+      assert.strictEqual(errors[0].status, '404', 'error status is correct');
+      assert.strictEqual(errors[0].detail, 'file not found', 'error detail is correct');
     });
 
     test('can retrieve errors after save', async function (assert) {
@@ -99,9 +99,9 @@ module(
         ({ errors } = adapterError);
       }
 
-      assert.equal(errors.length, 2, 'both errors recorded');
-      assert.equal(errors[0].detail, 'firstName is required', 'first error is that firstName is required');
-      assert.equal(errors[1].detail, 'lastName is required', 'second error is that lastName is required');
+      assert.strictEqual(errors.length, 2, 'both errors recorded');
+      assert.strictEqual(errors[0].detail, 'firstName is required', 'first error is that firstName is required');
+      assert.strictEqual(errors[1].detail, 'lastName is required', 'second error is that lastName is required');
     });
   }
 );

--- a/packages/unpublished-serializer-encapsulation-test-app/tests/integration/normalize-test.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/tests/integration/normalize-test.js
@@ -31,7 +31,7 @@ module('integration/serializer - normalize method forwards to Serializer#normali
       normalize(modelClass, rawPayload) {
         normalizeCalled++;
 
-        assert.equal(modelClass.name, 'Person', 'modelClass was passed to normalize');
+        assert.strictEqual(modelClass.name, 'Person', 'modelClass was passed to normalize');
         assert.deepEqual(
           rawPayload,
           {
@@ -63,7 +63,7 @@ module('integration/serializer - normalize method forwards to Serializer#normali
       },
     });
 
-    assert.equal(normalizeCalled, 1, 'normalize called once');
+    assert.strictEqual(normalizeCalled, 1, 'normalize called once');
     assert.deepEqual(
       payload,
       {

--- a/packages/unpublished-serializer-encapsulation-test-app/tests/integration/push-payload-test.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/tests/integration/push-payload-test.js
@@ -72,7 +72,7 @@ module('integration/push-payload - pushPayload method forwards to Serializer#pus
     });
     let person = store.peekRecord('person', '1');
 
-    assert.equal(pushPayloadCalled, 1, 'pushPayload called once');
+    assert.strictEqual(pushPayloadCalled, 1, 'pushPayload called once');
     assert.deepEqual(
       person.toJSON(),
       {

--- a/packages/unpublished-serializer-encapsulation-test-app/tests/integration/relationships-test.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/tests/integration/relationships-test.js
@@ -40,7 +40,7 @@ module('integration/relationships - running requests for async relatonships with
     class TestMinimumSerializer extends EmberObject {
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
-        assert.equal(requestType, 'findMany', 'expected method name is correct');
+        assert.strictEqual(requestType, 'findMany', 'expected method name is correct');
         assert.deepEqual(rawPayload, { data: [] });
         return {
           data: [
@@ -117,7 +117,7 @@ module('integration/relationships - running requests for async relatonships with
     });
     let comments = await post.get('comments');
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse is called once');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse is called once');
     assert.deepEqual(comments.mapBy('message'), ['Message 1', 'Message 2'], 'response is expected response');
   });
 
@@ -127,7 +127,7 @@ module('integration/relationships - running requests for async relatonships with
     class TestMinimumSerializer extends EmberObject {
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
-        assert.equal(requestType, 'findHasMany', 'expected method name is correct');
+        assert.strictEqual(requestType, 'findHasMany', 'expected method name is correct');
         assert.deepEqual(rawPayload, { data: [] });
         return {
           data: [
@@ -181,7 +181,7 @@ module('integration/relationships - running requests for async relatonships with
     });
     let comments = await post.get('comments');
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse is called once');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse is called once');
     assert.deepEqual(comments.mapBy('message'), ['Message 1', 'Message 2'], 'response is expected response');
   });
 
@@ -191,7 +191,7 @@ module('integration/relationships - running requests for async relatonships with
     class TestMinimumSerializer extends EmberObject {
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
-        assert.equal(requestType, 'findBelongsTo', 'expected method name is correct');
+        assert.strictEqual(requestType, 'findBelongsTo', 'expected method name is correct');
         assert.deepEqual(rawPayload, {
           data: {
             id: 1,
@@ -252,7 +252,7 @@ module('integration/relationships - running requests for async relatonships with
     });
     let post = await comment.get('post');
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse is called once');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse is called once');
     assert.deepEqual(post.title, 'Chris', 'response is expected response');
   });
 });

--- a/packages/unpublished-serializer-encapsulation-test-app/tests/integration/requests-test.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/tests/integration/requests-test.js
@@ -28,7 +28,7 @@ module('integration/requests - running requests with minimum serializer', functi
     class TestMinimumSerializer extends EmberObject {
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
-        assert.equal(requestType, 'findAll', 'expected method name is correct');
+        assert.strictEqual(requestType, 'findAll', 'expected method name is correct');
         assert.deepEqual(rawPayload, { data: [] });
         return {
           data: [
@@ -58,7 +58,7 @@ module('integration/requests - running requests with minimum serializer', functi
 
     let response = await store.findAll('person');
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse is called once');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse is called once');
     assert.deepEqual(response.mapBy('id'), ['urn:person:1'], 'response is expected response');
   });
 
@@ -68,7 +68,7 @@ module('integration/requests - running requests with minimum serializer', functi
     class TestMinimumSerializer extends EmberObject {
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
-        assert.equal(requestType, 'findRecord', 'expected method name is correct');
+        assert.strictEqual(requestType, 'findRecord', 'expected method name is correct');
         assert.deepEqual(rawPayload, {
           data: {
             type: 'person',
@@ -112,7 +112,7 @@ module('integration/requests - running requests with minimum serializer', functi
 
     let response = await store.findRecord('person', 'urn:person:1');
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse is called once');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse is called once');
     assert.deepEqual(response.name, 'John', 'response is expected response');
   });
 
@@ -122,7 +122,7 @@ module('integration/requests - running requests with minimum serializer', functi
     class TestMinimumSerializer extends EmberObject {
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
-        assert.equal(requestType, 'query', 'expected method name is correct');
+        assert.strictEqual(requestType, 'query', 'expected method name is correct');
         assert.deepEqual(rawPayload, { data: [] });
         return {
           data: [
@@ -152,7 +152,7 @@ module('integration/requests - running requests with minimum serializer', functi
 
     let response = await store.query('person', { name: 'Chris' });
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse is called once');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse is called once');
     assert.deepEqual(response.mapBy('id'), ['urn:person:1'], 'response is expected response');
   });
 
@@ -162,7 +162,7 @@ module('integration/requests - running requests with minimum serializer', functi
     class TestMinimumSerializer extends EmberObject {
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
-        assert.equal(requestType, 'queryRecord', 'expected method name is correct');
+        assert.strictEqual(requestType, 'queryRecord', 'expected method name is correct');
         assert.deepEqual(rawPayload, {
           data: {
             type: 'person',
@@ -206,7 +206,7 @@ module('integration/requests - running requests with minimum serializer', functi
 
     let response = await store.queryRecord('person', { name: 'Chris' });
 
-    assert.equal(normalizeResponseCalled, 1, 'normalizeResponse is called once');
+    assert.strictEqual(normalizeResponseCalled, 1, 'normalizeResponse is called once');
     assert.deepEqual(response.name, 'John', 'response is expected response');
   });
 });

--- a/packages/unpublished-serializer-encapsulation-test-app/tests/integration/serialize-test.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/tests/integration/serialize-test.js
@@ -45,7 +45,7 @@ module('integration/serializer - serialize methods forward to Serializer#seriali
         serializeCalled++;
 
         assert.strictEqual(snapshot.id, '1', 'id is correct');
-        assert.equal(snapshot.modelName, 'person', 'modelName is correct');
+        assert.strictEqual(snapshot.modelName, 'person', 'modelName is correct');
         assert.deepEqual(snapshot.attributes(), { firstName: 'John', lastName: 'Smith' }, 'attributes are correct');
 
         const serializedResource = {
@@ -81,7 +81,7 @@ module('integration/serializer - serialize methods forward to Serializer#seriali
 
     let serializedPerson = person.serialize();
 
-    assert.equal(serializeCalled, 1, 'serialize called once');
+    assert.strictEqual(serializeCalled, 1, 'serialize called once');
     assert.deepEqual(serializedPerson, {
       id: '1',
       type: 'person',
@@ -100,7 +100,7 @@ module('integration/serializer - serialize methods forward to Serializer#seriali
         serializeCalled++;
 
         assert.strictEqual(snapshot.id, '1', 'id is correct');
-        assert.equal(snapshot.modelName, 'person', 'modelName is correct');
+        assert.strictEqual(snapshot.modelName, 'person', 'modelName is correct');
         assert.deepEqual(snapshot.attributes(), { firstName: 'John', lastName: 'Smith' }, 'attributes are correct');
 
         const serializedResource = {
@@ -136,7 +136,7 @@ module('integration/serializer - serialize methods forward to Serializer#seriali
 
     let serializedPerson = person._createSnapshot().serialize();
 
-    assert.equal(serializeCalled, 1, 'serialize called once');
+    assert.strictEqual(serializeCalled, 1, 'serialize called once');
     assert.deepEqual(serializedPerson, {
       id: '1',
       type: 'person',
@@ -156,7 +156,7 @@ module('integration/serializer - serialize methods forward to Serializer#seriali
           serializeCalled++;
 
           assert.strictEqual(snapshot.id, '1', 'id is correct');
-          assert.equal(snapshot.modelName, 'person', 'modelName is correct');
+          assert.strictEqual(snapshot.modelName, 'person', 'modelName is correct');
           assert.deepEqual(snapshot.attributes(), { firstName: 'John', lastName: 'Smith' }, 'attributes are correct');
 
           const serializedResource = {
@@ -192,7 +192,7 @@ module('integration/serializer - serialize methods forward to Serializer#seriali
 
       let serializedPerson = store.serializeRecord(person);
 
-      assert.equal(serializeCalled, 1, 'serialize called once');
+      assert.strictEqual(serializeCalled, 1, 'serialize called once');
       assert.deepEqual(serializedPerson, {
         id: '1',
         type: 'person',

--- a/packages/unpublished-serializer-encapsulation-test-app/tests/integration/update-record-test.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/tests/integration/update-record-test.js
@@ -65,7 +65,7 @@ module('integration/create-record - running createRecord with minimum serializer
         serializeCalled++;
 
         assert.strictEqual(snapshot.id, '1', 'id is correct');
-        assert.equal(snapshot.modelName, 'person', 'modelName is correct');
+        assert.strictEqual(snapshot.modelName, 'person', 'modelName is correct');
         assert.deepEqual(snapshot.attributes(), { firstName: 'Chris', lastName: 'Thoburn' }, 'attributes are correct');
 
         const serializedResource = {
@@ -84,7 +84,7 @@ module('integration/create-record - running createRecord with minimum serializer
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
 
-        assert.equal(requestType, this._methods.shift(), 'expected method name is correct');
+        assert.strictEqual(requestType, this._methods.shift(), 'expected method name is correct');
         assert.deepEqual(rawPayload, this._payloads.shift(), 'payload is correct');
 
         return {
@@ -123,8 +123,8 @@ module('integration/create-record - running createRecord with minimum serializer
 
     await person.save();
 
-    assert.equal(normalizeResponseCalled, 2, 'normalizeResponse called twice');
-    assert.equal(serializeCalled, 1, 'serialize called once');
+    assert.strictEqual(normalizeResponseCalled, 2, 'normalizeResponse called twice');
+    assert.strictEqual(serializeCalled, 1, 'serialize called once');
     assert.deepEqual(person.toJSON(), {
       id: '1',
       type: 'person',
@@ -170,7 +170,7 @@ module('integration/create-record - running createRecord with minimum serializer
         serializeCalled++;
 
         assert.strictEqual(snapshot.id, '1', 'id is correct');
-        assert.equal(snapshot.modelName, 'person', 'modelName is correct');
+        assert.strictEqual(snapshot.modelName, 'person', 'modelName is correct');
         assert.deepEqual(snapshot.attributes(), { firstName: 'Chris', lastName: 'Thoburn' }, 'attributes are correct');
 
         const serializedResource = {
@@ -189,7 +189,7 @@ module('integration/create-record - running createRecord with minimum serializer
       normalizeResponse(store, schema, rawPayload, id, requestType) {
         normalizeResponseCalled++;
 
-        assert.equal(requestType, this._methods.shift(), 'expected method name is correct');
+        assert.strictEqual(requestType, this._methods.shift(), 'expected method name is correct');
         assert.deepEqual(rawPayload, this._payloads.shift(), 'payload is correct');
 
         return {
@@ -228,9 +228,9 @@ module('integration/create-record - running createRecord with minimum serializer
 
     await person.save();
 
-    assert.equal(normalizeResponseCalled, 2, 'normalizeResponse called twice');
-    assert.equal(serializeIntoHashCalled, 1, 'serializeIntoHash called once');
-    assert.equal(serializeCalled, 1, 'serialize called once');
+    assert.strictEqual(normalizeResponseCalled, 2, 'normalizeResponse called twice');
+    assert.strictEqual(serializeIntoHashCalled, 1, 'serializeIntoHash called once');
+    assert.strictEqual(serializeCalled, 1, 'serialize called once');
     assert.deepEqual(person.toJSON(), {
       id: '1',
       type: 'person',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7993,10 +7993,10 @@ eslint-plugin-prettier@^3.4.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-qunit@^6.1.0:
-  version "6.1.1"
-  resolved "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.1.1.tgz#f0a02fab4f61dc02b96b3ce25cbeb480623e1cc5"
-  integrity sha512-XAEULG0Std1wtAZrFDzL//TcJDQhLBOe2DeZDCQ4fxjbk9grDkKaWh4xpNhPQdCp4cL0Wx3PVE2yP7s4VCMH2g==
+eslint-plugin-qunit@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-7.0.0.tgz#a782fafe930820f6b62880958ebc3e93de462f02"
+  integrity sha512-yPh02tbQoZK43voIfJFO9CUN5Q6j8ebfrnxEqPr7I4UiYln4RWKDQ4ajaHgV3gJKSAUZwymJ0DsB/YH6btRxIQ==
   dependencies:
     eslint-utils "^3.0.0"
     requireindex "^1.2.0"


### PR DESCRIPTION
<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->

[no-assert-equal](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md) is now a recommended rule in [eslint-plugin-qunit v7](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/CHANGELOG.md#700). In JavaScript, we should generally use strict equality checks like [assert.strictEqual](https://api.qunitjs.com/assert/strictEqual/).

This PR updates all references in the codebase. In several dozen tests, I had to fix type mismatches (string vs. number, undefined vs. null).

Related to how we are upgrading ember-cli to use eslint-plugin-qunit v7:
* https://github.com/ember-cli/ember-cli/pull/9671
* https://github.com/ember-cli/ember-cli/pull/9667
* https://github.com/emberjs/ember.js/pull/19795