### PR TITLE
Various Backported Fixes for 4.12 LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ benchmarks/results/*.json
 /tests/*/DEBUG
 
 .vscode/
+.idea/
+*.iml

--- a/docs-generator/compile-docs.js
+++ b/docs-generator/compile-docs.js
@@ -29,16 +29,54 @@ function generateOptions() {
   return Y.Project.init(config);
 }
 
+function rewritePath(filePath) {
+  if (filePath.startsWith('../packages')) {
+    return filePath.replace('../packages/', '../');
+  }
+  if (filePath.startsWith('../')) {
+    return filePath.replace('../', '../../');
+  }
+  return filePath;
+}
+
 async function main() {
   const options = generateOptions();
 
   const yuidocCompiler = new Y.YUIDoc(options);
-  const json = yuidocCompiler.run();
-  const builder = new Y.DocBuilder(options, json);
+  const initialJson = yuidocCompiler.run();
+
+  const builder = new Y.DocBuilder(options, initialJson);
 
   await new Promise((resolve) => {
     builder.compile(resolve);
   });
+
+  const dataFile = path.join(__dirname, '../packages/-ember-data/dist/docs/data.json');
+  const json = JSON.parse(fs.readFileSync(dataFile));
+
+  const newFiles = {};
+  Object.keys(json.files).forEach((key) => {
+    const newKey = rewritePath(key);
+    newFiles[newKey] = json.files[key];
+    newFiles[newKey].name = newKey;
+  });
+  json.files = newFiles;
+
+  Object.keys(json.classes).forEach((key) => {
+    const val = json.classes[key];
+    if (val.file) {
+      val.file = rewritePath(val.file);
+    }
+  });
+
+  Object.keys(json.modules).forEach((key) => {
+    const val = json.modules[key];
+    if (val.file) {
+      val.file = rewritePath(val.file);
+    }
+  });
+
+  fs.writeFileSync(dataFile, JSON.stringify(json, null, 2));
 }
 
 main();

--- a/ember-data-types/cache/cache.ts
+++ b/ember-data-types/cache/cache.ts
@@ -1,13 +1,14 @@
 /**
  * @module @ember-data/experimental-preview-types
  */
+import { StoreRequestContext } from '@ember-data/store/-private/cache-handler';
 import { StableRecordIdentifier } from '@ember-data/types/q/identifier';
 
 import { CollectionResourceRelationship, SingleResourceRelationship } from '../q/ember-data-json-api';
 import { JsonApiError } from '../q/record-data-json-api';
 import { ResourceBlob } from './aliases';
 import { Change } from './change';
-import { ResourceDocument, StructuredDocument } from './document';
+import { ResourceDocument, SingleResourceDataDocument, StructuredDataDocument, StructuredDocument } from './document';
 import { StableDocumentIdentifier } from './identifier';
 import { Mutation } from './mutations';
 import { Operation } from './operations';
