### PR TITLE
feat: stable document identity

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
   parser: '@babel/eslint-parser',
   root: true,
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2022,
     sourceType: 'module',
     babelOptions: {
       // eslint-disable-next-line node/no-unpublished-require
@@ -84,15 +84,11 @@ module.exports = {
     'qunit/no-identical-names': 'off',
     'qunit/require-expect': 'off',
   },
-  globals: {
-    Map: false,
-    WeakMap: true,
-    Set: true,
-    Promise: false,
-  },
+  globals: {},
   env: {
     browser: true,
     node: false,
+    es6: true,
   },
   overrides: [
     {

--- a/packages/model/src/-private/legacy-relationships-support.ts
+++ b/packages/model/src/-private/legacy-relationships-support.ts
@@ -459,6 +459,7 @@ export class LegacySupport {
           op: 'findHasMany',
           records: identifiers || [],
           data: request,
+          cacheOptions: { [Symbol.for('ember-data:skip-cache')]: true },
         }) as unknown as Promise<void>;
       }
 
@@ -481,6 +482,7 @@ export class LegacySupport {
           op: 'findHasMany',
           records: identifiers,
           data: request,
+          cacheOptions: { [Symbol.for('ember-data:skip-cache')]: true },
         }) as unknown as Promise<void>;
       }
 
@@ -538,6 +540,7 @@ export class LegacySupport {
         op: 'findBelongsTo',
         records: identifier ? [identifier] : [],
         data: request,
+        cacheOptions: { [Symbol.for('ember-data:skip-cache')]: true },
       });
       this._pending = future
         .then((doc) => doc.content)
