### PR TITLE
Backport Train for LTS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -300,10 +300,10 @@ jobs:
       matrix:
         partner:
           [
-            ember-data-relationship-tracker,
+            # ember-data-relationship-tracker,
             ember-m3,
             ember-observer,
-            ember-resource-metadata,
+            # ember-resource-metadata,
             factory-guy,
             ilios-frontend,
             model-fragments,

--- a/packages/-ember-data/tests/acceptance/relationships/tracking-record-state-test.js
+++ b/packages/-ember-data/tests/acceptance/relationships/tracking-record-state-test.js
@@ -34,7 +34,7 @@ module('tracking state flags on a record', function (hooks) {
         enumerable: true,
         configurable: true,
         get() {
-          tag.reg; // subscribe
+          tag.rev; // subscribe
           if (_isDirty && !_isUpdating) {
             _isUpdating = true;
             resolve(desc.get.call(this)).then((v) => {

--- a/packages/-ember-data/tests/integration/records/create-record-test.js
+++ b/packages/-ember-data/tests/integration/records/create-record-test.js
@@ -38,6 +38,25 @@ module('Store.createRecord() coverage', function (hooks) {
     store = owner.lookup('service:store');
   });
 
+  test("createRecord doesn't crash when setter is involved", async function (assert) {
+    class User extends Model {
+      @attr() email;
+
+      get name() {
+        return this.email ? this.email.substring(0, this.email.indexOf('@')) : '';
+      }
+
+      set name(value) {
+        this.email = `${value.toLowerCase()}@ember.js`;
+      }
+    }
+    this.owner.register(`model:user`, User);
+    const store = this.owner.lookup('service:store');
+
+    const user = store.createRecord('user', { name: 'Robert' });
+    assert.strictEqual(user.email, 'robert@ember.js');
+  });
+
   test('unloading a newly created a record with a sync belongsTo relationship', async function (assert) {
     let chris = store.push({
       data: {

--- a/packages/-ember-data/tests/integration/references/autotracking-test.js
+++ b/packages/-ember-data/tests/integration/references/autotracking-test.js
@@ -1,0 +1,128 @@
+import EmberObject from '@ember/object';
+import { getRootElement, render } from '@ember/test-helpers';
+import settled from '@ember/test-helpers/settled';
+
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+import { setupRenderingTest } from 'ember-qunit';
+
+import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import { recordIdentifierFor } from '@ember-data/store';
+
+if (CUSTOM_MODEL_CLASS) {
+  module('integration/references/autotracking', function (hooks) {
+    setupRenderingTest(hooks);
+
+    class User extends Model {
+      @attr name;
+      @belongsTo('user', { inverse: null, async: false })
+      bestFriend;
+      @hasMany('user', { inverse: null, async: false })
+      friends;
+    }
+
+    let store, user;
+    hooks.beforeEach(function () {
+      const { owner } = this;
+      owner.register('model:user', User);
+      store = owner.lookup('service:store');
+
+      owner.register(
+        'adapter:user',
+        class extends EmberObject {
+          createRecord() {
+            return { data: { id: '6', type: 'user' } };
+          }
+        }
+      );
+      owner.register(
+        'serializer:user',
+        class extends EmberObject {
+          normalizeResponse(_, __, data) {
+            return data;
+          }
+        }
+      );
+
+      user = store.push({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Chris',
+          },
+          relationships: {
+            bestFriend: {
+              data: { type: 'user', id: '2' },
+            },
+            friends: {
+              data: [{ type: 'user', id: '2' }],
+            },
+          },
+        },
+        included: [
+          { type: 'user', id: '2', attributes: { name: 'Igor' } },
+          { type: 'user', id: '3', attributes: { name: 'David' } },
+          { type: 'user', id: '4', attributes: { name: 'Scott' } },
+          { type: 'user', id: '5', attributes: { name: 'Rob' } },
+        ],
+      });
+    });
+
+    test('BelongsToReference.id() is autotracked', async function (assert) {
+      class TestContext {
+        user = user;
+
+        get bestFriendId() {
+          return this.user.belongsTo('bestFriend').id();
+        }
+      }
+
+      const testContext = new TestContext();
+      this.set('context', testContext);
+      await render(hbs`id: {{if this.context.bestFriendId this.context.bestFriendId 'null'}}`);
+
+      assert.strictEqual(getRootElement().textContent, 'id: 2', 'the id is initially correct');
+      assert.strictEqual(testContext.bestFriendId, '2', 'the id is initially correct');
+      user.bestFriend = store.createRecord('user', { name: 'Bill' });
+      await settled();
+      assert.strictEqual(getRootElement().textContent, 'id: null', 'the id updates to null');
+      assert.strictEqual(testContext.bestFriendId, null, 'the id is correct when we swap records');
+      await user.bestFriend.save();
+      await settled();
+      assert.strictEqual(getRootElement().textContent, 'id: 6', 'the id updates when the related record id updates');
+      assert.strictEqual(testContext.bestFriendId, '6', 'the id is correct when the record is saved');
+    });
+
+    test('HasManyReference.ids() is autotracked', async function (assert) {
+      class TestContext {
+        user = user;
+
+        get friendIds() {
+          return this.user.hasMany('friends').ids();
+        }
+      }
+      const testContext = new TestContext();
+      this.set('context', testContext);
+      await render(hbs`{{#each this.context.friendIds as |id|}}id: {{if id id 'null'}}, {{/each}}`);
+
+      assert.strictEqual(getRootElement().textContent, 'id: 2, ', 'the ids are initially correct');
+      assert.deepEqual(testContext.friendIds, ['2'], 'the ids are initially correct');
+      const bill = store.createRecord('user', { name: 'Bill' });
+      user.friends.pushObject(bill);
+      await settled();
+      assert.strictEqual(getRootElement().textContent, 'id: 2, id: null, ', 'the id is added for the new record');
+      assert.deepEqual(testContext.friendIds, ['2', null], 'the ids are correct when we add a new record');
+      await bill.save();
+      await settled();
+      assert.strictEqual(
+        getRootElement().textContent,
+        'id: 2, id: 6, ',
+        'the id updates when the related record id updates'
+      );
+      assert.deepEqual(testContext.friendIds, ['2', '6'], 'the ids are correct when the new record is saved');
+    });
+  });
+}

--- a/packages/-ember-data/tests/integration/relationships/promise-many-array-test.js
+++ b/packages/-ember-data/tests/integration/relationships/promise-many-array-test.js
@@ -1,0 +1,39 @@
+import { A } from '@ember/array';
+import { w } from '@ember/string';
+
+import { module, test } from 'qunit';
+
+import { setupRenderingTest } from 'ember-qunit';
+
+import Model, { attr, hasMany } from '@ember-data/model';
+
+module('PromiseManyArray side-affected by EmberArray', (hooks) => {
+  setupRenderingTest(hooks);
+
+  test('PromiseManyArray is not side-affected by EmberArray', async function (assert) {
+    const { owner } = this;
+    class Person extends Model {
+      @attr('string') name;
+    }
+    class Group extends Model {
+      @hasMany('person', { inverse: null }) members;
+    }
+    owner.register('model:person', Person);
+    owner.register('model:group', Group);
+    const store = owner.lookup('service:store');
+    const members = w('Bob John Michael Larry Lucy').map((name) => store.createRecord('person', { name }));
+    const group = store.createRecord('group', { members });
+
+    const replaceFn = group.members.replace;
+    assert.strictEqual(group.members.length, 5, 'initial length is correct');
+
+    group.members.replace(0, 1);
+    assert.strictEqual(group.members.length, 4, 'updated length is correct');
+
+    A(group.members);
+
+    assert.strictEqual(replaceFn, group.members.replace, 'we have the same function for replace');
+    group.members.replace(0, 1);
+    assert.strictEqual(group.members.length, 3, 'updated length is correct');
+  });
+});

--- a/packages/model/addon/-private/has-many.js
+++ b/packages/model/addon/-private/has-many.js
@@ -24,17 +24,17 @@ import { computedMacroWithOptionalParams } from './util';
 
   ```app/models/post.js
   import Model, { hasMany } from '@ember-data/model';
-  
+
   export default class PostModel extends Model {
-    @hasMany('comment') comments; 
+    @hasMany('comment') comments;
   }
   ```
 
   ```app/models/comment.js
   import Model, { belongsTo } from '@ember-data/model';
-  
+
   export default class CommentModel extends Model {
-    @belongsTo('post') post; 
+    @belongsTo('post') post;
   }
   ```
 
@@ -54,7 +54,7 @@ import { computedMacroWithOptionalParams } from './util';
   import Model, { hasMany } from '@ember-data/model';
 
   export default class TagModel extends Model {
-    @hasMany('post') posts; 
+    @hasMany('post') posts;
   }
   ```
 

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -119,8 +119,10 @@ function computeOnce(target, key, desc) {
   @uses EmberData.DeprecatedEvented
 */
 class Model extends EmberObject {
-  init(...args) {
-    super.init(...args);
+  init(options = {}) {
+    const createProps = options._createProps;
+    delete options._createProps;
+    super.init(options);
 
     if (DEBUG) {
       if (!this._internalModel) {
@@ -133,6 +135,7 @@ class Model extends EmberObject {
     if (CUSTOM_MODEL_CLASS) {
       this.___recordState = new RecordState(this);
     }
+    this.setProperties(createProps);
   }
 
   /**
@@ -2076,6 +2079,7 @@ class Model extends EmberObject {
 // the values initialized during create to `setUnknownProperty`
 Model.prototype._internalModel = null;
 Model.prototype.store = null;
+Model.prototype._createProps = null;
 
 if (HAS_DEBUG_PACKAGE) {
   /**

--- a/packages/model/addon/-private/system/promise-many-array.ts
+++ b/packages/model/addon/-private/system/promise-many-array.ts
@@ -1,3 +1,4 @@
+import ArrayMixin from '@ember/array';
 import { assert } from '@ember/debug';
 import { dependentKeyCompat } from '@ember/object/compat';
 import { tracked } from '@glimmer/tracking';
@@ -16,7 +17,7 @@ import { DEPRECATE_EVENTED_API_USAGE } from '@ember-data/private-build-infra/dep
 
   A PromiseManyArray is an array-like proxy that also proxies certain method calls
   to the underlying ManyArray in addition to being "promisified".
-   
+
   Right now we proxy:
 
     * `reload()`
@@ -41,6 +42,14 @@ export default class PromiseManyArray {
     this._update(promise, content);
     this.isDestroyed = false;
     this.isDestroying = false;
+
+    const meta = Ember.meta(this);
+    meta.hasMixin = (mixin: Object) => {
+      if (mixin === ArrayMixin) {
+        return true;
+      }
+      return false;
+    };
   }
 
   //---- Methods/Properties on ArrayProxy that we will keep as our API

--- a/packages/record-data/addon/-private/graph/operations/replace-related-records.ts
+++ b/packages/record-data/addon/-private/graph/operations/replace-related-records.ts
@@ -76,19 +76,15 @@ export default function replaceRelatedRecords(graph: Graph, op: ReplaceRelatedRe
 
 function replaceRelatedRecordsLocal(graph: Graph, op: ReplaceRelatedRecordsOperation, isRemote: boolean) {
   const identifiers = op.value;
-  const identifiersLength = identifiers.length;
   const relationship = graph.get(op.record, op.field);
   assert(`expected hasMany relationship`, isHasMany(relationship));
   relationship.state.hasReceivedData = true;
 
-  const newValues = Object.create(null);
-  for (let i = 0; i < identifiersLength; i++) {
-    newValues[identifiers[i].lid] = true;
-  }
-
   // cache existing state
   const { currentState, members, definition } = relationship;
-  const newState = new Array(identifiers.length);
+  const newValues = new Set(identifiers);
+  const identifiersLength = identifiers.length;
+  const newState = new Array(newValues.size);
   const newMembership = new Set<StableRecordIdentifier>();
 
   // wipe existing state
@@ -106,6 +102,9 @@ function replaceRelatedRecordsLocal(graph: Graph, op: ReplaceRelatedRecordsOpera
   for (let i = 0; i < iterationLength; i++) {
     if (i < identifiersLength) {
       const identifier = identifiers[i];
+      if (newMembership.has(identifier)) {
+        break; // skip processing if we encounter a duplicate identifier in the array
+      }
       if (type !== identifier.type) {
         assertPolymorphicType(relationship.identifier, relationship.definition, identifier, graph.store);
         graph.registerPolymorphicType(type, identifier.type);
@@ -126,7 +125,7 @@ function replaceRelatedRecordsLocal(graph: Graph, op: ReplaceRelatedRecordsOpera
         changed = true;
       }
 
-      if (!newValues[identifier.lid]) {
+      if (!newValues.has(identifier)) {
         changed = true;
         removeFromInverse(graph, identifier, definition.inverseKey, op.record, isRemote);
       }
@@ -140,7 +139,6 @@ function replaceRelatedRecordsLocal(graph: Graph, op: ReplaceRelatedRecordsOpera
 
 function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOperation, isRemote: boolean) {
   const identifiers = op.value;
-  const identifiersLength = identifiers.length;
   const relationship = graph.get(op.record, op.field);
 
   assert(
@@ -152,14 +150,11 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
   }
   relationship.state.hasReceivedData = true;
 
-  const newValues = Object.create(null);
-  for (let i = 0; i < identifiersLength; i++) {
-    newValues[identifiers[i].lid] = true;
-  }
-
   // cache existing state
   const { canonicalState, canonicalMembers, definition } = relationship;
-  const newState = new Array(identifiers.length);
+  const newValues = new Set(identifiers);
+  const identifiersLength = identifiers.length;
+  const newState = new Array(newValues.size);
   const newMembership = new Set<StableRecordIdentifier>();
 
   // wipe existing state
@@ -177,6 +172,9 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
   for (let i = 0; i < iterationLength; i++) {
     if (i < identifiersLength) {
       const identifier = identifiers[i];
+      if (newMembership.has(identifier)) {
+        break;
+      }
       if (type !== identifier.type) {
         assertPolymorphicType(relationship.identifier, relationship.definition, identifier, graph.store);
         graph.registerPolymorphicType(type, identifier.type);
@@ -197,7 +195,7 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
         changed = true;
       }
 
-      if (!newValues[identifier.lid]) {
+      if (!newValues.has(identifier)) {
         changed = true;
         removeFromInverse(graph, identifier, definition.inverseKey, op.record, isRemote);
       }

--- a/packages/record-data/addon/-private/graph/operations/update-relationship.ts
+++ b/packages/record-data/addon/-private/graph/operations/update-relationship.ts
@@ -153,7 +153,5 @@ export default function updateRelationshipOperation(graph: Graph, op: UpdateRela
     } else {
       relationship.state.isStale = false;
     }
-  } else {
-    relationship.state.isStale = false;
   }
 }

--- a/packages/record-data/addon/-private/record-data.ts
+++ b/packages/record-data/addon/-private/record-data.ts
@@ -111,7 +111,9 @@ export default class RecordDataDefault implements RelationshipRecordData {
     }
 
     if (data.id) {
-      this.id = coerceId(data.id);
+      if (!this.id) {
+        this.id = coerceId(data.id);
+      }
     }
 
     return changedKeys;

--- a/packages/store/addon/-private/system/ds-model-store.ts
+++ b/packages/store/addon/-private/system/ds-model-store.ts
@@ -2,7 +2,6 @@ import { getOwner, setOwner } from '@ember/application';
 import { assert, deprecate } from '@ember/debug';
 import EmberError from '@ember/error';
 import { get } from '@ember/object';
-import { assign } from '@ember/polyfills';
 import { isPresent } from '@ember/utils';
 import { DEBUG } from '@glimmer/env';
 
@@ -39,9 +38,10 @@ class Store extends CoreStore {
     let createOptions: any = {
       store: this,
       _internalModel: internalModel,
+      // TODO deprecate allowing unknown args setting
+      _createProps: createRecordArgs,
       container: null,
     };
-    assign(createOptions, createRecordArgs);
 
     // ensure that `getOwner(this)` works inside a model instance
     setOwner(createOptions, getOwner(this));

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -28,6 +28,8 @@ import Snapshot from '../snapshot';
 import { internalModelFactoryFor, setRecordIdentifier } from '../store/internal-model-factory';
 import RootState from './states';
 
+type DSModel = import('../../ts-interfaces/ds-model').DSModel;
+
 type BelongsToRelationship = import('@ember-data/record-data/-private').BelongsToRelationship;
 type ManyRelationship = import('@ember-data/record-data/-private').ManyRelationship;
 
@@ -130,7 +132,7 @@ export default class InternalModel {
   declare _deferredTriggers: any;
   declare __recordArrays: any;
   declare references: any;
-  declare _recordReference: any;
+  declare _recordReference: RecordReference;
   declare _manyArrayCache: ConfidentDict<ManyArray>;
 
   declare _relationshipPromisesCache: ConfidentDict<RSVP.Promise<any>>;
@@ -202,7 +204,7 @@ export default class InternalModel {
     }
   }
 
-  get recordReference() {
+  get recordReference(): RecordReference {
     if (this._recordReference === null) {
       this._recordReference = new RecordReference(this.store, this.identifier);
     }
@@ -294,7 +296,7 @@ export default class InternalModel {
     }
   }
 
-  getRecord(properties?) {
+  getRecord(properties?): Object {
     if (!this._record && !this._isDematerializing) {
       let { store } = this;
 
@@ -616,7 +618,7 @@ export default class InternalModel {
             "' with id " +
             parentInternalModel.id +
             ' but some of the associated records were not loaded. Either make sure they are all loaded together with the parent record, or specify that the relationship is async (`belongsTo({ async: true })`)',
-          toReturn === null || !toReturn.get('isEmpty')
+          toReturn === null || !(toReturn as DSModel).isEmpty
         );
         return toReturn;
       }
@@ -675,7 +677,7 @@ export default class InternalModel {
     assert(`hasMany only works with the @ember-data/record-data package`);
   }
 
-  getHasMany(key: string, options) {
+  getHasMany(key: string, options?) {
     if (HAS_RECORD_DATA_PACKAGE) {
       const graphFor = require('@ember-data/record-data/-private').graphFor;
       const relationship = graphFor(this.store).get(this.identifier, key);
@@ -793,11 +795,22 @@ export default class InternalModel {
       !this._record || this._record.get('isDestroyed') || this._record.get('isDestroying')
     );
     this.isDestroying = true;
+    if (this._recordReference) {
+      this._recordReference.destroy();
+    }
+    this._recordReference = null;
     let cache = this._manyArrayCache;
     Object.keys(cache).forEach((key) => {
       cache[key].destroy();
       delete cache[key];
     });
+    if (this.references) {
+      cache = this.references;
+      Object.keys(cache).forEach((key) => {
+        cache[key].destroy();
+        delete cache[key];
+      });
+    }
 
     internalModelFactoryFor(this.store).remove(this);
     this._isDestroyed = true;
@@ -806,6 +819,7 @@ export default class InternalModel {
   setupData(data) {
     let changedKeys = this._recordData.pushData(data, this.hasRecord);
     if (this.hasRecord) {
+      // TODO @runspired should this be going through the notification manager?
       this._record._notifyProperties(changedKeys);
     }
     this.send('pushedData');
@@ -905,11 +919,18 @@ export default class InternalModel {
 
   notifyHasManyChange(key: string) {
     if (this.hasRecord) {
+      let manyArray = this._manyArrayCache[key];
+      let hasPromise = !!this._relationshipPromisesCache[key];
+
+      if (manyArray && hasPromise) {
+        // do nothing, we will notify the ManyArray directly
+        // once the fetch has completed.
+        return;
+      }
+
       if (CUSTOM_MODEL_CLASS) {
         this.store._notificationManager.notify(this.identifier, 'relationships', key);
       } else {
-        let manyArray = this._manyArrayCache[key];
-
         if (manyArray) {
           manyArray.notify();
 
@@ -959,10 +980,10 @@ export default class InternalModel {
         this.store._notificationManager.notify(this.identifier, 'state');
       } else {
         if (!key || key === 'isNew') {
-          this.getRecord().notifyPropertyChange('isNew');
+          (this.getRecord() as DSModel).notifyPropertyChange('isNew');
         }
         if (!key || key === 'isDeleted') {
-          this.getRecord().notifyPropertyChange('isDeleted');
+          (this.getRecord() as DSModel).notifyPropertyChange('isDeleted');
         }
       }
     }
@@ -1266,12 +1287,12 @@ export default class InternalModel {
       if (this._recordData.getErrors) {
         return this._recordData.getErrors(this.identifier).length > 0;
       } else {
-        let errors = get(this.getRecord(), 'errors');
-        return errors.get('length') > 0;
+        let errors = (this.getRecord() as DSModel).errors;
+        return errors.length > 0;
       }
     } else {
-      let errors = get(this.getRecord(), 'errors');
-      return errors.get('length') > 0;
+      let errors = (this.getRecord() as DSModel).errors;
+      return errors.length > 0;
     }
   }
 
@@ -1286,7 +1307,7 @@ export default class InternalModel {
         if (!this._recordData.getErrors) {
           for (attribute in parsedErrors) {
             if (hasOwnProperty.call(parsedErrors, attribute)) {
-              this.getRecord().errors._add(attribute, parsedErrors[attribute]);
+              (this.getRecord() as DSModel).errors._add(attribute, parsedErrors[attribute]);
             }
           }
         }
@@ -1306,7 +1327,7 @@ export default class InternalModel {
 
       for (attribute in parsedErrors) {
         if (hasOwnProperty.call(parsedErrors, attribute)) {
-          this.getRecord().errors._add(attribute, parsedErrors[attribute]);
+          (this.getRecord() as DSModel).errors._add(attribute, parsedErrors[attribute]);
         }
       }
 

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -3,7 +3,7 @@
 */
 import { assert } from '@ember/debug';
 
-import { REQUEST_SERVICE } from '@ember-data/canary-features';
+import { CUSTOM_MODEL_CLASS, REQUEST_SERVICE } from '@ember-data/canary-features';
 /*
   This file encapsulates the various states that a record can transition
   through during its lifecycle.
@@ -431,6 +431,12 @@ createdState.uncommitted.rollback = function (internalModel) {
 };
 
 createdState.uncommitted.pushedData = function (internalModel) {
+  // TODO @runspired consider where to do this once we kill off state machine
+  if (CUSTOM_MODEL_CLASS) {
+    internalModel.store._notificationManager.notify(internalModel.identifier, 'identity');
+  } else {
+    internalModel.notifyPropertyChange('id');
+  }
   internalModel.transitionTo('loaded.updated.uncommitted');
   internalModel.triggerLater('didLoad');
 };

--- a/packages/store/addon/-private/system/references/has-many.ts
+++ b/packages/store/addon/-private/system/references/has-many.ts
@@ -1,11 +1,25 @@
+import { dependentKeyCompat } from '@ember/object/compat';
 import { DEBUG } from '@glimmer/env';
+import { cached, tracked } from '@glimmer/tracking';
 
 import { resolve } from 'rsvp';
 
+import { CUSTOM_MODEL_CLASS } from '@ember-data/canary-features';
 import { assertPolymorphicType } from '@ember-data/store/-debug';
 
+import { unsubscribe } from '../record-notification-manager';
 import { internalModelFactoryFor, recordIdentifierFor } from '../store/internal-model-factory';
 import Reference, { internalModelForReference } from './reference';
+
+type RecordReference = import('./record').default;
+type NotificationType = import('../record-notification-manager').NotificationType;
+type CoreStore = import('../core-store').default;
+type StableRecordIdentifier = import('../../ts-interfaces/identifier').StableRecordIdentifier;
+type CollectionResourceDocument = import('../../ts-interfaces/ember-data-json-api').CollectionResourceDocument;
+type ExistingResourceObject = import('../../ts-interfaces/ember-data-json-api').ExistingResourceObject;
+type SingleResourceDocument = import('../../ts-interfaces/ember-data-json-api').SingleResourceDocument;
+
+type ManyRelationship = import('@ember-data/record-data/-private').ManyRelationship;
 
 /**
   @module @ember-data/store
@@ -20,15 +34,86 @@ import Reference, { internalModelForReference } from './reference';
  @extends Reference
  */
 export default class HasManyReference extends Reference {
-  constructor(store, parentIMOrIdentifier, hasManyRelationship, key) {
-    super(store, parentIMOrIdentifier);
+  declare key: string;
+  declare hasManyRelationship: ManyRelationship;
+  declare type: string;
+  declare parent: RecordReference;
+  declare parentIdentifier: StableRecordIdentifier;
+
+  // unsubscribe tokens given to us by the notification manager
+  #token!: Object;
+  #relatedTokenMap!: Map<StableRecordIdentifier, Object>;
+
+  @tracked _ref = 0;
+
+  constructor(
+    store: CoreStore,
+    parentIdentifier: StableRecordIdentifier,
+    hasManyRelationship: ManyRelationship,
+    key: string
+  ) {
+    super(store, parentIdentifier);
     this.key = key;
     this.hasManyRelationship = hasManyRelationship;
     this.type = hasManyRelationship.definition.type;
 
-    this.parent = internalModelFactoryFor(store).peek(parentIMOrIdentifier).recordReference;
+    this.parent = internalModelFactoryFor(store).peek(parentIdentifier)!.recordReference;
 
+    if (CUSTOM_MODEL_CLASS) {
+      this.#token = store._notificationManager.subscribe(
+        parentIdentifier,
+        (_: StableRecordIdentifier, bucket: NotificationType, notifiedKey?: string) => {
+          if ((bucket === 'relationships' || bucket === 'property') && notifiedKey === key) {
+            this._ref++;
+          }
+        }
+      );
+      this.#relatedTokenMap = new Map();
+    }
     // TODO inverse
+  }
+
+  destroy() {
+    if (CUSTOM_MODEL_CLASS) {
+      unsubscribe(this.#token);
+      this.#relatedTokenMap.forEach((token) => {
+        unsubscribe(token);
+      });
+      this.#relatedTokenMap.clear();
+    }
+  }
+
+  @cached
+  @dependentKeyCompat
+  get _relatedIdentifiers(): StableRecordIdentifier[] {
+    this._ref; // consume the tracked prop
+
+    let resource = this._resource();
+
+    this.#relatedTokenMap.forEach((token) => {
+      unsubscribe(token);
+    });
+    this.#relatedTokenMap.clear();
+
+    if (resource && resource.data) {
+      return resource.data.map((resourceIdentifier) => {
+        const identifier = this.store.identifierCache.getOrCreateRecordIdentifier(resourceIdentifier);
+        const token = this.store._notificationManager.subscribe(
+          identifier,
+          (_: StableRecordIdentifier, bucket: NotificationType, notifiedKey?: string) => {
+            if (bucket === 'identity' || ((bucket === 'attributes' || bucket === 'property') && notifiedKey === 'id')) {
+              this._ref++;
+            }
+          }
+        );
+
+        this.#relatedTokenMap.set(identifier, token);
+
+        return identifier;
+      });
+    }
+
+    return [];
   }
 
   _resource() {
@@ -77,7 +162,7 @@ export default class HasManyReference extends Reference {
    @public
    @return {String} The name of the remote type. This should either be `link` or `ids`
    */
-  remoteType() {
+  remoteType(): 'link' | 'ids' {
     let value = this._resource();
     if (value && value.links && value.links.related) {
       return 'link';
@@ -121,15 +206,22 @@ export default class HasManyReference extends Reference {
     @public
    @return {Array} The ids in this has-many relationship
    */
-  ids() {
-    let resource = this._resource();
-
-    let ids = [];
-    if (resource.data) {
-      ids = resource.data.map((data) => data.id);
+  ids(): Array<string | null> {
+    if (CUSTOM_MODEL_CLASS) {
+      return this._relatedIdentifiers.map((identifier) => identifier.id);
     }
 
-    return ids;
+    let resource = this._resource();
+
+    if (resource && resource.data) {
+      return resource.data.map((resourceIdentifier) => {
+        const identifier = this.store.identifierCache.getOrCreateRecordIdentifier(resourceIdentifier);
+
+        return identifier.id;
+      });
+    }
+
+    return [];
   }
 
   /**
@@ -177,45 +269,50 @@ export default class HasManyReference extends Reference {
    @param {Array|Promise} objectOrPromise a promise that resolves to a JSONAPI document object describing the new value of this relationship.
    @return {ManyArray}
    */
-  push(objectOrPromise) {
-    return resolve(objectOrPromise).then((payload) => {
-      let array = payload;
+  async push(
+    objectOrPromise: ExistingResourceObject[] | CollectionResourceDocument | { data: SingleResourceDocument[] }
+  ): Promise<any> {
+    const payload = await resolve(objectOrPromise);
+    let array: Array<ExistingResourceObject | SingleResourceDocument>;
 
-      if (typeof payload === 'object' && payload.data) {
-        array = payload.data;
+    if (!Array.isArray(payload) && typeof payload === 'object' && Array.isArray(payload.data)) {
+      array = payload.data;
+    } else {
+      array = payload as ExistingResourceObject[];
+    }
+
+    const internalModel = internalModelForReference(this)!;
+    const { store } = this;
+
+    let identifiers = array.map((obj) => {
+      let record;
+      if ('data' in obj) {
+        // TODO deprecate pushing non-valid JSON:API here
+        record = store.push(obj);
+      } else {
+        record = store.push({ data: obj });
       }
 
-      let internalModel = internalModelForReference(this);
-
-      let identifiers = array.map((obj) => {
-        let record = this.store.push(obj);
-
-        if (DEBUG) {
-          let relationshipMeta = this.hasManyRelationship.definition;
-          assertPolymorphicType(
-            internalModel.identifier,
-            relationshipMeta,
-            record._internalModel.identifier,
-            this.store
-          );
-        }
-        return recordIdentifierFor(record);
-      });
-
-      const { graph, identifier } = this.hasManyRelationship;
-      this.store._backburner.join(() => {
-        graph.push({
-          op: 'replaceRelatedRecords',
-          record: identifier,
-          field: this.key,
-          value: identifiers,
-        });
-      });
-
-      return internalModel.getHasMany(this.key);
-      // TODO IGOR it seems wrong that we were returning the many array here
-      //return this.hasManyRelationship.manyArray;
+      if (DEBUG) {
+        let relationshipMeta = this.hasManyRelationship.definition;
+        let identifier = this.hasManyRelationship.identifier;
+        assertPolymorphicType(identifier, relationshipMeta, recordIdentifierFor(record), store);
+      }
+      return recordIdentifierFor(record);
     });
+
+    const { graph, identifier } = this.hasManyRelationship;
+    store._backburner.join(() => {
+      graph.push({
+        op: 'replaceRelatedRecords',
+        record: identifier,
+        field: this.key,
+        value: identifiers,
+      });
+    });
+
+    // TODO IGOR it seems wrong that we were returning the many array here
+    return internalModel.getHasMany(this.key);
   }
 
   _isLoaded() {
@@ -275,7 +372,7 @@ export default class HasManyReference extends Reference {
    @return {ManyArray}
    */
   value() {
-    let internalModel = internalModelForReference(this);
+    let internalModel = internalModelForReference(this)!;
     if (this._isLoaded()) {
       return internalModel.getManyArray(this.key);
     }
@@ -348,7 +445,7 @@ export default class HasManyReference extends Reference {
    this has-many relationship.
    */
   load(options) {
-    let internalModel = internalModelForReference(this);
+    let internalModel = internalModelForReference(this)!;
     return internalModel.getHasMany(this.key, options);
   }
 
@@ -403,7 +500,7 @@ export default class HasManyReference extends Reference {
    @return {Promise} a promise that resolves with the ManyArray in this has-many relationship.
    */
   reload(options) {
-    let internalModel = internalModelForReference(this);
+    let internalModel = internalModelForReference(this)!;
     return internalModel.reloadHasMany(this.key, options);
   }
 }

--- a/packages/store/addon/-private/system/references/reference.ts
+++ b/packages/store/addon/-private/system/references/reference.ts
@@ -100,7 +100,7 @@ abstract class Reference {
    @public
    @return {String} The name of the remote type. This should either be "link" or "ids"
    */
-  remoteType(): 'link' | 'id' | 'identity' {
+  remoteType(): 'link' | 'id' | 'ids' | 'identity' {
     let value = this._resource();
     if (isResourceIdentiferWithRelatedLinks(value)) {
       return 'link';

--- a/packages/store/addon/-private/ts-interfaces/ds-model.ts
+++ b/packages/store/addon/-private/ts-interfaces/ds-model.ts
@@ -19,6 +19,7 @@ export interface DSModel extends RecordInstance, EmberObject {
   isDeleted: boolean;
   deleteRecord(): void;
   unloadRecord(): void;
+  errors: any;
 }
 
 // Implemented by both ShimModelClass and DSModel

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -10,6 +10,8 @@ module.exports = Object.assign({}, addonBaseConfig, {
   shouldRollupPrivate: true,
   externalDependenciesForPrivateModule() {
     return [
+      'ember-cached-decorator-polyfill',
+
       '@ember-data/canary-features',
       '@ember-data/store/-debug',
 
@@ -23,6 +25,7 @@ module.exports = Object.assign({}, addonBaseConfig, {
       '@ember/object/evented',
       '@ember/object/internals',
       '@ember/object/mixin',
+      '@ember/object/compat',
       '@ember/object/promise-proxy-mixin',
       '@ember/object/proxy',
       '@ember/polyfills',

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@ember-data/canary-features": "3.28.6",
     "@ember-data/private-build-infra": "3.28.6",
+    "ember-cached-decorator-polyfill": "^0.1.4",
     "@ember/string": "^3.0.0",
     "@glimmer/tracking": "^1.0.4",
     "ember-cli-babel": "^7.26.6",

--- a/packages/store/types/ember/index.d.ts
+++ b/packages/store/types/ember/index.d.ts
@@ -2,3 +2,4 @@ export function run(callback: Function);
 export const ENV: {
   DS_WARN_ON_UNKNOWN_KEYS?: boolean;
 };
+export function meta(obj: Object): any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,6 +181,11 @@
   resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
   integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
 
+"@babel/helper-plugin-utils@^7.14.5":
+  version "7.16.5"
+  resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz#afe37a45f39fce44a3d50a7958129ea5b1a5c074"
+  integrity sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ==
+
 "@babel/helper-remap-async-to-generator@^7.13.0":
   version "7.13.0"
   resolved "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.13.0.tgz#376a760d9f7b4b2077a9dd05aa9c3927cadb2209"
@@ -684,11 +689,11 @@
     "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/plugin-transform-object-assign@^7.8.3":
-  version "7.12.13"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.12.13.tgz#d9b9200a69e03403a813e44a933ad9f4bddfd050"
-  integrity sha512-4QxDMc0lAOkIBSfCrnSGbAJ+4epDBF2XXwcLXuBcG1xl9u7LrktNVD4+LwhL47XuKVPQ7R25e/WdcV+h97HyZA==
+  version "7.16.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.16.0.tgz#750c726397f1f6402fb1ceffe9d8ff3595c8a0df"
+  integrity sha512-TftKY6Hxo5Uf/EIoC3BKQyLvlH46tbtK4xub90vzi9+yS8z1+O/52YHyywCZvYeLPOvv//1j3BPokLuHTWPcbg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-object-super@^7.12.13":
   version "7.12.13"


### PR DESCRIPTION
* deactivate broken partner tests

* feat: autotracking for reference id access (#7796)

* feat: autotracking for reference id access

* ensure references are torn down

* fix build

* add dep

* add to deps

* fix invalid json:api support and add valid json:api support

* autotracking tests and cleanup

* fix test failure, add comment

* skip tests when feature not available

* update test and fix lid reflection (#7800)

* update test and fix lid reflection

* remove debugger

* fix ff off branch

* add test and fix push of duplicate identifiers to a relationship (#7801)

* add test + fix for chained async has many (#7691)

* [bugfix]: fix for chained async has many

* add fix and update tests

* remove console.logs

* make work with flags off

* fix test for lts

Co-authored-by: Chris Thoburn <runspired@users.noreply.github.com>

* Fix: assign unknown properties in init after initialization is finished to ensure proper setup timing (#7771)

* Add failing test case which illustrates the createRecord bug

createRecord crashes when a setter which sets an attribute is involved
in the createRecord.

* update test location and add fix

Co-authored-by: Chris Thoburn <runspired@users.noreply.github.com>

* fix: A(PromiseManyArray) should have no-effect (#7802)

Co-authored-by: Sylvain Mina <sylvain.mina@gmail.com>
Co-authored-by: Andrey Fel <andrey.fel@retailnext.net>

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
