### PR TITLE
feat: implement graph diffing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,17 +8,19 @@
 **/dist-control/
 **/dist-experiment/
 **/tmp/
+/packages/-ember-data/docs/
 /packages/tracking/addon/
 /packages/request/addon/
 /packages/store/addon/
 /packages/adapter/addon/
-/packages/-ember-data/docs/
-/packages/tracking/addon/
 /packages/serializer/addon/
 /packages/model/addon/
 /packages/json-api/addon/
 /packages/graph/addon/
 /packages/legacy-compat/addon/
+/packages/request-utils/addon/
+/packages/rest/addon/
+/packages/active-record/addon/
 
 **/DEBUG/
 

--- a/@types/ember-data-qunit-asserts/index.d.ts
+++ b/@types/ember-data-qunit-asserts/index.d.ts
@@ -22,6 +22,7 @@ declare global {
     expectNoWarning(callback: () => unknown): Promise<void>;
     expectAssertion(callback: () => unknown, matcher: string | RegExp): Promise<void>;
     expectNoAssertion(callback: () => unknown): Promise<void>;
+    arrayStrictEquals<T>(actual: T[], expected: T[], message: string): void;
   }
 
   namespace QUnit {
@@ -33,6 +34,7 @@ declare global {
       expectNoWarning(callback: () => unknown): Promise<void>;
       expectAssertion(callback: () => unknown, matcher: string | RegExp): Promise<void>;
       expectNoAssertion(callback: () => unknown): Promise<void>;
+      arrayStrictEquals<T>(actual: T[], expected: T[], message: string): void;
     }
   }
 

