### PR TITLE
feat: full-relationship definitions when scaffolding with blueprints

### DIFF
--- a/packages/graph/src/-private/graph/graph.ts
+++ b/packages/graph/src/-private/graph/graph.ts
@@ -182,7 +182,7 @@ export class Graph {
 
    export default class Post extends Model {
      @attr title;
-     @hasMany('comment') comments;
+     @hasMany('comment', { async: true, inverse: null }) comments;
    }
    ```
 

--- a/packages/model/blueprints/model/HELP.md
+++ b/packages/model/blueprints/model/HELP.md
@@ -17,8 +17,8 @@ would result in the following model:
 import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
 
 export default class TacoModel extends Model {
-  @belongsTo('protein') filling;
-  @hasMany('topping') toppings;
+  @belongsTo('protein', { async: false, inverse: null }) filling;
+  @hasMany('topping', { async: false, inverse: null }) toppings;
   @attr('string') name;
   @attr('number') price;
   @attr misc;

--- a/packages/model/blueprints/model/index.js
+++ b/packages/model/blueprints/model/index.js
@@ -118,19 +118,11 @@ function nativeAttr(attr) {
     result;
 
   if (type === 'belongs-to') {
-    if (name === propertyName) {
-      result = '@belongsTo';
-    } else {
-      result = "@belongsTo('" + name + "')";
-    }
+    result = "@belongsTo('" + name + "', { async: false, inverse: null })";
   } else if (type === 'has-many') {
-    if (inflection.pluralize(name) === propertyName) {
-      result = '@hasMany';
-    } else {
-      result = "@hasMany('" + name + "')";
-    }
+    result = "@hasMany('" + name + "', { async: false, inverse: null })";
   } else if (type === '') {
-    result = '@attr()';
+    result = '@attr';
   } else {
     result = "@attr('" + type + "')";
   }
@@ -144,9 +136,9 @@ function classicAttr(attr) {
     result;
 
   if (type === 'belongs-to') {
-    result = "belongsTo('" + name + "')";
+    result = "belongsTo('" + name + "', { async: false, inverse: null })";
   } else if (type === 'has-many') {
-    result = "hasMany('" + name + "')";
+    result = "hasMany('" + name + "', { async: false, inverse: null })";
   } else if (type === '') {
     //"If you don't specify the type of the attribute, it will be whatever was provided by the server"
     //https://emberjs.com/guides/models/defining-models/

--- a/packages/model/src/-private/belongs-to.js
+++ b/packages/model/src/-private/belongs-to.js
@@ -59,6 +59,7 @@ function normalizeType(type) {
   ```
 
   #### One-To-Many
+
   To declare a one-to-many relationship between two models, use
   `belongsTo` in combination with `hasMany`, like this:
 
@@ -66,7 +67,7 @@ function normalizeType(type) {
   import Model, { hasMany } from '@ember-data/model';
 
   export default class PostModel extends Model {
-    @hasMany('comment') comments;
+    @hasMany('comment', { async: false, inverse: 'post' }) comments;
   }
   ```
 
@@ -74,22 +75,9 @@ function normalizeType(type) {
   import Model, { belongsTo } from '@ember-data/model';
 
   export default class CommentModel extends Model {
-    @belongsTo('post') post;
+    @belongsTo('post', { async: false, inverse: 'comments' }) post;
   }
   ```
-
-  You can avoid passing a string as the first parameter. In that case Ember Data
-  will infer the type from the key name.
-
-  ```app/models/comment.js
-  import Model, { belongsTo } from '@ember-data/model';
-
-  export default class CommentModel extends Model {
-    @belongsTo post;
-  }
-  ```
-
-  will lookup for a Post type.
 
   #### Sync relationships
 
@@ -102,7 +90,8 @@ function normalizeType(type) {
 
   export default class CommentModel extends Model {
     @belongsTo('post', {
-      async: false
+      async: false,
+      inverse: null
     })
     post;
   }

--- a/tests/blueprints/tests/model-test.js
+++ b/tests/blueprints/tests/model-test.js
@@ -75,8 +75,8 @@ describe('Acceptance: generate and destroy model blueprints', function () {
         expect(_file('app/models/comment.js'))
           .to.contain(`import Model, { belongsTo } from '@ember-data/model';`)
           .to.contain('export default Model.extend(')
-          .to.contain("  post: belongsTo('post'),")
-          .to.contain("  author: belongsTo('user')");
+          .to.contain("  post: belongsTo('post', { async: false, inverse: null }),")
+          .to.contain("  author: belongsTo('user', { async: false, inverse: null })");
 
         expect(_file('tests/unit/models/comment-test.js')).to.equal(
           fixture(__dirname, 'model-test/comment-default.js')
@@ -91,8 +91,8 @@ describe('Acceptance: generate and destroy model blueprints', function () {
         expect(_file('app/models/post.js'))
           .to.contain(`import Model, { hasMany } from '@ember-data/model';`)
           .to.contain('export default Model.extend(')
-          .to.contain("  comments: hasMany('comment')")
-          .to.contain("  otherComments: hasMany('comment')");
+          .to.contain("  comments: hasMany('comment', { async: false, inverse: null })")
+          .to.contain("  otherComments: hasMany('comment', { async: false, inverse: null })");
 
         expect(_file('tests/unit/models/post-test.js')).to.equal(fixture(__dirname, 'model-test/post-default.js'));
       });
@@ -197,7 +197,7 @@ describe('Acceptance: generate and destroy model blueprints', function () {
         expect(_file('app/models/foo.js'))
           .to.contain(`import Model, { attr } from '@ember-data/model';`)
           .to.contain('export default class FooModel extends Model {')
-          .to.contain('  @attr() misc;')
+          .to.contain('  @attr misc;')
           .to.contain("  @attr('array') skills;")
           .to.contain("  @attr('boolean') isActive;")
           .to.contain("  @attr('date') birthday;")
@@ -217,8 +217,8 @@ describe('Acceptance: generate and destroy model blueprints', function () {
         expect(_file('app/models/comment.js'))
           .to.contain(`import Model, { belongsTo } from '@ember-data/model';`)
           .to.contain('export default class CommentModel extends Model {')
-          .to.contain('  @belongsTo post;')
-          .to.contain("  @belongsTo('user') author;");
+          .to.contain(`  @belongsTo('post', { async: false, inverse: null }) post;`)
+          .to.contain("  @belongsTo('user', { async: false, inverse: null }) author;");
 
         expect(_file('tests/unit/models/comment-test.js')).to.equal(
           fixture(__dirname, 'model-test/comment-default.js')
@@ -233,8 +233,8 @@ describe('Acceptance: generate and destroy model blueprints', function () {
         expect(_file('app/models/post.js'))
           .to.contain(`import Model, { hasMany } from '@ember-data/model';`)
           .to.contain('export default class PostModel extends Model {')
-          .to.contain('  @hasMany comments;')
-          .to.contain("  @hasMany('comment') otherComments;");
+          .to.contain(`  @hasMany('comment', { async: false, inverse: null }) comments;`)
+          .to.contain("  @hasMany('comment', { async: false, inverse: null }) otherComments;");
 
         expect(_file('tests/unit/models/post-test.js')).to.equal(fixture(__dirname, 'model-test/post-default.js'));
       });


### PR DESCRIPTION
also show correct relationship definitions in some docs, generally api docs need a lot of review for correctness in this sort of area. Grep shows at least 30 places to audit.