### PR TITLE
fix: dont notify RecordArrayManager if deletion already accounted

### DIFF
--- a/packages/store/addon/-private/caches/instance-cache.ts
+++ b/packages/store/addon/-private/caches/instance-cache.ts
@@ -423,16 +423,21 @@ export class InstanceCache {
         }
       }
 
+      let removeFromRecordArray = true;
       if (recordData) {
+        removeFromRecordArray = !recordData.isDeletionCommitted(identifier);
         recordData.unloadRecord(identifier);
         this.__instances.recordData.delete(identifier);
         removeRecordDataFor(identifier);
       } else {
+        removeFromRecordArray = false;
         this.disconnect(identifier);
       }
 
       this.store._fetchManager.clearEntries(identifier);
-      this.store.recordArrayManager.identifierRemoved(identifier);
+      if (removeFromRecordArray) {
+        this.store.recordArrayManager.identifierRemoved(identifier);
+      }
       if (LOG_INSTANCE_CACHE) {
         // eslint-disable-next-line no-console
         console.log(`InstanceCache: unloaded RecordData for ${String(identifier)}`);

--- a/packages/store/addon/-private/managers/record-array-manager.ts
+++ b/packages/store/addon/-private/managers/record-array-manager.ts
@@ -357,7 +357,10 @@ function sync(array: IdentifierArray, changes: Map<StableRecordIdentifier, 'add'
       // state = array[SOURCE] = [];
     } else {
       removes.forEach((i) => {
-        state.splice(state.indexOf(i), 1);
+        const index = state.indexOf(i);
+        if (index !== -1) {
+          state.splice(index, 1);
+        }
       });
     }
   }

--- a/tests/main/tests/integration/record-array-test.js
+++ b/tests/main/tests/integration/record-array-test.js
@@ -206,9 +206,8 @@ module('unit/record-array - RecordArray', function (hooks) {
 
     assert.strictEqual(recordArray.length, 0, 'initial length 0');
 
-    const rey = store.createRecord('person', { name: 'Rey' });
-
-    const [one, two, three] = store.push({
+    // eslint-disable-next-line no-unused-vars
+    const [_one, _two, three] = store.push({
       data: [
         { type: 'person', id: '1', attributes: { name: 'Chris' } },
         { type: 'person', id: '2', attributes: { name: 'Ross' } },
@@ -216,16 +215,16 @@ module('unit/record-array - RecordArray', function (hooks) {
       ],
     });
 
-    assert.strictEqual(recordArray.length, 4, 'populated length 4');
+    assert.strictEqual(recordArray.length, 3, 'populated length 3');
 
     three.deleteRecord();
-    assert.strictEqual(recordArray.length, 4, 'populated length 4');
+    assert.strictEqual(recordArray.length, 3, 'populated length 3');
     await three.save();
-    assert.strictEqual(recordArray.length, 3, 'after save persisted length 3');
+    assert.strictEqual(recordArray.length, 2, 'after save persisted length 2');
     three.unloadRecord();
     await settled();
 
-    assert.strictEqual(recordArray.length, 3, 'updated length 3');
+    assert.strictEqual(recordArray.length, 2, 'updated length 2');
   });
 
   test("a loaded record is not removed from a relationship ManyArray when it is deleted even if the belongsTo side isn't defined", async function (assert) {


### PR DESCRIPTION
also defends against cache duplicate notifications for removals since user-land API calls could otherwise similarly trigger this.

resolves #8327 