### PR TITLE
fix: make willCommit slightly safer when race conditions occur

### DIFF
--- a/ember-data-types/q/ds-model.ts
+++ b/ember-data-types/q/ds-model.ts
@@ -33,7 +33,7 @@ export interface ModelSchema {
   relationshipsByName: Map<string, RelationshipSchema>;
   eachAttribute<T>(callback: (this: T, key: string, attribute: AttributeSchema) => void, binding?: T): void;
   eachRelationship<T>(callback: (this: T, key: string, relationship: RelationshipSchema) => void, binding?: T): void;
-  eachTransformedAttribute<T>(callback: (this: T, key: string, type?: string) => void, binding?: T): void;
+  eachTransformedAttribute<T>(callback: (this: T, key: string, type: string | null) => void, binding?: T): void;
   toString(): string;
 }
 

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -670,6 +670,40 @@ export default class JSONAPICache implements Cache {
    */
   willCommit(identifier: StableRecordIdentifier): void {
     const cached = this.__peek(identifier, false);
+
+    /*
+      if we have multiple saves in flight at once then
+      we have information loss no matter what. This
+      attempts to lose the least information.
+
+      If we were to clear inflightAttrs, previous requests
+      would not be able to use it during their didCommit.
+
+      If we upsert inflightattrs, previous requests incorrectly
+      see more recent inflight changes as part of their own and
+      will incorrectly mark the new state as the correct remote state.
+
+      We choose this latter behavior to avoid accidentally removing
+      earlier changes.
+
+      If apps do not want this behavior they can either
+
+      - chain save requests serially vs allowing concurrent saves
+      - move to using a request handler that caches the inflight state
+        on a per-request basis
+      - change their save requests to only send a "PATCH" instead of a "PUT"
+        so that only latest changes are involved in each request, and then also
+        ensure that the API or their handler reflects only those changes back
+        for upsert into the cache.
+    */
+    if (cached.inflightAttrs) {
+      if (!cached.localAttrs) {
+        return;
+      }
+      Object.assign(cached.inflightAttrs, cached.localAttrs);
+      cached.localAttrs = null;
+      return;
+    }
     cached.inflightAttrs = cached.localAttrs;
     cached.localAttrs = null;
   }

--- a/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts
@@ -8,9 +8,9 @@ import { DEBUG, TESTING } from '@ember-data/env';
 import type { Handler, NextFn } from '@ember-data/request/-private/types';
 import type Store from '@ember-data/store';
 import type { StoreRequestContext, StoreRequestInfo } from '@ember-data/store/-private/cache-handler';
-import type ShimModelClass from '@ember-data/store/-private/legacy-model-support/shim-model-class';
 import type { Collection } from '@ember-data/store/-private/record-arrays/identifier-array';
 import { SingleResourceDataDocument } from '@ember-data/types/cache/document';
+import type { ModelSchema } from '@ember-data/types/q/ds-model';
 import type {
   CollectionResourceDocument,
   JsonApiDocument,
@@ -35,7 +35,7 @@ import SnapshotRecordArray from './snapshot-record-array';
 
 type AdapterErrors = Error & { errors?: unknown[]; isAdapterError?: true; code?: string };
 type SerializerWithParseErrors = MinimumSerializerInterface & {
-  extractErrors?(store: Store, modelClass: ShimModelClass, error: AdapterErrors, recordId: string | null): unknown;
+  extractErrors?(store: Store, modelClass: ModelSchema, error: AdapterErrors, recordId: string | null): unknown;
 };
 
 const PotentialLegacyOperations = new Set([

--- a/packages/legacy-compat/src/legacy-network-handler/serializer-response.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/serializer-response.ts
@@ -2,7 +2,7 @@ import { assert } from '@ember/debug';
 
 import { DEBUG } from '@ember-data/env';
 import type Store from '@ember-data/store';
-import type ShimModelClass from '@ember-data/store/-private/legacy-model-support/shim-model-class';
+import type { ModelSchema } from '@ember-data/types/q/ds-model';
 import type { JsonApiDocument } from '@ember-data/types/q/ember-data-json-api';
 import type { AdapterPayload } from '@ember-data/types/q/minimum-adapter-interface';
 import type { MinimumSerializerInterface, RequestType } from '@ember-data/types/q/minimum-serializer-interface';
@@ -70,7 +70,7 @@ function validateDocumentStructure(doc?: AdapterPayload | JsonApiDocument): asse
 export function normalizeResponseHelper(
   serializer: MinimumSerializerInterface | null,
   store: Store,
-  modelClass: ShimModelClass,
+  modelClass: ModelSchema,
   payload: AdapterPayload,
   id: string | null,
   requestType: RequestType

--- a/packages/legacy-compat/src/legacy-network-handler/snapshot.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/snapshot.ts
@@ -32,7 +32,7 @@ type RecordId = string | null;
   @class Snapshot
   @public
 */
-export default class Snapshot implements Snapshot {
+export default class Snapshot {
   declare __attributes: Dict<unknown> | null;
   declare _belongsToRelationships: Dict<Snapshot>;
   declare _belongsToIds: Dict<RecordId>;

--- a/packages/model/src/-private/model.d.ts
+++ b/packages/model/src/-private/model.d.ts
@@ -1,0 +1,82 @@
+import type EmberObject from '@ember/object';
+
+import type { Errors } from '@ember-data/model/-private';
+import type Store from '@ember-data/store';
+
+import type { AttributeSchema, RelationshipSchema, RelationshipsSchema } from '@ember-data/types/q/record-data-schemas';
+import type { JsonApiError } from '@ember-data/types/q/record-data-json-api';
+import type HasManyReference from './references/has-many';
+import type BelongsToReference from './references/belongs-to';
+import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
+import type { LegacySupport } from './legacy-relationships-support';
+import type { Cache } from '@ember-data/types/q/cache';
+import type RecordState from './record-state';
+
+export type ModelCreateArgs = {
+  _createProps: Record<string, unknown>;
+  // TODO @deprecate consider deprecating accessing record properties during init which the below is necessary for
+  _secretInit: {
+    identifier: StableRecordIdentifier;
+    cache: Cache;
+    store: Store;
+    cb: (record: Model, cache: Cache, identifier: StableRecordIdentifier, store: Store) => void;
+  };
+};
+
+
+class Model extends EmberObject {
+  store: Store;
+  errors: Errors;
+  currentState: RecordState;
+  adapterError?: Error;
+  toString(): string;
+  save(): Promise<this>;
+  hasMany(key: string): HasManyReference;
+  belongsTo(key: string): BelongsToReference
+  eachRelationship<T>(callback: (this: T, key: string, meta: RelationshipSchema) => void, binding?: T): void;
+  eachAttribute<T>(callback: (this: T, key: string, meta: AttributeSchema) => void, binding?: T): void;
+  invalidErrorsChanged(errors: JsonApiError[]): void;
+  rollbackAttributes(): void;
+  changedAttributes(): Record<string, [unknown, unknown]>;
+  [key: string]: unknown;
+  isSaving: boolean;
+  isNew: boolean;
+  isDeleted: boolean;
+  hasDirtyAttributes: boolean;
+  deleteRecord(): void;
+  unloadRecord(): void;
+  serialize(): Record<string, unknown>;
+
+  static modelName: string;
+  static fields: Map<string, 'attribute' | 'belongsTo' | 'hasMany'>;
+  static attributes: Map<string, AttributeSchema>;
+  static relationshipsByName: Map<string, RelationshipSchema>;
+  static eachAttribute<T>(callback: (this: T, key: string, attribute: AttributeSchema) => void, binding?: T): void;
+  static eachRelationship<T>(callback: (this: T, key: string, relationship: RelationshipSchema) => void, binding?: T): void;
+  static eachTransformedAttribute<T>(callback: (this: T, key: string, type: string | null) => void, binding?: T): void;
+
+  static toString(): string;
+  static isModel: true;
+  static relationshipsObject: RelationshipsSchema;
+  static extend(...mixins: unknown[]): typeof Model;
+  static reopenClass(...mixins: unknown[]): void;
+  static create(createArgs: ModelCreateArgs): Model;
+  static __isMixin?: true;
+  static __mixin?: unknown;
+}
+
+interface Model {
+  constructor: typeof Model;
+}
+
+export default Model;
+
+export type StaticModel = typeof Model;
+
+export const LEGACY_SUPPORT: Map<StableRecordIdentifier | Model, LegacySupport>;
+
+export type ModelFactory = { class: StaticModel };
+export type FactoryCache = Record<string, ModelFactory>;
+// we put this on the store for interop because it's used by modelFor and
+// instantiateRecord as well.
+export type ModelStore = Store & { _modelFactoryCache: FactoryCache };

--- a/packages/model/src/-private/record-state.ts
+++ b/packages/model/src/-private/record-state.ts
@@ -13,7 +13,7 @@ import { addToTransaction, subscribe } from '@ember-data/tracking/-private';
 import type { Cache } from '@ember-data/types/q/cache';
 import type { StableRecordIdentifier } from '@ember-data/types/q/identifier';
 
-type Model = InstanceType<typeof import('./model')>;
+import Model from './model';
 
 const SOURCE_POINTER_REGEXP = /^\/?data\/(attributes|relationships)\/(.*)/;
 const SOURCE_POINTER_PRIMARY_REGEXP = /^\/?data/;

--- a/packages/store/src/-private/legacy-model-support/schema-definition-service.ts
+++ b/packages/store/src/-private/legacy-model-support/schema-definition-service.ts
@@ -5,6 +5,7 @@ import { importSync } from '@embroider/macros';
 
 import { DEPRECATE_STRING_ARG_SCHEMAS } from '@ember-data/deprecations';
 import type Model from '@ember-data/model';
+import type { ModelFactory } from '@ember-data/model/-private/model';
 import { HAS_MODEL_PACKAGE } from '@ember-data/packages';
 import type { RecordIdentifier } from '@ember-data/types/q/identifier';
 import type { AttributesSchema, RelationshipsSchema } from '@ember-data/types/q/record-data-schemas';
@@ -99,7 +100,7 @@ export class DSModelSchemaDefinitionService {
     relationships = this._relationshipsDefCache[modelName];
 
     if (relationships === undefined) {
-      let modelClass = this.store.modelFor(modelName);
+      let modelClass = this.store.modelFor(modelName) as typeof Model;
       relationships = modelClass.relationshipsObject || null;
       this._relationshipsDefCache[modelName] = relationships;
     }
@@ -115,7 +116,7 @@ export class DSModelSchemaDefinitionService {
   }
 }
 
-export function getModelFactory(store: Store, cache, normalizedModelName: string): Model | null {
+export function getModelFactory(store: Store, cache, normalizedModelName: string): ModelFactory | null {
   let factory = cache[normalizedModelName];
 
   if (!factory) {

--- a/packages/store/src/-private/legacy-model-support/shim-model-class.ts
+++ b/packages/store/src/-private/legacy-model-support/shim-model-class.ts
@@ -81,11 +81,11 @@ export default class ShimModelClass implements ModelSchema {
     });
   }
 
-  eachTransformedAttribute<T>(callback: (this: T | undefined, key: string, type?: string) => void, binding?: T) {
+  eachTransformedAttribute<T>(callback: (this: T | undefined, key: string, type: string | null) => void, binding?: T) {
     const attrDefs = this.__store.getSchemaDefinitionService().attributesDefinitionFor({ type: this.modelName });
     Object.keys(attrDefs).forEach((key) => {
       if (attrDefs[key]!.type) {
-        callback.call(binding, key, attrDefs[key]!.type);
+        callback.call(binding, key, attrDefs[key]?.type ?? null);
       }
     });
   }

--- a/tests/main/tests/integration/records/concurrent-save-test.ts
+++ b/tests/main/tests/integration/records/concurrent-save-test.ts
@@ -1,0 +1,320 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+import Model, { attr } from '@ember-data/model';
+import Store from '@ember-data/store';
+import { createDeferred } from '@ember-data/request';
+import type { Snapshot } from '@ember-data/legacy-compat/-private'
+
+module('Integration | Record | concurrent saves', function(hooks) {
+  setupTest(hooks);
+
+  test('Concurrent Saves do not lose inflightattr values from earlier requests', async function(assert) {
+    /*
+      inflight cache state is a broken concept. Since there can only be one concurrent inflight state
+      concurrent requests are theoretically impossible. Yet, we still allow them. Request handlers could
+      intelligently manage inflight state on a per-request basis in a way the cache could not.
+
+      This test is here to ensure we codify the current behavior of inflight data when concurrent requests
+      do occur. This test is not meant to be a test of the ideal behavior of concurrent requests.
+    */
+    class User extends Model {
+      @attr declare firstName: string;
+      @attr declare lastName: string;
+    }
+
+    const gates = [
+      createDeferred<Record<string, unknown>>(),
+      createDeferred<Record<string, unknown>>()
+    ];
+    const savePromises = [
+      createDeferred(),
+      createDeferred()
+    ];
+    const resultPromises: Promise<User>[] = [];
+    let requestCount = 0;
+
+    this.owner.register('model:user', User);
+    this.owner.register('adapter:application', class Adapter {
+      async updateRecord(_store, _schema, snapshot: Snapshot) {
+        assert.step('updateRecord');
+        if (requestCount > gates.length) {
+          throw new Error('Too many requests');
+        }
+        const promise = savePromises[requestCount];
+
+        gates[requestCount++].resolve(snapshot.attributes());
+        return promise.promise;
+      }
+      static create() { return new this(); }
+    });
+
+    const store = this.owner.lookup('service:store') as Store;
+    const user = store.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          firstName: 'Kristan',
+          lastName: 'Huff-menne'
+        }
+      }
+    }) as unknown as User;
+
+
+    user.firstName = 'Krystan';
+    resultPromises.push(user.save());
+    const serialized1 = await gates[0].promise;
+
+    assert.deepEqual(serialized1, {
+      firstName: 'Krystan',
+      lastName: 'Huff-menne'
+    }, 'inflight attrs are correct after first request');
+
+    user.lastName = 'HuffMenne';
+    resultPromises.push(user.save());
+    const serialized2 = await gates[1].promise;
+
+    assert.deepEqual(serialized2, {
+      firstName: 'Krystan',
+      lastName: 'HuffMenne'
+    }, 'inflight attrs are correct after second request');
+
+    savePromises[0].resolve({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: serialized1
+      }
+    });
+    savePromises[1].resolve({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: serialized2
+      }
+    });
+
+    await Promise.all(resultPromises);
+
+    assert.verifySteps([
+      'updateRecord',
+      'updateRecord'
+    ], 'The correct number of requests were made');
+    assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
+    assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is correct');
+    assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
+  });
+
+  test('Concurrent Saves prefers payload response over inflightattr values when the first request resolves', async function(assert) {
+/*
+      inflight cache state is a broken concept. Since there can only be one concurrent inflight state
+      concurrent requests are theoretically impossible. Yet, we still allow them. Request handlers could
+      intelligently manage inflight state on a per-request basis in a way the cache could not.
+
+      This test is here to ensure we codify the current behavior of inflight data when concurrent requests
+      do occur. This test is not meant to be a test of the ideal behavior of concurrent requests.
+    */
+      class User extends Model {
+        @attr declare firstName: string;
+        @attr declare lastName: string;
+      }
+
+      const gates = [
+        createDeferred<Record<string, unknown>>(),
+        createDeferred<Record<string, unknown>>()
+      ];
+      const savePromises = [
+        createDeferred(),
+        createDeferred()
+      ];
+      const resultPromises: Promise<User>[] = [];
+      let requestCount = 0;
+
+      this.owner.register('model:user', User);
+      this.owner.register('adapter:application', class Adapter {
+        async updateRecord(_store, _schema, snapshot: Snapshot) {
+          assert.step('updateRecord');
+          if (requestCount > gates.length) {
+            throw new Error('Too many requests');
+          }
+          const promise = savePromises[requestCount];
+
+          gates[requestCount++].resolve(snapshot.attributes());
+          return promise.promise;
+        }
+        static create() { return new this(); }
+      });
+
+      const store = this.owner.lookup('service:store') as Store;
+      const user = store.push({
+        data: {
+          id: '1',
+          type: 'user',
+          attributes: {
+            firstName: 'Kristan',
+            lastName: 'Huff-menne'
+          }
+        }
+      }) as unknown as User;
+
+
+      user.firstName = 'Krystan';
+      resultPromises.push(user.save());
+      const serialized1 = await gates[0].promise;
+
+      assert.deepEqual(serialized1, {
+        firstName: 'Krystan',
+        lastName: 'Huff-menne'
+      }, 'inflight attrs are correct after first request');
+
+      user.lastName = 'HuffMenne';
+      resultPromises.push(user.save());
+      const serialized2 = await gates[1].promise;
+
+      assert.deepEqual(serialized2, {
+        firstName: 'Krystan',
+        lastName: 'HuffMenne'
+      }, 'inflight attrs are correct after second request');
+
+      savePromises[0].resolve({
+        data: {
+          id: '1',
+          type: 'user',
+          attributes: serialized1
+        }
+      });
+
+      await resultPromises[0];
+
+      assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
+      assert.strictEqual(user.lastName, 'Huff-menne', 'The last name is the old state because the first api response "reset" it');
+      assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
+
+      savePromises[1].resolve({
+        data: {
+          id: '1',
+          type: 'user',
+          attributes: serialized2
+        }
+      });
+
+      await resultPromises[1];
+
+      assert.verifySteps([
+        'updateRecord',
+        'updateRecord'
+      ], 'The correct number of requests were made');
+      assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
+      assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is correct');
+      assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
+  });
+
+  test('Concurrent Saves use incorrect inflightattr values when the first request resolves', async function(assert) {
+    /*
+          inflight cache state is a broken concept. Since there can only be one concurrent inflight state
+          concurrent requests are theoretically impossible. Yet, we still allow them. Request handlers could
+          intelligently manage inflight state on a per-request basis in a way the cache could not.
+
+          This test is here to ensure we codify the current behavior of inflight data when concurrent requests
+          do occur. This test is not meant to be a test of the ideal behavior of concurrent requests.
+        */
+          class User extends Model {
+            @attr declare firstName: string;
+            @attr declare lastName: string;
+          }
+
+          const gates = [
+            createDeferred<Record<string, unknown>>(),
+            createDeferred<Record<string, unknown>>()
+          ];
+          const savePromises = [
+            createDeferred(),
+            createDeferred()
+          ];
+          const resultPromises: Promise<User>[] = [];
+          let requestCount = 0;
+
+          this.owner.register('model:user', User);
+          this.owner.register('adapter:application', class Adapter {
+            async updateRecord(_store, _schema, snapshot: Snapshot) {
+              assert.step('updateRecord');
+              if (requestCount > gates.length) {
+                throw new Error('Too many requests');
+              }
+              const promise = savePromises[requestCount];
+
+              gates[requestCount++].resolve(snapshot.attributes());
+              return promise.promise;
+            }
+            static create() { return new this(); }
+          });
+
+          const store = this.owner.lookup('service:store') as Store;
+          const user = store.push({
+            data: {
+              id: '1',
+              type: 'user',
+              attributes: {
+                firstName: 'Kristan',
+                lastName: 'Huff-menne'
+              }
+            }
+          }) as unknown as User;
+
+
+          user.firstName = 'Krystan';
+          resultPromises.push(user.save());
+          const serialized1 = await gates[0].promise;
+
+          assert.deepEqual(serialized1, {
+            firstName: 'Krystan',
+            lastName: 'Huff-menne'
+          }, 'inflight attrs are correct after first request');
+
+          user.lastName = 'HuffMenne';
+          resultPromises.push(user.save());
+          const serialized2 = await gates[1].promise;
+
+          assert.deepEqual(serialized2, {
+            firstName: 'Krystan',
+            lastName: 'HuffMenne'
+          }, 'inflight attrs are correct after second request');
+
+          savePromises[0].resolve({
+            data: {
+              id: '1',
+              type: 'user',
+              attributes: {
+                firstName: 'Krystan',
+              }
+            }
+          });
+
+          await resultPromises[0];
+
+          assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
+          assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is the new state even though the second request is still pending');
+          assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
+
+          savePromises[1].resolve({
+            data: {
+              id: '1',
+              type: 'user',
+              attributes: {
+                lastName: 'HuffMenne'
+              }
+            }
+          });
+
+          await resultPromises[1];
+
+          assert.verifySteps([
+            'updateRecord',
+            'updateRecord'
+          ], 'The correct number of requests were made');
+          assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
+          assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is correct');
+          assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
+      });
+});

--- a/tests/main/tests/integration/records/concurrent-save-test.ts
+++ b/tests/main/tests/integration/records/concurrent-save-test.ts
@@ -1,15 +1,16 @@
 import { module, test } from 'qunit';
 
 import { setupTest } from 'ember-qunit';
-import Model, { attr } from '@ember-data/model';
-import Store from '@ember-data/store';
-import { createDeferred } from '@ember-data/request';
-import type { Snapshot } from '@ember-data/legacy-compat/-private'
 
-module('Integration | Record | concurrent saves', function(hooks) {
+import type { Snapshot } from '@ember-data/legacy-compat/-private';
+import Model, { attr } from '@ember-data/model';
+import { createDeferred } from '@ember-data/request';
+import Store from '@ember-data/store';
+
+module('Integration | Record | concurrent saves', function (hooks) {
   setupTest(hooks);
 
-  test('Concurrent Saves do not lose inflightattr values from earlier requests', async function(assert) {
+  test('Concurrent Saves do not lose inflightattr values from earlier requests', async function (assert) {
     /*
       inflight cache state is a broken concept. Since there can only be one concurrent inflight state
       concurrent requests are theoretically impossible. Yet, we still allow them. Request handlers could
@@ -23,116 +24,15 @@ module('Integration | Record | concurrent saves', function(hooks) {
       @attr declare lastName: string;
     }
 
-    const gates = [
-      createDeferred<Record<string, unknown>>(),
-      createDeferred<Record<string, unknown>>()
-    ];
-    const savePromises = [
-      createDeferred(),
-      createDeferred()
-    ];
+    const gates = [createDeferred<Record<string, unknown>>(), createDeferred<Record<string, unknown>>()];
+    const savePromises = [createDeferred(), createDeferred()];
     const resultPromises: Promise<User>[] = [];
     let requestCount = 0;
 
     this.owner.register('model:user', User);
-    this.owner.register('adapter:application', class Adapter {
-      async updateRecord(_store, _schema, snapshot: Snapshot) {
-        assert.step('updateRecord');
-        if (requestCount > gates.length) {
-          throw new Error('Too many requests');
-        }
-        const promise = savePromises[requestCount];
-
-        gates[requestCount++].resolve(snapshot.attributes());
-        return promise.promise;
-      }
-      static create() { return new this(); }
-    });
-
-    const store = this.owner.lookup('service:store') as Store;
-    const user = store.push({
-      data: {
-        id: '1',
-        type: 'user',
-        attributes: {
-          firstName: 'Kristan',
-          lastName: 'Huff-menne'
-        }
-      }
-    }) as unknown as User;
-
-
-    user.firstName = 'Krystan';
-    resultPromises.push(user.save());
-    const serialized1 = await gates[0].promise;
-
-    assert.deepEqual(serialized1, {
-      firstName: 'Krystan',
-      lastName: 'Huff-menne'
-    }, 'inflight attrs are correct after first request');
-
-    user.lastName = 'HuffMenne';
-    resultPromises.push(user.save());
-    const serialized2 = await gates[1].promise;
-
-    assert.deepEqual(serialized2, {
-      firstName: 'Krystan',
-      lastName: 'HuffMenne'
-    }, 'inflight attrs are correct after second request');
-
-    savePromises[0].resolve({
-      data: {
-        id: '1',
-        type: 'user',
-        attributes: serialized1
-      }
-    });
-    savePromises[1].resolve({
-      data: {
-        id: '1',
-        type: 'user',
-        attributes: serialized2
-      }
-    });
-
-    await Promise.all(resultPromises);
-
-    assert.verifySteps([
-      'updateRecord',
-      'updateRecord'
-    ], 'The correct number of requests were made');
-    assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
-    assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is correct');
-    assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
-  });
-
-  test('Concurrent Saves prefers payload response over inflightattr values when the first request resolves', async function(assert) {
-/*
-      inflight cache state is a broken concept. Since there can only be one concurrent inflight state
-      concurrent requests are theoretically impossible. Yet, we still allow them. Request handlers could
-      intelligently manage inflight state on a per-request basis in a way the cache could not.
-
-      This test is here to ensure we codify the current behavior of inflight data when concurrent requests
-      do occur. This test is not meant to be a test of the ideal behavior of concurrent requests.
-    */
-      class User extends Model {
-        @attr declare firstName: string;
-        @attr declare lastName: string;
-      }
-
-      const gates = [
-        createDeferred<Record<string, unknown>>(),
-        createDeferred<Record<string, unknown>>()
-      ];
-      const savePromises = [
-        createDeferred(),
-        createDeferred()
-      ];
-      const resultPromises: Promise<User>[] = [];
-      let requestCount = 0;
-
-      this.owner.register('model:user', User);
-      this.owner.register('adapter:application', class Adapter {
+    this.owner.register(
+      'adapter:application',
+      class Adapter {
         async updateRecord(_store, _schema, snapshot: Snapshot) {
           assert.step('updateRecord');
           if (requestCount > gates.length) {
@@ -143,74 +43,185 @@ module('Integration | Record | concurrent saves', function(hooks) {
           gates[requestCount++].resolve(snapshot.attributes());
           return promise.promise;
         }
-        static create() { return new this(); }
-      });
-
-      const store = this.owner.lookup('service:store') as Store;
-      const user = store.push({
-        data: {
-          id: '1',
-          type: 'user',
-          attributes: {
-            firstName: 'Kristan',
-            lastName: 'Huff-menne'
-          }
+        static create() {
+          return new this();
         }
-      }) as unknown as User;
+      }
+    );
 
+    const store = this.owner.lookup('service:store') as Store;
+    const user = store.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          firstName: 'Kristan',
+          lastName: 'Huff-menne',
+        },
+      },
+    }) as unknown as User;
 
-      user.firstName = 'Krystan';
-      resultPromises.push(user.save());
-      const serialized1 = await gates[0].promise;
+    user.firstName = 'Krystan';
+    resultPromises.push(user.save());
+    const serialized1 = await gates[0].promise;
 
-      assert.deepEqual(serialized1, {
+    assert.deepEqual(
+      serialized1,
+      {
         firstName: 'Krystan',
-        lastName: 'Huff-menne'
-      }, 'inflight attrs are correct after first request');
+        lastName: 'Huff-menne',
+      },
+      'inflight attrs are correct after first request'
+    );
 
-      user.lastName = 'HuffMenne';
-      resultPromises.push(user.save());
-      const serialized2 = await gates[1].promise;
+    user.lastName = 'HuffMenne';
+    resultPromises.push(user.save());
+    const serialized2 = await gates[1].promise;
 
-      assert.deepEqual(serialized2, {
+    assert.deepEqual(
+      serialized2,
+      {
         firstName: 'Krystan',
-        lastName: 'HuffMenne'
-      }, 'inflight attrs are correct after second request');
+        lastName: 'HuffMenne',
+      },
+      'inflight attrs are correct after second request'
+    );
 
-      savePromises[0].resolve({
-        data: {
-          id: '1',
-          type: 'user',
-          attributes: serialized1
-        }
-      });
+    savePromises[0].resolve({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: serialized1,
+      },
+    });
+    savePromises[1].resolve({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: serialized2,
+      },
+    });
 
-      await resultPromises[0];
+    await Promise.all(resultPromises);
 
-      assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
-      assert.strictEqual(user.lastName, 'Huff-menne', 'The last name is the old state because the first api response "reset" it');
-      assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
-
-      savePromises[1].resolve({
-        data: {
-          id: '1',
-          type: 'user',
-          attributes: serialized2
-        }
-      });
-
-      await resultPromises[1];
-
-      assert.verifySteps([
-        'updateRecord',
-        'updateRecord'
-      ], 'The correct number of requests were made');
-      assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
-      assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is correct');
-      assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
+    assert.verifySteps(['updateRecord', 'updateRecord'], 'The correct number of requests were made');
+    assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
+    assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is correct');
+    assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
   });
 
-  test('Concurrent Saves use incorrect inflightattr values when the first request resolves', async function(assert) {
+  test('Concurrent Saves prefers payload response over inflightattr values when the first request resolves', async function (assert) {
+    /*
+      inflight cache state is a broken concept. Since there can only be one concurrent inflight state
+      concurrent requests are theoretically impossible. Yet, we still allow them. Request handlers could
+      intelligently manage inflight state on a per-request basis in a way the cache could not.
+
+      This test is here to ensure we codify the current behavior of inflight data when concurrent requests
+      do occur. This test is not meant to be a test of the ideal behavior of concurrent requests.
+    */
+    class User extends Model {
+      @attr declare firstName: string;
+      @attr declare lastName: string;
+    }
+
+    const gates = [createDeferred<Record<string, unknown>>(), createDeferred<Record<string, unknown>>()];
+    const savePromises = [createDeferred(), createDeferred()];
+    const resultPromises: Promise<User>[] = [];
+    let requestCount = 0;
+
+    this.owner.register('model:user', User);
+    this.owner.register(
+      'adapter:application',
+      class Adapter {
+        async updateRecord(_store, _schema, snapshot: Snapshot) {
+          assert.step('updateRecord');
+          if (requestCount > gates.length) {
+            throw new Error('Too many requests');
+          }
+          const promise = savePromises[requestCount];
+
+          gates[requestCount++].resolve(snapshot.attributes());
+          return promise.promise;
+        }
+        static create() {
+          return new this();
+        }
+      }
+    );
+
+    const store = this.owner.lookup('service:store') as Store;
+    const user = store.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          firstName: 'Kristan',
+          lastName: 'Huff-menne',
+        },
+      },
+    }) as unknown as User;
+
+    user.firstName = 'Krystan';
+    resultPromises.push(user.save());
+    const serialized1 = await gates[0].promise;
+
+    assert.deepEqual(
+      serialized1,
+      {
+        firstName: 'Krystan',
+        lastName: 'Huff-menne',
+      },
+      'inflight attrs are correct after first request'
+    );
+
+    user.lastName = 'HuffMenne';
+    resultPromises.push(user.save());
+    const serialized2 = await gates[1].promise;
+
+    assert.deepEqual(
+      serialized2,
+      {
+        firstName: 'Krystan',
+        lastName: 'HuffMenne',
+      },
+      'inflight attrs are correct after second request'
+    );
+
+    savePromises[0].resolve({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: serialized1,
+      },
+    });
+
+    await resultPromises[0];
+
+    assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
+    assert.strictEqual(
+      user.lastName,
+      'Huff-menne',
+      'The last name is the old state because the first api response "reset" it'
+    );
+    assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
+
+    savePromises[1].resolve({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: serialized2,
+      },
+    });
+
+    await resultPromises[1];
+
+    assert.verifySteps(['updateRecord', 'updateRecord'], 'The correct number of requests were made');
+    assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
+    assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is correct');
+    assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
+  });
+
+  test('Concurrent Saves use incorrect inflightattr values when the first request resolves', async function (assert) {
     /*
           inflight cache state is a broken concept. Since there can only be one concurrent inflight state
           concurrent requests are theoretically impossible. Yet, we still allow them. Request handlers could
@@ -219,102 +230,109 @@ module('Integration | Record | concurrent saves', function(hooks) {
           This test is here to ensure we codify the current behavior of inflight data when concurrent requests
           do occur. This test is not meant to be a test of the ideal behavior of concurrent requests.
         */
-          class User extends Model {
-            @attr declare firstName: string;
-            @attr declare lastName: string;
+    class User extends Model {
+      @attr declare firstName: string;
+      @attr declare lastName: string;
+    }
+
+    const gates = [createDeferred<Record<string, unknown>>(), createDeferred<Record<string, unknown>>()];
+    const savePromises = [createDeferred(), createDeferred()];
+    const resultPromises: Promise<User>[] = [];
+    let requestCount = 0;
+
+    this.owner.register('model:user', User);
+    this.owner.register(
+      'adapter:application',
+      class Adapter {
+        async updateRecord(_store, _schema, snapshot: Snapshot) {
+          assert.step('updateRecord');
+          if (requestCount > gates.length) {
+            throw new Error('Too many requests');
           }
+          const promise = savePromises[requestCount];
 
-          const gates = [
-            createDeferred<Record<string, unknown>>(),
-            createDeferred<Record<string, unknown>>()
-          ];
-          const savePromises = [
-            createDeferred(),
-            createDeferred()
-          ];
-          const resultPromises: Promise<User>[] = [];
-          let requestCount = 0;
+          gates[requestCount++].resolve(snapshot.attributes());
+          return promise.promise;
+        }
+        static create() {
+          return new this();
+        }
+      }
+    );
 
-          this.owner.register('model:user', User);
-          this.owner.register('adapter:application', class Adapter {
-            async updateRecord(_store, _schema, snapshot: Snapshot) {
-              assert.step('updateRecord');
-              if (requestCount > gates.length) {
-                throw new Error('Too many requests');
-              }
-              const promise = savePromises[requestCount];
+    const store = this.owner.lookup('service:store') as Store;
+    const user = store.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          firstName: 'Kristan',
+          lastName: 'Huff-menne',
+        },
+      },
+    }) as unknown as User;
 
-              gates[requestCount++].resolve(snapshot.attributes());
-              return promise.promise;
-            }
-            static create() { return new this(); }
-          });
+    user.firstName = 'Krystan';
+    resultPromises.push(user.save());
+    const serialized1 = await gates[0].promise;
 
-          const store = this.owner.lookup('service:store') as Store;
-          const user = store.push({
-            data: {
-              id: '1',
-              type: 'user',
-              attributes: {
-                firstName: 'Kristan',
-                lastName: 'Huff-menne'
-              }
-            }
-          }) as unknown as User;
+    assert.deepEqual(
+      serialized1,
+      {
+        firstName: 'Krystan',
+        lastName: 'Huff-menne',
+      },
+      'inflight attrs are correct after first request'
+    );
 
+    user.lastName = 'HuffMenne';
+    resultPromises.push(user.save());
+    const serialized2 = await gates[1].promise;
 
-          user.firstName = 'Krystan';
-          resultPromises.push(user.save());
-          const serialized1 = await gates[0].promise;
+    assert.deepEqual(
+      serialized2,
+      {
+        firstName: 'Krystan',
+        lastName: 'HuffMenne',
+      },
+      'inflight attrs are correct after second request'
+    );
 
-          assert.deepEqual(serialized1, {
-            firstName: 'Krystan',
-            lastName: 'Huff-menne'
-          }, 'inflight attrs are correct after first request');
+    savePromises[0].resolve({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          firstName: 'Krystan',
+        },
+      },
+    });
 
