### PR TITLE
chore: add eslint-plugin-eslint-comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,9 +39,16 @@ module.exports = {
     requireConfigFile: false,
   },
   plugins: ['prettier', 'qunit', 'mocha', 'simple-import-sort', 'import'],
-  extends: ['eslint:recommended', 'plugin:prettier/recommended', 'plugin:qunit/recommended'],
+  extends: [
+    'eslint:recommended',
+    'plugin:eslint-comments/recommended',
+    'plugin:prettier/recommended',
+    'plugin:qunit/recommended',
+  ],
   rules: {
     eqeqeq: 'error',
+
+    'eslint-comments/no-unused-disable': 'error',
 
     // Imports
     'import/first': 'error',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "yarn workspace ember-data build",
     "build:production": "yarn workspace ember-data build:production",
     "lint:features": "node ./scripts/lint-features.js",
-    "lint:js": "eslint --report-unused-disable-directives --cache --ext=js,ts .",
+    "lint:js": "eslint --cache --ext=js,ts .",
     "lint:js:changed": "node ./scripts/lint-changed-js.js",
     "problems": "tsc -p tsconfig.json --noEmit --pretty false",
     "start": "yarn workspace ember-data start",
@@ -42,9 +42,9 @@
     "test-external:ember-data-relationship-tracker": "node ./scripts/test-external-partner-project.js ember-data-relationship-tracker https://github.com/ef4/ember-data-relationship-tracker.git"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.17.0",
     "@babel/plugin-proposal-decorators": "^7.17.2",
     "@babel/plugin-transform-typescript": "^7.16.8",
-    "@babel/eslint-parser": "^7.17.0",
     "@ember/edition-utils": "^1.2.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
@@ -105,6 +105,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ember": "^10.5.8",
     "eslint-plugin-ember-data": "link:./packages/unpublished-eslint-rules",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-mocha": "^9.0.0",
     "eslint-plugin-node": "^11.1.0",

--- a/packages/-ember-data/lib/yui-docs-preprocessor.js
+++ b/packages/-ember-data/lib/yui-docs-preprocessor.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint no-console:"off" */
 function hasProp(obj, prop) {
   return Object.hasOwnProperty.call(obj, prop);
 }

--- a/packages/unpublished-test-infra/addon-test-support/assert-all-deprecations.js
+++ b/packages/unpublished-test-infra/addon-test-support/assert-all-deprecations.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint no-console:"off" */
 import { DEBUG } from '@glimmer/env';
 
 import QUnit from 'qunit';

--- a/scripts/lint-changed-js.js
+++ b/scripts/lint-changed-js.js
@@ -32,7 +32,7 @@ if (LIST) {
       eslintInfo.extends.push('plugin:qunit/recommended');
       fs.writeFileSync(tmpEslint, `module.exports = ${JSON.stringify(eslintInfo)}`);
       // execut the linter with additional qunit rules
-      execa.sync(`yarn eslint --config ${tmpEslint} --report-unused-disable-directives --ext=js,ts ${LIST}`, {
+      execa.sync(`yarn eslint --config ${tmpEslint} --ext=js,ts ${LIST}`, {
         stdio: 'inherit',
         shell: true,
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7415,7 +7415,8 @@ eslint-module-utils@^2.7.2:
     find-up "^2.1.0"
 
 "eslint-plugin-ember-data@link:./packages/unpublished-eslint-rules":
-  version "4.2.0-alpha.9"
+  version "0.0.0"
+  uid ""
 
 eslint-plugin-ember@^10.5.8:
   version "10.5.8"
@@ -7438,6 +7439,14 @@ eslint-plugin-es@^3.0.0:
   dependencies:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
+
+eslint-plugin-eslint-comments@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
+  integrity sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
 
 eslint-plugin-import@^2.25.4:
   version "2.25.4"
@@ -9381,7 +9390,7 @@ ignore@^4.0.6:
   resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.0.5, ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==


### PR DESCRIPTION
Alternative to using ESLint's built-in [--no-unused-disable-directives](https://eslint.org/docs/user-guide/command-line-interface#--report-unused-disable-directives) CLI option, since that CLI option cannot be disable in a single problematic location, as we encountered issues with in https://github.com/emberjs/data/pull/7882/files#r809271031.

If necessary, we can use:

```js
// eslint-disable-next-line eslint-comments/no-unused-disable
```

to avoid the same problem.