--- a/@types/ember-data-qunit-asserts/index.d.ts
+++ b/@types/ember-data-qunit-asserts/index.d.ts
@@ -22,7 +22,7 @@ declare global {
     expectNoWarning(callback: () => unknown): Promise<void>;
     expectAssertion(callback: () => unknown, matcher: string | RegExp): Promise<void>;
     expectNoAssertion(callback: () => unknown): Promise<void>;
-    arrayStrictEquals<T>(actual: T[], expected: T[], message: string): void;
+    arrayStrictEquals<T>(actual: unknown, expected: T[], message: string): void;
   }
 
   namespace QUnit {

--- a/@types/ember-data-qunit-asserts/index.d.ts
+++ b/@types/ember-data-qunit-asserts/index.d.ts
@@ -1,3 +1,7 @@
+import type { CacheOperation, NotificationType } from "@ember-data/store/-private/managers/notification-manager";
+import type { StableDocumentIdentifier } from "@ember-data/types/cache/identifier";
+import type { StableRecordIdentifier } from "@ember-data/types/q/identifier";
+
 declare global {
   interface DeprecationConfig {
     id: string;
@@ -27,6 +31,21 @@ declare global {
      * Asserts that actual is an array and has the same length as expected.
      */
     arrayStrictEquals<T>(actual: unknown, expected: T[], message: string): void;
+    /**
+     * Asserts that the given identifier has been notified of a change to the given bucket
+     * and optional key the given number of times during the test.
+     *
+     * Clears the notification count for the given identifier, bucket and key after the assertion
+     * is made so that it is easy to assert notification counts in between steps of a test.
+     */
+    notified(
+      identifier: StableDocumentIdentifier | StableRecordIdentifier,
+      bucket: NotificationType | CacheOperation,
+      key: string | null,
+      count: number
+    ): void;
+
+    clearNotifications(): void;
   }
 
   namespace QUnit {
@@ -39,6 +58,14 @@ declare global {
       expectAssertion(callback: () => unknown, matcher: string | RegExp): Promise<void>;
       expectNoAssertion(callback: () => unknown): Promise<void>;
       arrayStrictEquals<T>(unknown, expected: T[], message: string): void;
+      notified(
+        identifier: StableDocumentIdentifier | StableRecordIdentifier,
+        bucket: NotificationType | CacheOperation,
+        key: string | null,
+        count: number
+      ): void;
+
+      clearNotifications(): void;
     }
   }
 

--- a/@types/ember-data-qunit-asserts/index.d.ts
+++ b/@types/ember-data-qunit-asserts/index.d.ts
@@ -22,6 +22,10 @@ declare global {
     expectNoWarning(callback: () => unknown): Promise<void>;
     expectAssertion(callback: () => unknown, matcher: string | RegExp): Promise<void>;
     expectNoAssertion(callback: () => unknown): Promise<void>;
+    /**
+     * Asserts that each member of actual strictly matches the corresponding member of expected.
+     * Asserts that actual is an array and has the same length as expected.
+     */
     arrayStrictEquals<T>(actual: unknown, expected: T[], message: string): void;
   }
 
@@ -34,7 +38,7 @@ declare global {
       expectNoWarning(callback: () => unknown): Promise<void>;
       expectAssertion(callback: () => unknown, matcher: string | RegExp): Promise<void>;
       expectNoAssertion(callback: () => unknown): Promise<void>;
-      arrayStrictEquals<T>(actual: T[], expected: T[], message: string): void;
+      arrayStrictEquals<T>(unknown, expected: T[], message: string): void;
     }
   }
 

--- a/ember-data-types/q/record-data-schemas.ts
+++ b/ember-data-types/q/record-data-schemas.ts
@@ -18,6 +18,7 @@ export interface RelationshipSchema {
     async: boolean; // controls inverse unloading "client side delete semantics" so we should replace that with a real flag
     polymorphic?: boolean;
     inverse: string | null; // property key on the related type (if any)
+    resetOnRemoteUpdate?: false; // manages the deprecation `DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE`
     [key: string]: unknown;
   };
   // inverse?: string | null;

--- a/packages/graph/src/-private/-diff.ts
+++ b/packages/graph/src/-private/-diff.ts
@@ -1,0 +1,289 @@
+import { assert, deprecate } from '@ember/debug';
+
+import { DEPRECATE_NON_UNIQUE_PAYLOADS } from '@ember-data/deprecations';
+import { DEBUG } from '@ember-data/env';
+import { StableRecordIdentifier } from '@ember-data/types/q/identifier';
+
+import { assertPolymorphicType } from './debug/assert-polymorphic-type';
+import type { CollectionEdge } from './edges/collection';
+import { Graph } from './graph';
+
+function _deprecatedCompare<T>(
+  newState: T[],
+  newMembers: Set<T>,
+  prevState: T[],
+  prevSet: Set<T>,
+  onAdd: (v: T) => void,
+  onDel: (v: T) => void
+): { duplicates: Map<T, number[]>; diff: Diff<T> } {
+  const newLength = newState.length;
+  const prevLength = prevState.length;
+  const iterationLength = Math.max(newLength, prevLength);
+  let changed: boolean = newMembers.size !== prevSet.size;
+  const added = new Set<T>();
+  const removed = new Set<T>();
+  const duplicates = new Map<T, number[]>();
+  const finalSet = new Set<T>();
+  const finalState: T[] = [];
+
+  for (let i = 0, j = 0; i < iterationLength; i++) {
+    let adv: boolean = false;
+    let member: T | undefined;
+
+    // accumulate anything added
+    if (i < newLength) {
+      member = newState[i];
+
+      if (!finalSet.has(member)) {
+        finalState[j] = member;
+        finalSet.add(member);
+        adv = true;
+
+        if (!prevSet.has(member)) {
+          changed = true;
+          added.add(member);
+          onAdd(member);
+        }
+      } else {
+        let list = duplicates.get(member);
+
+        if (list === undefined) {
+          list = [];
+          duplicates.set(member, list);
+        }
+
+        list.push(i);
+      }
+    }
+
+    // accumulate anything removed
+    if (i < prevLength) {
+      const prevMember = prevState[i];
+
+      // detect reordering, adjusting index for duplicates
+      // j is always less than i and so if i < prevLength, j < prevLength
+      if (member !== prevState[j]) {
+        changed = true;
+      }
+
+      if (!newMembers.has(prevMember)) {
+        changed = true;
+        removed.add(prevMember);
+        onDel(prevMember);
+      }
+    } else if (adv && j < prevLength && member !== prevState[j]) {
+      changed = true;
+    }
+
+    if (adv) {
+      j++;
+    }
+  }
+
+  const diff = {
+    add: added,
+    del: removed,
+    finalState,
+    finalSet,
+    changed,
+  };
+
+  return {
+    diff,
+    duplicates,
+  };
+}
+
+function _compare<T>(
+  finalState: T[],
+  finalSet: Set<T>,
+  prevState: T[],
+  prevSet: Set<T>,
+  onAdd: (v: T) => void,
+  onDel: (v: T) => void
+): Diff<T> {
+  const finalLength = finalState.length;
+  const prevLength = prevState.length;
+  const iterationLength = Math.max(finalLength, prevLength);
+  const equalLength = finalLength === prevLength;
+  let changed: boolean = finalSet.size !== prevSet.size;
+  const added = new Set<T>();
+  const removed = new Set<T>();
+
+  for (let i = 0; i < iterationLength; i++) {
+    let member: T | undefined;
+
+    // accumulate anything added
+    if (i < finalLength) {
+      member = finalState[i];
+      if (!prevSet.has(member)) {
+        changed = true;
+        added.add(member);
+        onAdd(member);
+      }
+    }
+
+    // accumulate anything removed
+    if (i < prevLength) {
+      const prevMember = prevState[i];
+
+      // detect reordering
+      if (equalLength && member !== prevMember) {
+        changed = true;
+      }
+
+      if (!finalSet.has(prevMember)) {
+        changed = true;
+        removed.add(prevMember);
+        onDel(prevMember);
+      }
+    }
+  }
+
+  return {
+    add: added,
+    del: removed,
+    finalState,
+    finalSet,
+    changed,
+  };
+}
+
+type Diff<T> = {
+  add: Set<T>;
+  del: Set<T>;
+  finalState: T[];
+  finalSet: Set<T>;
+  changed: boolean;
+};
+
+export function diffCollection(
+  finalState: StableRecordIdentifier[],
+  relationship: CollectionEdge,
+  onAdd: (v: StableRecordIdentifier) => void,
+  onDel: (v: StableRecordIdentifier) => void
+): Diff<StableRecordIdentifier> {
+  const finalSet = new Set(finalState);
+  const { remoteState, remoteMembers } = relationship;
+
+  if (DEPRECATE_NON_UNIQUE_PAYLOADS) {
+    if (finalState.length !== finalSet.size) {
+      const { diff, duplicates } = _deprecatedCompare(finalState, finalSet, remoteState, remoteMembers, onAdd, onDel);
+
+      if (DEBUG) {
+        deprecate(
+          `Expected all entries in the relationship ${relationship.definition.type}:${relationship.definition.key} to be unique, see log for a list of duplicate entry indeces`,
+          false,
+          {
+            id: 'ember-data:deprecate-non-unique-relationship-entries',
+            for: 'ember-data',
+            until: '6.0',
+            since: { available: '5.3', enabled: '5.3' },
+          }
+        );
+        // eslint-disable-next-line no-console
+        console.log(duplicates);
+      }
+
+      return diff;
+    }
+  } else {
+    assert(
+      `Expected all entries in the relationship to be unique, found duplicates`,
+      finalState.length === finalSet.size
+    );
+  }
+
+  return _compare(finalState, finalSet, remoteState, remoteMembers, onAdd, onDel);
+}
+
+export function computeLocalState(storage: CollectionEdge): StableRecordIdentifier[] {
+  if (!storage.isDirty) {
+    assert(`Expected localState to be present`, Array.isArray(storage.localState));
+    return storage.localState;
+  }
+
+  let state = storage.remoteState.slice();
+
+  storage.removals?.forEach((v) => {
+    let index = state.indexOf(v);
+    state.splice(index, 1);
+  });
+
+  storage.additions?.forEach((v) => {
+    state.push(v);
+  });
+  storage.localState = state;
+  storage.isDirty = false;
+
+  return state;
+}
+
+export function _addLocal(
+  graph: Graph,
+  record: StableRecordIdentifier,
+  relationship: CollectionEdge,
+  value: StableRecordIdentifier
+): boolean {
+  const { remoteMembers, removals } = relationship;
+  let additions = relationship.additions;
+  const hasPresence = remoteMembers.has(value) || additions?.has(value);
+
+  if (hasPresence && !removals?.has(value)) {
+    assert(
+      `Attempted to add the resource '${value.lid}' to the collection <${relationship.identifier.type}>.${relationship.definition.key} it was already in`,
+      hasPresence && !removals?.has(value)
+    );
+    return false;
+  }
+
+  if (removals?.has(value)) {
+    removals.delete(value);
+  } else {
+    if (!additions) {
+      additions = relationship.additions = new Set();
+    }
+
+    relationship.state.hasReceivedData = true;
+    additions.add(value);
+
+    const { type } = relationship.definition;
+    if (type !== value.type) {
+      if (DEBUG) {
+        assertPolymorphicType(record, relationship.definition, value, graph.store);
+      }
+      graph.registerPolymorphicType(value.type, type);
+    }
+  }
+
+  relationship.isDirty = true;
+  return true;
+}
+
+export function _removeLocal(relationship: CollectionEdge, value: StableRecordIdentifier): boolean {
+  assert(`expected an identifier to remove from the collection relationship`, value);
+  const { remoteMembers, additions } = relationship;
+  let removals = relationship.removals;
+  const hasPresence = remoteMembers.has(value) || additions?.has(value);
+
+  if (!hasPresence || removals?.has(value)) {
+    assert(
+      `Attempted to remove the resource '${value.lid}' from the collection <${relationship.identifier.type}>.${relationship.definition.key} but it was not present`,
+      !hasPresence || removals?.has(value)
+    );
+    return false;
+  }
+
+  if (additions?.has(value)) {
+    additions.delete(value);
+  } else {
+    if (!removals) {
+      removals = relationship.removals = new Set();
+    }
+
+    removals.add(value);
+  }
+
+  relationship.isDirty = true;
+  return true;
+}

--- a/packages/graph/src/-private/-edge-definition.ts
+++ b/packages/graph/src/-private/-edge-definition.ts
@@ -92,6 +92,7 @@ export interface UpgradedMeta {
   isImplicit: boolean;
   isCollection: boolean;
   isPolymorphic: boolean;
+  resetOnRemoteUpdate: boolean;
 
   inverseKind: 'hasMany' | 'belongsTo' | 'implicit';
   /**
@@ -163,6 +164,10 @@ function syncMeta(definition: UpgradedMeta, inverseDefinition: UpgradedMeta) {
   definition.inverseIsCollection = inverseDefinition.isCollection;
   definition.inverseIsPolymorphic = inverseDefinition.isPolymorphic;
   definition.inverseIsImplicit = inverseDefinition.isImplicit;
+  const resetOnRemoteUpdate =
+    definition.resetOnRemoteUpdate === false || inverseDefinition.resetOnRemoteUpdate === false ? false : true;
+  definition.resetOnRemoteUpdate = resetOnRemoteUpdate;
+  inverseDefinition.resetOnRemoteUpdate = resetOnRemoteUpdate;
 }
 
 function upgradeMeta(meta: RelationshipSchema): UpgradedMeta {
@@ -182,6 +187,8 @@ function upgradeMeta(meta: RelationshipSchema): UpgradedMeta {
   niceMeta.inverseIsAsync = BOOL_LATER;
   niceMeta.inverseIsImplicit = (options && options.inverse === null) || BOOL_LATER;
   niceMeta.inverseIsCollection = BOOL_LATER;
+
+  niceMeta.resetOnRemoteUpdate = options && options.resetOnRemoteUpdate === false ? false : true;
 
   return niceMeta;
 }

--- a/packages/graph/src/-private/debug/assert-polymorphic-type.ts
+++ b/packages/graph/src/-private/debug/assert-polymorphic-type.ts
@@ -137,7 +137,8 @@ if (DEBUG) {
       inverseIsAsync: definition.isAsync,
       inverseIsPolymorphic: definition.isPolymorphic,
       inverseIsImplicit: definition.isImplicit,
-      inverseIsCollection: definition.isCollection
+      inverseIsCollection: definition.isCollection,
+      resetOnRemoteUpdate: definition.resetOnRemoteUpdate,
     };
   }
   function definitionWithPolymorphic(definition: UpgradedMeta) {

--- a/packages/graph/src/-private/edges/resource.ts
+++ b/packages/graph/src/-private/edges/resource.ts
@@ -1,4 +1,5 @@
-import type { Links, Meta, PaginationLinks, SingleResourceRelationship } from '@ember-data/types/q/ember-data-json-api';
+import { ResourceRelationship } from '@ember-data/types/cache/relationship';
+import type { Links, Meta, PaginationLinks } from '@ember-data/types/q/ember-data-json-api';
 import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
 
 import type { UpgradedMeta } from '../-edge-definition';
@@ -37,9 +38,9 @@ export function createResourceEdge(definition: UpgradedMeta, identifier: StableR
   };
 }
 
-export function legacyGetResourceRelationshipData(source: ResourceEdge): SingleResourceRelationship {
+export function legacyGetResourceRelationshipData(source: ResourceEdge): ResourceRelationship {
   let data: StableRecordIdentifier | null | undefined;
-  let payload: SingleResourceRelationship = {};
+  let payload: ResourceRelationship = {};
   if (source.localState) {
     data = source.localState;
   }

--- a/packages/graph/src/-private/graph.ts
+++ b/packages/graph/src/-private/graph.ts
@@ -279,6 +279,25 @@ export class Graph {
     }
   }
 
+  _isDirty(identifier: StableRecordIdentifier, field: string): boolean {
+    const relationships = this.identifiers.get(identifier);
+    if (!relationships) {
+      return false;
+    }
+    const relationship = relationships[field];
+    if (!relationship) {
+      return false;
+    }
+    if (isBelongsTo(relationship)) {
+      return relationship.localState !== relationship.remoteState;
+    } else if (isHasMany(relationship)) {
+      const hasAdditions = relationship.additions !== null && relationship.additions.size > 0;
+      const hasRemovals = relationship.removals !== null && relationship.removals.size > 0;
+      return hasAdditions || hasRemovals;
+    }
+    return false;
+  }
+
   remove(identifier: StableRecordIdentifier) {
     if (LOG_GRAPH) {
       // eslint-disable-next-line no-console

--- a/packages/graph/src/-private/operations/add-to-related-records.ts
+++ b/packages/graph/src/-private/operations/add-to-related-records.ts
@@ -41,7 +41,7 @@ function addRelatedRecord(
 ) {
   assert(`expected an identifier to add to the collection relationship`, value);
 
-  if (_addLocal(graph, record, relationship, value)) {
+  if (_addLocal(graph, record, relationship, value, index ?? null)) {
     addToInverse(graph, value, relationship.definition.inverseKey, record, isRemote);
   }
 }

--- a/packages/graph/src/-private/operations/merge-identifier.ts
+++ b/packages/graph/src/-private/operations/merge-identifier.ts
@@ -50,12 +50,19 @@ function mergeHasMany(graph: Graph, rel: CollectionEdge, op: MergeOperation): vo
     rel.remoteMembers.add(op.value);
     const index = rel.remoteState.indexOf(op.record);
     rel.remoteState.splice(index, 1, op.value);
+    rel.isDirty = true;
   }
-  if (rel.localMembers.has(op.record)) {
-    rel.localMembers.delete(op.record);
-    rel.localMembers.add(op.value);
-    const index = rel.localState.indexOf(op.record);
-    rel.localState.splice(index, 1, op.value);
+  if (rel.additions?.has(op.record)) {
+    rel.additions.delete(op.record);
+    rel.additions.add(op.value);
+    rel.isDirty = true;
+  }
+  if (rel.removals?.has(op.record)) {
+    rel.removals.delete(op.record);
+    rel.removals.add(op.value);
+    rel.isDirty = true;
+  }
+  if (rel.isDirty) {
     notifyChange(graph, rel.identifier, rel.definition.key);
   }
 }

--- a/packages/graph/src/-private/operations/remove-from-related-records.ts
+++ b/packages/graph/src/-private/operations/remove-from-related-records.ts
@@ -20,6 +20,10 @@ export default function removeFromRelatedRecords(graph: Graph, op: RemoveFromRel
     `You can only '${op.op}' on a hasMany relationship. ${record.type}.${op.field} is a ${relationship.definition.kind}`,
     isHasMany(relationship)
   );
+  // TODO we should potentially thread the index information through here
+  // when available as it may make it faster to remove from the local state
+  // when trying to patch more efficiently without blowing away the entire
+  // local state array
   if (Array.isArray(value)) {
     for (let i = 0; i < value.length; i++) {
       removeRelatedRecord(graph, relationship, record, value[i], isRemote);

--- a/packages/graph/src/-private/operations/replace-related-record.ts
+++ b/packages/graph/src/-private/operations/replace-related-record.ts
@@ -102,6 +102,7 @@ export default function replaceRelatedRecord(graph: Graph, op: ReplaceRelatedRec
               for: 'ember-data',
               since: { enabled: '5.3', available: '5.3' },
               until: '6.0',
+              url: 'https://deprecations.emberjs.com/v5.x#ember-data-deprecate-relationship-remote-update-clearing-local-state',
             }
           );
 
@@ -176,6 +177,7 @@ export default function replaceRelatedRecord(graph: Graph, op: ReplaceRelatedRec
             for: 'ember-data',
             since: { enabled: '5.3', available: '5.3' },
             until: '6.0',
+            url: 'https://deprecations.emberjs.com/v5.x#ember-data-deprecate-relationship-remote-update-clearing-local-state',
           }
         );
 

--- a/packages/graph/src/-private/operations/replace-related-record.ts
+++ b/packages/graph/src/-private/operations/replace-related-record.ts
@@ -85,7 +85,7 @@ export default function replaceRelatedRecord(graph: Graph, op: ReplaceRelatedRec
       } else if (DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE) {
         // if localState does not match existingState then we know
         // we have a local mutation that has not been persisted yet
-        if (localState !== op.value) {
+        if (localState !== op.value && relationship.definition.resetOnRemoteUpdate !== false) {
           relationship.localState = existingState;
 
           deprecate(
@@ -160,7 +160,11 @@ export default function replaceRelatedRecord(graph: Graph, op: ReplaceRelatedRec
       // and localState !== existingState then we know we have a local mutation
       // that has not been persisted yet.
     } else if (DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE) {
-      if (localState !== remoteState && localState !== existingState) {
+      if (
+        localState !== remoteState &&
+        localState !== existingState &&
+        relationship.definition.resetOnRemoteUpdate !== false
+      ) {
         relationship.localState = existingState;
 
         deprecate(

--- a/packages/graph/src/-private/operations/replace-related-records.ts
+++ b/packages/graph/src/-private/operations/replace-related-records.ts
@@ -82,6 +82,7 @@ function replaceRelatedRecordsLocal(graph: Graph, op: ReplaceRelatedRecordsOpera
   const { additions, removals } = relationship;
   const { inverseKey, type } = relationship.definition;
   const { record } = op;
+  const wasDirty = relationship.isDirty;
   relationship.isDirty = false;
 
   const diff = diffCollection(
@@ -112,13 +113,13 @@ function replaceRelatedRecordsLocal(graph: Graph, op: ReplaceRelatedRecordsOpera
     }
   );
 
-  const becameDirty = relationship.isDirty;
+  const becameDirty = relationship.isDirty || diff.changed;
   relationship.additions = diff.add;
   relationship.removals = diff.del;
   relationship.localState = diff.finalState;
-  relationship.isDirty = false;
+  relationship.isDirty = wasDirty;
 
-  if (becameDirty) {
+  if (!wasDirty && becameDirty) {
     notifyChange(graph, op.record, op.field);
   }
 }

--- a/packages/graph/src/-private/operations/replace-related-records.ts
+++ b/packages/graph/src/-private/operations/replace-related-records.ts
@@ -240,7 +240,7 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
             relationship.identifier.type
           }>.${
             relationship.definition.key
-          } hasMany relationship but will not be once this deprecation is resolved:\n\n\tAdded: [${deprecationInfo.additions
+          } hasMany relationship but will not be once this deprecation is resolved by opting into the new behavior:\n\n\tAdded: [${deprecationInfo.additions
             .map((i) => i.lid)
             .join(', ')}]\n\tRemoved: [${deprecationInfo.removals.map((i) => i.lid).join(', ')}]`,
           false,
@@ -249,6 +249,7 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
             for: 'ember-data',
             since: { enabled: '5.3', available: '5.3' },
             until: '6.0',
+            url: 'https://deprecations.emberjs.com/v5.x#ember-data-deprecate-relationship-remote-update-clearing-local-state',
           }
         );
       }

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -1226,7 +1226,7 @@ function getLocalState(rel) {
   if (rel.definition.kind === 'belongsTo') {
     return rel.localState ? [rel.localState] : [];
   }
-  return rel.localState;
+  return rel.additions ? [...rel.additions] : [];
 }
 function getRemoteState(rel) {
   if (rel.definition.kind === 'belongsTo') {

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -189,7 +189,7 @@ export default class JSONAPICache implements Cache {
     let i: number, length: number;
     const { identifierCache } = this.__storeWrapper;
 
-    if (true) {
+    if (LOG_REQUESTS) {
       const Counts = new Map();
       if (included) {
         for (i = 0, length = included.length; i < length; i++) {

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -4,7 +4,7 @@
 import { assert } from '@ember/debug';
 import { schedule } from '@ember/runloop';
 
-import { LOG_MUTATIONS, LOG_OPERATIONS } from '@ember-data/debugging';
+import { LOG_MUTATIONS, LOG_OPERATIONS, LOG_REQUESTS } from '@ember-data/debugging';
 import { DEBUG } from '@ember-data/env';
 import { graphFor, peekGraph } from '@ember-data/graph/-private';
 import type { LocalRelationshipOperation } from '@ember-data/graph/-private/-operations';
@@ -188,6 +188,35 @@ export default class JSONAPICache implements Cache {
     let included = jsonApiDoc.included;
     let i: number, length: number;
     const { identifierCache } = this.__storeWrapper;
+
+    if (true) {
+      const Counts = new Map();
+      if (included) {
+        for (i = 0, length = included.length; i < length; i++) {
+          const type = included[i].type;
+          Counts.set(type, (Counts.get(type) || 0) + 1);
+        }
+      }
+      if (Array.isArray(jsonApiDoc.data)) {
+        for (i = 0, length = jsonApiDoc.data.length; i < length; i++) {
+          const type = jsonApiDoc.data[i].type;
+          Counts.set(type, (Counts.get(type) || 0) + 1);
+        }
+      } else if (jsonApiDoc.data) {
+        const type = jsonApiDoc.data.type;
+        Counts.set(type, (Counts.get(type) || 0) + 1);
+      }
+
+      let str = `JSON:API Cache - put (${doc.content?.lid || doc.request?.url || 'unknown-request'})\n\tContents:`;
+      Counts.forEach((count, type) => {
+        str += `\n\t\t${type}: ${count}`;
+      });
+      if (Counts.size === 0) {
+        str += `\t(empty)`;
+      }
+      // eslint-disable-next-line no-console
+      console.log(str);
+    }
 
     if (included) {
       for (i = 0, length = included.length; i < length; i++) {

--- a/packages/model/src/-private/legacy-relationships-support.ts
+++ b/packages/model/src/-private/legacy-relationships-support.ts
@@ -18,6 +18,7 @@ import {
   SOURCE,
   storeFor,
 } from '@ember-data/store/-private';
+import { CollectionRelationship } from '@ember-data/types/cache/relationship';
 import type { Cache } from '@ember-data/types/q/cache';
 import { CollectionResourceRelationship, SingleResourceRelationship } from '@ember-data/types/q/ember-data-json-api';
 import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
@@ -699,9 +700,14 @@ function extractIdentifierFromRecord(record: PromiseProxyRecord | RecordInstance
 }
 
 function anyUnloaded(store: Store, relationship: CollectionEdge) {
-  let state = relationship.localState;
+  const graph = store._graph!;
+  const relationshipData = graph.getData(
+    relationship.identifier,
+    relationship.definition.key
+  ) as CollectionRelationship;
+  const state = relationshipData.data;
   const cache = store._instanceCache;
-  const unloaded = state.find((s) => {
+  const unloaded = state?.find((s) => {
     let isLoaded = cache.recordIsLoaded(s, true);
     return !isLoaded;
   });

--- a/packages/model/src/-private/references/has-many.ts
+++ b/packages/model/src/-private/references/has-many.ts
@@ -11,6 +11,7 @@ import type { Graph } from '@ember-data/graph/-private/graph';
 import type Store from '@ember-data/store';
 import { recordIdentifierFor } from '@ember-data/store';
 import type { NotificationType } from '@ember-data/store/-private/managers/notification-manager';
+import { CollectionRelationship } from '@ember-data/types/cache/relationship';
 import type {
   CollectionResourceDocument,
   CollectionResourceRelationship,
@@ -449,9 +450,9 @@ export default class HasManyReference {
       return false;
     }
 
-    let localState = this.hasManyRelationship.localState;
+    const relationship = this.graph.getData(this.hasManyRelationship.identifier, this.key) as CollectionRelationship;
 
-    return localState.every((identifier) => {
+    return relationship.data?.every((identifier) => {
       return this.store._instanceCache.recordIsLoaded(identifier, true) === true;
     });
   }

--- a/packages/private-build-infra/virtual-packages/deprecations.d.ts
+++ b/packages/private-build-infra/virtual-packages/deprecations.d.ts
@@ -5,3 +5,4 @@ export const DEPRECATE_NON_STRICT_TYPES: boolean;
 export const DEPRECATE_NON_STRICT_ID: boolean;
 export const DEPRECATE_LEGACY_IMPORTS: boolean;
 export const DEPRECATE_NON_UNIQUE_PAYLOADS: boolean;
+export const DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE: boolean;

--- a/packages/private-build-infra/virtual-packages/deprecations.js
+++ b/packages/private-build-infra/virtual-packages/deprecations.js
@@ -188,6 +188,36 @@ export const DEPRECATE_LEGACY_IMPORTS = '5.3';
  * Deprecates when the data for a hasMany relationship contains
  * duplicate identifiers.
  *
+ * Previously, relationships would silently de-dupe the data
+ * when received, but this behavior is being removed in favor
+ * of erroring if the same related record is included multiple
+ * times.
+ *
+ * For instance, in JSON:API the below relationship data would
+ * be considered invalid:
+ *
+ * ```json
+ * {
+ *  "data": {
+ *   "type": "article",
+ *    "id": "1",
+ *    "relationships": {
+ *      "comments": {
+ *        "data": [
+ *          { "type": "comment", "id": "1" },
+ *          { "type": "comment", "id": "2" },
+ *          { "type": "comment", "id": "1" } // duplicate
+ *        ]
+ *     }
+ *  }
+ * }
+ * ```
+ *
+ * To resolve this deprecation, either update your server to
+ * not include duplicate data, or implement normalization logic
+ * in either a request handler or serializer which removes
+ * duplicate data from relationship payloads.
+ *
  * @property DEPRECATE_NON_UNIQUE_PAYLOADS
  * @since 5.3
  * @until 6.0
@@ -287,6 +317,51 @@ export const DEPRECATE_NON_UNIQUE_PAYLOADS = '5.3';
  *
  * Once you have migrated all relationships, you can remove the the resetOnRemoteUpdate
  * option and set the deprecation flag to false in ember-cli-build.
+ *
+ * ### What if I don't want the new behavior?
+ *
+ * EmberData's philosophy is to not make assumptions about your application. Where possible
+ * we seek out "100%" solutions – solutions that work for all use cases - and where that is
+ * not possible we default to "90%" solutions – solutions that work for the vast majority of use
+ * cases. In the case of "90%" solutions we look for primitives that allow you to resolve the
+ * 10% case in your application. If no such primitives exist, we provide an escape hatch that
+ * ensures you can build the behavior you need without adopting the cost of the default solution.
+ *
+ * In this case, the old behavior was a "40%" solution. The inability for an application developer
+ * to determine what changes were made locally, and thus what changes should be preserved, made
+ * it impossible to build certain features easily, or in some cases at all. The proliferation of
+ * feature requests, bug reports (from folks surprised by the prior behavior) and addon attempts
+ * in this space are all evidence of this.
+ *
+ * We believe the new behavior is a "90%" solution. It works for the vast majority of use cases,
+ * often without noticeable changes to existing application behavior, and provides primitives that
+ * allow you to build the behavior you need for the remaining 10%.
+ *
+ * The great news is that this behavior defaults to trusting your API similar to the old behavior.
+ * If your API is correct, you will not need to make any changes to your application to adopt
+ * the new behavior.
+ *
+ * This means the 10% cases are those where you can't trust your API to provide the correct
+ * information. In these cases, because you now have cheap access to a diff of the relationship
+ * state, there are a few options that weren't available before:
+ *
+ * - you can adjust returned API payloads to contain the expected changes that it doesn't include
+ * - you can modify local state by adding or removing records on the HasMany record array to remove
+ *   any local changes that were not returned by the API.
+ * - you can use `<Cache>.mutate(mutation)` to directly modify the local cache state of the relationship
+ *   to match the expected state.
+ *
+ * What this version (5.3) does not yet provide is a way to directly modify the cache's remote state
+ * for the relationship via public APIs other than via the broader action of upserting a response via
+ * `<Cache>.put(document)`. However, such an API was sketched in the Cache 2.1 RFC
+ * `<Cache>.patch(operation)` and is likely to be added in a future 5.x release of EmberData.
+ *
+ * This version (5.3) also does not yet provide a way to directly modify the graph (a general purpose
+ * subset of cache behaviors specific to relationships) via public APIs. However, during the
+ * 5.x release series we will be working on finalizing the Graph API and making it public.
+ *
+ * If none of these options work for you, you can always opt-out more broadly by implementing
+ * a custom Cache with the relationship behaviors you need.
  *
  * @property DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE
  * @since 5.3

--- a/packages/private-build-infra/virtual-packages/deprecations.js
+++ b/packages/private-build-infra/virtual-packages/deprecations.js
@@ -1,3 +1,21 @@
+//
+// ========================
+// FOR CONTRIBUTING AUTHORS
+//
+// Deprecations here should also have guides PR'd to the emberjs deprecation app
+//
+// github: https://github.com/ember-learn/deprecation-app
+// website: https://deprecations.emberjs.com
+//
+// Each deprecation should also be given an associated URL pointing to the
+// relevant guide.
+//
+// URLs should be of the form: https://deprecations.emberjs.com/v<major>.x#toc_<fileName>
+// where <major> is the major version of the deprecation and <fileName> is the
+// name of the markdown file in the guides repo.
+//
+// ========================
+//
 /**
  * ## Deprecations
  *

--- a/packages/private-build-infra/virtual-packages/deprecations.js
+++ b/packages/private-build-infra/virtual-packages/deprecations.js
@@ -98,11 +98,11 @@ export const DEPRECATE_3_12 = '3.12';
  * e.g. `app/models/foo/bar-bem.js` must have a type of `foo/bar-bem`
  *
  * @property DEPRECATE_NON_STRICT_TYPES
- * @since 5.2
+ * @since 5.3
  * @until 6.0
  * @public
  */
-export const DEPRECATE_NON_STRICT_TYPES = '5.2';
+export const DEPRECATE_NON_STRICT_TYPES = '5.3';
 
 /**
  * **id: ember-data:deprecate-non-strict-id**
@@ -122,11 +122,11 @@ export const DEPRECATE_NON_STRICT_TYPES = '5.2';
  * custom identifier configuration should provide a string ID.
  *
  * @property DEPRECATE_NON_STRICT_ID
- * @since 5.2
+ * @since 5.3
  * @until 6.0
  * @public
  */
-export const DEPRECATE_NON_STRICT_ID = '5.2';
+export const DEPRECATE_NON_STRICT_ID = '5.3';
 
 /**
  * **id: <none yet assigned>**
@@ -135,8 +135,8 @@ export const DEPRECATE_NON_STRICT_ID = '5.2';
  * chains are used to watch for changes on any EmberData RecordArray, ManyArray
  * or PromiseManyArray.
  *
- * Support for these chains is currently guarded by the inactive deprecation flag
- * listed here.
+ * Support for these chains is currently guarded by the deprecation flag
+ * listed here, enabling removal of the behavior if desired.
  *
  * @property DEPRECATE_COMPUTED_CHAINS
  * @since 5.0
@@ -158,21 +158,121 @@ export const DEPRECATE_COMPUTED_CHAINS = '5.0';
  * of defaults.
  *
  * @property DEPRECATE_LEGACY_IMPORTS
- * @since 5.2
+ * @since 5.3
  * @until 6.0
  * @public
  */
-export const DEPRECATE_LEGACY_IMPORTS = '5.2';
+export const DEPRECATE_LEGACY_IMPORTS = '5.3';
 
-/* PLANNED
+/**
  * **id: ember-data:deprecate-non-unique-collection-payloads**
  *
  * Deprecates when the data for a hasMany relationship contains
  * duplicate identifiers.
  *
  * @property DEPRECATE_NON_UNIQUE_PAYLOADS
- * @since 5.2
+ * @since 5.3
  * @until 6.0
  * @public
  */
-export const DEPRECATE_NON_UNIQUE_PAYLOADS = '5.2';
+export const DEPRECATE_NON_UNIQUE_PAYLOADS = '5.3';
+
+/**
+ * **id: ember-data:deprecate-relationship-remote-update-clearing-local-state**
+ *
+ * Deprecates when a relationship is updated remotely and the local state
+ * is cleared of all changes except for "new" records.
+ *
+ * Instead, any records not present in the new payload will be considered
+ * "removed" while any records present in the new payload will be considered "added".
+ *
+ * This allows us to "commit" local additions and removals, preserving any additions
+ * or removals that are not yet reflected in the remote state.
+ *
+ * For instance, given the following initial state:
+ *
+ * remote: A, B, C
+ * local: add D, E
+ *        remove B, C
+ * => A, D, E
+ *
+ *
+ * If after an update, the remote state is now A, B, D, F then the new state will be
+ *
+ * remote: A, B, D, F
+ * local: add E
+ *        remove B
+ * => A, D, E, F
+ *
+ * Under the old behavior the updated local state would instead have been
+ * => A, B, D, F
+ *
+ * Similarly, if a belongsTo remote State was A while its local state was B,
+ * then under the old behavior if the remote state changed to C, the local state
+ * would be updated to C. Under the new behavior, the local state would remain B.
+ *
+ * If the remote state was A while its local state was `null`, then under the old
+ * behavior if the remote state changed to C, the local state would be updated to C.
+ * Under the new behavior, the local state would remain `null`.
+ *
+ * Thus the new correct mental model is that the state of the relationship at any point
+ * in time is whatever the most recent remote state is, plus any local additions or removals
+ * you have made that have not yet been reflected by the remote state.
+ *
+ * > Note: The old behavior extended to modifying the inverse of a relationship. So if
+ * > you had local state not reflected in the new remote state, inverses would be notified
+ * > and their state reverted as well when "resetting" the relationship.
+ * > Under the new behavior, since the local state is preserved the inverses will also
+ * > not be reverted.
+ *
+ * ### Resolving this deprecation
+ *
+ * Resolving this deprecation can be done individually for each relationship
+ * or globally for all relationships.
+ *
+ * To resolve it globally, set the `DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE`
+ * to `false` in ember-cli-build.js
+ *
+ * ```js
+ * let app = new EmberApp(defaults, {
+ *   emberData: {
+ *     deprecations: {
+ *        // set to false to strip the deprecated code (thereby opting into the new behavior)
+ *       DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE: false
+ *     }
+ *   }
+ * })
+ * ```
+ *
+ * To resolve this deprecation on an individual relationship, adjust the `options` passed to
+ * the relationship. For relationships with inverses, both sides MUST be migrated to the new
+ * behavior at the same time.
+ *
+ * ```js
+ * class Person extends Model {
+ *  @hasMany('person', {
+ *    async: false,
+ *    inverse: null,
+ *    resetOnRemoteUpdate: false
+ *  }) children;
+ *
+ *  @belongsTo('person', {
+ *    async: false,
+ *    inverse: null,
+ *    resetOnRemoteUpdate: false
+ *  }) parent;
+ * }
+ * ```
+ *
+ * > Note: false is the only valid value here, all other values (including missing)
+ * > will be treated as true, where `true` is the legacy behavior that is now deprecated.
+ *
+ * Once you have migrated all relationships, you can remove the the resetOnRemoteUpdate
+ * option and set the deprecation flag to false in ember-cli-build.
+ *
+ * @property DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE
+ * @since 5.3
+ * @until 6.0
+ * @public
+ */
+export const DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE = '5.3';

--- a/packages/store/src/-private/caches/identifier-cache.ts
+++ b/packages/store/src/-private/caches/identifier-cache.ts
@@ -310,12 +310,8 @@ export class IdentifierCache {
       console.log(`Identifiers: ${lid ? 'no ' : ''}lid ${lid ? lid + ' ' : ''}determined for resource`, resource);
     }
 
-    let identifier: StableRecordIdentifier | undefined = /*#__NOINLINE__*/ getIdentifierFromLid(
-      this._cache,
-      lid,
-      resource
-    );
-    if (identifier !== undefined) {
+    let identifier: StableRecordIdentifier | null = /*#__NOINLINE__*/ getIdentifierFromLid(this._cache, lid, resource);
+    if (identifier !== null) {
       if (LOG_IDENTIFIERS) {
         // eslint-disable-next-line no-console
         console.groupEnd();
@@ -756,7 +752,7 @@ function detectMerge(
     // we trigger a merge of the identifiers
     // though probably we should just throw an error here
     if (id !== null && id === newId && newType === type && hasLid(data) && data.lid !== lid) {
-      return cache.resources.get(data.lid) || false;
+      return getIdentifierFromLid(cache, data.lid, data) || false;
 
       // If the lids are the same, and ids are the same, but types are different we should trigger a merge of the identifiers
     } else if (id !== null && id === newId && newType && newType !== type && hasLid(data) && data.lid === lid) {
@@ -770,13 +766,13 @@ function detectMerge(
   return false;
 }
 
-function getIdentifierFromLid(cache: StableCache, lid: string, resource: unknown): StableRecordIdentifier | undefined {
+function getIdentifierFromLid(cache: StableCache, lid: string, resource: unknown): StableRecordIdentifier | null {
   const identifier = cache.resources.get(lid);
   if (LOG_IDENTIFIERS) {
     // eslint-disable-next-line no-console
     console.log(`Identifiers: cache ${identifier ? 'HIT' : 'MISS'} - Non-Stable ${lid}`, resource);
   }
-  return identifier;
+  return identifier || null;
 }
 
 function addResourceToCache(cache: StableCache, identifier: StableRecordIdentifier): void {

--- a/packages/unpublished-test-infra/addon-test-support/deprecated-test.ts
+++ b/packages/unpublished-test-infra/addon-test-support/deprecated-test.ts
@@ -19,10 +19,13 @@ function gte(EDVersion: string, DeprecationVersion: string): boolean {
 export function deprecatedTest(
   testName: string,
   deprecation: {
-    until: `${number}.${number}.${number}`;
+    until: `${number}.${number}`;
     id: string;
     count: number;
+    // this test should only run in debug mode
     debugOnly?: boolean;
+    // this test should remain in the codebase but
+    // should be refactored to no longer use the deprecated feature
     refactor?: boolean;
   },
   testCallback: <T extends TestContext>(this: T, assert: Assert) => void | Promise<void>

--- a/packages/unpublished-test-infra/addon-test-support/deprecated-test.ts
+++ b/packages/unpublished-test-infra/addon-test-support/deprecated-test.ts
@@ -1,10 +1,12 @@
+import { type TestContext } from '@ember/test-helpers';
+
 import { skip, test } from 'qunit';
 
 import { DEBUG } from '@ember-data/env';
 import VERSION, { COMPAT_VERSION } from '@ember-data/unpublished-test-infra/test-support/version';
 
 // small comparison function for major and minor semver values
-function gte(EDVersion, DeprecationVersion) {
+function gte(EDVersion: string, DeprecationVersion: string): boolean {
   let _edv = EDVersion.split('.');
   let _depv = DeprecationVersion.split('.');
   // compare major
@@ -14,7 +16,17 @@ function gte(EDVersion, DeprecationVersion) {
   return major || minor;
 }
 
-export function deprecatedTest(testName, deprecation, testCallback) {
+export function deprecatedTest(
+  testName: string,
+  deprecation: {
+    until: `${number}.${number}.${number}`;
+    id: string;
+    count: number;
+    debugOnly?: boolean;
+    refactor?: boolean;
+  },
+  testCallback: <T extends TestContext>(this: T, assert: Assert) => void | Promise<void>
+) {
   // '4.0'
   if (typeof deprecation.until !== 'string' || deprecation.until.length < 3) {
     throw new Error(`deprecatedTest expects { until } to be a version.`);
@@ -24,10 +36,14 @@ export function deprecatedTest(testName, deprecation, testCallback) {
     throw new Error(`deprecatedTest expects { id } to be a meaningful string`);
   }
 
-  async function interceptor(assert) {
+  async function interceptor<T extends TestContext>(this: T, assert: Assert) {
     await testCallback.call(this, assert);
     if (DEBUG) {
+      // @ts-expect-error test is not typed correctly
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (typeof assert.test.expected === 'number') {
+        // @ts-expect-error test is not typed correctly
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         assert.test.expected += 1;
       }
       assert.expectDeprecation(deprecation);

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-better.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-better.ts
@@ -20,6 +20,24 @@ export function configureBetterAsserts() {
   HAS_REGISTERED = true;
 
   QUnit.assert.arrayStrictEquals = function <T>(actual: T[], expected: T[], message: string): void {
+    if (!Array.isArray(actual)) {
+      this.pushResult({
+        result: false,
+        actual: false,
+        expected: true,
+        message: 'Expected the value for "actual" to be an array | ' + message,
+      });
+      return;
+    }
+    if (!Array.isArray(expected)) {
+      this.pushResult({
+        result: false,
+        actual: false,
+        expected: true,
+        message: 'Expected the value for "expected"" to be an array',
+      });
+      return;
+    }
     let passed = actual.length === expected.length;
 
     let actualRefs = new Map<T, string>();

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-better.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-better.ts
@@ -1,0 +1,51 @@
+import QUnit from 'qunit';
+
+let HAS_REGISTERED = false;
+
+function refFromIndex(index: number, suffix: string): string {
+  return `<ref:@${index}${suffix}>`;
+}
+function getRefForItem<T>(map: Map<T, string>, item: T, index: number): string {
+  let ref = map.get(item);
+  if (ref === undefined) {
+    ref = refFromIndex(index, 'b');
+  }
+  return ref;
+}
+
+export function configureBetterAsserts() {
+  if (HAS_REGISTERED === true) {
+    throw new Error(`Attempting to re-register better assertion tools`);
+  }
+  HAS_REGISTERED = true;
+
+  QUnit.assert.arrayStrictEquals = function <T>(actual: T[], expected: T[], message: string): void {
+    let passed = actual.length === expected.length;
+
+    let actualRefs = new Map<T, string>();
+    let actualSerialized: string[] = actual.map((item, index) => {
+      let ref = refFromIndex(index, '');
+      actualRefs.set(item, ref);
+      return ref;
+    });
+    let expectedSerialized: string[] = expected.map((item, index) => {
+      return getRefForItem(actualRefs, item, index);
+    });
+
+    if (passed) {
+      for (let i = 0; i < actual.length; i++) {
+        if (actual[i] !== expected[i]) {
+          passed = false;
+          break;
+        }
+      }
+    }
+
+    this.pushResult({
+      result: passed,
+      actual: actualSerialized,
+      expected: expectedSerialized,
+      message,
+    });
+  };
+}

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-notification.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/assert-notification.ts
@@ -1,0 +1,34 @@
+import type { TestContext } from '@ember/test-helpers';
+
+import QUnit from 'qunit';
+
+import type { CacheOperation, NotificationType } from '@ember-data/store/-private/managers/notification-manager';
+import type { StableDocumentIdentifier } from '@ember-data/types/cache/identifier';
+import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
+
+import { clearNotifications, getCounter } from '../setup-notifications';
+
+export function configureNotificationsAssert() {
+  QUnit.assert.notified = function (
+    this: Assert & { test: { testEnvironment: TestContext } },
+    identifier: StableRecordIdentifier | StableDocumentIdentifier,
+    bucket: NotificationType | CacheOperation,
+    key: string | null,
+    count: number
+  ) {
+    const counter = getCounter(this.test.testEnvironment, identifier, bucket, key);
+
+    this.pushResult({
+      result: counter.count === count,
+      actual: counter.count,
+      expected: count,
+      message: `Expected ${count} ${bucket} notifications for ${identifier.lid} ${key || ''}, got ${counter.count}`,
+    });
+
+    counter.count = 0;
+  };
+
+  QUnit.assert.clearNotifications = function (this: Assert & { test: { testEnvironment: TestContext } }) {
+    clearNotifications(this.test.testEnvironment);
+  };
+}

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/index.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/index.ts
@@ -1,6 +1,7 @@
 import { configureAssertionHandler } from './assert-assertion';
 import { configureBetterAsserts } from './assert-better';
 import { configureDeprecationHandler } from './assert-deprecation';
+import { configureNotificationsAssert } from './assert-notification';
 import { configureWarningHandler } from './assert-warning';
 
 export default function configureAsserts() {
@@ -8,4 +9,5 @@ export default function configureAsserts() {
   configureDeprecationHandler();
   configureWarningHandler();
   configureBetterAsserts();
+  configureNotificationsAssert();
 }

--- a/packages/unpublished-test-infra/addon-test-support/qunit-asserts/index.ts
+++ b/packages/unpublished-test-infra/addon-test-support/qunit-asserts/index.ts
@@ -1,4 +1,5 @@
 import { configureAssertionHandler } from './assert-assertion';
+import { configureBetterAsserts } from './assert-better';
 import { configureDeprecationHandler } from './assert-deprecation';
 import { configureWarningHandler } from './assert-warning';
 
@@ -6,4 +7,5 @@ export default function configureAsserts() {
   configureAssertionHandler();
   configureDeprecationHandler();
   configureWarningHandler();
+  configureBetterAsserts();
 }

--- a/packages/unpublished-test-infra/addon-test-support/setup-notifications.ts
+++ b/packages/unpublished-test-infra/addon-test-support/setup-notifications.ts
@@ -1,0 +1,83 @@
+import { type TestContext } from '@ember/test-helpers';
+
+import type Store from '@ember-data/store';
+import type { CacheOperation, NotificationType } from '@ember-data/store/-private/managers/notification-manager';
+import type { StableDocumentIdentifier } from '@ember-data/types/cache/identifier';
+import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
+
+type Counter = { count: number };
+type NotificationStorage = Map<
+  StableDocumentIdentifier | StableRecordIdentifier | 'document' | 'resource',
+  Map<NotificationType | CacheOperation, Counter | Map<string | symbol, Counter>>
+>;
+
+export function getCounter(
+  context: TestContext,
+  identifier: StableRecordIdentifier | StableDocumentIdentifier,
+  bucket: NotificationType | CacheOperation,
+  key: string | null
+) {
+  const storage = (context as unknown as { _notifications: NotificationStorage })._notifications;
+  if (!storage) {
+    throw new Error(`setupNotifications must be called before calling notified`);
+  }
+
+  let identifierStorage = storage.get(identifier);
+  if (!identifierStorage) {
+    identifierStorage = new Map();
+    storage.set(identifier, identifierStorage);
+  }
+
+  let bucketStorage = identifierStorage.get(bucket);
+  if (!bucketStorage) {
+    if (bucket === 'added' || bucket === 'removed' || bucket === 'updated' || bucket === 'state') {
+      bucketStorage = { count: 0 };
+    } else {
+      bucketStorage = new Map();
+    }
+    identifierStorage.set(bucket, bucketStorage);
+  }
+
+  let counter: Counter;
+  if (bucketStorage instanceof Map) {
+    const _key = key || Symbol.for(bucket);
+    counter = bucketStorage.get(_key)!;
+    if (!counter) {
+      counter = { count: 0 };
+      bucketStorage.set(_key, counter);
+    }
+  } else {
+    counter = bucketStorage;
+  }
+
+  return counter;
+}
+
+export function clearNotifications(context: TestContext) {
+  const storage = (context as unknown as { _notifications: NotificationStorage })._notifications;
+  if (!storage) {
+    throw new Error(`setupNotifications must be called before calling notified`);
+  }
+  storage.clear();
+}
+
+export function setupNotifications(context: TestContext) {
+  const { owner } = context;
+  const store = owner.lookup('service:store') as unknown as Store;
+  (context as unknown as { _notifications: NotificationStorage })._notifications = new Map();
+
+  const notifications = store.notifications;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const originalNotify = notifications.notify;
+  notifications.notify = function (
+    identifier: StableRecordIdentifier | StableDocumentIdentifier,
+    bucket: NotificationType | CacheOperation,
+    key?: string
+  ) {
+    const counter = getCounter(context, identifier, bucket, key ?? null);
+    counter.count++;
+
+    // @ts-expect-error TS is bad at curried overloads
+    return originalNotify.apply(notifications, [identifier, bucket, key]);
+  };
+}

--- a/packages/unpublished-test-infra/addon-test-support/test-in-debug.ts
+++ b/packages/unpublished-test-infra/addon-test-support/test-in-debug.ts
@@ -1,11 +1,10 @@
 import { type TestContext } from '@ember/test-helpers';
 
-import type { Assert } from 'qunit';
 import { skip, test as qunitTest } from 'qunit';
 
 import { DEBUG } from '@ember-data/env';
 
-export function test(label: string, callback: (this: TestContext, assert: Assert) => Promise<void>): void {
+export function test(label: string, callback: (this: TestContext, assert: Assert) => void | Promise<void>): void {
   if (DEBUG) {
     qunitTest(`[DEBUG-ONLY] ${label}`, callback);
   } else {

--- a/packages/unpublished-test-infra/addon-test-support/version.d.ts
+++ b/packages/unpublished-test-infra/addon-test-support/version.d.ts
@@ -1,0 +1,5 @@
+const VERSION: string;
+
+export default VERSION;
+
+export const COMPAT_VERSION: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2143,6 +2143,9 @@ importers:
       '@ember/test-helpers':
         specifier: ^3.2.0
         version: 3.2.0(@babel/core@7.22.11)(ember-source@5.2.0)(webpack@5.88.2)
+      '@embroider/macros':
+        specifier: ^1.12.2
+        version: 1.13.1(@babel/core@7.22.11)
       '@glimmer/component':
         specifier: ^1.1.2
         version: 1.1.2(@babel/core@7.22.11)

--- a/tests/docs/fixtures/expected.js
+++ b/tests/docs/fixtures/expected.js
@@ -56,6 +56,8 @@ module.exports = {
     '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_LEGACY_IMPORTS',
     '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_NON_STRICT_ID',
     '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_NON_STRICT_TYPES',
+    '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_NON_UNIQUE_PAYLOADS',
+    '(public) @ember-data/deprecations CurrentDeprecations#DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE',
     '(private) @ember-data/legacy-compat SnapshotRecordArray#_recordArray',
     '(private) @ember-data/legacy-compat SnapshotRecordArray#_snapshots',
     '(private) @ember-data/legacy-compat SnapshotRecordArray#constructor',

--- a/tests/graph/package.json
+++ b/tests/graph/package.json
@@ -74,6 +74,7 @@
     "ember-cli-blueprint-test-helpers": "^0.19.2",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.3.0",
+    "@embroider/macros": "^1.13.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "~4.0.2",

--- a/tests/graph/tests/integration/graph/diff-preservation-test.ts
+++ b/tests/graph/tests/integration/graph/diff-preservation-test.ts
@@ -8,7 +8,7 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import type Store from '@ember-data/store';
 import { deprecatedTest } from '@ember-data/unpublished-test-infra/test-support/deprecated-test';
 
-module('Integration | Graph | Remote State Does Not Reset Local State', function (hooks: NestedHooks) {
+module('Integration | Graph | Diff Preservation', function (hooks: NestedHooks) {
   setupTest(hooks);
 
   deprecatedTest(

--- a/tests/graph/tests/integration/graph/duplicate-data-test.ts
+++ b/tests/graph/tests/integration/graph/duplicate-data-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module } from 'qunit';
 
 import { setupTest } from 'ember-qunit';
 
@@ -7,6 +7,7 @@ import { graphFor } from '@ember-data/graph/-private';
 import Model, { attr, hasMany } from '@ember-data/model';
 import type Store from '@ember-data/store';
 import { deprecatedTest } from '@ember-data/unpublished-test-infra/test-support/deprecated-test';
+import testInDebug from '@ember-data/unpublished-test-infra/test-support/test-in-debug';
 
 module('Integration | Graph | Duplicate Data', function (hooks: NestedHooks) {
   setupTest(hooks);
@@ -134,7 +135,7 @@ module('Integration | Graph | Duplicate Data', function (hooks: NestedHooks) {
   );
 
   if (!DEPRECATE_NON_UNIQUE_PAYLOADS) {
-    test('updateRelationship operation asserts on duplicates in remote payloads', function (assert: Assert) {
+    testInDebug('updateRelationship operation asserts on duplicates in remote payloads', function (assert: Assert) {
       const { owner } = this;
 
       class App extends Model {
@@ -181,7 +182,7 @@ module('Integration | Graph | Duplicate Data', function (hooks: NestedHooks) {
       }
     });
 
-    test('replaceRelatedRecords asserts on duplicates in a local replace', function (assert) {
+    testInDebug('replaceRelatedRecords asserts on duplicates in a local replace', function (assert) {
       const { owner } = this;
 
       class App extends Model {

--- a/tests/graph/tests/integration/graph/duplicate-data-test.ts
+++ b/tests/graph/tests/integration/graph/duplicate-data-test.ts
@@ -1,13 +1,14 @@
-import { module } from 'qunit';
+import { module, test } from 'qunit';
 
 import { setupTest } from 'ember-qunit';
 
+import { DEPRECATE_NON_UNIQUE_PAYLOADS } from '@ember-data/deprecations';
 import { graphFor } from '@ember-data/graph/-private';
 import Model, { attr, hasMany } from '@ember-data/model';
 import type Store from '@ember-data/store';
 import { deprecatedTest } from '@ember-data/unpublished-test-infra/test-support/deprecated-test';
 
-module('Integration | Graph | Operations', function (hooks: NestedHooks) {
+module('Integration | Graph | Duplicate Data', function (hooks: NestedHooks) {
   setupTest(hooks);
 
   deprecatedTest(
@@ -131,4 +132,102 @@ module('Integration | Graph | Operations', function (hooks: NestedHooks) {
       );
     }
   );
+
+  if (!DEPRECATE_NON_UNIQUE_PAYLOADS) {
+    test('updateRelationship operation asserts on duplicates in remote payloads', function (assert: Assert) {
+      const { owner } = this;
+
+      class App extends Model {
+        @attr declare name: string;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        @hasMany('config', { async: false, inverse: null }) declare configs: Config[];
+      }
+
+      class Config extends Model {
+        @attr declare name: string;
+      }
+
+      owner.register('model:app', App);
+      owner.register('model:config', Config);
+      const store = owner.lookup('service:store') as unknown as Store;
+      const graph = graphFor(store);
+      const appIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'app', id: '1' });
+
+      try {
+        store._join(() => {
+          graph.push({
+            op: 'updateRelationship',
+            field: 'configs',
+            record: appIdentifier,
+            value: {
+              data: [
+                { type: 'config', id: '1' },
+                { type: 'config', id: '1' },
+                { type: 'config', id: '1' },
+                { type: 'config', id: '2' },
+                { type: 'config', id: '3' },
+                { type: 'config', id: '4' },
+              ],
+            },
+          });
+        });
+        assert.ok(false, 'expected assertion');
+      } catch (e: unknown) {
+        assert.strictEqual(
+          (e as Error)?.message,
+          'Assertion Failed: Expected all entries in the relationship to be unique, found duplicates',
+          'assertion is thrown'
+        );
+      }
+    });
+
+    test('replaceRelatedRecords asserts on duplicates in a local replace', function (assert) {
+      const { owner } = this;
+
+      class App extends Model {
+        @attr declare name: string;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        @hasMany('config', { async: false, inverse: null }) declare configs: Config[];
+      }
+
+      class Config extends Model {
+        @attr declare name: string;
+      }
+
+      owner.register('model:app', App);
+      owner.register('model:config', Config);
+      const store = owner.lookup('service:store') as unknown as Store;
+      const graph = graphFor(store);
+      const appIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'app', id: '1' });
+      const configIdentifier1 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '1' });
+      const configIdentifier2 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '2' });
+      const configIdentifier3 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '3' });
+      const configIdentifier4 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '4' });
+
+      try {
+        store._join(() => {
+          graph.update({
+            op: 'replaceRelatedRecords',
+            field: 'configs',
+            record: appIdentifier,
+            value: [
+              configIdentifier1,
+              configIdentifier1,
+              configIdentifier1,
+              configIdentifier2,
+              configIdentifier3,
+              configIdentifier4,
+            ],
+          });
+        });
+        assert.ok(false, 'expected assertion');
+      } catch (e: unknown) {
+        assert.strictEqual(
+          (e as Error)?.message,
+          'Assertion Failed: Expected all entries in the relationship to be unique, found duplicates',
+          'assertion is thrown'
+        );
+      }
+    });
+  }
 });

--- a/tests/graph/tests/integration/graph/duplicate-data-test.ts
+++ b/tests/graph/tests/integration/graph/duplicate-data-test.ts
@@ -7,7 +7,7 @@ import { graphFor } from '@ember-data/graph/-private';
 import Model, { attr, hasMany } from '@ember-data/model';
 import type Store from '@ember-data/store';
 import { deprecatedTest } from '@ember-data/unpublished-test-infra/test-support/deprecated-test';
-import testInDebug from '@ember-data/unpublished-test-infra/test-support/test-in-debug';
+import { test } from '@ember-data/unpublished-test-infra/test-support/test-in-debug';
 
 module('Integration | Graph | Duplicate Data', function (hooks: NestedHooks) {
   setupTest(hooks);
@@ -135,7 +135,7 @@ module('Integration | Graph | Duplicate Data', function (hooks: NestedHooks) {
   );
 
   if (!DEPRECATE_NON_UNIQUE_PAYLOADS) {
-    testInDebug('updateRelationship operation asserts on duplicates in remote payloads', function (assert: Assert) {
+    test('updateRelationship operation asserts on duplicates in remote payloads', function (assert) {
       const { owner } = this;
 
       class App extends Model {
@@ -182,7 +182,7 @@ module('Integration | Graph | Duplicate Data', function (hooks: NestedHooks) {
       }
     });
 
-    testInDebug('replaceRelatedRecords asserts on duplicates in a local replace', function (assert) {
+    test('replaceRelatedRecords asserts on duplicates in a local replace', function (assert) {
       const { owner } = this;
 
       class App extends Model {

--- a/tests/graph/tests/integration/graph/edge-removal/helpers.ts
+++ b/tests/graph/tests/integration/graph/edge-removal/helpers.ts
@@ -154,8 +154,8 @@ export async function setInitialState(context: Context, config: TestConfig, asse
   assert.false(chris.isDeleted, 'PreCond: Chris is not deleted');
   assert.false(john.isDeleted, 'PreCond: John is not deleted');
 
-  const chrisState = stateOf(chrisBestFriend);
-  const johnState = stateOf(johnBestFriend);
+  const chrisState = stateOf(store._graph!, chrisBestFriend);
+  const johnState = stateOf(store._graph!, johnBestFriend);
 
   assert.deepEqual(
     chrisState.remote,
@@ -191,7 +191,7 @@ export async function setInitialState(context: Context, config: TestConfig, asse
 
     assert.ok(chrisImplicitFriend, 'PreCond: Chris has an implicit best friend');
 
-    const chrisImplicitState = stateOf(chrisImplicitFriend);
+    const chrisImplicitState = stateOf(store._graph!, chrisImplicitFriend);
 
     assert.deepEqual(
       chrisImplicitState.remote,
@@ -214,7 +214,7 @@ export async function setInitialState(context: Context, config: TestConfig, asse
     } else {
       assert.strictEqual(Object.keys(johnImplicits).length, 1, 'PreCond: John has one implicit relationship');
       assert.ok(johnImplicitFriend, 'PreCond: John has no implicit best friend');
-      const johnImplicitState = stateOf(johnImplicitFriend);
+      const johnImplicitState = stateOf(store._graph!, johnImplicitFriend);
       assert.deepEqual(
         johnImplicitState.remote,
         config.dirtyLocal || config.useCreate ? [] : [chrisIdentifier],
@@ -252,11 +252,11 @@ export async function testFinalState(
   statuses: ExpectedTestOutcomes,
   assert
 ) {
-  const { graph } = context;
+  const { graph, store } = context;
   const { chrisIdentifier, johnIdentifier } = testState;
 
   const chrisBestFriend = graph.get(chrisIdentifier, 'bestFriends');
-  const chrisState = stateOf(chrisBestFriend);
+  const chrisState = stateOf(store._graph!, chrisBestFriend);
 
   // this specific case gets it's own WAT
   // this is something ideally a refactor should do away with.
@@ -323,7 +323,7 @@ export async function testFinalState(
     assert.false(graph.identifiers.has(johnIdentifier), 'Result: Relationships for John were cleared from the cache');
   } else {
     const johnBestFriend = graph.get(johnIdentifier, 'bestFriends');
-    const johnState = stateOf(johnBestFriend);
+    const johnState = stateOf(store._graph!, johnBestFriend);
 
     assert.deepEqual(
       johnState.remote,
@@ -349,7 +349,7 @@ export async function testFinalState(
     const chrisImplicitFriend = chrisImplicits[testState.chrisInverseKey] as ImplicitEdge;
 
     assert.ok(chrisImplicitFriend, 'Result: Chris has an implicit relationship for best friend');
-    const chrisImplicitState = stateOf(chrisImplicitFriend);
+    const chrisImplicitState = stateOf(store._graph!, chrisImplicitFriend);
 
     assert.deepEqual(
       chrisImplicitState.remote,
@@ -377,7 +377,7 @@ export async function testFinalState(
         'Result: John has one implicit relationship in the cache'
       );
       assert.ok(johnImplicitFriend, 'Result: John has an implicit key for best friend');
-      const johnImplicitState = stateOf(johnImplicitFriend);
+      const johnImplicitState = stateOf(store._graph!, johnImplicitFriend);
 
       assert.deepEqual(
         johnImplicitState.remote,

--- a/tests/graph/tests/integration/graph/edge-removal/setup.ts
+++ b/tests/graph/tests/integration/graph/edge-removal/setup.ts
@@ -4,9 +4,10 @@ import { graphFor } from '@ember-data/graph/-private';
 import type { CollectionEdge } from '@ember-data/graph/-private/edges/collection';
 import type { ImplicitEdge } from '@ember-data/graph/-private/edges/implicit';
 import type { ResourceEdge } from '@ember-data/graph/-private/edges/resource';
-import type { GraphEdge } from '@ember-data/graph/-private/graph';
+import type { Graph, GraphEdge } from '@ember-data/graph/-private/graph';
 import type Model from '@ember-data/model';
 import type Store from '@ember-data/store';
+import type { CollectionRelationship } from '@ember-data/types/cache/relationship';
 import type {
   CollectionResourceDocument,
   EmptyResourceDocument,
@@ -81,7 +82,10 @@ function setToArray<T>(set: Set<T>): T[] {
   return Array.from(set);
 }
 
-export function stateOf(rel: GraphEdge): {
+export function stateOf(
+  graph: Graph,
+  rel: GraphEdge
+): {
   remote: StableRecordIdentifier[];
   local: StableRecordIdentifier[];
 } {
@@ -93,8 +97,10 @@ export function stateOf(rel: GraphEdge): {
     local = rel.localState ? [rel.localState] : [];
     remote = rel.remoteState ? [rel.remoteState] : [];
   } else if (isHasMany(rel)) {
-    local = rel.localState.filter((m) => m !== null) as StableRecordIdentifier[];
-    remote = rel.remoteState.filter((m) => m !== null) as StableRecordIdentifier[];
+    // ensure we calculate what is otherwise lazy
+    const data = graph.getData(rel.identifier, rel.definition.key) as CollectionRelationship;
+    local = data.data || [];
+    remote = rel.remoteState;
   } else {
     local = setToArray<StableRecordIdentifier>(rel.localMembers);
     remote = setToArray<StableRecordIdentifier>(rel.remoteMembers);

--- a/tests/graph/tests/integration/graph/edge-test.ts
+++ b/tests/graph/tests/integration/graph/edge-test.ts
@@ -69,7 +69,7 @@ module('Integration | Graph | Edges', function (hooks) {
         'We still have no record data instance after push of only an identifier within a relationship'
       );
 
-      let state = stateOf(bestFriend);
+      let state = stateOf(graph, bestFriend);
       assert.deepEqual(state.remote, [identifier2], 'Our initial canonical state is correct');
       assert.deepEqual(state.local, [identifier2], 'Our initial current state is correct');
 
@@ -118,7 +118,7 @@ module('Integration | Graph | Edges', function (hooks) {
         'We have no record data instance after push of only an identifier within a relationship'
       );
 
-      let state = stateOf(bestFriend);
+      let state = stateOf(graph, bestFriend);
       assert.deepEqual(state.remote, [identifier2], 'Our initial canonical state is correct');
       assert.deepEqual(state.local, [identifier2], 'Our initial current state is correct');
 
@@ -132,7 +132,7 @@ module('Integration | Graph | Edges', function (hooks) {
         });
       });
 
-      state = stateOf(bestFriend);
+      state = stateOf(graph, bestFriend);
       assert.deepEqual(state.remote, [identifier3], 'Our canonical state is correct after canonical update');
       assert.deepEqual(state.local, [identifier3], 'Our current state is correct after canonical update');
 
@@ -151,7 +151,7 @@ module('Integration | Graph | Edges', function (hooks) {
         });
       });
 
-      state = stateOf(bestFriend);
+      state = stateOf(graph, bestFriend);
       assert.deepEqual(state.remote, [identifier3], 'Our canonical state is correct after local update');
       assert.deepEqual(state.local, [identifier2], 'Our current state is correct after local update');
 
@@ -204,7 +204,7 @@ module('Integration | Graph | Edges', function (hooks) {
         'We have no record data instance after push of only an identifier within a relationship'
       );
 
-      let state = stateOf(bestFriend);
+      let state = stateOf(graph, bestFriend);
       assert.deepEqual(state.remote, [identifier2], 'Our initial canonical state is correct');
       assert.deepEqual(state.local, [identifier2], 'Our initial current state is correct');
 
@@ -218,7 +218,7 @@ module('Integration | Graph | Edges', function (hooks) {
         });
       });
 
-      state = stateOf(bestFriend);
+      state = stateOf(graph, bestFriend);
       assert.deepEqual(state.remote, [identifier3], 'Our canonical state is correct after canonical update');
       assert.deepEqual(state.local, [identifier3], 'Our current state is correct after canonical update');
 
@@ -237,7 +237,7 @@ module('Integration | Graph | Edges', function (hooks) {
         });
       });
 
-      state = stateOf(bestFriend);
+      state = stateOf(graph, bestFriend);
       assert.deepEqual(state.remote, [identifier3], 'Our canonical state is correct after local update');
       assert.deepEqual(state.local, [identifier2], 'Our current state is correct after local update');
 
@@ -295,7 +295,7 @@ module('Integration | Graph | Edges', function (hooks) {
         'We have no record data instance after push of only an identifier within a relationship'
       );
 
-      let state = stateOf(bestFriends);
+      let state = stateOf(graph, bestFriends);
       assert.deepEqual(state.remote, [identifier2], 'Our initial canonical state is correct');
       assert.deepEqual(state.local, [identifier2], 'Our initial current state is correct');
 
@@ -308,7 +308,7 @@ module('Integration | Graph | Edges', function (hooks) {
         });
       });
 
-      state = stateOf(bestFriends);
+      state = stateOf(graph, bestFriends);
       assert.deepEqual(
         state.remote,
         [identifier2, identifier3],
@@ -332,7 +332,7 @@ module('Integration | Graph | Edges', function (hooks) {
         });
       });
 
-      state = stateOf(bestFriends);
+      state = stateOf(graph, bestFriends);
       assert.deepEqual(state.remote, [identifier2, identifier3], 'Our canonical state is correct after local update');
       assert.deepEqual(
         state.local,
@@ -394,7 +394,7 @@ module('Integration | Graph | Edges', function (hooks) {
         'We have no record data instance after push of only an identifier within a relationship'
       );
 
-      let state = stateOf(bestFriends);
+      let state = stateOf(graph, bestFriends);
       assert.deepEqual(state.remote, [identifier2], 'Our initial canonical state is correct');
       assert.deepEqual(state.local, [identifier2], 'Our initial current state is correct');
 
@@ -407,7 +407,7 @@ module('Integration | Graph | Edges', function (hooks) {
         });
       });
 
-      state = stateOf(bestFriends);
+      state = stateOf(graph, bestFriends);
       assert.deepEqual(
         state.remote,
         [identifier2, identifier3],
@@ -431,7 +431,7 @@ module('Integration | Graph | Edges', function (hooks) {
         });
       });
 
-      state = stateOf(bestFriends);
+      state = stateOf(graph, bestFriends);
       assert.deepEqual(state.remote, [identifier2, identifier3], 'Our canonical state is correct after local update');
       assert.deepEqual(
         state.local,

--- a/tests/graph/tests/integration/graph/operations-test.ts
+++ b/tests/graph/tests/integration/graph/operations-test.ts
@@ -1,117 +1,134 @@
-import { module, test } from 'qunit';
+import { module } from 'qunit';
 
 import { setupTest } from 'ember-qunit';
 
 import { graphFor } from '@ember-data/graph/-private';
 import Model, { attr, hasMany } from '@ember-data/model';
 import type Store from '@ember-data/store';
+import { deprecatedTest } from '@ember-data/unpublished-test-infra/test-support/deprecated-test';
 
 module('Integration | Graph | Operations', function (hooks: NestedHooks) {
   setupTest(hooks);
 
-  test('updateRelationship operation filters duplicates', function (assert: Assert) {
-    const { owner } = this;
+  deprecatedTest(
+    'updateRelationship operation filters duplicates',
+    {
+      id: 'ember-data:deprecate-non-unique-relationship-entries',
+      until: '6.0.0',
+      count: 1,
+    },
+    function (assert: Assert) {
+      const { owner } = this;
 
-    class App extends Model {
-      @attr declare name: string;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      @hasMany('config', { async: false, inverse: null }) declare configs: Config[];
-    }
+      class App extends Model {
+        @attr declare name: string;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        @hasMany('config', { async: false, inverse: null }) declare configs: Config[];
+      }
 
-    class Config extends Model {
-      @attr declare name: string;
-    }
+      class Config extends Model {
+        @attr declare name: string;
+      }
 
-    owner.register('model:app', App);
-    owner.register('model:config', Config);
-    const store = owner.lookup('service:store') as unknown as Store;
-    const graph = graphFor(store);
-    const appIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'app', id: '1' });
+      owner.register('model:app', App);
+      owner.register('model:config', Config);
+      const store = owner.lookup('service:store') as unknown as Store;
+      const graph = graphFor(store);
+      const appIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'app', id: '1' });
 
-    store._join(() => {
-      graph.push({
-        op: 'updateRelationship',
-        field: 'configs',
-        record: appIdentifier,
-        value: {
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'configs',
+          record: appIdentifier,
+          value: {
+            data: [
+              { type: 'config', id: '1' },
+              { type: 'config', id: '1' },
+              { type: 'config', id: '1' },
+              { type: 'config', id: '2' },
+              { type: 'config', id: '3' },
+              { type: 'config', id: '4' },
+            ],
+          },
+        });
+      });
+
+      const data = graph.getData(appIdentifier, 'configs');
+      assert.deepEqual(
+        JSON.parse(JSON.stringify(data)),
+        {
           data: [
-            { type: 'config', id: '1' },
-            { type: 'config', id: '1' },
-            { type: 'config', id: '1' },
-            { type: 'config', id: '2' },
-            { type: 'config', id: '3' },
-            { type: 'config', id: '4' },
+            { type: 'config', id: '1', lid: '@lid:config-1' },
+            { type: 'config', id: '2', lid: '@lid:config-2' },
+            { type: 'config', id: '3', lid: '@lid:config-3' },
+            { type: 'config', id: '4', lid: '@lid:config-4' },
           ],
         },
-      });
-    });
-
-    const data = graph.getData(appIdentifier, 'configs');
-    assert.deepEqual(
-      JSON.parse(JSON.stringify(data)),
-      {
-        data: [
-          { type: 'config', id: '1', lid: '@lid:config-1' },
-          { type: 'config', id: '2', lid: '@lid:config-2' },
-          { type: 'config', id: '3', lid: '@lid:config-3' },
-          { type: 'config', id: '4', lid: '@lid:config-4' },
-        ],
-      },
-      'we have the expected data'
-    );
-  });
-
-  test('replaceRelatedRecords operation filters duplicates in a local replace', function (assert) {
-    const { owner } = this;
-
-    class App extends Model {
-      @attr declare name: string;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      @hasMany('config', { async: false, inverse: null }) declare configs: Config[];
+        'we have the expected data'
+      );
     }
+  );
 
-    class Config extends Model {
-      @attr declare name: string;
-    }
+  deprecatedTest(
+    'replaceRelatedRecords operation filters duplicates in a local replace',
+    {
+      id: 'ember-data:deprecate-non-unique-relationship-entries',
+      until: '6.0.0',
+      count: 1,
+    },
+    function (assert) {
+      const { owner } = this;
 
-    owner.register('model:app', App);
-    owner.register('model:config', Config);
-    const store = owner.lookup('service:store') as unknown as Store;
-    const graph = graphFor(store);
-    const appIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'app', id: '1' });
-    const configIdentifier1 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '1' });
-    const configIdentifier2 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '2' });
-    const configIdentifier3 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '3' });
-    const configIdentifier4 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '4' });
+      class App extends Model {
+        @attr declare name: string;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        @hasMany('config', { async: false, inverse: null }) declare configs: Config[];
+      }
 
-    store._join(() => {
-      graph.update({
-        op: 'replaceRelatedRecords',
-        field: 'configs',
-        record: appIdentifier,
-        value: [
-          configIdentifier1,
-          configIdentifier1,
-          configIdentifier1,
-          configIdentifier2,
-          configIdentifier3,
-          configIdentifier4,
-        ],
+      class Config extends Model {
+        @attr declare name: string;
+      }
+
+      owner.register('model:app', App);
+      owner.register('model:config', Config);
+      const store = owner.lookup('service:store') as unknown as Store;
+      const graph = graphFor(store);
+      const appIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'app', id: '1' });
+      const configIdentifier1 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '1' });
+      const configIdentifier2 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '2' });
+      const configIdentifier3 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '3' });
+      const configIdentifier4 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '4' });
+
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecords',
+          field: 'configs',
+          record: appIdentifier,
+          value: [
+            configIdentifier1,
+            configIdentifier1,
+            configIdentifier1,
+            configIdentifier2,
+            configIdentifier3,
+            configIdentifier4,
+          ],
+        });
       });
-    });
 
-    const data = graph.getData(appIdentifier, 'configs');
-    assert.deepEqual(
-      JSON.parse(JSON.stringify(data)),
-      {
-        data: [
-          { type: 'config', id: '1', lid: '@lid:config-1' },
-          { type: 'config', id: '2', lid: '@lid:config-2' },
-          { type: 'config', id: '3', lid: '@lid:config-3' },
-          { type: 'config', id: '4', lid: '@lid:config-4' },
-        ],
-      },
-      'we have the expected data'
-    );
-  });
+      const data = graph.getData(appIdentifier, 'configs');
+      assert.deepEqual(
+        JSON.parse(JSON.stringify(data)),
+        {
+          data: [
+            { type: 'config', id: '1', lid: '@lid:config-1' },
+            { type: 'config', id: '2', lid: '@lid:config-2' },
+            { type: 'config', id: '3', lid: '@lid:config-3' },
+            { type: 'config', id: '4', lid: '@lid:config-4' },
+          ],
+        },
+        'we have the expected data'
+      );
+    }
+  );
 });

--- a/tests/graph/tests/integration/graph/order-preservation-test.ts
+++ b/tests/graph/tests/integration/graph/order-preservation-test.ts
@@ -1,0 +1,620 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import { graphFor } from '@ember-data/graph/-private';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import Store from '@ember-data/store';
+
+class App extends Model {
+  @attr declare name: string;
+  @hasMany('config', { async: false, inverse: 'app' }) declare configs: Config[];
+  @belongsTo('cluster', { async: false, inverse: 'apps' }) declare cluster: Cluster | null;
+  @hasMany('group', { async: false, inverse: 'apps' }) declare groups: Groups[];
+}
+
+class Config extends Model {
+  @attr declare name: string;
+  @belongsTo('app', { async: false, inverse: 'configs' }) declare app: App | null;
+}
+
+class Cluster extends Model {
+  @attr declare name: string;
+  @hasMany('app', { async: false, inverse: 'cluster' }) declare apps: App[];
+}
+
+class Groups extends Model {
+  @attr declare name: string;
+  @hasMany('app', { async: false, inverse: 'groups' }) declare apps: App[];
+}
+
+module('Graph | Order Preservation', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    const { owner } = this;
+
+    owner.register('model:app', App);
+    owner.register('model:config', Config);
+    owner.register('model:cluster', Cluster);
+    owner.register('model:group', Groups);
+  });
+
+  module('during local mutation', function (innerHooks) {
+    innerHooks.beforeEach(function () {
+      const { owner } = this;
+
+      const store = owner.lookup('service:store') as Store;
+      const graph = graphFor(store);
+
+      const appIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'app', id: '1' });
+      const clusterIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'cluster', id: '1' });
+
+      // setup initial state
+      // app 1 has configs 1, 2, 3
+      // app 1 is in cluster 1
+      // cluster 1 has apps 1, 2, 3
+      // app 1 is in groups 1, 2, 3
+      // each group has apps 1, 2, 3
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'configs',
+          record: appIdentifier,
+          value: {
+            data: [
+              { type: 'config', id: '1' },
+              { type: 'config', id: '2' },
+              { type: 'config', id: '3' },
+            ],
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'cluster',
+          record: appIdentifier,
+          value: {
+            data: { type: 'cluster', id: '1' },
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'apps',
+          record: clusterIdentifier,
+          value: {
+            data: [
+              { type: 'app', id: '1' },
+              { type: 'app', id: '2' },
+              { type: 'app', id: '3' },
+            ],
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'groups',
+          record: appIdentifier,
+          value: {
+            data: [
+              { type: 'group', id: '1' },
+              { type: 'group', id: '2' },
+              { type: 'group', id: '3' },
+            ],
+          },
+        });
+        ['1', '2', '3'].forEach((id) => {
+          const groupIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'group', id });
+          graph.push({
+            op: 'updateRelationship',
+            field: 'apps',
+            record: groupIdentifier,
+            value: {
+              data: [
+                { type: 'app', id: '1' },
+                { type: 'app', id: '2' },
+                { type: 'app', id: '3' },
+              ],
+            },
+          });
+        });
+      });
+    });
+
+    test('order is preserved when doing a full replace of a hasMany', function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as Store;
+      const graph = graphFor(store);
+
+      function identifier(type: string, id: string) {
+        return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+      }
+
+      const appIdentifier = identifier('app', '1');
+
+      // change the order of configs
+      // from '1', '2', '3'
+      // to '3', '1', '2'
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecords',
+          field: 'configs',
+          record: appIdentifier,
+          value: [identifier('config', '3'), identifier('config', '1'), identifier('config', '2')],
+        });
+      });
+
+      const configState = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configState.data,
+        [identifier('config', '3'), identifier('config', '1'), identifier('config', '2')],
+        'we have the expected order'
+      );
+
+      // change the order of groups
+      // from '1', '2', '3'
+      // to '3', '1', '2'
+      // this should not affect ordering within the groups
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecords',
+          field: 'groups',
+          record: appIdentifier,
+          value: [identifier('group', '3'), identifier('group', '1'), identifier('group', '2')],
+        });
+      });
+
+      const groupState = graph.getData(appIdentifier, 'groups');
+      assert.arrayStrictEquals(
+        groupState.data,
+        [identifier('group', '3'), identifier('group', '1'), identifier('group', '2')],
+        'we have the expected order'
+      );
+      ['1', '2', '3'].forEach((id) => {
+        const groupIdentifier = identifier('group', id);
+        const groupAppsState = graph.getData(groupIdentifier, 'apps');
+        assert.arrayStrictEquals(
+          groupAppsState.data,
+          [identifier('app', '1'), identifier('app', '2'), identifier('app', '3')],
+          `group ${id} has the expected order`
+        );
+      });
+    });
+
+    test('order is preserved when adding to a hasMany', function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as Store;
+      const graph = graphFor(store);
+
+      function identifier(type: string, id: string) {
+        return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+      }
+
+      const appIdentifier = identifier('app', '1');
+
+      // add a new config '4' without an index
+      store._join(() => {
+        graph.update({
+          op: 'addToRelatedRecords',
+          field: 'configs',
+          record: appIdentifier,
+          value: identifier('config', '4'),
+        });
+      });
+
+      let configState = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configState.data,
+        [identifier('config', '1'), identifier('config', '2'), identifier('config', '3'), identifier('config', '4')],
+        'we have the expected order'
+      );
+
+      // add a new config '5' with an index
+      store._join(() => {
+        graph.update({
+          op: 'addToRelatedRecords',
+          field: 'configs',
+          record: appIdentifier,
+          value: identifier('config', '5'),
+          index: 1,
+        });
+      });
+
+      configState = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configState.data,
+        [
+          identifier('config', '1'),
+          identifier('config', '5'),
+          identifier('config', '2'),
+          identifier('config', '3'),
+          identifier('config', '4'),
+        ],
+        'we have the expected order'
+      );
+
+      // setup group 4 with apps 2, 3, 4
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'apps',
+          record: identifier('group', '4'),
+          value: {
+            data: [identifier('app', '2'), identifier('app', '3'), identifier('app', '4')],
+          },
+        });
+      });
+
+      // assert starting state
+      let appsState = graph.getData(identifier('group', '4'), 'apps');
+      assert.arrayStrictEquals(
+        appsState.data,
+        [identifier('app', '2'), identifier('app', '3'), identifier('app', '4')],
+        'we have the expected order'
+      );
+
+      // mutate group 4 order to 3, 4, 2
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecords',
+          field: 'apps',
+          record: identifier('group', '4'),
+          value: [identifier('app', '3'), identifier('app', '4'), identifier('app', '2')],
+        });
+      });
+
+      // assert mutated state
+      appsState = graph.getData(identifier('group', '4'), 'apps');
+      assert.arrayStrictEquals(
+        appsState.data,
+        [identifier('app', '3'), identifier('app', '4'), identifier('app', '2')],
+        'we have the expected order'
+      );
+
+      // add a group '4' to app '1'
+      store._join(() => {
+        graph.update({
+          op: 'addToRelatedRecords',
+          field: 'groups',
+          record: appIdentifier,
+          value: identifier('group', '4'),
+        });
+      });
+
+      // assert mutated state
+      const groupsState = graph.getData(appIdentifier, 'groups');
+      assert.arrayStrictEquals(
+        groupsState.data,
+        [identifier('group', '1'), identifier('group', '2'), identifier('group', '3'), identifier('group', '4')],
+        'we have the expected order'
+      );
+
+      // assert group 4 has the expected order
+      appsState = graph.getData(identifier('group', '4'), 'apps');
+      assert.arrayStrictEquals(
+        appsState.data,
+        [identifier('app', '3'), identifier('app', '4'), identifier('app', '2'), identifier('app', '1')],
+        'we have the expected order'
+      );
+    });
+
+    test('order is preserved when removing from a hasMany', function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as Store;
+      const graph = graphFor(store);
+
+      function identifier(type: string, id: string) {
+        return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+      }
+
+      const appIdentifier = identifier('app', '1');
+
+      // remove config '2'
+      store._join(() => {
+        graph.update({
+          op: 'removeFromRelatedRecords',
+          field: 'configs',
+          record: appIdentifier,
+          value: identifier('config', '2'),
+        });
+      });
+
+      let configState = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configState.data,
+        [identifier('config', '1'), identifier('config', '3')],
+        'we have the expected order'
+      );
+
+      // add config '2' back to the end
+      store._join(() => {
+        graph.update({
+          op: 'addToRelatedRecords',
+          field: 'configs',
+          record: appIdentifier,
+          value: identifier('config', '2'),
+        });
+      });
+
+      configState = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configState.data,
+        [identifier('config', '1'), identifier('config', '3'), identifier('config', '2')],
+        'we have the expected order'
+      );
+
+      // remove config '3' with an index
+      store._join(() => {
+        graph.update({
+          op: 'removeFromRelatedRecords',
+          field: 'configs',
+          record: appIdentifier,
+          value: identifier('config', '3'),
+          index: 1,
+        });
+      });
+
+      configState = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configState.data,
+        [identifier('config', '1'), identifier('config', '2')],
+        'we have the expected order'
+      );
+    });
+
+    test('order is preserved when adding via the inverse hasMany of a hasMany', function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as Store;
+      const graph = graphFor(store);
+
+      function identifier(type: string, id: string) {
+        return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+      }
+
+      const appIdentifier = identifier('app', '1');
+
+      // setup group 4 with apps 2, 3, 4
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'apps',
+          record: identifier('group', '4'),
+          value: {
+            data: [identifier('app', '2'), identifier('app', '3'), identifier('app', '4')],
+          },
+        });
+      });
+
+      // assert starting state
+      let appsState = graph.getData(identifier('group', '4'), 'apps');
+      assert.arrayStrictEquals(
+        appsState.data,
+        [identifier('app', '2'), identifier('app', '3'), identifier('app', '4')],
+        'we have the expected order'
+      );
+
+      // mutate group 4 order to 3, 4, 2
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecords',
+          field: 'apps',
+          record: identifier('group', '4'),
+          value: [identifier('app', '3'), identifier('app', '4'), identifier('app', '2')],
+        });
+      });
+
+      // assert mutated state
+      appsState = graph.getData(identifier('group', '4'), 'apps');
+      assert.arrayStrictEquals(
+        appsState.data,
+        [identifier('app', '3'), identifier('app', '4'), identifier('app', '2')],
+        'we have the expected order'
+      );
+
+      // add a group '4' to app '1'
+      store._join(() => {
+        graph.update({
+          op: 'addToRelatedRecords',
+          field: 'groups',
+          record: appIdentifier,
+          value: identifier('group', '4'),
+        });
+      });
+
+      // assert mutated state
+      const groupsState = graph.getData(appIdentifier, 'groups');
+      assert.arrayStrictEquals(
+        groupsState.data,
+        [identifier('group', '1'), identifier('group', '2'), identifier('group', '3'), identifier('group', '4')],
+        'we have the expected order'
+      );
+
+      // assert group 4 has the expected order
+      appsState = graph.getData(identifier('group', '4'), 'apps');
+      assert.arrayStrictEquals(
+        appsState.data,
+        [identifier('app', '3'), identifier('app', '4'), identifier('app', '2'), identifier('app', '1')],
+        'we have the expected order'
+      );
+    });
+
+    test('order is preserved when removing via the inverse hasMany of a hasMany', function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as Store;
+      const graph = graphFor(store);
+
+      function identifier(type: string, id: string) {
+        return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+      }
+
+      const appIdentifier = identifier('app', '1');
+      const groupIdentifier = identifier('group', '3');
+
+      // setup group 3 with apps 2, 1, 3, 4
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'apps',
+          record: groupIdentifier,
+          value: {
+            data: [identifier('app', '2'), appIdentifier, identifier('app', '3'), identifier('app', '4')],
+          },
+        });
+      });
+
+      // assert starting state
+      let appsState = graph.getData(groupIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        appsState.data,
+        [identifier('app', '2'), appIdentifier, identifier('app', '3'), identifier('app', '4')],
+        'we have the expected order'
+      );
+
+      // mutate group 3 order to 3, 1, 4, 2
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecords',
+          field: 'apps',
+          record: groupIdentifier,
+          value: [identifier('app', '3'), appIdentifier, identifier('app', '4'), identifier('app', '2')],
+        });
+      });
+
+      // assert mutated state
+      appsState = graph.getData(groupIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        appsState.data,
+        [identifier('app', '3'), appIdentifier, identifier('app', '4'), identifier('app', '2')],
+        'we have the expected order'
+      );
+
+      // now, remove group 3 from app 1
+      store._join(() => {
+        graph.update({
+          op: 'removeFromRelatedRecords',
+          field: 'groups',
+          record: appIdentifier,
+          value: groupIdentifier,
+        });
+      });
+
+      // assert mutated state
+      const groupsState = graph.getData(appIdentifier, 'groups');
+      assert.arrayStrictEquals(
+        groupsState.data,
+        [identifier('group', '1'), identifier('group', '2')],
+        'we have the expected order'
+      );
+
+      // assert group 3 has the expected order
+      appsState = graph.getData(groupIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        appsState.data,
+        [identifier('app', '3'), identifier('app', '4'), identifier('app', '2')],
+        'we have the expected order'
+      );
+    });
+
+    test('order is preserved when adding via the inverse belongsTo of a hasMany', function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as Store;
+      const graph = graphFor(store);
+
+      function identifier(type: string, id: string) {
+        return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+      }
+
+      const appIdentifier = identifier('app', '1');
+
+      // change the order of configs
+      // from '1', '2', '3'
+      // to '3', '1', '2'
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecords',
+          field: 'configs',
+          record: appIdentifier,
+          value: [identifier('config', '3'), identifier('config', '1'), identifier('config', '2')],
+        });
+      });
+
+      const configState = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configState.data,
+        [identifier('config', '3'), identifier('config', '1'), identifier('config', '2')],
+        'we have the expected order'
+      );
+
+      // add a new config '4'
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecord',
+          field: 'app',
+          record: identifier('config', '4'),
+          value: appIdentifier,
+        });
+      });
+
+      // assert mutated state
+      const config4State = graph.getData(identifier('config', '4'), 'app');
+      assert.strictEqual(config4State.data, appIdentifier, 'config 4 has the expected app');
+
+      const configState2 = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configState2.data,
+        [identifier('config', '3'), identifier('config', '1'), identifier('config', '2'), identifier('config', '4')],
+        'we have the expected order'
+      );
+    });
+
+    test('order is preserved when removing via the inverse belongsTo of a hasMany', function (assert) {
+      const { owner } = this;
+      const store = owner.lookup('service:store') as Store;
+      const graph = graphFor(store);
+
+      function identifier(type: string, id: string) {
+        return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+      }
+
+      const appIdentifier = identifier('app', '1');
+
+      // change the order of configs
+      // from '1', '2', '3'
+      // to '3', '1', '2'
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecords',
+          field: 'configs',
+          record: appIdentifier,
+          value: [identifier('config', '3'), identifier('config', '1'), identifier('config', '2')],
+        });
+      });
+
+      const configState = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configState.data,
+        [identifier('config', '3'), identifier('config', '1'), identifier('config', '2')],
+        'we have the expected order'
+      );
+
+      // remove config '1'
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecord',
+          field: 'app',
+          record: identifier('config', '1'),
+          value: null,
+        });
+      });
+
+      // assert mutated state
+      const config1State = graph.getData(identifier('config', '1'), 'app');
+      assert.strictEqual(config1State.data, null, 'config 1 has the expected app');
+
+      const configState2 = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configState2.data,
+        [identifier('config', '3'), identifier('config', '2')],
+        'we have the expected order'
+      );
+    });
+  });
+});

