### PR TITLE
fix: ensure cache-handler works as expected

### DIFF
--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -173,7 +173,6 @@ export default class JSONAPICache implements Cache {
     doc: StructuredDocument<T>
   ): ResourceMetaDocument | ResourceErrorDocument;
   put(doc: StructuredDocument<JsonApiDocument>): ResourceDocument {
-    debugger;
     assert(`Cannot currently cache an ErrorDocument`, !('error' in doc));
     const jsonApiDoc = doc.content;
     let included = jsonApiDoc.included;

--- a/packages/store/src/-private/cache-handler.ts
+++ b/packages/store/src/-private/cache-handler.ts
@@ -17,6 +17,18 @@ export interface LifetimesService {
   isSoftExpired(key: string, url: string, method: HTTPMethod): boolean;
 }
 
+const CacheOperations = new Set([
+  'findRecord',
+  'findAll',
+  'query',
+  'queryRecord',
+  'findBelongsTo',
+  'findHasMany',
+  'updateRecord',
+  'createRecord',
+  'deleteRecord',
+]);
+
 export interface StoreRequestInfo extends ImmutableRequestInfo {
   cacheOptions?: { key?: string; reload?: boolean; backgroundReload?: boolean };
   store?: Store;
@@ -38,7 +50,10 @@ export interface StoreRequestContext extends RequestContext {
   request: StoreRequestInfo & { store: Store };
 }
 
-function getHydratedContent<T>(store: Store, request: ImmutableRequestInfo, document: ResourceDataDocument): T {
+function getHydratedContent<T>(store: Store, request: StoreRequestInfo, document: ResourceDataDocument): T {
+  if (!request.op || !CacheOperations.has(request.op)) {
+    return document as T;
+  }
   if (Array.isArray(document.data)) {
     const { lid } = document;
     const { recordArrayManager } = store;
@@ -61,7 +76,14 @@ function getHydratedContent<T>(store: Store, request: ImmutableRequestInfo, docu
     }
     return managed as T;
   } else {
-    return (document.data ? store.peekRecord(document.data) : null) as T;
+    switch (request.op) {
+      case 'findBelongsTo':
+      case 'queryRecord':
+      case 'findRecord':
+        return (document.data ? store.peekRecord(document.data) : null) as T;
+      default:
+        return document.data as T;
+    }
   }
 }
 
@@ -72,9 +94,11 @@ function calcShouldFetch(
   lid: string | null | undefined
 ): boolean {
   const { cacheOptions, url, method } = request;
-  return cacheOptions?.reload || !hasCachedValue || (store.lifetimes && lid && url && method)
-    ? store.lifetimes!.isHardExpired(lid as string, url as string, method as HTTPMethod)
-    : false;
+  return (
+    cacheOptions?.reload ||
+    !hasCachedValue ||
+    (store.lifetimes && lid && url && method ? store.lifetimes.isHardExpired(lid, url, method as HTTPMethod) : false)
+  );
 }
 
 function calcShouldBackgroundFetch(
@@ -86,9 +110,8 @@ function calcShouldBackgroundFetch(
   const { cacheOptions, url, method } = request;
   return (
     !willFetch &&
-    (cacheOptions?.backgroundReload || (store.lifetimes && lid && url && method)
-      ? store.lifetimes!.isSoftExpired(lid as string, url as string, method as HTTPMethod)
-      : false)
+    (cacheOptions?.backgroundReload ||
+      (store.lifetimes && lid && url && method ? store.lifetimes.isSoftExpired(lid, url, method as HTTPMethod) : false))
   );
 }
 
@@ -120,7 +143,10 @@ function fetchContentAndHydrate<T>(
 export const CacheHandler: Handler = {
   request<T>(context: StoreRequestContext, next: NextFn<T>): Promise<T> | Future<T> {
     // if we are a legacy request or did not originate from the store, skip cache handling
-    if (!context.request.store || (context.request.op && !context.request.url)) {
+    if (
+      !context.request.store ||
+      (context.request.op && CacheOperations.has(context.request.op) && !context.request.url)
+    ) {
       return next(context.request);
     }
     const { store } = context.request;

--- a/packages/store/src/-private/caches/instance-cache.ts
+++ b/packages/store/src/-private/caches/instance-cache.ts
@@ -365,7 +365,7 @@ export class InstanceCache {
   }
 
   recordIsLoaded(identifier: StableRecordIdentifier, filterDeleted: boolean = false) {
-    const cache = DEPRECATE_V1_RECORD_DATA ? this.__instances.resourceCache.get(identifier) : this.cache;
+    const cache = DEPRECATE_V1_RECORD_DATA ? this.__instances.resourceCache.get(identifier) || this.cache : this.cache;
     if (!cache) {
       return false;
     }

--- a/packages/store/src/-private/managers/record-array-manager.ts
+++ b/packages/store/src/-private/managers/record-array-manager.ts
@@ -98,6 +98,7 @@ class RecordArrayManager {
     this._managed = new Set();
     this._pending = new Map();
     this._staged = new Map();
+    this._keyedArrays = new Map();
     this._identifiers = RecordArraysCache;
 
     this._subscription = this.store.notifications.subscribe(

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -411,7 +411,6 @@ class Store {
       if (requestConfig.op === 'findBelongsTo' && !requestConfig.url) {
         return;
       }
-      debugger;
       this.notifications._flush();
     });
 

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -411,6 +411,7 @@ class Store {
       if (requestConfig.op === 'findBelongsTo' && !requestConfig.url) {
         return;
       }
+      debugger;
       this.notifications._flush();
     });
 

--- a/tests/main/app/cache-handler/meta-package-setup-test.js
+++ b/tests/main/app/cache-handler/meta-package-setup-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+
+import MetaStore from 'ember-data/store';
+import { setupTest } from 'ember-qunit';
+
+module('Store | CacheHandler - setup with ember-data/store', function (hooks) {
+  setupTest(hooks);
+
+  test('When using ember-data/store, we are configured correctly', async function (assert) {
+    const { owner } = this;
+    owner.register('service:store', MetaStore);
+    assert.ok(true, 'more tests later');
+  });
+});

--- a/tests/main/app/cache-handler/meta-package-setup-test.js
+++ b/tests/main/app/cache-handler/meta-package-setup-test.js
@@ -3,12 +3,50 @@ import { module, test } from 'qunit';
 import MetaStore from 'ember-data/store';
 import { setupTest } from 'ember-qunit';
 
+import Model, { attr } from '@ember-data/model';
+
 module('Store | CacheHandler - setup with ember-data/store', function (hooks) {
   setupTest(hooks);
 
   test('When using ember-data/store, we are configured correctly', async function (assert) {
     const { owner } = this;
     owner.register('service:store', MetaStore);
-    assert.ok(true, 'more tests later');
+    owner.register(
+      'model:user',
+      class extends Model {
+        @attr name;
+      }
+    );
+
+    const store = owner.lookup('service:store');
+
+    const userDocument = await store.request({
+      url: '/assets/demo-fetch.json',
+    });
+
+    assert.strictEqual(
+      userDocument.content.data,
+      store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' }),
+      'we get a stable identifier back as data'
+    );
+
+    assert.strictEqual(userDocument.content.lid, '/assets/demo-fetch.json', 'we get back url as the cache key');
+
+    assert.deepEqual(
+      userDocument.content.links,
+      { self: '/assets/demo-fetch.json' },
+      'we get access to the document links'
+    );
+
+    assert.deepEqual(
+      userDocument.content.meta,
+      {
+        expiration: 120000,
+      },
+      'we get access to the document meta'
+    );
+
+    const record = store.peekRecord(userDocument.content.data);
+    assert.strictEqual(record?.name, 'Chris Thoburn');
   });
 });

--- a/tests/main/app/cache-handler/store-package-setup-test.ts
+++ b/tests/main/app/cache-handler/store-package-setup-test.ts
@@ -1,0 +1,70 @@
+import { service } from '@ember/service';
+
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import Cache from '@ember-data/json-api';
+import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
+import RequestManager from '@ember-data/request';
+import Fetch from '@ember-data/request/fetch';
+import Store, { CacheHandler } from '@ember-data/store';
+import type { SingleResourceDataDocument } from '@ember-data/types/cache/document';
+import type { CacheStoreWrapper } from '@ember-data/types/q/cache-store-wrapper';
+
+module('Store | CacheHandler - setup with @ember-data/store', function (hooks) {
+  setupTest(hooks);
+
+  test('When using @ember-data/store, we can use @ember-data/request as a service', async function (assert) {
+    const { owner } = this;
+
+    class RequestManagerService extends RequestManager {
+      constructor() {
+        super(...arguments);
+        this.use([LegacyNetworkHandler, Fetch]);
+        this.useCache(CacheHandler);
+      }
+    }
+
+    class TestStore extends Store {
+      @service('request') declare requestManager: RequestManager;
+
+      createCache(wrapper: CacheStoreWrapper) {
+        return new Cache(wrapper);
+      }
+    }
+
+    owner.register('service:store', TestStore);
+    owner.register('service:request', RequestManagerService);
+
+    const store = owner.lookup('service:store') as TestStore;
+    const userDocument = await store.request<SingleResourceDataDocument>({
+      url: '/assets/demo-fetch.json',
+    });
+
+    assert.strictEqual(
+      userDocument.content.data,
+      store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' }),
+      'we get a stable identifier back as data'
+    );
+
+    assert.strictEqual(userDocument.content.lid, '/assets/demo-fetch.json', 'we get back url as the cache key');
+
+    assert.deepEqual(
+      userDocument.content.links,
+      { self: '/assets/demo-fetch.json' },
+      'we get access to the document links'
+    );
+
+    assert.deepEqual(
+      userDocument.content.meta,
+      {
+        expiration: 120000,
+      },
+      'we get access to the document meta'
+    );
+
+    const record = store.peekRecord(userDocument.content.data!);
+    assert.strictEqual(record?.name, 'Chris Thoburn');
+  });
+});

--- a/tests/main/public/assets/demo-fetch.json
+++ b/tests/main/public/assets/demo-fetch.json
@@ -1,0 +1,15 @@
+{
+  "links": {
+    "self": "/assets/demo-fetch.json"
+  },
+  "meta": {
+    "expiration": 120000
+  },
+  "data": {
+    "type": "user",
+    "id": "1",
+    "attributes": {
+      "name": "Chris Thoburn"
+    }
+  }
+}


### PR DESCRIPTION
- Adds additional testing for the CacheHandler. resolves #8510 
- Ensures `cacheOptions.key` is used before `url` (needs test). resolves #8516 
- resolves #8515 by ensuring keyedArrays is setup properly (needs test)