### PR TITLE
Fix: assign unknown properties in init after initialization is finished to ensure proper setup timing

### DIFF
--- a/packages/-ember-data/tests/integration/records/create-record-test.js
+++ b/packages/-ember-data/tests/integration/records/create-record-test.js
@@ -38,6 +38,25 @@ module('Store.createRecord() coverage', function (hooks) {
     store = owner.lookup('service:store');
   });
 
+  test("createRecord doesn't crash when setter is involved", async function (assert) {
+    class User extends Model {
+      @attr() email;
+
+      get name() {
+        return this.email ? this.email.substring(0, this.email.indexOf('@')) : '';
+      }
+
+      set name(value) {
+        this.email = `${value.toLowerCase()}@ember.js`;
+      }
+    }
+    this.owner.register(`model:user`, User);
+    const store = this.owner.lookup('service:store');
+
+    const user = store.createRecord('user', { name: 'Robert' });
+    assert.strictEqual(user.email, 'robert@ember.js');
+  });
+
   test('unloading a newly created a record with a sync belongsTo relationship', async function (assert) {
     let chris = store.push({
       data: {

--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -1,4 +1,3 @@
-import { set } from '@ember/object';
 import { run } from '@ember/runloop';
 import { settled } from '@ember/test-helpers';
 import Ember from 'ember';
@@ -11,7 +10,6 @@ import { setupTest } from 'ember-qunit';
 
 import RESTAdapter from '@ember-data/adapter/rest';
 import { REQUEST_SERVICE } from '@ember-data/canary-features';
-import Model, { attr } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import RESTSerializer from '@ember-data/serializer/rest';
 import deepCopy from '@ember-data/unpublished-test-infra/test-support/deep-copy';
@@ -1342,28 +1340,5 @@ module('integration/store - queryRecord', function (hooks) {
     } catch (error) {
       assert.strictEqual(error.message, 'Refusing to serialize');
     }
-  });
-});
-
-module('integration/store - createRecord', function (hooks) {
-  setupTest(hooks);
-
-  test("createRecord doesn't crash when setter is involved", async function (assert) {
-    class User extends Model {
-      @attr() email;
-
-      get name() {
-        return this.email ? this.email.substring(0, this.email.indexOf('@')) : '';
-      }
-
-      set name(value) {
-        set(this, 'email', `${value.toLowerCase()}@ember.js`);
-      }
-    }
-    this.owner.register(`model:user`, User);
-    const store = this.owner.lookup('service:store');
-
-    const user = store.createRecord('user', { name: 'Robert' });
-    assert.strictEqual(user.email, 'robert@ember.js');
   });
 });

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -118,8 +118,10 @@ function computeOnce(target, key, desc) {
   @uses DeprecatedEvented
 */
 class Model extends EmberObject {
-  init(...args) {
-    super.init(...args);
+  init(options = {}) {
+    const createProps = options._createProps;
+    delete options._createProps;
+    super.init(options);
 
     if (DEBUG) {
       if (!this._internalModel) {
@@ -132,6 +134,7 @@ class Model extends EmberObject {
     if (CUSTOM_MODEL_CLASS) {
       this.___recordState = new RecordState(this);
     }
+    this.setProperties(createProps);
   }
 
   /**
@@ -2075,6 +2078,7 @@ class Model extends EmberObject {
 // the values initialized during create to `setUnknownProperty`
 Model.prototype._internalModel = null;
 Model.prototype.store = null;
+Model.prototype._createProps = null;
 
 if (HAS_DEBUG_PACKAGE) {
   /**

--- a/packages/store/addon/-private/system/ds-model-store.ts
+++ b/packages/store/addon/-private/system/ds-model-store.ts
@@ -37,9 +37,10 @@ class Store extends CoreStore {
     let createOptions: any = {
       store: this,
       _internalModel: internalModel,
+      // TODO deprecate allowing unknown args setting
+      _createProps: createRecordArgs,
       container: null,
     };
-    Object.assign(createOptions, createRecordArgs);
 
     // ensure that `getOwner(this)` works inside a model instance
     setOwner(createOptions, getOwner(this));


### PR DESCRIPTION
createRecord crashes when a setter which sets an attribute is involved
in the createRecord.

resolves #7772 
