### PR TITLE
fix: live-array delete sync should not clear the set on length match

### DIFF
--- a/packages/store/src/-private/managers/record-array-manager.ts
+++ b/packages/store/src/-private/managers/record-array-manager.ts
@@ -404,13 +404,13 @@ function sync(
     } else {
       if (arraySet.has(key)) {
         removes.push(key);
+        arraySet.delete(key);
       }
     }
   });
   if (removes.length) {
     if (removes.length === state.length) {
       state.length = 0;
-      arraySet.clear();
       // changing the reference breaks the Proxy
       // state = array[SOURCE] = [];
     } else {

--- a/tests/main/tests/integration/records/unload-all-test.js
+++ b/tests/main/tests/integration/records/unload-all-test.js
@@ -142,8 +142,6 @@ module('Integration | Records | unloadAll', function(hooks) {
     store.unloadAll('post');
     await settled();
 
-    debugger;
-
     // round 3
     store.push({
       data: [
@@ -164,7 +162,6 @@ module('Integration | Records | unloadAll', function(hooks) {
       ]
     });
     await settled();
-    debugger;
     assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
     store.unloadAll('post');
     await settled();

--- a/tests/main/tests/integration/records/unload-all-test.js
+++ b/tests/main/tests/integration/records/unload-all-test.js
@@ -1,15 +1,21 @@
-import { setupTest } from 'ember-qunit';
-import { module, test } from 'qunit';
-import Model, { attr } from '@ember-data/model';
 import { settled } from '@ember/test-helpers';
 
-module('Integration | Records | unloadAll', function(hooks) {
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import Model, { attr } from '@ember-data/model';
+
+module('Integration | Records | unloadAll', function (hooks) {
   setupTest(hooks);
 
-  test('repeat unloadAll works when queues are given the chance to settle', async function(assert) {
-    this.owner.register('model:post', class Post extends Model {
-      @attr title;
-    });
+  test('repeat unloadAll works when queues are given the chance to settle', async function (assert) {
+    this.owner.register(
+      'model:post',
+      class Post extends Model {
+        @attr title;
+      }
+    );
     const store = this.owner.lookup('service:store');
 
     // round 1
@@ -19,17 +25,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     await settled();
     assert.strictEqual(store.peekAll('post').length, 2, 'precond - 2 posts in the store');
@@ -44,17 +50,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     await settled();
     assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
@@ -69,17 +75,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     await settled();
     assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
@@ -88,10 +94,13 @@ module('Integration | Records | unloadAll', function(hooks) {
     assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after third unloadAll');
   });
 
-  test('repeat unloadAll works when queues are given the chance to settle, no peekAll after unloadAll', async function(assert) {
-    this.owner.register('model:post', class Post extends Model {
-      @attr title;
-    });
+  test('repeat unloadAll works when queues are given the chance to settle, no peekAll after unloadAll', async function (assert) {
+    this.owner.register(
+      'model:post',
+      class Post extends Model {
+        @attr title;
+      }
+    );
     const store = this.owner.lookup('service:store');
 
     // round 1
@@ -101,17 +110,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     await settled();
     assert.strictEqual(store.peekAll('post').length, 2, 'precond - 2 posts in the store');
@@ -125,17 +134,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     await settled();
     assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
@@ -149,17 +158,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     await settled();
     assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
@@ -168,10 +177,13 @@ module('Integration | Records | unloadAll', function(hooks) {
     assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after third unloadAll');
   });
 
-  test('repeat unloadAll works when queues are given the chance to settle, no peekAll until end', async function(assert) {
-    this.owner.register('model:post', class Post extends Model {
-      @attr title;
-    });
+  test('repeat unloadAll works when queues are given the chance to settle, no peekAll until end', async function (assert) {
+    this.owner.register(
+      'model:post',
+      class Post extends Model {
+        @attr title;
+      }
+    );
     const store = this.owner.lookup('service:store');
     assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store');
 
@@ -182,17 +194,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     await settled();
     store.unloadAll('post');
@@ -205,17 +217,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     await settled();
     store.unloadAll('post');
@@ -224,10 +236,13 @@ module('Integration | Records | unloadAll', function(hooks) {
     assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after second unloadAll');
   });
 
-  test('(crazytown) repeat unloadAll works when queues are not given the chance to settle, no peekAll after unloadAll', async function(assert) {
-    this.owner.register('model:post', class Post extends Model {
-      @attr title;
-    });
+  test('(crazytown) repeat unloadAll works when queues are not given the chance to settle, no peekAll after unloadAll', async function (assert) {
+    this.owner.register(
+      'model:post',
+      class Post extends Model {
+        @attr title;
+      }
+    );
     const store = this.owner.lookup('service:store');
 
     // round 1
@@ -237,17 +252,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     assert.strictEqual(store.peekAll('post').length, 2, 'precond - 2 posts in the store');
     store.unloadAll('post');
@@ -259,17 +274,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
     store.unloadAll('post');
@@ -281,17 +296,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
     store.unloadAll('post');
@@ -301,10 +316,13 @@ module('Integration | Records | unloadAll', function(hooks) {
     assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store at the end');
   });
 
-  test('(crazytown) repeat unloadAll works when queues are not given the chance to settle, no peekAll until the end', async function(assert) {
-    this.owner.register('model:post', class Post extends Model {
-      @attr title;
-    });
+  test('(crazytown) repeat unloadAll works when queues are not given the chance to settle, no peekAll until the end', async function (assert) {
+    this.owner.register(
+      'model:post',
+      class Post extends Model {
+        @attr title;
+      }
+    );
     const store = this.owner.lookup('service:store');
 
     // round 1
@@ -314,17 +332,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     store.unloadAll('post');
 
@@ -335,17 +353,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     store.unloadAll('post');
 
@@ -356,17 +374,17 @@ module('Integration | Records | unloadAll', function(hooks) {
           type: 'post',
           id: '1',
           attributes: {
-            title: 'Lorem ipsum'
-          }
+            title: 'Lorem ipsum',
+          },
         },
         {
           type: 'post',
           id: '2',
           attributes: {
-            title: 'Lorem ipsum'
-          }
-        }
-      ]
+            title: 'Lorem ipsum',
+          },
+        },
+      ],
     });
     store.unloadAll('post');
     assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after third unloadAll');

--- a/tests/main/tests/integration/records/unload-all-test.js
+++ b/tests/main/tests/integration/records/unload-all-test.js
@@ -1,0 +1,380 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import Model, { attr } from '@ember-data/model';
+import { settled } from '@ember/test-helpers';
+
+module('Integration | Records | unloadAll', function(hooks) {
+  setupTest(hooks);
+
+  test('repeat unloadAll works when queues are given the chance to settle', async function(assert) {
+    this.owner.register('model:post', class Post extends Model {
+      @attr title;
+    });
+    const store = this.owner.lookup('service:store');
+
+    // round 1
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 2, 'precond - 2 posts in the store');
+    store.unloadAll('post');
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after first unloadAll');
+
+    // round 2
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
+    store.unloadAll('post');
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after second unloadAll');
+
+    // round 3
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
+    store.unloadAll('post');
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after third unloadAll');
+  });
+
+  test('repeat unloadAll works when queues are given the chance to settle, no peekAll after unloadAll', async function(assert) {
+    this.owner.register('model:post', class Post extends Model {
+      @attr title;
+    });
+    const store = this.owner.lookup('service:store');
+
+    // round 1
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 2, 'precond - 2 posts in the store');
+    store.unloadAll('post');
+    await settled();
+
+    // round 2
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
+    store.unloadAll('post');
+    await settled();
+
+    debugger;
+
+    // round 3
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    await settled();
+    debugger;
+    assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
+    store.unloadAll('post');
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after third unloadAll');
+  });
+
+  test('repeat unloadAll works when queues are given the chance to settle, no peekAll until end', async function(assert) {
+    this.owner.register('model:post', class Post extends Model {
+      @attr title;
+    });
+    const store = this.owner.lookup('service:store');
+    assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store');
+
+    // round 1
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    await settled();
+    store.unloadAll('post');
+    await settled();
+
+    // round 2
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    await settled();
+    store.unloadAll('post');
+    await settled();
+
+    assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after second unloadAll');
+  });
+
+  test('(crazytown) repeat unloadAll works when queues are not given the chance to settle, no peekAll after unloadAll', async function(assert) {
+    this.owner.register('model:post', class Post extends Model {
+      @attr title;
+    });
+    const store = this.owner.lookup('service:store');
+
+    // round 1
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    assert.strictEqual(store.peekAll('post').length, 2, 'precond - 2 posts in the store');
+    store.unloadAll('post');
+
+    // round 2
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
+    store.unloadAll('post');
+
+    // round 3
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    assert.strictEqual(store.peekAll('post').length, 2, '2 posts in the store');
+    store.unloadAll('post');
+    assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after third unloadAll');
+
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store at the end');
+  });
+
+  test('(crazytown) repeat unloadAll works when queues are not given the chance to settle, no peekAll until the end', async function(assert) {
+    this.owner.register('model:post', class Post extends Model {
+      @attr title;
+    });
+    const store = this.owner.lookup('service:store');
+
+    // round 1
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    store.unloadAll('post');
+
+    // round 2
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    store.unloadAll('post');
+
+    // round 3
+    store.push({
+      data: [
+        {
+          type: 'post',
+          id: '1',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        },
+        {
+          type: 'post',
+          id: '2',
+          attributes: {
+            title: 'Lorem ipsum'
+          }
+        }
+      ]
+    });
+    store.unloadAll('post');
+    assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store after third unloadAll');
+
+    await settled();
+    assert.strictEqual(store.peekAll('post').length, 0, '0 posts in the store at the end');
+  });
+});


### PR DESCRIPTION
test from #8926
resolves #8924 

adds test for unloadAll not fully cleaning up

The rough issue is that if all records are removed and the same number re-added before the array has synced we were then fully clearing membership which would make the next sync after this fail to work properly.

e.g.

```ts
arr.length; // 2
arrSet.size; // 2
<add> C
<add> D
<rem> A
<rem> B

if (rem.length === arr.length) { arrSet.clear() }

arr.length; // 2
arrSet.size; // 0
```