@@ -262,7 +263,7 @@ export interface Cache {
    * @public
    * @param identifier
    */
-  willCommit(identifier: StableRecordIdentifier): void;
+  willCommit(identifier: StableRecordIdentifier, context: StoreRequestContext): void;
 
   /**
    * [LIFECYCLE] Signals to the cache that a resource
@@ -270,10 +271,11 @@ export interface Cache {
    *
    * @method didCommit
    * @public
-   * @param identifier
-   * @param data
+   * @param identifier - the primary identifier that was operated on
+   * @param data - a document in the cache format containing any updated data
+   * @return {SingleResourceDataDocument}
    */
-  didCommit(identifier: StableRecordIdentifier, data: ResourceBlob | null): void;
+  didCommit(identifier: StableRecordIdentifier, result: StructuredDataDocument<unknown>): SingleResourceDataDocument;
 
   /**
    * [LIFECYCLE] Signals to the cache that a resource

--- a/packages/adapter/src/rest.ts
+++ b/packages/adapter/src/rest.ts
@@ -1268,7 +1268,11 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
         {
           status: `${status}`, // Set to a string per the JSON API spec: https://jsonapi.org/format/#errors
           title: 'The backend responded with an error',
-          detail: `${payload}`,
+          // Detail is intended to be a string, but backends be non-compliant.
+          // stringifying gives the user a more friendly error in this situation, whereas
+          // they'd instead receive [object Object].
+          // JSON.stringify will convert *anything* to a string without erroring.
+          detail: typeof payload === 'string' ? payload : JSON.stringify(payload),
         },
       ];
     }

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -57,10 +57,11 @@ const EMPTY_ITERATOR = {
 };
 
 interface CachedResource {
-  remoteAttrs: Dict<unknown> | null;
-  localAttrs: Dict<unknown> | null;
-  inflightAttrs: Dict<unknown> | null;
-  changes: Dict<unknown[]> | null;
+  id: string | null;
+  remoteAttrs: Record<string, unknown> | null;
+  localAttrs: Record<string, unknown> | null;
+  inflightAttrs: Record<string, unknown> | null;
+  changes: Record<string, unknown[]> | null;
   errors: JsonApiError[] | null;
   isNew: boolean;
   isDeleted: boolean;
@@ -69,6 +70,7 @@ interface CachedResource {
 
 function makeCache(): CachedResource {
   return {
+    id: null,
     remoteAttrs: null,
     localAttrs: null,
     inflightAttrs: null,
@@ -448,6 +450,10 @@ export default class JSONAPICache implements Cache {
       this.__storeWrapper.notifyChange(identifier, 'added');
     }
 
+    if (data.id) {
+      cached.id = data.id;
+    }
+
     if (data.relationships) {
       setupRelationships(this.__storeWrapper, identifier, data);
     }
@@ -677,7 +683,28 @@ export default class JSONAPICache implements Cache {
    * @param identifier
    * @param data
    */
-  didCommit(identifier: StableRecordIdentifier, data: JsonApiResource | null): void {
+  didCommit(
+    committedIdentifier: StableRecordIdentifier,
+    result: StructuredDataDocument<SingleResourceDocument>
+  ): SingleResourceDataDocument {
+    const payload = result.content;
+    const operation = result.request!.op;
+    const data = payload && payload.data;
+
+    if (!data) {
+      assert(
+        `Your ${committedIdentifier.type} record was saved to the server, but the response does not have an id and no id has been set client side. Records must have ids. Please update the server response to provide an id in the response or generate the id on the client side either before saving the record or while normalizing the response.`,
+        committedIdentifier.id
+      );
+    }
+
+    const { identifierCache } = this.__storeWrapper;
+    const existingId = committedIdentifier.id;
+    const identifier: StableRecordIdentifier =
+      operation !== 'deleteRecord' && data
+        ? identifierCache.updateRecordIdentifier(committedIdentifier, data)
+        : committedIdentifier;
+
     const cached = this.__peek(identifier, false);
     if (cached.isDeleted) {
       graphFor(this.__storeWrapper).push({
@@ -704,14 +731,18 @@ export default class JSONAPICache implements Cache {
     cached.isNew = false;
     let newCanonicalAttributes: AttributesHash | undefined;
     if (data) {
-      if (data.id) {
-        // didCommit provided an ID, notify the store of it
-        assert(
-          `Expected resource id to be a string, got a value of type ${typeof data.id}`,
-          typeof data.id === 'string'
-        );
-        this.__storeWrapper.setRecordId(identifier, data.id);
+      if (data.id && !cached.id) {
+        cached.id = data.id;
       }
+      if (identifier === committedIdentifier && identifier.id !== existingId) {
+        this.__storeWrapper.notifyChange(identifier, 'identity');
+      }
+
+      assert(
+        `Expected the ID received for the primary '${identifier.type}' resource being saved to match the current id '${cached.id}' but received '${identifier.id}'.`,
+        identifier.id === cached.id
+      );
+
       if (data.relationships) {
         setupRelationships(this.__storeWrapper, identifier, data);
       }
@@ -734,6 +765,17 @@ export default class JSONAPICache implements Cache {
 
     notifyAttributes(this.__storeWrapper, identifier, changedKeys);
     this.__storeWrapper.notifyChange(identifier, 'state');
+
+    const included = payload && payload.included;
+    if (included) {
+      for (let i = 0, length = included.length; i < length; i++) {
+        putOne(this, identifierCache, included[i]);
+      }
+    }
+
+    return {
+      data: identifier as StableExistingRecordIdentifier,
+    };
   }
 
   /**

--- a/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts
@@ -10,6 +10,7 @@ import type Store from '@ember-data/store';
 import type { StoreRequestContext, StoreRequestInfo } from '@ember-data/store/-private/cache-handler';
 import type ShimModelClass from '@ember-data/store/-private/legacy-model-support/shim-model-class';
 import type { Collection } from '@ember-data/store/-private/record-arrays/identifier-array';
+import { SingleResourceDataDocument } from '@ember-data/types/cache/document';
 import type {
   CollectionResourceDocument,
   JsonApiDocument,
@@ -189,6 +190,7 @@ function saveRecord<T>(context: StoreRequestContext): Promise<T> {
           console.log(`EmberData | Payload - ${operation!}`, payload);
         }
       }
+      let result: SingleResourceDataDocument;
       /*
       // TODO @runspired re-evaluate the below claim now that
       // the save request pipeline is more streamlined.
@@ -218,13 +220,13 @@ function saveRecord<T>(context: StoreRequestContext): Promise<T> {
 
         //We first make sure the primary data has been updated
         const cache = DEPRECATE_V1_RECORD_DATA ? store._instanceCache.getResourceCache(actualIdentifier) : store.cache;
-        cache.didCommit(identifier, data);
+        result = cache.didCommit(identifier, { request: context.request, content: payload });
 
         if (payload && payload.included) {
           store._push({ data: null, included: payload.included }, true);
         }
       });
-      return store.peekRecord(identifier);
+      return store.peekRecord(result!.data!);
     })
     .catch((e: unknown) => {
       let err = e;

--- a/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts
@@ -204,22 +204,8 @@ function saveRecord<T>(context: StoreRequestContext): Promise<T> {
       call to `store._push`;
      */
       store._join(() => {
-        let data = payload && payload.data;
-        if (!data) {
-          assert(
-            `Your ${identifier.type} record was saved to the server, but the response does not have an id and no id has been set client side. Records must have ids. Please update the server response to provide an id in the response or generate the id on the client side either before saving the record or while normalizing the response.`,
-            identifier.id
-          );
-        }
-
-        const identifierCache = store.identifierCache;
-        let actualIdentifier = identifier;
-        if (operation !== 'deleteRecord' && data) {
-          actualIdentifier = identifierCache.updateRecordIdentifier(identifier, data);
-        }
-
         //We first make sure the primary data has been updated
-        const cache = DEPRECATE_V1_RECORD_DATA ? store._instanceCache.getResourceCache(actualIdentifier) : store.cache;
+        const cache = DEPRECATE_V1_RECORD_DATA ? store._instanceCache.getResourceCache(identifier) : store.cache;
         result = cache.didCommit(identifier, { request: context.request, content: payload });
 
         if (payload && payload.included) {

--- a/packages/request/src/-private/context.ts
+++ b/packages/request/src/-private/context.ts
@@ -33,8 +33,10 @@ export class ContextOwner {
       request
     ) as ImmutableRequestInfo;
     if (DEBUG) {
-      request = deepFreeze(request) as ImmutableRequestInfo;
-      enhancedRequest = deepFreeze(enhancedRequest);
+      if (!request?.cacheOptions?.[Symbol.for('ember-data:skip-cache')]) {
+        request = deepFreeze(request) as ImmutableRequestInfo;
+        enhancedRequest = deepFreeze(enhancedRequest);
+      }
     } else {
       if (request.headers) {
         (request.headers as ImmutableHeaders).clone = () => {

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -87,7 +87,7 @@ Now that we have a `cache` let's setup something to handle fetching and saving d
 
 When *Ember***Data** needs to fetch or save data it will pass that request to your application's `RequestManager` for fulfillment. How this fulfillment occurs (in-memory, device storage, via single or multiple API requests, etc.) is then up to the registered request handlers.
 
-To start, let's install the `FetchManager` from `@ember-data/request` and the basic `Fetch` handler from ``@ember-data/request/fetch`.
+To start, let's install the `RequestManager` from `@ember-data/request` and the basic `Fetch` handler from ``@ember-data/request/fetch`.
 
 > **Note** If your app uses `GraphQL`, `REST` or different conventions for `JSON:API` than your cache expects, other handlers may better fit your data. You can author your own handler by creating one that conforms to the [handler interface](https://github.com/emberjs/data/tree/main/packages/request#handling-requests).
 

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -3,6 +3,7 @@
  */
 import { getOwner, setOwner } from '@ember/application';
 import { assert, deprecate } from '@ember/debug';
+import EmberObject from '@ember/object';
 import { _backburner as emberBackburner } from '@ember/runloop';
 
 import { importSync } from '@embroider/macros';
@@ -102,11 +103,12 @@ export interface CreateRecordProperties {
   @public
 */
 
+// @ts-expect-error
 interface Store {
   createRecordDataFor?(identifier: StableRecordIdentifier, wrapper: CacheStoreWrapper): Cache | CacheV1;
 }
 
-class Store {
+class Store extends EmberObject {
   declare recordArrayManager: RecordArrayManager;
 
   /**
@@ -223,14 +225,30 @@ class Store {
   // DEBUG-only properties
   declare DISABLE_WAITER?: boolean;
 
-  isDestroying: boolean = false;
-  isDestroyed: boolean = false;
+  declare _isDestroying: boolean;
+  declare _isDestroyed: boolean;
+
+  // @ts-expect-error
+  get isDestroying(): boolean {
+    return this._isDestroying;
+  }
+  set isDestroying(value: boolean) {
+    this._isDestroying = value;
+  }
+  // @ts-expect-error
+  get isDestroyed(): boolean {
+    return this._isDestroyed;
+  }
+  set isDestroyed(value: boolean) {
+    this._isDestroyed = value;
+  }
 
   /**
     @method init
     @private
   */
   constructor(createArgs?: Record<string, unknown>) {
+    super(createArgs);
     Object.assign(this, createArgs);
 
     this.identifierCache = new IdentifierCache();
@@ -247,6 +265,9 @@ class Store {
     this._serializerCache = Object.create(null);
     this._modelFactoryCache = Object.create(null);
     this._documentCache = new Map();
+
+    this.isDestroying = false;
+    this.isDestroyed = false;
   }
 
   _run(cb: () => void) {
@@ -2594,7 +2615,8 @@ class Store {
     return null;
   }
 
-  destroy() {
+  // @ts-expect-error
+  destroy(): void {
     if (this.isDestroyed) {
       // @ember/test-helpers will call destroy multiple times
       return;

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -69,7 +69,7 @@
  *
  * When *Ember***Data** needs to fetch or save data it will pass that request to your application's `RequestManager` for fulfillment. How this fulfillment occurs (in-memory, device storage, via single or multiple API requests, etc.) is then up to the registered request handlers.
  *
- * To start, let's install the `FetchManager` from `@ember-data/request` and the basic `Fetch` handler from ``@ember-data/request/fetch`.
+ * To start, let's install the `RequestManager` from `@ember-data/request` and the basic `Fetch` handler from ``@ember-data/request/fetch`.
  *
  * > **Note** If your app uses `GraphQL`, `REST` or different conventions for `JSON:API` than your cache expects, other handlers may better fit your data. You can author your own handler by creating one that conforms to the [handler interface](https://github.com/emberjs/data/tree/main/packages/request#handling-requests).
  *

--- a/tests/docs/index.js
+++ b/tests/docs/index.js
@@ -1,4 +1,7 @@
 'use strict';
+const path = require('path');
+const fs = require('fs');
+
 const QUnit = require('qunit');
 
 const { test } = QUnit;
@@ -38,6 +41,7 @@ QUnit.module('Docs coverage', function (hooks) {
       const module = docs.modules[moduleName];
       if (isOwnModule(module)) {
         test(`${moduleName} is configured correctly`, function (assert) {
+          assert.ok(docs.files[module.file], `${moduleName} has a file in ${linkItem(module)}`);
           assert.strictEqual(module.tag, 'main', `${moduleName} is tagged as main in ${linkItem(module)}`);
           assert.true(isNonEmptyString(module.description), `${moduleName} has a description in ${linkItem(module)}`);
           assert.false(
@@ -56,6 +60,7 @@ QUnit.module('Docs coverage', function (hooks) {
         return;
       }
       test(`Class ${className} is documented correctly at ${linkItem(def)}`, function (assert) {
+        assert.ok(docs.files[def.file], `${className} has a file`);
         assert.true(
           def.access === 'public' || def.access === 'private',
           `${def.name} must declare either as either @internal @private or @public`
@@ -148,6 +153,16 @@ QUnit.module('Docs coverage', function (hooks) {
         extraneous,
         'If you have added new features, please update tests/docs/expected.js and confirm that any public properties are marked both @public and @static to be included in the Ember API Docs viewer.'
       );
+    });
+  });
+
+  QUnit.module('files', function (hooks) {
+    test(`All files have meaningful paths`, function (assert) {
+      const root = path.join(__dirname, '../../packages/-ember-data');
+      Object.keys(docs.files).forEach((fileName) => {
+        const filePath = path.join(root, fileName);
+        assert.true(fs.existsSync(filePath), `${fileName} is resolvable as ${filePath}`);
+      });
     });
   });
 });

--- a/tests/main/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/main/tests/integration/adapter/rest-adapter-test.js
@@ -283,15 +283,15 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
 
     post = store.createRecord('post', { name: 'The Parley Letter' });
     await post.save();
-    assert.strictEqual(passedUrl, '/posts');
-    assert.strictEqual(passedVerb, 'POST');
-    assert.deepEqual(passedHash.data, { post: { name: 'The Parley Letter' } });
+    assert.strictEqual(passedUrl, '/posts', 'we pass the correct url');
+    assert.strictEqual(passedVerb, 'POST', 'we pass the correct http method');
+    assert.deepEqual(passedHash.data, { post: { name: 'The Parley Letter' } }, 'we pass the correct post data');
 
     assert.strictEqual(post.id, '1', 'the post has the updated ID');
     assert.false(post.hasDirtyAttributes, "the post isn't dirty anymore");
     assert.strictEqual(post.name, 'Dat Parley Letter', 'the post was updated');
 
-    let comment = store.peekRecord('comment', 1);
+    let comment = store.peekRecord('comment', '1');
     assert.strictEqual(comment.name, 'FIRST', 'The comment was sideloaded');
   });
 

--- a/tests/main/tests/integration/record-data/record-data-errors-test.ts
+++ b/tests/main/tests/integration/record-data/record-data-errors-test.ts
@@ -10,6 +10,7 @@ import { InvalidError } from '@ember-data/adapter/error';
 import { DEPRECATE_V1_RECORD_DATA } from '@ember-data/deprecations';
 import type { LocalRelationshipOperation } from '@ember-data/graph/-private/graph/-operations';
 import Model, { attr } from '@ember-data/model';
+import type { StructuredDataDocument } from '@ember-data/request/-private/types';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { recordIdentifierFor } from '@ember-data/store';
 import type { ResourceBlob } from '@ember-data/types/cache/aliases';
@@ -33,9 +34,13 @@ import type {
   SingleResourceDocument,
   SingleResourceRelationship,
 } from '@ember-data/types/q/ember-data-json-api';
-import type { NewRecordIdentifier, RecordIdentifier, StableRecordIdentifier } from '@ember-data/types/q/identifier';
+import type {
+  NewRecordIdentifier,
+  RecordIdentifier,
+  StableExistingRecordIdentifier,
+  StableRecordIdentifier,
+} from '@ember-data/types/q/identifier';
 import type { JsonApiError, JsonApiResource } from '@ember-data/types/q/record-data-json-api';
-import type { Dict } from '@ember-data/types/q/utils';
 
 if (!DEPRECATE_V1_RECORD_DATA) {
   class Person extends Model {
@@ -114,12 +119,20 @@ if (!DEPRECATE_V1_RECORD_DATA) {
       this.wrapper.notifyChange(identifier, 'attributes');
       this.wrapper.notifyChange(identifier, 'relationships');
     }
-    clientDidCreate(identifier: StableRecordIdentifier, options?: Dict<unknown> | undefined): Dict<unknown> {
+    clientDidCreate(
+      identifier: StableRecordIdentifier,
+      options?: Record<string, unknown> | undefined
+    ): Record<string, unknown> {
       this._isNew = true;
       return {};
     }
     willCommit(identifier: StableRecordIdentifier): void {}
-    didCommit(identifier: StableRecordIdentifier, data: JsonApiResource | null): void {}
+    didCommit(
+      identifier: StableRecordIdentifier,
+      response: StructuredDataDocument<SingleResourceDocument>
+    ): SingleResourceDataDocument {
+      return { data: identifier as StableExistingRecordIdentifier };
+    }
     commitWasRejected(identifier: StableRecordIdentifier, errors?: JsonApiError[] | undefined): void {
       this._errors = errors;
     }

--- a/tests/main/tests/integration/record-data/record-data-state-test.ts
+++ b/tests/main/tests/integration/record-data/record-data-state-test.ts
@@ -10,6 +10,7 @@ import { setupTest } from 'ember-qunit';
 import { DEPRECATE_V1_RECORD_DATA } from '@ember-data/deprecations';
 import { LocalRelationshipOperation } from '@ember-data/graph/-private/graph/-operations';
 import Model, { attr } from '@ember-data/model';
+import { StructuredDataDocument } from '@ember-data/request/-private/types';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { recordIdentifierFor } from '@ember-data/store';
 import type { ResourceBlob } from '@ember-data/types/cache/aliases';
@@ -32,7 +33,12 @@ import type {
   SingleResourceDocument,
   SingleResourceRelationship,
 } from '@ember-data/types/q/ember-data-json-api';
-import type { NewRecordIdentifier, RecordIdentifier, StableRecordIdentifier } from '@ember-data/types/q/identifier';
+import type {
+  NewRecordIdentifier,
+  RecordIdentifier,
+  StableExistingRecordIdentifier,
+  StableRecordIdentifier,
+} from '@ember-data/types/q/identifier';
 import type { JsonApiError, JsonApiResource } from '@ember-data/types/q/record-data-json-api';
 import { Dict } from '@ember-data/types/q/utils';
 
@@ -231,7 +237,9 @@ class V2TestRecordData implements Cache {
     return {};
   }
   willCommit(identifier: StableRecordIdentifier): void {}
-  didCommit(identifier: StableRecordIdentifier, data: JsonApiResource | null): void {}
+  didCommit(identifier: StableRecordIdentifier, result: StructuredDataDocument<unknown>): SingleResourceDataDocument {
+    return { data: identifier as StableExistingRecordIdentifier };
+  }
   commitWasRejected(identifier: StableRecordIdentifier, errors?: JsonApiError[] | undefined): void {
     this._errors = errors;
   }

--- a/tests/main/tests/integration/record-data/record-data-test.ts
+++ b/tests/main/tests/integration/record-data/record-data-test.ts
@@ -10,6 +10,7 @@ import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { DEPRECATE_V1_RECORD_DATA } from '@ember-data/deprecations';
 import type { LocalRelationshipOperation } from '@ember-data/graph/-private/graph/-operations';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import { StructuredDataDocument } from '@ember-data/request/-private/types';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { ResourceBlob } from '@ember-data/types/cache/aliases';
 import { Change } from '@ember-data/types/cache/change';
@@ -32,7 +33,11 @@ import type {
   SingleResourceDocument,
   SingleResourceRelationship,
 } from '@ember-data/types/q/ember-data-json-api';
-import type { RecordIdentifier, StableRecordIdentifier } from '@ember-data/types/q/identifier';
+import type {
+  RecordIdentifier,
+  StableExistingRecordIdentifier,
+  StableRecordIdentifier,
+} from '@ember-data/types/q/identifier';
 import type { JsonApiError, JsonApiResource } from '@ember-data/types/q/record-data-json-api';
 import type { Dict } from '@ember-data/types/q/utils';
 
@@ -209,7 +214,9 @@ class V2TestRecordData implements Cache {
     return {};
   }
   willCommit(identifier: StableRecordIdentifier): void {}
-  didCommit(identifier: StableRecordIdentifier, data: JsonApiResource | null): void {}
+  didCommit(identifier: StableRecordIdentifier, result: StructuredDataDocument<unknown>): SingleResourceDataDocument {
+    return { data: identifier as StableExistingRecordIdentifier };
+  }
   commitWasRejected(identifier: StableRecordIdentifier, errors?: JsonApiError[] | undefined): void {
     this._errors = errors;
   }
@@ -393,9 +400,10 @@ module('integration/record-data - Custom RecordData Implementations', function (
         calledRollbackAttributes++;
       }
 
-      didCommit(data) {
+      didCommit(identifier, result) {
         calledDidCommit++;
         isNew = false;
+        return { data: identifier };
       }
 
       isNew() {

--- a/tests/main/tests/integration/relationships/belongs-to-test.js
+++ b/tests/main/tests/integration/relationships/belongs-to-test.js
@@ -1,3 +1,4 @@
+import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
 
 import { module, test } from 'qunit';
@@ -1976,5 +1977,57 @@ module('integration/relationship/belongs_to Belongs-To Relationships', function 
     });
 
     assert.strictEqual(count, 0);
+  });
+
+  test('accessing multiple async belongsTo relationships works as expected', async function (assert) {
+    const { owner } = this;
+    owner.register(
+      'model:user',
+      class extends Model {
+        @attr name;
+        @belongsTo('user', { async: true, inverse: null }) bestFriend;
+        @belongsTo('user', { async: true, inverse: null }) worstEnemy;
+      }
+    );
+    owner.register(
+      'adapter:user',
+      class extends EmberObject {
+        findRecord(_store, _schema, id) {
+          return {
+            data: {
+              type: 'user',
+              id,
+              attributes: {
+                name: id === '2' ? 'Peach' : 'Bowser',
+              },
+            },
+          };
+        }
+      }
+    );
+
+    const store = owner.lookup('service:store');
+    const user = store.push({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Mario',
+        },
+        relationships: {
+          bestFriend: { data: { type: 'user', id: '2' } },
+          worstEnemy: { data: { type: 'user', id: '3' } },
+        },
+      },
+    });
+
+    const bestFriendPromise = user.bestFriend;
+    const worstEnemyPromise = user.worstEnemy;
+
+    const friend = await bestFriendPromise;
+    const enemy = await worstEnemyPromise;
+
+    // eslint-disable-next-line qunit/no-ok-equality
+    assert.true(friend !== enemy, 'we got separate records');
   });
 });


### PR DESCRIPTION
- fix: restore Store extends EmberObject (#8594)
- fix: LegacyHandler should provide unfrozen options to Adapters (#8576)
- fix: dont share promise cache for all fields (#8597)
- fix: docs generation should maintain a stable relative path (#8598)
- docs: fix forgotten references to FetchManager (#8601)
- Avoid unnecessary identity notification when record is saved (#8566)
- fix: normalizeErrorResponse should be resilient to non-string details (#8621)