### PR TITLE
Ignore destroyed objects in proxiedMethod to avoid errors on teardown

### DIFF
--- a/packages/model/addon/-private/system/promise-many-array.ts
+++ b/packages/model/addon/-private/system/promise-many-array.ts
@@ -329,6 +329,9 @@ const InheritedProxyMethods = [
 ];
 InheritedProxyMethods.forEach((method) => {
   PromiseManyArray.prototype[method] = function proxiedMethod(...args) {
+    if (this.isDestroyed) {
+      return [];
+    }
     assert(`Cannot call ${method} before content is assigned.`, this.content);
     return this.content[method](...args);
   };


### PR DESCRIPTION
## Description

Because `content` is tracked, and when a promiseArray is `destroyed`, it is set to `null`, anything trying to use these methods will get recalculated and fail on the assert. Just return empty array in these cases because we know content is `null`. 

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


