### PR TITLE
fix: `JSONAPISerializer.shouldSerializeHasMany` relation param type

### DIFF
--- a/packages/serializer/src/json.js
+++ b/packages/serializer/src/json.js
@@ -942,7 +942,7 @@ const JSONSerializer = Serializer.extend({
     @public
     @param {Snapshot} snapshot
     @param {String} key
-    @param {String} relationshipType
+    @param {RelationshipSchema} relationship
     @return {boolean} true if the hasMany relationship should be serialized
   */
   shouldSerializeHasMany(snapshot, key, relationship) {


### PR DESCRIPTION
`##` Description

<!-- insert description here -->

Reported here: https://github.com/emberjs/data/issues/7996

JSON API Serializer `shouldSerializeHasMany` third param `relation` is of type `RelationshipSchema`.

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