--- a/tests/graph/tests/integration/graph/reset-on-remote-update-test.ts
+++ b/tests/graph/tests/integration/graph/reset-on-remote-update-test.ts
@@ -1,0 +1,1331 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import { DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE } from '@ember-data/deprecations';
+import { graphFor } from '@ember-data/graph/-private';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import type Store from '@ember-data/store';
+import { deprecatedTest } from '@ember-data/unpublished-test-infra/test-support/deprecated-test';
+
+module('Integration | Graph | Remote State Does Not Reset Local State', function (hooks: NestedHooks) {
+  setupTest(hooks);
+
+  deprecatedTest(
+    'updateRelationship operation filters duplicates',
+    {
+      id: 'ember-data:deprecate-non-unique-relationship-entries',
+      until: '6.0.0',
+      count: 1,
+    },
+    function (assert: Assert) {
+      const { owner } = this;
+
+      class App extends Model {
+        @attr declare name: string;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        @hasMany('config', { async: false, inverse: null }) declare configs: Config[];
+      }
+
+      class Config extends Model {
+        @attr declare name: string;
+      }
+
+      owner.register('model:app', App);
+      owner.register('model:config', Config);
+      const store = owner.lookup('service:store') as unknown as Store;
+      const graph = graphFor(store);
+      const appIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'app', id: '1' });
+
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'configs',
+          record: appIdentifier,
+          value: {
+            data: [
+              { type: 'config', id: '1' },
+              { type: 'config', id: '1' },
+              { type: 'config', id: '1' },
+              { type: 'config', id: '2' },
+              { type: 'config', id: '3' },
+              { type: 'config', id: '4' },
+            ],
+          },
+        });
+      });
+
+      const data = graph.getData(appIdentifier, 'configs');
+      assert.deepEqual(
+        JSON.parse(JSON.stringify(data)),
+        {
+          data: [
+            { type: 'config', id: '1', lid: '@lid:config-1' },
+            { type: 'config', id: '2', lid: '@lid:config-2' },
+            { type: 'config', id: '3', lid: '@lid:config-3' },
+            { type: 'config', id: '4', lid: '@lid:config-4' },
+          ],
+        },
+        'we have the expected data'
+      );
+    }
+  );
+
+  deprecatedTest(
+    'replaceRelatedRecords operation filters duplicates in a local replace',
+    {
+      id: 'ember-data:deprecate-non-unique-relationship-entries',
+      until: '6.0.0',
+      count: 1,
+    },
+    function (assert) {
+      const { owner } = this;
+
+      class App extends Model {
+        @attr declare name: string;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        @hasMany('config', { async: false, inverse: null }) declare configs: Config[];
+      }
+
+      class Config extends Model {
+        @attr declare name: string;
+      }
+
+      owner.register('model:app', App);
+      owner.register('model:config', Config);
+      const store = owner.lookup('service:store') as unknown as Store;
+      const graph = graphFor(store);
+      const appIdentifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'app', id: '1' });
+      const configIdentifier1 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '1' });
+      const configIdentifier2 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '2' });
+      const configIdentifier3 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '3' });
+      const configIdentifier4 = store.identifierCache.getOrCreateRecordIdentifier({ type: 'config', id: '4' });
+
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecords',
+          field: 'configs',
+          record: appIdentifier,
+          value: [
+            configIdentifier1,
+            configIdentifier1,
+            configIdentifier1,
+            configIdentifier2,
+            configIdentifier3,
+            configIdentifier4,
+          ],
+        });
+      });
+
+      const data = graph.getData(appIdentifier, 'configs');
+      assert.deepEqual(
+        JSON.parse(JSON.stringify(data)),
+        {
+          data: [
+            { type: 'config', id: '1', lid: '@lid:config-1' },
+            { type: 'config', id: '2', lid: '@lid:config-2' },
+            { type: 'config', id: '3', lid: '@lid:config-3' },
+            { type: 'config', id: '4', lid: '@lid:config-4' },
+          ],
+        },
+        'we have the expected data'
+      );
+    }
+  );
+
+  if (!DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE) {
+    test('updateRelationship operation from the collection side does not clear local state', function (assert: Assert) {
+      // tests that Many:Many, Many:One do not clear local state from
+      // either side when updating the relationship from the Many side
+      const { owner } = this;
+
+      class App extends Model {
+        @attr declare name: string;
+        @hasMany('config', { async: false, inverse: 'app' }) declare configs: Config[];
+        @hasMany('namespace', { async: false, inverse: 'apps' }) declare namespaces: Namespace | null;
+      }
+
+      class Namespace extends Model {
+        @attr declare name: string;
+        @hasMany('app', { async: false, inverse: 'namespaces' }) declare apps: App[];
+      }
+
+      class Config extends Model {
+        @attr declare name: string;
+        @belongsTo('app', { async: false, inverse: 'configs' }) declare app: App | null;
+      }
+
+      function identifier(type: string, id: string) {
+        return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+      }
+
+      owner.register('model:app', App);
+      owner.register('model:namespace', Namespace);
+      owner.register('model:config', Config);
+      const store = owner.lookup('service:store') as unknown as Store;
+      const graph = graphFor(store);
+      const appIdentifier = identifier('app', '1');
+
+      // set initial state
+      // one app, with 4 configs and 4 namespaces
+      // each config belongs to the app
+      // each namespace has the app and 2 more namespaces
+      store._join(() => {
+        // setup primary app relationships
+        // this also convers the belongsTo side on config
+        graph.push({
+          op: 'updateRelationship',
+          field: 'configs',
+          record: appIdentifier,
+          value: {
+            data: [
+              { type: 'config', id: '1' },
+              { type: 'config', id: '2' },
+              { type: 'config', id: '3' },
+              { type: 'config', id: '4' },
+            ],
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'namespaces',
+          record: appIdentifier,
+          value: {
+            data: [
+              { type: 'namespace', id: '1' },
+              { type: 'namespace', id: '2' },
+              { type: 'namespace', id: '3' },
+              { type: 'namespace', id: '4' },
+            ],
+          },
+        });
+        // setup namespace relationships
+        ['1', '2', '3', '4'].forEach((id) => {
+          graph.push({
+            op: 'updateRelationship',
+            field: 'apps',
+            record: identifier('namespace', id),
+            value: {
+              data: [
+                { type: 'app', id: '1' },
+                { type: 'app', id: '2' },
+                { type: 'app', id: '3' },
+              ],
+            },
+          });
+        });
+      });
+
+      // mutate each relationship
+      // we change the app for each config to either null or a different app
+      // we remove each namespace from the app
+      store._join(() => {
+        ['1', '2', '3', '4'].forEach((id) => {
+          graph.update({
+            op: 'replaceRelatedRecord',
+            field: 'app',
+            record: identifier('config', id),
+            value: id === '1' || id === '2' ? null : identifier('app', '2'),
+          });
+        });
+        graph.update({
+          op: 'replaceRelatedRecords',
+          field: 'namespaces',
+          record: appIdentifier,
+          value: [],
+        });
+      });
+
+      // assert app relationships
+      let configRelationship = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(configRelationship.data, [], 'configs are correct');
+
+      let namespaceRelationship = graph.getData(appIdentifier, 'namespaces');
+      assert.arrayStrictEquals(namespaceRelationship.data, [], 'namespaces are correct');
+
+      // assert config relationships
+      ['1', '2', '3', '4'].forEach((id) => {
+        const configIdentifier = identifier('config', id);
+        const appRelationship = graph.getData(configIdentifier, 'app');
+        assert.deepEqual(
+          appRelationship.data,
+          id === '1' || id === '2' ? null : identifier('app', '2'),
+          `config ${id} app relationship is correct`
+        );
+      });
+
+      // assert namespace relationships
+      ['1', '2', '3', '4'].forEach((id) => {
+        const namespaceIdentifier = identifier('namespace', id);
+        const appRelationship = graph.getData(namespaceIdentifier, 'apps');
+        assert.arrayStrictEquals(
+          appRelationship.data,
+          [identifier('app', '2'), identifier('app', '3')],
+          `namespace ${id} apps relationship is correct`
+        );
+      });
+
+      // updateRelationship from the collection side
+      // this should not clear the local state
+      // so the configs should still be empty or have the new app
+      // and the namespaces should still have the app removed
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'configs',
+          record: appIdentifier,
+          value: {
+            data: [
+              { type: 'config', id: '1' },
+              { type: 'config', id: '2' },
+              { type: 'config', id: '3' },
+              { type: 'config', id: '4' },
+            ],
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'namespaces',
+          record: appIdentifier,
+          value: {
+            data: [
+              { type: 'namespace', id: '1' },
+              { type: 'namespace', id: '2' },
+              { type: 'namespace', id: '3' },
+              { type: 'namespace', id: '4' },
+            ],
+          },
+        });
+      });
+
+      // assert app relationships
+      configRelationship = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(configRelationship.data, [], 'configs are correct');
+
+      namespaceRelationship = graph.getData(appIdentifier, 'namespaces');
+      assert.arrayStrictEquals(namespaceRelationship.data, [], 'namespaces are correct');
+
+      // assert config relationships
+      ['1', '2', '3', '4'].forEach((id) => {
+        const configIdentifier = identifier('config', id);
+        const appRelationship = graph.getData(configIdentifier, 'app');
+        assert.deepEqual(
+          appRelationship.data,
+          id === '1' || id === '2' ? null : identifier('app', '2'),
+          `config ${id} app relationship is correct`
+        );
+      });
+
+      // assert namespace relationships
+      ['1', '2', '3', '4'].forEach((id) => {
+        const namespaceIdentifier = identifier('namespace', id);
+        const appRelationship = graph.getData(namespaceIdentifier, 'apps');
+        assert.arrayStrictEquals(
+          appRelationship.data,
+          [identifier('app', '2'), identifier('app', '3')],
+          `namespace ${id} apps relationship is correct`
+        );
+      });
+
+      // Commit the dirty state
+      store._join(() => {
+        ['1', '2', '3', '4'].forEach((id) => {
+          let record = identifier('config', id);
+          graph.push({
+            op: 'updateRelationship',
+            field: 'app',
+            record,
+            value: graph.getData(record, 'app'),
+          });
+
+          record = identifier('namespace', id);
+          graph.push({
+            op: 'updateRelationship',
+            field: 'apps',
+            record,
+            value: graph.getData(record, 'apps'),
+          });
+        });
+      });
+
+      // Ensure our state is still the same
+      // assert app relationships
+      configRelationship = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(configRelationship.data, [], 'configs are correct');
+
+      namespaceRelationship = graph.getData(appIdentifier, 'namespaces');
+      assert.arrayStrictEquals(namespaceRelationship.data, [], 'namespaces are correct');
+
+      // assert config relationships
+      ['1', '2', '3', '4'].forEach((id) => {
+        const configIdentifier = identifier('config', id);
+        const appRelationship = graph.getData(configIdentifier, 'app');
+        assert.deepEqual(
+          appRelationship.data,
+          id === '1' || id === '2' ? null : identifier('app', '2'),
+          `config ${id} app relationship is correct`
+        );
+      });
+
+      // assert namespace relationships
+      ['1', '2', '3', '4'].forEach((id) => {
+        const namespaceIdentifier = identifier('namespace', id);
+        const appRelationship = graph.getData(namespaceIdentifier, 'apps');
+        assert.arrayStrictEquals(
+          appRelationship.data,
+          [identifier('app', '2'), identifier('app', '3')],
+          `namespace ${id} apps relationship is correct`
+        );
+      });
+
+      // push a new state from the server
+      // there should be no local state left, so this should result
+      // in the observable state matching the new remote state
+      // however the order of the namespaces should now be different
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'configs',
+          record: appIdentifier,
+          value: {
+            data: [
+              { type: 'config', id: '1' },
+              { type: 'config', id: '2' },
+              { type: 'config', id: '3' },
+              { type: 'config', id: '4' },
+            ],
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'namespaces',
+          record: appIdentifier,
+          value: {
+            data: [
+              { type: 'namespace', id: '1' },
+              { type: 'namespace', id: '2' },
+              { type: 'namespace', id: '3' },
+              { type: 'namespace', id: '4' },
+            ],
+          },
+        });
+      });
+
+      // assert app relationships
+      configRelationship = graph.getData(appIdentifier, 'configs');
+      assert.arrayStrictEquals(
+        configRelationship.data,
+        [identifier('config', '1'), identifier('config', '2'), identifier('config', '3'), identifier('config', '4')],
+        'configs are correct'
+      );
+
+      namespaceRelationship = graph.getData(appIdentifier, 'namespaces');
+      assert.arrayStrictEquals(
+        namespaceRelationship.data,
+        [
+          identifier('namespace', '1'),
+          identifier('namespace', '2'),
+          identifier('namespace', '3'),
+          identifier('namespace', '4'),
+        ],
+        'namespaces are correct'
+      );
+
+      // assert config relationships
+      ['1', '2', '3', '4'].forEach((id) => {
+        const configIdentifier = identifier('config', id);
+        const appRelationship = graph.getData(configIdentifier, 'app');
+        assert.deepEqual(appRelationship.data, identifier('app', '1'), `config ${id} app relationship is correct`);
+      });
+
+      // assert namespace relationships
+      ['1', '2', '3', '4'].forEach((id) => {
+        const namespaceIdentifier = identifier('namespace', id);
+        const appRelationship = graph.getData(namespaceIdentifier, 'apps');
+        assert.arrayStrictEquals(
+          appRelationship.data,
+          [identifier('app', '2'), identifier('app', '3'), identifier('app', '1')],
+          `namespace ${id} apps relationship is correct`
+        );
+      });
+    });
+
+    test('updateRelationship operation from the belongsTo side does not clear local state', function (assert: Assert) {
+      // tests that One:Many, One:One do not clear local state from
+      // either side when updating the relationship from the One side
+      const { owner } = this;
+
+      class App extends Model {
+        @attr declare name: string;
+        @belongsTo('config', { async: false, inverse: 'app' }) declare config: Config[];
+        @belongsTo('namespace', { async: false, inverse: 'apps' }) declare namespace: Namespace | null;
+        @belongsTo('cluster', { async: false, inverse: 'app' }) declare cluster: Cluster | null;
+      }
+      class Cluster extends Model {
+        @attr declare name: string;
+        @belongsTo('app', { async: false, inverse: 'cluster' }) declare app: App | null;
+      }
+
+      class Namespace extends Model {
+        @attr declare name: string;
+        @hasMany('app', { async: false, inverse: 'namespace' }) declare apps: App[];
+      }
+
+      class Config extends Model {
+        @attr declare name: string;
+        @belongsTo('app', { async: false, inverse: 'config' }) declare app: App | null;
+      }
+
+      function identifier(type: string, id: string) {
+        return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+      }
+
+      owner.register('model:app', App);
+      owner.register('model:namespace', Namespace);
+      owner.register('model:config', Config);
+      owner.register('model:cluster', Cluster);
+      const store = owner.lookup('service:store') as unknown as Store;
+      const graph = graphFor(store);
+      const appIdentifier = identifier('app', '1');
+      const configIdentifier = identifier('config', '1');
+      const clusterIdentifier = identifier('cluster', '1');
+      const namespaceIdentifier = identifier('namespace', '1');
+
+      // set initial state
+      // one app, with 1 config, 1 cluster and 1 namespace
+      // the config belongs to the app
+      // the cluster belongs to the app
+      // the namespace has the app and 2 more apps
+      store._join(() => {
+        // setup primary app relationships
+        // this also convers the belongsTo side on config
+        graph.push({
+          op: 'updateRelationship',
+          field: 'config',
+          record: appIdentifier,
+          value: {
+            data: { type: 'config', id: '1' },
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'cluster',
+          record: appIdentifier,
+          value: {
+            data: { type: 'cluster', id: '1' },
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'namespace',
+          record: appIdentifier,
+          value: {
+            data: { type: 'namespace', id: '1' },
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'apps',
+          record: identifier('namespace', '1'),
+          value: {
+            data: [
+              { type: 'app', id: '1' },
+              { type: 'app', id: '2' },
+              { type: 'app', id: '3' },
+            ],
+          },
+        });
+      });
+
+      // mutate each relationship
+      // we change the app for the config null
+      // we change the app for the cluster to a different app
+      // we remove the app from the namespace
+      store._join(() => {
+        graph.update({
+          op: 'replaceRelatedRecord',
+          field: 'app',
+          record: identifier('config', '1'),
+          value: null,
+        });
+        graph.update({
+          op: 'removeFromRelatedRecords',
+          field: 'apps',
+          record: identifier('namespace', '1'),
+          value: appIdentifier,
+        });
+        graph.update({
+          op: 'replaceRelatedRecord',
+          field: 'app',
+          record: identifier('cluster', '1'),
+          value: identifier('app', '3'),
+        });
+      });
+
+      // assert app relationships
+      let configRelationship = graph.getData(appIdentifier, 'config');
+      assert.strictEqual(configRelationship.data, null, 'config is correct');
+      let clusterRelationship = graph.getData(appIdentifier, 'cluster');
+      assert.deepEqual(clusterRelationship.data, null, 'cluster is correct');
+      let namespaceRelationship = graph.getData(appIdentifier, 'namespace');
+      assert.deepEqual(namespaceRelationship.data, null, 'namespace is correct');
+
+      // assert config relationships
+      let appRelationship = graph.getData(configIdentifier, 'app');
+      assert.strictEqual(appRelationship.data, null, 'config app relationship is correct');
+      let clusterAppRelationship = graph.getData(clusterIdentifier, 'app');
+      assert.deepEqual(clusterAppRelationship.data, identifier('app', '3'), 'cluster app relationship is correct');
+      let namespaceAppsRelationship = graph.getData(namespaceIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        namespaceAppsRelationship.data,
+        [identifier('app', '2'), identifier('app', '3')],
+        'namespace apps relationship is correct'
+      );
+
+      // update the belongsTo side
+      // this should not clear the local state
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'config',
+          record: appIdentifier,
+          value: {
+            data: { type: 'config', id: '1' },
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'cluster',
+          record: appIdentifier,
+          value: {
+            data: { type: 'cluster', id: '1' },
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'namespace',
+          record: appIdentifier,
+          value: {
+            data: { type: 'namespace', id: '1' },
+          },
+        });
+      });
+
+      // assert app relationships
+      configRelationship = graph.getData(appIdentifier, 'config');
+      assert.strictEqual(configRelationship.data, null, 'config is correct');
+      clusterRelationship = graph.getData(appIdentifier, 'cluster');
+      assert.deepEqual(clusterRelationship.data, null, 'cluster is correct');
+      namespaceRelationship = graph.getData(appIdentifier, 'namespace');
+      assert.deepEqual(namespaceRelationship.data, null, 'namespace is correct');
+
+      // assert config relationships
+      appRelationship = graph.getData(configIdentifier, 'app');
+      assert.strictEqual(appRelationship.data, null, 'config app relationship is correct');
+      clusterAppRelationship = graph.getData(clusterIdentifier, 'app');
+      assert.deepEqual(clusterAppRelationship.data, identifier('app', '3'), 'cluster app relationship is correct');
+      namespaceAppsRelationship = graph.getData(namespaceIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        namespaceAppsRelationship.data,
+        [identifier('app', '2'), identifier('app', '3')],
+        'namespace apps relationship is correct'
+      );
+
+      // Commit the dirty state
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'app',
+          record: configIdentifier,
+          value: graph.getData(configIdentifier, 'app'),
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'app',
+          record: clusterIdentifier,
+          value: graph.getData(clusterIdentifier, 'app'),
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'apps',
+          record: namespaceIdentifier,
+          value: graph.getData(namespaceIdentifier, 'apps'),
+        });
+      });
+
+      // Ensure our state is still the same
+      // assert app relationships
+      configRelationship = graph.getData(appIdentifier, 'config');
+      assert.strictEqual(configRelationship.data, null, 'config is correct');
+      clusterRelationship = graph.getData(appIdentifier, 'cluster');
+      assert.deepEqual(clusterRelationship.data, null, 'cluster is correct');
+      namespaceRelationship = graph.getData(appIdentifier, 'namespace');
+      assert.deepEqual(namespaceRelationship.data, null, 'namespace is correct');
+
+      // assert config relationships
+      appRelationship = graph.getData(configIdentifier, 'app');
+      assert.strictEqual(appRelationship.data, null, 'config app relationship is correct');
+      clusterAppRelationship = graph.getData(clusterIdentifier, 'app');
+      assert.deepEqual(clusterAppRelationship.data, identifier('app', '3'), 'cluster app relationship is correct');
+      namespaceAppsRelationship = graph.getData(namespaceIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        namespaceAppsRelationship.data,
+        [identifier('app', '2'), identifier('app', '3')],
+        'namespace apps relationship is correct'
+      );
+
+      // push a new state from the server
+      // there should be no local state left, so this should result
+      // in the observable state matching the new remote state
+      // however the order of the namespaces should now be different
+      // since we removed the app from the namespace
+      // and then readd it
+      // without receiving a new ordering for the array from the API
+      store._join(() => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'config',
+          record: appIdentifier,
+          value: {
+            data: { type: 'config', id: '1' },
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'cluster',
+          record: appIdentifier,
+          value: {
+            data: { type: 'cluster', id: '1' },
+          },
+        });
+        graph.push({
+          op: 'updateRelationship',
+          field: 'namespace',
+          record: appIdentifier,
+          value: {
+            data: { type: 'namespace', id: '1' },
+          },
+        });
+      });
+
+      // assert app relationships
+      configRelationship = graph.getData(appIdentifier, 'config');
+      assert.strictEqual(configRelationship.data, configIdentifier, 'config is correct');
+      clusterRelationship = graph.getData(appIdentifier, 'cluster');
+      assert.deepEqual(clusterRelationship.data, clusterIdentifier, 'cluster is correct');
+      namespaceRelationship = graph.getData(appIdentifier, 'namespace');
+      assert.deepEqual(namespaceRelationship.data, namespaceIdentifier, 'namespace is correct');
+
+      // assert config relationships
+      appRelationship = graph.getData(configIdentifier, 'app');
+      assert.strictEqual(appRelationship.data, appIdentifier, 'config app relationship is correct');
+      clusterAppRelationship = graph.getData(clusterIdentifier, 'app');
+      assert.deepEqual(clusterAppRelationship.data, appIdentifier, 'cluster app relationship is correct');
+      namespaceAppsRelationship = graph.getData(namespaceIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        namespaceAppsRelationship.data,
+        [identifier('app', '2'), identifier('app', '3'), appIdentifier],
+        'namespace apps relationship is correct'
+      );
+    });
+  }
+
+  test('updateRelationship operation from the collection side does not clear local state when `resetOnRemoteUpdate: false` is set', function (assert: Assert) {
+    // tests that Many:Many, Many:One do not clear local state from
+    // either side when updating the relationship from the Many side
+    // we set the flag on the inverse to ensure that we detect this
+    // from either side
+    const { owner } = this;
+
+    class App extends Model {
+      @attr declare name: string;
+      @hasMany('config', { async: false, inverse: 'app' }) declare configs: Config[];
+      @hasMany('namespace', { async: false, inverse: 'apps' }) declare namespaces: Namespace | null;
+    }
+
+    class Namespace extends Model {
+      @attr declare name: string;
+      @hasMany('app', { async: false, inverse: 'namespaces', resetOnRemoteUpdate: false }) declare apps: App[];
+    }
+
+    class Config extends Model {
+      @attr declare name: string;
+      @belongsTo('app', { async: false, inverse: 'configs', resetOnRemoteUpdate: false }) declare app: App | null;
+    }
+
+    function identifier(type: string, id: string) {
+      return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+    }
+
+    owner.register('model:app', App);
+    owner.register('model:namespace', Namespace);
+    owner.register('model:config', Config);
+    const store = owner.lookup('service:store') as unknown as Store;
+    const graph = graphFor(store);
+    const appIdentifier = identifier('app', '1');
+
+    // set initial state
+    // one app, with 4 configs and 4 namespaces
+    // each config belongs to the app
+    // each namespace has the app and 2 more namespaces
+    store._join(() => {
+      // setup primary app relationships
+      // this also convers the belongsTo side on config
+      graph.push({
+        op: 'updateRelationship',
+        field: 'configs',
+        record: appIdentifier,
+        value: {
+          data: [
+            { type: 'config', id: '1' },
+            { type: 'config', id: '2' },
+            { type: 'config', id: '3' },
+            { type: 'config', id: '4' },
+          ],
+        },
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'namespaces',
+        record: appIdentifier,
+        value: {
+          data: [
+            { type: 'namespace', id: '1' },
+            { type: 'namespace', id: '2' },
+            { type: 'namespace', id: '3' },
+            { type: 'namespace', id: '4' },
+          ],
+        },
+      });
+      // setup namespace relationships
+      ['1', '2', '3', '4'].forEach((id) => {
+        graph.push({
+          op: 'updateRelationship',
+          field: 'apps',
+          record: identifier('namespace', id),
+          value: {
+            data: [
+              { type: 'app', id: '1' },
+              { type: 'app', id: '2' },
+              { type: 'app', id: '3' },
+            ],
+          },
+        });
+      });
+    });
+
+    // mutate each relationship
+    // we change the app for each config to either null or a different app
+    // we remove each namespace from the app
+    store._join(() => {
+      ['1', '2', '3', '4'].forEach((id) => {
+        graph.update({
+          op: 'replaceRelatedRecord',
+          field: 'app',
+          record: identifier('config', id),
+          value: id === '1' || id === '2' ? null : identifier('app', '2'),
+        });
+      });
+      graph.update({
+        op: 'replaceRelatedRecords',
+        field: 'namespaces',
+        record: appIdentifier,
+        value: [],
+      });
+    });
+
+    // assert app relationships
+    let configRelationship = graph.getData(appIdentifier, 'configs');
+    assert.arrayStrictEquals(configRelationship.data, [], 'configs are correct');
+
+    let namespaceRelationship = graph.getData(appIdentifier, 'namespaces');
+    assert.arrayStrictEquals(namespaceRelationship.data, [], 'namespaces are correct');
+
+    // assert config relationships
+    ['1', '2', '3', '4'].forEach((id) => {
+      const configIdentifier = identifier('config', id);
+      const appRelationship = graph.getData(configIdentifier, 'app');
+      assert.deepEqual(
+        appRelationship.data,
+        id === '1' || id === '2' ? null : identifier('app', '2'),
+        `config ${id} app relationship is correct`
+      );
+    });
+
+    // assert namespace relationships
+    ['1', '2', '3', '4'].forEach((id) => {
+      const namespaceIdentifier = identifier('namespace', id);
+      const appRelationship = graph.getData(namespaceIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        appRelationship.data,
+        [identifier('app', '2'), identifier('app', '3')],
+        `namespace ${id} apps relationship is correct`
+      );
+    });
+
+    // updateRelationship from the collection side
+    // this should not clear the local state
+    // so the configs should still be empty or have the new app
+    // and the namespaces should still have the app removed
+    store._join(() => {
+      graph.push({
+        op: 'updateRelationship',
+        field: 'configs',
+        record: appIdentifier,
+        value: {
+          data: [
+            { type: 'config', id: '1' },
+            { type: 'config', id: '2' },
+            { type: 'config', id: '3' },
+            { type: 'config', id: '4' },
+          ],
+        },
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'namespaces',
+        record: appIdentifier,
+        value: {
+          data: [
+            { type: 'namespace', id: '1' },
+            { type: 'namespace', id: '2' },
+            { type: 'namespace', id: '3' },
+            { type: 'namespace', id: '4' },
+          ],
+        },
+      });
+    });
+
+    // assert app relationships
+    configRelationship = graph.getData(appIdentifier, 'configs');
+    assert.arrayStrictEquals(configRelationship.data, [], 'configs are correct');
+
+    namespaceRelationship = graph.getData(appIdentifier, 'namespaces');
+    assert.arrayStrictEquals(namespaceRelationship.data, [], 'namespaces are correct');
+
+    // assert config relationships
+    ['1', '2', '3', '4'].forEach((id) => {
+      const configIdentifier = identifier('config', id);
+      const appRelationship = graph.getData(configIdentifier, 'app');
+      assert.deepEqual(
+        appRelationship.data,
+        id === '1' || id === '2' ? null : identifier('app', '2'),
+        `config ${id} app relationship is correct`
+      );
+    });
+
+    // assert namespace relationships
+    ['1', '2', '3', '4'].forEach((id) => {
+      const namespaceIdentifier = identifier('namespace', id);
+      const appRelationship = graph.getData(namespaceIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        appRelationship.data,
+        [identifier('app', '2'), identifier('app', '3')],
+        `namespace ${id} apps relationship is correct`
+      );
+    });
+
+    // Commit the dirty state
+    store._join(() => {
+      ['1', '2', '3', '4'].forEach((id) => {
+        let record = identifier('config', id);
+        graph.push({
+          op: 'updateRelationship',
+          field: 'app',
+          record,
+          value: graph.getData(record, 'app'),
+        });
+
+        record = identifier('namespace', id);
+        graph.push({
+          op: 'updateRelationship',
+          field: 'apps',
+          record,
+          value: graph.getData(record, 'apps'),
+        });
+      });
+    });
+
+    // Ensure our state is still the same
+    // assert app relationships
+    configRelationship = graph.getData(appIdentifier, 'configs');
+    assert.arrayStrictEquals(configRelationship.data, [], 'configs are correct');
+
+    namespaceRelationship = graph.getData(appIdentifier, 'namespaces');
+    assert.arrayStrictEquals(namespaceRelationship.data, [], 'namespaces are correct');
+
+    // assert config relationships
+    ['1', '2', '3', '4'].forEach((id) => {
+      const configIdentifier = identifier('config', id);
+      const appRelationship = graph.getData(configIdentifier, 'app');
+      assert.deepEqual(
+        appRelationship.data,
+        id === '1' || id === '2' ? null : identifier('app', '2'),
+        `config ${id} app relationship is correct`
+      );
+    });
+
+    // assert namespace relationships
+    ['1', '2', '3', '4'].forEach((id) => {
+      const namespaceIdentifier = identifier('namespace', id);
+      const appRelationship = graph.getData(namespaceIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        appRelationship.data,
+        [identifier('app', '2'), identifier('app', '3')],
+        `namespace ${id} apps relationship is correct`
+      );
+    });
+
+    // push a new state from the server
+    // there should be no local state left, so this should result
+    // in the observable state matching the new remote state
+    // however the order of the namespaces should now be different
+    store._join(() => {
+      graph.push({
+        op: 'updateRelationship',
+        field: 'configs',
+        record: appIdentifier,
+        value: {
+          data: [
+            { type: 'config', id: '1' },
+            { type: 'config', id: '2' },
+            { type: 'config', id: '3' },
+            { type: 'config', id: '4' },
+          ],
+        },
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'namespaces',
+        record: appIdentifier,
+        value: {
+          data: [
+            { type: 'namespace', id: '1' },
+            { type: 'namespace', id: '2' },
+            { type: 'namespace', id: '3' },
+            { type: 'namespace', id: '4' },
+          ],
+        },
+      });
+    });
+
+    // assert app relationships
+    configRelationship = graph.getData(appIdentifier, 'configs');
+    assert.arrayStrictEquals(
+      configRelationship.data,
+      [identifier('config', '1'), identifier('config', '2'), identifier('config', '3'), identifier('config', '4')],
+      'configs are correct'
+    );
+
+    namespaceRelationship = graph.getData(appIdentifier, 'namespaces');
+    assert.arrayStrictEquals(
+      namespaceRelationship.data,
+      [
+        identifier('namespace', '1'),
+        identifier('namespace', '2'),
+        identifier('namespace', '3'),
+        identifier('namespace', '4'),
+      ],
+      'namespaces are correct'
+    );
+
+    // assert config relationships
+    ['1', '2', '3', '4'].forEach((id) => {
+      const configIdentifier = identifier('config', id);
+      const appRelationship = graph.getData(configIdentifier, 'app');
+      assert.deepEqual(appRelationship.data, identifier('app', '1'), `config ${id} app relationship is correct`);
+    });
+
+    // assert namespace relationships
+    ['1', '2', '3', '4'].forEach((id) => {
+      const namespaceIdentifier = identifier('namespace', id);
+      const appRelationship = graph.getData(namespaceIdentifier, 'apps');
+      assert.arrayStrictEquals(
+        appRelationship.data,
+        [identifier('app', '2'), identifier('app', '3'), identifier('app', '1')],
+        `namespace ${id} apps relationship is correct`
+      );
+    });
+  });
+
+  test('updateRelationship operation from the belongsTo side does not clear local state when `resetOnRemoteUpdate: false` is set', function (assert: Assert) {
+    // tests that One:Many, One:One do not clear local state from
+    // either side when updating the relationship from the One side
+    // we set the flag on the inverse to ensure that we detect this
+    // from either side
+    const { owner } = this;
+
+    class App extends Model {
+      @attr declare name: string;
+      @belongsTo('config', { async: false, inverse: 'app' }) declare config: Config[];
+      @belongsTo('namespace', { async: false, inverse: 'apps' }) declare namespace: Namespace | null;
+      @belongsTo('cluster', { async: false, inverse: 'app' }) declare cluster: Cluster | null;
+    }
+    class Cluster extends Model {
+      @attr declare name: string;
+      @belongsTo('app', { async: false, inverse: 'cluster', resetOnRemoteUpdate: false }) declare app: App | null;
+    }
+
+    class Namespace extends Model {
+      @attr declare name: string;
+      @hasMany('app', { async: false, inverse: 'namespace', resetOnRemoteUpdate: false }) declare apps: App[];
+    }
+
+    class Config extends Model {
+      @attr declare name: string;
+      @belongsTo('app', { async: false, inverse: 'config', resetOnRemoteUpdate: false }) declare app: App | null;
+    }
+
+    function identifier(type: string, id: string) {
+      return store.identifierCache.getOrCreateRecordIdentifier({ type, id });
+    }
+
+    owner.register('model:app', App);
+    owner.register('model:namespace', Namespace);
+    owner.register('model:config', Config);
+    owner.register('model:cluster', Cluster);
+    const store = owner.lookup('service:store') as unknown as Store;
+    const graph = graphFor(store);
+    const appIdentifier = identifier('app', '1');
+    const configIdentifier = identifier('config', '1');
+    const clusterIdentifier = identifier('cluster', '1');
+    const namespaceIdentifier = identifier('namespace', '1');
+
+    // set initial state
+    // one app, with 1 config, 1 cluster and 1 namespace
+    // the config belongs to the app
+    // the cluster belongs to the app
+    // the namespace has the app and 2 more apps
+    store._join(() => {
+      // setup primary app relationships
+      // this also convers the belongsTo side on config
+      graph.push({
+        op: 'updateRelationship',
+        field: 'config',
+        record: appIdentifier,
+        value: {
+          data: { type: 'config', id: '1' },
+        },
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'cluster',
+        record: appIdentifier,
+        value: {
+          data: { type: 'cluster', id: '1' },
+        },
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'namespace',
+        record: appIdentifier,
+        value: {
+          data: { type: 'namespace', id: '1' },
+        },
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'apps',
+        record: identifier('namespace', '1'),
+        value: {
+          data: [
+            { type: 'app', id: '1' },
+            { type: 'app', id: '2' },
+            { type: 'app', id: '3' },
+          ],
+        },
+      });
+    });
+
+    // mutate each relationship
+    // we change the app for the config null
+    // we change the app for the cluster to a different app
+    // we remove the app from the namespace
+    store._join(() => {
+      graph.update({
+        op: 'replaceRelatedRecord',
+        field: 'app',
+        record: identifier('config', '1'),
+        value: null,
+      });
+      graph.update({
+        op: 'removeFromRelatedRecords',
+        field: 'apps',
+        record: identifier('namespace', '1'),
+        value: appIdentifier,
+      });
+      graph.update({
+        op: 'replaceRelatedRecord',
+        field: 'app',
+        record: identifier('cluster', '1'),
+        value: identifier('app', '3'),
+      });
+    });
+
+    // assert app relationships
+    let configRelationship = graph.getData(appIdentifier, 'config');
+    assert.strictEqual(configRelationship.data, null, 'config is correct');
+    let clusterRelationship = graph.getData(appIdentifier, 'cluster');
+    assert.deepEqual(clusterRelationship.data, null, 'cluster is correct');
+    let namespaceRelationship = graph.getData(appIdentifier, 'namespace');
+    assert.deepEqual(namespaceRelationship.data, null, 'namespace is correct');
+
+    // assert config relationships
+    let appRelationship = graph.getData(configIdentifier, 'app');
+    assert.strictEqual(appRelationship.data, null, 'config app relationship is correct');
+    let clusterAppRelationship = graph.getData(clusterIdentifier, 'app');
+    assert.deepEqual(clusterAppRelationship.data, identifier('app', '3'), 'cluster app relationship is correct');
+    let namespaceAppsRelationship = graph.getData(namespaceIdentifier, 'apps');
+    assert.arrayStrictEquals(
+      namespaceAppsRelationship.data,
+      [identifier('app', '2'), identifier('app', '3')],
+      'namespace apps relationship is correct'
+    );
+
+    // update the belongsTo side
+    // this should not clear the local state
+    store._join(() => {
+      graph.push({
+        op: 'updateRelationship',
+        field: 'config',
+        record: appIdentifier,
+        value: {
+          data: { type: 'config', id: '1' },
+        },
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'cluster',
+        record: appIdentifier,
+        value: {
+          data: { type: 'cluster', id: '1' },
+        },
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'namespace',
+        record: appIdentifier,
+        value: {
+          data: { type: 'namespace', id: '1' },
+        },
+      });
+    });
+
+    // assert app relationships
+    configRelationship = graph.getData(appIdentifier, 'config');
+    assert.strictEqual(configRelationship.data, null, 'config is correct');
+    clusterRelationship = graph.getData(appIdentifier, 'cluster');
+    assert.deepEqual(clusterRelationship.data, null, 'cluster is correct');
+    namespaceRelationship = graph.getData(appIdentifier, 'namespace');
+    assert.deepEqual(namespaceRelationship.data, null, 'namespace is correct');
+
+    // assert config relationships
+    appRelationship = graph.getData(configIdentifier, 'app');
+    assert.strictEqual(appRelationship.data, null, 'config app relationship is correct');
+    clusterAppRelationship = graph.getData(clusterIdentifier, 'app');
+    assert.deepEqual(clusterAppRelationship.data, identifier('app', '3'), 'cluster app relationship is correct');
+    namespaceAppsRelationship = graph.getData(namespaceIdentifier, 'apps');
+    assert.arrayStrictEquals(
+      namespaceAppsRelationship.data,
+      [identifier('app', '2'), identifier('app', '3')],
+      'namespace apps relationship is correct'
+    );
+
+    // Commit the dirty state
+    store._join(() => {
+      graph.push({
+        op: 'updateRelationship',
+        field: 'app',
+        record: configIdentifier,
+        value: graph.getData(configIdentifier, 'app'),
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'app',
+        record: clusterIdentifier,
+        value: graph.getData(clusterIdentifier, 'app'),
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'apps',
+        record: namespaceIdentifier,
+        value: graph.getData(namespaceIdentifier, 'apps'),
+      });
+    });
+
+    // Ensure our state is still the same
+    // assert app relationships
+    configRelationship = graph.getData(appIdentifier, 'config');
+    assert.strictEqual(configRelationship.data, null, 'config is correct');
+    clusterRelationship = graph.getData(appIdentifier, 'cluster');
+    assert.deepEqual(clusterRelationship.data, null, 'cluster is correct');
+    namespaceRelationship = graph.getData(appIdentifier, 'namespace');
+    assert.deepEqual(namespaceRelationship.data, null, 'namespace is correct');
+
+    // assert config relationships
+    appRelationship = graph.getData(configIdentifier, 'app');
+    assert.strictEqual(appRelationship.data, null, 'config app relationship is correct');
+    clusterAppRelationship = graph.getData(clusterIdentifier, 'app');
+    assert.deepEqual(clusterAppRelationship.data, identifier('app', '3'), 'cluster app relationship is correct');
+    namespaceAppsRelationship = graph.getData(namespaceIdentifier, 'apps');
+    assert.arrayStrictEquals(
+      namespaceAppsRelationship.data,
+      [identifier('app', '2'), identifier('app', '3')],
+      'namespace apps relationship is correct'
+    );
+
+    // push a new state from the server
+    // there should be no local state left, so this should result
+    // in the observable state matching the new remote state
+    // however the order of the namespaces should now be different
+    // since we removed the app from the namespace
+    // and then readd it
+    // without receiving a new ordering for the array from the API
+    store._join(() => {
+      graph.push({
+        op: 'updateRelationship',
+        field: 'config',
+        record: appIdentifier,
+        value: {
+          data: { type: 'config', id: '1' },
+        },
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'cluster',
+        record: appIdentifier,
+        value: {
+          data: { type: 'cluster', id: '1' },
+        },
+      });
+      graph.push({
+        op: 'updateRelationship',
+        field: 'namespace',
+        record: appIdentifier,
+        value: {
+          data: { type: 'namespace', id: '1' },
+        },
+      });
+    });
+
+    // assert app relationships
+    configRelationship = graph.getData(appIdentifier, 'config');
+    assert.strictEqual(configRelationship.data, configIdentifier, 'config is correct');
+    clusterRelationship = graph.getData(appIdentifier, 'cluster');
+    assert.deepEqual(clusterRelationship.data, clusterIdentifier, 'cluster is correct');
+    namespaceRelationship = graph.getData(appIdentifier, 'namespace');
+    assert.deepEqual(namespaceRelationship.data, namespaceIdentifier, 'namespace is correct');
+
+    // assert config relationships
+    appRelationship = graph.getData(configIdentifier, 'app');
+    assert.strictEqual(appRelationship.data, appIdentifier, 'config app relationship is correct');
+    clusterAppRelationship = graph.getData(clusterIdentifier, 'app');
+    assert.deepEqual(clusterAppRelationship.data, appIdentifier, 'cluster app relationship is correct');
+    namespaceAppsRelationship = graph.getData(namespaceIdentifier, 'apps');
+    assert.arrayStrictEquals(
+      namespaceAppsRelationship.data,
+      [identifier('app', '2'), identifier('app', '3'), appIdentifier],
+      'namespace apps relationship is correct'
+    );
+  });
+});

