### PR TITLE
fix: ensure valid jsonapi error members are accessible

### DIFF
--- a/packages/serializer/src/json.js
+++ b/packages/serializer/src/json.js
@@ -1476,19 +1476,25 @@ const JSONSerializer = Serializer.extend({
       const extracted = {};
 
       payload.errors.forEach((error) => {
-        if (error.source && error.source.pointer) {
-          let key = error.source.pointer.match(SOURCE_POINTER_REGEXP);
-
-          if (key) {
-            key = key[2];
-          } else if (error.source.pointer.search(SOURCE_POINTER_PRIMARY_REGEXP) !== -1) {
-            key = PRIMARY_ATTRIBUTE_KEY;
-          }
-
-          if (key) {
-            extracted[key] = extracted[key] || [];
-            extracted[key].push(error.detail || error.title);
-          }
+        const errorPointer = error.source?.pointer ?? '/data'
+        let key = errorPointer.match(SOURCE_POINTER_REGEXP);
+        if (key) {
+          key = key[2];
+        } else if (errorPointer.search(SOURCE_POINTER_PRIMARY_REGEXP) !== -1) {
+          key = PRIMARY_ATTRIBUTE_KEY;
+        }
+        if (key) {
+          extracted[key] = extracted[key] || [];
+          // Keep only what are valid attr's for a jsonapi error
+          extracted[key].push({
+            id: error.id,
+            links: error.links ? { about: error.links.about, type: error.links.type } : undefined,
+            status: error.status,
+            code: error.code,
+            detail: error.detail,
+            title: error.title,
+            meta: error.meta
+          });
         }
       });
 


### PR DESCRIPTION
## Description

An attempt to resolve issues detailed in https://github.com/emberjs/data/issues/8188

## Notes for the release

The error handling was changed in 4.7.3 to require the use of these functions, so I think this fix for those functions to correctly parse jsonapi error members should be backported to 4.8 LTS and 4.12 LTS

I think this fix is important, as it will help folks get to 4.8 and beyond to ember-data 5.

I would also like to point out the Ember guides are incorrect, but I'm not sure where/how to edit those at this time.
https://jsonapi.org/format/#error-objects spec says it should be `/data` but the guides say `data`
https://api.emberjs.com/ember-data/4.12/classes/JSONAPISerializer/methods/extractErrors?anchor=extractErrors
![image](https://github.com/emberjs/data/assets/1049837/a90751d5-cc38-4204-a285-bbb67827bddc)