-          user.lastName = 'HuffMenne';
-          resultPromises.push(user.save());
-          const serialized2 = await gates[1].promise;
+    await resultPromises[0];
 
-          assert.deepEqual(serialized2, {
-            firstName: 'Krystan',
-            lastName: 'HuffMenne'
-          }, 'inflight attrs are correct after second request');
+    assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
+    assert.strictEqual(
+      user.lastName,
+      'HuffMenne',
+      'The last name is the new state even though the second request is still pending'
+    );
+    assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
 
-          savePromises[0].resolve({
-            data: {
-              id: '1',
-              type: 'user',
-              attributes: {
-                firstName: 'Krystan',
-              }
-            }
-          });
+    savePromises[1].resolve({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          lastName: 'HuffMenne',
+        },
+      },
+    });
 
-          await resultPromises[0];
+    await resultPromises[1];
 
-          assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
-          assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is the new state even though the second request is still pending');
-          assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
-
-          savePromises[1].resolve({
-            data: {
-              id: '1',
-              type: 'user',
-              attributes: {
-                lastName: 'HuffMenne'
-              }
-            }
-          });
-
-          await resultPromises[1];
-
-          assert.verifySteps([
-            'updateRecord',
-            'updateRecord'
-          ], 'The correct number of requests were made');
-          assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
-          assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is correct');
-          assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
-      });
+    assert.verifySteps(['updateRecord', 'updateRecord'], 'The correct number of requests were made');
+    assert.strictEqual(user.firstName, 'Krystan', 'The first name is correct');
+    assert.strictEqual(user.lastName, 'HuffMenne', 'The last name is correct');
+    assert.deepEqual(user.changedAttributes(), {}, 'There are no changed attributes');
+  });
 });