--- a/tests/main/tests/integration/adapter/rest-adapter-test.js
+++ b/tests/main/tests/integration/adapter/rest-adapter-test.js
@@ -427,9 +427,9 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
       posts: { id: '1', name: 'Not everyone uses Rails', comments: [2] },
     });
 
-    await store.findRecord('comment', 2);
-    let post = await store.findRecord('post', 1);
-    let newComment = store.peekRecord('comment', 2);
+    await store.findRecord('comment', '2');
+    let post = await store.findRecord('post', '1');
+    let newComment = store.peekRecord('comment', '2');
     let comments = post.comments;
 
     // Replace the comment with a new one

--- a/tests/main/tests/integration/records/unload-test.js
+++ b/tests/main/tests/integration/records/unload-test.js
@@ -719,7 +719,7 @@ module('integration/unload - Unloading Records', function (hooks) {
   });
 
   test('unloadAll(type) does not leave stranded internalModels in relationships (rediscover via store.push)', async function (assert) {
-    assert.expect(13);
+    assert.expect(16);
 
     let person = store.push({
       data: {
@@ -749,7 +749,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     let boatPerson = await boat.person;
 
     assert.strictEqual(relationshipState.remoteState.length, 1, 'remoteMembers size should be 1');
-    assert.strictEqual(relationshipState.localMembers.size, 1, 'localMembers size should be 1');
+    assert.strictEqual(relationshipState.additions, null, 'additions should be empty');
+    assert.strictEqual(relationshipState.removals, null, 'removals should be empty');
     assert.strictEqual(get(peopleBoats, 'length'), 1, 'Our person has a boat');
     assert.strictEqual(peopleBoats.at(0), boat, 'Our person has the right boat');
     assert.strictEqual(boatPerson, person, 'Our boat has the right person');
@@ -760,7 +761,8 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     // ensure that our new state is correct
     assert.strictEqual(relationshipState.remoteState.length, 1, 'remoteMembers size should still be 1');
-    assert.strictEqual(relationshipState.localMembers.size, 1, 'localMembers size should still be 1');
+    assert.strictEqual(relationshipState.additions, null, 'additions should be empty');
+    assert.strictEqual(relationshipState.removals, null, 'removals should be empty');
     assert.strictEqual(get(peopleBoats, 'length'), 0, 'Our person thinks they have no boats');
 
     run(() =>
@@ -773,7 +775,8 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     // ensure that our new state is correct
     assert.strictEqual(relationshipState.remoteState.length, 1, 'remoteMembers size should still be 1');
-    assert.strictEqual(relationshipState.localMembers.size, 1, 'localMembers size should still be 1');
+    assert.strictEqual(relationshipState.additions, null, 'additions should be empty');
+    assert.strictEqual(relationshipState.removals, null, 'removals should be empty');
     assert.strictEqual(get(peopleBoats, 'length'), 1, 'Our person has their boats');
   });
 

--- a/tests/main/tests/integration/records/unload-test.js
+++ b/tests/main/tests/integration/records/unload-test.js
@@ -781,7 +781,7 @@ module('integration/unload - Unloading Records', function (hooks) {
   });
 
   test('unloadAll(type) does not leave stranded internalModels in relationships (rediscover via relationship reload)', async function (assert) {
-    assert.expect(15);
+    assert.expect(18);
 
     adapter.findRecord = (store, type, id) => {
       assert.strictEqual(type.modelName, 'boat', 'We refetch the boat');
@@ -818,7 +818,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     let boatPerson = await boat.person;
 
     assert.strictEqual(relationshipState.remoteState.length, 1, 'remoteMembers size should be 1');
-    assert.strictEqual(relationshipState.localMembers.size, 1, 'localMembers size should be 1');
+    assert.strictEqual(relationshipState.additions, null, 'additions should be empty');
+    assert.strictEqual(relationshipState.removals, null, 'removals should be empty');
     assert.strictEqual(peopleBoats.length, 1, 'Our person has a boat');
     assert.strictEqual(peopleBoats.at(0), boat, 'Our person has the right boat');
     assert.strictEqual(boatPerson, person, 'Our boat has the right person');
@@ -828,7 +829,8 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     // ensure that our new state is correct
     assert.strictEqual(relationshipState.remoteState.length, 1, 'remoteMembers size should still be 1');
-    assert.strictEqual(relationshipState.localMembers.size, 1, 'localMembers size should still be 1');
+    assert.strictEqual(relationshipState.additions, null, 'additions should be empty');
+    assert.strictEqual(relationshipState.removals, null, 'removals should be empty');
     assert.strictEqual(peopleBoats.length, 0, 'Our person thinks they have no boats');
 
     await person.boats;
@@ -836,7 +838,8 @@ module('integration/unload - Unloading Records', function (hooks) {
     store.peekRecord('boat', '1');
 
     assert.strictEqual(relationshipState.remoteState.length, 1, 'remoteMembers size should still be 1');
-    assert.strictEqual(relationshipState.localMembers.size, 1, 'localMembers size should still be 1');
+    assert.strictEqual(relationshipState.additions, null, 'additions should be empty');
+    assert.strictEqual(relationshipState.removals, null, 'removals should be empty');
     assert.strictEqual(peopleBoats.length, 1, 'Our person has their boats');
   });
 

--- a/tests/main/tests/integration/relationships/has-many-test.js
+++ b/tests/main/tests/integration/relationships/has-many-test.js
@@ -2461,43 +2461,28 @@ If using this relationship in a polymorphic manner is desired, the relationships
     assert.strictEqual(run(post, 'get', 'comments.length'), 0);
   });
 
-  test('If reordered hasMany data has been pushed to the store, the many array reflects the ordering change - sync', function (assert) {
+  test('If reordered hasMany data has been pushed to the store, the many array reflects the ordering change - sync', async function (assert) {
     let store = this.owner.lookup('service:store');
 
-    let comment1, comment2, comment3, comment4;
-    let post;
-
-    run(() => {
-      store.push({
-        data: [
-          {
-            type: 'comment',
-            id: '1',
-          },
-          {
-            type: 'comment',
-            id: '2',
-          },
-          {
-            type: 'comment',
-            id: '3',
-          },
-          {
-            type: 'comment',
-            id: '4',
-          },
-        ],
-      });
-
-      comment1 = store.peekRecord('comment', 1);
-      comment2 = store.peekRecord('comment', 2);
-      comment3 = store.peekRecord('comment', 3);
-      comment4 = store.peekRecord('comment', 4);
-    });
-
-    run(() => {
-      store.push({
-        data: {
+    const [comment1, comment2, comment3, comment4, post] = store.push({
+      data: [
+        {
+          type: 'comment',
+          id: '1',
+        },
+        {
+          type: 'comment',
+          id: '2',
+        },
+        {
+          type: 'comment',
+          id: '3',
+        },
+        {
+          type: 'comment',
+          id: '4',
+        },
+        {
           type: 'post',
           id: '1',
           relationships: {
@@ -2509,103 +2494,99 @@ If using this relationship in a polymorphic manner is desired, the relationships
             },
           },
         },
-      });
-      post = store.peekRecord('post', 1);
-
-      assert.deepEqual(post.comments.slice(), [comment1, comment2], 'Initial ordering is correct');
+      ],
     });
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'post',
-          id: '1',
-          relationships: {
-            comments: {
-              data: [
-                { type: 'comment', id: '2' },
-                { type: 'comment', id: '1' },
-              ],
-            },
+    assert.arrayStrictEquals(post.comments.slice(), [comment1, comment2], 'Initial ordering is correct');
+
+    store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        relationships: {
+          comments: {
+            data: [
+              { type: 'comment', id: '2' },
+              { type: 'comment', id: '1' },
+            ],
           },
         },
-      });
+      },
     });
-    assert.deepEqual(post.comments.slice(), [comment2, comment1], 'Updated ordering is correct');
+    assert.arrayStrictEquals(post.comments.slice(), [comment2, comment1], 'Updated ordering is correct');
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'post',
-          id: '1',
-          relationships: {
-            comments: {
-              data: [{ type: 'comment', id: '2' }],
-            },
+    store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        relationships: {
+          comments: {
+            data: [{ type: 'comment', id: '2' }],
           },
         },
-      });
+      },
     });
-    assert.deepEqual(post.comments.slice(), [comment2], 'Updated ordering is correct');
+    assert.arrayStrictEquals(post.comments.slice(), [comment2], 'Updated ordering is correct');
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'post',
-          id: '1',
-          relationships: {
-            comments: {
-              data: [
-                { type: 'comment', id: '1' },
-                { type: 'comment', id: '2' },
-                { type: 'comment', id: '3' },
-                { type: 'comment', id: '4' },
-              ],
-            },
+    store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        relationships: {
+          comments: {
+            data: [
+              { type: 'comment', id: '1' },
+              { type: 'comment', id: '2' },
+              { type: 'comment', id: '3' },
+              { type: 'comment', id: '4' },
+            ],
           },
         },
-      });
+      },
     });
