### PR TITLE
Remove TARGET_IE11 flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,6 +249,7 @@ jobs:
       matrix:
         scenario:
           [
+            with-max-transpilation,
             with-native-fetch,
             with-ember-fetch-no-jquery,
             with-ember-fetch-and-jquery,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,13 +147,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        launcher: [Chrome, Firefox, IE]
+        launcher: [Chrome, Firefox]
         os: [macos-latest, windows-latest, ubuntu-latest]
         exclude:
-          - os: macos-latest
-            launcher: IE
-          - os: ubuntu-latest
-            launcher: IE
           - os: ubuntu-latest
             launcher: Firefox
           - os: windows-latest
@@ -253,7 +249,6 @@ jobs:
       matrix:
         scenario:
           [
-            with-max-transpilation,
             with-native-fetch,
             with-ember-fetch-no-jquery,
             with-ember-fetch-and-jquery,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,7 +249,6 @@ jobs:
       matrix:
         scenario:
           [
-            with-max-transpilation,
             with-native-fetch,
             with-ember-fetch-no-jquery,
             with-ember-fetch-and-jquery,

--- a/packages/-ember-data/config/ember-try.js
+++ b/packages/-ember-data/config/ember-try.js
@@ -8,13 +8,6 @@ module.exports = function () {
       useYarn: true,
       scenarios: [
         {
-          name: 'with-max-transpilation',
-          env: {
-            TARGET_IE11: true,
-          },
-          npm: {},
-        },
-        {
           name: 'with-ember-fetch-no-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': false }),

--- a/packages/-ember-data/config/ember-try.js
+++ b/packages/-ember-data/config/ember-try.js
@@ -8,13 +8,6 @@ module.exports = function () {
       useYarn: true,
       scenarios: [
         {
-          name: 'with-max-transpilation',
-          env: {
-            SHOULD_TRANSPILE: true,
-          },
-          npm: {},
-        },
-        {
           name: 'with-ember-fetch-no-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': false }),

--- a/packages/-ember-data/config/ember-try.js
+++ b/packages/-ember-data/config/ember-try.js
@@ -8,6 +8,13 @@ module.exports = function () {
       useYarn: true,
       scenarios: [
         {
+          name: 'with-max-transpilation',
+          env: {
+            SHOULD_TRANSPILE: true,
+          },
+          npm: {},
+        },
+        {
           name: 'with-ember-fetch-no-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': false }),

--- a/packages/-ember-data/ember-cli-build.js
+++ b/packages/-ember-data/ember-cli-build.js
@@ -5,13 +5,14 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function (defaults) {
   const isTest = process.env.EMBER_CLI_TEST_COMMAND;
   const isProd = process.env.EMBER_ENV === 'production';
+  const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
   const compatWith = process.env.EMBER_DATA_FULL_COMPAT ? '99.0' : null;
 
   const terserSettings = {
     exclude: ['assets/dummy.js', 'assets/tests.js', 'assets/test-support.js', 'dist/docs/*', 'docs/*'],
   };
 
-  if (isTest && isProd) {
+  if (isTest && isProd && shouldTranspile) {
     terserSettings.enabled = false;
   }
 

--- a/packages/-ember-data/ember-cli-build.js
+++ b/packages/-ember-data/ember-cli-build.js
@@ -5,14 +5,13 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function (defaults) {
   const isTest = process.env.EMBER_CLI_TEST_COMMAND;
   const isProd = process.env.EMBER_ENV === 'production';
-  const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
   const compatWith = process.env.EMBER_DATA_FULL_COMPAT ? '99.0' : null;
 
   const terserSettings = {
     exclude: ['assets/dummy.js', 'assets/tests.js', 'assets/test-support.js', 'dist/docs/*', 'docs/*'],
   };
 
-  if (isTest && isProd && shouldTranspile) {
+  if (isTest && isProd) {
     terserSettings.enabled = false;
   }
 

--- a/packages/-ember-data/ember-cli-build.js
+++ b/packages/-ember-data/ember-cli-build.js
@@ -5,14 +5,13 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function (defaults) {
   const isTest = process.env.EMBER_CLI_TEST_COMMAND;
   const isProd = process.env.EMBER_ENV === 'production';
-  const needsIE11 = !!process.env.TARGET_IE11;
   const compatWith = process.env.EMBER_DATA_FULL_COMPAT ? '99.0' : null;
 
   const terserSettings = {
     exclude: ['assets/dummy.js', 'assets/tests.js', 'assets/test-support.js', 'dist/docs/*', 'docs/*'],
   };
 
-  if (isTest && isProd && needsIE11) {
+  if (isTest && isProd) {
     terserSettings.enabled = false;
   }
 

--- a/packages/-ember-data/tests/dummy/config/targets.js
+++ b/packages/-ember-data/tests/dummy/config/targets.js
@@ -1,11 +1,6 @@
 'use strict';
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-const targetIsIE11 = process.env.TESTEM_CI_LAUNCHER === 'IE' || !!process.env.TARGET_IE11;
-
-if (targetIsIE11) {
-  browsers.push('ie 11');
-}
 
 module.exports = {
   browsers,

--- a/packages/-ember-data/tests/dummy/config/targets.js
+++ b/packages/-ember-data/tests/dummy/config/targets.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+
+if (shouldTranspile) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
+}
 
 module.exports = {
   browsers,

--- a/packages/-ember-data/tests/dummy/config/targets.js
+++ b/packages/-ember-data/tests/dummy/config/targets.js
@@ -1,9 +1,9 @@
 'use strict';
 
 let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+const isProd = process.env.EMBER_ENV === 'production';
 
-if (shouldTranspile) {
+if (isProd) {
   browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 

--- a/packages/adapter/tests/dummy/config/targets.js
+++ b/packages/adapter/tests/dummy/config/targets.js
@@ -2,12 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const needsIE11 = !!process.env.TARGET_IE11;
-
-if (needsIE11) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
   node: 'current',

--- a/packages/adapter/tests/dummy/config/targets.js
+++ b/packages/adapter/tests/dummy/config/targets.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+
+if (shouldTranspile) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
+}
 
 module.exports = {
   browsers,

--- a/packages/adapter/tests/dummy/config/targets.js
+++ b/packages/adapter/tests/dummy/config/targets.js
@@ -1,9 +1,9 @@
 'use strict';
 
 let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+const isProd = process.env.EMBER_ENV === 'production';
 
-if (shouldTranspile) {
+if (isProd) {
   browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 

--- a/packages/debug/tests/dummy/config/targets.js
+++ b/packages/debug/tests/dummy/config/targets.js
@@ -2,12 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const needsIE11 = !!process.env.TARGET_IE11;
-
-if (needsIE11) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
   node: 'current',

--- a/packages/debug/tests/dummy/config/targets.js
+++ b/packages/debug/tests/dummy/config/targets.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+
+if (shouldTranspile) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
+}
 
 module.exports = {
   browsers,

--- a/packages/debug/tests/dummy/config/targets.js
+++ b/packages/debug/tests/dummy/config/targets.js
@@ -1,9 +1,9 @@
 'use strict';
 
 let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+const isProd = process.env.EMBER_ENV === 'production';
 
-if (shouldTranspile) {
+if (isProd) {
   browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 

--- a/packages/model/tests/dummy/config/targets.js
+++ b/packages/model/tests/dummy/config/targets.js
@@ -2,12 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const needsIE11 = !!process.env.TARGET_IE11;
-
-if (needsIE11) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
   node: 'current',

--- a/packages/model/tests/dummy/config/targets.js
+++ b/packages/model/tests/dummy/config/targets.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+
+if (shouldTranspile) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
+}
 
 module.exports = {
   browsers,

--- a/packages/model/tests/dummy/config/targets.js
+++ b/packages/model/tests/dummy/config/targets.js
@@ -1,9 +1,9 @@
 'use strict';
 
 let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+const isProd = process.env.EMBER_ENV === 'production';
 
-if (shouldTranspile) {
+if (isProd) {
   browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 

--- a/packages/record-data/tests/dummy/config/targets.js
+++ b/packages/record-data/tests/dummy/config/targets.js
@@ -1,11 +1,6 @@
 'use strict';
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-const targetIsIE11 = process.env.TESTEM_CI_LAUNCHER === 'IE' || !!process.env.TARGET_IE11;
-
-if (targetIsIE11) {
-  browsers.push('ie 11');
-}
 
 module.exports = {
   browsers,

--- a/packages/record-data/tests/dummy/config/targets.js
+++ b/packages/record-data/tests/dummy/config/targets.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+
+if (shouldTranspile) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
+}
 
 module.exports = {
   browsers,

--- a/packages/record-data/tests/dummy/config/targets.js
+++ b/packages/record-data/tests/dummy/config/targets.js
@@ -1,9 +1,9 @@
 'use strict';
 
 let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+const isProd = process.env.EMBER_ENV === 'production';
 
-if (shouldTranspile) {
+if (isProd) {
   browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 

--- a/packages/serializer/tests/dummy/config/targets.js
+++ b/packages/serializer/tests/dummy/config/targets.js
@@ -2,12 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const needsIE11 = !!process.env.TARGET_IE11;
-
-if (needsIE11) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
   node: 'current',

--- a/packages/serializer/tests/dummy/config/targets.js
+++ b/packages/serializer/tests/dummy/config/targets.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+
+if (shouldTranspile) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
+}
 
 module.exports = {
   browsers,

--- a/packages/serializer/tests/dummy/config/targets.js
+++ b/packages/serializer/tests/dummy/config/targets.js
@@ -1,9 +1,9 @@
 'use strict';
 
 let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+const isProd = process.env.EMBER_ENV === 'production';
 
-if (shouldTranspile) {
+if (isProd) {
   browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 

--- a/packages/store/tests/dummy/config/targets.js
+++ b/packages/store/tests/dummy/config/targets.js
@@ -2,12 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const needsIE11 = !!process.env.TARGET_IE11;
-
-if (needsIE11) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
   node: 'current',

--- a/packages/store/tests/dummy/config/targets.js
+++ b/packages/store/tests/dummy/config/targets.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+
+if (shouldTranspile) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
+}
 
 module.exports = {
   browsers,

--- a/packages/store/tests/dummy/config/targets.js
+++ b/packages/store/tests/dummy/config/targets.js
@@ -1,9 +1,9 @@
 'use strict';
 
 let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-const shouldTranspile = !!process.env.SHOULD_TRANSPILE;
+const isProd = process.env.EMBER_ENV === 'production';
 
-if (shouldTranspile) {
+if (isProd) {
   browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 

--- a/packages/unpublished-adapter-encapsulation-test-app/config/targets.js
+++ b/packages/unpublished-adapter-encapsulation-test-app/config/targets.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const isProd = process.env.EMBER_ENV === 'production';
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
+if (isProd) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 
 module.exports = {

--- a/packages/unpublished-debug-encapsulation-test-app/config/targets.js
+++ b/packages/unpublished-debug-encapsulation-test-app/config/targets.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const isProd = process.env.EMBER_ENV === 'production';
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
+if (isProd) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 
 module.exports = {

--- a/packages/unpublished-fastboot-test-app/config/targets.js
+++ b/packages/unpublished-fastboot-test-app/config/targets.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const isProd = process.env.EMBER_ENV === 'production';
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
+if (isProd) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 
 module.exports = {

--- a/packages/unpublished-model-encapsulation-test-app/config/targets.js
+++ b/packages/unpublished-model-encapsulation-test-app/config/targets.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const isProd = process.env.EMBER_ENV === 'production';
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
+if (isProd) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 
 module.exports = {

--- a/packages/unpublished-model-encapsulation-test-app/testem.js
+++ b/packages/unpublished-model-encapsulation-test-app/testem.js
@@ -1,18 +1,11 @@
 // eslint-disable-next-line node/no-unpublished-require
 const customDotReporter = require('@ember-data/unpublished-test-infra/src/testem/custom-dot-reporter');
 
-const TestIE = process.env.TEST_IE11;
-
-if (TestIE) {
-  // eslint-disable-next-line no-console
-  console.log('\n\nLaunching with IE\n\n');
-}
-
 module.exports = {
   test_page: 'tests/index.html?hidepassed&nocontainer',
   disable_watching: true,
   reporter: customDotReporter,
-  launch_in_ci: TestIE ? ['IE'] : ['Chrome'],
+  launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
   browser_args: {

--- a/packages/unpublished-record-data-encapsulation-test-app/config/targets.js
+++ b/packages/unpublished-record-data-encapsulation-test-app/config/targets.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const isProd = process.env.EMBER_ENV === 'production';
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
+if (isProd) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 
 module.exports = {

--- a/packages/unpublished-serializer-encapsulation-test-app/config/targets.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/config/targets.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const isProd = process.env.EMBER_ENV === 'production';
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
+if (isProd) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 
 module.exports = {

--- a/packages/unpublished-test-infra/tests/dummy/config/targets.js
+++ b/packages/unpublished-test-infra/tests/dummy/config/targets.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+let browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const isProd = process.env.EMBER_ENV === 'production';
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
+if (isProd) {
+  browsers = ['last 2 Chrome versions', 'last 2 Firefox versions', 'Safari 12', 'last 2 Edge versions'];
 }
 
 module.exports = {


### PR DESCRIPTION
prep for 4.0!

ref https://github.com/emberjs/data/issues/7724

There are some comments about IE11 in the codebase and features we couldn't use due to lack of APIs.  Will follow up after to remove all comments and apply necessary changes.

This PR ultimately aligns our browser targets with ember.js

- https://github.com/emberjs/ember.js/blob/master/config/targets.js