--- a/tests/main/tests/integration/records/delete-record-test.js
+++ b/tests/main/tests/integration/records/delete-record-test.js
@@ -2,7 +2,6 @@
 
 import EmberObject, { get } from '@ember/object';
 import { settled } from '@ember/test-helpers';
-import { DEBUG } from '@ember-data/env';
 
 import { module, test } from 'qunit';
 import { all, Promise as EmberPromise } from 'rsvp';
@@ -12,6 +11,7 @@ import { setupTest } from 'ember-qunit';
 import Adapter from '@ember-data/adapter';
 import { InvalidError } from '@ember-data/adapter/error';
 import { DEPRECATE_V1_RECORD_DATA } from '@ember-data/deprecations';
+import { DEBUG } from '@ember-data/env';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { recordIdentifierFor } from '@ember-data/store';

--- a/tests/main/tests/integration/records/delete-record-test.js
+++ b/tests/main/tests/integration/records/delete-record-test.js
@@ -2,6 +2,7 @@
 
 import EmberObject, { get } from '@ember/object';
 import { settled } from '@ember/test-helpers';
+import { DEBUG } from '@ember-data/env';
 
 import { module, test } from 'qunit';
 import { all, Promise as EmberPromise } from 'rsvp';
@@ -506,11 +507,17 @@ module('integration/deletedRecord - Deleting Records', function (hooks) {
 
     await company.destroyRecord();
 
+    // wait for ember's runloop to flush
+    await settled();
+
     try {
       assert.true(company.isDeleted, 'isDeleted should be true');
       assert.true(company.isDestroying, 'isDestroying should be true');
       assert.true(company.isDestroyed, 'isDestroyed should be true');
-      assert.strictEqual(company.id, undefined, 'id access should be safe');
+
+      if (DEBUG) {
+        assert.strictEqual(company.id, undefined, 'id access should be safe');
+      }
     } catch (e) {
       assert.ok(false, `Should not throw an error, threw ${e.message}`);
     }


### PR DESCRIPTION
the timing changes in 4.12 made this race condition slightly easier to hit. The approach here is still "known to be buggy" but results in less potential information loss.