### PR TITLE
[BUG] strictNullChecks TS -> JS

### DIFF
--- a/packages/-ember-data/tests/integration/identifiers/configuration-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/configuration-test.ts
@@ -180,7 +180,7 @@ module('Integration | Identifiers - configuration', function (hooks) {
     assert.ok(updateMethodCalls === 0, 'Precond: We have not updated the identifier yet');
     updateCallback = (updatedIdentifier, resource) => {
       assert.strictEqual(identifier, updatedIdentifier, 'We updated the expected identifier');
-      assert.strictEqual(resource.attributes!.firstName, 'James', 'We received the expected resource to update with');
+      assert.strictEqual(resource.attributes?.firstName, 'James', 'We received the expected resource to update with');
     };
 
     await record.save();
@@ -243,7 +243,7 @@ module('Integration | Identifiers - configuration', function (hooks) {
     assert.ok(updateMethodCalls === 0, 'Precond: We have not updated the identifier yet');
     updateCallback = (updatedIdentifier, resource) => {
       assert.strictEqual(identifier, updatedIdentifier, 'We updated the expected identifier');
-      assert.strictEqual(resource.attributes!.firstName, 'James', 'We received the expected resource to update with');
+      assert.strictEqual(resource.attributes?.firstName, 'James', 'We received the expected resource to update with');
     };
 
     await record.save();
@@ -316,7 +316,7 @@ module('Integration | Identifiers - configuration', function (hooks) {
     assert.ok(updateMethodCalls === 0, 'Precond: We have not updated the identifier yet');
     updateCallback = (updatedIdentifier, resource) => {
       assert.strictEqual(identifier, updatedIdentifier, 'We updated the expected identifier');
-      assert.strictEqual(resource.attributes!.firstName, 'Chris', 'We received the expected resource to update with');
+      assert.strictEqual(resource.attributes?.firstName, 'Chris', 'We received the expected resource to update with');
     };
 
     set(record, 'age', 23);

--- a/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -368,9 +368,9 @@ if (CUSTOM_MODEL_CLASS) {
       store = this.owner.lookup('service:store');
       let person = store.push({ data: { type: 'person', id: '1', attributes: { name: 'chris' } } });
       store.deleteRecord(person);
-      assert.true(rd!.isDeleted!(), 'record has been marked as deleted');
+      assert.true(rd?.isDeleted!(), 'record has been marked as deleted');
       await store.saveRecord(person);
-      assert.true(rd!.isDeletionCommitted!(), 'deletion has been commited');
+      assert.true(rd?.isDeletionCommitted!(), 'deletion has been commited');
     });
 
     test('record serialize', function (assert) {

--- a/packages/model/addon/-private/system/promise-many-array.ts
+++ b/packages/model/addon/-private/system/promise-many-array.ts
@@ -131,7 +131,7 @@ export default class PromiseManyArray {
    * @returns Promise
    */
   then(s, f) {
-    return this.promise!.then(s, f);
+    return this.promise?.then(s, f);
   }
 
   /**
@@ -142,7 +142,7 @@ export default class PromiseManyArray {
    * @returns Promise
    */
   catch(cb) {
-    return this.promise!.catch(cb);
+    return this.promise?.catch(cb);
   }
 
   /**
@@ -154,7 +154,7 @@ export default class PromiseManyArray {
    * @returns Promise
    */
   finally(cb) {
-    return this.promise!.finally(cb);
+    return this.promise?.finally(cb);
   }
 
   //---- Methods on EmberObject that we should keep

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -3323,7 +3323,7 @@ abstract class CoreStore extends Service {
       let identifier = recordIdentifierFor(record);
       let internalModel = internalModelFactoryFor(this).peek(identifier);
       // TODO we used to check if the record was destroyed here
-      return internalModel!.createSnapshot(options).serialize(options);
+      return internalModel?.createSnapshot(options).serialize(options);
     }
 
     assert('serializeRecord is only available when CUSTOM_MODEL_CLASS ff is on', false);
@@ -3336,7 +3336,7 @@ abstract class CoreStore extends Service {
       // TODO we used to check if the record was destroyed here
       // Casting can be removed once REQUEST_SERVICE ff is turned on
       // because a `Record` is provided there will always be a matching internalModel
-      return (internalModel!.save(options) as RSVP.Promise<void>).then(() => record);
+      return (internalModel?.save(options) as RSVP.Promise<void>).then(() => record);
     }
 
     assert('saveRecord is only available when CUSTOM_MODEL_CLASS ff is on');
@@ -3347,7 +3347,7 @@ abstract class CoreStore extends Service {
       let stableIdentifier = identifierCacheFor(this).getOrCreateRecordIdentifier(identifier);
       let internalModel = internalModelFactoryFor(this).peek(stableIdentifier);
       // TODO we used to check if the record was destroyed here
-      return internalModel!.referenceFor(null, key);
+      return internalModel?.referenceFor(null, key);
     }
 
     assert('relationshipReferenceFor is only available when CUSTOM_MODEL_CLASS ff is on', false);

--- a/packages/store/addon/-private/system/model/shim-model-class.ts
+++ b/packages/store/addon/-private/system/model/shim-model-class.ts
@@ -41,7 +41,7 @@ export default class ShimModelClass implements ModelSchema {
     let relationships = this.__store._relationshipsDefinitionFor(this.modelName);
     let fields = new Map<string, 'attribute' | 'belongsTo' | 'hasMany'>();
     Object.keys(attrs).forEach((key) => fields.set(key, 'attribute'));
-    Object.keys(relationships).forEach((key) => fields.set(key, relationships[key]!.kind));
+    Object.keys(relationships).forEach((key) => fields.set(key, relationships[key]?.kind));
     return fields;
   }
 
@@ -78,7 +78,7 @@ export default class ShimModelClass implements ModelSchema {
   ) {
     let relationshipDefs = this.__store._relationshipsDefinitionFor(this.modelName);
     Object.keys(relationshipDefs).forEach((key) => {
-      if (relationshipDefs[key]!.type) {
+      if (relationshipDefs[key]?.type) {
         callback.call(binding, key, relationshipDefs[key] as RelationshipSchema);
       }
     });

--- a/packages/store/addon/-private/system/references/belongs-to.ts
+++ b/packages/store/addon/-private/system/references/belongs-to.ts
@@ -54,7 +54,7 @@ export default class BelongsToReference extends Reference {
     this.belongsToRelationship = belongsToRelationship;
     this.type = belongsToRelationship.definition.type;
     const parent = internalModelFactoryFor(store).peek(parentIdentifier);
-    this.parent = parent!.recordReference;
+    this.parent = parent?.recordReference;
     this.parentIdentifier = parentIdentifier;
 
     if (CUSTOM_MODEL_CLASS) {
@@ -378,7 +378,7 @@ export default class BelongsToReference extends Reference {
    */
   load(options) {
     let parentInternalModel = internalModelFactoryFor(this.store).peek(this.parentIdentifier);
-    return parentInternalModel!.getBelongsTo(this.key, options);
+    return parentInternalModel?.getBelongsTo(this.key, options);
   }
 
   /**
@@ -433,7 +433,7 @@ export default class BelongsToReference extends Reference {
    */
   reload(options) {
     let parentInternalModel = internalModelFactoryFor(this.store).peek(this.parentIdentifier);
-    return parentInternalModel!.reloadBelongsTo(this.key, options).then((internalModel) => {
+    return parentInternalModel?.reloadBelongsTo(this.key, options).then((internalModel) => {
       return this.value();
     });
   }

--- a/packages/store/addon/-private/system/references/has-many.ts
+++ b/packages/store/addon/-private/system/references/has-many.ts
@@ -56,7 +56,7 @@ export default class HasManyReference extends Reference {
     this.hasManyRelationship = hasManyRelationship;
     this.type = hasManyRelationship.definition.type;
 
-    this.parent = internalModelFactoryFor(store).peek(parentIdentifier)!.recordReference;
+    this.parent = internalModelFactoryFor(store).peek(parentIdentifier)?.recordReference;
 
     if (CUSTOM_MODEL_CLASS) {
       this.#token = store._notificationManager.subscribe(


### PR DESCRIPTION
JS does not know the concept of the Non-null assertion operator since this is a TS feature

TS code
```
  then(s, f) {
    return this.promise!.then(s, f);
  }
  ```
  will compile to 
  
  ```
    then(s, f) {
      return this.promise.then(s, f);
    }
  ```
  
  In this case I get error ` Cannot read properties of null (reading 'then')` when I use `await` helper and hasMany in computed property
  
  this bug also affected 3.28 version
  @snewcomer 