### PR TITLE
[BUGFIX] Model state error 3.28

### DIFF
--- a/packages/-ember-data/tests/integration/model-errors-test.ts
+++ b/packages/-ember-data/tests/integration/model-errors-test.ts
@@ -2,7 +2,7 @@ import 'qunit-dom'; // tell TS consider *.dom extension for assert
 
 // @ts-ignore
 import { setComponentTemplate } from '@ember/component';
-import { get, set } from '@ember/object';
+import { get } from '@ember/object';
 import { render, settled } from '@ember/test-helpers';
 import Component from '@glimmer/component';
 
@@ -12,6 +12,8 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 
 import Model, { attr } from '@ember-data/model';
+
+type DSModel = import('@ember-data/store/-private/ts-interfaces/ds-model').DSModel;
 
 class Tag extends Model {
   @attr('string', {})
@@ -30,7 +32,7 @@ const template = hbs`
 `;
 
 interface CurrentTestContext {
-  tag: Tag;
+  tag: Tag & DSModel;
   owner: any;
 }
 
@@ -74,7 +76,7 @@ module('integration/model.errors', function (hooks) {
   test('Uncommitted model can become valid after changing 2 erred fields', async function (this: CurrentTestContext, assert) {
     this.tag = this.owner.lookup('service:store').createRecord('tag');
     // @ts-ignore
-    const errors = get(this.tag, 'errors');
+    const errors = this.tag.errors;
     errors.add('name', 'the-error');
     errors.add('slug', 'the-error');
 
@@ -83,13 +85,13 @@ module('integration/model.errors', function (hooks) {
     assert.deepEqual(this.tag.errors.errorsFor('name'), [{ attribute: 'name', message: 'the-error' }]);
     assert.deepEqual(this.tag.errors.errorsFor('slug'), [{ attribute: 'slug', message: 'the-error' }]);
 
-    set(this.tag, 'name', 'something');
+    this.tag.name = 'something';
     await settled();
 
     assert.deepEqual(this.tag.errors.errorsFor('name'), []);
     assert.deepEqual(this.tag.errors.errorsFor('slug'), [{ attribute: 'slug', message: 'the-error' }]);
 
-    set(this.tag, 'slug', 'else');
+    this.tag.slug = 'else';
     await settled();
 
     assert.deepEqual(this.tag.errors.errorsFor('name'), []);

--- a/packages/-ember-data/tests/integration/model-errors-test.ts
+++ b/packages/-ember-data/tests/integration/model-errors-test.ts
@@ -82,10 +82,9 @@ module('integration/model.errors', function (hooks) {
 
     assert.dom('.error-list__error').hasText('the-error');
 
-    // @ts-ignore
     set(this.tag, 'name', 'something');
     await settled();
-    // @ts-ignore
+
     set(this.tag, 'slug', 'else');
     await settled();
 

--- a/packages/-ember-data/tests/integration/model-errors-test.ts
+++ b/packages/-ember-data/tests/integration/model-errors-test.ts
@@ -2,7 +2,7 @@ import 'qunit-dom'; // tell TS consider *.dom extension for assert
 
 // @ts-ignore
 import { setComponentTemplate } from '@ember/component';
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
 import { render, settled } from '@ember/test-helpers';
 import Component from '@glimmer/component';
 
@@ -12,7 +12,6 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 
 import Model, { attr } from '@ember-data/model';
-import { set } from '@ember/object';
 
 class Tag extends Model {
   @attr('string', {})

--- a/packages/-ember-data/tests/integration/model-errors-test.ts
+++ b/packages/-ember-data/tests/integration/model-errors-test.ts
@@ -80,14 +80,20 @@ module('integration/model.errors', function (hooks) {
 
     await render(hbs`<ErrorList @model={{this.tag}} @field="name"/>`);
 
-    assert.dom('.error-list__error').hasText('the-error');
+    assert.deepEqual(this.tag.errors.errorsFor('name'), [{ attribute: 'name', message: 'the-error' }]);
+    assert.deepEqual(this.tag.errors.errorsFor('slug'), [{ attribute: 'slug', message: 'the-error' }]);
 
     set(this.tag, 'name', 'something');
     await settled();
 
+    assert.deepEqual(this.tag.errors.errorsFor('name'), []);
+    assert.deepEqual(this.tag.errors.errorsFor('slug'), [{ attribute: 'slug', message: 'the-error' }]);
+
     set(this.tag, 'slug', 'else');
     await settled();
 
+    assert.deepEqual(this.tag.errors.errorsFor('name'), []);
+    assert.deepEqual(this.tag.errors.errorsFor('email'), []);
     assert.dom('.error-list__error').doesNotExist();
   });
 });

--- a/packages/store/addon/-private/system/model/states.js
+++ b/packages/store/addon/-private/system/model/states.js
@@ -238,6 +238,7 @@ const DirtyState = {
     //TODO(Igor) reloading now triggers a
     //loadingData event, though it seems fine?
     loadingData() {},
+    becameValid() {},
 
     propertyWasReset(internalModel, name) {
       if (!internalModel.hasChangedAttributes()) {


### PR DESCRIPTION
Changed base branch from #8009 

Hey guys,

I faced a problem and did a test + added a fix, the simplest way to replicate:
```js
myModel = this.store.createRecord('my-model');
myModel.errors.add('fieldA', ['blank']);
myModel.errors.add('fieldB', ['blank']);
later(() => {
  set(myModel, 'fieldA', 'value');
  set(myModel, 'fieldB', 'value');
}, 1000);
```

It raises an error: 
```
Attempted to handle event `becameValid` on <my-model:null> while in state root.loaded.created.uncommitted.
```

I'm not sure why it is being raised only if there are 2 or more fields with errors.