### PR TITLE
Use array notation instead of at for accessing values (#8184)

### DIFF
--- a/packages/-ember-data/tests/unit/record-arrays/record-array-test.js
+++ b/packages/-ember-data/tests/unit/record-arrays/record-array-test.js
@@ -141,6 +141,48 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     }
   );
 
+  deprecatedTest(
+    '#lastObject and #firstObject',
+    { id: 'ember-data:deprecate-array-like', until: '5.0', count: 2 },
+    async function (assert) {
+      this.owner.register('model:tag', Tag);
+      let store = this.owner.lookup('service:store');
+
+      let records = store.push({
+        data: [
+          {
+            type: 'tag',
+            id: '1',
+            attributes: {
+              name: 'first',
+            },
+          },
+          {
+            type: 'tag',
+            id: '3',
+          },
+          {
+            type: 'tag',
+            id: '5',
+            attributes: {
+              name: 'fifth',
+            },
+          },
+        ],
+      });
+
+      let recordArray = new RecordArray({
+        type: 'recordType',
+        identifiers: records.map(recordIdentifierFor),
+        store,
+      });
+
+      assert.strictEqual(recordArray.length, 3);
+      assert.strictEqual(recordArray.firstObject.id, '1');
+      assert.strictEqual(recordArray.lastObject.id, '5');
+    }
+  );
+
   test('#update', async function (assert) {
     let findAllCalled = 0;
     let deferred = RSVP.defer();

--- a/packages/store/addon/-private/record-arrays/identifier-array.ts
+++ b/packages/store/addon/-private/record-arrays/identifier-array.ts
@@ -286,10 +286,10 @@ class IdentifierArray {
           if (DEPRECATE_ARRAY_LIKE) {
             if (prop === 'firstObject') {
               deprecateArrayLike(self.DEPRECATED_CLASS_NAME, prop, '[0]');
-              return receiver.at(0);
+              return receiver[0];
             } else if (prop === 'lastObject') {
               deprecateArrayLike(self.DEPRECATED_CLASS_NAME, prop, 'at(-1)');
-              return receiver.at(-1);
+              return receiver[receiver.length - 1];
             }
           }
 


### PR DESCRIPTION
Backport #8184 to release:

Array.at isn't supported in Safari until 15.4, using brackets isn't as pretty, but enjoys universal support.

