### PR TITLE
fix: reopen deprecation should properly pass original arguments

### DIFF
--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -2413,7 +2413,7 @@ if (DEBUG) {
         until: '5.0',
         since: { available: '4.8', enabled: '4.8' },
       });
-      return originalReopen.call(this, arguments);
+      return originalReopen.call(this, ...arguments);
     };
 
     Model.reopenClass = function deprecatedReopenClass() {
@@ -2427,7 +2427,7 @@ if (DEBUG) {
           since: { available: '4.8', enabled: '4.8' },
         }
       );
-      return originalReopenClass.call(this, arguments);
+      return originalReopenClass.call(this, ...arguments);
     };
   }
 }


### PR DESCRIPTION
Call original reopen with "...arguments"

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->

## Description

Recall the original reopen function with "arguments" instead of "...arguments".

## Type of PR

What kind of change is this?

- [ ] refactor
- [x] internal bugfix
- [ ] user-facing bugfix
- [ ] new feature
- [ ] deprecation
- [ ] documentation
- [ ] something else (please describe)
- [ ] tests

## Notes for the release

Does this PR need to be described in the Ember release blog post? Please briefly describe what should be shared.


