### PR TITLE
feat: don't extend EmberObject/Service for Store

### DIFF
--- a/tests/main/tests/integration/application-test.js
+++ b/tests/main/tests/integration/application-test.js
@@ -22,7 +22,12 @@ module('integration/application - Injecting a Custom Store', function (hooks) {
     let { owner } = this;
 
     owner.unregister('service:store');
-    owner.register('service:store', Store.extend({ isCustom: true }));
+    owner.register(
+      'service:store',
+      class extends Store {
+        isCustom = true;
+      }
+    );
     owner.register('controller:foo', Controller.extend({ store: service() }));
     owner.register(
       'controller:baz',
@@ -180,9 +185,9 @@ module('integration/application - Attaching initializer', function (hooks) {
   });
 
   test('ember-data initializer does not register the store service when it was already registered', async function (assert) {
-    let AppStore = Store.extend({
-      isCustomStore: true,
-    });
+    class AppStore extends Store {
+      isCustomStore = true;
+    }
 
     this.TestApplication.initializer({
       name: 'before-ember-data',

--- a/tests/main/tests/integration/identifiers/configuration-test.ts
+++ b/tests/main/tests/integration/identifiers/configuration-test.ts
@@ -339,7 +339,7 @@ module('Integration | Identifiers - configuration', function (hooks) {
       resetMethodCalled = true;
     });
 
-    const store = this.owner.lookup('service:store') as Store;
+    const store = new Store();
     run(() => store.destroy());
     assert.ok(resetMethodCalled, 'We called the reset method when the application was torn down');
   });

--- a/tests/main/tests/integration/record-data/record-data-errors-test.ts
+++ b/tests/main/tests/integration/record-data/record-data-errors-test.ts
@@ -401,11 +401,11 @@ if (!DEPRECATE_V1_RECORD_DATA) {
       }
     }
 
-    let CustomStore = Store.extend({
+    class CustomStore extends Store {
       createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
         return new TestRecordData();
-      },
-    });
+      }
+    }
 
     hooks.beforeEach(function () {
       let { owner } = this;
@@ -436,11 +436,11 @@ if (!DEPRECATE_V1_RECORD_DATA) {
         }
       }
 
-      let TestStore = Store.extend({
+      class TestStore extends Store {
         createRecordDataFor(identifier: StableRecordIdentifier, storeWrapper: RecordDataStoreWrapper) {
           return new LifecycleRecordData();
-        },
-      });
+        }
+      }
 
       let TestAdapter = EmberObject.extend({
         updateRecord() {
@@ -496,11 +496,11 @@ if (!DEPRECATE_V1_RECORD_DATA) {
         }
       }
 
-      let TestStore = Store.extend({
+      class TestStore extends Store {
         createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
           return new LifecycleRecordData();
-        },
-      });
+        }
+      }
 
       let TestAdapter = EmberObject.extend({
         updateRecord() {
@@ -557,11 +557,11 @@ if (!DEPRECATE_V1_RECORD_DATA) {
         }
       }
 
-      let TestStore = Store.extend({
+      class TestStore extends Store {
         createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
           return new LifecycleRecordData(wrapper);
-        },
-      });
+        }
+      }
 
       owner.register('service:store', TestStore);
       store = owner.lookup('service:store');

--- a/tests/main/tests/integration/record-data/record-data-state-test.ts
+++ b/tests/main/tests/integration/record-data/record-data-state-test.ts
@@ -195,11 +195,11 @@ class V2TestRecordData implements RecordData {
 }
 const TestRecordData = DEPRECATE_V1_RECORD_DATA ? V1TestRecordData : V2TestRecordData;
 
-const CustomStore = Store.extend({
+class CustomStore extends Store {
   createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
     return new TestRecordData();
-  },
-});
+  }
+}
 
 module('integration/record-data - Record Data State', function (hooks) {
   setupTest(hooks);
@@ -250,11 +250,12 @@ module('integration/record-data - Record Data State', function (hooks) {
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
         return new LifecycleRecordData();
-      },
-    });
+      }
+    }
 
     let TestAdapter = EmberObject.extend({
       deleteRecord() {
@@ -345,11 +346,12 @@ module('integration/record-data - Record Data State', function (hooks) {
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
         return new LifecycleRecordData(wrapper);
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
 

--- a/tests/main/tests/integration/record-data/record-data-test.ts
+++ b/tests/main/tests/integration/record-data/record-data-test.ts
@@ -186,11 +186,12 @@ const TestRecordData: typeof V2TestRecordData | typeof V1TestRecordData = !DEPRE
   ? V2TestRecordData
   : V1TestRecordData;
 
-const CustomStore = Store.extend({
+class CustomStore extends Store {
+  // @ts-expect-error
   createRecordDataFor(identifier: StableRecordIdentifier, storeWrapper: RecordDataStoreWrapper) {
     return new TestRecordData(storeWrapper, identifier);
-  },
-});
+  }
+}
 
 let houseHash, davidHash, runspiredHash, igorHash;
 
@@ -350,11 +351,12 @@ module('integration/record-data - Custom RecordData Implementations', function (
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, storeWrapper: RecordDataStoreWrapper) {
         return new LifecycleRecordData(storeWrapper, identifier);
-      },
-    });
+      }
+    }
 
     let TestAdapter = EmberObject.extend({
       updateRecord() {
@@ -491,11 +493,12 @@ module('integration/record-data - Custom RecordData Implementations', function (
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, storeWrapper: RecordDataStoreWrapper) {
         return new AttributeRecordData(storeWrapper, identifier);
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
 
@@ -559,15 +562,16 @@ module('integration/record-data - Custom RecordData Implementations', function (
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, storeWrapper: RecordDataStoreWrapper) {
         if (identifier.type === 'house') {
           return new RelationshipRecordData(storeWrapper, identifier);
         } else {
-          return this._super(identifier, storeWrapper);
+          return super.createRecordDataFor(identifier, storeWrapper);
         }
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
 
@@ -629,16 +633,15 @@ module('integration/record-data - Custom RecordData Implementations', function (
         }
       };
     }
-
-    let TestStore = Store.extend({
+    class TestStore extends Store {
       createRecordDataFor(identifier: StableRecordIdentifier, storeWrapper: RecordDataStoreWrapper) {
         if (identifier.type === 'house') {
           return new RelationshipRecordData(storeWrapper, identifier);
         } else {
-          return this._super(identifier, storeWrapper);
+          return super.createRecordDataFor(identifier, storeWrapper);
         }
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
 
@@ -722,17 +725,18 @@ module('integration/record-data - Custom RecordData Implementations', function (
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, storeWrapper: RecordDataStoreWrapper) {
         if (identifier.type === 'house') {
           notifier = storeWrapper;
           houseIdentifier = identifier;
           return new RelationshipRecordData(storeWrapper, identifier);
         } else {
-          return this._super(identifier, storeWrapper);
+          return super.createRecordDataFor(identifier, storeWrapper);
         }
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
 
@@ -866,15 +870,16 @@ module('integration/record-data - Custom RecordData Implementations', function (
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, storeWrapper: RecordDataStoreWrapper) {
         if (identifier.type === 'house') {
           return new RelationshipRecordData(storeWrapper, identifier);
         } else {
-          return this._super(identifier, storeWrapper);
+          return super.createRecordDataFor(identifier, storeWrapper);
         }
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
 

--- a/tests/main/tests/integration/record-data/store-wrapper-test.ts
+++ b/tests/main/tests/integration/record-data/store-wrapper-test.ts
@@ -95,11 +95,12 @@ class TestRecordData {
   _initRecordCreateOptions(options) {}
 }
 
-const CustomStore = Store.extend({
+class CustomStore extends Store {
+  // @ts-expect-error
   createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
     return new TestRecordData();
-  },
-});
+  }
+}
 
 let houseHash, houseHash2;
 
@@ -202,15 +203,16 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
         if (identifier.type === 'house') {
           return new RelationshipRD(identifier, wrapper);
         } else {
-          return this._super(identifier, wrapper);
+          return super.createRecordDataFor(identifier, wrapper);
         }
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
     store = owner.lookup('service:store');
@@ -256,15 +258,16 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
         if (identifier.type === 'house') {
           return new RecordDataForTest(identifier, wrapper);
         } else {
-          return this._super(identifier, wrapper);
+          return super.createRecordDataFor(identifier, wrapper);
         }
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
     store = owner.lookup('service:store');
@@ -316,15 +319,16 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
       }
     }
 
-    const TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
         if (identifier.type === 'house') {
           return new RecordDataForTest(identifier, wrapper);
         } else {
-          return this._super(identifier, wrapper);
+          return super.createRecordDataFor(identifier, wrapper);
         }
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
     store = owner.lookup('service:store');
@@ -365,15 +369,16 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
         if (identifier.type === 'house') {
           return new RecordDataForTest(identifier, wrapper);
         } else {
-          return this._super(identifier, wrapper);
+          return super.createRecordDataFor(identifier, wrapper);
         }
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
     store = owner.lookup('service:store');
@@ -408,15 +413,16 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
         if (identifier.type === 'house') {
           return new RecordDataForTest(identifier, wrapper);
         } else {
-          return this._super(identifier, wrapper);
+          return super.createRecordDataFor(identifier, wrapper);
         }
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
     store = owner.lookup('service:store');
@@ -450,15 +456,16 @@ module('integration/store-wrapper - RecordData StoreWrapper tests', function (ho
       }
     }
 
-    let TestStore = Store.extend({
+    class TestStore extends Store {
+      // @ts-expect-error
       createRecordDataFor(identifier: StableRecordIdentifier, wrapper: RecordDataStoreWrapper) {
         if (identifier.type === 'house') {
           return new RecordDataForTest(identifier, wrapper);
         } else {
-          return this._super(identifier, wrapper);
+          return super.createRecordDataFor(identifier, wrapper);
         }
-      },
-    });
+      }
+    }
 
     owner.register('service:store', TestStore);
     store = owner.lookup('service:store');

--- a/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -329,7 +329,7 @@ module('unit/model - Custom Class Model', function (hooks) {
         },
       })
     );
-    let CreationStore = CustomStore.extend({
+    class CreationStore extends CustomStore {
       instantiateRecord(identifier, createRecordArgs, recordDataFor, notificationManager) {
         ident = identifier;
         rd = recordDataFor(identifier);
@@ -339,11 +339,11 @@ module('unit/model - Custom Class Model', function (hooks) {
           assert.true(recordDataFor(identifier).isDeleted(identifier), 'we have been marked as deleted');
         });
         return {};
-      },
+      }
       teardownRecord(record) {
         assert.strictEqual(record, person, 'Passed in person to teardown');
-      },
-    });
+      }
+    }
     this.owner.register('service:store', CreationStore);
     store = this.owner.lookup('service:store') as Store;
     let person = store.push({ data: { type: 'person', id: '1', attributes: { name: 'chris' } } });

--- a/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -29,8 +29,8 @@ module('unit/model - Custom Class Model', function (hooks) {
   }
 
   class CustomStore extends Store {
-    init() {
-      super.init();
+    constructor(args) {
+      super(args);
       this.registerSchemaDefinitionService({
         attributesDefinitionFor() {
           let schema: AttributesSchema = {};

--- a/tests/main/tests/unit/store/asserts-test.js
+++ b/tests/main/tests/unit/store/asserts-test.js
@@ -9,14 +9,11 @@ import Store from '@ember-data/store';
 import test from '@ember-data/unpublished-test-infra/test-support/test-in-debug';
 
 module('unit/store/asserts - DS.Store methods produce useful assertion messages', function (hooks) {
-  let store;
-
   setupTest(hooks);
   hooks.beforeEach(function () {
     let { owner } = this;
     owner.register('model:foo', Model.extend());
     owner.register('service:store', Store);
-    store = owner.lookup('service:store');
   });
 
   const MODEL_NAME_METHODS = [
@@ -35,6 +32,8 @@ module('unit/store/asserts - DS.Store methods produce useful assertion messages'
 
   test('Calling Store methods with no modelName asserts', function (assert) {
     assert.expect(MODEL_NAME_METHODS.length);
+
+    let store = this.owner.lookup('service:store');
 
     MODEL_NAME_METHODS.forEach((methodName) => {
       let assertion = `You need to pass a model name to the store's ${methodName} method`;
@@ -71,6 +70,7 @@ module('unit/store/asserts - DS.Store methods produce useful assertion messages'
   ];
 
   test('Calling Store methods after the store has been destroyed asserts', function (assert) {
+    const store = new Store();
     store.shouldAssertMethodCallsOnDestroyedStore = true;
     assert.expect(STORE_ENTRY_METHODS.length);
     run(() => store.destroy());
@@ -79,27 +79,6 @@ module('unit/store/asserts - DS.Store methods produce useful assertion messages'
       assert.expectAssertion(() => {
         store[methodName]();
       }, `Attempted to call store.${methodName}(), but the store instance has already been destroyed.`);
-    });
-  });
-
-  const STORE_TEARDOWN_METHODS = ['unloadAll', 'modelFor'];
-
-  test('Calling Store teardown methods during destroy does not assert, but calling other methods does', function (assert) {
-    store.shouldAssertMethodCallsOnDestroyedStore = true;
-    assert.expect(STORE_ENTRY_METHODS.length - STORE_TEARDOWN_METHODS.length);
-
-    run(() => {
-      store.destroy();
-
-      STORE_ENTRY_METHODS.forEach((methodName) => {
-        if (STORE_TEARDOWN_METHODS.indexOf(methodName) !== -1) {
-          store[methodName]('foo');
-        } else {
-          assert.expectAssertion(() => {
-            store[methodName]();
-          }, `Attempted to call store.${methodName}(), but the store instance has already been destroyed.`);
-        }
-      });
     });
   });
 });


### PR DESCRIPTION
If anyone happens to still be doing `Store.extend` we can restore with a deprecation. Extending the Store as a pattern was rare enough until well into Octane that likely this is safe-enough.