### PR TITLE
fix: handle Immutable Response objects

### DIFF
--- a/packages/request/src/-private/context.ts
+++ b/packages/request/src/-private/context.ts
@@ -6,21 +6,21 @@ import type { Deferred, GodContext, ImmutableHeaders, ImmutableRequestInfo, Requ
 
 export function cloneResponseProperties(response: Response): ResponseInfo {
   const { headers, ok, redirected, status, statusText, type, url } = response;
-      (headers as ImmutableHeaders).clone = () => {
-        return new Headers(headers);
-      };
-      (headers as ImmutableHeaders).toJSON = () => {
-        return Array.from(headers);
-      };
-      return {
-        headers: headers as ImmutableHeaders,
-        ok,
-        redirected,
-        status,
-        statusText,
-        type,
-        url,
-      }
+  (headers as ImmutableHeaders).clone = () => {
+    return new Headers(headers);
+  };
+  (headers as ImmutableHeaders).toJSON = () => {
+    return Array.from(headers);
+  };
+  return {
+    headers: headers as ImmutableHeaders,
+    ok,
+    redirected,
+    status,
+    statusText,
+    type,
+    url,
+  };
 }
 
 export class ContextOwner {

--- a/packages/request/src/-private/context.ts
+++ b/packages/request/src/-private/context.ts
@@ -119,22 +119,8 @@ export class ContextOwner {
     }
     this.hasSetResponse = true;
     if (response instanceof Response) {
-      const { headers, ok, redirected, status, statusText, type, url } = response;
-      (headers as ImmutableHeaders).clone = () => {
-        return new Headers([...headers.entries()]);
-      };
-      (headers as ImmutableHeaders).toJSON = () => {
-        return [...headers.entries()];
-      };
-      let responseData: ResponseInfo = {
-        headers: headers as ImmutableHeaders,
-        ok,
-        redirected,
-        status,
-        statusText,
-        type,
-        url,
-      };
+      let responseData = cloneResponseProperties(response);
+
       if (DEBUG) {
         responseData = deepFreeze(responseData);
       }

--- a/packages/request/src/-private/context.ts
+++ b/packages/request/src/-private/context.ts
@@ -4,6 +4,25 @@ import { deepFreeze } from './debug';
 import { createDeferred } from './future';
 import type { Deferred, GodContext, ImmutableHeaders, ImmutableRequestInfo, RequestInfo, ResponseInfo } from './types';
 
+export function cloneResponseProperties(response: Response): ResponseInfo {
+  const { headers, ok, redirected, status, statusText, type, url } = response;
+      (headers as ImmutableHeaders).clone = () => {
+        return new Headers(headers);
+      };
+      (headers as ImmutableHeaders).toJSON = () => {
+        return Array.from(headers);
+      };
+      return {
+        headers: headers as ImmutableHeaders,
+        ok,
+        redirected,
+        status,
+        statusText,
+        type,
+        url,
+      }
+}
+
 export class ContextOwner {
   hasSetStream = false;
   hasSetResponse = false;

--- a/packages/request/src/fetch.ts
+++ b/packages/request/src/fetch.ts
@@ -46,7 +46,7 @@ const Fetch = {
   async request(context: Context) {
     let response = await _fetch(context.request.url!, context.request);
 
-    if (!response.headers.has('date1')) {
+    if (!response.headers.has('date')) {
       const headers = new Headers(response.headers);
       headers.set('date1', new Date().toUTCString());
       response = cloneResponse(response, { headers });

--- a/packages/request/src/fetch.ts
+++ b/packages/request/src/fetch.ts
@@ -48,7 +48,7 @@ const Fetch = {
 
     if (!response.headers.has('date')) {
       const headers = new Headers(response.headers);
-      headers.set('date1', new Date().toUTCString());
+      headers.set('date', new Date().toUTCString());
       response = cloneResponse(response, { headers });
     }
 

--- a/packages/request/src/fetch.ts
+++ b/packages/request/src/fetch.ts
@@ -12,7 +12,7 @@
  * @main @ember-data/request/fetch
  */
 
-import type { Context } from './-private/context';
+import { cloneResponseProperties, type Context } from './-private/context';
 
 const _fetch: typeof fetch =
   typeof fetch !== 'undefined'
@@ -22,6 +22,13 @@ const _fetch: typeof fetch =
     : ((() => {
         throw new Error('No Fetch Implementation Found');
       }) as typeof fetch);
+
+// clones a response in a way that should still
+// allow it to stream
+function cloneResponse(response: Response, overrides: Partial<Response>) {
+  const props = cloneResponseProperties(response);
+  return new Response(response.body, Object.assign(props, overrides));
+}
 /**
  * A basic handler which converts a request into a
  * `fetch` call presuming the response to be `json`.
@@ -37,10 +44,12 @@ const _fetch: typeof fetch =
  */
 const Fetch = {
   async request(context: Context) {
-    const response = await _fetch(context.request.url!, context.request);
+    let response = await _fetch(context.request.url!, context.request);
 
-    if (!response.headers.has('date')) {
-      response.headers.set('date', new Date().toUTCString());
+    if (!response.headers.has('date1')) {
+      const headers = new Headers(response.headers);
+      headers.set('date1', new Date().toUTCString());
+      response = cloneResponse(response, { headers });
     }
 
     context.setResponse(response);


### PR DESCRIPTION
Response headers returned by fetch are both readonly and Immutable:

- listed as readonly https://developer.mozilla.org/en-US/docs/Web/API/Response/headers
- spec lists it as immutable https://fetch.spec.whatwg.org/#concept-headers-guard

This clones the response, allowing us to adjust the response headers, but does so in a way that passes the stream through.