### PR TITLE
chore: reduce PR CI noise

### DIFF
--- a/.github/workflows/enforce-pr-labels-beta.yml
+++ b/.github/workflows/enforce-pr-labels-beta.yml
@@ -2,7 +2,7 @@ name: PR
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+    types: [labeled, unlabeled, opened, reopened]
     branches:
       - beta
 

--- a/.github/workflows/enforce-pr-labels-canary.yml
+++ b/.github/workflows/enforce-pr-labels-canary.yml
@@ -2,7 +2,7 @@ name: PR
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+    types: [labeled, unlabeled, opened, reopened]
     branches:
       - main
 

--- a/.github/workflows/enforce-pr-labels-lts-prev.yml
+++ b/.github/workflows/enforce-pr-labels-lts-prev.yml
@@ -2,7 +2,7 @@ name: PR
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+    types: [labeled, unlabeled, opened, reopened]
     branches:
       - lts-4-4
       - lts-3-28

--- a/.github/workflows/enforce-pr-labels-lts.yml
+++ b/.github/workflows/enforce-pr-labels-lts.yml
@@ -2,7 +2,7 @@ name: PR
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+    types: [labeled, unlabeled, opened, reopened]
     branches:
       - lts-4-8
       - lts-4-12

--- a/.github/workflows/enforce-pr-labels-old-release.yml
+++ b/.github/workflows/enforce-pr-labels-old-release.yml
@@ -2,7 +2,7 @@ name: PR
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+    types: [labeled, unlabeled, opened, reopened]
     branches:
       - release-*
 

--- a/.github/workflows/enforce-pr-labels-release.yml
+++ b/.github/workflows/enforce-pr-labels-release.yml
@@ -2,7 +2,7 @@ name: PR
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+    types: [labeled, unlabeled, opened, reopened]
     branches:
       - release
 


### PR DESCRIPTION
don't re-run label checks for commits