### PR TITLE
chore: remove unused evented infra

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-path-utils": "^1.0.0",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -59,7 +59,7 @@
     "broccoli-uglify-sourcemap": "^4.0.0",
     "ember-cli": "~4.3.0",
     "ember-cli-app-version": "^5.0.0",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -34,7 +34,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~4.3.0",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -32,7 +32,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~4.3.0",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -39,7 +39,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~4.3.0",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -37,7 +37,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~4.3.0",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -33,7 +33,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~4.3.0",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -262,7 +262,6 @@ const DirtyState = {
 
     rolledBack(internalModel) {
       internalModel.transitionTo('loaded.saved');
-      internalModel.triggerLater('rolledBack');
     },
 
     becameInvalid(internalModel) {
@@ -271,7 +270,6 @@ const DirtyState = {
 
     rollback(internalModel) {
       internalModel.rollbackAttributes();
-      internalModel.triggerLater('ready');
     },
   },
 
@@ -297,9 +295,7 @@ const DirtyState = {
       internalModel.send('invokeLifecycleCallbacks', this.dirtyType);
     },
 
-    rolledBack(internalModel) {
-      internalModel.triggerLater('rolledBack');
-    },
+    rolledBack() {},
 
     becameInvalid(internalModel) {
       internalModel.transitionTo('invalid');
@@ -308,7 +304,6 @@ const DirtyState = {
 
     becameError(internalModel) {
       internalModel.transitionTo('uncommitted');
-      internalModel.triggerLater('becameError', internalModel);
     },
   },
 
@@ -345,16 +340,13 @@ const DirtyState = {
     rolledBack(internalModel) {
       clearErrorMessages(internalModel);
       internalModel.transitionTo('loaded.saved');
-      internalModel.triggerLater('ready');
     },
 
     becameValid(internalModel) {
       internalModel.transitionTo('uncommitted');
     },
 
-    invokeLifecycleCallbacks(internalModel) {
-      internalModel.triggerLater('becameInvalid', internalModel);
-    },
+    invokeLifecycleCallbacks() {},
   },
 };
 
@@ -403,12 +395,10 @@ const createdState = dirtyState({
 
 createdState.invalid.rolledBack = function (internalModel) {
   internalModel.transitionTo('deleted.saved');
-  internalModel.triggerLater('rolledBack');
 };
 
 createdState.uncommitted.rolledBack = function (internalModel) {
   internalModel.transitionTo('deleted.saved');
-  internalModel.triggerLater('rolledBack');
 };
 
 const updatedState = dirtyState({
@@ -433,7 +423,6 @@ createdState.uncommitted.pushedData = function (internalModel) {
   // TODO @runspired consider where to do this once we kill off state machine
   internalModel.store._notificationManager.notify(internalModel.identifier, 'identity');
   internalModel.transitionTo('loaded.updated.uncommitted');
-  internalModel.triggerLater('didLoad');
 };
 
 createdState.uncommitted.propertyWasReset = function () {};
@@ -458,7 +447,6 @@ updatedState.uncommitted.deleteRecord = function (internalModel) {
 updatedState.invalid.rolledBack = function (internalModel) {
   clearErrorMessages(internalModel);
   internalModel.transitionTo('loaded.saved');
-  internalModel.triggerLater('rolledBack');
 };
 
 const RootState = {
@@ -500,13 +488,10 @@ const RootState = {
 
     loadedData(internalModel) {
       internalModel.transitionTo('loaded.created.uncommitted');
-      internalModel.triggerLater('ready');
     },
 
     pushedData(internalModel) {
       internalModel.transitionTo('loaded.saved');
-      internalModel.triggerLater('didLoad');
-      internalModel.triggerLater('ready');
     },
 
     // Record is already in an empty state, triggering transition to empty here
@@ -533,15 +518,11 @@ const RootState = {
     // EVENTS
     pushedData(internalModel) {
       internalModel.transitionTo('loaded.saved');
-      internalModel.triggerLater('didLoad');
-      internalModel.triggerLater('ready');
       //TODO this seems out of place here
       internalModel.didCleanError();
     },
 
-    becameError(internalModel) {
-      internalModel.triggerLater('becameError', internalModel);
-    },
+    becameError() {},
 
     notFound(internalModel) {
       internalModel.transitionTo('empty');
@@ -640,7 +621,6 @@ const RootState = {
 
       rollback(internalModel) {
         internalModel.rollbackAttributes();
-        internalModel.triggerLater('ready');
       },
 
       pushedData() {},
@@ -649,8 +629,6 @@ const RootState = {
 
       rolledBack(internalModel) {
         internalModel.transitionTo('loaded.saved');
-        internalModel.triggerLater('ready');
-        internalModel.triggerLater('rolledBack');
       },
     },
 
@@ -676,12 +654,10 @@ const RootState = {
 
       becameError(internalModel) {
         internalModel.transitionTo('uncommitted');
-        internalModel.triggerLater('becameError', internalModel);
       },
 
       becameInvalid(internalModel) {
         internalModel.transitionTo('invalid');
-        internalModel.triggerLater('becameInvalid', internalModel);
       },
     },
 
@@ -696,10 +672,7 @@ const RootState = {
         internalModel.removeFromInverseRelationships();
       },
 
-      invokeLifecycleCallbacks(internalModel) {
-        internalModel.triggerLater('didDelete', internalModel);
-        internalModel.triggerLater('didCommit', internalModel);
-      },
+      invokeLifecycleCallbacks() {},
 
       willCommit() {},
       didCommit() {},
@@ -727,7 +700,6 @@ const RootState = {
       rolledBack(internalModel) {
         clearErrorMessages(internalModel);
         internalModel.transitionTo('loaded.saved');
-        internalModel.triggerLater('ready');
       },
 
       becameValid(internalModel) {
@@ -736,15 +708,7 @@ const RootState = {
     },
   },
 
-  invokeLifecycleCallbacks(internalModel, dirtyType) {
-    if (dirtyType === 'created') {
-      internalModel.triggerLater('didCreate', internalModel);
-    } else {
-      internalModel.triggerLater('didUpdate', internalModel);
-    }
-
-    internalModel.triggerLater('didCommit', internalModel);
-  },
+  invokeLifecycleCallbacks() {},
 };
 
 function wireState(object, parent, name) {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -36,7 +36,7 @@
     "@types/rsvp": "^4.0.4",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~4.3.0",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",

--- a/packages/unpublished-adapter-encapsulation-test-app/package.json
+++ b/packages/unpublished-adapter-encapsulation-test-app/package.json
@@ -40,7 +40,7 @@
     "ember-cli": "~4.3.0",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-export-application-global": "^2.0.1",

--- a/packages/unpublished-debug-encapsulation-test-app/package.json
+++ b/packages/unpublished-debug-encapsulation-test-app/package.json
@@ -39,7 +39,7 @@
     "ember-cli": "~4.3.0",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-export-application-global": "^2.0.1",

--- a/packages/unpublished-fastboot-test-app/package.json
+++ b/packages/unpublished-fastboot-test-app/package.json
@@ -42,7 +42,7 @@
     "ember-cli": "~4.3.0",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-fastboot": "^3.2.0-beta.5",
     "ember-cli-fastboot-testing": "^0.6.0",
     "ember-cli-htmlbars": "^6.0.1",

--- a/packages/unpublished-model-encapsulation-test-app/package.json
+++ b/packages/unpublished-model-encapsulation-test-app/package.json
@@ -40,7 +40,7 @@
     "ember-cli": "~4.3.0",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-export-application-global": "^2.0.1",

--- a/packages/unpublished-record-data-encapsulation-test-app/package.json
+++ b/packages/unpublished-record-data-encapsulation-test-app/package.json
@@ -40,7 +40,7 @@
     "ember-cli": "~4.3.0",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-export-application-global": "^2.0.1",

--- a/packages/unpublished-relationship-performance-test-app/package.json
+++ b/packages/unpublished-relationship-performance-test-app/package.json
@@ -33,7 +33,7 @@
     "ember-cli": "~4.3.0",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-export-application-global": "^2.0.1",

--- a/packages/unpublished-serializer-encapsulation-test-app/package.json
+++ b/packages/unpublished-serializer-encapsulation-test-app/package.json
@@ -39,7 +39,7 @@
     "ember-cli": "~4.3.0",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-export-application-global": "^2.0.1",

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -42,7 +42,7 @@
     "@glimmer/tracking": "^1.0.0",
     "broccoli-merge-trees": "^4.2.0",
     "ember-cli": "~4.3.0",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-test-info": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6606,10 +6606,10 @@ ember-cli-blueprint-test-helpers@^0.19.1, ember-cli-blueprint-test-helpers@^0.19
     testdouble "^3.2.6"
     tmp-sync "^1.0.0"
 
-ember-cli-dependency-checker@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/ember-cli-dependency-checker/-/ember-cli-dependency-checker-3.2.0.tgz#9202ad9e14d6fda33cffc22a11c343c2a8885330"
-  integrity sha512-dkSmcJ/jY/2ms/S6ph2jXSfOW5VfOpLfg5DFEbra0SaMNgYkNDFF1o0U4OdTsG37L5h/AXWNuVtnOa4TMabz9Q==
+ember-cli-dependency-checker@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/ember-cli-dependency-checker/-/ember-cli-dependency-checker-3.3.1.tgz#16b44d7a1a1e946f59859fad97f32e616d78323a"
+  integrity sha512-Tg6OeijjXNKWkDm6057Tr0N9j9Vlz/ITewXWpn1A/+Wbt3EowBx5ZKfvoupqz05EznKgL1B/ecG0t+JN7Qm6MA==
   dependencies:
     chalk "^2.3.0"
     find-yarn-workspace-root "^1.1.0"
@@ -7420,7 +7420,8 @@ eslint-module-utils@^2.7.2:
     find-up "^2.1.0"
 
 "eslint-plugin-ember-data@link:./packages/unpublished-eslint-rules":
-  version "4.4.0-alpha.8"
+  version "0.0.0"
+  uid ""
 
 eslint-plugin-ember@^10.5.8:
   version "10.6.0"


### PR DESCRIPTION
We were still running all the plumbing for firing lifecycle events on models even though we removed the Evented and trigger infra. The deletes that, saves bytes and should speed up some things.