### PR TITLE
Add tests for filter-empty request util

### DIFF
--- a/packages/request-utils/src/index.ts
+++ b/packages/request-utils/src/index.ts
@@ -350,8 +350,8 @@ export function filterEmpty(source: Record<string, Serializable>): Record<string
   const result: Record<string, Serializable> = {};
   for (const key in source) {
     const value = source[key];
-    // Allow falsy values except for undefined and null
-    if (value !== undefined && value !== null) {
+    // Allow `0` and `false` but filter falsy values that indicate "empty"
+    if (value !== undefined && value !== null && value !== '') {
       if (!Array.isArray(value) || value.length > 0) {
         result[key] = source[key];
       }

--- a/packages/request-utils/src/index.ts
+++ b/packages/request-utils/src/index.ts
@@ -350,7 +350,8 @@ export function filterEmpty(source: Record<string, Serializable>): Record<string
   const result: Record<string, Serializable> = {};
   for (const key in source) {
     const value = source[key];
-    if (value) {
+    // Allow falsy values except for undefined and null
+    if (value !== undefined && value !== null) {
       if (!Array.isArray(value) || value.length > 0) {
         result[key] = source[key];
       }

--- a/tests/builders/tests/unit/filter-empty-test.ts
+++ b/tests/builders/tests/unit/filter-empty-test.ts
@@ -7,21 +7,21 @@ module('filterEmpty', function () {
     assert.deepEqual(filterEmpty({}), {});
   });
 
-  test('it returns an object with only truthy values', function (assert) {
+  test('it returns an object with truthy values and meaningful falsy values like `false` and `0`', function (assert) {
     assert.deepEqual(
       filterEmpty({
         foo: 'bar',
         baz: null,
         zero: 0,
+        booleanFalse: false,
         emptyArray: [],
         fullArray: [1, 2, 3],
-        // arrayOfEmptyArray: [[]],
-        // arrayWithEmptyArray: [[], [1, 2, 3]],
       }),
       {
+        zero: 0,
+        booleanFalse: false,
         foo: 'bar',
         fullArray: [1, 2, 3],
-        // arrayWithEmptyArray: [[], [1, 2, 3]],
       }
     );
   });

--- a/tests/builders/tests/unit/filter-empty-test.ts
+++ b/tests/builders/tests/unit/filter-empty-test.ts
@@ -14,6 +14,7 @@ module('filterEmpty', function () {
         baz: null,
         zero: 0,
         booleanFalse: false,
+        emptyString: '',
         emptyArray: [],
         fullArray: [1, 2, 3],
       }),

--- a/tests/builders/tests/unit/filter-empty-test.ts
+++ b/tests/builders/tests/unit/filter-empty-test.ts
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+
+import { filterEmpty } from '@ember-data/request-utils';
+
+module('filterEmpty', function () {
+  test('it returns an empty object when given an empty object', function (assert) {
+    assert.deepEqual(filterEmpty({}), {});
+  });
+
+  test('it returns an object with only truthy values', function (assert) {
+    assert.deepEqual(
+      filterEmpty({
+        foo: 'bar',
+        baz: null,
+        zero: 0,
+        emptyArray: [],
+        fullArray: [1, 2, 3],
+        // arrayOfEmptyArray: [[]],
+        // arrayWithEmptyArray: [[], [1, 2, 3]],
+      }),
+      {
+        foo: 'bar',
+        fullArray: [1, 2, 3],
+        // arrayWithEmptyArray: [[], [1, 2, 3]],
+      }
+    );
+  });
+});


### PR DESCRIPTION
@runspired small quick one PR here, please let me know if there is some cases I missed. Please also check if I put this file in correct place. 

there is 2 commented out fields, it fails `SerializablePrimitive` type, so I cannot even put it there... I am not sure if those should be even tested.