### PR TITLE
fix: backgroundReloads should not affect recordIsLoaded (#8125)

### DIFF
--- a/packages/-ember-data/tests/integration/store-test.js
+++ b/packages/-ember-data/tests/integration/store-test.js
@@ -351,6 +351,46 @@ module('integration/store - findRecord', function (hooks) {
     assert.strictEqual(car.model, 'Princess', 'Updated car record is returned');
   });
 
+  test('multiple calls to store#findRecord return the cached record without firing new requests', async function (assert) {
+    assert.expect(3);
+
+    this.owner.unregister('serializer:application');
+    let adapter = store.adapterFor('application');
+    let calls = 0;
+
+    adapter.shouldReloadRecord = () => false;
+    adapter.shouldBackgroundReloadRecord = () => false;
+
+    adapter.findRecord = () => {
+      if (calls++ === 0) {
+        return resolve({
+          data: {
+            type: 'car',
+            id: '1',
+            attributes: {
+              make: 'BMC',
+              model: 'Mini',
+            },
+          },
+        });
+      }
+      assert.ok(false, 'should not call findRecord');
+      throw 'unexpected call';
+    };
+
+    const proxiedCar = store.findRecord('car', '1');
+    const car = await proxiedCar;
+
+    assert.strictEqual(car.model, 'Mini', 'car record is returned from cache');
+    const proxiedCar2 = store.findRecord('car', '1');
+    assert.strictEqual(proxiedCar2.get('model'), undefined, 'car record is returned from cache');
+    // assert.strictEqual(proxiedCar2.get('model'), 'Mini', 'car record is returned from cache');
+    const car2 = await proxiedCar2;
+
+    assert.strictEqual(car2?.model, 'Mini', 'car record is returned from cache');
+    assert.strictEqual(car, car2, 'we found the same car');
+  });
+
   test('store#findRecord { reload: true } ignores cached record and reloads record from server', async function (assert) {
     assert.expect(2);
 

--- a/packages/model/addon/-private/legacy-relationships-support.ts
+++ b/packages/model/addon/-private/legacy-relationships-support.ts
@@ -704,7 +704,7 @@ function areAllInverseRecordsLoaded(store: Store, resource: JsonApiRelationship)
 function isEmpty(store: Store, cache: IdentifierCache, resource: ResourceIdentifierObject): boolean {
   const identifier = cache.getOrCreateRecordIdentifier(resource);
   const recordData = store._instanceCache.peek({ identifier, bucket: 'recordData' });
-  return !recordData || !!recordData.isEmpty?.(identifier);
+  return !recordData || recordData.isEmpty(identifier);
 }
 
 function isBelongsTo(

--- a/packages/store/addon/-private/caches/instance-cache.ts
+++ b/packages/store/addon/-private/caches/instance-cache.ts
@@ -139,7 +139,7 @@ export class InstanceCache {
       return false;
     }
     const isNew = recordData.isNew(identifier);
-    const isEmpty = recordData.isEmpty?.(identifier) || false;
+    const isEmpty = recordData.isEmpty(identifier);
 
     // if we are new we must consider ourselves loaded
     if (isNew) {
@@ -152,18 +152,23 @@ export class InstanceCache {
     // we should consider allowing for something to be loaded that is simply "not empty".
     // which is how RecordState currently handles this case; however, RecordState is buggy
     // in that it does not account for unloading.
-    // return !isEmpty;
+    return filterDeleted && recordData.isDeletionCommitted(identifier) ? false : !isEmpty;
 
+    /*
     const req = this.store.getRequestStateService();
     const fulfilled = req.getLastRequestForRecord(identifier);
+    const isLocallyLoaded = !isEmpty;
     const isLoading =
-      fulfilled !== null && req.getPendingRequestsForRecord(identifier).some((req) => req.type === 'query');
+      !isLocallyLoaded &&
+      fulfilled === null &&
+      req.getPendingRequestsForRecord(identifier).some((req) => req.type === 'query');
 
     if (isEmpty || (filterDeleted && recordData.isDeletionCommitted(identifier)) || isLoading) {
       return false;
     }
 
     return true;
+    */
   }
 
   constructor(store: Store) {
@@ -684,7 +689,7 @@ function _isEmpty(cache: InstanceCache, identifier: StableRecordIdentifier): boo
   }
   const isNew = recordData.isNew(identifier);
   const isDeleted = recordData.isDeleted(identifier);
-  const isEmpty = recordData.isEmpty?.(identifier) || false;
+  const isEmpty = recordData.isEmpty(identifier);
 
   return (!isNew || isDeleted) && isEmpty;
 }

--- a/packages/store/addon/-private/network/fetch-manager.ts
+++ b/packages/store/addon/-private/network/fetch-manager.ts
@@ -213,7 +213,7 @@ export default class FetchManager {
       },
       (error) => {
         const recordData = store._instanceCache.peek({ identifier, bucket: 'recordData' });
-        if (!recordData || recordData.isEmpty?.(identifier) || isLoading) {
+        if (!recordData || recordData.isEmpty(identifier) || isLoading) {
           store._instanceCache.unloadRecord(identifier);
         }
         throw error;


### PR DESCRIPTION
Currently doesn't appear to be a regression here, but probably a good test to have around anyway. The regression might be in the timing of the promise-record setup, if so we'll need more info to track it down. Another hypothesis is there is an unloadRecord call involved which previously the findRecord call was "cancelling". Now the unloadRecord call would succeed and the data be cleared and refetch required.