### PR TITLE
fix: <Cache>.changedAttrs should be empty if no local mutations exist

### DIFF
--- a/packages/record-data/addon/-private/record-data.ts
+++ b/packages/record-data/addon/-private/record-data.ts
@@ -599,6 +599,7 @@ function setupRelationships(
 function patchLocalAttributes(cached: CachedResource): boolean {
   const { localAttrs, remoteAttrs, inflightAttrs, changes } = cached;
   if (!localAttrs) {
+    cached.changes = null;
     return false;
   }
   let hasAppliedPatch = false;

--- a/tests/main/tests/unit/model-test.js
+++ b/tests/main/tests/unit/model-test.js
@@ -1217,43 +1217,45 @@ module('unit/model - Model', function (hooks) {
       await cat.save();
     });
 
-    test('changedAttributes() reset after save', async function(assert) {
-      adapter.updateRecord = function(store, type, snapshot) {
+    test('changedAttributes() reset after save', async function (assert) {
+      adapter.updateRecord = function (store, type, snapshot) {
         return resolve({
           data: {
             id: '1',
             type: 'person',
             attributes: {
-              name: snapshot.attr('name')
-            }
-          }
+              name: snapshot.attr('name'),
+            },
+          },
         });
-      }
+      };
 
-      const originalName = 'the original name'
-      const newName = 'a new name'
+      const originalName = 'the original name';
+      const newName = 'a new name';
 
       store.push({
         data: {
           type: 'person',
           id: '1',
           attributes: {
-            name: originalName
-          }
+            name: originalName,
+          },
         },
       });
 
       let person = await store.findRecord('person', '1');
       person.set('name', newName);
 
-      assert.deepEqual(person.changedAttributes().name, [originalName, newName],
-        'changedAttributes() reports old/new values before save');
+      assert.deepEqual(
+        person.changedAttributes().name,
+        [originalName, newName],
+        'changedAttributes() reports old/new values before save'
+      );
 
-      await person.save()
+      await person.save();
 
-      assert.deepEqual(person.changedAttributes(), {},
-        'changedAttributes() reset after save')
-    })
+      assert.deepEqual(person.changedAttributes(), {}, 'changedAttributes() reset after save');
+    });
 
     if (gte('3.10.0')) {
       test('@attr decorator works without parens', async function (assert) {

--- a/tests/main/tests/unit/model-test.js
+++ b/tests/main/tests/unit/model-test.js
@@ -1233,7 +1233,7 @@ module('unit/model - Model', function (hooks) {
       const originalName = 'the original name';
       const newName = 'a new name';
 
-      store.push({
+      const person = store.push({
         data: {
           type: 'person',
           id: '1',
@@ -1243,8 +1243,7 @@ module('unit/model - Model', function (hooks) {
         },
       });
 
-      let person = await store.findRecord('person', '1');
-      person.set('name', newName);
+      person.name = newName;
 
       assert.deepEqual(
         person.changedAttributes().name,
@@ -1254,7 +1253,8 @@ module('unit/model - Model', function (hooks) {
 
       await person.save();
 
-      assert.deepEqual(person.changedAttributes(), {}, 'changedAttributes() reset after save');
+      const changes = person.changedAttributes();
+      assert.deepEqual(changes, {}, 'changedAttributes() reset after save');
     });
 
     if (gte('3.10.0')) {

--- a/tests/main/tests/unit/model-test.js
+++ b/tests/main/tests/unit/model-test.js
@@ -1217,6 +1217,44 @@ module('unit/model - Model', function (hooks) {
       await cat.save();
     });
 
+    test('changedAttributes() reset after save', async function(assert) {
+      adapter.updateRecord = function(store, type, snapshot) {
+        return resolve({
+          data: {
+            id: '1',
+            type: 'person',
+            attributes: {
+              name: snapshot.attr('name')
+            }
+          }
+        });
+      }
+
+      const originalName = 'the original name'
+      const newName = 'a new name'
+
+      store.push({
+        data: {
+          type: 'person',
+          id: '1',
+          attributes: {
+            name: originalName
+          }
+        },
+      });
+
+      let person = await store.findRecord('person', '1');
+      person.set('name', newName);
+
+      assert.deepEqual(person.changedAttributes().name, [originalName, newName],
+        'changedAttributes() reports old/new values before save');
+
+      await person.save()
+
+      assert.deepEqual(person.changedAttributes(), {},
+        'changedAttributes() reset after save')
+    })
+
     if (gte('3.10.0')) {
       test('@attr decorator works without parens', async function (assert) {
         assert.expect(1);


### PR DESCRIPTION
resolves #8329