### PR TITLE
Use array notation instead of at for accessing object at values

### DIFF
--- a/packages/-ember-data/tests/unit/record-arrays/record-array-test.js
+++ b/packages/-ember-data/tests/unit/record-arrays/record-array-test.js
@@ -183,6 +183,52 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     }
   );
 
+  deprecatedTest(
+    '#objectAt and #objectsAt',
+    { id: 'ember-data:deprecate-array-like', until: '5.0', count: 5 },
+    async function (assert) {
+      this.owner.register('model:tag', Tag);
+      let store = this.owner.lookup('service:store');
+
+      let records = store.push({
+        data: [
+          {
+            type: 'tag',
+            id: '1',
+            attributes: {
+              name: 'first',
+            },
+          },
+          {
+            type: 'tag',
+            id: '3',
+          },
+          {
+            type: 'tag',
+            id: '5',
+            attributes: {
+              name: 'fifth',
+            },
+          },
+        ],
+      });
+
+      let recordArray = new RecordArray({
+        type: 'recordType',
+        identifiers: records.map(recordIdentifierFor),
+        store,
+      });
+
+      assert.strictEqual(recordArray.length, 3);
+      assert.strictEqual(recordArray.objectAt(0).id, '1');
+      assert.strictEqual(recordArray.objectAt(-1).id, '5');
+      assert.deepEqual(
+        recordArray.objectsAt([2, 1]).map((r) => r.id),
+        ['5', '3']
+      );
+    }
+  );
+
   test('#update', async function (assert) {
     let findAllCalled = 0;
     let deferred = RSVP.defer();

--- a/packages/store/addon/-private/record-arrays/identifier-array.ts
+++ b/packages/store/addon/-private/record-arrays/identifier-array.ts
@@ -631,12 +631,14 @@ if (DEPRECATE_ARRAY_LIKE) {
 
   IdentifierArray.prototype.objectAt = function (index: number) {
     deprecateArrayLike(this.DEPRECATED_CLASS_NAME, 'objectAt', 'at');
-    return this.at(index);
+    //For negative index values go back from the end of the array
+    let arrIndex = Math.sign(index) === -1 ? this.length + index : index;
+    return this[arrIndex];
   };
 
   IdentifierArray.prototype.objectsAt = function (indeces: number[]) {
     deprecateArrayLike(this.DEPRECATED_CLASS_NAME, 'objectsAt', 'at');
-    return indeces.map((index) => this.at(index)!);
+    return indeces.map((index) => this.objectAt(index)!);
   };
 
   IdentifierArray.prototype.removeAt = function (index: number) {


### PR DESCRIPTION
## Description

Array.at isn't supported in Safari until 15.4, using brackets isn't as pretty, but enjoys universal support.

## Type of PR

- [x] user-facing bugfix