-    assert.deepEqual(post.comments.slice(), [comment1, comment2, comment3, comment4], 'Updated ordering is correct');
+    assert.arrayStrictEquals(
+      post.comments.slice(),
+      [comment1, comment2, comment3, comment4],
+      'Updated ordering is correct'
+    );
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'post',
-          id: '1',
-          relationships: {
-            comments: {
-              data: [
-                { type: 'comment', id: '4' },
-                { type: 'comment', id: '3' },
-              ],
-            },
+    store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        relationships: {
+          comments: {
+            data: [
+              { type: 'comment', id: '4' },
+              { type: 'comment', id: '3' },
+            ],
           },
         },
-      });
+      },
     });
-    assert.deepEqual(post.comments.slice(), [comment4, comment3], 'Updated ordering is correct');
+    assert.arrayStrictEquals(post.comments.slice(), [comment4, comment3], 'Updated ordering is correct');
 
-    run(() => {
-      store.push({
-        data: {
-          type: 'post',
-          id: '1',
-          relationships: {
-            comments: {
-              data: [
-                { type: 'comment', id: '4' },
-                { type: 'comment', id: '2' },
-                { type: 'comment', id: '3' },
-                { type: 'comment', id: '1' },
-              ],
-            },
+    store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        relationships: {
+          comments: {
+            data: [
+              { type: 'comment', id: '4' },
+              { type: 'comment', id: '2' },
+              { type: 'comment', id: '3' },
+              { type: 'comment', id: '1' },
+            ],
           },
         },
-      });
+      },
     });
-
-    assert.deepEqual(post.comments.slice(), [comment4, comment2, comment3, comment1], 'Updated ordering is correct');
+    assert.arrayStrictEquals(
+      post.comments.slice(),
+      [comment4, comment2, comment3, comment1],
+      'Updated ordering is correct'
+    );
   });
 
   test('Rollbacking attributes for deleted record restores implicit relationship correctly when the hasMany side has been deleted - async', async function (assert) {
@@ -4043,49 +4024,58 @@ If using this relationship in a polymorphic manner is desired, the relationships
     assert.strictEqual(commentsAgain.length, 2, 'comments have 2 length');
   });
 
