### PR TITLE
feat: strip deprecations with macros

### DIFF
--- a/packages/model/addon/-private/belongs-to.js
+++ b/packages/model/addon/-private/belongs-to.js
@@ -13,8 +13,10 @@ import { lookupLegacySupport } from './model';
 import { computedMacroWithOptionalParams } from './util';
 
 function normalizeType(type) {
-  if (DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE && !type) {
-    return;
+  if (DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE) {
+    if (!type) {
+      return;
+    }
   }
 
   return dasherize(type);
@@ -127,60 +129,69 @@ function normalizeType(type) {
 function belongsTo(modelName, options) {
   let opts = options;
   let userEnteredModelName = modelName;
-  if (DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE && (typeof modelName !== 'string' || !modelName.length)) {
-    deprecate('belongsTo() must specify the string type of the related resource as the first parameter', false, {
-      id: 'ember-data:deprecate-non-strict-relationships',
-      for: 'ember-data',
-      until: '5.0',
-      since: { enabled: '4.7', available: '4.7' },
-    });
-
-    if (typeof modelName === 'object') {
-      opts = modelName;
-      userEnteredModelName = undefined;
-    } else {
-      opts = options;
-      userEnteredModelName = modelName;
-    }
-
-    assert(
-      'The first argument to belongsTo must be a string representing a model type key, not an instance of ' +
-        typeof userEnteredModelName +
-        ". E.g., to define a relation to the Person model, use belongsTo('person')",
-      typeof userEnteredModelName === 'string' || typeof userEnteredModelName === 'undefined'
-    );
-  }
-
-  if (DEPRECATE_RELATIONSHIPS_WITHOUT_ASYNC && (!opts || typeof opts.async !== 'boolean')) {
-    opts = opts || {};
-    if (!('async' in opts)) {
-      opts.async = true;
-    }
-    deprecate('belongsTo(<type>, <options>) must specify options.async as either `true` or `false`.', false, {
-      id: 'ember-data:deprecate-non-strict-relationships',
-      for: 'ember-data',
-      until: '5.0',
-      since: { enabled: '4.7', available: '4.7' },
-    });
-  } else {
-    assert(`Expected belongsTo options.async to be a boolean`, opts && typeof opts.async === 'boolean');
-  }
-
-  if (
-    DEPRECATE_RELATIONSHIPS_WITHOUT_INVERSE &&
-    opts.inverse !== null &&
-    (typeof opts.inverse !== 'string' || opts.inverse.length === 0)
-  ) {
-    deprecate(
-      'belongsTo(<type>, <options>) must specify options.inverse as either `null` or string type of the related resource.',
-      false,
-      {
+  if (DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE) {
+    if (typeof modelName !== 'string' || !modelName.length) {
+      deprecate('belongsTo() must specify the string type of the related resource as the first parameter', false, {
         id: 'ember-data:deprecate-non-strict-relationships',
         for: 'ember-data',
         until: '5.0',
         since: { enabled: '4.7', available: '4.7' },
+      });
+
+      if (typeof modelName === 'object') {
+        opts = modelName;
+        userEnteredModelName = undefined;
+      } else {
+        opts = options;
+        userEnteredModelName = modelName;
       }
-    );
+
+      assert(
+        'The first argument to belongsTo must be a string representing a model type key, not an instance of ' +
+          typeof userEnteredModelName +
+          ". E.g., to define a relation to the Person model, use belongsTo('person')",
+        typeof userEnteredModelName === 'string' || typeof userEnteredModelName === 'undefined'
+      );
+    }
+  }
+
+  if (DEPRECATE_RELATIONSHIPS_WITHOUT_ASYNC) {
+    if (!opts || typeof opts.async !== 'boolean') {
+      opts = opts || {};
+      if (!('async' in opts)) {
+        opts.async = true;
+      }
+      deprecate('belongsTo(<type>, <options>) must specify options.async as either `true` or `false`.', false, {
+        id: 'ember-data:deprecate-non-strict-relationships',
+        for: 'ember-data',
+        until: '5.0',
+        since: { enabled: '4.7', available: '4.7' },
+      });
+    } else {
+      assert(`Expected belongsTo options.async to be a boolean`, opts && typeof opts.async === 'boolean');
+    }
+  } else {
+    assert(`Expected belongsTo options.async to be a boolean`, opts && typeof opts.async === 'boolean');
+  }
+
+  if (DEPRECATE_RELATIONSHIPS_WITHOUT_INVERSE) {
+    if (opts.inverse !== null && (typeof opts.inverse !== 'string' || opts.inverse.length === 0)) {
+      deprecate(
+        'belongsTo(<type>, <options>) must specify options.inverse as either `null` or string type of the related resource.',
+        false,
+        {
+          id: 'ember-data:deprecate-non-strict-relationships',
+          for: 'ember-data',
+          until: '5.0',
+          since: { enabled: '4.7', available: '4.7' },
+        }
+      );
+    } else {
+      assert(
+        `Expected belongsTo options.inverse to be either null or the string type of the related resource.`,
+        opts.inverse === null || (typeof opts.inverse === 'string' && opts.inverse.length > 0)
+      );
+    }
   } else {
     assert(
       `Expected belongsTo options.inverse to be either null or the string type of the related resource.`,

--- a/packages/model/addon/-private/has-many.js
+++ b/packages/model/addon/-private/has-many.js
@@ -19,8 +19,10 @@ import { lookupLegacySupport } from './model';
 import { computedMacroWithOptionalParams } from './util';
 
 function normalizeType(type) {
-  if (DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE && !type) {
-    return;
+  if (DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE) {
+    if (!type) {
+      return;
+    }
   }
 
   return singularize(dasherize(type));
@@ -168,60 +170,64 @@ function normalizeType(type) {
   @return {Ember.computed} relationship
 */
 function hasMany(type, options) {
-  if (DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE && (typeof type !== 'string' || !type.length)) {
-    deprecate(
-      'hasMany(<type>, <options>) must specify the string type of the related resource as the first parameter',
-      false,
-      {
+  if (DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE) {
+    if (typeof type !== 'string' || !type.length) {
+      deprecate(
+        'hasMany(<type>, <options>) must specify the string type of the related resource as the first parameter',
+        false,
+        {
+          id: 'ember-data:deprecate-non-strict-relationships',
+          for: 'ember-data',
+          until: '5.0',
+          since: { enabled: '4.7', available: '4.7' },
+        }
+      );
+      if (typeof type === 'object') {
+        options = type;
+        type = undefined;
+      }
+
+      assert(
+        `The first argument to hasMany must be a string representing a model type key, not an instance of ${inspect(
+          type
+        )}. E.g., to define a relation to the Comment model, use hasMany('comment')`,
+        typeof type === 'string' || typeof type === 'undefined'
+      );
+    }
+  }
+
+  if (DEPRECATE_RELATIONSHIPS_WITHOUT_ASYNC) {
+    if (!options || typeof options.async !== 'boolean') {
+      options = options || {};
+      if (!('async' in options)) {
+        options.async = true;
+      }
+      deprecate('hasMany(<type>, <options>) must specify options.async as either `true` or `false`.', false, {
         id: 'ember-data:deprecate-non-strict-relationships',
         for: 'ember-data',
         until: '5.0',
         since: { enabled: '4.7', available: '4.7' },
-      }
-    );
-    if (typeof type === 'object') {
-      options = type;
-      type = undefined;
+      });
+    } else {
+      assert(`Expected hasMany options.async to be a boolean`, options && typeof options.async === 'boolean');
     }
-
-    assert(
-      `The first argument to hasMany must be a string representing a model type key, not an instance of ${inspect(
-        type
-      )}. E.g., to define a relation to the Comment model, use hasMany('comment')`,
-      typeof type === 'string' || typeof type === 'undefined'
-    );
-  }
-
-  if (DEPRECATE_RELATIONSHIPS_WITHOUT_ASYNC && (!options || typeof options.async !== 'boolean')) {
-    options = options || {};
-    if (!('async' in options)) {
-      options.async = true;
-    }
-    deprecate('hasMany(<type>, <options>) must specify options.async as either `true` or `false`.', false, {
-      id: 'ember-data:deprecate-non-strict-relationships',
-      for: 'ember-data',
-      until: '5.0',
-      since: { enabled: '4.7', available: '4.7' },
-    });
   } else {
     assert(`Expected hasMany options.async to be a boolean`, options && typeof options.async === 'boolean');
   }
 
-  if (
-    DEPRECATE_RELATIONSHIPS_WITHOUT_INVERSE &&
-    options.inverse !== null &&
-    (typeof options.inverse !== 'string' || options.inverse.length === 0)
-  ) {
-    deprecate(
-      'hasMany(<type>, <options>) must specify options.inverse as either `null` or string type of the related resource.',
-      false,
-      {
-        id: 'ember-data:deprecate-non-strict-relationships',
-        for: 'ember-data',
-        until: '5.0',
-        since: { enabled: '4.7', available: '4.7' },
-      }
-    );
+  if (DEPRECATE_RELATIONSHIPS_WITHOUT_INVERSE) {
+    if (options.inverse !== null && (typeof options.inverse !== 'string' || options.inverse.length === 0)) {
+      deprecate(
+        'hasMany(<type>, <options>) must specify options.inverse as either `null` or string type of the related resource.',
+        false,
+        {
+          id: 'ember-data:deprecate-non-strict-relationships',
+          for: 'ember-data',
+          until: '5.0',
+          since: { enabled: '4.7', available: '4.7' },
+        }
+      );
+    }
   }
 
   // Metadata about relationships is stored on the meta of

--- a/packages/model/addon/-private/legacy-data-fetch.js
+++ b/packages/model/addon/-private/legacy-data-fetch.js
@@ -244,9 +244,11 @@ function inverseForRelationship(store, identifier, key) {
     return null;
   }
 
-  if (DEPRECATE_RELATIONSHIPS_WITHOUT_INVERSE && metaIsRelationshipDefinition(definition)) {
-    const modelClass = store.modelFor(identifier.type);
-    return definition._inverseKey(store, modelClass);
+  if (DEPRECATE_RELATIONSHIPS_WITHOUT_INVERSE) {
+    if (metaIsRelationshipDefinition(definition)) {
+      const modelClass = store.modelFor(identifier.type);
+      return definition._inverseKey(store, modelClass);
+    }
   }
   assert(
     `Expected the relationship defintion to specify the inverse type or null.`,

--- a/packages/model/addon/-private/legacy-relationships-support.ts
+++ b/packages/model/addon/-private/legacy-relationships-support.ts
@@ -705,26 +705,28 @@ function extractIdentifierFromRecord(recordOrPromiseRecord: PromiseProxyRecord |
     return null;
   }
 
-  if (DEPRECATE_PROMISE_PROXIES && isPromiseRecord(recordOrPromiseRecord)) {
-    let content = recordOrPromiseRecord.content;
-    assert(
-      'You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo or hasMany relationship to the get call.',
-      content !== undefined
-    );
-    deprecate(
-      `You passed in a PromiseProxy to a Relationship API that now expects a resolved value. await the value before setting it.`,
-      false,
-      {
-        id: 'ember-data:deprecate-promise-proxies',
-        until: '5.0',
-        since: {
-          enabled: '4.7',
-          available: '4.7',
-        },
-        for: 'ember-data',
-      }
-    );
-    return content ? recordIdentifierFor(content) : null;
+  if (DEPRECATE_PROMISE_PROXIES) {
+    if (isPromiseRecord(recordOrPromiseRecord)) {
+      let content = recordOrPromiseRecord.content;
+      assert(
+        'You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo or hasMany relationship to the get call.',
+        content !== undefined
+      );
+      deprecate(
+        `You passed in a PromiseProxy to a Relationship API that now expects a resolved value. await the value before setting it.`,
+        false,
+        {
+          id: 'ember-data:deprecate-promise-proxies',
+          until: '5.0',
+          since: {
+            enabled: '4.7',
+            available: '4.7',
+          },
+          for: 'ember-data',
+        }
+      );
+      return content ? recordIdentifierFor(content) : null;
+    }
   }
 
   return recordIdentifierFor(recordOrPromiseRecord);

--- a/packages/model/addon/-private/many-array.ts
+++ b/packages/model/addon/-private/many-array.ts
@@ -367,27 +367,29 @@ function extractIdentifiersFromRecords(records: RecordInstance[]): StableRecordI
 }
 
 function extractIdentifierFromRecord(recordOrPromiseRecord: PromiseProxyRecord | RecordInstance) {
-  if (DEPRECATE_PROMISE_PROXIES && isPromiseRecord(recordOrPromiseRecord)) {
-    let content = recordOrPromiseRecord.content;
-    assert(
-      'You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo relationship.',
-      content !== undefined && content !== null
-    );
-    deprecate(
-      `You passed in a PromiseProxy to a Relationship API that now expects a resolved value. await the value before setting it.`,
-      false,
-      {
-        id: 'ember-data:deprecate-promise-proxies',
-        until: '5.0',
-        since: {
-          enabled: '4.7',
-          available: '4.7',
-        },
-        for: 'ember-data',
-      }
-    );
-    assertRecordPassedToHasMany(content);
-    return recordIdentifierFor(content);
+  if (DEPRECATE_PROMISE_PROXIES) {
+    if (isPromiseRecord(recordOrPromiseRecord)) {
+      let content = recordOrPromiseRecord.content;
+      assert(
+        'You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo relationship.',
+        content !== undefined && content !== null
+      );
+      deprecate(
+        `You passed in a PromiseProxy to a Relationship API that now expects a resolved value. await the value before setting it.`,
+        false,
+        {
+          id: 'ember-data:deprecate-promise-proxies',
+          until: '5.0',
+          since: {
+            enabled: '4.7',
+            available: '4.7',
+          },
+          for: 'ember-data',
+        }
+      );
+      assertRecordPassedToHasMany(content);
+      return recordIdentifierFor(content);
+    }
   }
 
   assertRecordPassedToHasMany(recordOrPromiseRecord);

--- a/packages/model/addon/-private/references/belongs-to.ts
+++ b/packages/model/addon/-private/references/belongs-to.ts
@@ -395,22 +395,24 @@ export default class BelongsToReference {
    */
   async push(data: SingleResourceDocument | Promise<SingleResourceDocument>): Promise<RecordInstance> {
     let jsonApiDoc: SingleResourceDocument = data as SingleResourceDocument;
-    if (DEPRECATE_PROMISE_PROXIES && (data as { then: unknown }).then) {
-      jsonApiDoc = await resolve(data);
-      if (jsonApiDoc !== data) {
-        deprecate(
-          `You passed in a Promise to a Reference API that now expects a resolved value. await the value before setting it.`,
-          false,
-          {
-            id: 'ember-data:deprecate-promise-proxies',
-            until: '5.0',
-            since: {
-              enabled: '4.7',
-              available: '4.7',
-            },
-            for: 'ember-data',
-          }
-        );
+    if (DEPRECATE_PROMISE_PROXIES) {
+      if ((data as { then: unknown }).then) {
+        jsonApiDoc = await resolve(data);
+        if (jsonApiDoc !== data) {
+          deprecate(
+            `You passed in a Promise to a Reference API that now expects a resolved value. await the value before setting it.`,
+            false,
+            {
+              id: 'ember-data:deprecate-promise-proxies',
+              until: '5.0',
+              since: {
+                enabled: '4.7',
+                available: '4.7',
+              },
+              for: 'ember-data',
+            }
+          );
+        }
       }
     }
     let record = this.store.push(jsonApiDoc);

--- a/packages/model/addon/-private/references/has-many.ts
+++ b/packages/model/addon/-private/references/has-many.ts
@@ -406,22 +406,24 @@ export default class HasManyReference {
     objectOrPromise: ExistingResourceObject[] | CollectionResourceDocument | { data: SingleResourceDocument[] }
   ): Promise<ManyArray> {
     let payload = objectOrPromise;
-    if (DEPRECATE_PROMISE_PROXIES && (objectOrPromise as unknown as { then: unknown }).then) {
-      payload = await resolve(objectOrPromise);
-      if (payload !== objectOrPromise) {
-        deprecate(
-          `You passed in a Promise to a Reference API that now expects a resolved value. await the value before setting it.`,
-          false,
-          {
-            id: 'ember-data:deprecate-promise-proxies',
-            until: '5.0',
-            since: {
-              enabled: '4.7',
-              available: '4.7',
-            },
-            for: 'ember-data',
-          }
-        );
+    if (DEPRECATE_PROMISE_PROXIES) {
+      if ((objectOrPromise as unknown as { then: unknown }).then) {
+        payload = await resolve(objectOrPromise);
+        if (payload !== objectOrPromise) {
+          deprecate(
+            `You passed in a Promise to a Reference API that now expects a resolved value. await the value before setting it.`,
+            false,
+            {
+              id: 'ember-data:deprecate-promise-proxies',
+              until: '5.0',
+              since: {
+                enabled: '4.7',
+                available: '4.7',
+              },
+              for: 'ember-data',
+            }
+          );
+        }
       }
     }
     let array: Array<ExistingResourceObject | SingleResourceDocument>;

--- a/packages/private-build-infra/src/addon-build-config-for-data-package.js
+++ b/packages/private-build-infra/src/addon-build-config-for-data-package.js
@@ -273,8 +273,18 @@ function addonBuildConfigForDataPackage(PackageName) {
         options.emberData.debug
       );
       options.emberData.debug = debugOptions;
+      const DEPRECATIONS = require('./deprecations')(options.emberData.compatWith || null);
+      options.emberData.__DEPRECATIONS = DEPRECATIONS;
 
-      return Object.assign({ compatWith: null }, options.emberData);
+      // copy configs forward
+      const ownConfig = this.options['@embroider/macros'].setOwnConfig;
+      ownConfig.compatWith = options.emberData.compatWith || null;
+      ownConfig.debug = debugOptions;
+      ownConfig.deprecations = Object.assign(DEPRECATIONS, ownConfig.deprecations || {});
+
+      const returnedOptions = Object.assign({ compatWith: null }, options.emberData);
+
+      return returnedOptions;
     },
   };
 }

--- a/packages/private-build-infra/src/debug-macros.js
+++ b/packages/private-build-infra/src/debug-macros.js
@@ -6,13 +6,12 @@ module.exports = function debugMacros(app, isProd, config) {
   const PACKAGES = require('./packages')(app);
   const FEATURES = require('./features')(isProd);
   const DEBUG = require('./debugging')(config.debug, isProd);
-  const DEPRECATIONS = require('./deprecations')(config.compatWith, isProd);
   const debugMacrosPath = require.resolve('babel-plugin-debug-macros');
-  const ConvertExistenceChecksToMacros = require.resolve(
-    './transforms/babel-plugin-convert-existence-checks-to-macros'
-  );
+  const TransformPackagePresence = require.resolve('./transforms/babel-plugin-convert-existence-checks-to-macros');
+  const TransformDeprecations = require.resolve('./transforms/babel-plugin-transform-deprecations');
 
   const ALL_PACKAGES = requireModule('@ember-data/private-build-infra/addon/available-packages.ts');
+  const DEPRECATIONS = requireModule('@ember-data/private-build-infra/addon/current-deprecations.ts');
   const MACRO_PACKAGE_FLAGS = Object.assign({}, ALL_PACKAGES.default);
   delete MACRO_PACKAGE_FLAGS['HAS_DEBUG_PACKAGE'];
 
@@ -34,21 +33,17 @@ module.exports = function debugMacros(app, isProd, config) {
       '@ember-data/canary-features-stripping',
     ],
     [
-      ConvertExistenceChecksToMacros,
+      TransformPackagePresence,
       {
         source: '@ember-data/private-build-infra',
         flags: MACRO_PACKAGE_FLAGS,
       },
     ],
     [
-      debugMacrosPath,
+      TransformDeprecations,
       {
-        flags: [
-          {
-            source: '@ember-data/private-build-infra/deprecations',
-            flags: DEPRECATIONS,
-          },
-        ],
+        source: '@ember-data/private-build-infra/deprecations',
+        flags: Object.assign({}, DEPRECATIONS.default),
       },
       '@ember-data/deprecation-stripping',
     ],

--- a/packages/private-build-infra/src/deprecations.js
+++ b/packages/private-build-infra/src/deprecations.js
@@ -8,7 +8,7 @@ function deprecationIsResolved(deprecatedSince, compatVersion) {
   return semver.lte(semver.minVersion(deprecatedSince), semver.minVersion(compatVersion));
 }
 
-function getDeprecations(compatVersion, isProd) {
+function getDeprecations(compatVersion) {
   const { default: CURRENT_DEPRECATIONS } = requireModule(
     '@ember-data/private-build-infra/addon/current-deprecations.ts'
   );
@@ -21,19 +21,16 @@ function getDeprecations(compatVersion, isProd) {
     // if we are told we are compatible with a version
     // we check if we can strip this flag
     if (compatVersion) {
-      // in DEBUG we never strip
-      if (isProd) {
-        const isResolved = deprecationIsResolved(deprecatedSince, compatVersion);
-        // if we've resolved, we strip (by setting the flag to false)
-        /*
-          if (DEPRECATED_FEATURE) {
-            // deprecated code path
-          } else {
-            // if needed a non-deprecated code path
-          }
-        */
-        flagState = !isResolved;
-      }
+      const isResolved = deprecationIsResolved(deprecatedSince, compatVersion);
+      // if we've resolved, we strip (by setting the flag to false)
+      /*
+        if (DEPRECATED_FEATURE) {
+          // deprecated code path
+        } else {
+          // if needed a non-deprecated code path
+        }
+      */
+      flagState = !isResolved;
     }
 
     // console.log(`${flag}=${flagState} (${deprecatedSince} <= ${compatVersion})`);

--- a/packages/private-build-infra/src/transforms/babel-plugin-convert-existence-checks-to-macros/index.js
+++ b/packages/private-build-infra/src/transforms/babel-plugin-convert-existence-checks-to-macros/index.js
@@ -4,7 +4,7 @@ module.exports = function (babel) {
   const { types: t } = babel;
 
   return {
-    name: 'ast-transform', // not required
+    name: 'existence-checks',
     visitor: {
       ImportDeclaration(path, state) {
         const replacements = state.opts.flags;

--- a/packages/private-build-infra/src/transforms/babel-plugin-transform-deprecations/index.js
+++ b/packages/private-build-infra/src/transforms/babel-plugin-transform-deprecations/index.js
@@ -1,0 +1,65 @@
+const { ImportUtil } = require('babel-import-util');
+
+function parentIsUnary(node) {
+  if (node.parent.type === 'UnaryExpression' && node.parent.operator === '!') {
+    return true;
+  }
+  return false;
+}
+
+module.exports = function (babel) {
+  const { types: t } = babel;
+
+  return {
+    name: 'deprecation-flags',
+    visitor: {
+      ImportDeclaration(path, state) {
+        const replacements = state.opts.flags;
+        const importPath = path.node.source.value;
+
+        if (importPath === state.opts.source) {
+          const specifiers = path.get('specifiers');
+          specifiers.forEach((specifier) => {
+            let name = specifier.node.imported.name;
+            if (replacements[name]) {
+              let localBindingName = specifier.node.local.name;
+              let binding = specifier.scope.getBinding(localBindingName);
+              binding.referencePaths.forEach((p, other) => {
+                let negateStatement = false;
+                let node = p;
+                if (parentIsUnary(p)) {
+                  negateStatement = true;
+                  node = p.parentPath;
+                }
+                let getConfig = t.memberExpression(
+                  t.memberExpression(
+                    t.callExpression(state.importer.import(p, '@embroider/macros', 'getOwnConfig'), []),
+                    t.identifier('deprecations')
+                  ),
+                  t.identifier(localBindingName)
+                );
+                node.replaceWith(
+                  // if (DEPRECATE_FOO)
+                  // =>
+                  // if (macroCondition(getOwnConfig().deprecations.DEPRECATE_FOO))
+                  t.callExpression(state.importer.import(p, '@embroider/macros', 'macroCondition'), [
+                    negateStatement ? t.unaryExpression('!', getConfig) : getConfig,
+                  ])
+                );
+              });
+              specifier.scope.removeOwnBinding(localBindingName);
+              specifier.remove();
+            }
+          });
+        }
+        if (path.get('specifiers').length === 0) {
+          path.remove();
+        }
+      },
+
+      Program(path, state) {
+        state.importer = new ImportUtil(t, path);
+      },
+    },
+  };
+};

--- a/packages/private-build-infra/src/transforms/babel-plugins-transform-features/index.js
+++ b/packages/private-build-infra/src/transforms/babel-plugins-transform-features/index.js
@@ -1,0 +1,44 @@
+const { ImportUtil } = require('babel-import-util');
+
+module.exports = function (babel) {
+  const { types: t } = babel;
+
+  return {
+    name: 'existence-checks',
+    visitor: {
+      ImportDeclaration(path, state) {
+        const replacements = state.opts.flags;
+        const importPath = path.node.source.value;
+
+        if (importPath === state.opts.source) {
+          const specifiers = path.get('specifiers');
+          specifiers.forEach((specifier) => {
+            let name = specifier.node.imported.name;
+            if (replacements[name]) {
+              let localBindingName = specifier.node.local.name;
+              let binding = specifier.scope.getBinding(localBindingName);
+              binding.referencePaths.forEach((p) => {
+                p.replaceWith(
+                  // t.callExpression(state.importer.import(p, '@embroider/macros', 'macroCondition'), [
+                  t.callExpression(state.importer.import(p, '@embroider/macros', 'moduleExists'), [
+                    t.stringLiteral(replacements[name]),
+                  ])
+                  // ])
+                );
+              });
+              specifier.scope.removeOwnBinding(localBindingName);
+              specifier.remove();
+            }
+          });
+        }
+        if (path.get('specifiers').length === 0) {
+          path.remove();
+        }
+      },
+
+      Program(path, state) {
+        state.importer = new ImportUtil(t, path);
+      },
+    },
+  };
+};

--- a/packages/record-data/addon/-private/graph/-edge-definition.ts
+++ b/packages/record-data/addon/-private/graph/-edge-definition.ts
@@ -334,9 +334,11 @@ function inverseForRelationship(store: Store, identifier: StableRecordIdentifier
     return null;
   }
 
-  if (DEPRECATE_RELATIONSHIPS_WITHOUT_INVERSE && metaIsRelationshipDefinition(definition)) {
-    const modelClass = store.modelFor(identifier.type);
-    return definition._inverseKey(store, modelClass);
+  if (DEPRECATE_RELATIONSHIPS_WITHOUT_INVERSE) {
+    if (metaIsRelationshipDefinition(definition)) {
+      const modelClass = store.modelFor(identifier.type);
+      return definition._inverseKey(store, modelClass);
+    }
   }
 
   assert(

--- a/packages/store/addon/-debug/index.js
+++ b/packages/store/addon/-debug/index.js
@@ -49,19 +49,21 @@ if (DEBUG) {
       }
     }
 
-    if (DEPRECATE_NON_EXPLICIT_POLYMORPHISM && !asserted) {
-      store = store._store ? store._store : store; // allow usage with storeWrapper
-      let addedModelName = addedIdentifier.type;
-      let parentModelName = parentIdentifier.type;
-      let key = parentDefinition.key;
-      let relationshipModelName = parentDefinition.type;
-      let relationshipClass = store.modelFor(relationshipModelName);
-      let addedClass = store.modelFor(addedModelName);
+    if (DEPRECATE_NON_EXPLICIT_POLYMORPHISM) {
+      if (!asserted) {
+        store = store._store ? store._store : store; // allow usage with storeWrapper
+        let addedModelName = addedIdentifier.type;
+        let parentModelName = parentIdentifier.type;
+        let key = parentDefinition.key;
+        let relationshipModelName = parentDefinition.type;
+        let relationshipClass = store.modelFor(relationshipModelName);
+        let addedClass = store.modelFor(addedModelName);
 
-      let assertionMessage = `The '${addedModelName}' type does not implement '${relationshipModelName}' and thus cannot be assigned to the '${key}' relationship in '${parentModelName}'. Make it a descendant of '${relationshipModelName}' or use a mixin of the same name.`;
-      let isPolymorphic = checkPolymorphic(relationshipClass, addedClass);
+        let assertionMessage = `The '${addedModelName}' type does not implement '${relationshipModelName}' and thus cannot be assigned to the '${key}' relationship in '${parentModelName}'. Make it a descendant of '${relationshipModelName}' or use a mixin of the same name.`;
+        let isPolymorphic = checkPolymorphic(relationshipClass, addedClass);
 
-      assert(assertionMessage, isPolymorphic);
+        assert(assertionMessage, isPolymorphic);
+      }
     }
   };
 }

--- a/packages/store/addon/-private/legacy-model-support/schema-definition-service.ts
+++ b/packages/store/addon/-private/legacy-model-support/schema-definition-service.ts
@@ -39,18 +39,22 @@ export class DSModelSchemaDefinitionService {
   // Following the existing RD implementation
   attributesDefinitionFor(identifier: RecordIdentifier | { type: string }): AttributesSchema {
     let modelName, attributes;
-    if (DEPRECATE_STRING_ARG_SCHEMAS && typeof identifier === 'string') {
-      deprecate(
-        `attributesDefinitionFor expects either a record identifier or an argument of shape { type: string }, received a string.`,
-        false,
-        {
-          id: 'ember-data:deprecate-string-arg-schemas',
-          for: 'ember-data',
-          until: '5.0',
-          since: { enabled: '4.5', available: '4.5' },
-        }
-      );
-      modelName = identifier;
+    if (DEPRECATE_STRING_ARG_SCHEMAS) {
+      if (typeof identifier === 'string') {
+        deprecate(
+          `attributesDefinitionFor expects either a record identifier or an argument of shape { type: string }, received a string.`,
+          false,
+          {
+            id: 'ember-data:deprecate-string-arg-schemas',
+            for: 'ember-data',
+            until: '5.0',
+            since: { enabled: '4.5', available: '4.5' },
+          }
+        );
+        modelName = identifier;
+      } else {
+        modelName = identifier.type;
+      }
     } else {
       modelName = identifier.type;
     }
@@ -72,18 +76,22 @@ export class DSModelSchemaDefinitionService {
   // Following the existing RD implementation
   relationshipsDefinitionFor(identifier: RecordIdentifier | { type: string }): RelationshipsSchema {
     let modelName, relationships;
-    if (DEPRECATE_STRING_ARG_SCHEMAS && typeof identifier === 'string') {
-      deprecate(
-        `relationshipsDefinitionFor expects either a record identifier or an argument of shape { type: string }, received a string.`,
-        false,
-        {
-          id: 'ember-data:deprecate-string-arg-schemas',
-          for: 'ember-data',
-          until: '5.0',
-          since: { enabled: '4.5', available: '4.5' },
-        }
-      );
-      modelName = identifier;
+    if (DEPRECATE_STRING_ARG_SCHEMAS) {
+      if (typeof identifier === 'string') {
+        deprecate(
+          `relationshipsDefinitionFor expects either a record identifier or an argument of shape { type: string }, received a string.`,
+          false,
+          {
+            id: 'ember-data:deprecate-string-arg-schemas',
+            for: 'ember-data',
+            until: '5.0',
+            since: { enabled: '4.5', available: '4.5' },
+          }
+        );
+        modelName = identifier;
+      } else {
+        modelName = identifier.type;
+      }
     } else {
       modelName = identifier.type;
     }

--- a/packages/store/addon/-private/managers/record-data-store-wrapper.ts
+++ b/packages/store/addon/-private/managers/record-data-store-wrapper.ts
@@ -297,19 +297,23 @@ class LegacyWrapper implements LegacyRecordDataStoreWrapper {
   disconnectRecord(type: StableRecordIdentifier): void;
   disconnectRecord(type: string | StableRecordIdentifier, id?: string | null, lid?: string | null): void {
     let identifier: StableRecordIdentifier;
-    if (DEPRECATE_V1CACHE_STORE_APIS && typeof type === 'string') {
-      deprecate(
-        `StoreWrapper.disconnectRecord(<type>) has been deprecated in favor of StoreWrapper.disconnectRecord(<identifier>)`,
-        false,
-        {
-          id: 'ember-data:deprecate-v1cache-store-apis',
-          for: 'ember-data',
-          until: '5.0',
-          since: { enabled: '4.7', available: '4.7' },
-        }
-      );
-      let resource = constructResource(type, id, lid) as RecordIdentifier;
-      identifier = this.identifierCache.peekRecordIdentifier(resource)!;
+    if (DEPRECATE_V1CACHE_STORE_APIS) {
+      if (typeof type === 'string') {
+        deprecate(
+          `StoreWrapper.disconnectRecord(<type>) has been deprecated in favor of StoreWrapper.disconnectRecord(<identifier>)`,
+          false,
+          {
+            id: 'ember-data:deprecate-v1cache-store-apis',
+            for: 'ember-data',
+            until: '5.0',
+            since: { enabled: '4.7', available: '4.7' },
+          }
+        );
+        let resource = constructResource(type, id, lid) as RecordIdentifier;
+        identifier = this.identifierCache.peekRecordIdentifier(resource)!;
+      } else {
+        identifier = type as StableRecordIdentifier;
+      }
     } else {
       identifier = type as StableRecordIdentifier;
     }

--- a/packages/store/addon/-private/store-service.ts
+++ b/packages/store/addon/-private/store-service.ts
@@ -73,6 +73,7 @@ import promiseRecord from './utils/promise-record';
 
 export { storeFor };
 
+// hello world
 type RecordDataConstruct = typeof RecordDataClass;
 let _RecordData: RecordDataConstruct | undefined;
 
@@ -2404,23 +2405,25 @@ class Store extends Service {
         ).RecordData;
       }
 
-      if (DEPRECATE_V1CACHE_STORE_APIS && arguments.length === 4) {
-        deprecate(
-          `Store.createRecordDataFor(<type>, <id>, <lid>, <storeWrapper>) has been deprecated in favor of Store.createRecordDataFor(<identifier>, <storeWrapper>)`,
-          false,
-          {
-            id: 'ember-data:deprecate-v1cache-store-apis',
-            for: 'ember-data',
-            until: '5.0',
-            since: { enabled: '4.7', available: '4.7' },
-          }
-        );
-        identifier = this.identifierCache.getOrCreateRecordIdentifier({
-          type: arguments[0],
-          id: arguments[1],
-          lid: arguments[2],
-        });
-        storeWrapper = arguments[3];
+      if (DEPRECATE_V1CACHE_STORE_APIS) {
+        if (arguments.length === 4) {
+          deprecate(
+            `Store.createRecordDataFor(<type>, <id>, <lid>, <storeWrapper>) has been deprecated in favor of Store.createRecordDataFor(<identifier>, <storeWrapper>)`,
+            false,
+            {
+              id: 'ember-data:deprecate-v1cache-store-apis',
+              for: 'ember-data',
+              until: '5.0',
+              since: { enabled: '4.7', available: '4.7' },
+            }
+          );
+          identifier = this.identifierCache.getOrCreateRecordIdentifier({
+            type: arguments[0],
+            id: arguments[1],
+            lid: arguments[2],
+          });
+          storeWrapper = arguments[3];
+        }
       }
 
       this.__private_singleton_recordData = this.__private_singleton_recordData || new _RecordData(storeWrapper);
@@ -2850,26 +2853,28 @@ function extractIdentifierFromRecord(
   }
   const extract = isForV1 ? recordDataFor : recordIdentifierFor;
 
-  if (DEPRECATE_PROMISE_PROXIES && isPromiseRecord(recordOrPromiseRecord)) {
-    let content = recordOrPromiseRecord.content;
-    assert(
-      'You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo or hasMany relationship to the get call.',
-      content !== undefined
-    );
-    deprecate(
-      `You passed in a PromiseProxy to a Relationship API that now expects a resolved value. await the value before setting it.`,
-      false,
-      {
-        id: 'ember-data:deprecate-promise-proxies',
-        until: '5.0',
-        since: {
-          enabled: '4.7',
-          available: '4.7',
-        },
-        for: 'ember-data',
-      }
-    );
-    return content ? extract(content) : null;
+  if (DEPRECATE_PROMISE_PROXIES) {
+    if (isPromiseRecord(recordOrPromiseRecord)) {
+      let content = recordOrPromiseRecord.content;
+      assert(
+        'You passed in a promise that did not originate from an EmberData relationship. You can only pass promises that come from a belongsTo or hasMany relationship to the get call.',
+        content !== undefined
+      );
+      deprecate(
+        `You passed in a PromiseProxy to a Relationship API that now expects a resolved value. await the value before setting it.`,
+        false,
+        {
+          id: 'ember-data:deprecate-promise-proxies',
+          until: '5.0',
+          since: {
+            enabled: '4.7',
+            available: '4.7',
+          },
+          for: 'ember-data',
+        }
+      );
+      return content ? extract(content) : null;
+    }
   }
 
   return extract(recordOrPromiseRecord);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1130,7 +1130,6 @@ importers:
       ember-cli-dependency-checker: ^3.3.1
       ember-cli-htmlbars: ^6.1.1
       ember-cli-inject-live-reload: ^2.1.0
-      ember-cli-sri: ^2.1.1
       ember-cli-terser: ~4.0.2
       ember-cli-test-loader: ^3.0.0
       ember-compatibility-helpers: ^1.2.6
@@ -1196,7 +1195,6 @@ importers:
       ember-cli-dependency-checker: 3.3.1_ember-cli@4.8.0
       ember-cli-htmlbars: 6.1.1
       ember-cli-inject-live-reload: 2.1.0
-      ember-cli-sri: 2.1.1
       ember-cli-terser: 4.0.2
       ember-cli-test-loader: 3.0.0
       ember-compatibility-helpers: 1.2.6_@babel+core@7.19.6

--- a/tests/main/ember-cli-build.js
+++ b/tests/main/ember-cli-build.js
@@ -50,6 +50,7 @@ module.exports = function (defaults) {
       LOG_GRAPH: process.env.DEBUG_DATA ? true : false,
       LOG_INSTANCE_CACHE: process.env.DEBUG_DATA ? true : false,
     },
+    deprecations: require('@ember-data/private-build-infra/src/deprecations')(compatWith || null),
   };
   let app = new EmberApp(defaults, {
     emberData: config,
@@ -70,6 +71,7 @@ module.exports = function (defaults) {
           polyfillUUID: true,
         },
       },
+      setOwnConfig: config,
     },
     sourcemaps: {
       enabled: false,

--- a/tests/main/package.json
+++ b/tests/main/package.json
@@ -76,7 +76,6 @@
     "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-inject-live-reload": "^2.1.0",
-    "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "~4.0.2",
     "ember-cli-test-loader": "^3.0.0",
     "ember-cached-decorator-polyfill": "^1.0.1",


### PR DESCRIPTION
seems to be working locally; however, output feels weird. Suspect `@embroider/macros` has a bug we need to address for `getOwnConfig` wherein it hard codes the config path from system root, which is obviously unpublishable but fine so long as we continue to publish v1 addons