### PR TITLE
fix: unloadAll(void) should not destroy the notification manager

### DIFF
--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -1863,12 +1863,11 @@ class Store extends EmberObject {
         if (HAS_GRAPH_PACKAGE) {
           const peekGraph = (importSync('@ember-data/graph/-private') as typeof import('@ember-data/graph/-private'))
             .peekGraph;
-          let graph = peekGraph(this);
+          const graph = peekGraph(this);
           if (graph) {
             graph.identifiers.clear();
           }
         }
-        this.notifications.destroy();
 
         this.recordArrayManager.clear();
         this._instanceCache.clear();
@@ -2472,6 +2471,7 @@ class Store extends EmberObject {
       }
     }
 
+    this.notifications.destroy();
     this.recordArrayManager.destroy();
     this.identifierCache.destroy();
 

--- a/tests/main/tests/integration/records/unload-test.js
+++ b/tests/main/tests/integration/records/unload-test.js
@@ -334,8 +334,8 @@ module('integration/unload - Unloading Records', function (hooks) {
       ],
     });
 
-    assert.strictEqual(records1.map(r => r.id).join(','), '1,2', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records1.map((r) => r.id).join(','), '1,2', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
 
     store.unloadAll('person');
@@ -366,8 +366,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
-    assert.strictEqual(records2.map(r => r.id).join(','), '1,3', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records2.map((r) => r.id).join(','), '1,3', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
   });
 
   test('unloadAll(<type>) clears the LiveArray, subsequent push repopulates (no intermediate peek, async)', async function (assert) {
@@ -392,8 +392,8 @@ module('integration/unload - Unloading Records', function (hooks) {
       ],
     });
 
-    assert.strictEqual(records1.map(r => r.id).join(','), '1,2', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records1.map((r) => r.id).join(','), '1,2', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
 
     store.unloadAll('person');
@@ -420,8 +420,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
-    assert.strictEqual(records2.map(r => r.id).join(','), '1,3', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records2.map((r) => r.id).join(','), '1,3', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
   });
 
   test('unloadAll(<type>) clears the LiveArray, subsequent push repopulates (no intermediate peek, sync)', async function (assert) {
@@ -446,8 +446,8 @@ module('integration/unload - Unloading Records', function (hooks) {
       ],
     });
 
-    assert.strictEqual(records1.map(r => r.id).join(','), '1,2', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records1.map((r) => r.id).join(','), '1,2', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
 
     store.unloadAll('person');
@@ -472,8 +472,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
-    assert.strictEqual(records2.map(r => r.id).join(','), '1,3', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records2.map((r) => r.id).join(','), '1,3', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
   });
 
   test('unloadAll(void) clears the LiveArray, subsequent push repopulates', async function (assert) {
@@ -498,8 +498,8 @@ module('integration/unload - Unloading Records', function (hooks) {
       ],
     });
 
-    assert.strictEqual(records1.map(r => r.id).join(','), '1,2', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records1.map((r) => r.id).join(','), '1,2', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
 
     store.unloadAll();
@@ -530,8 +530,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
-    assert.strictEqual(records2.map(r => r.id).join(','), '1,3', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records2.map((r) => r.id).join(','), '1,3', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
   });
 
   test('unloadAll(void) clears the LiveArray, subsequent push repopulates (no intermediate peek, async)', async function (assert) {
@@ -556,8 +556,8 @@ module('integration/unload - Unloading Records', function (hooks) {
       ],
     });
 
-    assert.strictEqual(records1.map(r => r.id).join(','), '1,2', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records1.map((r) => r.id).join(','), '1,2', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
 
     store.unloadAll();
@@ -584,8 +584,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
-    assert.strictEqual(records2.map(r => r.id).join(','), '1,3', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records2.map((r) => r.id).join(','), '1,3', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
   });
 
   test('unloadAll(void) clears the LiveArray, subsequent push repopulates (no intermediate peek, sync)', async function (assert) {
@@ -610,8 +610,8 @@ module('integration/unload - Unloading Records', function (hooks) {
       ],
     });
 
-    assert.strictEqual(records1.map(r => r.id).join(','), '1,2', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records1.map((r) => r.id).join(','), '1,2', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
 
     store.unloadAll();
@@ -636,8 +636,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     });
 
     assert.strictEqual(store.peekAll('person').length, 2, 'two person records loaded in LiveArray');
-    assert.strictEqual(records2.map(r => r.id).join(','), '1,3', 'two person records loaded');
-    assert.strictEqual(records1.map(r => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
+    assert.strictEqual(records2.map((r) => r.id).join(','), '1,3', 'two person records loaded');
+    assert.strictEqual(records1.map((r) => r.name).join(','), 'Adam Sunderland,Bob Bobson', 'attributes are present');
   });
 
   test('unloading all records also updates record array from peekAll()', function (assert) {


### PR DESCRIPTION
Addresses an issue reported in discord where in 4.12+ unloadAll(void) led to silently no data appearing to be in the store. This was due to improper teardown timing of the notification manager which this PR fixes.

https://discord.com/channels/480462759797063690/486549196837486592/1126451975467323422

