### PR TITLE
perf: optimize factory.create

### DIFF
--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -1,5 +1,4 @@
 import { computed, get, observer, set } from '@ember/object';
-import { guidFor } from '@ember/object/internals';
 
 import { module, test } from 'qunit';
 import { reject, resolve } from 'rsvp';

--- a/packages/-ember-data/tests/unit/model-test.js
+++ b/packages/-ember-data/tests/unit/model-test.js
@@ -196,11 +196,7 @@ module('unit/model - Model', function (hooks) {
         },
       });
 
-      assert.strictEqual(
-        person.toString(),
-        `<dummy@model:${person.constructor.modelName}::${guidFor(person)}:1>`,
-        'reports id in toString'
-      );
+      assert.strictEqual(person.toString(), `<model::${person.constructor.modelName}:1>`, 'reports id in toString');
     });
 
     testInDebug('trying to use `id` as an attribute should raise', async function (assert) {

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -494,7 +494,7 @@ class Model extends EmberObject {
   }
 
   toString() {
-    return `model::${this.constructor.modelName}:${this.id}`;
+    return `<model::${this.constructor.modelName}:${this.id}>`;
   }
 
   /**

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -130,18 +130,18 @@ class Model extends EmberObject {
     }
     const createProps = options._createProps;
     const _secretInit = options._secretInit;
-    delete options._createProps;
-    delete options._secretInit;
+    options._createProps = null;
+    options._secretInit = null;
     super.init(options);
 
-    _secretInit(this);
+    let identity = _secretInit.identifier;
+    _secretInit.cb(this, _secretInit.recordData, identity, _secretInit.store);
     this.___recordState = DEBUG ? new RecordState(this) : null;
 
     this.setProperties(createProps);
 
     let store = storeFor(this);
     let notifications = store._notificationManager;
-    let identity = recordIdentifierFor(this);
 
     this.___private_notifications = notifications.subscribe(identity, (identifier, type, key) => {
       notifyChanges(identifier, type, key, this, store);

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -493,9 +493,8 @@ class Model extends EmberObject {
     }
   }
 
-  // TODO just write a nice toString
-  toStringExtension() {
-    return this.id;
+  toString() {
+    return `model::${this.constructor.modelName}:${this.id}`;
   }
 
   /**


### PR DESCRIPTION
Ports @ember-data/model init optimizations from #8134. Same as #8139 this is to ensure that the benchmark for that PR is as close as possible to "just the cost of moving to proxies"