### PR TITLE
Fix check for new records in JSONAPISerializer.serializeHasMany

### DIFF
--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -712,7 +712,7 @@ const JSONAPISerializer = JSONSerializer.extend({
         }
 
         // only serialize has many relationships that are not new
-        let nonNewHasMany = hasMany.filter((item) => item.record && !item.record.isNew);
+        let nonNewHasMany = hasMany.filter((item) => !item.isNew);
         let data = new Array(nonNewHasMany.length);
 
         for (let i = 0; i < nonNewHasMany.length; i++) {


### PR DESCRIPTION
## Description
Use `!Snapshot.isNew` instead of `Snapshot.record && !Snapshot.record.isNew` to avoid the access to `record`. Accessing `record` creates an entry in `instanceCache.record` which causes the `hasRecord` checks in `Snapshot` to return true. This results in an error when serializing associated records via hasMany that have not been loaded.

fixes #8793


