### PR TITLE
[backport / beta] Fix: don't clear RecordArray if remaining record does not match the removed record

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ not wish to use `ember-data`, remove `ember-data` from your project's `package.j
 - [@ember-data/tracking](./packages/tracking) is required when using the core and provides tracking primitives for change notification of Tracked properties
 - [@ember-data/json-api](./packages/json-api) is a resource cache for JSON:API structured data. It integrates with the store via the hook `createRecordDataFor`
 - [@ember-data/model](./packages/model) is a presentation layer, it integrates with the store via the hooks `instantiateRecord` and `teardownRecord`.
+- [@ember-data/request](./packages/request) provides a pipeline for requesting data from an API. It integrates with the store via the `requestManager` property
+- [@ember-data/legacy-compat](./packages/legacy-compat) provides a compatibility layer for legacy APIs (Adapter, Serializer etc.)
 - [@ember-data/adapter](./packages/adapter) provides various network API integrations for APIS built over specific REST or JSON:API conventions.
 - [@ember-data/serializer](./packages/serializer) pairs with `@ember-data/adapter` to normalize and serialize data to and from an API format into the `JSON:API` format understood by `@ember-data/json-api`.
 - [@ember-data/debug](./packages/debug) provides debugging support for the `ember-inspector`.

--- a/packages/-ember-data/addon/index.js
+++ b/packages/-ember-data/addon/index.js
@@ -74,6 +74,8 @@ not wish to use `ember-data`, remove `ember-data` from your project's `package.j
 - [@ember-data/store](/ember-data/release/modules/@ember-data%2Fstore) is the core and handles coordination
 - [@ember-data/json-api](/ember-data/release/modules/@ember-data%2Fjson-api) provides a resource cache for JSON:API structured data. It integrates with the store via the hook `createCache`
 - [@ember-data/model](/ember-data/release/modules/@ember-data%2Fmodel) is a presentation layer, it integrates with the store via the hooks `instantiateRecord` and `teardownRecord`.
+- [@ember-data/request](/ember-data/release/modules/@ember-data%2Frequest) provides a pipeline for requesting data from an API. It integrates with the store via the `requestManager` property
+- [@ember-data/legacy-compat](/ember-data/release/modules/@ember-data%2Flegacy-compat) provides a compatibility layer for legacy APIs (Adapter, Serializer etc.)
 - [@ember-data/adapter](/ember-data/release/modules/@ember-data%2Fadapter) provides various network API integrations for APIS built over specific REST or JSON:API conventions.
 - [@ember-data/serializer](/ember-data/release/modules/@ember-data%2Fserializer) pairs with `@ember-data/adapter` to normalize and serialize data to and from an API format into the `JSON:API` format understood by `@ember-data/json-api`.
 - [@ember-data/debug](/ember-data/release/modules/@ember-data%2Fdebug) provides debugging support for the `ember-inspector`.

--- a/packages/store/src/-private/managers/record-array-manager.ts
+++ b/packages/store/src/-private/managers/record-array-manager.ts
@@ -369,7 +369,9 @@ function sync(array: IdentifierArray, changes: Map<StableRecordIdentifier, 'add'
       }
       adds.push(key);
     } else {
-      removes.push(key);
+      if (state.includes(key)) {
+        removes.push(key);
+      }
     }
   });
   if (removes.length) {

--- a/tests/main/tests/integration/record-array-test.js
+++ b/tests/main/tests/integration/record-array-test.js
@@ -200,7 +200,7 @@ module('integration/record-array - RecordArray', function (hooks) {
     assert.strictEqual(recordArray.length, 0, 'initial length 0');
 
     // eslint-disable-next-line no-unused-vars
-    const [_one, _two, three] = store.push({
+    const [one, two, three] = store.push({
       data: [
         { type: 'person', id: '1', attributes: { name: 'Chris' } },
         { type: 'person', id: '2', attributes: { name: 'Ross' } },
@@ -214,10 +214,25 @@ module('integration/record-array - RecordArray', function (hooks) {
     assert.strictEqual(recordArray.length, 3, 'populated length 3');
     await three.save();
     assert.strictEqual(recordArray.length, 2, 'after save persisted length 2');
+    assert.strictEqual(recordArray.at(0).name, 'Chris', 'after save persisted first record is Chris');
+    assert.strictEqual(recordArray.at(1).name, 'Ross', 'after save persisted second record is Ross');
     three.unloadRecord();
+
     await settled();
 
     assert.strictEqual(recordArray.length, 2, 'updated length 2');
+
+    // Leaving a single record
+    two.deleteRecord();
+    assert.strictEqual(recordArray.length, 2, 'populated length 2');
+    await two.save();
+    assert.strictEqual(recordArray.length, 1, 'after save persisted length 1');
+    assert.strictEqual(recordArray.at(0).name, 'Chris', 'after save persisted first record is Chris');
+
+    two.unloadRecord();
+    await settled();
+
+    assert.strictEqual(recordArray.length, 1, 'updated length 1');
   });
 
   test('destroyRecord on a newly create record that is staged for a live record array only removes itself', async function (assert) {


### PR DESCRIPTION
resolves #8569

Previously, removing a record only checked that the record was still a member of the array if `removes.length !== state.length`, this missed the case where when exactly two records exist and one is removed and the removal is double-notified the record to remove may not be the record in the array.

The double-notification is something we should also investigate, it's likely that we should not notify the state change for `isDeleted`, only for when the deletion is persisted. We also likely should not notify when unloadRecord is called on something whose deletion has been persisted. Both of these cases are leading the over-notification, the first for an extra add, the second for an extra remove.