### PR TITLE
perf: reduce allocations during graph population

### DIFF
--- a/tests/main/tests/integration/records/delete-record-test.js
+++ b/tests/main/tests/integration/records/delete-record-test.js
@@ -440,8 +440,8 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
     };
 
     // Server push with the group and employee
-    store.push(jsonEmployee);
-    store.push(jsonGroup);
+    store.push(structuredClone(jsonEmployee));
+    store.push(structuredClone(jsonGroup));
 
     group = store.peekRecord('group', '1');
     const groupCompany = await group.company;


### PR DESCRIPTION
eliminates most GC work during graph build out. Metas are still a big hot spot but we should wait for some of the schema work before diving in too hard on optimizing them as there's a lot of cross over.