### PR TITLE
fix: move defaultValue into RecordData to better encapsulate and prevent eager instantiations

### DIFF
--- a/ember-data-types/q/record-data-record-wrapper.ts
+++ b/ember-data-types/q/record-data-record-wrapper.ts
@@ -24,9 +24,6 @@ export interface RecordDataWrapper {
 
   setDirtyBelongsTo(name: string, recordData: RecordDataWrapper | null): void;
 
-  // ----- unspecced
-  hasAttr(key: string): boolean;
-
   // new
   getErrors(recordIdentifier: RecordIdentifier): JsonApiValidationError[];
 

--- a/ember-data-types/q/record-data.ts
+++ b/ember-data-types/q/record-data.ts
@@ -45,7 +45,6 @@ export interface RecordData {
   didCommit(data: JsonApiResource | null): void;
 
   // ----- unspecced
-  hasAttr(key: string): boolean;
   _initRecordCreateOptions(options: any): { [key: string]: unknown };
 
   // new

--- a/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-errors-test.ts
@@ -73,10 +73,6 @@ class TestRecordData implements RecordData {
     return 'test';
   }
 
-  hasAttr(key: string): boolean {
-    return false;
-  }
-
   getHasMany(key: string) {
     return {};
   }
@@ -105,9 +101,6 @@ class TestRecordData implements RecordData {
 
   didCommit(data) {}
 
-  isAttrDirty(key: string) {
-    return false;
-  }
   removeFromInverseRelationships() {}
 
   _initRecordCreateOptions(options) {

--- a/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-state-test.ts
@@ -75,10 +75,6 @@ class TestRecordData implements RecordData {
     return 'test';
   }
 
-  hasAttr(key: string): boolean {
-    return false;
-  }
-
   getHasMany(key: string) {
     return {};
   }
@@ -103,9 +99,6 @@ class TestRecordData implements RecordData {
 
   didCommit(data) {}
 
-  isAttrDirty(key: string) {
-    return false;
-  }
   removeFromInverseRelationships() {}
 
   _initRecordCreateOptions(options) {

--- a/packages/-ember-data/tests/integration/record-data/record-data-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/record-data-test.ts
@@ -68,10 +68,6 @@ class TestRecordData {
     return 'test';
   }
 
-  hasAttr(key: string): boolean {
-    return false;
-  }
-
   getHasMany(key: string) {
     return {};
   }
@@ -86,9 +82,6 @@ class TestRecordData {
 
   didCommit(data) {}
 
-  isAttrDirty(key: string) {
-    return false;
-  }
   removeFromInverseRelationships() {}
 
   _initRecordCreateOptions(options) {}
@@ -345,7 +338,7 @@ module('integration/record-data - Custom RecordData Implementations', function (
   });
 
   test('Record Data attribute setting', async function (assert) {
-    let expectedCount = 15;
+    let expectedCount = 13;
     assert.expect(expectedCount);
     const personHash = {
       type: 'person',
@@ -376,15 +369,6 @@ module('integration/record-data - Custom RecordData Implementations', function (
         calledGet++;
         assert.strictEqual(key, 'name', 'key passed to getAttr');
         return 'new attribute';
-      }
-
-      hasAttr(key: string): boolean {
-        assert.strictEqual(key, 'name', 'key passed to hasAttr');
-        return true;
-      }
-
-      isAttrDirty(key: string) {
-        return false;
       }
     }
 

--- a/packages/-ember-data/tests/integration/record-data/store-wrapper-test.ts
+++ b/packages/-ember-data/tests/integration/record-data/store-wrapper-test.ts
@@ -62,10 +62,6 @@ class TestRecordData {
     return 'test';
   }
 
-  hasAttr(key: string): boolean {
-    return false;
-  }
-
   getHasMany(key: string) {
     return {};
   }
@@ -80,9 +76,6 @@ class TestRecordData {
 
   didCommit(data) {}
 
-  isAttrDirty(key: string) {
-    return false;
-  }
   isNew() {
     return this._isNew;
   }

--- a/packages/-ember-data/tests/integration/record-data/unloading-record-data-test.js
+++ b/packages/-ember-data/tests/integration/record-data/unloading-record-data-test.js
@@ -61,10 +61,6 @@ module('RecordData Compatibility', function (hooks) {
       return this.attributes !== null ? this.attributes[member] : undefined;
     }
 
-    hasAttr(key) {
-      return key in this.attributes;
-    }
-
     // TODO missing from RFC but required to implement
     _initRecordCreateOptions(options) {
       return options !== undefined ? options : {};

--- a/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/packages/-ember-data/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -175,7 +175,7 @@ module('unit/model - Custom Class Model', function (hooks) {
   });
 
   test('attribute and relationship with custom schema definition', async function (assert) {
-    assert.expect(17);
+    assert.expect(18);
     this.owner.register(
       'adapter:application',
       JSONAPIAdapter.extend({

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -442,7 +442,7 @@ module('unit/model - Model', function (hooks) {
       class Tag extends Model {
         @attr('string', {
           defaultValue(record, options, key) {
-            assert.deepEqual(record, tag, 'the record is passed in properly');
+            assert.deepEqual(record, undefined, 'the record is passed in properly');
             assert.strictEqual(key, 'createdAt', 'the attribute being defaulted is passed in properly');
             return 'le default value';
           },

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -443,7 +443,7 @@ module('unit/model - Model', function (hooks) {
         @attr('string', {
           defaultValue(record, options, key) {
             assert.deepEqual(record, undefined, 'the record is passed in properly');
-            assert.strictEqual(key, 'createdAt', 'the attribute being defaulted is passed in properly');
+            assert.strictEqual(key, undefined, 'the attribute being defaulted is passed in properly');
             return 'le default value';
           },
         })

--- a/packages/model/addon/-private/attr.js
+++ b/packages/model/addon/-private/attr.js
@@ -11,19 +11,6 @@ import { computedMacroWithOptionalParams } from './util';
   @module @ember-data/model
 */
 
-function getDefaultValue(record, options, key) {
-  if (typeof options.defaultValue === 'function') {
-    return options.defaultValue.apply(null, arguments);
-  } else {
-    let defaultValue = options.defaultValue;
-    assert(
-      `Non primitive defaultValues are not supported because they are shared between all instances. If you would like to use a complex object as a default value please provide a function that returns the complex object.`,
-      typeof defaultValue !== 'object' || defaultValue === null
-    );
-    return defaultValue;
-  }
-}
-
 /**
   `attr` defines an attribute on a [Model](/ember-data/release/classes/Model).
   By default, attributes are passed through as-is, however you can specify an
@@ -138,20 +125,7 @@ function attr(type, options) {
       if (this.isDestroyed || this.isDestroying) {
         return;
       }
-      let recordData = recordDataFor(this);
-      // TODO hasAttr is not spec'd
-      // essentially this is needed because
-      // there is a difference between "undefined" meaning never set
-      // and "undefined" meaning set to "undefined". In the "key present"
-      // case we want to return undefined. In the "key absent" case
-      // we want to return getDefaultValue. RecordDataV2 can fix this
-      // by providing the attributes blob such that we can make our
-      // own determination.
-      if (recordData.hasAttr(key)) {
-        return recordData.getAttr(key);
-      } else {
-        return getDefaultValue(this, options, key);
-      }
+      return recordDataFor(this).getAttr(key);
     },
     set(key, value) {
       if (DEBUG) {

--- a/packages/record-data/addon/-private/record-data.ts
+++ b/packages/record-data/addon/-private/record-data.ts
@@ -410,7 +410,7 @@ export default class RecordDataDefault implements RelationshipRecordData {
       return this._data[key];
     } else {
       const attr = this.storeWrapper.getSchemaDefinitionService().attributesDefinitionFor(this.identifier)[key];
-      return getDefaultValue(undefined, attr?.options, key);
+      return getDefaultValue(attr?.options);
     }
   }
 
@@ -740,14 +740,15 @@ function getRemoteState(rel) {
   return rel.canonicalState;
 }
 
-// If anyone opens an issue for _record not working right, we'll deprecate it via a Proxy
-// that lazily instantiates the record.
-function getDefaultValue(_record: undefined, options: { defaultValue?: unknown } | undefined, _key: string) {
+function getDefaultValue(options: { defaultValue?: unknown } | undefined) {
   if (!options) {
     return;
   }
   if (typeof options.defaultValue === 'function') {
-    return options.defaultValue.apply(null, arguments);
+    // If anyone opens an issue for args not working right, we'll restore + deprecate it via a Proxy
+    // that lazily instantiates the record. We don't want to provide any args here
+    // because in a non @ember-data/model world they don't make sense.
+    return options.defaultValue();
   } else {
     let defaultValue = options.defaultValue;
     assert(

--- a/packages/store/addon/-private/legacy-model-support/schema-definition-service.ts
+++ b/packages/store/addon/-private/legacy-model-support/schema-definition-service.ts
@@ -26,10 +26,15 @@ if (HAS_MODEL_PACKAGE) {
 }
 
 export class DSModelSchemaDefinitionService {
-  private _relationshipsDefCache = Object.create(null);
-  private _attributesDefCache = Object.create(null);
+  declare store: Store;
+  declare _relationshipsDefCache;
+  declare _attributesDefCache;
 
-  constructor(public store: Store) {}
+  constructor(store: Store) {
+    this.store = store;
+    this._relationshipsDefCache = Object.create(null);
+    this._attributesDefCache = Object.create(null);
+  }
 
   // Following the existing RD implementation
   attributesDefinitionFor(identifier: RecordIdentifier | { type: string }): AttributesSchema {

--- a/packages/store/addon/-private/network/snapshot.ts
+++ b/packages/store/addon/-private/network/snapshot.ts
@@ -9,7 +9,6 @@ import { HAS_RECORD_DATA_PACKAGE } from '@ember-data/private-build-infra';
 import { DEPRECATE_SNAPSHOT_MODEL_CLASS_ACCESS } from '@ember-data/private-build-infra/deprecations';
 import type BelongsToRelationship from '@ember-data/record-data/addon/-private/relationships/state/belongs-to';
 import type ManyRelationship from '@ember-data/record-data/addon/-private/relationships/state/has-many';
-import type { DSModelSchema, ModelSchema } from '@ember-data/types/q/ds-model';
 import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
 import type { OptionsHash } from '@ember-data/types/q/minimum-serializer-interface';
 import type { ChangedAttributesHash } from '@ember-data/types/q/record-data';
@@ -21,10 +20,6 @@ import type { Dict } from '@ember-data/types/q/utils';
 import type Store from '../store-service';
 
 type RecordId = string | null;
-
-function schemaIsDSModel(schema: ModelSchema | DSModelSchema): schema is DSModelSchema {
-  return (schema as DSModelSchema).isModel === true;
-}
 
 /**
   Snapshot is not directly instantiable.
@@ -158,19 +153,12 @@ export default class Snapshot implements Snapshot {
     if (this.__attributes !== null) {
       return this.__attributes;
     }
-    let record = this.record;
     let attributes = (this.__attributes = Object.create(null));
     let attrs = Object.keys(this._store.getSchemaDefinitionService().attributesDefinitionFor(this.identifier));
     let recordData = this._store._instanceCache.getRecordData(this.identifier);
-    const modelClass = this._store.modelFor(this.identifier.type);
-    const isDSModel = schemaIsDSModel(modelClass);
+
     attrs.forEach((keyName) => {
-      if (isDSModel) {
-        // if the schema is for a DSModel then the instance is too
-        attributes[keyName] = record[keyName];
-      } else {
-        attributes[keyName] = recordData.getAttr(keyName);
-      }
+      attributes[keyName] = recordData.getAttr(keyName);
     });
 
     return attributes;


### PR DESCRIPTION
This prevents needing to instantiate and iterate the record to retrieve default values. We may end up needing to deprecate record-access, but the hope is that folks generally weren't using the undocumented arguments passed to defaultValue.

Additionally, this lets us remove the un-spec'd `hasAttr` from V1 cache which was necessary to distinguish between `undefined` meaning never-set and `undefined` meaning set to undefined for default-value determination.