### PR TITLE
chore: bump pnpm version

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -17,7 +17,7 @@ jobs:
           fi
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/asset-size-check.yml
+++ b/.github/workflows/asset-size-check.yml
@@ -24,7 +24,7 @@ jobs:
       - run: git fetch origin master --depth=1
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -237,7 +237,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -273,7 +273,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -299,7 +299,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -325,7 +325,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/.github/workflows/partner-tests.yml
+++ b/.github/workflows/partner-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -35,7 +35,7 @@ jobs:
           git show --format=short --no-patch $originSha
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: tracerbench/tracerbench-compare-action@master
         with:
           experiment-build-command: npm run --if-present build-v2-addons && pnpm --filter relationship-performance-test-app exec ember build -e production --output-path dist-experiment

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -35,7 +35,7 @@ jobs:
           git show --format=short --no-patch $originSha
       - uses: pnpm/action-setup@v2
         with:
-          version: '7.12.2'
+          version: '7.13.5'
       - uses: tracerbench/tracerbench-compare-action@master
         with:
           experiment-build-command: npm run --if-present build-v2-addons && pnpm --filter relationship-performance-test-app exec ember build -e production --output-path dist-experiment

--- a/package.json
+++ b/package.json
@@ -159,13 +159,13 @@
     "node": "^14.8.0 || 16.* || >= 18.*",
     "yarn": "use pnpm",
     "npm": "use pnpm",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2",
+	"packageManager": "pnpm@7.13.5",
   "changelog": {
     "labels": {
       "changelog:breaking": ":boom: Breaking Change",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -110,7 +110,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -69,7 +69,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/canary-features/package.json
+++ b/packages/canary-features/package.json
@@ -46,7 +46,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -63,7 +63,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -76,7 +76,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/private-build-infra/package.json
+++ b/packages/private-build-infra/package.json
@@ -48,7 +48,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -76,7 +76,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -67,7 +67,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -73,7 +73,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/unpublished-adapter-encapsulation-test-app/package.json
+++ b/packages/unpublished-adapter-encapsulation-test-app/package.json
@@ -64,7 +64,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/unpublished-debug-encapsulation-test-app/package.json
+++ b/packages/unpublished-debug-encapsulation-test-app/package.json
@@ -63,7 +63,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/unpublished-fastboot-test-app/package.json
+++ b/packages/unpublished-fastboot-test-app/package.json
@@ -76,7 +76,7 @@
   ],
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/unpublished-model-encapsulation-test-app/package.json
+++ b/packages/unpublished-model-encapsulation-test-app/package.json
@@ -64,7 +64,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/unpublished-record-data-encapsulation-test-app/package.json
+++ b/packages/unpublished-record-data-encapsulation-test-app/package.json
@@ -64,7 +64,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/unpublished-relationship-performance-test-app/package.json
+++ b/packages/unpublished-relationship-performance-test-app/package.json
@@ -58,7 +58,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/unpublished-serializer-encapsulation-test-app/package.json
+++ b/packages/unpublished-serializer-encapsulation-test-app/package.json
@@ -63,7 +63,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -70,7 +70,7 @@
   },
   "volta": {
     "node": "16.18.0",
-    "pnpm": "7.12.2"
+    "pnpm": "7.13.5"
   },
-	"packageManager": "pnpm@7.12.2"
+	"packageManager": "pnpm@7.13.5"
 }


### PR DESCRIPTION
replaces #8235 which didn't bump pnpm in github actions