### PR TITLE
chore: get last request for any record on instantiation

### DIFF
--- a/packages/model/src/-private/record-state.ts
+++ b/packages/model/src/-private/record-state.ts
@@ -238,11 +238,9 @@ export default class RecordState {
 
     // we instantiate lazily
     // so we grab anything we don't have yet
-    if (!DEBUG) {
-      const lastRequest = requests.getLastRequestForRecord(identity);
-      if (lastRequest) {
-        handleRequest(lastRequest);
-      }
+    const lastRequest = requests.getLastRequestForRecord(identity);
+    if (lastRequest) {
+      handleRequest(lastRequest);
     }
 
     this.handler = notifications.subscribe(


### PR DESCRIPTION
probably not actually a fix for anything but noticed this while poking around the `isLoaded` codepaths. We already always ran this in prod. As we move more and more away from `@ember-data/model` the odds of this occurring in dev too go up so the guard isn't needed.