### PR TITLE
fix: NotificationManager should only invoke resource/document callbacks owned by the originating store

### DIFF
--- a/packages/store/src/-private/legacy-model-support/record-reference.ts
+++ b/packages/store/src/-private/legacy-model-support/record-reference.ts
@@ -9,7 +9,6 @@ import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
 import type { RecordInstance } from '@ember-data/types/q/record-instance';
 
 import type { NotificationType } from '../managers/notification-manager';
-import { unsubscribe } from '../managers/notification-manager';
 import type Store from '../store-service';
 
 /**
@@ -46,7 +45,7 @@ export default class RecordReference {
   }
 
   destroy() {
-    unsubscribe(this.___token);
+    this.store.notifications.unsubscribe(this.___token);
   }
 
   get type(): string {

--- a/packages/store/src/-private/managers/record-array-manager.ts
+++ b/packages/store/src/-private/managers/record-array-manager.ts
@@ -17,9 +17,7 @@ import IdentifierArray, {
 import type Store from '../store-service';
 import { CacheOperation, UnsubscribeToken } from './notification-manager';
 
-const RecordArraysCache = new Map<StableRecordIdentifier, Set<Collection>>();
 const FAKE_ARR = {};
-
 const SLICE_BATCH_SIZE = 1200;
 /**
  * This is a clever optimization.
@@ -98,7 +96,7 @@ class RecordArrayManager {
     this._pending = new Map();
     this._staged = new Map();
     this._keyedArrays = new Map();
-    this._identifiers = RecordArraysCache;
+    this._identifiers = new Map();
 
     this._subscription = this.store.notifications.subscribe(
       'resource',
@@ -181,7 +179,7 @@ class RecordArrayManager {
     let array = new Collection(options);
     this._managed.add(array);
     if (config.identifiers) {
-      associate(array, config.identifiers);
+      associate(this._identifiers, array, config.identifiers);
     }
 
     return array;
@@ -214,7 +212,7 @@ class RecordArrayManager {
     let pending: Map<IdentifierArray, ChangeSet> = new Map();
 
     if (includeManaged) {
-      let managed = RecordArraysCache.get(identifier);
+      let managed = this._identifiers.get(identifier);
       if (managed) {
         managed.forEach((arr) => {
           let changes = allPending.get(arr);
@@ -269,8 +267,8 @@ class RecordArrayManager {
     array.links = payload.links || null;
     array.isLoaded = true;
 
-    disassociate(array, old);
-    associate(array, identifiers);
+    disassociate(this._identifiers, array, old);
+    associate(this._identifiers, array, identifiers);
   }
 
   identifierAdded(identifier: StableRecordIdentifier): void {
@@ -319,7 +317,7 @@ class RecordArrayManager {
     this._live.forEach((array) => array.destroy());
     this._managed.forEach((array) => array.destroy());
     this._managed.clear();
-    RecordArraysCache.clear();
+    this._identifiers.clear();
   }
 
   destroy() {
@@ -332,26 +330,38 @@ class RecordArrayManager {
   }
 }
 
-function associate(array: Collection, identifiers: StableRecordIdentifier[]) {
+function associate(
+  ArraysCache: Map<StableRecordIdentifier, Set<Collection>>,
+  array: Collection,
+  identifiers: StableRecordIdentifier[]
+) {
   for (let i = 0; i < identifiers.length; i++) {
     let identifier = identifiers[i];
-    let cache = RecordArraysCache.get(identifier);
+    let cache = ArraysCache.get(identifier);
     if (!cache) {
       cache = new Set();
-      RecordArraysCache.set(identifier, cache);
+      ArraysCache.set(identifier, cache);
     }
     cache.add(array);
   }
 }
 
-function disassociate(array: Collection, identifiers: StableRecordIdentifier[]) {
+function disassociate(
+  ArraysCache: Map<StableRecordIdentifier, Set<Collection>>,
+  array: Collection,
+  identifiers: StableRecordIdentifier[]
+) {
   for (let i = 0; i < identifiers.length; i++) {
-    disassociateIdentifier(array, identifiers[i]);
+    disassociateIdentifier(ArraysCache, array, identifiers[i]);
   }
 }
 
-export function disassociateIdentifier(array: Collection, identifier: StableRecordIdentifier) {
-  let cache = RecordArraysCache.get(identifier);
+export function disassociateIdentifier(
+  ArraysCache: Map<StableRecordIdentifier, Set<Collection>>,
+  array: Collection,
+  identifier: StableRecordIdentifier
+) {
+  let cache = ArraysCache.get(identifier);
   if (cache) {
     cache.delete(array);
   }

--- a/tests/main/tests/acceptance/concurrency-test.js
+++ b/tests/main/tests/acceptance/concurrency-test.js
@@ -1,0 +1,91 @@
+import { settled } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import Store from 'ember-data/store';
+import { setupTest } from 'ember-qunit';
+
+import Model, { attr } from '@ember-data/model';
+import { recordIdentifierFor } from '@ember-data/store';
+
+module('Acceptance | concurrency', function (hooks) {
+  setupTest(hooks);
+
+  test('multiple store instances do not share identifier', async function (assert) {
+    this.owner.register('service:store2', Store);
+    this.owner.register(
+      'model:user',
+      class extends Model {
+        @attr name;
+      }
+    );
+    const store1 = this.owner.lookup('service:store');
+    const store2 = this.owner.lookup('service:store2');
+
+    assert.notStrictEqual(store1, store2, 'different stores are not the same instance');
+
+    const record1 = store1.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          name: 'Chris',
+        },
+      },
+    });
+    const record2 = store2.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          name: 'Chris',
+        },
+      },
+    });
+    assert.notStrictEqual(record1, record2, 'different records are not the same instance');
+    assert.notStrictEqual(
+      recordIdentifierFor(record1),
+      recordIdentifierFor(record2),
+      'different records have different identifiers'
+    );
+  });
+
+  test("destroying a store instance does not result in removing another store's identifier", async function (assert) {
+    this.owner.register('service:store2', Store);
+    this.owner.register(
+      'model:user',
+      class extends Model {
+        @attr name;
+      }
+    );
+    const store1 = this.owner.lookup('service:store');
+    const store2 = this.owner.lookup('service:store2');
+
+    assert.notStrictEqual(store1, store2, 'different stores are not the same instance');
+
+    const record1 = store1.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          name: 'Chris',
+        },
+      },
+    });
+    store2.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          name: 'Chris',
+        },
+      },
+    });
+
+    store2.destroy();
+    await settled();
+
+    const record1Again = store1.peekRecord('user', '1');
+    assert.strictEqual(record1, record1Again, 'record is still in store1');
+  });
+});


### PR DESCRIPTION
The underlying bug is that the NotificationManager was storing callbacks for `resource` and `document` in the global Cache where we only need to store the callbacks for actual identifiers.

While investigating I also noticed that RecordArrayManager.clear cleared a global cache that it did not own. So on top of fixing those things I also reviewed teardown for the NotificationManager global cache, and opted to make it more safely encapsulated.