### PR TITLE
fix: graph instantiation should not be required

### DIFF
--- a/packages/-ember-data/addon/store.ts
+++ b/packages/-ember-data/addon/store.ts
@@ -1,4 +1,3 @@
-import { graphFor } from '@ember-data/graph/-private';
 import JSONAPICache from '@ember-data/json-api';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import { FetchManager } from '@ember-data/legacy-compat/-private';
@@ -20,7 +19,6 @@ export default class Store extends BaseStore {
     this.requestManager.use([LegacyNetworkHandler, Fetch]);
     this.requestManager.useCache(CacheHandler);
     this.registerSchema(buildSchema(this));
-    graphFor(this);
   }
 
   createCache(storeWrapper: CacheCapabilitiesManager): Cache {

--- a/tests/adapter-encapsulation/app/services/store.js
+++ b/tests/adapter-encapsulation/app/services/store.js
@@ -1,4 +1,3 @@
-import { graphFor } from '@ember-data/graph/-private';
 import JSONAPICache from '@ember-data/json-api';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import { FetchManager } from '@ember-data/legacy-compat/-private';
@@ -14,7 +13,6 @@ export default class Store extends BaseStore {
     this.requestManager.use([LegacyNetworkHandler, Fetch]);
     this.requestManager.useCache(CacheHandler);
     this.registerSchema(buildSchema(this));
-    this._graph = graphFor(this);
   }
 
   createCache(storeWrapper) {

--- a/tests/graph/app/services/store.ts
+++ b/tests/graph/app/services/store.ts
@@ -1,4 +1,3 @@
-import { graphFor } from '@ember-data/graph/-private';
 import JSONAPICache from '@ember-data/json-api';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import type Model from '@ember-data/model';
@@ -20,7 +19,6 @@ export default class Store extends BaseStore {
     this.requestManager.use([LegacyNetworkHandler, Fetch]);
     this.requestManager.useCache(CacheHandler);
     this.registerSchema(buildSchema(this));
-    this._graph = graphFor(this);
   }
 
   createCache(storeWrapper: CacheCapabilitiesManager): Cache {

--- a/tests/serializer-encapsulation/app/services/store.js
+++ b/tests/serializer-encapsulation/app/services/store.js
@@ -1,4 +1,3 @@
-import { graphFor } from '@ember-data/graph/-private';
 import JSONAPICache from '@ember-data/json-api';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import { FetchManager } from '@ember-data/legacy-compat/-private';
@@ -14,7 +13,6 @@ export default class Store extends BaseStore {
     this.requestManager.use([LegacyNetworkHandler, Fetch]);
     this.requestManager.useCache(CacheHandler);
     this.registerSchema(buildSchema(this));
-    this._graph = graphFor(this);
   }
 
   createCache(storeWrapper) {


### PR DESCRIPTION
While refactoring for 5.3 we'd ended up in a position where `graphFor` needed to be called from the store's constructor. We no longer need this.