### PR TITLE
Fix: don't clear RecordArray if remaining record does not match the removed record

### DIFF
--- a/packages/store/src/-private/managers/record-array-manager.ts
+++ b/packages/store/src/-private/managers/record-array-manager.ts
@@ -369,7 +369,9 @@ function sync(array: IdentifierArray, changes: Map<StableRecordIdentifier, 'add'
       }
       adds.push(key);
     } else {
-      removes.push(key);
+      if (state.includes(key)) {
+        removes.push(key);
+      }
     }
   });
   if (removes.length) {

--- a/tests/main/tests/integration/record-array-test.js
+++ b/tests/main/tests/integration/record-array-test.js
@@ -200,7 +200,7 @@ module('integration/record-array - RecordArray', function (hooks) {
     assert.strictEqual(recordArray.length, 0, 'initial length 0');
 
     // eslint-disable-next-line no-unused-vars
-    const [_one, _two, three] = store.push({
+    const [_one, two, three] = store.push({
       data: [
         { type: 'person', id: '1', attributes: { name: 'Chris' } },
         { type: 'person', id: '2', attributes: { name: 'Ross' } },
@@ -218,6 +218,16 @@ module('integration/record-array - RecordArray', function (hooks) {
     await settled();
 
     assert.strictEqual(recordArray.length, 2, 'updated length 2');
+
+    // Leaving a single record
+    two.deleteRecord();
+    assert.strictEqual(recordArray.length, 2, 'populated length 2');
+    await two.save();
+    assert.strictEqual(recordArray.length, 1, 'after save persisted length 1');
+    two.unloadRecord();
+    await settled();
+
+    assert.strictEqual(recordArray.length, 1, 'updated length 1');
   });
 
   test('destroyRecord on a newly create record that is staged for a live record array only removes itself', async function (assert) {

--- a/tests/main/tests/integration/record-array-test.js
+++ b/tests/main/tests/integration/record-array-test.js
@@ -200,7 +200,7 @@ module('integration/record-array - RecordArray', function (hooks) {
     assert.strictEqual(recordArray.length, 0, 'initial length 0');
 
     // eslint-disable-next-line no-unused-vars
-    const [_one, two, three] = store.push({
+    const [one, two, three] = store.push({
       data: [
         { type: 'person', id: '1', attributes: { name: 'Chris' } },
         { type: 'person', id: '2', attributes: { name: 'Ross' } },
@@ -214,7 +214,10 @@ module('integration/record-array - RecordArray', function (hooks) {
     assert.strictEqual(recordArray.length, 3, 'populated length 3');
     await three.save();
     assert.strictEqual(recordArray.length, 2, 'after save persisted length 2');
+    assert.strictEqual(recordArray.at(0).name, 'Chris', 'after save persisted first record is Chris');
+    assert.strictEqual(recordArray.at(1).name, 'Ross', 'after save persisted second record is Ross');
     three.unloadRecord();
+
     await settled();
 
     assert.strictEqual(recordArray.length, 2, 'updated length 2');
@@ -224,6 +227,8 @@ module('integration/record-array - RecordArray', function (hooks) {
     assert.strictEqual(recordArray.length, 2, 'populated length 2');
     await two.save();
     assert.strictEqual(recordArray.length, 1, 'after save persisted length 1');
+    assert.strictEqual(recordArray.at(0).name, 'Chris', 'after save persisted first record is Chris');
+
     two.unloadRecord();
     await settled();
 


### PR DESCRIPTION
resolves #8569

Previously, removing a record only checked that the record was still a member of the array if `removes.length !== state.length`, this missed the case where when exactly two records exist and one is removed and the removal is double-notified the record to remove may not be the record in the array.

The double-notification is something we should also investigate, it's likely that we should not notify the state change for `isDeleted`, only for when the deletion is persisted. We also likely should not notify when unloadRecord is called on something whose deletion has been persisted. Both of these cases are leading the over-notification, the first for an extra add, the second for an extra remove.