### PR TITLE
docs: add additional 4.x deprecation guides

### DIFF
--- a/packages/private-build-infra/virtual-packages/deprecations.d.ts
+++ b/packages/private-build-infra/virtual-packages/deprecations.d.ts
@@ -10,7 +10,6 @@ export const DEPRECATE_STRING_ARG_SCHEMAS: boolean;
 export const DEPRECATE_JSON_API_FALLBACK: boolean;
 export const DEPRECATE_MODEL_REOPEN: boolean;
 export const DEPRECATE_EARLY_STATIC: boolean;
-export const DEPRECATE_CLASSIC: boolean;
 export const DEPRECATE_HELPERS: boolean;
 export const DEPRECATE_PROMISE_MANY_ARRAY_BEHAVIORS: boolean;
 export const DEPRECATE_V1CACHE_STORE_APIS: boolean;

--- a/packages/private-build-infra/virtual-packages/deprecations.js
+++ b/packages/private-build-infra/virtual-packages/deprecations.js
@@ -563,7 +563,14 @@ export const DEPRECATE_PROMISE_PROXIES = '4.7';
 export const DEPRECATE_ARRAY_LIKE = '4.7';
 
 /**
- * id:
+ * id: <none yet assigned>
+ *
+ * This is a planned deprecation which will trigger when observer or computed
+ * chains are used to watch for changes on any EmberData RecordArray, ManyArray
+ * or PromiseManyArray.
+ *
+ * Support for these chains is currently guarded by the inactive deprecation flag
+ * listed here.
  *
  * @property DEPRECATE_COMPUTED_CHAINS
  * @since 5.0
@@ -573,7 +580,36 @@ export const DEPRECATE_ARRAY_LIKE = '4.7';
 export const DEPRECATE_COMPUTED_CHAINS = '5.0';
 
 /**
- * id:
+ * id: ember-data:non-explicit-relationships
+ *
+ * Deprecates when polymorphic relationships are detected via inheritance or mixins
+ * and no polymorphic relationship configuration has been setup.
+ *
+ * For further reading please review [RFC#793](https://rfcs.emberjs.com/id/0793-polymporphic-relations-without-inheritance)
+ * which introduced support for explicit relationship polymorphism without
+ * mixins or inheritance.
+ *
+ * You may still use mixins and inheritance to setup your polymorphism; however, the class
+ * structure is no longer what drives the design. Instead polymorphism is "traits" based or "structural":
+ * so long as each model which can satisfy the polymorphic relationship defines the inverse in the same
+ * way they work.
+ *
+ * Notably: `inverse: null` relationships can receive any type as a record with no additional configuration
+ * at all.
+ *
+ * Example Polymorphic Relationship Configuration
+ *
+ * ```ts
+ * // polymorphic relationship
+ * class Tag extends Model {
+ *    @hasMany("taggable", { async: false, polymorphic: true, inverse: "tags" }) tagged;
+ * }
+ *
+ * // an inverse concrete relationship (e.g. satisfies "taggable")
+ * class Post extends Model {
+ *    @hasMany("tag", { async: false, inverse: "tagged", as: "taggable" }) tags;
+ * }
+ * ```
  *
  * @property DEPRECATE_NON_EXPLICIT_POLYMORPHISM
  * @since 4.7

--- a/packages/private-build-infra/virtual-packages/deprecations.js
+++ b/packages/private-build-infra/virtual-packages/deprecations.js
@@ -270,7 +270,38 @@ export const DEPRECATE_JSON_API_FALLBACK = '4.5';
 export const DEPRECATE_MODEL_REOPEN = '4.7';
 
 /**
- * id:
+ * id: ember-data:deprecate-early-static
+ *
+ * This deprecation triggers if static computed properties
+ * or methods are triggered without looking up the record
+ * via the store service's `modelFor` hook. Accessing this
+ * static information without looking up the model via the
+ * store most commonly occurs when
+ *
+ * - using ember-cli-mirage (to fix, refactor to not use its auto-discovery of ember-data models)
+ * - importing a model class and accessing its static information via the import
+ *
+ * Instead of
+ *
+ * ```js
+ * import User from 'my-app/models/user';
+ *
+ * const relationships = User.relationshipsByName;
+ * ```
+ *
+ * Do *at least* this
+ *
+ * ```js
+ * const relationships = store.modelFor('user').relationshipsByName;
+ * ```
+ *
+ * However, the much more future proof refactor is to not use `modelFor` at all but instead
+ * to utilize the schema service for this static information.
+ *
+ * ```js
+ * const relationships = store.getSchemaDefinitionService().relationshipsDefinitionFor({ type: 'user' });
+ * ```
+ *
  *
  * @property DEPRECATE_EARLY_STATIC
  * @since 4.7
@@ -280,17 +311,19 @@ export const DEPRECATE_MODEL_REOPEN = '4.7';
 export const DEPRECATE_EARLY_STATIC = '4.7';
 
 /**
- * id:
+ * id: ember-data:deprecate-errors-hash-to-array-helper
+ * id: ember-data:deprecate-errors-array-to-hash-helper
+ * id: ember-data:deprecate-normalize-modelname-helper
  *
- * @property DEPRECATE_CLASSIC
- * @since 4.9
- * @until 5.0
- * @public
- */
-export const DEPRECATE_CLASSIC = '4.9';
-
-/**
- * id:
+ * Deprecates `errorsHashToArray` `errorsArrayToHash` and `normalizeModelName`
+ *
+ * Users making use of these (already private) utilities can trivially copy them
+ * into their own codebase to continue using them, though we recommend refactoring
+ * to a more direct conversion into the expected errors format for the errors helpers.
+ *
+ * For refactoring normalizeModelName we also recommend following the guidance in
+ * [RFC#740 Deprecate Non-Strict Types](https://github.com/emberjs/rfcs/pull/740).
+ *
  *
  * @property DEPRECATE_HELPERS
  * @since 4.7
@@ -300,7 +333,35 @@ export const DEPRECATE_CLASSIC = '4.9';
 export const DEPRECATE_HELPERS = '4.7';
 
 /**
- * id:
+ * id: ember-data:deprecate-promise-many-array-behavior
+ *
+ * [RFC Documentation](https://rfcs.emberjs.com/id/0745-ember-data-deprecate-methods-on-promise-many-array)
+ *
+ * This deprecation deprecates accessing values on the asynchronous proxy
+ * in favor of first "resolving" or "awaiting" the promise to retrieve a
+ * synchronous value.
+ *
+ * Template iteration of the asynchronous value will still work and not trigger
+ * the deprecation, but all JS access should be avoided and HBS access for anything
+ * but `{{#each}}` should also be refactored.
+ *
+ * Recommended approaches include using the addon `ember-promise-helpers`, using
+ * Ember's `resource` pattern (including potentially the addon `ember-data-resources`),
+ * resolving the value in routes/provider components, or using the references API.
+ *
+ * An example of using the [hasMany](https://api.emberjs.com/ember-data/4.11/classes/Model/methods/hasMany?anchor=hasMany) [reference API](https://api.emberjs.com/ember-data/release/classes/HasManyReference):
+ *
+ * ```ts
+ * // get the synchronous "ManyArray" value for the asynchronous "friends" relationship.
+ * // note, this will return `null` if the relationship has not been loaded yet
+ * const value = person.hasMany('friends').value();
+ *
+ * // to get just the list of related IDs
+ * const ids = person.hasMany('friends').ids();
+ * ```
+ *
+ * References participate in autotracking and getters/cached getters etc. which consume them
+ * will recompute if the value changes.
  *
  * @property DEPRECATE_PROMISE_MANY_ARRAY_BEHAVIORS
  * @since 4.7
@@ -310,7 +371,7 @@ export const DEPRECATE_HELPERS = '4.7';
 export const DEPRECATE_PROMISE_MANY_ARRAY_BEHAVIORS = '4.7';
 
 /**
- * id:
+ * id: ember-data:deprecate-v1cache-store-apis
  *
  * @property DEPRECATE_V1CACHE_STORE_APIS
  * @since 4.7
@@ -320,7 +381,33 @@ export const DEPRECATE_PROMISE_MANY_ARRAY_BEHAVIORS = '4.7';
 export const DEPRECATE_V1CACHE_STORE_APIS = '4.7';
 
 /**
- * id:
+ * id: ember-data:deprecate-non-strict-relationships
+ *
+ * Deprecates when belongsTo and hasMany relationships are defined
+ * without specifying the inverse record's type.
+ *
+ * Instead of
+ *
+ * ```ts
+ * class Company extends Model {
+ *   @hasMany() employees;
+ * }
+ * class Employee extends Model {
+ *   @belongsTo() company;
+ * }
+ * ```
+ *
+ * Use
+ *
+ * ```ts
+ * class Company extends Model {
+ *   @hasMany('employee', { async: true, inverse: 'company' }) employees;
+ * }
+ *
+ * class Employee extends Model {
+ *   @belongsTo('company', { async: true, inverse: 'employees' }) company;
+ * }
+ * ```
  *
  * @property DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE
  * @since 4.7
@@ -330,7 +417,36 @@ export const DEPRECATE_V1CACHE_STORE_APIS = '4.7';
 export const DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE = '4.7';
 
 /**
- * id:
+ * id: ember-data:deprecate-non-strict-relationships
+ *
+ * Deprecates when belongsTo and hasMany relationships are defined
+ * without specifying whether the relationship is asynchronous.
+ *
+ * The current behavior is that relationships which do not define
+ * this setting are aschronous (`{ async: true }`).
+ *
+ * Instead of
+ *
+ * ```ts
+ * class Company extends Model {
+ *   @hasMany('employee') employees;
+ * }
+ * class Employee extends Model {
+ *   @belongsTo('company') company;
+ * }
+ * ```
+ *
+ * Use
+ *
+ * ```ts
+ * class Company extends Model {
+ *   @hasMany('employee', { async: true, inverse: 'company' }) employees;
+ * }
+ *
+ * class Employee extends Model {
+ *   @belongsTo('company', { async: true, inverse: 'employees' }) company;
+ * }
+ * ```
  *
  * @property DEPRECATE_RELATIONSHIPS_WITHOUT_ASYNC
  * @since 4.7
@@ -340,7 +456,64 @@ export const DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE = '4.7';
 export const DEPRECATE_RELATIONSHIPS_WITHOUT_ASYNC = '4.7';
 
 /**
- * id:
+ * id: ember-data:deprecate-non-strict-relationships
+ *
+ * Deprecates when belongsTo and hasMany relationships are defined
+ * without specifying the inverse field on the related type.
+ *
+ * The current behavior is that relationships which do not define
+ * this setting have their inverse determined at runtime, which is
+ * potentially non-deterministic when mixins and polymorphism are involved.
+ *
+ * If an inverse relationship exists and you wish changes on one side to
+ * reflect onto the other side, use the inverse key. If you wish to not have
+ * changes reflected or no inverse relationship exists, specify `inverse: null`.
+ *
+ * Instead of
+ *
+ * ```ts
+ * class Company extends Model {
+ *   @hasMany('employee') employees;
+ * }
+ * class Employee extends Model {
+ *   @belongsTo('company') company;
+ * }
+ * ```
+ *
+ * Use
+ *
+ * ```ts
+ * class Company extends Model {
+ *   @hasMany('employee', { async: true, inverse: 'company' }) employees;
+ * }
+ *
+ * class Employee extends Model {
+ *   @belongsTo('company', { async: true, inverse: 'employees' }) company;
+ * }
+ * ```
+ *
+ * Instead of
+ *
+ * ```ts
+ * class Company extends Model {
+ *   @hasMany('employee') employees;
+ * }
+ * class Employee extends Model {
+ *   @attr name;
+ * }
+ * ```
+ *
+ * Use
+ *
+ * ```ts
+ * class Company extends Model {
+ *   @hasMany('employee', { async: true, inverse: null }) employees;
+ * }
+ *
+ * class Employee extends Model {
+ *   @attr name;
+ * }
+ * ```
  *
  * @property DEPRECATE_RELATIONSHIPS_WITHOUT_INVERSE
  * @since 4.7

--- a/tests/docs/fixtures/expected.js
+++ b/tests/docs/fixtures/expected.js
@@ -45,7 +45,6 @@ module.exports = {
     '(private) @ember-data/debug InspectorDataAdapter#watchTypeIfUnseen',
     '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_ARRAY_LIKE',
     '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_A_USAGE',
-    '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_CLASSIC',
     '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_COMPUTED_CHAINS',
     '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_CREATE_RECORD_DATA_FOR_HOOK',
     '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_EARLY_STATIC',


### PR DESCRIPTION
- DEPRECATE_EARLY_STATIC
- DEPRECATE_HELPERS
- DEPRECATE_PROMISE_MANY_ARRAY_BEHAVIORS
- DEPRECATE_RELATIONSHIPS_WITHOUT_TYPE
- DEPRECATE_RELATIONSHIPS_WITHOUT_ASYNC
- DEPRECATE_RELATIONSHIPS_WITHOUT_INVERSE
- DEPRECATE_NON_EXPLICIT_POLYMORPHISM
- DEPRECATE_COMPUTED_CHAINS