### PR TITLE
fix for #8125

### DIFF
--- a/packages/store/addon/-private/caches/instance-cache.ts
+++ b/packages/store/addon/-private/caches/instance-cache.ts
@@ -157,7 +157,7 @@ export class InstanceCache {
     const req = this.store.getRequestStateService();
     const fulfilled = req.getLastRequestForRecord(identifier);
     const isLoading =
-      fulfilled !== null && req.getPendingRequestsForRecord(identifier).some((req) => req.type === 'query');
+      fulfilled === null && req.getPendingRequestsForRecord(identifier).some((req) => req.type === 'query');
 
     if (isEmpty || (filterDeleted && recordData.isDeletionCommitted(identifier)) || isLoading) {
       return false;


### PR DESCRIPTION
## Description

Calling `findRecord` for the same ID/Model a couple of times do not fail since the second call starts a background reload and the third call notices an active request.

Thanks to @runspired for the ideas.

## Type of PR

What kind of change is this?

- [ ] refactor
- [x] internal bugfix
- [ ] user-facing bugfix
- [ ] new feature
- [ ] deprecation
- [ ] documentation
- [ ] something else (please describe)
- [ ] tests


