### PR TITLE
feat: implement a simple LifetimeService utility, improve document reconstruction

### DIFF
--- a/ember-data-types/cache/document.ts
+++ b/ember-data-types/cache/document.ts
@@ -20,6 +20,7 @@ export interface SingleResourceDataDocument<T = StableExistingRecordIdentifier> 
   links?: Links | PaginationLinks;
   meta?: Meta;
   data: T | null;
+  included?: T[];
 }
 
 export interface CollectionResourceDataDocument<T = StableExistingRecordIdentifier> {
@@ -28,6 +29,7 @@ export interface CollectionResourceDataDocument<T = StableExistingRecordIdentifi
   links?: Links | PaginationLinks;
   meta?: Meta;
   data: T[];
+  included?: T[];
 }
 
 export type ResourceDataDocument<T = StableExistingRecordIdentifier> =

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -179,9 +179,9 @@ export default class JSONAPICache implements Cache {
       doc instanceof Error || (typeof doc.content === 'object' && doc.content !== null)
     );
     if (isErrorDocument(doc)) {
-      return this._putDocument(doc as StructuredErrorDocument<ResourceErrorDocument>);
+      return this._putDocument(doc as StructuredErrorDocument<ResourceErrorDocument>, undefined, undefined);
     } else if (isMetaDocument(doc)) {
-      return this._putDocument(doc);
+      return this._putDocument(doc, undefined, undefined);
     }
 
     const jsonApiDoc = doc.content as SingleResourceDocument | CollectionResourceDocument;
@@ -202,11 +202,19 @@ export default class JSONAPICache implements Cache {
       for (i = 0; i < length; i++) {
         identifiers.push(putOne(this, identifierCache, jsonApiDoc.data[i]));
       }
-      return this._putDocument(doc as StructuredDataDocument<CollectionResourceDocument>, identifiers, included);
+      return this._putDocument(
+        doc as StructuredDataDocument<CollectionResourceDocument>,
+        identifiers,
+        included as StableExistingRecordIdentifier[]
+      );
     }
 
     if (jsonApiDoc.data === null) {
-      return this._putDocument(doc as StructuredDataDocument<SingleResourceDocument>, null, included);
+      return this._putDocument(
+        doc as StructuredDataDocument<SingleResourceDocument>,
+        null,
+        included as StableExistingRecordIdentifier[]
+      );
     }
 
     assert(
@@ -215,11 +223,23 @@ export default class JSONAPICache implements Cache {
     );
 
     let identifier = putOne(this, identifierCache, jsonApiDoc.data);
-    return this._putDocument(doc as StructuredDataDocument<SingleResourceDocument>, identifier, included);
+    return this._putDocument(
+      doc as StructuredDataDocument<SingleResourceDocument>,
+      identifier,
+      included as StableExistingRecordIdentifier[]
+    );
   }
 