@@ -574,6 +577,7 @@ export class LegacySupport {
           op: 'findBelongsTo',
           records: [identifier],
           data: request,
+          cacheOptions: { [Symbol.for('ember-data:skip-cache')]: true },
         })
         .then((doc) => doc.content)
         .finally(() => {

--- a/packages/model/src/-private/model.js
+++ b/packages/model/src/-private/model.js
@@ -980,6 +980,7 @@ class Model extends EmberObject {
           options,
           record: identifier,
         },
+        cacheOptions: { [Symbol.for('ember-data:skip-cache')]: true },
       })
       .then(() => this)
       .finally(() => {

--- a/packages/request/src/-private/types.ts
+++ b/packages/request/src/-private/types.ts
@@ -124,8 +124,15 @@ export interface RequestInfo extends Request {
   options?: Record<string, unknown>;
 }
 
+const SkipCache = Symbol.for('ember-data:skip-cache');
+
 export interface ImmutableRequestInfo {
-  readonly cacheOptions?: { key?: string; reload?: boolean; backgroundReload?: boolean };
+  readonly cacheOptions?: {
+    key?: string;
+    reload?: boolean;
+    backgroundReload?: boolean;
+    [SkipCache]?: true;
+  };
   readonly store?: Store;
 
   readonly op?: string;

--- a/packages/store/src/-private/cache-handler.ts
+++ b/packages/store/src/-private/cache-handler.ts
@@ -121,10 +121,13 @@ function fetchContentAndHydrate<T>(
   ) as Promise<T>;
 }
 
+export const SkipCache = Symbol.for('ember-data:skip-cache');
+export const EnableHydration = Symbol.for('ember-data:enable-hydration');
+
 export const CacheHandler: Handler = {
   request<T>(context: StoreRequestContext, next: NextFn<T>): Promise<T> | Future<T> {
     // if we have no cache or no cache-key skip cache handling
-    if (!context.request.store) {
+    if (!context.request.store || context.request.cacheOptions?.[SkipCache]) {
       return next(context.request);
     }
 
@@ -147,8 +150,7 @@ export const CacheHandler: Handler = {
       throw peeked.error;
     }
 
-    const shouldHydrate: boolean =
-      (context.request[Symbol.for('ember-data:enable-hydration')] as boolean | undefined) || false;
+    const shouldHydrate: boolean = (context.request[EnableHydration] as boolean | undefined) || false;
 
     return Promise.resolve(
       shouldHydrate

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -40,7 +40,7 @@ import type { SchemaService } from '@ember-data/types/q/schema-service';
 import type { FindOptions } from '@ember-data/types/q/store';
 import type { Dict } from '@ember-data/types/q/utils';
 
-import { type LifetimesService, type StoreRequestInfo } from './cache-handler';
+import { EnableHydration, type LifetimesService, SkipCache, type StoreRequestInfo } from './cache-handler';
 import peekCache, { setCacheFor } from './caches/cache-utils';
 import { IdentifierCache } from './caches/identifier-cache';
 import {
@@ -388,10 +388,9 @@ class Store {
     // we lazily set the cache handler when we issue the first request
     // because constructor doesn't allow for this to run after
     // the user has had the chance to set the prop.
-    const storeSymbol = Symbol.for('ember-data:enable-hydration');
-    let opts: { store: Store; disableTestWaiter?: boolean; [storeSymbol]: true } = {
+    let opts: { store: Store; disableTestWaiter?: boolean; [EnableHydration]: true } = {
       store: this,
-      [storeSymbol]: true,
+      [EnableHydration]: true,
     };
 
     if (TESTING) {
@@ -1325,6 +1324,7 @@ class Store {
         record: identifier,
         options,
       },
+      cacheOptions: { [SkipCache as symbol]: true },
     });
 
     if (DEPRECATE_PROMISE_PROXIES) {
@@ -1602,6 +1602,7 @@ class Store {
         query,
         options: options || {},
       },
+      cacheOptions: { [SkipCache as symbol]: true },
     });
 
     if (DEPRECATE_PROMISE_PROXIES) {
@@ -1730,6 +1731,7 @@ class Store {
         query,
         options: options || {},
       },
+      cacheOptions: { [SkipCache as symbol]: true },
     });
 
     if (DEPRECATE_PROMISE_PROXIES) {
@@ -1945,6 +1947,7 @@ class Store {
         type: normalizeModelName(modelName),
         options: options || {},
       },
+      cacheOptions: { [SkipCache as symbol]: true },
     });
 
     if (DEPRECATE_PROMISE_PROXIES) {
@@ -2413,6 +2416,7 @@ class Store {
         options,
         record: identifier,
       },
+      cacheOptions: { [SkipCache as symbol]: true },
     }).then((document) => document.content);
   }
 

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -232,20 +232,23 @@ class Store {
    * A Property which an App may set to provide a Lifetimes Service
    * to control when a cached request becomes stale.
    *
-   * Note, when defined, these methods will only be invoked if `key` `url` and `method`
-   * are all present.
+   * Note, when defined, these methods will only be invoked if a
+   * cache key exists for the request, either because the request
+   * contains `cacheOptions.key` or because the [IdentifierCache](/ember-data/release/classes/IdentifierCache)
+   * was able to generate a key for the request using the configured
+   * [generation method](/ember-data/release/functions/@ember-data%2Fstore/setIdentifierGenerationMethod).
    *
    * `isSoftExpired` will only be invoked if `isHardExpired` returns `false`.
    *
    * ```ts
    * store.lifetimes = {
    *   // make the request and ignore the current cache state
-   *   isHardExpired(key: string, url: string, method?: HTTPMethod): boolean {
+   *   isHardExpired(identifier: StableDocumentIdentifier): boolean {
    *     return false;
    *   }
    *
    *   // make the request in the background if true, return cache state
-   *   isSoftExpired(key: string, url: string, method: HTTPMethod): boolean {
+   *   isSoftExpired(identifier: StableDocumentIdentifier): boolean {
    *     return false;
    *   }
    * }

--- a/packages/unpublished-test-infra/addon-test-support/todo.js
+++ b/packages/unpublished-test-infra/addon-test-support/todo.js
@@ -1,4 +1,3 @@
-/* global Proxy */
 import QUnit, { skip, test } from 'qunit';
 
 import { DEBUG } from '@ember-data/env';

--- a/tests/main/tests/integration/identifiers/configuration-test.ts
+++ b/tests/main/tests/integration/identifiers/configuration-test.ts
@@ -20,6 +20,7 @@ import Store, {
 } from '@ember-data/store';
 import type { DSModel } from '@ember-data/types/q/ds-model';
 import type {
+  GenerationMethod,
   IdentifierBucket,
   ResourceData,
   StableIdentifier,
@@ -46,7 +47,13 @@ module('Integration | Identifiers - configuration', function (hooks) {
     owner.register('model:user', User);
 
     let localIdInc = 9000;
-    const generationMethod = (resource: ResourceData | { type: string }) => {
+    const generationMethod: GenerationMethod = (resource: unknown, bucket: IdentifierBucket) => {
+      if (bucket !== 'record') {
+        throw new Error('Test cannot generate an lid for a non-record');
+      }
+      if (typeof resource !== 'object' || resource === null) {
+        throw new Error('Test cannot generate an lid for a non-object');
+      }
       if (!('type' in resource) || typeof resource.type !== 'string' || resource.type.length < 1) {
         throw new Error(`Cannot generate an lid for a record without a type`);
       }
@@ -91,7 +98,13 @@ module('Integration | Identifiers - configuration', function (hooks) {
 
   test(`The configured generation method is used for newly created records`, async function (assert) {
     let localIdInc = 9000;
-    const generationMethod = (resource: ResourceData | { type: string }) => {
+    const generationMethod: GenerationMethod = (resource: unknown, bucket: IdentifierBucket) => {
+      if (bucket !== 'record') {
+        throw new Error('Test cannot generate an lid for a non-record');
+      }
+      if (typeof resource !== 'object' || resource === null) {
+        throw new Error('Test cannot generate an lid for a non-object');
+      }
       if (!('type' in resource) || typeof resource.type !== 'string' || resource.type.length < 1) {
         throw new Error(`Cannot generate an lid for a record without a type`);
       }
@@ -368,7 +381,13 @@ module('Integration | Identifiers - configuration', function (hooks) {
     this.owner.register('serializer:application', TestSerializer);
 
     let generateLidCalls = 0;
-    setIdentifierGenerationMethod((resource: ResourceData | { type: string }) => {
+    setIdentifierGenerationMethod((resource: unknown, bucket: IdentifierBucket) => {
+      if (bucket !== 'record') {
+        throw new Error('Test cannot generate an lid for a non-record');
+      }
+      if (typeof resource !== 'object' || resource === null || !('type' in resource)) {
+        throw new Error('Test cannot generate an lid for a non-object');
+      }
       if (!('id' in resource)) {
         throw new Error(`Unexpected generation of new resource identifier`);
       }


### PR DESCRIPTION
resolves #8530 

Originally for the RFC we'd intended for the lifetimes service to take a stable identifier, as the implementation was built it felt like maybe we didn't actually need this concept, but now that we're deeper in we find our initial design was correct.

This makes use of the existing `IdentifiersCache` which serves as a configurable way to determine stable identity from any opaque data (in this case, the `Request`). We provide default generation of identity (`cacheOptions.key` falling back to `url` only when `method` is absent or `GET`), but users may configure this themselves.

