### PR TITLE
[chore] update `coalesceFindRequests` docstring

### DIFF
--- a/packages/adapter/addon/index.ts
+++ b/packages/adapter/addon/index.ts
@@ -596,7 +596,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
   }
 
   /**
-    By default the store will try to coalesce all `fetchRecord` calls within the same runloop
+    By default the store will try to coalesce all `findRecord` calls within the same runloop
     into as few requests as possible by calling groupRecordsForFindMany and passing it into a findMany call.
     You can opt out of this behaviour by either not implementing the findMany hook or by setting
     coalesceFindRequests to false.


### PR DESCRIPTION
_Note: Re-opening from [previous PR](https://github.com/emberjs/data/pull/7681) that was incorrectly targeting the wrong base branch._

Description for `coalesceFindRequests` indicates that it will attempt to coalesce `fetchRecord` calls, but the relevant public API concept is `findRecord`. It is a bit confusing to have `fetchRecord` here since it hints at a framework concept that does not have any definition in the public API.

- updates "fetchRecord" -> "findRecord" in `coalesceFindRequests` docstring