-  _putDocument<T extends ResourceErrorDocument>(doc: StructuredErrorDocument<T>): ResourceErrorDocument;
-  _putDocument<T extends ResourceMetaDocument>(doc: StructuredDataDocument<T>): ResourceMetaDocument;
+  _putDocument<T extends ResourceErrorDocument>(
+    doc: StructuredErrorDocument<T>,
+    data: undefined,
+    included: undefined
+  ): ResourceErrorDocument;
+  _putDocument<T extends ResourceMetaDocument>(
+    doc: StructuredDataDocument<T>,
+    data: undefined,
+    included: undefined
+  ): ResourceMetaDocument;
   _putDocument<T extends SingleResourceDocument>(
     doc: StructuredDataDocument<T>,
     data: StableExistingRecordIdentifier | null,
@@ -232,7 +252,7 @@ export default class JSONAPICache implements Cache {
   ): CollectionResourceDataDocument;
   _putDocument<T extends ResourceDocument>(
     doc: StructuredDocument<T>,
-    data?: StableExistingRecordIdentifier[] | StableExistingRecordIdentifier | null,
+    data: StableExistingRecordIdentifier[] | StableExistingRecordIdentifier | null | undefined,
     included: StableExistingRecordIdentifier[] | undefined
   ): SingleResourceDataDocument | CollectionResourceDataDocument | ResourceErrorDocument | ResourceMetaDocument {
     // @ts-expect-error narrowing within is just horrible  in TS :/
@@ -244,7 +264,9 @@ export default class JSONAPICache implements Cache {
     }
 
     if (included !== undefined) {
-      resourceDocument.included = included;
+      assert(`There should not be included data on an Error document`, !isErrorDocument(doc));
+      assert(`There should not be included data on a Meta document`, !isMetaDocument(doc));
+      (resourceDocument as SingleResourceDataDocument | CollectionResourceDataDocument).included = included;
     }
 
     const request = doc.request as StoreRequestInfo | undefined;

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -191,7 +191,7 @@ export default class JSONAPICache implements Cache {
 
     if (included) {
       for (i = 0, length = included.length; i < length; i++) {
-        putOne(this, identifierCache, included[i]);
+        included[i] = putOne(this, identifierCache, included[i]);
       }
     }
 
@@ -202,11 +202,11 @@ export default class JSONAPICache implements Cache {
       for (i = 0; i < length; i++) {
         identifiers.push(putOne(this, identifierCache, jsonApiDoc.data[i]));
       }
-      return this._putDocument(doc as StructuredDataDocument<CollectionResourceDocument>, identifiers);
+      return this._putDocument(doc as StructuredDataDocument<CollectionResourceDocument>, identifiers, included);
     }
 
     if (jsonApiDoc.data === null) {
-      return this._putDocument(doc as StructuredDataDocument<SingleResourceDocument>, null);
+      return this._putDocument(doc as StructuredDataDocument<SingleResourceDocument>, null, included);
     }
 
     assert(
@@ -215,22 +215,25 @@ export default class JSONAPICache implements Cache {
     );
 
     let identifier = putOne(this, identifierCache, jsonApiDoc.data);
-    return this._putDocument(doc as StructuredDataDocument<SingleResourceDocument>, identifier);
+    return this._putDocument(doc as StructuredDataDocument<SingleResourceDocument>, identifier, included);
   }
 
   _putDocument<T extends ResourceErrorDocument>(doc: StructuredErrorDocument<T>): ResourceErrorDocument;
   _putDocument<T extends ResourceMetaDocument>(doc: StructuredDataDocument<T>): ResourceMetaDocument;
   _putDocument<T extends SingleResourceDocument>(
     doc: StructuredDataDocument<T>,
-    data: StableExistingRecordIdentifier | null
+    data: StableExistingRecordIdentifier | null,
+    included: StableExistingRecordIdentifier[] | undefined
   ): SingleResourceDataDocument;
   _putDocument<T extends CollectionResourceDocument>(
     doc: StructuredDataDocument<T>,
-    data: StableExistingRecordIdentifier[]
+    data: StableExistingRecordIdentifier[],
+    included: StableExistingRecordIdentifier[] | undefined
   ): CollectionResourceDataDocument;
   _putDocument<T extends ResourceDocument>(
     doc: StructuredDocument<T>,
-    data?: StableExistingRecordIdentifier[] | StableExistingRecordIdentifier | null
+    data?: StableExistingRecordIdentifier[] | StableExistingRecordIdentifier | null,
+    included: StableExistingRecordIdentifier[] | undefined
   ): SingleResourceDataDocument | CollectionResourceDataDocument | ResourceErrorDocument | ResourceMetaDocument {
     // @ts-expect-error narrowing within is just horrible  in TS :/
     const resourceDocument: SingleResourceDataDocument | CollectionResourceDataDocument | ResourceErrorDocument =
@@ -238,6 +241,10 @@ export default class JSONAPICache implements Cache {
 
     if (data !== undefined) {
       (resourceDocument as SingleResourceDataDocument | CollectionResourceDataDocument).data = data;
+    }
+
+    if (included !== undefined) {
+      resourceDocument.included = included;
     }
 
     const request = doc.request as StoreRequestInfo | undefined;

--- a/packages/request-utils/src/index.ts
+++ b/packages/request-utils/src/index.ts
@@ -451,6 +451,11 @@ function isStale(headers: Headers, expirationTime: number): boolean {
   // const expires = headers.get('expires');
   // const lastModified = headers.get('last-modified');
   const date = headers.get('date');
+
+  if (!date) {
+    return true;
+  }
+
   const time = new Date(date).getTime();
   const now = Date.now();
   const deadline = time + expirationTime;
@@ -472,10 +477,10 @@ export class LifetimesService {
 
   isHardExpired(identifier: StableDocumentIdentifier): boolean {
     const cached = this.store.cache.peekRequest(identifier);
-    return !cached || isStale(cached.response.headers, this.config.apiCacheHardExpires);
+    return !cached || !cached.response || isStale(cached.response.headers, this.config.apiCacheHardExpires);
   }
   isSoftExpired(identifier: StableDocumentIdentifier): boolean {
     const cached = this.store.cache.peekRequest(identifier);
-    return !cached || isStale(cached.response.headers, this.config.apiCacheSoftExpires);
+    return !cached || !cached.response || isStale(cached.response.headers, this.config.apiCacheSoftExpires);
   }
 }

--- a/packages/request/src/fetch.ts
+++ b/packages/request/src/fetch.ts
@@ -40,6 +40,10 @@ const Fetch = {
     const response = await _fetch(context.request.url!, context.request);
     context.setResponse(response);
 
+    if (!response.headers.has('date')) {
+      response.headers.set('date', new Date().toUTCString());
+    }
+
     // if we are an error, we will want to throw
     if (!response.ok || response.status >= 400) {
       const text = await response.text();


### PR DESCRIPTION
Various bits of polish extracted from the DataWorker effort in #8698 

- Provides additional request utils
- Adds a simple lifetimes handler good for most applications.
- Updates the StructuredDocument API to return `included` records as well for use in advanced caching scenarios