### PR TITLE
fix: ensure we are not allowing embroider to do anything

### DIFF
--- a/tests/embroider-basic-compat/ember-cli-build.js
+++ b/tests/embroider-basic-compat/ember-cli-build.js
@@ -33,25 +33,21 @@ module.exports = function (defaults) {
       },
     ],
     compatAdapters: new Map([
-      ['@ember-data/store', null],
-      ['@ember-data/record-data', null],
-      ['@ember-data/serializer', null],
+      ['@ember-data/active-record', null],
       ['@ember-data/adapter', null],
-      ['@ember-data/model', null],
       ['@ember-data/debug', null],
-      ['@ember-data/tracking', null],
+      ['@ember-data/graph', null],
+      ['@ember-data/json-api', null],
+      ['@ember-data/legacy-compat', null],
+      ['@ember-data/model', null],
+      ['@ember-data/record-data', null],
+      ['@ember-data/request-utils', null],
       ['@ember-data/request', null],
+      ['@ember-data/rest', null],
+      ['@ember-data/serializer', null],
+      ['@ember-data/store', null],
+      ['@ember-data/tracking', null],
       ['ember-data', null],
     ]),
-    packageRules: [
-      {
-        package: '@ember-data/store',
-        addonModules: {
-          '-private.js': {
-            dependsOnModules: ['@ember-data/json-api'],
-          },
-        },
-      },
-    ],
   });
 };


### PR DESCRIPTION
noticed while looking at https://github.com/emberjs/data/issues/8748 that our embroider compat adapter removal in our test is no longer aggressive enough. We should backport this to 4.12 since its a long-term LTS though it shouldn't affect any actual compatibility since most of these packages weren't there at the time.