### PR TITLE
fix: correct deprecation message for toArray

### DIFF
--- a/packages/store/addon/-private/record-arrays/identifier-array.ts
+++ b/packages/store/addon/-private/record-arrays/identifier-array.ts
@@ -664,7 +664,7 @@ if (DEPRECATE_ARRAY_LIKE) {
   };
 
   IdentifierArray.prototype.toArray = function () {
-    deprecateArrayLike(this.DEPRECATED_CLASS_NAME, 'unshiftObjects', 'unshift');
+    deprecateArrayLike(this.DEPRECATED_CLASS_NAME, 'toArray', 'slice');
     return this.slice();
   };
 


### PR DESCRIPTION
## Description

Will display the correct deprecation message for toArray instead of one for unshiftObjects.

## Type of PR

What kind of change is this?

- [ ] refactor
- [ ] internal bugfix
- [x] user-facing bugfix
- [ ] new feature
- [ ] deprecation
- [ ] documentation
- [ ] something else (please describe)
- [ ] tests
