### PR TITLE
cleanup: Switch all uses of `@ember/error` to native Error

### DIFF
--- a/packages/adapter/rollup.config.mjs
+++ b/packages/adapter/rollup.config.mjs
@@ -21,7 +21,6 @@ export default {
     '@ember/debug',
     '@ember/string',
     '@ember/object',
-    '@ember/error',
     '@ember/object/mixin',
     '@ember/application',
     '@glimmer/env',

--- a/packages/adapter/src/error.js
+++ b/packages/adapter/src/error.js
@@ -2,7 +2,6 @@
   @module @ember-data/adapter/error
  */
 import { assert, deprecate } from '@ember/debug';
-import EmberError from '@ember/error';
 
 import { DEPRECATE_HELPERS } from '@ember-data/private-build-infra/deprecations';
 
@@ -76,10 +75,8 @@ import { DEPRECATE_HELPERS } from '@ember-data/private-build-infra/deprecations'
 */
 function AdapterError(errors, message = 'Adapter operation failed') {
   this.isAdapterError = true;
-  let error = EmberError.call(this, message);
+  let error = Error.call(this, message);
 
-  // in ember 3.8+ Error is a Native Error and we don't
-  // gain these automatically from the EmberError.call
   if (error) {
     this.stack = error.stack;
     this.description = error.description;
@@ -117,7 +114,7 @@ function extend(ParentErrorClass, defaultMessage) {
   return ErrorClass;
 }
 
-AdapterError.prototype = Object.create(EmberError.prototype);
+AdapterError.prototype = Object.create(Error.prototype);
 AdapterError.prototype.code = 'AdapterError';
 AdapterError.extend = extendFn(AdapterError);
 

--- a/packages/graph/rollup.config.mjs
+++ b/packages/graph/rollup.config.mjs
@@ -22,7 +22,6 @@ export default {
     '@ember/debug',
     '@ember/string',
     '@ember/object',
-    '@ember/error',
     '@ember/object/mixin',
     '@ember/application',
     '@glimmer/env',

--- a/packages/json-api/rollup.config.mjs
+++ b/packages/json-api/rollup.config.mjs
@@ -23,7 +23,6 @@ export default {
     '@ember/debug',
     '@ember/string',
     '@ember/object',
-    '@ember/error',
     '@ember/object/mixin',
     '@ember/application',
     '@glimmer/env',

--- a/packages/model/index.js
+++ b/packages/model/index.js
@@ -27,7 +27,6 @@ module.exports = Object.assign({}, addonBaseConfig, {
       '@ember/array/mutable',
       '@ember/array/proxy',
       '@ember/debug',
-      '@ember/error',
       '@ember/object',
       '@ember/object/compat',
       '@ember/object/computed',

--- a/packages/model/rollup.config.mjs
+++ b/packages/model/rollup.config.mjs
@@ -32,7 +32,6 @@ export default {
     '@ember/array/proxy',
     '@ember/string',
     '@ember/object',
-    '@ember/error',
     '@ember/object/mixin',
     '@ember/application',
     '@glimmer/env',

--- a/tests/main/tests/unit/adapter-errors-test.js
+++ b/tests/main/tests/unit/adapter-errors-test.js
@@ -1,5 +1,3 @@
-import EmberError from '@ember/error';
-
 import { module, test } from 'qunit';
 
 import AdapterError, {
@@ -22,7 +20,6 @@ module('unit/adapter-errors - AdapterError', function () {
     let error = new AdapterError();
 
     assert.ok(error instanceof Error);
-    assert.ok(error instanceof EmberError);
     assert.ok(error.isAdapterError);
     assert.strictEqual(error.message, 'Adapter operation failed');
   });


### PR DESCRIPTION
## Description

Ember 3.8 began simply re-exporting `Error` at this specifier, and Ember 5.0 drops the old package entirely. Switch to just using native `Error` accordingly, and drop all bits referring to the old class.

## Notes for the release

N/A (I think?) – this shouldn't change literally anything from consumers' POV.

---

This unblocks emberjs/ember.js#20379 (part of the Ember 5.0 cleanup).