-  test('Pushing a relationship with duplicate identifiers results in a single entry for the record in the relationship', async function (assert) {
-    class PhoneUser extends Model {
-      @hasMany('phone-number', { async: false, inverse: null })
-      phoneNumbers;
-      @attr name;
-    }
-    class PhoneNumber extends Model {
-      @attr number;
-    }
-    const { owner } = this;
+  deprecatedTest(
+    'Pushing a relationship with duplicate identifiers results in a single entry for the record in the relationship',
+    {
+      id: 'ember-data:deprecate-non-unique-relationship-entries',
+      until: '6.0',
+      count: 1,
+      refactor: true, // should assert
+    },
+    async function (assert) {
+      class PhoneUser extends Model {
+        @hasMany('phone-number', { async: false, inverse: null })
+        phoneNumbers;
+        @attr name;
+      }
+      class PhoneNumber extends Model {
+        @attr number;
+      }
+      const { owner } = this;
 
-    owner.register('model:phone-user', PhoneUser);
-    owner.register('model:phone-number', PhoneNumber);
+      owner.register('model:phone-user', PhoneUser);
+      owner.register('model:phone-number', PhoneNumber);
 
-    const store = owner.lookup('service:store');
+      const store = owner.lookup('service:store');
 
-    store.push({
-      data: {
-        id: 'call-me-anytime',
-        type: 'phone-number',
-        attributes: {
-          number: '1-800-DATA',
-        },
-      },
-    });
-
-    const person = store.push({
-      data: {
-        id: '1',
-        type: 'phone-user',
-        attributes: {},
-        relationships: {
-          phoneNumbers: {
-            data: [
-              { type: 'phone-number', id: 'call-me-anytime' },
-              { type: 'phone-number', id: 'call-me-anytime' },
-              { type: 'phone-number', id: 'call-me-anytime' },
-            ],
+      store.push({
+        data: {
+          id: 'call-me-anytime',
+          type: 'phone-number',
+          attributes: {
+            number: '1-800-DATA',
           },
         },
-      },
-    });
+      });
 
-    assert.strictEqual(person.phoneNumbers.length, 1);
-  });
+      const person = store.push({
+        data: {
+          id: '1',
+          type: 'phone-user',
+          attributes: {},
+          relationships: {
+            phoneNumbers: {
+              data: [
+                { type: 'phone-number', id: 'call-me-anytime' },
+                { type: 'phone-number', id: 'call-me-anytime' },
+                { type: 'phone-number', id: 'call-me-anytime' },
+              ],
+            },
+          },
+        },
+      });
+
+      assert.strictEqual(person.phoneNumbers.length, 1);
+    }
+  );
 });

