### PR TITLE
fix: de-cycle ember-concurrency access of promise

### DIFF
--- a/packages/store/src/-private/proxies/promise-proxies.ts
+++ b/packages/store/src/-private/proxies/promise-proxies.ts
@@ -135,7 +135,7 @@ export function promiseArray<I, T extends EmberArrayLike<I>>(promise: Promise<T>
         return Reflect.get(target, prop, receiver);
       }
       if (ALLOWABLE_PROPS.includes(prop)) {
-        return receiver[prop];
+        return target[prop];
       }
       if (!ALLOWABLE_METHODS.includes(prop)) {
         deprecate(

--- a/packages/store/src/-private/proxies/promise-proxies.ts
+++ b/packages/store/src/-private/proxies/promise-proxies.ts
@@ -190,7 +190,7 @@ export function promiseObject<T>(promise: Promise<T>): PromiseObjectProxy<T> {
       }
 
       if (ALLOWABLE_PROPS.includes(prop)) {
-        return receiver[prop];
+        return target[prop];
       }
 
       if (!ALLOWABLE_METHODS.includes(prop)) {


### PR DESCRIPTION
fix #8312 