### PR TITLE
fix: deprecated record-array reject use callback

### DIFF
--- a/packages/store/src/-private/record-arrays/identifier-array.ts
+++ b/packages/store/src/-private/record-arrays/identifier-array.ts
@@ -865,16 +865,11 @@ if (DEPRECATE_ARRAY_LIKE) {
     );
   };
 
-  // @ts-expect-error
-  IdentifierArray.prototype.reject = function (key: string, value?: unknown) {
+  IdentifierArray.prototype.reject = function (callback, target?: unknown) {
     deprecateArrayLike(this.DEPRECATED_CLASS_NAME, 'reject', 'filter');
-    if (arguments.length === 2) {
-      return this.filter((value) => {
-        return !get(value, key);
-      });
-    }
-    return this.filter((value) => {
-      return !get(value, key);
+    assert('`reject` expects a function as first argument.', typeof callback === 'function');
+    return this.filter((...args) => {
+      return !callback.apply(target, args);
     });
   };
 

--- a/tests/main/tests/unit/record-arrays/record-array-test.js
+++ b/tests/main/tests/unit/record-arrays/record-array-test.js
@@ -141,6 +141,45 @@ module('unit/record-arrays/record-array - DS.RecordArray', function (hooks) {
     }
   );
 
+  deprecatedTest('#reject', { id: 'ember-data:deprecate-array-like', until: '5.0', count: 3 }, async function (assert) {
+    this.owner.register('model:tag', Tag);
+    let store = this.owner.lookup('service:store');
+
+    let records = store.push({
+      data: [
+        {
+          type: 'tag',
+          id: '1',
+          attributes: {
+            name: 'first',
+          },
+        },
+        {
+          type: 'tag',
+          id: '3',
+        },
+        {
+          type: 'tag',
+          id: '5',
+          attributes: {
+            name: 'fifth',
+          },
+        },
+      ],
+    });
+
+    let recordArray = new RecordArray({
+      type: 'recordType',
+      identifiers: records.map(recordIdentifierFor),
+      store,
+    });
+
+    assert.strictEqual(recordArray.length, 3);
+    assert.strictEqual(recordArray.reject(({ id }) => id === '3').length, 2);
+    assert.strictEqual(recordArray.reject(({ id }) => id).length, 0);
+    assert.strictEqual(recordArray.reject(({ name }) => name).length, 1);
+  });
+
   deprecatedTest(
     '#lastObject and #firstObject',
     { id: 'ember-data:deprecate-array-like', until: '5.0', count: 2 },


### PR DESCRIPTION
## Description

`reject` expects a callback function

## Notes for the release

Fix regression in deprecated reject function so callback is used.


