### PR TITLE
updates to lifetimes service and CacheHandler install

### DIFF
--- a/packages/-ember-data/addon/-private/index.ts
+++ b/packages/-ember-data/addon/-private/index.ts
@@ -6,13 +6,14 @@ import ObjectProxy from '@ember/object/proxy';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
-import BaseStore from '@ember-data/store';
+import BaseStore, { CacheHandler } from '@ember-data/store';
 
 export class Store extends BaseStore {
   constructor(args: Record<string, unknown>) {
     super(args);
     this.requestManager = new RequestManager();
     this.requestManager.use([LegacyNetworkHandler, Fetch]);
+    this.requestManager.useCache(CacheHandler);
   }
 }
 

--- a/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts
@@ -37,10 +37,22 @@ type SerializerWithParseErrors = MinimumSerializerInterface & {
   extractErrors?(store: Store, modelClass: ShimModelClass, error: AdapterErrors, recordId: string | null): unknown;
 };
 
+const PotentialLegacyOperations = new Set([
+  'findRecord',
+  'findAll',
+  'query',
+  'queryRecord',
+  'findBelongsTo',
+  'findHasMany',
+  'updateRecord',
+  'createRecord',
+  'deleteRecord',
+]);
+
 export const LegacyNetworkHandler: Handler = {
   request<T>(context: StoreRequestContext, next: NextFn<T>): Promise<T> {
     // if we are not a legacy request, move on
-    if (context.request.url || !context.request.op) {
+    if (context.request.url || !context.request.op || !PotentialLegacyOperations.has(context.request.op)) {
       return next(context.request) as unknown as Promise<T>;
     }
 

--- a/packages/request/README.md
+++ b/packages/request/README.md
@@ -328,7 +328,7 @@ export default class extends RequestManager {
 To have a request service unique to a Store:
 
 ```ts
-import Store from '@ember-data/store';
+import Store, { CacheHandler } from '@ember-data/store';
 import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 
@@ -338,6 +338,7 @@ class extends Store {
   constructor(args) {
     super(args);
     this.requestManager.use([Fetch]);
+    this.requestManager.useCache(CacheHandler);
   }
 }
 ```
@@ -347,7 +348,7 @@ class extends Store {
 If using the package [ember-data](https://github.com/emberjs/data/tree/main/packages/-ember-data), the following configuration will automatically be done in order to preserve the legacy [Adapter](https://github.com/emberjs/data/tree/main/packages/adapter) and [Serializer](https://github.com/emberjs/data/tree/main/packages/serializer) behavior. Additional handlers or a service injection like the above would need to be done by the consuming application in order to make broader use of `RequestManager`.
 
 ```ts
-import Store from '@ember-data/store';
+import Store, { CacheHandler } from '@ember-data/store';
 import RequestManager from '@ember-data/request';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 
@@ -357,6 +358,7 @@ export default class extends Store {
   constructor(args) {
     super(args);
     this.requestManager.use([LegacyNetworkHandler]);
+    this.requestManager.useCache(CacheHandler);
   }
 }
 ```

--- a/packages/request/src/-private/manager.ts
+++ b/packages/request/src/-private/manager.ts
@@ -275,7 +275,7 @@ export default class extends RequestManager {
 To have a request service unique to a Store:
 
 ```ts
-import Store from '@ember-data/store';
+import Store, { CacheHandler } from '@ember-data/store';
 import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 
@@ -285,6 +285,7 @@ class extends Store {
   constructor(args) {
     super(args);
     this.requestManager.use([Fetch]);
+    this.requestManager.useCache(CacheHandler);
   }
 }
 ```
@@ -294,7 +295,7 @@ class extends Store {
 If using the package [ember-data](https://github.com/emberjs/data/tree/main/packages/-ember-data), the following configuration will automatically be done in order to preserve the legacy [Adapter](https://github.com/emberjs/data/tree/main/packages/adapter) and [Serializer](https://github.com/emberjs/data/tree/main/packages/serializer) behavior. Additional handlers or a service injection like the above would need to be done by the consuming application in order to make broader use of `RequestManager`.
 
 ```ts
-import Store from '@ember-data/store';
+import Store, { CacheHandler } from '@ember-data/store';
 import RequestManager from '@ember-data/request';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 
@@ -304,6 +305,7 @@ export default class extends Store {
   constructor(args) {
     super(args);
     this.requestManager.use([LegacyNetworkHandler]);
+    this.requestManager.useCache(CacheHandler);
   }
 }
 ```

--- a/packages/store/src/-private/cache-handler.ts
+++ b/packages/store/src/-private/cache-handler.ts
@@ -119,8 +119,8 @@ function fetchContentAndHydrate<T>(
 
 export const CacheHandler: Handler = {
   request<T>(context: StoreRequestContext, next: NextFn<T>): Promise<T> | Future<T> {
-    // if we are a legacy request, skip cache handling
-    if (context.request.op && !context.request.url) {
+    // if we are a legacy request or did not originate from the store, skip cache handling
+    if (!context.request.store || (context.request.op && !context.request.url)) {
       return next(context.request);
     }
     const { store } = context.request;

--- a/packages/store/src/-private/index.ts
+++ b/packages/store/src/-private/index.ts
@@ -12,6 +12,8 @@ export { default as Store, storeFor } from './store-service';
 
 export { recordIdentifierFor } from './caches/instance-cache';
 
+export { CacheHandler } from './cache-handler';
+
 export {
   setIdentifierGenerationMethod,
   setIdentifierUpdateMethod,

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -145,6 +145,7 @@
 
 export {
   Store as default,
+  CacheHandler,
   normalizeModelName,
   setIdentifierGenerationMethod,
   setIdentifierUpdateMethod,

--- a/tests/adapter-encapsulation/app/services/store.js
+++ b/tests/adapter-encapsulation/app/services/store.js
@@ -1,13 +1,14 @@
 import Cache from '@ember-data/json-api';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import RequestManager from '@ember-data/request';
-import Store from '@ember-data/store';
+import Store, { CacheHandler } from '@ember-data/store';
 
 export default class DefaultStore extends Store {
   constructor() {
     super(...arguments);
     this.requestManager = new RequestManager();
     this.requestManager.use([LegacyNetworkHandler]);
+    this.requestManager.useCache(CacheHandler);
   }
   createCache(storeWrapper) {
     return new Cache(storeWrapper);

--- a/tests/graph/app/services/store.ts
+++ b/tests/graph/app/services/store.ts
@@ -1,12 +1,13 @@
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
-import BaseStore from '@ember-data/store';
+import BaseStore, { CacheHandler } from '@ember-data/store';
 
 export default class Store extends BaseStore {
   constructor(args: Record<string, unknown>) {
     super(args);
     this.requestManager = new RequestManager();
     this.requestManager.use([LegacyNetworkHandler, Fetch]);
+    this.requestManager.useCache(CacheHandler);
   }
 }

--- a/tests/serializer-encapsulation/app/services/store.js
+++ b/tests/serializer-encapsulation/app/services/store.js
@@ -1,13 +1,14 @@
 import Cache from '@ember-data/json-api';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import RequestManager from '@ember-data/request';
-import Store from '@ember-data/store';
+import Store, { CacheHandler } from '@ember-data/store';
 
 export default class DefaultStore extends Store {
   constructor() {
     super(...arguments);
     this.requestManager = new RequestManager();
     this.requestManager.use([LegacyNetworkHandler]);
+    this.requestManager.useCache(CacheHandler);
   }
   createCache(storeWrapper) {
     return new Cache(storeWrapper);


### PR DESCRIPTION
- [x] Improve documentation for LifetimesService, resolves #8510 
- [x] Fix for CacheHandler not checking first for `store` before assuming request originated from the store reported in #8510 
- [x] Reconfigure how CacheHandler is setup to ensure it can be configured correctly for service-injected RequestManager approach. (resolves #8508)
- [x] Update documentation examples for `import { CacheHandler } from '@ember-data/store';`
- [x] allow `body` on request (resolves #8507)
- [x] enable any `op` per RFC
- [x] only intercept legacy ops missing a url, not all ops
