### PR TITLE
Correction made to the Model.relatedTypes documentation

### DIFF
--- a/packages/model/src/-private/model.js
+++ b/packages/model/src/-private/model.js
@@ -1734,7 +1734,7 @@ class Model extends EmberObject {
    import Blog from 'app/models/blog';
 
    let relatedTypes = Blog.relatedTypes');
-   //=> [ User, Post ]
+   //=> ['user', 'post']
    ```
 
    @property relatedTypes


### PR DESCRIPTION
## Description

The `.relatedTypes` method returns the names of the model classes as small-case strings. Correction made to the related documentation.

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


