### PR TITLE
Remove some usage of runtime require

### DIFF
--- a/packages/-ember-data/addon/index.js
+++ b/packages/-ember-data/addon/index.js
@@ -3,7 +3,7 @@ import 'ember-inflector';
 import EmberError from '@ember/error';
 import { VERSION } from '@ember/version';
 
-import require, { has } from 'require';
+import { dependencySatisfies, importSync, macroCondition } from '@embroider/macros';
 
 import Adapter, { BuildURLMixin } from '@ember-data/adapter';
 import AdapterError, {
@@ -46,8 +46,6 @@ import {
 } from './-private';
 import setupContainer from './setup-container';
 
-const HAS_DEBUG_PACKAGE = has('@ember-data/debug') || false;
-
 if (VERSION.match(/^1\.([0-9]|1[0-2])\./)) {
   throw new EmberError(
     'Ember Data requires at least Ember 1.13.0, but you have ' +
@@ -88,8 +86,8 @@ DS.errorsArrayToHash = errorsArrayToHash;
 
 DS.Serializer = Serializer;
 
-if (HAS_DEBUG_PACKAGE) {
-  DS.DebugAdapter = require('@ember-data/debug').default;
+if (macroCondition(dependencySatisfies('@ember-data/debug', '*'))) {
+  DS.DebugAdapter = importSync('@ember-data/debug').default;
 }
 
 DS.RecordArray = RecordArray;

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -31,6 +31,7 @@
     "@ember-data/store": "4.4.0-alpha.7",
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^3.0.0",
+    "@embroider/macros": "^1.2.0",
     "@glimmer/env": "^0.1.7",
     "broccoli-merge-trees": "^4.2.0",
     "ember-auto-import": "^2.2.4",

--- a/packages/store/addon/-private/system/core-store.ts
+++ b/packages/store/addon/-private/system/core-store.ts
@@ -13,7 +13,7 @@ import { isNone, isPresent, typeOf } from '@ember/utils';
 import { DEBUG } from '@glimmer/env';
 import Ember from 'ember';
 
-import require from 'require';
+import { importSync } from '@embroider/macros';
 import { all, default as RSVP, Promise, resolve } from 'rsvp';
 
 import { HAS_RECORD_DATA_PACKAGE } from '@ember-data/private-build-infra';
@@ -2908,7 +2908,9 @@ abstract class CoreStore extends Service {
       // it can be reproduced in partner tests by running
       // node ./scripts/packages-for-commit.js && yarn test-external:ember-observer
       if (_RecordData === undefined) {
-        _RecordData = require('@ember-data/record-data/-private').RecordData as RecordDataConstruct;
+        _RecordData = (
+          importSync('@ember-data/record-data/-private') as typeof import('@ember-data/record-data/-private')
+        ).RecordData as RecordDataConstruct;
       }
 
       let identifier = this.identifierCache.getOrCreateRecordIdentifier({
@@ -3155,7 +3157,9 @@ abstract class CoreStore extends Service {
     }
 
     if (HAS_RECORD_DATA_PACKAGE) {
-      const peekGraph = require('@ember-data/record-data/-private').peekGraph;
+      const peekGraph = (
+        importSync('@ember-data/record-data/-private') as typeof import('@ember-data/record-data/-private')
+      ).peekGraph;
       let graph = peekGraph(this);
       if (graph) {
         graph.destroy();
@@ -3175,7 +3179,9 @@ abstract class CoreStore extends Service {
     // since then we avoid churning relationships
     // during unload
     if (HAS_RECORD_DATA_PACKAGE) {
-      const peekGraph = require('@ember-data/record-data/-private').peekGraph;
+      const peekGraph = (
+        importSync('@ember-data/record-data/-private') as typeof import('@ember-data/record-data/-private')
+      ).peekGraph;
       let graph = peekGraph(this);
       if (graph) {
         graph.willDestroy();

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -5,6 +5,7 @@ import { get } from '@ember/object';
 import { _backburner as emberBackburner, cancel, run } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
 
+import { importSync } from '@embroider/macros';
 import RSVP, { Promise } from 'rsvp';
 
 import { HAS_MODEL_PACKAGE, HAS_RECORD_DATA_PACKAGE } from '@ember-data/private-build-infra';
@@ -51,7 +52,7 @@ let _getModelPackage: () => boolean;
 if (HAS_MODEL_PACKAGE) {
   _getModelPackage = function () {
     if (!_found) {
-      let modelPackage = require('@ember-data/model/-private');
+      let modelPackage = importSync('@ember-data/model/-private') as typeof import('@ember-data/model/-private');
       ({ ManyArray, PromiseBelongsTo, PromiseManyArray: _PromiseManyArray } = modelPackage);
       if (ManyArray && PromiseBelongsTo && _PromiseManyArray) {
         _found = true;
@@ -490,7 +491,9 @@ export default class InternalModel {
     if (HAS_RECORD_DATA_PACKAGE) {
       let manyArray = this._manyArrayCache[key];
       if (!definition) {
-        const graphFor = require('@ember-data/record-data/-private').graphFor;
+        const graphFor = (
+          importSync('@ember-data/record-data/-private') as typeof import('@ember-data/record-data/-private')
+        ).graphFor;
         definition = graphFor(this.store).get(this.identifier, key).definition as UpgradedMeta;
       }
 
@@ -511,7 +514,7 @@ export default class InternalModel {
 
       return manyArray;
     }
-    assert(`hasMany only works with the @ember-data/record-data package`, HAS_RECORD_DATA_PACKAGE);
+    assert('hasMany only works with the @ember-data/record-data package');
   }
 
   fetchAsyncHasMany(
@@ -535,13 +538,15 @@ export default class InternalModel {
       this._relationshipPromisesCache[key] = loadingPromise;
       return loadingPromise;
     }
-    assert(`hasMany only works with the @ember-data/record-data package`);
+    assert('hasMany only works with the @ember-data/record-data package');
   }
 
   getHasMany(key: string, options?) {
     if (HAS_RECORD_DATA_PACKAGE) {
-      const graphFor = require('@ember-data/record-data/-private').graphFor;
-      const relationship = graphFor(this.store).get(this.identifier, key);
+      const graphFor = (
+        importSync('@ember-data/record-data/-private') as typeof import('@ember-data/record-data/-private')
+      ).graphFor;
+      const relationship = graphFor(this.store).get(this.identifier, key) as ManyRelationship;
       const { definition, state } = relationship;
       let manyArray = this.getManyArray(key, definition);
 
@@ -604,8 +609,10 @@ export default class InternalModel {
       if (loadingPromise) {
         return loadingPromise;
       }
-      const graphFor = require('@ember-data/record-data/-private').graphFor;
-      const relationship = graphFor(this.store).get(this.identifier, key);
+      const graphFor = (
+        importSync('@ember-data/record-data/-private') as typeof import('@ember-data/record-data/-private')
+      ).graphFor;
+      const relationship = graphFor(this.store).get(this.identifier, key) as ManyRelationship;
       const { definition, state } = relationship;
 
       state.hasFailedLoadAttempt = false;
@@ -1117,7 +1124,9 @@ export default class InternalModel {
         // because of the intimate API access involved. This is something we will need to redesign.
         assert(`snapshot.belongsTo only supported for @ember-data/record-data`);
       }
-      const graphFor = require('@ember-data/record-data/-private').graphFor;
+      const graphFor = (
+        importSync('@ember-data/record-data/-private') as typeof import('@ember-data/record-data/-private')
+      ).graphFor;
       const relationship = graphFor(this.store._storeWrapper).get(this.identifier, name);
 
       if (DEBUG && kind) {

--- a/packages/store/addon/-private/system/schema-definition-service.ts
+++ b/packages/store/addon/-private/system/schema-definition-service.ts
@@ -1,7 +1,7 @@
 import { getOwner } from '@ember/application';
 import { get } from '@ember/object';
 
-import require from 'require';
+import { importSync } from '@embroider/macros';
 
 import type Model from '@ember-data/model';
 import { HAS_MODEL_PACKAGE } from '@ember-data/private-build-infra';
@@ -18,7 +18,7 @@ if (HAS_MODEL_PACKAGE) {
   let _found;
   _modelForMixin = function () {
     if (!_found) {
-      _found = require('@ember-data/model/-private')._modelForMixin;
+      _found = (importSync('@ember-data/model/-private') as typeof import('@ember-data/model/-private'))._modelForMixin;
     }
     return _found(...arguments);
   };

--- a/packages/store/addon/-private/system/snapshot.ts
+++ b/packages/store/addon/-private/system/snapshot.ts
@@ -4,7 +4,15 @@
 import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 
+import { importSync } from '@embroider/macros';
+
 import { HAS_RECORD_DATA_PACKAGE } from '@ember-data/private-build-infra';
+import type BelongsToRelationship from '@ember-data/record-data/addon/-private/relationships/state/belongs-to';
+import type ManyRelationship from '@ember-data/record-data/addon/-private/relationships/state/has-many';
+import type {
+  ExistingResourceIdentifierObject,
+  NewResourceIdentifierObject,
+} from '@ember-data/store/-private/ts-interfaces/ember-data-json-api';
 
 import type { DSModel, DSModelSchema, ModelSchema } from '../ts-interfaces/ds-model';
 import type { StableRecordIdentifier } from '../ts-interfaces/identifier';
@@ -322,9 +330,11 @@ export default class Snapshot implements Snapshot {
       assert(`snapshot.belongsTo only supported when using the package @ember-data/record-data`);
     }
 
-    const graphFor = require('@ember-data/record-data/-private').graphFor;
+    const graphFor = (
+      importSync('@ember-data/record-data/-private') as typeof import('@ember-data/record-data/-private')
+    ).graphFor;
     const { identifier } = this;
-    const relationship = graphFor(this._store._storeWrapper).get(identifier, keyName);
+    const relationship = graphFor(this._store._storeWrapper).get(identifier, keyName) as BelongsToRelationship;
 
     assert(
       `You looked up the ${keyName} belongsTo relationship for { type: ${identifier.type}, id: ${identifier.id}, lid: ${identifier.lid} but no such relationship was found.`,
@@ -421,9 +431,11 @@ export default class Snapshot implements Snapshot {
       assert(`snapshot.hasMany only supported when using the package @ember-data/record-data`);
     }
 
-    const graphFor = require('@ember-data/record-data/-private').graphFor;
+    const graphFor = (
+      importSync('@ember-data/record-data/-private') as typeof import('@ember-data/record-data/-private')
+    ).graphFor;
     const { identifier } = this;
-    const relationship = graphFor(this._store._storeWrapper).get(identifier, keyName);
+    const relationship = graphFor(this._store._storeWrapper).get(identifier, keyName) as ManyRelationship;
     assert(
       `You looked up the ${keyName} hasMany relationship for { type: ${identifier.type}, id: ${identifier.id}, lid: ${identifier.lid} but no such relationship was found.`,
       relationship
@@ -441,7 +453,9 @@ export default class Snapshot implements Snapshot {
         let internalModel = store._internalModelForResource(member);
         if (!internalModel.isDeleted()) {
           if (returnModeIsIds) {
-            (results as RecordId[]).push(member.id || null);
+            (results as RecordId[]).push(
+              (member as ExistingResourceIdentifierObject | NewResourceIdentifierObject).id || null
+            );
           } else {
             (results as Snapshot[]).push(internalModel.createSnapshot());
           }

--- a/packages/store/addon/-private/system/store/internal-model-factory.ts
+++ b/packages/store/addon/-private/system/store/internal-model-factory.ts
@@ -160,7 +160,7 @@ export default class InternalModelFactory {
       TODO @runspired consider adding this to make polymorphism even nicer
       if (HAS_RECORD_DATA_PACKAGE) {
         if (identifier.type !== matchedIdentifier.type) {
-          const graphFor = require('@ember-data/record-data/-private').graphFor;
+          const graphFor = importSync('@ember-data/record-data/-private').graphFor;
           graphFor(this).registerPolymorphicType(identifier.type, matchedIdentifier.type);
         }
       }

--- a/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
+++ b/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
@@ -1,3 +1,5 @@
+import { importSync } from '@embroider/macros';
+
 import type { RelationshipDefinition } from '@ember-data/model/-private/system/relationships/relationship-meta';
 import { HAS_RECORD_DATA_PACKAGE } from '@ember-data/private-build-infra';
 
@@ -26,7 +28,9 @@ let peekGraph;
 if (HAS_RECORD_DATA_PACKAGE) {
   let _peekGraph;
   peekGraph = (wrapper) => {
-    _peekGraph = _peekGraph || require('@ember-data/record-data/-private').peekGraph;
+    _peekGraph =
+      _peekGraph ||
+      (importSync('@ember-data/record-data/-private') as typeof import('@ember-data/record-data/-private')).peekGraph;
     return _peekGraph(wrapper);
   };
 }

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -35,6 +35,9 @@ module.exports = Object.assign({}, addonBaseConfig, {
       '@ember/test',
       '@ember/utils',
 
+      '@embroider/macros/es-compat',
+      '@embroider/macros/runtime',
+
       'ember-inflector',
       'ember',
       'rsvp',

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -20,6 +20,7 @@
     "@ember-data/canary-features": "4.4.0-alpha.7",
     "@ember-data/private-build-infra": "4.4.0-alpha.7",
     "@ember/string": "^3.0.0",
+    "@embroider/macros": "^1.2.0",
     "@glimmer/tracking": "^1.0.4",
     "ember-auto-import": "^2.2.4",
     "ember-cached-decorator-polyfill": "^0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,7 +1229,7 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
-"@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0":
+"@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@embroider/macros/-/macros-1.2.0.tgz#9a2d99225fba6dcb69e795cddad9f4948c2a2b6b"
   integrity sha512-WD2V3OKXZB73OymI/zC2+MbqIYaAskhjtSOVVY6yG6kWILyVsJ6+fcbNHEnZyGqs4sm0TvHVJfevmA2OXV8Pww==
@@ -7302,7 +7302,8 @@ eslint-module-utils@^2.7.2:
     find-up "^2.1.0"
 
 "eslint-plugin-ember-data@link:./packages/unpublished-eslint-rules":
-  version "4.4.0-alpha.7"
+  version "0.0.0"
+  uid ""
 
 eslint-plugin-ember@^10.5.8:
   version "10.5.9"


### PR DESCRIPTION
<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->
Came across `embroider-optimized` build issues in https://github.com/poteto/ember-changeset/pull/630 and it appears we need a fix similar to https://github.com/miragejs/ember-cli-mirage/pull/2297.

Looks like TS is not happy as `importSync` return type is `unknown` whereas `require()` was successfully resolved by TS.

@ef4 Would you maybe have some advise here how to make TS happy?