### PR TITLE
reference: Fix broken `meta()` snippet

### DIFF
--- a/packages/store/addon/-private/system/references/reference.ts
+++ b/packages/store/addon/-private/system/references/reference.ts
@@ -181,9 +181,9 @@ abstract class Reference {
               related: {
                 href: '/articles/1/author'
               },
-              meta: {
-                lastUpdated: 1458014400000
-              }
+            },
+            meta: {
+              lastUpdated: 1458014400000
             }
           }
         }


### PR DESCRIPTION
The `meta` field is supposed to be inside of the relationship object, not inside of `links`