### PR TITLE
docs: typo in hasChangedRelationships description

### DIFF
--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -1188,7 +1188,7 @@ export default class JSONAPICache implements Cache {
   }
 
   /**
-   * Query the cache for whether any mutated attributes exist
+   * Query the cache for whether any mutated relationships exist
    *
    * @method hasChangedRelationships
    * @public


### PR DESCRIPTION

## Description

It said "mutated attributes" but should be "mutated relationships"

## Notes for the release

-


