### PR TITLE
fix: @ember-data/debug should declare its peer-dependency on @ember-data/store

### DIFF
--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -15,7 +15,8 @@
   "directories": {},
   "scripts": {},
   "peerDependencies": {
-    "@ember/string": "^3.0.1"
+    "@ember/string": "^3.0.1",
+    "@ember-data/store": "workspace:4.12.2"
   },
   "dependenciesMeta": {
     "@ember-data/private-build-infra": {


### PR DESCRIPTION
This fix will need to be brought forward for newer releases as well.

resolves #8701 