### PR TITLE
Cleanup eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,6 @@
 // See https://github.com/lydell/eslint-plugin-simple-import-sort#custom-grouping
 const ImportSortGroups = [
   // Side effect imports.
-  // eslint-disable-next-line no-useless-escape
   [`^\u0000`],
   // Glimmer & Ember Dependencies
   [`^(@ember/|@glimmer|ember$)`],
@@ -28,6 +27,7 @@ const ImportSortGroups = [
 
 module.exports = {
   parser: '@babel/eslint-parser',
+  reportUnusedDisableDirectives: true,
   root: true,
   parserOptions: {
     ecmaVersion: 2018,
@@ -39,24 +39,24 @@ module.exports = {
     requireConfigFile: false,
   },
   plugins: ['prettier', 'qunit', 'mocha', 'simple-import-sort', 'import'],
-  extends: ['eslint:recommended', 'prettier', 'plugin:qunit/recommended'],
+  extends: ['eslint:recommended', 'plugin:prettier/recommended', 'plugin:qunit/recommended'],
   rules: {
-    'no-restricted-globals': ['error', { name: 'Promise', message: 'Global Promise does not work in IE11' }],
-    'mocha/no-exclusive-tests': 'error',
-    'prettier/prettier': 'error',
-    'no-unused-vars': ['error', { args: 'none' }],
-    'no-cond-assign': ['error', 'except-parens'],
     eqeqeq: 'error',
-    'no-eval': 'error',
-    'new-cap': ['error', { capIsNew: false }],
-    'no-caller': 'error',
-    'no-eq-null': 'error',
-    'no-console': 'error', // no longer recommended in eslint v6, this restores it
-    'simple-import-sort/imports': ['error', { groups: ImportSortGroups }],
-    'sort-imports': 'off',
-    'import/order': 'off',
     'import/first': 'error',
     'import/newline-after-import': 'error',
+    'import/order': 'off',
+    'mocha/no-exclusive-tests': 'error',
+    'new-cap': ['error', { capIsNew: false }],
+    'no-caller': 'error',
+    'no-cond-assign': ['error', 'except-parens'],
+    'no-console': 'error', // no longer recommended in eslint v6, this restores it
+    'no-eq-null': 'error',
+    'no-eval': 'error',
+    'no-restricted-globals': ['error', { name: 'Promise', message: 'Global Promise does not work in IE11' }],
+    'no-unused-vars': ['error', { args: 'none' }],
+    'simple-import-sort/imports': ['error', { groups: ImportSortGroups }],
+    'sort-imports': 'off',
+
     // this rule doesn't work properly with --fix
     // https://github.com/benmosher/eslint-plugin-import/issues/1504
     'import/no-duplicates': 'warn',
@@ -71,13 +71,13 @@ module.exports = {
     // eslint-plugin-qunit
     'qunit/assert-args': 'off',
     'qunit/literal-compare-order': 'off',
+    'qunit/no-assert-logical-expression': 'off',
+    'qunit/no-conditional-assertions': 'off',
+    'qunit/no-early-return': 'off',
     'qunit/no-identical-names': 'off',
     'qunit/no-ok-equality': 'off',
-    'qunit/no-assert-logical-expression': 'off',
     'qunit/require-expect': 'off',
     'qunit/resolve-async': 'off',
-    'qunit/no-early-return': 'off',
-    'qunit/no-conditional-assertions': 'off',
   },
   globals: {
     Map: false,
@@ -106,13 +106,13 @@ module.exports = {
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
       ],
       rules: {
-        'no-restricted-globals': ['off'],
-        '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
-        'no-unused-vars': 'off',
-        'prefer-rest-params': 'off',
-        'prefer-const': 'off',
-        'ember-data/prefer-static-type-import': 'error',
         '@typescript-eslint/no-explicit-any': 'error',
+        '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
+        'ember-data/prefer-static-type-import': 'error',
+        'no-restricted-globals': ['off'],
+        'no-unused-vars': 'off',
+        'prefer-const': 'off',
+        'prefer-rest-params': 'off',
       },
     },
     // Typescript files in non-strict mode
@@ -130,29 +130,29 @@ module.exports = {
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
       ],
       rules: {
-        'no-restricted-globals': ['off'],
-        '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
-        'no-unused-vars': 'off',
-        'prefer-rest-params': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',
-        'prefer-const': 'off',
+        '@typescript-eslint/no-unused-vars': ['error', { args: 'none' }],
         'ember-data/prefer-static-type-import': 'error',
+        'no-restricted-globals': ['off'],
+        'no-unused-vars': 'off',
+        'prefer-const': 'off',
+        'prefer-rest-params': 'off',
         // rules we should likely activate but which currently have too many violations
         // files converted to strict must pass these rules before they can be removed from
         // the files list here and the files list in tsconfig.json
         // see https://github.com/emberjs/data/issues/6233#issuecomment-849279594
         '@typescript-eslint/no-explicit-any': 'off', // TODO activate this and use // eslint-disable-line @typescript-eslint/no-explicit-any
-        '@typescript-eslint/require-await': 'off',
-        '@typescript-eslint/no-unsafe-member-access': 'off',
-        '@typescript-eslint/no-unsafe-call': 'off',
-        '@typescript-eslint/no-unsafe-return': 'off',
-        '@typescript-eslint/restrict-template-expressions': 'off',
-        '@typescript-eslint/no-unsafe-assignment': 'off',
-        '@typescript-eslint/restrict-plus-operands': 'off',
-        '@typescript-eslint/unbound-method': 'off',
         '@typescript-eslint/no-floating-promises': 'off',
-        '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         '@typescript-eslint/no-misused-promises': 'off',
+        '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+        '@typescript-eslint/no-unsafe-assignment': 'off',
+        '@typescript-eslint/no-unsafe-call': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
+        '@typescript-eslint/no-unsafe-return': 'off',
+        '@typescript-eslint/require-await': 'off',
+        '@typescript-eslint/restrict-plus-operands': 'off',
+        '@typescript-eslint/restrict-template-expressions': 'off',
+        '@typescript-eslint/unbound-method': 'off',
       },
       files: [
         'packages/unpublished-test-infra/addon-test-support/qunit-asserts/utils/is-thenable.ts',
@@ -373,12 +373,12 @@ module.exports = {
       plugins: ['node', 'import'],
       extends: 'plugin:node/recommended',
       rules: {
-        'simple-import-sort/sort': 'off',
-        'no-restricted-globals': 'off',
         'import/first': 'error',
         'import/newline-after-import': 'error',
         'import/no-duplicates': 'error',
         'import/order': ['error', { 'newlines-between': 'always' }],
+        'no-restricted-globals': 'off',
+        'simple-import-sort/sort': 'off',
       },
     },
 
@@ -413,13 +413,13 @@ module.exports = {
     // scripts files
     {
       files: ['scripts/**'],
-      // eslint-disable-next-line node/no-unpublished-require
-      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+      extends: ['plugin:node/recommended'],
+      rules: {
         'no-console': 'off',
         'no-process-exit': 'off',
         'node/no-unpublished-require': 'off',
         'node/no-unsupported-features/node-builtins': 'off',
-      }),
+      },
     },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "yarn workspace ember-data build",
     "build:production": "yarn workspace ember-data build:production",
     "lint:features": "node ./scripts/lint-features.js",
-    "lint:js": "eslint --cache --ext=js,ts .",
+    "lint:js": "eslint --report-unused-disable-directives --cache --ext=js,ts .",
     "lint:js:changed": "node ./scripts/lint-changed-js.js",
     "problems": "tsc -p tsconfig.json --noEmit --pretty false",
     "start": "yarn workspace ember-data start",

--- a/packages/-ember-data/node-tests/docs/test-coverage.js
+++ b/packages/-ember-data/node-tests/docs/test-coverage.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 'use strict';
 const QUnit = require('qunit');
 

--- a/packages/store/addon/-private/system/references/belongs-to.ts
+++ b/packages/store/addon/-private/system/references/belongs-to.ts
@@ -197,7 +197,6 @@ export default class BelongsToReference extends Reference {
     const jsonApiDoc = await resolve(data);
     let record = this.store.push(jsonApiDoc);
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     assertPolymorphicType(
       this.belongsToRelationship.identifier,
       this.belongsToRelationship.definition,

--- a/packages/store/addon/-private/ts-interfaces/minimum-adapter-interface.ts
+++ b/packages/store/addon/-private/ts-interfaces/minimum-adapter-interface.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 // the above eslint rule checks return types. This is an interface
 // and we intend Promise whether it is Native or polyfilled is of
 // no consequence.

--- a/scripts/lint-changed-js.js
+++ b/scripts/lint-changed-js.js
@@ -32,7 +32,7 @@ if (LIST) {
       eslintInfo.extends.push('plugin:qunit/recommended');
       fs.writeFileSync(tmpEslint, `module.exports = ${JSON.stringify(eslintInfo)}`);
       // execut the linter with additional qunit rules
-      execa.sync(`yarn eslint --config ${tmpEslint} --ext=js,ts ${LIST}`, {
+      execa.sync(`yarn eslint --config ${tmpEslint} --report-unused-disable-directives --ext=js,ts ${LIST}`, {
         stdio: 'inherit',
         shell: true,
       });

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,5 +1,4 @@
 'use strict';
-/* eslint-disable node/no-unsupported-features/es-syntax */
 
 /*
 Usage


### PR DESCRIPTION
<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->

Here are the changes I made. There's essentially no behavior change from any of these except now catching unused disable directives.

* Switch to prettier [recommended](https://github.com/prettier/eslint-plugin-prettier#recommended-configuration) config as a better way of enabling prettier
* Alphabetize lists of rules in .eslintrc.js
* Have ESLint report and autofix [unused disable directives](https://eslint.org/docs/user-guide/command-line-interface#--report-unused-disable-directives)
* ESLint now allows `extends` in an override without a hack so we can use this for `plugin:node/recommended`