### PR TITLE
Avoid unnecessary identity notification when record is saved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ benchmarks/results/*.json
 /tests/*/DEBUG
 
 .vscode/
+.idea/
+*.iml

--- a/ember-data-types/cache/cache.ts
+++ b/ember-data-types/cache/cache.ts
@@ -1,13 +1,14 @@
 /**
  * @module @ember-data/experimental-preview-types
  */
+import { StoreRequestContext } from '@ember-data/store/-private/cache-handler';
 import { StableRecordIdentifier } from '@ember-data/types/q/identifier';
 
 import { CollectionResourceRelationship, SingleResourceRelationship } from '../q/ember-data-json-api';
 import { JsonApiError } from '../q/record-data-json-api';
 import { ResourceBlob } from './aliases';
 import { Change } from './change';
-import { ResourceDocument, StructuredDocument } from './document';
+import { ResourceDocument, SingleResourceDataDocument, StructuredDataDocument, StructuredDocument } from './document';
 import { StableDocumentIdentifier } from './identifier';
 import { Mutation } from './mutations';
 import { Operation } from './operations';
@@ -262,7 +263,7 @@ export interface Cache {
    * @public
    * @param identifier
    */
-  willCommit(identifier: StableRecordIdentifier): void;
+  willCommit(identifier: StableRecordIdentifier, context: StoreRequestContext): void;
 
   /**
    * [LIFECYCLE] Signals to the cache that a resource
@@ -270,10 +271,11 @@ export interface Cache {
    *
    * @method didCommit
    * @public
-   * @param identifier
-   * @param data
+   * @param identifier - the primary identifier that was operated on
+   * @param data - a document in the cache format containing any updated data
+   * @return {SingleResourceDataDocument}
    */
-  didCommit(identifier: StableRecordIdentifier, data: ResourceBlob | null): void;
+  didCommit(identifier: StableRecordIdentifier, result: StructuredDataDocument<unknown>): SingleResourceDataDocument;
 
   /**
    * [LIFECYCLE] Signals to the cache that a resource

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -56,6 +56,7 @@ const EMPTY_ITERATOR = {
 };
 
 interface CachedResource {
+  id: string | null;
   remoteAttrs: Record<string, unknown> | null;
   localAttrs: Record<string, unknown> | null;
   inflightAttrs: Record<string, unknown> | null;
@@ -68,6 +69,7 @@ interface CachedResource {
 
 function makeCache(): CachedResource {
   return {
+    id: null,
     remoteAttrs: null,
     localAttrs: null,
     inflightAttrs: null,
@@ -451,6 +453,10 @@ export default class JSONAPICache implements Cache {
       this.__storeWrapper.notifyChange(identifier, 'added');
     }
 
+    if (data.id) {
+      cached.id = data.id;
+    }
+
     if (data.relationships) {
       setupRelationships(this.__storeWrapper, identifier, data);
     }
@@ -683,7 +689,28 @@ export default class JSONAPICache implements Cache {
    * @param identifier
    * @param data
    */
-  didCommit(identifier: StableRecordIdentifier, data: JsonApiResource | null): void {
+  didCommit(
+    committedIdentifier: StableRecordIdentifier,
+    result: StructuredDataDocument<SingleResourceDocument>
+  ): SingleResourceDataDocument {
+    const payload = result.content;
+    const operation = result.request!.op;
+    const data = payload && payload.data;
+
+    if (!data) {
+      assert(
+        `Your ${committedIdentifier.type} record was saved to the server, but the response does not have an id and no id has been set client side. Records must have ids. Please update the server response to provide an id in the response or generate the id on the client side either before saving the record or while normalizing the response.`,
+        committedIdentifier.id
+      );
+    }
+
+    const { identifierCache } = this.__storeWrapper;
+    const existingId = committedIdentifier.id;
+    const identifier: StableRecordIdentifier =
+      operation !== 'deleteRecord' && data
+        ? identifierCache.updateRecordIdentifier(committedIdentifier, data)
+        : committedIdentifier;
+
     const cached = this.__peek(identifier, false);
     if (cached.isDeleted) {
       graphFor(this.__storeWrapper).push({
@@ -707,18 +734,21 @@ export default class JSONAPICache implements Cache {
       }
     }
 
-    const wasNew = cached.isNew;
     cached.isNew = false;
     let newCanonicalAttributes: AttributesHash | undefined;
     if (data) {
-      if (data.id && wasNew) {
-        // didCommit provided an ID, notify the store of it
-        assert(
-          `Expected resource id to be a string, got a value of type ${typeof data.id}`,
-          typeof data.id === 'string'
-        );
-        this.__storeWrapper.setRecordId(identifier, data.id);
+      if (data.id && !cached.id) {
+        cached.id = data.id;
       }
+      if (identifier === committedIdentifier && identifier.id !== existingId) {
+        this.__storeWrapper.notifyChange(identifier, 'identity');
+      }
+
+      assert(
+        `Expected the ID received for the primary '${identifier.type}' resource being saved to match the current id '${cached.id}' but received '${identifier.id}'.`,
+        identifier.id === cached.id
+      );
+
       if (data.relationships) {
         setupRelationships(this.__storeWrapper, identifier, data);
       }
@@ -741,6 +771,17 @@ export default class JSONAPICache implements Cache {
 
     notifyAttributes(this.__storeWrapper, identifier, changedKeys);
     this.__storeWrapper.notifyChange(identifier, 'state');
+
+    const included = payload && payload.included;
+    if (included) {
+      for (let i = 0, length = included.length; i < length; i++) {
+        putOne(this, identifierCache, included[i]);
+      }
+    }
+
+    return {
+      data: identifier as StableExistingRecordIdentifier,
+    };
   }
 
   /**

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -707,10 +707,11 @@ export default class JSONAPICache implements Cache {
       }
     }
 
+    const wasNew = cached.isNew;
     cached.isNew = false;
     let newCanonicalAttributes: AttributesHash | undefined;
     if (data) {
-      if (data.id) {
+      if (data.id && wasNew) {
         // didCommit provided an ID, notify the store of it
         assert(
           `Expected resource id to be a string, got a value of type ${typeof data.id}`,

--- a/packages/store/src/-private/managers/cache-manager.ts
+++ b/packages/store/src/-private/managers/cache-manager.ts
@@ -1,6 +1,11 @@
 import type { LocalRelationshipOperation } from '@ember-data/graph/-private/graph/-operations';
+import type { StructuredDataDocument } from '@ember-data/request/-private/types';
 import type { Change } from '@ember-data/types/cache/change';
-import type { ResourceDocument, StructuredDocument } from '@ember-data/types/cache/document';
+import type {
+  ResourceDocument,
+  SingleResourceDataDocument,
+  StructuredDocument,
+} from '@ember-data/types/cache/document';
 import type { StableDocumentIdentifier } from '@ember-data/types/cache/identifier';
 import type { Cache, ChangedAttributesHash, MergeOperation } from '@ember-data/types/q/cache';
 import type {
@@ -9,6 +14,8 @@ import type {
 } from '@ember-data/types/q/ember-data-json-api';
 import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
 import type { JsonApiError, JsonApiResource } from '@ember-data/types/q/record-data-json-api';
+
+import type { StoreRequestContext } from '../cache-handler';
 
 /**
  * The CacheManager wraps a Cache enforcing that only
@@ -296,8 +303,8 @@ export class CacheManager implements Cache {
    * @public
    * @param identifier
    */
-  willCommit(identifier: StableRecordIdentifier): void {
-    this.#cache.willCommit(identifier);
+  willCommit(identifier: StableRecordIdentifier, context: StoreRequestContext): void {
+    this.#cache.willCommit(identifier, context);
   }
 
   /**
@@ -309,8 +316,8 @@ export class CacheManager implements Cache {
    * @param identifier
    * @param data
    */
-  didCommit(identifier: StableRecordIdentifier, data: JsonApiResource | null): void {
-    this.#cache.didCommit(identifier, data);
+  didCommit(identifier: StableRecordIdentifier, result: StructuredDataDocument<unknown>): SingleResourceDataDocument {
+    return this.#cache.didCommit(identifier, result);
   }
 
   /**

--- a/tests/main/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/main/tests/integration/adapter/rest-adapter-test.js
@@ -283,15 +283,15 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     post = store.createRecord('post', { name: 'The Parley Letter' });
     await post.save();
-    assert.strictEqual(passedUrl, '/posts');
-    assert.strictEqual(passedVerb, 'POST');
-    assert.deepEqual(passedHash.data, { post: { name: 'The Parley Letter' } });
+    assert.strictEqual(passedUrl, '/posts', 'we pass the correct url');
+    assert.strictEqual(passedVerb, 'POST', 'we pass the correct http method');
+    assert.deepEqual(passedHash.data, { post: { name: 'The Parley Letter' } }, 'we pass the correct post data');
 
     assert.strictEqual(post.id, '1', 'the post has the updated ID');
     assert.false(post.hasDirtyAttributes, "the post isn't dirty anymore");
     assert.strictEqual(post.name, 'Dat Parley Letter', 'the post was updated');
 
-    let comment = store.peekRecord('comment', 1);
+    let comment = store.peekRecord('comment', '1');
     assert.strictEqual(comment.name, 'FIRST', 'The comment was sideloaded');
   });
 

--- a/tests/main/tests/integration/record-data/record-data-errors-test.ts
+++ b/tests/main/tests/integration/record-data/record-data-errors-test.ts
@@ -9,6 +9,7 @@ import { setupTest } from 'ember-qunit';
 import { InvalidError } from '@ember-data/adapter/error';
 import type { LocalRelationshipOperation } from '@ember-data/graph/-private/graph/-operations';
 import Model, { attr } from '@ember-data/model';
+import { StructuredDataDocument } from '@ember-data/request/-private/types';
 import { recordIdentifierFor } from '@ember-data/store';
 import type { ResourceBlob } from '@ember-data/types/cache/aliases';
 import type { Change } from '@ember-data/types/cache/change';
@@ -31,7 +32,11 @@ import type {
   SingleResourceDocument,
   SingleResourceRelationship,
 } from '@ember-data/types/q/ember-data-json-api';
-import type { RecordIdentifier, StableRecordIdentifier } from '@ember-data/types/q/identifier';
+import type {
+  RecordIdentifier,
+  StableExistingRecordIdentifier,
+  StableRecordIdentifier,
+} from '@ember-data/types/q/identifier';
 import type { JsonApiError, JsonApiResource } from '@ember-data/types/q/record-data-json-api';
 
 class Person extends Model {
@@ -116,7 +121,12 @@ class TestRecordData implements Cache {
     return {};
   }
   willCommit(identifier: StableRecordIdentifier): void {}
-  didCommit(identifier: StableRecordIdentifier, data: JsonApiResource | null): void {}
+  didCommit(
+    identifier: StableRecordIdentifier,
+    response: StructuredDataDocument<SingleResourceDocument>
+  ): SingleResourceDataDocument {
+    return { data: identifier as StableExistingRecordIdentifier };
+  }
   commitWasRejected(identifier: StableRecordIdentifier, errors?: JsonApiError[] | undefined): void {
     this._errors = errors;
   }

--- a/tests/main/tests/integration/record-data/record-data-state-test.ts
+++ b/tests/main/tests/integration/record-data/record-data-state-test.ts
@@ -9,6 +9,7 @@ import { setupTest } from 'ember-qunit';
 
 import { LocalRelationshipOperation } from '@ember-data/graph/-private/graph/-operations';
 import Model, { attr } from '@ember-data/model';
+import { StructuredDataDocument } from '@ember-data/request/-private/types';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { recordIdentifierFor } from '@ember-data/store';
 import type { ResourceBlob } from '@ember-data/types/cache/aliases';
@@ -31,7 +32,11 @@ import type {
   SingleResourceDocument,
   SingleResourceRelationship,
 } from '@ember-data/types/q/ember-data-json-api';
-import type { RecordIdentifier, StableRecordIdentifier } from '@ember-data/types/q/identifier';
+import type {
+  RecordIdentifier,
+  StableExistingRecordIdentifier,
+  StableRecordIdentifier,
+} from '@ember-data/types/q/identifier';
 import type { JsonApiError, JsonApiResource } from '@ember-data/types/q/record-data-json-api';
 
 class Person extends Model {
@@ -136,7 +141,9 @@ class TestRecordData implements Cache {
     return {};
   }
   willCommit(identifier: StableRecordIdentifier): void {}
-  didCommit(identifier: StableRecordIdentifier, data: JsonApiResource | null): void {}
+  didCommit(identifier: StableRecordIdentifier, result: StructuredDataDocument<unknown>): SingleResourceDataDocument {
+    return { data: identifier as StableExistingRecordIdentifier };
+  }
   commitWasRejected(identifier: StableRecordIdentifier, errors?: JsonApiError[] | undefined): void {
     this._errors = errors;
   }

--- a/tests/main/tests/integration/record-data/record-data-test.ts
+++ b/tests/main/tests/integration/record-data/record-data-test.ts
@@ -9,6 +9,7 @@ import { setupTest } from 'ember-qunit';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import type { LocalRelationshipOperation } from '@ember-data/graph/-private/graph/-operations';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import { StructuredDataDocument } from '@ember-data/request/-private/types';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { ResourceBlob } from '@ember-data/types/cache/aliases';
 import { Change } from '@ember-data/types/cache/change';
@@ -31,7 +32,11 @@ import type {
   SingleResourceDocument,
   SingleResourceRelationship,
 } from '@ember-data/types/q/ember-data-json-api';
-import type { RecordIdentifier, StableRecordIdentifier } from '@ember-data/types/q/identifier';
+import type {
+  RecordIdentifier,
+  StableExistingRecordIdentifier,
+  StableRecordIdentifier,
+} from '@ember-data/types/q/identifier';
 import type { JsonApiError, JsonApiResource } from '@ember-data/types/q/record-data-json-api';
 
 class Person extends Model {
@@ -140,7 +145,9 @@ class TestRecordData implements Cache {
     return {};
   }
   willCommit(identifier: StableRecordIdentifier): void {}
-  didCommit(identifier: StableRecordIdentifier, data: JsonApiResource | null): void {}
+  didCommit(identifier: StableRecordIdentifier, result: StructuredDataDocument<unknown>): SingleResourceDataDocument {
+    return { data: identifier as StableExistingRecordIdentifier };
+  }
   commitWasRejected(identifier: StableRecordIdentifier, errors?: JsonApiError[] | undefined): void {
     this._errors = errors;
   }
@@ -302,9 +309,10 @@ module('integration/record-data - Custom RecordData Implementations', function (
         calledRollbackAttributes++;
       }
 
-      didCommit(data) {
+      didCommit(identifier, result) {
         calledDidCommit++;
         isNew = false;
+        return { data: identifier };
       }
 
       isNew() {

--- a/tests/main/tests/integration/references/autotracking-test.js
+++ b/tests/main/tests/integration/references/autotracking-test.js
@@ -241,8 +241,10 @@ module('integration/references/autotracking', function (hooks) {
 
     class TestContext {
       user = reference;
+      updates = 0;
 
       get id() {
+        this.updates++;
         return this.user.id();
       }
     }
@@ -254,9 +256,17 @@ module('integration/references/autotracking', function (hooks) {
 
     assert.strictEqual(getRootElement().textContent, 'id: null', 'the id is null');
     assert.strictEqual(testContext.id, null, 'the id is correct initially');
+    assert.strictEqual(testContext.updates, 1, 'id() has been invoked once');
     await dan.save();
     await settled();
     assert.strictEqual(getRootElement().textContent, 'id: 6', 'the id updates when the record id updates');
     assert.strictEqual(testContext.id, '6', 'the id is correct when the record is saved');
+    assert.strictEqual(testContext.updates, 2, 'id() has been invoked twice');
+    // Subsequent saves should do nothing
+    await dan.save();
+    await settled();
+    assert.strictEqual(getRootElement().textContent, 'id: 6', 'the id updates when the record id updates');
+    assert.strictEqual(testContext.id, '6', 'the id is correct when the record is saved');
+    assert.strictEqual(testContext.updates, 2, 'id() has been invoked only twice');
   });
 });


### PR DESCRIPTION
## Description

Since the [elimination of InternalModel](https://github.com/emberjs/data/commit/7e66606481bf9b601f18a209ef20d58a41473936) in 4.7.0, every time an existing record is updated, the Record Data/Cache (by invoking InstanceCache.setRecordId) notifies that the `identity` of the record has changed, even if the `id` was not changed, which is the typical case.  

This behavior leads to unnecessary invalidation (and therefore recomputation) of properties that are subscribed to `model.id`, leading to worse performance and possible bugs due to the unexpected behavior.

## Notes for the release

N/A?