### PR TITLE
Backport Train for Release (#7803)

### DIFF
--- a/packages/-ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/has-many-test.js
@@ -908,25 +908,6 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       });
     };
 
-    let post = await store.findRecord('post', 1);
-    let comments = await post.comments;
-    assert.true(comments.get('isLoaded'), 'comments are loaded');
-    assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
-
-    adapter.findHasMany = function (store, snapshot, link, relationship) {
-      assert.strictEqual(relationship.type, 'comment', 'findHasMany relationship type was Comment');
-      assert.strictEqual(relationship.key, 'comments', 'findHasMany relationship key was comments');
-      assert.strictEqual(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
-
-      return resolve({
-        data: [
-          { id: 1, type: 'comment', attributes: { body: 'First' } },
-          { id: 2, type: 'comment', attributes: { body: 'Second' } },
-          { id: 3, type: 'comment', attributes: { body: 'Thirds' } },
-        ],
-      });
-    };
-
     await comments.reload();
 
     assert.strictEqual(comments.length, 3, 'reloaded comments have 3 length');

--- a/packages/-ember-data/tests/integration/relationships/has-many-test.js
+++ b/packages/-ember-data/tests/integration/relationships/has-many-test.js
@@ -908,6 +908,25 @@ module('integration/relationships/has_many - Has-Many Relationships', function (
       });
     };
 
+    let post = await store.findRecord('post', 1);
+    let comments = await post.comments;
+    assert.true(comments.get('isLoaded'), 'comments are loaded');
+    assert.strictEqual(comments.get('length'), 2, 'comments have 2 length');
+
+    adapter.findHasMany = function (store, snapshot, link, relationship) {
+      assert.strictEqual(relationship.type, 'comment', 'findHasMany relationship type was Comment');
+      assert.strictEqual(relationship.key, 'comments', 'findHasMany relationship key was comments');
+      assert.strictEqual(link, '/posts/1/comments', 'findHasMany link was /posts/1/comments');
+
+      return resolve({
+        data: [
+          { id: 1, type: 'comment', attributes: { body: 'First' } },
+          { id: 2, type: 'comment', attributes: { body: 'Second' } },
+          { id: 3, type: 'comment', attributes: { body: 'Thirds' } },
+        ],
+      });
+    };
+
     await comments.reload();
 
     assert.strictEqual(comments.length, 3, 'reloaded comments have 3 length');

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,6 +779,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
+"@babel/plugin-transform-object-assign@^7.8.3":
+  version "7.16.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.16.0.tgz#750c726397f1f6402fb1ceffe9d8ff3595c8a0df"
+  integrity sha512-TftKY6Hxo5Uf/EIoC3BKQyLvlH46tbtK4xub90vzi9+yS8z1+O/52YHyywCZvYeLPOvv//1j3BPokLuHTWPcbg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-object-super@^7.12.13":
   version "7.12.13"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.13.tgz#b4416a2d63b8f7be314f3d349bd55a9c1b5171f7"
@@ -10370,6 +10377,11 @@ jest-worker@^26.6.2:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+jquery@^3.5.1:
+  version "3.6.0"
+  resolved "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
 js-string-escape@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
* deactivate broken partner tests

* feat: autotracking for reference id access (#7796)

* feat: autotracking for reference id access

* ensure references are torn down

* fix build

* add dep

* add to deps

* fix invalid json:api support and add valid json:api support

* autotracking tests and cleanup

* fix test failure, add comment

* skip tests when feature not available

* update test and fix lid reflection (#7800)

* update test and fix lid reflection

* remove debugger

* fix ff off branch

* add test and fix push of duplicate identifiers to a relationship (#7801)

* add test + fix for chained async has many (#7691)

* [bugfix]: fix for chained async has many

* add fix and update tests

* remove console.logs

* make work with flags off

* fix test for lts

Co-authored-by: Chris Thoburn <runspired@users.noreply.github.com>

* Fix: assign unknown properties in init after initialization is finished to ensure proper setup timing (#7771)

* Add failing test case which illustrates the createRecord bug

createRecord crashes when a setter which sets an attribute is involved
in the createRecord.

* update test location and add fix

Co-authored-by: Chris Thoburn <runspired@users.noreply.github.com>

* fix: A(PromiseManyArray) should have no-effect (#7802)

Co-authored-by: Sylvain Mina <sylvain.mina@gmail.com>
Co-authored-by: Andrey Fel <andrey.fel@retailnext.net>

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
