### PR TITLE
There are cases where payload is an object, and normalizeErrorRespons…

### DIFF
--- a/packages/adapter/src/rest.ts
+++ b/packages/adapter/src/rest.ts
@@ -1280,7 +1280,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
           // stringifying gives the user a more friendly error in this situation, whereas
           // they'd instead receive [object Object].
           // JSON.stringify will convert *anything* to a string without erroring.
-          detail: JSON.stringify(payload),
+          detail: typeof payload === 'string' ? payload : JSON.stringify(payload),
         },
       ];
     }

--- a/packages/adapter/src/rest.ts
+++ b/packages/adapter/src/rest.ts
@@ -1276,6 +1276,10 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
         {
           status: `${status}`, // Set to a string per the JSON API spec: https://jsonapi.org/format/#errors
           title: 'The backend responded with an error',
+          // Detail is intended to be a string, but backends be non-compliant.
+          // stringifying gives the user a more friendly error in this situation, whereas
+          // they'd instead receive [object Object].
+          // JSON.stringify will convert *anything* to a string without erroring.
           detail: JSON.stringify(payload),
         },
       ];

--- a/packages/adapter/src/rest.ts
+++ b/packages/adapter/src/rest.ts
@@ -1276,7 +1276,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
         {
           status: `${status}`, // Set to a string per the JSON API spec: https://jsonapi.org/format/#errors
           title: 'The backend responded with an error',
-          detail: `${payload}`,
+          detail: JSON.stringify(payload),
         },
       ];
     }


### PR DESCRIPTION
…e ends up returning [object Object] for "detail"

## Description

Found this while debugging an error I was getting from Mirage (500).
It seems Mirage doesn't have a way to serialize errors -- so.. that's fun.
In any case, I think giving a best-effort attempt to show more details for the detail part of the normalizeErrorResponse return object would be beneficial for everyone.

## Notes for the release

When 500 errors send an object back to the client, that object will be serialized JSON instead of `[object Object]`

