### PR TITLE
feat: Rich Documents

### DIFF
--- a/packages/request/src/-private/context.ts
+++ b/packages/request/src/-private/context.ts
@@ -15,8 +15,10 @@ export class ContextOwner {
   nextCalled: number = 0;
   declare god: GodContext;
   declare controller: AbortController;
+  declare requestId: number;
 
   constructor(request: RequestInfo, god: GodContext) {
+    this.requestId = god.id;
     this.controller = request.controller || god.controller;
     if (request.controller) {
       if (request.controller !== god.controller) {
@@ -127,8 +129,10 @@ export class ContextOwner {
 export class Context {
   #owner: ContextOwner;
   declare request: ImmutableRequestInfo;
+  declare id: number;
 
   constructor(owner: ContextOwner) {
+    this.id = owner.requestId;
     this.#owner = owner;
     this.request = owner.enhancedRequest;
   }

--- a/packages/request/src/-private/manager.ts
+++ b/packages/request/src/-private/manager.ts
@@ -327,6 +327,8 @@ import { assertValidRequest } from './debug';
 import { upgradePromise } from './future';
 import { Future, GenericCreateArgs, Handler, RequestInfo } from './types';
 import { executeNextHandler } from './utils';
+
+let REQ_ID = 0;
 /**
  * ```js
  * import RequestManager from '@ember-data/request';
@@ -406,9 +408,11 @@ import { executeNextHandler } from './utils';
 export class RequestManager {
   #handlers: Handler[] = [];
   declare _hasCacheHandler: boolean;
+  declare _pending: Map<number, Promise<unknown>>;
 
   constructor(options?: GenericCreateArgs) {
     Object.assign(this, options);
+    this._pending = new Map();
   }
 
   /**
@@ -499,6 +503,7 @@ export class RequestManager {
       controller,
       response: null,
       stream: null,
+      id: REQ_ID++,
     });
     if (TESTING) {
       if (!request.disableTestWaiter) {

--- a/packages/request/src/-private/types.ts
+++ b/packages/request/src/-private/types.ts
@@ -39,6 +39,7 @@ export interface GodContext {
   controller: AbortController;
   response: ResponseInfo | null;
   stream: ReadableStream | Promise<ReadableStream | null> | null;
+  id: number;
 }
 
 export interface StructuredDataDocument<T> {
@@ -189,6 +190,7 @@ export interface ResponseInfo {
 
 export interface RequestContext {
   request: ImmutableRequestInfo;
+  id: number;
 
   setStream(stream: ReadableStream): void;
   setResponse(response: Response | ResponseInfo): void;

--- a/packages/store/src/-private/cache-handler.ts
+++ b/packages/store/src/-private/cache-handler.ts
@@ -26,15 +26,25 @@ export interface StoreRequestContext extends RequestContext {
   request: StoreRequestInfo & { store: Store };
 }
 
-function getHydratedContent<T>(
+function maybeUpdateUiObjects<T>(
   store: Store,
   request: StoreRequestInfo,
-  identifier: StableDocumentIdentifier | null,
-  document: ResourceDataDocument
+  options: {
+    shouldHydrate?: boolean;
+    shouldFetch?: boolean;
+    shouldBackgroundFetch?: boolean;
+    identifier: StableDocumentIdentifier | null;
+  },
+  document: ResourceDataDocument,
+  isFromCache: boolean
 ): T {
+  const { identifier } = options;
   if (Array.isArray(document.data)) {
     const { recordArrayManager } = store;
     if (!identifier) {
+      if (!options.shouldHydrate) {
+        return document as T;
+      }
       const data = recordArrayManager.createArray({
         identifiers: document.data,
         doc: document as CollectionResourceDataDocument,
@@ -49,6 +59,7 @@ function getHydratedContent<T>(
       return doc as T;
     }
     let managed = recordArrayManager._keyedArrays.get(identifier.lid);
+
     if (!managed) {
       managed = recordArrayManager.createArray({
         identifiers: document.data,
@@ -60,15 +71,23 @@ function getHydratedContent<T>(
       doc.meta = document.meta;
       doc.links = document.links;
       store._documentCache.set(identifier, doc);
+
+      return options.shouldHydrate ? (doc as T) : (document as T);
     } else {
-      recordArrayManager.populateManagedArray(managed, document.data, document as CollectionResourceDataDocument);
       const doc = store._documentCache.get(identifier)!;
-      doc.data = managed;
-      doc.meta = document.meta;
-      doc.links = document.links;
+      if (!isFromCache) {
+        recordArrayManager.populateManagedArray(managed, document.data, document as CollectionResourceDataDocument);
+        doc.data = managed;
+        doc.meta = document.meta;
+        doc.links = document.links;
+      }
+
+      return options.shouldHydrate ? (doc as T) : (document as T);
     }
-    return managed as T;
   } else {
+    if (!identifier && !options.shouldHydrate) {
+      return document as T;
+    }
     const data = document.data ? store.peekRecord(document.data) : null;
     let doc: Document<RecordInstance | null> | undefined;
     if (identifier) {
@@ -77,17 +96,20 @@ function getHydratedContent<T>(
 
     if (!doc) {
       doc = new Document<RecordInstance | null>(store, identifier);
+      doc.data = data;
+      doc.meta = document.meta;
+      doc.links = document.links;
 
       if (identifier) {
         store._documentCache.set(identifier, doc);
       }
+    } else if (!isFromCache) {
+      doc.data = data;
+      doc.meta = document.meta;
+      doc.links = document.links;
     }
 
-    doc.data = data;
-    doc.meta = document.meta;
-    doc.links = document.links;
-
-    return doc as T;
+    return options.shouldHydrate ? (doc as T) : (document as T);
   }
 }
 
@@ -131,22 +153,29 @@ function fetchContentAndHydrate<T>(
     (context.request[Symbol.for('ember-data:enable-hydration')] as boolean | undefined) || false;
   return next(context.request).then(
     (document) => {
+      store.requestManager._pending.delete(context.id);
       store._enableAsyncFlush = true;
       let response: ResourceDataDocument;
       store._join(() => {
         response = store.cache.put(document) as ResourceDataDocument;
-
-        if (shouldFetch && shouldHydrate) {
-          response = getHydratedContent(store, context.request, identifier, response);
-        }
+        response = maybeUpdateUiObjects(
+          store,
+          context.request,
+          { shouldHydrate, shouldFetch, shouldBackgroundFetch, identifier },
+          response,
+          false
+        );
       });
       store._enableAsyncFlush = null;
 
       if (shouldFetch) {
         return response!;
+      } else if (shouldBackgroundFetch) {
+        store.notifications._flush();
       }
     },
     (error: StructuredErrorDocument) => {
+      store.requestManager._pending.delete(context.id);
       store._enableAsyncFlush = true;
       store._join(() => {
         store.cache.put(error);
@@ -183,7 +212,8 @@ export const CacheHandler: Handler = {
 
     // if we have not skipped cache, determine if we should update behind the scenes
     if (calcShouldBackgroundFetch(store, context.request, false, identifier)) {
-      void fetchContentAndHydrate(next, context, identifier, false, true);
+      let promise = fetchContentAndHydrate(next, context, identifier, false, true);
+      store.requestManager._pending.set(context.id, promise);
     }
 
     if ('error' in peeked!) {
@@ -194,7 +224,13 @@ export const CacheHandler: Handler = {
 
     return Promise.resolve(
       shouldHydrate
-        ? getHydratedContent<T>(store, context.request, identifier, peeked!.content as ResourceDataDocument)
+        ? maybeUpdateUiObjects<T>(
+            store,
+            context.request,
+            { shouldHydrate, identifier },
+            peeked!.content as ResourceDataDocument,
+            true
+          )
         : (peeked!.content as T)
     );
   },

--- a/packages/store/src/-private/document.ts
+++ b/packages/store/src/-private/document.ts
@@ -1,0 +1,62 @@
+import { assert } from '@ember/debug';
+import { tracked } from '@glimmer/tracking';
+
+import { RequestInfo } from '@ember-data/request/-private/types';
+import { StableDocumentIdentifier } from '@ember-data/types/cache/identifier';
+import { Link, PaginationLinks } from '@ember-data/types/q/ember-data-json-api';
+
+import type Store from './store-service';
+
+function urlFromLink(link: Link): string {
+  if (typeof link === 'string') return link;
+  return link.href;
+}
+
+export class Document<T> {
+  @tracked links?: PaginationLinks;
+  @tracked data?: T;
+  @tracked errors?: object;
+  @tracked meta?: object;
+
+  declare identifier: StableDocumentIdentifier | null;
+
+  #store: Store;
+  constructor(store: Store, identifier: StableDocumentIdentifier | null) {
+    this.#store = store;
+    this.identifier = identifier;
+  }
+
+  async #request(link: keyof PaginationLinks, options: object = {}): Promise<Document<T> | null> {
+    const href = this.links?.[link];
+    if (!href) {
+      return null;
+    }
+
+    const response = await this.#store.request<Document<T>>(Object.assign(options, { url: urlFromLink(href) }));
+
+    return response.content;
+  }
+
+  fetch(options: Partial<RequestInfo> = {}): Promise<Document<T>> {
+    assert(`No self link`, this.links?.self);
+    options.cacheOptions = options.cacheOptions || {};
+    options.cacheOptions.key = this.identifier?.lid;
+    return this.#request('self', options) as Promise<Document<T>>;
+  }
+
+  next(options?: object): Promise<Document<T> | null> {
+    return this.#request('next', options);
+  }
+
+  prev(options?: object): Promise<Document<T> | null> {
+    return this.#request('prev', options);
+  }
+
+  first(options?: object): Promise<Document<T> | null> {
+    return this.#request('first', options);
+  }
+
+  last(options?: object): Promise<Document<T> | null> {
+    return this.#request('last', options);
+  }
+}

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -22,6 +22,7 @@ import type DSModelClass from '@ember-data/model';
 import { HAS_COMPAT_PACKAGE, HAS_GRAPH_PACKAGE, HAS_JSON_API_PACKAGE, HAS_MODEL_PACKAGE } from '@ember-data/packages';
 import type RequestManager from '@ember-data/request';
 import type { Future } from '@ember-data/request/-private/types';
+import { StableDocumentIdentifier } from '@ember-data/types/cache/identifier';
 import type { Cache, CacheV1 } from '@ember-data/types/q/cache';
 import type { CacheStoreWrapper } from '@ember-data/types/q/cache-store-wrapper';
 import type { DSModel } from '@ember-data/types/q/ds-model';
@@ -53,6 +54,7 @@ import {
   storeFor,
   StoreMap,
 } from './caches/instance-cache';
+import { Document } from './document';
 import RecordReference from './legacy-model-support/record-reference';
 import { DSModelSchemaDefinitionService, getModelFactory } from './legacy-model-support/schema-definition-service';
 import type ShimModelClass from './legacy-model-support/shim-model-class';
@@ -212,6 +214,7 @@ class Store {
   declare _fetchManager: FetchManager;
   declare _requestCache: RequestStateService;
   declare _instanceCache: InstanceCache;
+  declare _documentCache: Map<StableDocumentIdentifier, Document<RecordInstance | RecordInstance[] | null>>;
 
   declare _cbs: { coalesce?: () => void; sync?: () => void; notify?: () => void } | null;
   declare _forceShim: boolean;
@@ -243,6 +246,7 @@ class Store {
     this._adapterCache = Object.create(null);
     this._serializerCache = Object.create(null);
     this._modelFactoryCache = Object.create(null);
+    this._documentCache = new Map();
   }
 
   _run(cb: () => void) {

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -302,6 +302,7 @@ class Store {
       lids.forEach((lid) => {
         all.push(...pending[lid].map((v) => v[RequestPromise]!));
       });
+      this.requestManager._pending.forEach((v) => all.push(v));
       const promise: Promise<unknown[]> & { length: number } = Promise.allSettled(all) as Promise<unknown[]> & {
         length: number;
       };

--- a/tests/main/tests/integration/cache-handler/meta-package-setup-test.js
+++ b/tests/main/tests/integration/cache-handler/meta-package-setup-test.js
@@ -32,7 +32,11 @@ module('Store | CacheHandler - setup with ember-data/store', function (hooks) {
     assert.strictEqual(record?.name, 'Chris Thoburn', 'record name is correct');
     assert.strictEqual(data, record, 'record was returned as data');
     assert.strictEqual(data && recordIdentifierFor(data), identifier, 'we get a record back as data');
-    assert.strictEqual(userDocument.content.identifier?.lid, '/assets/users/1.json', 'we get back url as the cache key');
+    assert.strictEqual(
+      userDocument.content.identifier?.lid,
+      '/assets/users/1.json',
+      'we get back url as the cache key'
+    );
     assert.deepEqual(
       userDocument.content.links,
       { self: '/assets/users/1.json' },

--- a/tests/main/tests/integration/cache-handler/meta-package-setup-test.js
+++ b/tests/main/tests/integration/cache-handler/meta-package-setup-test.js
@@ -32,7 +32,7 @@ module('Store | CacheHandler - setup with ember-data/store', function (hooks) {
     assert.strictEqual(record?.name, 'Chris Thoburn', 'record name is correct');
     assert.strictEqual(data, record, 'record was returned as data');
     assert.strictEqual(data && recordIdentifierFor(data), identifier, 'we get a record back as data');
-    assert.strictEqual(userDocument.content.lid, '/assets/users/1.json', 'we get back url as the cache key');
+    assert.strictEqual(userDocument.content.identifier?.lid, '/assets/users/1.json', 'we get back url as the cache key');
     assert.deepEqual(
       userDocument.content.links,
       { self: '/assets/users/1.json' },

--- a/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
+++ b/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
@@ -12,7 +12,11 @@ import Fetch from '@ember-data/request/fetch';
 import Store, { CacheHandler, recordIdentifierFor } from '@ember-data/store';
 import type { Document } from '@ember-data/store/-private/document';
 import type { NotificationType } from '@ember-data/store/-private/managers/notification-manager';
-import type { CollectionResourceDataDocument, ResourceDataDocument, SingleResourceDataDocument } from '@ember-data/types/cache/document';
+import type {
+  CollectionResourceDataDocument,
+  ResourceDataDocument,
+  SingleResourceDataDocument,
+} from '@ember-data/types/cache/document';
 import type { CacheStoreWrapper } from '@ember-data/types/q/cache-store-wrapper';
 import type { ResourceIdentifierObject } from '@ember-data/types/q/ember-data-json-api';
 import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
@@ -497,14 +501,16 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
                 expiration: 120000,
                 total: handlerCalls,
               },
-              data: handlerCalls === 1
+              data:
+                handlerCalls === 1
                   ? {
-                    type: 'user',
-                    id: '1',
-                    attributes: {
-                      name: 'Chris Thoburn',
-                    },
-                  } : {
+                      type: 'user',
+                      id: '1',
+                      attributes: {
+                        name: 'Chris Thoburn',
+                      },
+                    }
+                  : {
                       type: 'user',
                       id: '2',
                       attributes: {
@@ -636,14 +642,16 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
                 expiration: 120000,
                 total: handlerCalls,
               },
-              data: handlerCalls === 1
+              data:
+                handlerCalls === 1
                   ? {
-                    type: 'user',
-                    id: '1',
-                    attributes: {
-                      name: 'Chris Thoburn',
-                    },
-                  } : {
+                      type: 'user',
+                      id: '1',
+                      attributes: {
+                        name: 'Chris Thoburn',
+                      },
+                    }
+                  : {
                       type: 'user',
                       id: '2',
                       attributes: {
@@ -780,14 +788,16 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
                 expiration: 120000,
                 total: handlerCalls,
               },
-              data: handlerCalls === 1
+              data:
+                handlerCalls === 1
                   ? {
-                    type: 'user',
-                    id: '1',
-                    attributes: {
-                      name: 'Chris Thoburn',
-                    },
-                  } : {
+                      type: 'user',
+                      id: '1',
+                      attributes: {
+                        name: 'Chris Thoburn',
+                      },
+                    }
+                  : {
                       type: 'user',
                       id: '2',
                       attributes: {
@@ -867,11 +877,7 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
       const identifier2 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '2' });
 
       assert.strictEqual(data3, identifier2, 'we get an identifier back as data');
-      assert.strictEqual(
-        updatedUserDocument.content.lid,
-        '/assets/users/1.json',
-        'we get back url as the cache key'
-      );
+      assert.strictEqual(updatedUserDocument.content.lid, '/assets/users/1.json', 'we get back url as the cache key');
       assert.deepEqual(
         updatedUserDocument.content.links,
         {

--- a/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
+++ b/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
@@ -7,17 +7,17 @@ import { setupTest } from 'ember-qunit';
 import Cache from '@ember-data/json-api';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import RequestManager from '@ember-data/request';
-import { StructuredErrorDocument } from '@ember-data/request/-private/types';
+import type { StructuredErrorDocument } from '@ember-data/request/-private/types';
 import Fetch from '@ember-data/request/fetch';
 import Store, { CacheHandler, recordIdentifierFor } from '@ember-data/store';
-import { NotificationType } from '@ember-data/store/-private/managers/notification-manager';
+import type { Document } from '@ember-data/store/-private/document';
+import type { NotificationType } from '@ember-data/store/-private/managers/notification-manager';
 import type { SingleResourceDataDocument } from '@ember-data/types/cache/document';
 import type { CacheStoreWrapper } from '@ember-data/types/q/cache-store-wrapper';
 import type { ResourceIdentifierObject } from '@ember-data/types/q/ember-data-json-api';
 import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
 import type { JsonApiResource } from '@ember-data/types/q/record-data-json-api';
 import type { RecordInstance } from '@ember-data/types/q/record-instance';
-import type { Document } from '@ember-data/store/-private/document';
 
 type FakeRecord = { [key: string]: unknown; destroy: () => void };
 
@@ -99,8 +99,12 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
 
     assert.strictEqual(record?.name, 'Chris Thoburn', 'record name is correct');
     assert.strictEqual(data, record, 'record was returned as data');
-    assert.strictEqual(data && recordIdentifierFor(data as RecordInstance), identifier, 'we get a record back as data');
-    assert.strictEqual(userDocument.content.identifier?.lid, '/assets/users/1.json', 'we get back url as the cache key');
+    assert.strictEqual(data && recordIdentifierFor(data), identifier, 'we get a record back as data');
+    assert.strictEqual(
+      userDocument.content.identifier?.lid,
+      '/assets/users/1.json',
+      'we get back url as the cache key'
+    );
     assert.deepEqual(
       userDocument.content.links,
       { self: '/assets/users/1.json' },
@@ -189,7 +193,11 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
     assert.strictEqual(record?.name, 'Chris Thoburn');
     assert.strictEqual(userDocument.content.data, record, 'we get a hydrated record back as data');
 
-    assert.strictEqual(userDocument.content.identifier?.lid, '/assets/users/1.json', 'we get back url as the cache key');
+    assert.strictEqual(
+      userDocument.content.identifier?.lid,
+      '/assets/users/1.json',
+      'we get back url as the cache key'
+    );
 
     assert.deepEqual(
       userDocument.content.links,

--- a/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
+++ b/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
@@ -7,12 +7,12 @@ import { setupTest } from 'ember-qunit';
 import Cache from '@ember-data/json-api';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import RequestManager from '@ember-data/request';
-import type { StructuredErrorDocument } from '@ember-data/request/-private/types';
+import type { StructuredDataDocument, StructuredErrorDocument } from '@ember-data/request/-private/types';
 import Fetch from '@ember-data/request/fetch';
 import Store, { CacheHandler, recordIdentifierFor } from '@ember-data/store';
 import type { Document } from '@ember-data/store/-private/document';
 import type { NotificationType } from '@ember-data/store/-private/managers/notification-manager';
-import type { SingleResourceDataDocument } from '@ember-data/types/cache/document';
+import type { CollectionResourceDataDocument, SingleResourceDataDocument } from '@ember-data/types/cache/document';
 import type { CacheStoreWrapper } from '@ember-data/types/q/cache-store-wrapper';
 import type { ResourceIdentifierObject } from '@ember-data/types/q/ember-data-json-api';
 import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
@@ -86,294 +86,943 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
     owner.register('service:request', RequestManagerService);
   });
 
-  test('fetching a resource document with loads the cache and hydrates the record', async function (assert) {
-    const { owner } = this;
+  module('Resource', function () {
+    test('fetching a resource document loads the cache and hydrates the record', async function (assert) {
+      const { owner } = this;
 
-    const store = owner.lookup('service:store') as TestStore;
-    const userDocument = await store.request<Document<RecordInstance>>({
-      url: '/assets/users/1.json',
-    });
-    const identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
-    const record = store.peekRecord(identifier);
-    const data = userDocument.content.data;
-
-    assert.strictEqual(record?.name, 'Chris Thoburn', 'record name is correct');
-    assert.strictEqual(data, record, 'record was returned as data');
-    assert.strictEqual(data && recordIdentifierFor(data), identifier, 'we get a record back as data');
-    assert.strictEqual(
-      userDocument.content.identifier?.lid,
-      '/assets/users/1.json',
-      'we get back url as the cache key'
-    );
-    assert.deepEqual(
-      userDocument.content.links,
-      { self: '/assets/users/1.json' },
-      'we get access to the document links'
-    );
-    assert.deepEqual(
-      userDocument.content.meta,
-      {
-        expiration: 120000,
-      },
-      'we get access to the document meta'
-    );
-  });
-
-  test('fetching a resource document that errors', async function (assert) {
-    const { owner } = this;
-
-    const store = owner.lookup('service:store') as TestStore;
-    try {
-      await store.request<SingleResourceDataDocument>({
-        url: '/assets/users/2.json',
+      const store = owner.lookup('service:store') as TestStore;
+      const userDocument = await store.request<Document<RecordInstance>>({
+        url: '/assets/users/1.json',
       });
-      assert.ok(false, 'we should error');
-    } catch (errorDocument: unknown) {
-      assertIsErrorDocument(assert, errorDocument);
-      assert.true(errorDocument.message.startsWith('[404] Not Found - '), 'We receive the correct error');
-      assert.strictEqual(errorDocument.response?.statusText, 'Not Found', 'Correct error code');
-      assert.strictEqual(errorDocument.response?.status, 404, 'correct code');
-    }
-  });
+      const identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+      const record = store.peekRecord(identifier);
+      const data = userDocument.content.data;
 
-  test('When using @ember-data/store, the cache-handler can hydrate any op code', async function (assert) {
-    const { owner } = this;
-
-    class RequestManagerService extends RequestManager {
-      constructor() {
-        super(...arguments);
-        this.use([LegacyNetworkHandler, Fetch]);
-        this.useCache(CacheHandler);
-      }
-    }
-
-    class TestStore extends Store {
-      @service('request') declare requestManager: RequestManager;
-
-      createCache(wrapper: CacheStoreWrapper) {
-        return new Cache(wrapper);
-      }
-
-      instantiateRecord(identifier: StableRecordIdentifier) {
-        const { id, lid, type } = identifier;
-        const record: FakeRecord = { id, lid, type } as unknown as FakeRecord;
-        Object.assign(record, (this.cache.peek(identifier) as JsonApiResource).attributes);
-
-        let token = this.notifications.subscribe(
-          identifier,
-          (_: StableRecordIdentifier, kind: NotificationType, key?: string) => {
-            if (kind === 'attributes' && key) {
-              record[key] = this.cache.getAttr(identifier, key);
-            }
-          }
-        );
-
-        record.destroy = () => {
-          this.notifications.unsubscribe(token);
-        };
-
-        return record;
-      }
-
-      teardownRecord(record: FakeRecord) {
-        record.destroy();
-      }
-    }
-
-    owner.register('service:store', TestStore);
-    owner.register('service:request', RequestManagerService);
-
-    const store = owner.lookup('service:store') as TestStore;
-    const userDocument = await store.request<Document<RecordInstance>>({
-      op: 'random-op',
-      url: '/assets/users/1.json',
-    });
-    const identifier = recordIdentifierFor(userDocument.content.data!);
-    const record = store.peekRecord(identifier);
-    assert.strictEqual(record?.name, 'Chris Thoburn');
-    assert.strictEqual(userDocument.content.data, record, 'we get a hydrated record back as data');
-
-    assert.strictEqual(
-      userDocument.content.identifier?.lid,
-      '/assets/users/1.json',
-      'we get back url as the cache key'
-    );
-
-    assert.deepEqual(
-      userDocument.content.links,
-      { self: '/assets/users/1.json' },
-      'we get access to the document links'
-    );
-
-    assert.deepEqual(
-      userDocument.content.meta,
-      {
-        expiration: 120000,
-      },
-      'we get access to the document meta'
-    );
-  });
-
-  test('When using @ember-data/store, the cache-handler will cache but not hydrate if the request has the store but does not originate from the store', async function (assert) {
-    const { owner } = this;
-
-    class RequestManagerService extends RequestManager {
-      constructor() {
-        super(...arguments);
-        this.use([LegacyNetworkHandler, Fetch]);
-        this.useCache(CacheHandler);
-      }
-    }
-
-    class TestStore extends Store {
-      @service('request') declare requestManager: RequestManager;
-
-      createCache(wrapper: CacheStoreWrapper) {
-        return new Cache(wrapper);
-      }
-
-      instantiateRecord(identifier: StableRecordIdentifier) {
-        const { id, lid, type } = identifier;
-        const record: FakeRecord = { id, lid, type } as unknown as FakeRecord;
-        Object.assign(record, (this.cache.peek(identifier) as JsonApiResource).attributes);
-
-        let token = this.notifications.subscribe(
-          identifier,
-          (_: StableRecordIdentifier, kind: NotificationType, key?: string) => {
-            if (kind === 'attributes' && key) {
-              record[key] = this.cache.getAttr(identifier, key);
-            }
-          }
-        );
-
-        record.destroy = () => {
-          this.notifications.unsubscribe(token);
-        };
-
-        return record;
-      }
-
-      teardownRecord(record: FakeRecord) {
-        record.destroy();
-      }
-    }
-
-    owner.register('service:store', TestStore);
-    owner.register('service:request', RequestManagerService);
-
-    const store = owner.lookup('service:store') as TestStore;
-    const userDocument = await store.requestManager.request<SingleResourceDataDocument>({
-      store,
-      url: '/assets/users/1.json',
-    });
-
-    assert.strictEqual(
-      userDocument.content.data,
-      store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' }),
-      'we get a stable identifier back as data'
-    );
-
-    assert.strictEqual(userDocument.content.lid, '/assets/users/1.json', 'we get back url as the cache key');
-
-    assert.deepEqual(
-      userDocument.content.links,
-      { self: '/assets/users/1.json' },
-      'we get access to the document links'
-    );
-
-    assert.deepEqual(
-      userDocument.content.meta,
-      {
-        expiration: 120000,
-      },
-      'we get access to the document meta'
-    );
-
-    const record = store.peekRecord(userDocument.content.data!);
-    assert.strictEqual(record?.name, 'Chris Thoburn');
-  });
-
-  test('When using @ember-data/store, the cache-handler will neither cache nor hydrate if the request does not originate from the store and no store is included', async function (assert) {
-    const { owner } = this;
-
-    class RequestManagerService extends RequestManager {
-      constructor() {
-        super(...arguments);
-        this.use([LegacyNetworkHandler, Fetch]);
-        this.useCache(CacheHandler);
-      }
-    }
-
-    class TestStore extends Store {
-      @service('request') declare requestManager: RequestManager;
-
-      createCache(wrapper: CacheStoreWrapper) {
-        return new Cache(wrapper);
-      }
-
-      instantiateRecord(identifier: StableRecordIdentifier) {
-        const { id, lid, type } = identifier;
-        const record: FakeRecord = { id, lid, type } as unknown as FakeRecord;
-        Object.assign(record, (this.cache.peek(identifier) as JsonApiResource).attributes);
-
-        let token = this.notifications.subscribe(
-          identifier,
-          (_: StableRecordIdentifier, kind: NotificationType, key?: string) => {
-            if (kind === 'attributes' && key) {
-              record[key] = this.cache.getAttr(identifier, key);
-            }
-          }
-        );
-
-        record.destroy = () => {
-          this.notifications.unsubscribe(token);
-        };
-
-        return record;
-      }
-
-      teardownRecord(record: FakeRecord) {
-        record.destroy();
-      }
-    }
-
-    owner.register('service:store', TestStore);
-    owner.register('service:request', RequestManagerService);
-
-    const store = owner.lookup('service:store') as TestStore;
-    const userDocument = await store.requestManager.request<SingleResourceDataDocument<JsonApiResource>>({
-      url: '/assets/users/1.json',
-    });
-
-    assert.deepEqual(
-      userDocument.content.data,
-      {
-        type: 'user',
-        id: '1',
-        attributes: {
-          name: 'Chris Thoburn',
+      assert.strictEqual(record?.name, 'Chris Thoburn', 'record name is correct');
+      assert.strictEqual(data, record, 'record was returned as data');
+      assert.strictEqual(data && recordIdentifierFor(data), identifier, 'we get a record back as data');
+      assert.strictEqual(
+        userDocument.content.identifier?.lid,
+        '/assets/users/1.json',
+        'we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument.content.links,
+        { self: '/assets/users/1.json' },
+        'we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument.content.meta,
+        {
+          expiration: 120000,
         },
-      },
-      'we the raw json back as data'
-    );
+        'we get access to the document meta'
+      );
+    });
 
-    assert.strictEqual(userDocument.content.lid, undefined, 'no cache key was set');
+    test('re-fetching a resource document returns from cache as expected', async function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as TestStore;
 
-    assert.deepEqual(
-      userDocument.content.links,
-      { self: '/assets/users/1.json' },
-      'we get access to the document links'
-    );
+      let handlerCalls = 0;
+      store.requestManager = new RequestManager();
+      store.requestManager.use([
+        LegacyNetworkHandler,
+        {
+          request<T>() {
+            if (handlerCalls > 0) {
+              assert.ok(false, 'fetch handler should not be called again');
+              throw new Error('fetch handler should not be called again');
+            }
+            handlerCalls++;
+            return Promise.resolve({
+              links: {
+                self: '/assets/users/1.json',
+              },
+              meta: {
+                expiration: 120000,
+              },
+              data: {
+                type: 'user',
+                id: '1',
+                attributes: {
+                  name: 'Chris Thoburn',
+                },
+              },
+            }) as T;
+          },
+        },
+      ]);
+      store.requestManager.useCache(CacheHandler);
 
-    assert.deepEqual(
-      userDocument.content.meta,
-      {
-        expiration: 120000,
-      },
-      'we get access to the document meta'
-    );
+      const userDocument = await store.request<Document<RecordInstance>>({
+        url: '/assets/users/1.json',
+      });
+      const identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+      const record = store.peekRecord(identifier);
+      const data = userDocument.content.data;
 
-    const record = store.peekRecord(userDocument.content.data as ResourceIdentifierObject);
-    assert.strictEqual(record, null, 'we did not get inserted into the cache');
+      assert.strictEqual(record?.name, 'Chris Thoburn', 'record name is correct');
+      assert.strictEqual(data, record, 'record was returned as data');
+      assert.strictEqual(data && recordIdentifierFor(data), identifier, 'we get a record back as data');
+      assert.strictEqual(
+        userDocument.content.identifier?.lid,
+        '/assets/users/1.json',
+        'we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument.content.links,
+        { self: '/assets/users/1.json' },
+        'we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument.content.meta,
+        {
+          expiration: 120000,
+        },
+        'we get access to the document meta'
+      );
+
+      const userDocument2 = await store.request<Document<RecordInstance>>({
+        url: '/assets/users/1.json',
+      });
+      const data2 = userDocument2.content.data;
+
+      assert.strictEqual(data2, record, '<Updated> record was returned as data');
+      assert.strictEqual(data2 && recordIdentifierFor(data2), identifier, '<Updated> we get a record back as data');
+      assert.strictEqual(
+        userDocument2.content.identifier?.lid,
+        '/assets/users/1.json',
+        '<Updated> we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument2.content.links,
+        { self: '/assets/users/1.json' },
+        '<Updated> we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument2.content.meta,
+        {
+          expiration: 120000,
+        },
+        '<Updated> we get access to the document meta'
+      );
+      assert.strictEqual(handlerCalls, 1, 'fetch handler should only be called once');
+    });
+
+    test('fetching a resource document that errors', async function (assert) {
+      const { owner } = this;
+
+      const store = owner.lookup('service:store') as TestStore;
+      try {
+        await store.request<SingleResourceDataDocument>({
+          url: '/assets/users/2.json',
+        });
+        assert.ok(false, 'we should error');
+      } catch (errorDocument: unknown) {
+        assertIsErrorDocument(assert, errorDocument);
+        assert.true(errorDocument.message.startsWith('[404] Not Found - '), 'We receive the correct error');
+        assert.strictEqual(errorDocument.response?.statusText, 'Not Found', 'Correct error code');
+        assert.strictEqual(errorDocument.response?.status, 404, 'correct code');
+      }
+    });
+
+    test('When using @ember-data/store, the cache-handler can hydrate any op code', async function (assert) {
+      const { owner } = this;
+
+      class RequestManagerService extends RequestManager {
+        constructor() {
+          super(...arguments);
+          this.use([LegacyNetworkHandler, Fetch]);
+          this.useCache(CacheHandler);
+        }
+      }
+
+      class TestStore extends Store {
+        @service('request') declare requestManager: RequestManager;
+
+        createCache(wrapper: CacheStoreWrapper) {
+          return new Cache(wrapper);
+        }
+
+        instantiateRecord(identifier: StableRecordIdentifier) {
+          const { id, lid, type } = identifier;
+          const record: FakeRecord = { id, lid, type } as unknown as FakeRecord;
+          Object.assign(record, (this.cache.peek(identifier) as JsonApiResource).attributes);
+
+          let token = this.notifications.subscribe(
+            identifier,
+            (_: StableRecordIdentifier, kind: NotificationType, key?: string) => {
+              if (kind === 'attributes' && key) {
+                record[key] = this.cache.getAttr(identifier, key);
+              }
+            }
+          );
+
+          record.destroy = () => {
+            this.notifications.unsubscribe(token);
+          };
+
+          return record;
+        }
+
+        teardownRecord(record: FakeRecord) {
+          record.destroy();
+        }
+      }
+
+      owner.register('service:store', TestStore);
+      owner.register('service:request', RequestManagerService);
+
+      const store = owner.lookup('service:store') as TestStore;
+      const userDocument = await store.request<Document<RecordInstance>>({
+        op: 'random-op',
+        url: '/assets/users/1.json',
+      });
+      const identifier = recordIdentifierFor(userDocument.content.data!);
+      const record = store.peekRecord(identifier);
+      assert.strictEqual(record?.name, 'Chris Thoburn');
+      assert.strictEqual(userDocument.content.data, record, 'we get a hydrated record back as data');
+
+      assert.strictEqual(
+        userDocument.content.identifier?.lid,
+        '/assets/users/1.json',
+        'we get back url as the cache key'
+      );
+
+      assert.deepEqual(
+        userDocument.content.links,
+        { self: '/assets/users/1.json' },
+        'we get access to the document links'
+      );
+
+      assert.deepEqual(
+        userDocument.content.meta,
+        {
+          expiration: 120000,
+        },
+        'we get access to the document meta'
+      );
+    });
+
+    test('When using @ember-data/store, the cache-handler will cache but not hydrate if the request has the store but does not originate from the store', async function (assert) {
+      const { owner } = this;
+
+      class RequestManagerService extends RequestManager {
+        constructor() {
+          super(...arguments);
+          this.use([LegacyNetworkHandler, Fetch]);
+          this.useCache(CacheHandler);
+        }
+      }
+
+      class TestStore extends Store {
+        @service('request') declare requestManager: RequestManager;
+
+        createCache(wrapper: CacheStoreWrapper) {
+          return new Cache(wrapper);
+        }
+
+        instantiateRecord(identifier: StableRecordIdentifier) {
+          const { id, lid, type } = identifier;
+          const record: FakeRecord = { id, lid, type } as unknown as FakeRecord;
+          Object.assign(record, (this.cache.peek(identifier) as JsonApiResource).attributes);
+
+          let token = this.notifications.subscribe(
+            identifier,
+            (_: StableRecordIdentifier, kind: NotificationType, key?: string) => {
+              if (kind === 'attributes' && key) {
+                record[key] = this.cache.getAttr(identifier, key);
+              }
+            }
+          );
+
+          record.destroy = () => {
+            this.notifications.unsubscribe(token);
+          };
+
+          return record;
+        }
+
+        teardownRecord(record: FakeRecord) {
+          record.destroy();
+        }
+      }
+
+      owner.register('service:store', TestStore);
+      owner.register('service:request', RequestManagerService);
+
+      const store = owner.lookup('service:store') as TestStore;
+      const userDocument = await store.requestManager.request<SingleResourceDataDocument>({
+        store,
+        url: '/assets/users/1.json',
+      });
+
+      assert.strictEqual(
+        userDocument.content.data,
+        store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' }),
+        'we get a stable identifier back as data'
+      );
+
+      assert.strictEqual(userDocument.content.lid, '/assets/users/1.json', 'we get back url as the cache key');
+
+      assert.deepEqual(
+        userDocument.content.links,
+        { self: '/assets/users/1.json' },
+        'we get access to the document links'
+      );
+
+      assert.deepEqual(
+        userDocument.content.meta,
+        {
+          expiration: 120000,
+        },
+        'we get access to the document meta'
+      );
+
+      const record = store.peekRecord(userDocument.content.data!);
+      assert.strictEqual(record?.name, 'Chris Thoburn');
+    });
+
+    test('When using @ember-data/store, the cache-handler will neither cache nor hydrate if the request does not originate from the store and no store is included', async function (assert) {
+      const { owner } = this;
+
+      class RequestManagerService extends RequestManager {
+        constructor() {
+          super(...arguments);
+          this.use([LegacyNetworkHandler, Fetch]);
+          this.useCache(CacheHandler);
+        }
+      }
+
+      class TestStore extends Store {
+        @service('request') declare requestManager: RequestManager;
+
+        createCache(wrapper: CacheStoreWrapper) {
+          return new Cache(wrapper);
+        }
+
+        instantiateRecord(identifier: StableRecordIdentifier) {
+          const { id, lid, type } = identifier;
+          const record: FakeRecord = { id, lid, type } as unknown as FakeRecord;
+          Object.assign(record, (this.cache.peek(identifier) as JsonApiResource).attributes);
+
+          let token = this.notifications.subscribe(
+            identifier,
+            (_: StableRecordIdentifier, kind: NotificationType, key?: string) => {
+              if (kind === 'attributes' && key) {
+                record[key] = this.cache.getAttr(identifier, key);
+              }
+            }
+          );
+
+          record.destroy = () => {
+            this.notifications.unsubscribe(token);
+          };
+
+          return record;
+        }
+
+        teardownRecord(record: FakeRecord) {
+          record.destroy();
+        }
+      }
+
+      owner.register('service:store', TestStore);
+      owner.register('service:request', RequestManagerService);
+
+      const store = owner.lookup('service:store') as TestStore;
+      const userDocument = await store.requestManager.request<SingleResourceDataDocument<JsonApiResource>>({
+        url: '/assets/users/1.json',
+      });
+
+      assert.deepEqual(
+        userDocument.content.data,
+        {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Chris Thoburn',
+          },
+        },
+        'we the raw json back as data'
+      );
+
+      assert.strictEqual(userDocument.content.lid, undefined, 'no cache key was set');
+
+      assert.deepEqual(
+        userDocument.content.links,
+        { self: '/assets/users/1.json' },
+        'we get access to the document links'
+      );
+
+      assert.deepEqual(
+        userDocument.content.meta,
+        {
+          expiration: 120000,
+        },
+        'we get access to the document meta'
+      );
+
+      const record = store.peekRecord(userDocument.content.data as ResourceIdentifierObject);
+      assert.strictEqual(record, null, 'we did not get inserted into the cache');
+    });
+  });
+
+  module('Collection', function () {
+    test('re-fetching a resource collection returns from cache as expected', async function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as TestStore;
+
+      let handlerCalls = 0;
+      store.requestManager = new RequestManager();
+      store.requestManager.use([
+        LegacyNetworkHandler,
+        {
+          request<T>() {
+            if (handlerCalls > 0) {
+              assert.ok(false, 'fetch handler should not be called again');
+              throw new Error('fetch handler should not be called again');
+            }
+            handlerCalls++;
+            return Promise.resolve({
+              links: {
+                self: '/assets/users/list.json',
+              },
+              meta: {
+                expiration: 120000,
+                total: 1,
+              },
+              data: [
+                {
+                  type: 'user',
+                  id: '1',
+                  attributes: {
+                    name: 'Chris Thoburn',
+                  },
+                },
+              ],
+            }) as T;
+          },
+        },
+      ]);
+      store.requestManager.useCache(CacheHandler);
+
+      const userDocument = await store.request<Document<RecordInstance[]>>({
+        url: '/assets/users/list.json',
+      });
+      const identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+      const record = store.peekRecord(identifier);
+      const data = userDocument.content.data!;
+
+      assert.strictEqual(record?.name, 'Chris Thoburn', 'record name is correct');
+      assert.true(Array.isArray(data), 'recordArray was returned as data');
+      assert.strictEqual(data.length, 1, 'recordArray has one record');
+      assert.strictEqual(data[0], record, 'record was returned as data');
+      assert.strictEqual(data[0] && recordIdentifierFor(data[0]), identifier, 'we get a record back as data');
+      assert.strictEqual(
+        userDocument.content.identifier?.lid,
+        '/assets/users/list.json',
+        'we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument.content.links,
+        { self: '/assets/users/list.json' },
+        'we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument.content.meta,
+        {
+          expiration: 120000,
+          total: 1,
+        },
+        'we get access to the document meta'
+      );
+
+      const userDocument2 = await store.request<Document<RecordInstance[]>>({
+        url: '/assets/users/list.json',
+      });
+      const data2 = userDocument2.content.data!;
+
+      assert.true(Array.isArray(data2), 'recordArray was returned as data');
+      assert.strictEqual(data2.length, 1, 'recordArray has one record');
+      assert.strictEqual(data2[0], record, 'record was returned as data');
+      assert.strictEqual(data2[0] && recordIdentifierFor(data2[0]), identifier, 'we get a record back as data');
+      assert.strictEqual(
+        userDocument2.content.identifier?.lid,
+        '/assets/users/list.json',
+        'we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument2.content.links,
+        { self: '/assets/users/list.json' },
+        'we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument2.content.meta,
+        {
+          expiration: 120000,
+          total: 1,
+        },
+        'we get access to the document meta'
+      );
+      assert.strictEqual(handlerCalls, 1, 'fetch handler should only be called once');
+    });
+
+    test('background re-fetching a resource collection returns from cache as expected, updates once complete', async function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as TestStore;
+
+      let handlerCalls = 0;
+      store.requestManager = new RequestManager();
+      store.requestManager.use([
+        LegacyNetworkHandler,
+        {
+          request<T>() {
+            if (handlerCalls > 1) {
+              assert.ok(false, 'fetch handler should not be called again');
+              throw new Error('fetch handler should not be called again');
+            }
+            handlerCalls++;
+            return Promise.resolve({
+              links:
+                handlerCalls === 1
+                  ? {
+                      self: '/assets/users/list.json',
+                    }
+                  : {
+                      self: '/assets/users/list.json',
+                      related: '/assets/users/page/1.json',
+                    },
+              meta: {
+                expiration: 120000,
+                total: handlerCalls,
+              },
+              data: [
+                {
+                  type: 'user',
+                  id: '1',
+                  attributes: {
+                    name: 'Chris Thoburn',
+                  },
+                },
+                handlerCalls === 2
+                  ? {
+                      type: 'user',
+                      id: '2',
+                      attributes: {
+                        name: 'Wesley Thoburn',
+                      },
+                    }
+                  : false,
+              ].filter(Boolean),
+            }) as T;
+          },
+        },
+      ]);
+      store.requestManager.useCache(CacheHandler);
+
+      const userDocument = await store.request<Document<RecordInstance[]>>({
+        url: '/assets/users/list.json',
+      });
+      const identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+      const record = store.peekRecord(identifier);
+      const data = userDocument.content.data!;
+
+      assert.strictEqual(record?.name, 'Chris Thoburn', 'record name is correct');
+      assert.true(Array.isArray(data), 'recordArray was returned as data');
+      assert.strictEqual(data.length, 1, 'recordArray has one record');
+      assert.strictEqual(data[0], record, 'record was returned as data');
+      assert.strictEqual(data[0] && recordIdentifierFor(data[0]), identifier, 'we get a record back as data');
+      assert.strictEqual(
+        userDocument.content.identifier?.lid,
+        '/assets/users/list.json',
+        'we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument.content.links,
+        { self: '/assets/users/list.json' },
+        'we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument.content.meta,
+        {
+          expiration: 120000,
+          total: 1,
+        },
+        'we get access to the document meta'
+      );
+
+      const userDocument2 = await store.request<Document<RecordInstance[]>>({
+        url: '/assets/users/list.json',
+        cacheOptions: { backgroundReload: true },
+      });
+      const data2 = userDocument2.content.data!;
+
+      assert.true(Array.isArray(data2), 'recordArray was returned as data');
+      assert.strictEqual(data2.length, 1, 'recordArray has one record');
+      assert.strictEqual(data2[0], record, 'record was returned as data');
+      assert.strictEqual(data2[0] && recordIdentifierFor(data2[0]), identifier, 'we get a record back as data');
+      assert.strictEqual(
+        userDocument2.content.identifier?.lid,
+        '/assets/users/list.json',
+        'we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument2.content.links,
+        { self: '/assets/users/list.json' },
+        'we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument2.content.meta,
+        {
+          expiration: 120000,
+          total: 1,
+        },
+        'we get access to the document meta'
+      );
+
+      await store._getAllPending();
+
+      const identifier2 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '2' });
+      const record2 = store.peekRecord(identifier2);
+
+      assert.strictEqual(record2?.name, 'Wesley Thoburn', 'record2 name is correct');
+      assert.strictEqual(data.length, 2, 'recordArray has two records');
+      assert.strictEqual(data2[0], record, 'record was returned as data');
+      assert.strictEqual(data2[0] && recordIdentifierFor(data2[0]), identifier, 'we get a record back as data');
+      assert.strictEqual(data2[1], record2, 'record was returned as data');
+      assert.strictEqual(data2[1] && recordIdentifierFor(data2[1]), identifier2, 'we get a record back as data');
+      assert.strictEqual(
+        userDocument2.content.identifier?.lid,
+        '/assets/users/list.json',
+        'we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument2.content.links,
+        {
+          related: '/assets/users/page/1.json',
+          self: '/assets/users/list.json',
+        },
+        'we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument2.content.meta,
+        {
+          expiration: 120000,
+          total: 2,
+        },
+        'we get access to the document meta'
+      );
+      assert.strictEqual(handlerCalls, 2, 'fetch handler should only be called twice');
+    });
+
+    test('fetching with hydration, then background re-fetching a resource collection without hydration returns from cache as expected, updates once complete', async function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as TestStore;
+
+      let handlerCalls = 0;
+      store.requestManager = new RequestManager();
+      store.requestManager.use([
+        LegacyNetworkHandler,
+        {
+          request<T>() {
+            if (handlerCalls > 1) {
+              assert.ok(false, 'fetch handler should not be called again');
+              throw new Error('fetch handler should not be called again');
+            }
+            handlerCalls++;
+            return Promise.resolve({
+              links:
+                handlerCalls === 1
+                  ? {
+                      self: '/assets/users/list.json',
+                    }
+                  : {
+                      self: '/assets/users/list.json',
+                      related: '/assets/users/page/1.json',
+                    },
+              meta: {
+                expiration: 120000,
+                total: handlerCalls,
+              },
+              data: [
+                {
+                  type: 'user',
+                  id: '1',
+                  attributes: {
+                    name: 'Chris Thoburn',
+                  },
+                },
+                handlerCalls === 2
+                  ? {
+                      type: 'user',
+                      id: '2',
+                      attributes: {
+                        name: 'Wesley Thoburn',
+                      },
+                    }
+                  : false,
+              ].filter(Boolean),
+            }) as T;
+          },
+        },
+      ]);
+      store.requestManager.useCache(CacheHandler);
+
+      // Initial Fetch with Hydration
+      const userDocument = await store.request<Document<RecordInstance[]>>({
+        url: '/assets/users/list.json',
+      });
+      const identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+      const data = userDocument.content.data!;
+      const record = store.peekRecord(identifier);
+
+      assert.strictEqual(record?.name, 'Chris Thoburn', 'record name is correct');
+      assert.true(Array.isArray(data), 'recordArray was returned as data');
+      assert.strictEqual(data.length, 1, 'recordArray has one record');
+      assert.strictEqual(data[0], record, 'record was returned as data');
+      assert.strictEqual(data[0] && recordIdentifierFor(data[0]), identifier, 'we get a record back as data');
+      assert.strictEqual(
+        userDocument.content.identifier?.lid,
+        '/assets/users/list.json',
+        'we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument.content.links,
+        { self: '/assets/users/list.json' },
+        'we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument.content.meta,
+        {
+          expiration: 120000,
+          total: 1,
+        },
+        'we get access to the document meta'
+      );
+
+      // Backgrond Re-Fetch without Hydration
+      const userDocument2 = await store.requestManager.request<CollectionResourceDataDocument>({
+        store,
+        url: '/assets/users/list.json',
+        cacheOptions: { backgroundReload: true },
+      });
+      const data2 = userDocument2.content.data;
+
+      // Assert Immediate Cache Return
+      assert.true(Array.isArray(data2), '<Cached> recordArray was returned as data');
+      assert.strictEqual(data2.length, 1, '<Cached> recordArray has one record');
+      assert.strictEqual(data2[0], identifier, '<Cached> identifier was returned as data');
+      assert.strictEqual(
+        userDocument2.content.lid,
+        '/assets/users/list.json',
+        '<Cached> we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument2.content.links,
+        { self: '/assets/users/list.json' },
+        '<Cached> we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument2.content.meta,
+        {
+          expiration: 120000,
+          total: 1,
+        },
+        '<Cached> we get access to the document meta'
+      );
+
+      // Await the Background Re-Fetch
+      await store._getAllPending();
+
+      // Assert the initial document was updated
+      const identifier2 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '2' });
+      const record2 = store.peekRecord(identifier2);
+
+      assert.strictEqual(handlerCalls, 2, 'fetch handler should only be called twice');
+      assert.strictEqual(record2?.name, 'Wesley Thoburn', 'record2 name is correct');
+      assert.strictEqual(data.length, 2, '<Initial Doc Updated> recordArray has two records');
+      assert.strictEqual(data[0], record, '<Initial Doc Updated> record was returned as data');
+      assert.strictEqual(
+        data[0] && recordIdentifierFor(data[0]),
+        identifier,
+        '<Initial Doc Updated> we get a record back as data'
+      );
+      assert.strictEqual(data[1], record2, '<Initial Doc Updated> record was returned as data');
+      assert.strictEqual(
+        data[1] && recordIdentifierFor(data[1]),
+        identifier2,
+        '<Initial Doc Updated> we get a record back as data'
+      );
+      assert.strictEqual(
+        userDocument.content.identifier?.lid,
+        '/assets/users/list.json',
+        '<Initial Doc Updated> we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument.content.links,
+        {
+          related: '/assets/users/page/1.json',
+          self: '/assets/users/list.json',
+        },
+        '<Initial Doc Updated> we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument.content.meta,
+        {
+          expiration: 120000,
+          total: 2,
+        },
+        '<Initial Doc Updated> we get access to the document meta'
+      );
+    });
+
+    test('background re-fetching a resource collection without hydration returns from cache as expected, updates once complete', async function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as TestStore;
+
+      let handlerCalls = 0;
+      store.requestManager = new RequestManager();
+      store.requestManager.use([
+        LegacyNetworkHandler,
+        {
+          request<T>() {
+            if (handlerCalls > 1) {
+              assert.ok(false, 'fetch handler should not be called again');
+              throw new Error('fetch handler should not be called again');
+            }
+            handlerCalls++;
+            return Promise.resolve({
+              links:
+                handlerCalls === 1
+                  ? {
+                      self: '/assets/users/list.json',
+                    }
+                  : {
+                      self: '/assets/users/list.json',
+                      related: '/assets/users/page/1.json',
+                    },
+              meta: {
+                expiration: 120000,
+                total: handlerCalls,
+              },
+              data: [
+                {
+                  type: 'user',
+                  id: '1',
+                  attributes: {
+                    name: 'Chris Thoburn',
+                  },
+                },
+                handlerCalls === 2
+                  ? {
+                      type: 'user',
+                      id: '2',
+                      attributes: {
+                        name: 'Wesley Thoburn',
+                      },
+                    }
+                  : false,
+              ].filter(Boolean),
+            }) as T;
+          },
+        },
+      ]);
+      store.requestManager.useCache(CacheHandler);
+
+      const userDocument = await store.requestManager.request<CollectionResourceDataDocument>({
+        store,
+        url: '/assets/users/list.json',
+      });
+      const identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+      const data = userDocument.content.data;
+
+      assert.true(Array.isArray(data), '<Initial> recordArray was returned as data');
+      assert.strictEqual(data.length, 1, '<Initial> recordArray has one record');
+      assert.strictEqual(data[0], identifier, '<Initial> identifier was returned as data');
+      assert.strictEqual(
+        userDocument.content.lid,
+        '/assets/users/list.json',
+        '<Initial> we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument.content.links,
+        { self: '/assets/users/list.json' },
+        '<Initial> we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument.content.meta,
+        {
+          expiration: 120000,
+          total: 1,
+        },
+        '<Initial> we get access to the document meta'
+      );
+
+      // Trigger the background re-fetch
+      const userDocument2 = await store.requestManager.request<CollectionResourceDataDocument>({
+        store,
+        url: '/assets/users/list.json',
+        cacheOptions: { backgroundReload: true },
+      });
+      const data2 = userDocument2.content.data;
+
+      assert.true(Array.isArray(data2), '<Cached> recordArray was returned as data');
+      assert.strictEqual(data2.length, 1, '<Cached> recordArray has one record');
+      assert.strictEqual(data2[0], identifier, '<Cached> identifier was returned as data');
+      assert.strictEqual(
+        userDocument2.content.lid,
+        '/assets/users/list.json',
+        '<Cached> we get back url as the cache key'
+      );
+      assert.deepEqual(
+        userDocument2.content.links,
+        { self: '/assets/users/list.json' },
+        '<Cached> we get access to the document links'
+      );
+      assert.deepEqual(
+        userDocument2.content.meta,
+        {
+          expiration: 120000,
+          total: 1,
+        },
+        '<Cached> we get access to the document meta'
+      );
+
+      await store._getAllPending();
+
+      const updatedUserDocument = store.cache.peekRequest(
+        store.identifierCache.getOrCreateDocumentIdentifier({ url: '/assets/users/list.json' })!
+      ) as unknown as StructuredDataDocument<CollectionResourceDataDocument>;
+      const data3 = updatedUserDocument?.content?.data;
+      const identifier2 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '2' });
+
+      assert.strictEqual(data3.length, 2, 'recordArray has two records');
+      assert.strictEqual(data3[0], identifier, 'we get an identifier back as data');
+      assert.strictEqual(data3[1], identifier2, 'second identifier was also returned as data');
+      assert.strictEqual(
+        updatedUserDocument.content.lid,
+        '/assets/users/list.json',
+        'we get back url as the cache key'
+      );
+      assert.deepEqual(
+        updatedUserDocument.content.links,
+        {
+          related: '/assets/users/page/1.json',
+          self: '/assets/users/list.json',
+        },
+        'we get access to the document links'
+      );
+      assert.deepEqual(
+        updatedUserDocument.content.meta,
+        {
+          expiration: 120000,
+          total: 2,
+        },
+        'we get access to the document meta'
+      );
+      assert.strictEqual(handlerCalls, 2, 'fetch handler should only be called twice');
+    });
   });
 });

--- a/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
+++ b/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
@@ -11,12 +11,13 @@ import { StructuredErrorDocument } from '@ember-data/request/-private/types';
 import Fetch from '@ember-data/request/fetch';
 import Store, { CacheHandler, recordIdentifierFor } from '@ember-data/store';
 import { NotificationType } from '@ember-data/store/-private/managers/notification-manager';
-import type { ResourceDataDocument, SingleResourceDataDocument } from '@ember-data/types/cache/document';
+import type { SingleResourceDataDocument } from '@ember-data/types/cache/document';
 import type { CacheStoreWrapper } from '@ember-data/types/q/cache-store-wrapper';
-import { ResourceIdentifierObject } from '@ember-data/types/q/ember-data-json-api';
-import { StableRecordIdentifier } from '@ember-data/types/q/identifier';
-import { JsonApiResource } from '@ember-data/types/q/record-data-json-api';
-import { RecordInstance } from '@ember-data/types/q/record-instance';
+import type { ResourceIdentifierObject } from '@ember-data/types/q/ember-data-json-api';
+import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
+import type { JsonApiResource } from '@ember-data/types/q/record-data-json-api';
+import type { RecordInstance } from '@ember-data/types/q/record-instance';
+import type { Document } from '@ember-data/store/-private/document';
 
 type FakeRecord = { [key: string]: unknown; destroy: () => void };
 
@@ -89,7 +90,7 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
     const { owner } = this;
 
     const store = owner.lookup('service:store') as TestStore;
-    const userDocument = await store.request<ResourceDataDocument<RecordInstance>>({
+    const userDocument = await store.request<Document<RecordInstance>>({
       url: '/assets/users/1.json',
     });
     const identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
@@ -99,7 +100,7 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
     assert.strictEqual(record?.name, 'Chris Thoburn', 'record name is correct');
     assert.strictEqual(data, record, 'record was returned as data');
     assert.strictEqual(data && recordIdentifierFor(data as RecordInstance), identifier, 'we get a record back as data');
-    assert.strictEqual(userDocument.content.lid, '/assets/users/1.json', 'we get back url as the cache key');
+    assert.strictEqual(userDocument.content.identifier?.lid, '/assets/users/1.json', 'we get back url as the cache key');
     assert.deepEqual(
       userDocument.content.links,
       { self: '/assets/users/1.json' },
@@ -179,7 +180,7 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
     owner.register('service:request', RequestManagerService);
 
     const store = owner.lookup('service:store') as TestStore;
-    const userDocument = await store.request<SingleResourceDataDocument<RecordInstance>>({
+    const userDocument = await store.request<Document<RecordInstance>>({
       op: 'random-op',
       url: '/assets/users/1.json',
     });
@@ -188,7 +189,7 @@ module('Store | CacheHandler - @ember-data/store', function (hooks) {
     assert.strictEqual(record?.name, 'Chris Thoburn');
     assert.strictEqual(userDocument.content.data, record, 'we get a hydrated record back as data');
 
-    assert.strictEqual(userDocument.content.lid, '/assets/users/1.json', 'we get back url as the cache key');
+    assert.strictEqual(userDocument.content.identifier?.lid, '/assets/users/1.json', 'we get back url as the cache key');
 
     assert.deepEqual(
       userDocument.content.links,


### PR DESCRIPTION
Implements `Document` class for hydrated responses.

Adds tests for various hydrated/non-hydrated/re-fetch scenarios

resolves #8535 