### PR TITLE
[BUGFIX] uncommitted model should be able to 'becameValid'

### DIFF
--- a/packages/-ember-data/tests/integration/model-errors-test.ts
+++ b/packages/-ember-data/tests/integration/model-errors-test.ts
@@ -82,10 +82,9 @@ module('integration/model.errors', function (hooks) {
 
     assert.dom('.error-list__error').hasText('the-error');
 
-    // @ts-ignore
     set(this.tag, 'name', 'something');
     await settled();
-    // @ts-ignore
+
     set(this.tag, 'slug', 'else');
     await settled();
 

--- a/packages/-ember-data/tests/integration/model-errors-test.ts
+++ b/packages/-ember-data/tests/integration/model-errors-test.ts
@@ -2,7 +2,7 @@ import 'qunit-dom'; // tell TS consider *.dom extension for assert
 
 // @ts-ignore
 import { setComponentTemplate } from '@ember/component';
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
 import { render, settled } from '@ember/test-helpers';
 import Component from '@glimmer/component';
 
@@ -12,7 +12,6 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 
 import Model, { attr } from '@ember-data/model';
-import { set } from '@ember/object';
 
 class Tag extends Model {
   @attr('string', {})

--- a/packages/-ember-data/tests/integration/model-errors-test.ts
+++ b/packages/-ember-data/tests/integration/model-errors-test.ts
@@ -12,17 +12,14 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 
 import Model, { attr } from '@ember-data/model';
+import { set } from '@ember/object';
 
 class Tag extends Model {
   @attr('string', {})
   name;
-}
 
-class ErrorList extends Component<{ model: Model; field: string }> {
-  get errors() {
-    const { model, field } = this.args;
-    return model.errors.errorsFor(field).map((error) => error.message);
-  }
+  @attr('string', {})
+  slug;
 }
 
 const template = hbs`
@@ -41,8 +38,15 @@ interface CurrentTestContext {
 module('integration/model.errors', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function (this: CurrentTestContext) {
+  hooks.beforeEach(function () {
     let { owner } = this;
+
+    class ErrorList extends Component<{ model: Model; field: string }> {
+      get errors() {
+        const { model, field } = this.args;
+        return model.errors.errorsFor(field).map((error) => error.message);
+      }
+    }
 
     owner.register('model:tag', Tag);
     owner.register('component:error-list', setComponentTemplate(template, ErrorList));
@@ -63,6 +67,27 @@ module('integration/model.errors', function (hooks) {
     assert.dom('.error-list__error').hasText('the-error');
 
     errors.remove('name');
+    await settled();
+
+    assert.dom('.error-list__error').doesNotExist();
+  });
+
+  test('Uncommitted model can become valid after changing 2 erred fields', async function (this: CurrentTestContext, assert) {
+    this.tag = this.owner.lookup('service:store').createRecord('tag');
+    // @ts-ignore
+    const errors = get(this.tag, 'errors');
+    errors.add('name', 'the-error');
+    errors.add('slug', 'the-error');
+
+    await render(hbs`<ErrorList @model={{this.tag}} @field="name"/>`);
+
+    assert.dom('.error-list__error').hasText('the-error');
+
+    // @ts-ignore
+    set(this.tag, 'name', 'something');
+    await settled();
+    // @ts-ignore
+    set(this.tag, 'slug', 'else');
     await settled();
 
     assert.dom('.error-list__error').doesNotExist();

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -237,6 +237,7 @@ const DirtyState = {
     //TODO(Igor) reloading now triggers a
     //loadingData event, though it seems fine?
     loadingData() {},
+    becameValid() {},
 
     propertyWasReset(internalModel, name) {
       if (!internalModel.hasChangedAttributes()) {


### PR DESCRIPTION
Hey guys,

I faced a problem and did a test + added a fix, the simplest way to replicate:
```js
myModel = this.store.createRecord('my-model');
myModel.errors.add('fieldA', ['blank']);
myModel.errors.add('fieldB', ['blank']);
later(() => {
  set(myModel, 'fieldA', 'value');
  set(myModel, 'fieldB', 'value');
}, 1000);
```

It raises an error: 
```
Attempted to handle event `becameValid` on <my-model:null> while in state root.loaded.created.uncommitted.
```

I'm not sure why it is being raised only if there are 2 or more fields with errors.