### PR TITLE
Don't use array.push(...spread) with unknown input

### DIFF
--- a/packages/serializer/addon/-private/embedded-records-mixin.js
+++ b/packages/serializer/addon/-private/embedded-records-mixin.js
@@ -580,7 +580,7 @@ export default Mixin.create({
       hash.included = hash.included || [];
       hash.included.push(data);
       if (included) {
-        hash.included.push(...included);
+        hash.included = hash.included.concat(included);
       }
 
       hasMany[i] = { id: data.id, type: data.type };
@@ -604,7 +604,7 @@ export default Mixin.create({
     hash.included = hash.included || [];
     hash.included.push(data);
     if (included) {
-      hash.included.push(...included);
+      hash.included = hash.included.concat(included);
     }
 
     let belongsTo = { id: data.id, type: data.type };

--- a/packages/serializer/addon/json.js
+++ b/packages/serializer/addon/json.js
@@ -540,7 +540,7 @@ const JSONSerializer = Serializer.extend({
         let item = payload[i];
         let { data, included } = this.normalize(primaryModelClass, item);
         if (included) {
-          documentHash.included.push(...included);
+          documentHash.included = documentHash.included.concat(included);
         }
         ret[i] = data;
       }

--- a/packages/serializer/addon/rest.js
+++ b/packages/serializer/addon/rest.js
@@ -185,7 +185,7 @@ const RESTSerializer = JSONSerializer.extend({
       let { data, included } = this._normalizePolymorphicRecord(store, hash, prop, modelClass, serializer);
       documentHash.data.push(data);
       if (included) {
-        documentHash.included.push(...included);
+        documentHash.included = documentHash.included.concat(included);
       }
     });
 
@@ -316,7 +316,7 @@ const RESTSerializer = JSONSerializer.extend({
         let { data, included } = this._normalizePolymorphicRecord(store, value, prop, primaryModelClass, this);
         documentHash.data = data;
         if (included) {
-          documentHash.included.push(...included);
+          documentHash.included = documentHash.included.concat(included);
         }
         continue;
       }
@@ -324,7 +324,7 @@ const RESTSerializer = JSONSerializer.extend({
       let { data, included } = this._normalizeArray(store, typeName, value, prop);
 
       if (included) {
-        documentHash.included.push(...included);
+        documentHash.included = documentHash.included.concat(included);
       }
 
       if (isSingle) {
@@ -352,7 +352,7 @@ const RESTSerializer = JSONSerializer.extend({
           documentHash.data = data;
         } else {
           if (data) {
-            documentHash.included.push(...data);
+            documentHash.included = documentHash.included.concat(data);
           }
         }
       }
@@ -418,7 +418,7 @@ const RESTSerializer = JSONSerializer.extend({
         let { data, included } = typeSerializer.normalize(type, hash, prop);
         documentHash.data.push(data);
         if (included) {
-          documentHash.included.push(...included);
+          documentHash.included = documentHash.included.concat(included);
         }
       });
     }


### PR DESCRIPTION
Using `array.push(...spread)` is quite nice and convenient, but unfortunately providing too many arguments to a function call can cause a stack overflow, which happened to us.

[Minimum reproduction Twiddle](https://ember-twiddle.com/a8b1b503f15f0c20fde2afe1be5d5bcb?openFiles=routes.application%5C.js%2C)

Also unfortunately, using `Array#concat` changes the API, since it returns a new array rather than modifying the original. Also also unfortunately, simply iterating over an array and pushing one-by-one is significantly slower than using spread or concat.

[Performance tests JSBin](https://jsbin.com/suropipiyi/edit?js,console)

This implementation is a hybrid approach of looping and spreading that remains stack safe.

If we can guarantee that using concat is safe, that'd be an even better implementation since it's both part of the standard lib and also faster.