### PR TITLE
assert missing crypto.randomUUID

### DIFF
--- a/packages/store/addon/-private/caches/identifier-cache.ts
+++ b/packages/store/addon/-private/caches/identifier-cache.ts
@@ -41,6 +41,10 @@ if (macroCondition(getOwnConfig<{ polyfillUUID: boolean }>().polyfillUUID)) {
 }
 
 function uuidv4(): string {
+  assert(
+    'crypto.randomUUID needs to be avaliable. Some browsers incorrectly disallow it in insecure contexts. You maybe want to enable the polyfill: https://github.com/emberjs/data#randomuuid-polyfill',
+    _crypto.randomUUID
+  );
   return _crypto.randomUUID();
 }
 


### PR DESCRIPTION
## Description

Add a little assert message when crypto.randomUUID does not exist

Sidenote: I was not able to test this, since I wasnt able to boot an app with the linked ember-data. :(


