### PR TITLE
fix: give more meaningful error if id matches but is number instead of string

### DIFF
--- a/packages/record-data/addon/-private/record-data.ts
+++ b/packages/record-data/addon/-private/record-data.ts
@@ -285,6 +285,10 @@ export default class SingletonRecordData implements RecordData {
     if (data) {
       if (data.id) {
         // didCommit provided an ID, notify the store of it
+        assert(
+          `Expected resource id to be a string, got a value of type ${typeof data.id}`,
+          typeof data.id === 'string'
+        );
         this.__storeWrapper.setRecordId(identifier, data.id);
       }
       if (data.relationships) {


### PR DESCRIPTION
resolves #7086 