### PR TITLE
Invoke ember-auto-import analyzer

### DIFF
--- a/packages/private-build-infra/src/utilities/rollup-private-module.js
+++ b/packages/private-build-infra/src/utilities/rollup-private-module.js
@@ -3,7 +3,7 @@ const Rollup = require('broccoli-rollup');
 const BroccoliDebug = require('broccoli-debug');
 
 module.exports = function rollupPrivateModule(tree, options) {
-  const { onWarn, destDir, babelCompiler, babelOptions, externalDependencies, packageName } = options;
+  const { onWarn, destDir, babelCompiler, babelOptions, externalDependencies, packageName, analyzer } = options;
   const debugTree = BroccoliDebug.buildDebugCallback(`ember-data:${packageName}:rollup-private`);
   tree = debugTree(tree, 'input');
 
@@ -60,6 +60,10 @@ module.exports = function rollupPrivateModule(tree, options) {
     babel: babelOptions,
     'ember-cli-babel': emberCliBabelOptions,
   });
+
+  if (analyzer) {
+    privateTree = analyzer.toTree.call(analyzer, privateTree, undefined, undefined, { treeType: 'addon' });
+  }
 
   privateTree = debugTree(privateTree, 'babel-private:output');
   privateTree = new Rollup(privateTree, {


### PR DESCRIPTION
## Type of PR

What kind of change is this?

- [ ] refactor
- [x] internal bugfix
- [ ] user-facing bugfix
- [ ] new feature
- [ ] deprecation
- [ ] documentation
- [ ] something else (please describe)
- [ ] tests

## Notes for the release

No release notes required.


## Description

Because the ember-data packages opt out of the standard ember-cli preprocessor registry, they won't get analyzed correctly by ember-auto-import. Instead, they're forced to manually configure the analyzer. That's what this PR does.

The `ember-auto-import/babel-plugin` that was being added before was doing nothing. As documented, it exists to support dynamic imports, which ember-data doesn't use. It's unrelated to the import analysis.

I confirmed manually that these changes make ember-auto-import work in both the public and private parts of the packages. The proper way to add test coverage for this is to start using it, as was begun in the branch ember-auto-import-v2-addon-bug.