### PR TITLE
chore: remove no-longer-needed misdirection for IdentifierCache lookup

### DIFF
--- a/packages/-ember-data/tests/integration/identifiers/cache-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/cache-test.ts
@@ -3,7 +3,6 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 import Store from '@ember-data/store';
-import { identifierCacheFor } from '@ember-data/store/-private';
 import testInDebug from '@ember-data/unpublished-test-infra/test-support/test-in-debug';
 
 module('Integration | Identifiers - cache', function (hooks) {
@@ -13,7 +12,7 @@ module('Integration | Identifiers - cache', function (hooks) {
   hooks.beforeEach(function () {
     this.owner.register(`service:store`, Store);
     store = this.owner.lookup('service:store');
-    cache = identifierCacheFor(store);
+    cache = store.identifierCache;
   });
 
   module('getOrCreateRecordIdentifier()', function () {
@@ -46,7 +45,7 @@ module('Integration | Identifiers - cache', function (hooks) {
           name: 'Moomin',
         },
       };
-      const cache = identifierCacheFor(store);
+      const cache = store.identifierCache;
       const identifier = cache.getOrCreateRecordIdentifier(houseHash);
 
       assert.strictEqual(
@@ -64,7 +63,7 @@ module('Integration | Identifiers - cache', function (hooks) {
           name: 'Moomin',
         },
       };
-      const cache = identifierCacheFor(store);
+      const cache = store.identifierCache;
       const identifier = cache.getOrCreateRecordIdentifier(houseHash);
 
       assert.strictEqual(

--- a/packages/-ember-data/tests/integration/identifiers/configuration-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/configuration-test.ts
@@ -18,7 +18,6 @@ import Store, {
   setIdentifierResetMethod,
   setIdentifierUpdateMethod,
 } from '@ember-data/store';
-import { identifierCacheFor } from '@ember-data/store/-private';
 import type {
   IdentifierBucket,
   ResourceData,
@@ -387,11 +386,11 @@ module('Integration | Identifiers - configuration', function (hooks) {
     assert.strictEqual(generateLidCalls, 2, 'We generated two lids');
     generateLidCalls = 0;
 
-    const originalUserByUsernameIdentifier = identifierCacheFor(store).getOrCreateRecordIdentifier({
+    const originalUserByUsernameIdentifier = store.identifierCache.getOrCreateRecordIdentifier({
       type: 'user',
       id: '@runspired',
     });
-    const originalUserByIdIdentifier = identifierCacheFor(store).getOrCreateRecordIdentifier({
+    const originalUserByIdIdentifier = store.identifierCache.getOrCreateRecordIdentifier({
       type: 'user',
       id: '1',
     });

--- a/packages/-ember-data/tests/integration/identifiers/scenarios-test.ts
+++ b/packages/-ember-data/tests/integration/identifiers/scenarios-test.ts
@@ -14,7 +14,6 @@ import Store, {
   setIdentifierResetMethod,
   setIdentifierUpdateMethod,
 } from '@ember-data/store';
-import { identifierCacheFor } from '@ember-data/store/-private';
 import type {
   IdentifierBucket,
   ResourceData,
@@ -184,7 +183,7 @@ module('Integration | Identifiers - scenarios', function (hooks) {
       // ensure we truly are in a good state internally
       const internalModels = store._internalModelsFor('user')._models;
       assert.strictEqual(internalModels.length, 1, 'Once settled there is only a single internal-model');
-      const lidCache = identifierCacheFor(store)._cache.lids;
+      const lidCache = store.identifierCache._cache.lids;
       const lids = Object.keys(lidCache);
       assert.strictEqual(
         lids.length,
@@ -206,7 +205,7 @@ module('Integration | Identifiers - scenarios', function (hooks) {
       // ensure we truly are in a good state internally
       const internalModels = store._internalModelsFor('user')._models;
       assert.strictEqual(internalModels.length, 1, 'Once settled there is only a single internal-model');
-      const lidCache = identifierCacheFor(store)._cache.lids;
+      const lidCache = store.identifierCache._cache.lids;
       const lids = Object.keys(lidCache);
       assert.strictEqual(
         lids.length,
@@ -237,7 +236,7 @@ module('Integration | Identifiers - scenarios', function (hooks) {
       // ensure we truly are in a good state internally
       const internalModels = store._internalModelsFor('user')._models;
       assert.strictEqual(internalModels.length, 1, 'Once settled there is only a single internal-model');
-      const lidCache = identifierCacheFor(store)._cache.lids;
+      const lidCache = store.identifierCache._cache.lids;
       const lids = Object.keys(lidCache);
       assert.strictEqual(
         lids.length,
@@ -415,7 +414,7 @@ module('Integration | Identifiers - scenarios', function (hooks) {
       // ensure we truly are in a good state internally
       const internalModels = store._internalModelsFor('user')._models;
       assert.strictEqual(internalModels.length, 1, 'Once settled there is only a single internal-model');
-      const lidCache = identifierCacheFor(store)._cache.lids;
+      const lidCache = store.identifierCache._cache.lids;
       const lids = Object.keys(lidCache);
       assert.strictEqual(
         lids.length,
@@ -439,7 +438,7 @@ module('Integration | Identifiers - scenarios', function (hooks) {
       // ensure we truly are in a good state internally
       const internalModels = store._internalModelsFor('user')._models;
       assert.strictEqual(internalModels.length, 1, 'Once settled there is only a single internal-model');
-      const lidCache = identifierCacheFor(store)._cache.lids;
+      const lidCache = store.identifierCache._cache.lids;
       const lids = Object.keys(lidCache);
       assert.strictEqual(
         lids.length,
@@ -466,7 +465,7 @@ module('Integration | Identifiers - scenarios', function (hooks) {
       // ensure we truly are in a good state internally
       const internalModels = store._internalModelsFor('user')._models;
       assert.strictEqual(internalModels.length, 1, 'Once settled there is only a single internal-model');
-      const lidCache = identifierCacheFor(store)._cache.lids;
+      const lidCache = store.identifierCache._cache.lids;
       const lids = Object.keys(lidCache);
       assert.strictEqual(
         lids.length,
@@ -500,7 +499,7 @@ module('Integration | Identifiers - scenarios', function (hooks) {
       // ensure we truly are in a good state internally
       const internalModels = store._internalModelsFor('user')._models;
       assert.strictEqual(internalModels.length, 1, 'Once settled there is only a single internal-model');
-      const lidCache = identifierCacheFor(store)._cache.lids;
+      const lidCache = store.identifierCache._cache.lids;
       const lids = Object.keys(lidCache);
       assert.strictEqual(
         lids.length,
@@ -553,7 +552,7 @@ module('Integration | Identifiers - scenarios', function (hooks) {
       // ensure we truly are in a good state internally
       const internalModels = store._internalModelsFor('user')._models;
       assert.strictEqual(internalModels.length, 1, 'Once settled there is only a single internal-model');
-      const lidCache = identifierCacheFor(store)._cache.lids;
+      const lidCache = store.identifierCache._cache.lids;
       const lids = Object.keys(lidCache);
       assert.strictEqual(
         lids.length,
@@ -587,7 +586,7 @@ module('Integration | Identifiers - scenarios', function (hooks) {
       // ensure we truly are in a good state internally
       const internalModels = store._internalModelsFor('user')._models;
       assert.strictEqual(internalModels.length, 1, 'Once settled there is only a single internal-model');
-      const lidCache = identifierCacheFor(store)._cache.lids;
+      const lidCache = store.identifierCache._cache.lids;
       const lids = Object.keys(lidCache);
       assert.strictEqual(
         lids.length,
@@ -620,7 +619,7 @@ module('Integration | Identifiers - scenarios', function (hooks) {
       // ensure we truly are in a good state internally
       const internalModels = store._internalModelsFor('user')._models;
       assert.strictEqual(internalModels.length, 1, 'Once settled there is only a single internal-model');
-      const lidCache = identifierCacheFor(store)._cache.lids;
+      const lidCache = store.identifierCache._cache.lids;
       const lids = Object.keys(lidCache);
       assert.strictEqual(
         lids.length,

--- a/packages/-ember-data/tests/integration/request-state-service-test.ts
+++ b/packages/-ember-data/tests/integration/request-state-service-test.ts
@@ -8,7 +8,6 @@ import { setupTest } from 'ember-qunit';
 import Model, { attr } from '@ember-data/model';
 import JSONSerializer from '@ember-data/serializer/json';
 import type Store from '@ember-data/store';
-import { identifierCacheFor } from '@ember-data/store/-private';
 import type { RequestStateEnum } from '@ember-data/store/-private/ts-interfaces/fetch-manager';
 
 class Person extends Model {
@@ -81,7 +80,7 @@ module('integration/request-state-service - Request State Service', function (ho
     let requestService = store.getRequestStateService();
 
     // Relying on sequential lids until identifiers land
-    let identifier = identifierCacheFor(store).getOrCreateRecordIdentifier({ type: 'person', id: '1' });
+    let identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'person', id: '1' });
     normalizedHash.data.lid = identifier.lid;
     let request = requestService.getPendingRequestsForRecord(identifier)[0];
 
@@ -175,7 +174,7 @@ module('integration/request-state-service - Request State Service', function (ho
 
     let requestService = store.getRequestStateService();
     // Relying on sequential lids until identifiers land
-    let identifier = identifierCacheFor(store).getOrCreateRecordIdentifier({ type: 'person', id: '1' });
+    let identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'person', id: '1' });
     let count = 0;
     let requestOp = {
       op: 'findRecord',

--- a/packages/store/addon/-private/identifiers/cache.ts
+++ b/packages/store/addon/-private/identifiers/cache.ts
@@ -81,19 +81,6 @@ function defaultGenerationMethod(data: ResourceData | { type: string }, bucket: 
   return uuidv4();
 }
 
-const IdentifierCaches = new WeakMap<CoreStore, IdentifierCache>();
-
-export function identifierCacheFor(store: CoreStore): IdentifierCache {
-  let cache = IdentifierCaches.get(store);
-
-  if (cache === undefined) {
-    cache = new IdentifierCache();
-    IdentifierCaches.set(store, cache);
-  }
-
-  return cache;
-}
-
 function defaultEmptyCallback(...args: any[]): any {}
 
 let DEBUG_MAP;

--- a/packages/store/addon/-private/index.ts
+++ b/packages/store/addon/-private/index.ts
@@ -8,7 +8,6 @@ export { recordIdentifierFor } from './system/store/internal-model-factory';
 
 export { default as Snapshot } from './system/snapshot';
 export {
-  identifierCacheFor,
   setIdentifierGenerationMethod,
   setIdentifierUpdateMethod,
   setIdentifierForgetMethod,

--- a/packages/store/addon/-private/system/model/internal-model.ts
+++ b/packages/store/addon/-private/system/model/internal-model.ts
@@ -15,7 +15,6 @@ import type {
 } from '@ember-data/record-data/-private';
 import type { UpgradedMeta } from '@ember-data/record-data/-private/graph/-edge-definition';
 
-import { identifierCacheFor } from '../../identifiers/cache';
 import { DSModel } from '../../ts-interfaces/ds-model';
 import type { StableRecordIdentifier } from '../../ts-interfaces/identifier';
 import type { RecordData } from '../../ts-interfaces/record-data';
@@ -174,7 +173,7 @@ export default class InternalModel {
   set id(value: string | null) {
     if (value !== this._id) {
       let newIdentifier = { type: this.identifier.type, lid: this.identifier.lid, id: value };
-      identifierCacheFor(this.store).updateRecordIdentifier(this.identifier, newIdentifier);
+      this.store.identifierCache.updateRecordIdentifier(this.identifier, newIdentifier);
       this.notifyPropertyChange('id');
     }
   }
@@ -437,7 +436,7 @@ export default class InternalModel {
   getBelongsTo(key, options) {
     let resource = (this._recordData as DefaultRecordData).getBelongsTo(key);
     let identifier =
-      resource && resource.data ? identifierCacheFor(this.store).getOrCreateRecordIdentifier(resource.data) : null;
+      resource && resource.data ? this.store.identifierCache.getOrCreateRecordIdentifier(resource.data) : null;
     let relationshipMeta = this.store._relationshipMetaFor(this.modelName, null, key);
     if (!relationshipMeta) return;
 

--- a/packages/store/addon/-private/system/record-data-for.ts
+++ b/packages/store/addon/-private/system/record-data-for.ts
@@ -25,23 +25,23 @@ type Reference = { internalModel: InternalModel };
 
 type Instance = StableRecordIdentifier | InternalModel | RecordData | DSModelOrSnapshot | Reference;
 
-const IdentifierCache = new WeakMap<StableRecordIdentifier, RecordData>();
+const RecordDataForIdentifierCache = new WeakMap<StableRecordIdentifier, RecordData>();
 
 export function setRecordDataFor(identifier: StableRecordIdentifier, recordData: RecordData) {
-  assert(`Illegal set of identifier`, !IdentifierCache.has(identifier));
-  IdentifierCache.set(identifier, recordData);
+  assert(`Illegal set of identifier`, !RecordDataForIdentifierCache.has(identifier));
+  RecordDataForIdentifierCache.set(identifier, recordData);
 }
 
 export function removeRecordDataFor(identifier) {
-  IdentifierCache.delete(identifier);
+  RecordDataForIdentifierCache.delete(identifier);
 }
 
 export default function recordDataFor(instance: StableRecordIdentifier): RecordData | null;
 export default function recordDataFor(instance: Instance): RecordData;
 export default function recordDataFor(instance: object): null;
 export default function recordDataFor(instance: Instance | object): RecordData | null {
-  if (IdentifierCache.has(instance as StableRecordIdentifier)) {
-    return IdentifierCache.get(instance as StableRecordIdentifier) as RecordData;
+  if (RecordDataForIdentifierCache.has(instance as StableRecordIdentifier)) {
+    return RecordDataForIdentifierCache.get(instance as StableRecordIdentifier) as RecordData;
   }
   let internalModel =
     (instance as DSModelOrSnapshot)._internalModel || (instance as Reference).internalModel || instance;

--- a/packages/store/addon/-private/system/record-notification-manager.ts
+++ b/packages/store/addon/-private/system/record-notification-manager.ts
@@ -1,4 +1,3 @@
-import { identifierCacheFor } from '../identifiers/cache';
 import type { RecordIdentifier, StableRecordIdentifier } from '../ts-interfaces/identifier';
 import type CoreStore from './core-store';
 
@@ -39,7 +38,7 @@ export default class NotificationManager {
   constructor(private store: CoreStore) {}
 
   subscribe(identifier: RecordIdentifier, callback: NotificationCallback): UnsubscribeToken {
-    let stableIdentifier = identifierCacheFor(this.store).getOrCreateRecordIdentifier(identifier);
+    let stableIdentifier = this.store.identifierCache.getOrCreateRecordIdentifier(identifier);
     let map = Cache.get(stableIdentifier);
     if (map === undefined) {
       map = new Map();
@@ -54,7 +53,7 @@ export default class NotificationManager {
   notify(identifier: RecordIdentifier, value: 'attributes' | 'relationships' | 'property', key?: string): boolean;
   notify(identifier: RecordIdentifier, value: 'errors' | 'meta' | 'identity' | 'unload' | 'state'): boolean;
   notify(identifier: RecordIdentifier, value: NotificationType, key?: string): boolean {
-    let stableIdentifier = identifierCacheFor(this.store).getOrCreateRecordIdentifier(identifier);
+    let stableIdentifier = this.store.identifierCache.getOrCreateRecordIdentifier(identifier);
     let callbackMap = Cache.get(stableIdentifier);
     if (!callbackMap || !callbackMap.size) {
       return false;

--- a/packages/store/addon/-private/system/store/internal-model-factory.ts
+++ b/packages/store/addon/-private/system/store/internal-model-factory.ts
@@ -3,7 +3,6 @@ import { isNone } from '@ember/utils';
 import { DEBUG } from '@glimmer/env';
 
 import type { IdentifierCache } from '../../identifiers/cache';
-import { identifierCacheFor } from '../../identifiers/cache';
 import type {
   ExistingResourceObject,
   NewResourceIdentifierObject,
@@ -93,7 +92,7 @@ export default class InternalModelFactory {
 
   constructor(store: CoreStore) {
     this.store = store;
-    this.identifierCache = identifierCacheFor(store);
+    this.identifierCache = store.identifierCache;
     this.identifierCache.__configureMerge((identifier, matchedIdentifier, resourceData) => {
       let intendedIdentifier = identifier;
       if (identifier.id !== matchedIdentifier.id) {

--- a/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
+++ b/packages/store/addon/-private/system/store/record-data-store-wrapper.ts
@@ -2,7 +2,6 @@ import type { RelationshipDefinition } from '@ember-data/model/-private/system/r
 import { HAS_RECORD_DATA_PACKAGE } from '@ember-data/private-build-infra';
 
 import type { IdentifierCache } from '../../identifiers/cache';
-import { identifierCacheFor } from '../../identifiers/cache';
 import type { StableRecordIdentifier } from '../../ts-interfaces/identifier';
 import type { RecordData } from '../../ts-interfaces/record-data';
 import type {
@@ -44,7 +43,7 @@ export default class RecordDataStoreWrapper implements StoreWrapper {
   }
 
   get identifierCache(): IdentifierCache {
-    return identifierCacheFor(this._store);
+    return this._store.identifierCache;
   }
 
   _scheduleNotification(identifier: StableRecordIdentifier, key: string, kind: 'belongsTo' | 'hasMany') {
@@ -70,7 +69,7 @@ export default class RecordDataStoreWrapper implements StoreWrapper {
   notifyErrorsChange(type: string, id: string | null, lid: string): void;
   notifyErrorsChange(type: string, id: string | null, lid: string | null): void {
     const resource = constructResource(type, id, lid);
-    const identifier = identifierCacheFor(this._store).getOrCreateRecordIdentifier(resource);
+    const identifier = this._store.identifierCache.getOrCreateRecordIdentifier(resource);
 
     let internalModel = internalModelFactoryFor(this._store).peek(identifier);
 
@@ -152,7 +151,7 @@ export default class RecordDataStoreWrapper implements StoreWrapper {
   notifyPropertyChange(type: string, id: string, lid: string | null | undefined, key: string): void;
   notifyPropertyChange(type: string, id: string | null, lid: string | null | undefined, key: string): void {
     const resource = constructResource(type, id, lid);
-    const identifier = identifierCacheFor(this._store).getOrCreateRecordIdentifier(resource);
+    const identifier = this._store.identifierCache.getOrCreateRecordIdentifier(resource);
     let internalModel = internalModelFactoryFor(this._store).peek(identifier);
 
     if (internalModel) {
@@ -164,7 +163,7 @@ export default class RecordDataStoreWrapper implements StoreWrapper {
   notifyHasManyChange(type: string, id: string, lid: string | null | undefined, key: string): void;
   notifyHasManyChange(type: string, id: string | null, lid: string | null | undefined, key: string): void {
     const resource = constructResource(type, id, lid);
-    const identifier = identifierCacheFor(this._store).getOrCreateRecordIdentifier(resource);
+    const identifier = this._store.identifierCache.getOrCreateRecordIdentifier(resource);
     this._scheduleNotification(identifier, key, 'hasMany');
   }
 
@@ -172,7 +171,7 @@ export default class RecordDataStoreWrapper implements StoreWrapper {
   notifyBelongsToChange(type: string, id: string, lid: string | null | undefined, key: string): void;
   notifyBelongsToChange(type: string, id: string | null, lid: string | null | undefined, key: string): void {
     const resource = constructResource(type, id, lid);
-    const identifier = identifierCacheFor(this._store).getOrCreateRecordIdentifier(resource);
+    const identifier = this._store.identifierCache.getOrCreateRecordIdentifier(resource);
 
     this._scheduleNotification(identifier, key, 'belongsTo');
   }
@@ -181,7 +180,7 @@ export default class RecordDataStoreWrapper implements StoreWrapper {
   notifyStateChange(type: string, id: string | null, lid: string, key?: string): void;
   notifyStateChange(type: string, id: string | null, lid: string | null, key?: string): void {
     const resource = constructResource(type, id, lid);
-    const identifier = identifierCacheFor(this._store).getOrCreateRecordIdentifier(resource);
+    const identifier = this._store.identifierCache.getOrCreateRecordIdentifier(resource);
     let internalModel = internalModelFactoryFor(this._store).peek(identifier);
 
     if (internalModel) {
@@ -200,7 +199,7 @@ export default class RecordDataStoreWrapper implements StoreWrapper {
       identifier = { type };
     } else {
       const resource = constructResource(type, id, lid);
-      identifier = identifierCacheFor(this._store).getOrCreateRecordIdentifier(resource);
+      identifier = this._store.identifierCache.getOrCreateRecordIdentifier(resource);
     }
 
     return this._store.recordDataFor(identifier, isCreate);
@@ -214,7 +213,7 @@ export default class RecordDataStoreWrapper implements StoreWrapper {
   isRecordInUse(type: string, id: string, lid?: string | null): boolean;
   isRecordInUse(type: string, id: string | null, lid?: string | null): boolean {
     const resource = constructResource(type, id, lid);
-    const identifier = identifierCacheFor(this._store).getOrCreateRecordIdentifier(resource);
+    const identifier = this._store.identifierCache.getOrCreateRecordIdentifier(resource);
     const internalModel = internalModelFactoryFor(this._store).peek(identifier);
 
     if (!internalModel) {
@@ -229,7 +228,7 @@ export default class RecordDataStoreWrapper implements StoreWrapper {
   disconnectRecord(type: string, id: string, lid?: string | null): void;
   disconnectRecord(type: string, id: string | null, lid?: string | null): void {
     const resource = constructResource(type, id, lid);
-    const identifier = identifierCacheFor(this._store).getOrCreateRecordIdentifier(resource);
+    const identifier = this._store.identifierCache.getOrCreateRecordIdentifier(resource);
     if (HAS_RECORD_DATA_PACKAGE) {
       let graph = peekGraph(this);
       if (graph) {

--- a/packages/unpublished-adapter-encapsulation-test-app/app/services/store.js
+++ b/packages/unpublished-adapter-encapsulation-test-app/app/services/store.js
@@ -1,10 +1,9 @@
 import { RecordData } from '@ember-data/record-data/-private';
 import Store from '@ember-data/store';
-import { identifierCacheFor } from '@ember-data/store/-private';
 
 export default class DefaultStore extends Store {
   createRecordDataFor(modelName, id, clientId, storeWrapper) {
-    let identifier = identifierCacheFor(this).getOrCreateRecordIdentifier({
+    let identifier = this.identifierCache.getOrCreateRecordIdentifier({
       type: modelName,
       id,
       lid: clientId,

--- a/packages/unpublished-serializer-encapsulation-test-app/app/services/store.js
+++ b/packages/unpublished-serializer-encapsulation-test-app/app/services/store.js
@@ -1,10 +1,9 @@
 import { RecordData } from '@ember-data/record-data/-private';
 import Store from '@ember-data/store';
-import { identifierCacheFor } from '@ember-data/store/-private';
 
 export default class DefaultStore extends Store {
   createRecordDataFor(modelName, id, clientId, storeWrapper) {
-    let identifier = identifierCacheFor(this).getOrCreateRecordIdentifier({
+    let identifier = this.identifierCache.getOrCreateRecordIdentifier({
       type: modelName,
       id,
       lid: clientId,


### PR DESCRIPTION
This weak-map cache had been required when we had not yet activated the feature flag which added the `store.identifierCache` property, now that it is active we do not need the helper to access the cache.