### PR TITLE
fix createRecord error when no adapter is present

### DIFF
--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -675,7 +675,7 @@ class Store extends EmberObject {
         // to avoid conflicts.
 
         if (properties.id === null || properties.id === undefined) {
-          let adapter = this.adapterFor(modelName);
+          let adapter = this.adapterFor(modelName, true);
 
           if (adapter && adapter.generateIdForRecord) {
             properties.id = adapter.generateIdForRecord(this, modelName, properties);
@@ -2256,7 +2256,7 @@ class Store extends EmberObject {
     @param {String} modelName
     @return Adapter
   */
-  adapterFor(modelName: string) {
+  adapterFor(modelName: string, _allowMissing?: boolean): MinimumAdapterInterface | undefined {
     if (DEBUG) {
       assertDestroyingStore(this, 'adapterFor');
     }
@@ -2292,7 +2292,10 @@ class Store extends EmberObject {
       return adapter;
     }
 
-    assert(`No adapter was found for '${modelName}' and no 'application' adapter was found as a fallback.`);
+    assert(
+      `No adapter was found for '${modelName}' and no 'application' adapter was found as a fallback.`,
+      _allowMissing
+    );
   }
 
   /**

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -2256,7 +2256,9 @@ class Store extends EmberObject {
     @param {String} modelName
     @return Adapter
   */
-  adapterFor(modelName: string, _allowMissing?: boolean): MinimumAdapterInterface | undefined {
+  adapterFor(modelName: string): MinimumAdapterInterface;
+  adapterFor(modelName: string, _allowMissing: true): MinimumAdapterInterface | undefined;
+  adapterFor(modelName: string, _allowMissing?: true): MinimumAdapterInterface | undefined {
     if (DEBUG) {
       assertDestroyingStore(this, 'adapterFor');
     }

--- a/tests/adapter-encapsulation/tests/integration/generate-id-test.js
+++ b/tests/adapter-encapsulation/tests/integration/generate-id-test.js
@@ -98,4 +98,22 @@ module('integration/generate-id - GenerateIdForRecord Tests', function (hooks) {
 
     assert.deepEqual(record.serialize().data.attributes, props, 'record created without error');
   });
+
+  test('store.createRecord does not error if adapter is undefined.', async function (assert) {
+    let store = this.owner.lookup('service:store');
+    let expectedData = {
+      data: {
+        type: 'person',
+        attributes: {
+          firstName: 'Gaurav',
+          lastName: 'Munjal',
+        },
+      },
+    };
+
+    let props = expectedData.data.attributes;
+    let record = store.createRecord('person', props);
+
+    assert.deepEqual(record.serialize().data.attributes, props, 'record created without error');
+  });
 });


### PR DESCRIPTION
realistically we shouldn't be taking this code-path when using fully modern, though we do allow use of the legacy finders without using adapters/serializers as a potential migration path so we should still fix this.