### PR TITLE
fix: deprecated record-array rejectBy use optional value if supplied

### DIFF
--- a/packages/store/src/-private/record-arrays/identifier-array.ts
+++ b/packages/store/src/-private/record-arrays/identifier-array.ts
@@ -881,12 +881,12 @@ if (DEPRECATE_ARRAY_LIKE) {
   IdentifierArray.prototype.rejectBy = function (key: string, value?: unknown) {
     deprecateArrayLike(this.DEPRECATED_CLASS_NAME, 'rejectBy', 'filter');
     if (arguments.length === 2) {
-      return this.filter((value) => {
-        return !get(value, key);
+      return this.filter((record) => {
+        return get(record, key) !== value;
       });
     }
-    return this.filter((value) => {
-      return !get(value, key);
+    return this.filter((record) => {
+      return !get(record, key);
     });
   };
 

--- a/tests/main/tests/unit/record-arrays/record-array-test.js
+++ b/tests/main/tests/unit/record-arrays/record-array-test.js
@@ -142,6 +142,49 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
   );
 
   deprecatedTest(
+    '#rejectBy',
+    { id: 'ember-data:deprecate-array-like', until: '5.0', count: 3 },
+    async function (assert) {
+      this.owner.register('model:tag', Tag);
+      let store = this.owner.lookup('service:store');
+
+      let records = store.push({
+        data: [
+          {
+            type: 'tag',
+            id: '1',
+            attributes: {
+              name: 'first',
+            },
+          },
+          {
+            type: 'tag',
+            id: '3',
+          },
+          {
+            type: 'tag',
+            id: '5',
+            attributes: {
+              name: 'fifth',
+            },
+          },
+        ],
+      });
+
+      let recordArray = new RecordArray({
+        type: 'recordType',
+        identifiers: records.map(recordIdentifierFor),
+        store,
+      });
+
+      assert.strictEqual(recordArray.length, 3);
+      assert.strictEqual(recordArray.rejectBy('id', '3').length, 2);
+      assert.strictEqual(recordArray.rejectBy('id').length, 0);
+      assert.strictEqual(recordArray.rejectBy('name').length, 1);
+    }
+  );
+
+  deprecatedTest(
     '#lastObject and #firstObject',
     { id: 'ember-data:deprecate-array-like', until: '5.0', count: 2 },
     async function (assert) {


### PR DESCRIPTION
## Description

If an optional value supplied as second arg to `rejectBy` it should be compared to the value retrieved using the `key`.

## Notes for the release

Fix regression in deprecated `rejectBy` behaviour when optional value to test against is used.


