### PR TITLE
chore: remove uneeded dep on ember-cli-test-info

### DIFF
--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -22,8 +22,7 @@
     "@ember/edition-utils": "^1.2.0",
     "@ember/string": "^3.0.0",
     "ember-auto-import": "^2.4.3",
-    "ember-cli-babel": "^7.26.11",
-    "ember-cli-test-info": "^1.0.0"
+    "ember-cli-babel": "^7.26.11"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",

--- a/packages/record-data/package.json
+++ b/packages/record-data/package.json
@@ -28,8 +28,7 @@
     "@ember-data/store": "4.9.0-alpha.6",
     "@ember/edition-utils": "^1.2.0",
     "ember-auto-import": "^2.4.3",
-    "ember-cli-babel": "^7.26.11",
-    "ember-cli-test-info": "^1.0.0"
+    "ember-cli-babel": "^7.26.11"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -47,7 +47,6 @@
     "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-inject-live-reload": "^2.1.0",
-    "ember-cli-test-info": "^1.0.0",
     "ember-cli-test-loader": "^3.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,7 +505,6 @@ importers:
       ember-cli-inject-live-reload: ^2.1.0
       ember-cli-sri: ^2.1.1
       ember-cli-terser: ~4.0.2
-      ember-cli-test-info: ^1.0.0
       ember-disable-prototype-extensions: ^1.1.3
       ember-export-application-global: ^2.0.1
       ember-load-initializers: ^2.1.2
@@ -526,7 +525,6 @@ importers:
       '@ember/string': 3.0.0
       ember-auto-import: 2.4.3_webpack@5.74.0
       ember-cli-babel: 7.26.11
-      ember-cli-test-info: 1.0.0
     devDependencies:
       '@babel/core': 7.19.3
       '@babel/runtime': 7.19.4
@@ -723,7 +721,6 @@ importers:
       ember-cli-inject-live-reload: ^2.1.0
       ember-cli-sri: ^2.1.1
       ember-cli-terser: ~4.0.2
-      ember-cli-test-info: ^1.0.0
       ember-cli-test-loader: ^3.0.0
       ember-disable-prototype-extensions: ^1.1.3
       ember-export-application-global: ^2.0.1
@@ -748,7 +745,6 @@ importers:
       '@ember/edition-utils': 1.2.0
       ember-auto-import: 2.4.3_webpack@5.74.0
       ember-cli-babel: 7.26.11
-      ember-cli-test-info: 1.0.0
     devDependencies:
       '@babel/core': 7.19.3
       '@babel/runtime': 7.19.4
@@ -1467,7 +1463,6 @@ importers:
       ember-cli-dependency-checker: ^3.3.1
       ember-cli-htmlbars: ^6.1.1
       ember-cli-inject-live-reload: ^2.1.0
-      ember-cli-test-info: ^1.0.0
       ember-cli-test-loader: ^3.0.0
       ember-disable-prototype-extensions: ^1.1.3
       ember-export-application-global: ^2.0.1
@@ -1510,7 +1505,6 @@ importers:
       ember-cli-dependency-checker: 3.3.1_ember-cli@4.8.0
       ember-cli-htmlbars: 6.1.1
       ember-cli-inject-live-reload: 2.1.0
-      ember-cli-test-info: 1.0.0
       ember-cli-test-loader: 3.0.0
       ember-disable-prototype-extensions: 1.1.3
       ember-export-application-global: 2.0.1
@@ -8304,6 +8298,7 @@ packages:
     resolution: {integrity: sha512-dEVTIpmUfCzweC97NGf6p7L6XKBwV2GmSM4elmzKvkttEp5P7AvGA9uGyN4GqFq+RwhW+2b0I2qlX00w+skm+A==}
     dependencies:
       ember-cli-string-utils: 1.1.0
+    dev: false
 
   /ember-cli-test-loader/3.0.0:
     resolution: {integrity: sha512-wfFRBrfO9gaKScYcdQxTfklx9yp1lWK6zv1rZRpkas9z2SHyJojF7NOQRWQgSB3ypm7vfpiF8VsFFVVr7VBzAQ==}


### PR DESCRIPTION
just ensuring we don't ship a larger node_modules tree than necessary