### PR TITLE
chore: cancel older CI jobs

### DIFF
--- a/.github/workflows/asset-size-check.yml
+++ b/.github/workflows/asset-size-check.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: asset-size-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   asset-size-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/enforce-pr-labels-beta.yml
+++ b/.github/workflows/enforce-pr-labels-beta.yml
@@ -5,6 +5,11 @@ on:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
     branches:
       - beta
+
+concurrency:
+  group: pr-labels-beta-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/enforce-pr-labels-canary.yml
+++ b/.github/workflows/enforce-pr-labels-canary.yml
@@ -5,6 +5,11 @@ on:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
     branches:
       - master
+
+concurrency:
+  group: pr-labels-canary-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/enforce-pr-labels-lts-prev.yml
+++ b/.github/workflows/enforce-pr-labels-lts-prev.yml
@@ -4,7 +4,12 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
     branches:
-      - lts-3-20
+      - lts-3-24
+
+concurrency:
+  group: pr-labels-lts-prev-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/enforce-pr-labels-lts.yml
+++ b/.github/workflows/enforce-pr-labels-lts.yml
@@ -4,7 +4,12 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
     branches:
-      - lts-3-24
+      - lts-3-28
+
+concurrency:
+  group: pr-labels-lts-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/enforce-pr-labels-old-release.yml
+++ b/.github/workflows/enforce-pr-labels-old-release.yml
@@ -5,6 +5,11 @@ on:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
     branches:
       - release-*
+
+concurrency:
+  group: pr-labels-old-release-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/enforce-pr-labels-release.yml
+++ b/.github/workflows/enforce-pr-labels-release.yml
@@ -5,6 +5,11 @@ on:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
     branches:
       - release
+
+concurrency:
+  group: pr-labels-release-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     timeout-minutes: 5
@@ -142,12 +146,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --network-timeout=300000
       - name: Fastboot Test ${{ matrix.scenario }}
-        timeout-minutes: 12 
+        timeout-minutes: 12
         run: yarn test:fastboot ${{ matrix.scenario }}
 
   browser-tests:
     needs: [lint]
-    timeout-minutes: 20 
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: perf-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   performance-checks:
     name: 'Performance Checks'


### PR DESCRIPTION
cancels jobs on PRs that aren't for the current head commit.
