### PR TITLE
chore: fix recursive pnpm on node 18.18

### DIFF
--- a/packages/holodeck/bin/cmd/run.js
+++ b/packages/holodeck/bin/cmd/run.js
@@ -8,7 +8,7 @@ import fs from 'fs';
 export default async function run(args) {
   const pkg = JSON.parse(fs.readFileSync('./package.json'), 'utf8');
   const cmd = args[0];
-  const isPkgScript = args.length === 1 && pkg.scripts[cmd];
+  const isPkgScript = pkg.scripts[cmd];
 
   if (isBun) {
     await spawn(['bun', 'run', 'holodeck:start-program']);
@@ -31,6 +31,9 @@ export default async function run(args) {
     try {
       if (isPkgScript) {
         const cmdArgs = pkg.scripts[cmd].split(' ');
+        if (args.length > 1) {
+          cmdArgs.push(...args.slice(1));
+        }
         console.log({ cmdArgs });
         await spawn(cmdArgs);
       } else {

--- a/packages/holodeck/bin/cmd/run.js
+++ b/packages/holodeck/bin/cmd/run.js
@@ -3,8 +3,13 @@
 const isBun = typeof Bun !== 'undefined';
 const { process } = globalThis;
 import { spawn } from './spawn.js';
+import fs from 'fs';
 
 export default async function run(args) {
+  const pkg = JSON.parse(fs.readFileSync('./package.json'), 'utf8');
+  const cmd = args[0];
+  const isPkgScript = args.length === 1 && pkg.scripts[cmd];
+
   if (isBun) {
     await spawn(['bun', 'run', 'holodeck:start-program']);
 
@@ -24,7 +29,12 @@ export default async function run(args) {
 
     let exitCode = 0;
     try {
-      await spawn(['pnpm', 'exec', ...args]);
+      if (isPkgScript) {
+        const cmdArgs = pkg.scripts[cmd].split(' ');
+        await spawn(cmdArgs);
+      } else {
+        await spawn(['pnpm', 'exec', ...args]);
+      }
     } catch (e) {
       exitCode = e;
     }

--- a/packages/holodeck/bin/cmd/run.js
+++ b/packages/holodeck/bin/cmd/run.js
@@ -31,6 +31,7 @@ export default async function run(args) {
     try {
       if (isPkgScript) {
         const cmdArgs = pkg.scripts[cmd].split(' ');
+        console.log({ cmdArgs });
         await spawn(cmdArgs);
       } else {
         await spawn(['pnpm', 'exec', ...args]);

--- a/packages/holodeck/bin/cmd/spawn.js
+++ b/packages/holodeck/bin/cmd/spawn.js
@@ -5,6 +5,8 @@ const isBun = typeof Bun !== 'undefined';
 export async function spawn(args, options) {
   if (isBun) {
     const proc = Bun.spawn(args, {
+      env: process.env,
+      cwd: process.cwd(),
       stdout: 'inherit',
       stderr: 'inherit',
     });
@@ -33,5 +35,6 @@ export async function spawn(args, options) {
 
   await pSpawn(args.shift(), args, {
     stdio: 'inherit',
+    shell: true,
   });
 }

--- a/tests/main/package.json
+++ b/tests/main/package.json
@@ -19,8 +19,8 @@
     "holodeck:start-program": "holodeck start",
     "holodeck:end-program": "holodeck end",
     "launch:tests": "ember test --port=0 --serve --no-launch",
-    "start": "holodeck run pnpm launch:tests",
-    "test": "holodeck run pnpm examine"
+    "start": "holodeck run launch:tests",
+    "test": "holodeck run examine"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
node 18.18 bump is failing due to recursive pnpm job while running holodeck, this remove a layer of indirection to avoid that