### PR TITLE
[BUGFIX] Serialize null array items as empty strings

### DIFF
--- a/packages/-ember-data/tests/unit/utils/serialize-query-params-test.js
+++ b/packages/-ember-data/tests/unit/utils/serialize-query-params-test.js
@@ -27,6 +27,19 @@ module('Unit | serializeQueryParams', function () {
     assert.deepEqual(result, 'filter%5Bchildren%5D%5B%5D=1&filter%5Bchildren%5D%5B%5D=2');
   });
 
+  test('it treats null values in arrays as empty strings', function (assert) {
+    assert.expect(1);
+
+    const qp = {
+      filter: {
+        children: [null, 2],
+      },
+    };
+    const result = serializeQueryParams(qp);
+
+    assert.deepEqual(result, 'filter%5Bchildren%5D%5B%5D=&filter%5Bchildren%5D%5B%5D=2');
+  });
+
   test('it works with + sign', function (assert) {
     assert.expect(1);
 

--- a/packages/adapter/addon/-private/utils/serialize-query-params.ts
+++ b/packages/adapter/addon/-private/utils/serialize-query-params.ts
@@ -19,7 +19,7 @@ export function serializeQueryParams(queryParamsObject: object | string): string
           if (RBRACKET.test(prefix)) {
             add(s, prefix, obj[i]);
           } else {
-            buildParams(prefix + '[' + (typeof obj[i] === 'object' ? i : '') + ']', obj[i]);
+            buildParams(prefix + '[' + (typeof obj[i] === 'object' && obj[i] !== null ? i : '') + ']', obj[i]);
           }
         }
       } else if (isPlainObject(obj)) {


### PR DESCRIPTION
## Description
While moving off jquery, I noticed a difference in how the ember-data serializes `null` in arrays in query params.

jQuery's buildParams  ([link](https://github.com/jquery/jquery/blob/main/src/serialize.js)) checks for `null` in an array and sets it to an empty string
```js
buildParams(prefix + "[" + ( typeof v === "object" && v != null ? i : "" ) + "]" ...
```

ember-data doesn't have the explicit `null` check ([link](https://github.com/emberjs/data/blob/v4.4.0/packages/adapter/addon/-private/utils/serialize-query-params.ts)), so `null` values in arrays get treated like objects.

This results in urls that decode to:
```
filter[children][0]=&...
```
rather than the expected
```
filter[children][]=&...
```

This PR fixes this by adding an explicit null check. 

Would like to see this fix back-ported to 3.28 as that's where I am experiencing it.

## Type of PR

What kind of change is this?

- [ ] refactor
- [ ] internal bugfix
- [x] user-facing bugfix
- [ ] new feature
- [ ] deprecation
- [ ] documentation
- [ ] something else (please describe)
- [ ] tests