--- a/tests/main/tests/integration/relationships/many-to-many-test.js
+++ b/tests/main/tests/integration/relationships/many-to-many-test.js
@@ -568,7 +568,7 @@ module('integration/relationships/many_to_many_test - ManyToMany relationships',
       let state = account.hasMany('users').hasManyRelationship.remoteState;
       let users = account.users;
 
-      assert.todo.equal(users.length, 1, 'Accounts were updated correctly (ui state)');
+      assert.todo.strictEqual(users.length, 1, 'Accounts were updated correctly (ui state)');
       assert.todo.deepEqual(
         users.map((r) => get(r, 'id')),
         ['1'],

--- a/tests/main/tests/test-helper.js
+++ b/tests/main/tests/test-helper.js
@@ -13,7 +13,7 @@ import customQUnitAdapter from '@ember-data/unpublished-test-infra/test-support/
 import Application from '../app';
 import config from '../config/environment';
 
-QUnit.dump.maxDepth = 3;
+QUnit.dump.maxDepth = 5;
 setup(QUnit.assert);
 
 configureAsserts();

--- a/tests/main/tests/unit/model/relationships/belongs-to-test.js
+++ b/tests/main/tests/unit/model/relationships/belongs-to-test.js
@@ -441,7 +441,7 @@ module('unit/model/relationships - belongsTo', function (hooks) {
       id: 'ember-data:deprecate-relationship-remote-update-clearing-local-state',
       until: '6.0',
       count: 1,
-      refactor: true, // should probably assert against this scenario in dev at the cache level by comparing to in-flight state
+      refactor: true, // we assert against this scenario in dev at the cache level by comparing to in-flight state
     },
     async function (assert) {
       class Tag extends Model {

--- a/tests/main/tests/unit/model/relationships/has-many-test.js
+++ b/tests/main/tests/unit/model/relationships/has-many-test.js
@@ -2077,11 +2077,11 @@ module('unit/model/relationships - hasMany', function (hooks) {
     );
 
     await shen.destroyRecord({});
-    // were ember-data to now preserve local edits during a relationship push, this would be '2'
+    // were ember-data to now preserve local edits during a relationship push, this would be 2 pets
     assert.deepEqual(
       pets.map((p) => p.id),
-      ['2'],
-      'relationship now has only one pet, we lost the local change'
+      ['2'], // ['2', '3'],
+      'we only have one pet' // 'relationship has two pets, we kept the local change'
     );
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,6 @@
       "ember-data-types/q/ember-data-json-api.ts",
       "tests/graph/tests/integration/graph/polymorphism/implicit-keys-test.ts",
       "tests/graph/tests/integration/graph/graph-test.ts",
-      "tests/graph/tests/integration/graph/operations-test.ts",
       "tests/graph/tests/integration/graph/edge-test.ts",
       "tests/graph/tests/integration/graph/edge-removal/setup.ts",
       "tests/graph/tests/integration/graph/edge-removal/helpers.ts",


### PR DESCRIPTION
- Attempts to implement diffing without the lazy semantics in #8806
- Mostly ports #7521 / #8131 
- Deprecates non-unique hasMany relationship payloads
- Deprecates legacy relationship remote state resets local state semantics
- did not require deprecating missing-being-considered-empty 

This currently passes the Graph tests and mostly passes the main test suite.

The implementation here is almost certainly less than ideal, but the shape is mostly correct and surfaces enough information that we ought to be able to use it for further passes at improving performance of updating ManyArray / updating the backing state / avoiding unneeded work.


TODO before merge

- [x] Test `resetOnRemoteUpdate` flag
- [x] Graph tests around local patching / inverse patching behavior
- [x] Test deprecation off paths assert
- [x] Notification tests around local patching / inverse patching behavior
- [x] Add capability or assert to Cache for belongsTo save return disagreeing with saved payload