### PR TITLE
chore: begin restricting imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,6 +47,16 @@ module.exports = {
     'import/newline-after-import': 'error',
     'import/no-duplicates': 'error',
     'simple-import-sort/imports': ['error', { groups: ImportSortGroups }],
+    'no-restricted-imports': [
+      'error',
+      // '@ember/runloop',
+      // '@ember/string',
+      // '@ember/object',
+      // '@ember/service',
+      // '@ember/object/compat',
+      // 'ember-inflector',
+      '@glimmer/env',
+    ],
 
     'mocha/no-exclusive-tests': 'error',
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,9 +50,9 @@ module.exports = {
     'no-restricted-imports': [
       'error',
       {
-        paths: ['ember-inflector', '@glimmer/env'],
+        paths: ['@glimmer/env', '@ember/utils'],
       },
-      // '@ember/runloop',@glimmer/env
+      // '@ember/runloop',
       // '@ember/string',
       // '@ember/object',
       // '@ember/service',
@@ -101,8 +101,8 @@ module.exports = {
         'no-restricted-imports': [
           'error',
           {
-            paths: ['ember-inflector', '@glimmer/env'],
-            patterns: ['@ember/*'],
+            paths: ['@glimmer/env', '@ember/utils'],
+            // patterns: ['@ember/*'],
           },
           // '@ember/runloop',@glimmer/env
           // '@ember/string',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,13 +49,15 @@ module.exports = {
     'simple-import-sort/imports': ['error', { groups: ImportSortGroups }],
     'no-restricted-imports': [
       'error',
-      // '@ember/runloop',
+      {
+        paths: ['ember-inflector', '@glimmer/env'],
+      },
+      // '@ember/runloop',@glimmer/env
       // '@ember/string',
       // '@ember/object',
       // '@ember/service',
       // '@ember/object/compat',
       // 'ember-inflector',
-      '@glimmer/env',
     ],
 
     'mocha/no-exclusive-tests': 'error',
@@ -93,6 +95,24 @@ module.exports = {
     node: false,
   },
   overrides: [
+    {
+      files: ['packages/**'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: ['ember-inflector', '@glimmer/env'],
+            patterns: ['@ember/*'],
+          },
+          // '@ember/runloop',@glimmer/env
+          // '@ember/string',
+          // '@ember/object',
+          // '@ember/service',
+          // '@ember/object/compat',
+          // 'ember-inflector',
+        ],
+      },
+    },
     // TypeScript files in strict-mode
     // see https://github.com/emberjs/data/issues/6233#issuecomment-849279594
     {

--- a/packages/graph/index.js
+++ b/packages/graph/index.js
@@ -15,7 +15,6 @@ module.exports = Object.assign({}, addonBaseConfig, {
       '@ember/polyfills',
       '@ember/object',
       '@ember/object/internals',
-      '@ember/utils',
       'ember',
       '@ember-data/store/-private',
       '@ember-data/store',

--- a/packages/json-api/index.js
+++ b/packages/json-api/index.js
@@ -15,7 +15,6 @@ module.exports = Object.assign({}, addonBaseConfig, {
       '@ember/polyfills',
       '@ember/object',
       '@ember/object/internals',
-      '@ember/utils',
       'ember',
       '@ember-data/store/-private',
       '@ember-data/store',

--- a/packages/model/index.js
+++ b/packages/model/index.js
@@ -33,7 +33,6 @@ module.exports = Object.assign({}, addonBaseConfig, {
       '@ember/object/internals',
       '@ember/polyfills',
       '@ember/runloop',
-      '@ember/utils',
       '@ember/service',
 
       '@glimmer/tracking/primitives/cache',

--- a/packages/model/src/-private/attr.js
+++ b/packages/model/src/-private/attr.js
@@ -74,9 +74,7 @@ import { computedMacroWithOptionalParams } from './util';
   ```
 
   ```app/transforms/text.js
-  import Transform from '@ember-data/serializer/transform';
-
-  export default class TextTransform extends Transform {
+  export default class TextTransform {
     serialize(value, options) {
       if (options.uppercase) {
         return value.toUpperCase();
@@ -87,6 +85,10 @@ import { computedMacroWithOptionalParams } from './util';
 
     deserialize(value) {
       return value;
+    }
+
+    static create() {
+      return new this();
     }
   }
   ```

--- a/packages/serializer/blueprints/transform/files/__root__/__path__/__name__.js
+++ b/packages/serializer/blueprints/transform/files/__root__/__path__/__name__.js
@@ -1,11 +1,13 @@
-import Transform from '@ember-data/serializer/transform';
-
-export default Transform.extend({
+export default class <%= classifiedModuleName %>Transform {
   deserialize(serialized) {
     return serialized;
-  },
+  }
 
   serialize(deserialized) {
     return deserialized;
   }
-});
+
+  static create() {
+    return new this();
+  }
+}

--- a/packages/serializer/blueprints/transform/native-files/__root__/__path__/__name__.js
+++ b/packages/serializer/blueprints/transform/native-files/__root__/__path__/__name__.js
@@ -1,11 +1,13 @@
-import Transform from '@ember-data/serializer/transform';
-
-export default class <%= classifiedModuleName %>Transform extends Transform {
+export default class <%= classifiedModuleName %>Transform {
   deserialize(serialized) {
     return serialized;
   }
 
   serialize(deserialized) {
     return deserialized;
+  }
+
+  static create() {
+    return new this();
   }
 }

--- a/packages/serializer/index.js
+++ b/packages/serializer/index.js
@@ -13,7 +13,6 @@ module.exports = Object.assign({}, addonBaseConfig, {
       '@ember/object',
       '@ember/application',
       '@ember/string',
-      '@ember/utils',
       '@ember/debug',
       '@ember/polyfills',
       '@ember/array',

--- a/packages/serializer/rollup.config.mjs
+++ b/packages/serializer/rollup.config.mjs
@@ -19,7 +19,6 @@ export default {
     '@ember/object',
     '@ember/application',
     '@ember/string',
-    '@ember/utils',
     '@ember/debug',
     '@ember/polyfills',
     '@ember/array',

--- a/packages/serializer/src/-private/embedded-records-mixin.js
+++ b/packages/serializer/src/-private/embedded-records-mixin.js
@@ -2,7 +2,6 @@ import { A } from '@ember/array';
 import { warn } from '@ember/debug';
 import Mixin from '@ember/object/mixin';
 import { camelize } from '@ember/string';
-import { typeOf } from '@ember/utils';
 
 /**
   @module @ember-data/serializer/rest
@@ -443,7 +442,7 @@ export default Mixin.create({
 
     warn(
       `The embedded relationship '${serializedKey}' is undefined for '${snapshot.modelName}' with id '${snapshot.id}'. Please include it in your original payload.`,
-      typeOf(snapshot.hasMany(relationship.key)) !== 'undefined',
+      typeof snapshot.hasMany(relationship.key) !== 'undefined',
       { id: 'ds.serializer.embedded-relationship-undefined' }
     );
 

--- a/packages/serializer/src/-private/transforms/boolean.js
+++ b/packages/serializer/src/-private/transforms/boolean.js
@@ -1,7 +1,3 @@
-import { isNone } from '@ember/utils';
-
-import Transform from './transform';
-
 /**
   @module @ember-data/serializer
 */
@@ -40,11 +36,10 @@ import Transform from './transform';
 
   @class BooleanTransform
   @public
-  @extends Transform
  */
-export default class BooleanTransform extends Transform {
+export default class BooleanTransform {
   deserialize(serialized, options) {
-    if (isNone(serialized) && options.allowNull === true) {
+    if ((serialized === null || serialized === undefined) && options.allowNull === true) {
       return null;
     }
 
@@ -61,10 +56,14 @@ export default class BooleanTransform extends Transform {
   }
 
   serialize(deserialized, options) {
-    if (isNone(deserialized) && options.allowNull === true) {
+    if ((deserialized === null || deserialized === undefined) && options.allowNull === true) {
       return null;
     }
 
     return Boolean(deserialized);
+  }
+
+  static create() {
+    return new this();
   }
 }

--- a/packages/serializer/src/-private/transforms/date.js
+++ b/packages/serializer/src/-private/transforms/date.js
@@ -1,5 +1,3 @@
-import Transform from './transform';
-
 /**
   @module @ember-data/serializer
 */
@@ -23,10 +21,9 @@ import Transform from './transform';
 
  @class DateTransform
   @public
- @extends Transform
  */
 
-export default class DateTransform extends Transform {
+export default class DateTransform {
   deserialize(serialized) {
     let type = typeof serialized;
 
@@ -55,5 +52,9 @@ export default class DateTransform extends Transform {
     } else {
       return null;
     }
+  }
+
+  static create() {
+    return new this();
   }
 }

--- a/packages/serializer/src/-private/transforms/number.js
+++ b/packages/serializer/src/-private/transforms/number.js
@@ -1,5 +1,3 @@
-import Transform from './transform';
-
 /**
   @module @ember-data/serializer
 */
@@ -28,9 +26,8 @@ function isNumber(value) {
 
   @class NumberTransform
   @public
-  @extends Transform
  */
-export default class NumberTransform extends Transform {
+export default class NumberTransform {
   deserialize(serialized) {
     let transformed;
 
@@ -53,5 +50,9 @@ export default class NumberTransform extends Transform {
 
       return isNumber(transformed) ? transformed : null;
     }
+  }
+
+  static create() {
+    return new this();
   }
 }

--- a/packages/serializer/src/-private/transforms/string.js
+++ b/packages/serializer/src/-private/transforms/string.js
@@ -25,10 +25,10 @@
  */
 export default class StringTransform {
   deserialize(serialized) {
-    return !serialized ? null : String(serialized);
+    return !serialized && serialized !== '' ? null : String(serialized);
   }
   serialize(deserialized) {
-    return !deserialized ? null : String(deserialized);
+    return !deserialized && deserialized !== '' ? null : String(deserialized);
   }
 
   static create() {

--- a/packages/serializer/src/-private/transforms/string.js
+++ b/packages/serializer/src/-private/transforms/string.js
@@ -1,7 +1,3 @@
-import { isNone as none } from '@ember/utils';
-
-import Transform from './transform';
-
 /**
   @module @ember-data/serializer
 */
@@ -26,13 +22,16 @@ import Transform from './transform';
 
   @class StringTransform
   @public
-  @extends Transform
  */
-export default class StringTransform extends Transform {
+export default class StringTransform {
   deserialize(serialized) {
-    return none(serialized) ? null : String(serialized);
+    return !serialized ? null : String(serialized);
   }
   serialize(deserialized) {
-    return none(deserialized) ? null : String(deserialized);
+    return !deserialized ? null : String(deserialized);
+  }
+
+  static create() {
+    return new this();
   }
 }

--- a/packages/serializer/src/-private/transforms/transform.js
+++ b/packages/serializer/src/-private/transforms/transform.js
@@ -1,5 +1,3 @@
-import EmberObject from '@ember/object';
-
 /**
   @module @ember-data/serializer
 */
@@ -14,16 +12,19 @@ import EmberObject from '@ember/object';
   Example
 
   ```app/transforms/temperature.js
-  import Transform from '@ember-data/serializer/transform';
 
   // Converts centigrade in the JSON to fahrenheit in the app
-  export default class TemperatureTransform extends Transform {
+  export default class TemperatureTransform {
     deserialize(serialized, options) {
       return (serialized *  1.8) + 32;
     }
 
     serialize(deserialized, options) {
       return (deserialized - 32) / 1.8;
+    }
+
+    static create() {
+      return new this();
     }
   }
   ```
@@ -58,9 +59,7 @@ import EmberObject from '@ember/object';
   ```
 
   ```app/transforms/markdown.js
-  import Transform from '@ember-data/serializer/transform';
-
-  export default class MarkdownTransform extends Transform {
+  export default class MarkdownTransform {
     serialize(deserialized, options) {
       return deserialized.raw;
     }
@@ -70,49 +69,50 @@ import EmberObject from '@ember/object';
 
       return marked(serialized, markdownOptions);
     }
+
+    static create() {
+      return new this();
+    }
   }
   ```
 
   @class Transform
   @public
  */
-export default class Transform extends EmberObject {
-  /**
-    When given a deserialized value from a record attribute this
-    method must return the serialized value.
+/**
+  When given a deserialized value from a record attribute this
+  method must return the serialized value.
 
-    Example
+  Example
 
-    ```javascript
-    import { isEmpty } from '@ember/utils';
+  ```javascript
+  serialize(deserialized, options) {
+    return deserialized ? null : Number(deserialized);
+  }
+  ```
 
-    serialize(deserialized, options) {
-      return isEmpty(deserialized) ? null : Number(deserialized);
-    }
-    ```
+  @method serialize
+  @public
+  @param deserialized The deserialized value
+  @param options hash of options passed to `attr`
+  @return The serialized value
+*/
+/**
+  When given a serialized value from a JSON object this method must
+  return the deserialized value for the record attribute.
 
-    @method serialize
-    @public
-    @param deserialized The deserialized value
-    @param options hash of options passed to `attr`
-    @return The serialized value
-  */
-  /**
-    When given a serialized value from a JSON object this method must
-    return the deserialized value for the record attribute.
+  Example
 
-    Example
+  ```javascript
+  deserialize(serialized, options) {
+    return empty(serialized) ? null : Number(serialized);
+  }
+  ```
 
-    ```javascript
-    deserialize(serialized, options) {
-      return empty(serialized) ? null : Number(serialized);
-    }
-    ```
-
-    @method deserialize
-    @public
-    @param serialized The serialized value
-    @param options hash of options passed to `attr`
-    @return The deserialized value
-  */
-}
+  @method deserialize
+  @public
+  @param serialized The serialized value
+  @param options hash of options passed to `attr`
+  @return The deserialized value
+*/
+export { default } from '@ember/object';

--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -186,7 +186,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     @private
   */
   _normalizeResourceHelper(resourceHash) {
-    assert(this.warnMessageForUndefinedType(), !resourceHash.type);
+    assert(this.warnMessageForUndefinedType(), resourceHash.type);
 
     let modelName, usedLookup;
 

--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -3,7 +3,6 @@
  */
 import { assert, warn } from '@ember/debug';
 import { dasherize } from '@ember/string';
-import { isNone, typeOf } from '@ember/utils';
 
 import { pluralize, singularize } from 'ember-inflector';
 
@@ -138,7 +137,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     @private
   */
   _normalizeDocumentHelper(documentHash) {
-    if (typeOf(documentHash.data) === 'object') {
+    if (typeof documentHash.data === 'object') {
       documentHash.data = this._normalizeResourceHelper(documentHash.data);
     } else if (Array.isArray(documentHash.data)) {
       let ret = new Array(documentHash.data.length);
@@ -187,7 +186,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     @private
   */
   _normalizeResourceHelper(resourceHash) {
-    assert(this.warnMessageForUndefinedType(), !isNone(resourceHash.type));
+    assert(this.warnMessageForUndefinedType(), !resourceHash.type);
 
     let modelName, usedLookup;
 
@@ -281,7 +280,7 @@ const JSONAPISerializer = JSONSerializer.extend({
      @return {Object}
   */
   extractRelationship(relationshipHash) {
-    if (typeOf(relationshipHash.data) === 'object') {
+    if (relationshipHash.data === 'object') {
       relationshipHash.data = this._normalizeRelationshipDataHelper(relationshipHash.data);
     }
 

--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -137,9 +137,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     @private
   */
   _normalizeDocumentHelper(documentHash) {
-    if (typeof documentHash.data === 'object') {
-      documentHash.data = this._normalizeResourceHelper(documentHash.data);
-    } else if (Array.isArray(documentHash.data)) {
+    if (Array.isArray(documentHash.data)) {
       let ret = new Array(documentHash.data.length);
 
       for (let i = 0; i < documentHash.data.length; i++) {
@@ -148,6 +146,8 @@ const JSONAPISerializer = JSONSerializer.extend({
       }
 
       documentHash.data = ret;
+    } else if (documentHash.data && typeof documentHash.data === 'object') {
+      documentHash.data = this._normalizeResourceHelper(documentHash.data);
     }
 
     if (Array.isArray(documentHash.included)) {
@@ -280,10 +280,6 @@ const JSONAPISerializer = JSONSerializer.extend({
      @return {Object}
   */
   extractRelationship(relationshipHash) {
-    if (relationshipHash.data === 'object') {
-      relationshipHash.data = this._normalizeRelationshipDataHelper(relationshipHash.data);
-    }
-
     if (Array.isArray(relationshipHash.data)) {
       let ret = new Array(relationshipHash.data.length);
 
@@ -293,6 +289,8 @@ const JSONAPISerializer = JSONSerializer.extend({
       }
 
       relationshipHash.data = ret;
+    } else if (relationshipHash.data && typeof relationshipHash.data === 'object') {
+      relationshipHash.data = this._normalizeRelationshipDataHelper(relationshipHash.data);
     }
 
     return relationshipHash;

--- a/packages/serializer/src/json.js
+++ b/packages/serializer/src/json.js
@@ -4,7 +4,6 @@
 import { getOwner } from '@ember/application';
 import { assert, warn } from '@ember/debug';
 import { dasherize } from '@ember/string';
-import { isNone, typeOf } from '@ember/utils';
 
 import { coerceId } from '@ember-data/store/-private';
 
@@ -524,8 +523,8 @@ const JSONSerializer = Serializer.extend({
     let meta = this.extractMeta(store, primaryModelClass, payload);
     if (meta) {
       assert(
-        'The `meta` returned from `extractMeta` has to be an object, not "' + typeOf(meta) + '".',
-        typeOf(meta) === 'object'
+        'The `meta` returned from `extractMeta` has to be an object, not "' + typeof meta + '".',
+        typeof meta === 'object'
       );
       documentHash.meta = meta;
     }
@@ -600,7 +599,7 @@ const JSONSerializer = Serializer.extend({
 
     if (resourceHash) {
       this.normalizeUsingDeclaredMapping(modelClass, resourceHash);
-      if (typeOf(resourceHash.links) === 'object') {
+      if (typeof resourceHash.links === 'object') {
         this.normalizeUsingDeclaredMapping(modelClass, resourceHash.links);
       }
 
@@ -669,7 +668,7 @@ const JSONSerializer = Serializer.extend({
     @return {Object}
   */
   extractRelationship(relationshipModelName, relationshipHash) {
-    if (isNone(relationshipHash)) {
+    if (!relationshipHash) {
       return null;
     }
     /*
@@ -677,7 +676,7 @@ const JSONSerializer = Serializer.extend({
       is polymorphic. It could however also be embedded resources that the
       EmbeddedRecordsMixin has be able to process.
     */
-    if (typeOf(relationshipHash) === 'object') {
+    if (typeof relationshipHash === 'object') {
       if (relationshipHash.id) {
         relationshipHash.id = coerceId(relationshipHash.id);
       }
@@ -751,7 +750,7 @@ const JSONSerializer = Serializer.extend({
             data = this.extractRelationship(relationshipMeta.type, relationshipHash);
           }
         } else if (relationshipMeta.kind === 'hasMany') {
-          if (!isNone(relationshipHash)) {
+          if (relationshipHash) {
             data = new Array(relationshipHash.length);
             if (relationshipMeta.options.polymorphic) {
               for (let i = 0, l = relationshipHash.length; i < l; i++) {
@@ -1216,7 +1215,6 @@ const JSONSerializer = Serializer.extend({
 
     ```app/serializers/post.js
     import JSONSerializer from '@ember-data/serializer/json';
-    import { isNone } from '@ember/utils';
 
     export default class PostSerializer extends JSONSerializer {
       serializeBelongsTo(snapshot, json, relationship) {
@@ -1225,7 +1223,7 @@ const JSONSerializer = Serializer.extend({
 
         key = this.keyForRelationship ? this.keyForRelationship(key, "belongsTo", "serialize") : key;
 
-        json[key] = isNone(belongsTo) ? belongsTo : belongsTo.record.toJSON();
+        json[key] = !belongsTo ? null : belongsTo.record.toJSON();
       }
     }
     ```
@@ -1251,7 +1249,7 @@ const JSONSerializer = Serializer.extend({
       }
 
       //Need to check whether the id is there for new&async records
-      if (isNone(belongsToId)) {
+      if (!belongsToId) {
         json[payloadKey] = null;
       } else {
         json[payloadKey] = belongsToId;
@@ -1320,7 +1318,6 @@ const JSONSerializer = Serializer.extend({
 
     ```app/serializers/comment.js
     import JSONSerializer from '@ember-data/serializer/json';
-    import { isNone } from '@ember/utils';
 
     export default class CommentSerializer extends JSONSerializer {
       serializePolymorphicType(snapshot, json, relationship) {
@@ -1329,7 +1326,7 @@ const JSONSerializer = Serializer.extend({
 
         key = this.keyForAttribute ? this.keyForAttribute(key, 'serialize') : key;
 
-        if (isNone(belongsTo)) {
+        if (!belongsTo) {
           json[key + '_type'] = null;
         } else {
           json[key + '_type'] = belongsTo.modelName;

--- a/packages/serializer/src/json.js
+++ b/packages/serializer/src/json.js
@@ -676,7 +676,7 @@ const JSONSerializer = Serializer.extend({
       is polymorphic. It could however also be embedded resources that the
       EmbeddedRecordsMixin has be able to process.
     */
-    if (typeof relationshipHash === 'object') {
+    if (relationshipHash && typeof relationshipHash === 'object' && !Array.isArray(relationshipHash)) {
       if (relationshipHash.id) {
         relationshipHash.id = coerceId(relationshipHash.id);
       }

--- a/packages/serializer/src/rest.js
+++ b/packages/serializer/src/rest.js
@@ -3,7 +3,6 @@
  */
 import { assert, warn } from '@ember/debug';
 import { camelize, dasherize } from '@ember/string';
-import { isNone, typeOf } from '@ember/utils';
 
 import { singularize } from 'ember-inflector';
 
@@ -232,8 +231,8 @@ const RESTSerializer = JSONSerializer.extend({
     let meta = this.extractMeta(store, primaryModelClass, payload);
     if (meta) {
       assert(
-        'The `meta` returned from `extractMeta` has to be an object, not "' + typeOf(meta) + '".',
-        typeOf(meta) === 'object'
+        'The `meta` returned from `extractMeta` has to be an object, not "' + typeof meta + '".',
+        typeof meta === 'object'
       );
       documentHash.meta = meta;
     }
@@ -735,7 +734,7 @@ const RESTSerializer = JSONSerializer.extend({
     let typeKey = this.keyForPolymorphicType(key, relationship.type, 'serialize');
     let belongsTo = snapshot.belongsTo(key);
 
-    if (isNone(belongsTo)) {
+    if (!belongsTo) {
       json[typeKey] = null;
     } else {
       json[typeKey] = camelize(belongsTo.modelName);

--- a/packages/store/rollup.config.mjs
+++ b/packages/store/rollup.config.mjs
@@ -30,7 +30,6 @@ export default {
     'rsvp',
 
     // investigate why these are present
-    '@ember/utils',
     '@ember/application',
     '@ember/object/computed',
 

--- a/packages/store/src/-private/record-arrays/identifier-array.ts
+++ b/packages/store/src/-private/record-arrays/identifier-array.ts
@@ -6,6 +6,7 @@ import { tagForProperty } from '@ember/-internals/metal';
 import { assert, deprecate } from '@ember/debug';
 import { get, set } from '@ember/object';
 import { dependentKeyCompat } from '@ember/object/compat';
+// eslint-disable-next-line no-restricted-imports
 import { compare } from '@ember/utils';
 import { tracked } from '@glimmer/tracking';
 // @ts-expect-error

--- a/tests/blueprints/tests/transform-test.js
+++ b/tests/blueprints/tests/transform-test.js
@@ -30,8 +30,7 @@ describe('Acceptance: generate and destroy transform blueprints', function () {
 
         return emberGenerateDestroy(args, (_file) => {
           expect(_file('app/transforms/foo.js'))
-            .to.contain(`import Transform from '@ember-data/serializer/transform';`)
-            .to.contain('export default Transform.extend(')
+            .to.contain('export default class FooTransform {')
             .to.contain('deserialize(serialized) {')
             .to.contain('serialize(deserialized) {');
 
@@ -124,8 +123,7 @@ describe('Acceptance: generate and destroy transform blueprints', function () {
 
         return emberGenerateDestroy(args, (_file) => {
           expect(_file('app/transforms/foo.js'))
-            .to.contain(`import Transform from '@ember-data/serializer/transform';`)
-            .to.contain('export default class FooTransform extends Transform {')
+            .to.contain('export default class FooTransform {')
             .to.contain('deserialize(serialized) {')
             .to.contain('serialize(deserialized) {');
 

--- a/tests/main/tests/unit/model/rollback-attributes-test.js
+++ b/tests/main/tests/unit/model/rollback-attributes-test.js
@@ -1,7 +1,6 @@
 import { addObserver } from '@ember/object/observers';
 import { later, run } from '@ember/runloop';
 import { settled } from '@ember/test-helpers';
-import { isPresent } from '@ember/utils';
 
 import { module, test } from 'qunit';
 import { Promise as EmberPromise, reject } from 'rsvp';
@@ -469,7 +468,6 @@ module('unit/model/rollbackAttributes - model.rollbackAttributes()', function (h
       assert.strictEqual(reason, thrownAdapterError);
       assert.strictEqual(dog.name, 'is a dwarf planet');
       assert.strictEqual(dog.breed, 'planet');
-      assert.ok(isPresent(dog.errors.get('name')));
       assert.strictEqual(dog.errors.get('name.length'), 1);
 
       dog.set('name', 'Seymour Asses');


### PR DESCRIPTION
For unplug we want to lint against imports which would keep us entangled with Ember.

refactors Transforms to simple native classes. If anyone turns out to be extending these with classic syntax we'll restore the extend from EmberObject, but by-and-large these are simple enough that anyone overriding ought to have simply been replacing... we hope.