### PR TITLE
chore: use composite mode for tsc

### DIFF
--- a/packages/-ember-data/tsconfig.json
+++ b/packages/-ember-data/tsconfig.json
@@ -20,7 +20,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "addon",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/active-record/tsconfig.json
+++ b/packages/active-record/tsconfig.json
@@ -20,7 +20,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/adapter/tsconfig.json
+++ b/packages/adapter/tsconfig.json
@@ -23,7 +23,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/core-types/tsconfig.json
+++ b/packages/core-types/tsconfig.json
@@ -30,7 +30,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     // Support generation of source maps. Note: you must *also* enable source
     // maps in your `ember-cli-babel` config and/or `babel.config.js`.

--- a/packages/diagnostic/tsconfig.json
+++ b/packages/diagnostic/tsconfig.json
@@ -18,7 +18,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/graph/tsconfig.json
+++ b/packages/graph/tsconfig.json
@@ -9,7 +9,6 @@
     "target": "esnext",
     "moduleResolution": "bundler",
     "moduleDetection": "force",
-    "rootDir": "src",
     "strict": true,
     "downlevelIteration": true,
     "skipLibCheck": true,
@@ -21,7 +20,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/holodeck/tsconfig.json
+++ b/packages/holodeck/tsconfig.json
@@ -31,7 +31,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "client",
 
     // Support generation of source maps. Note: you must *also* enable source
     // maps in your `ember-cli-babel` config and/or `babel.config.js`.

--- a/packages/json-api/tsconfig.json
+++ b/packages/json-api/tsconfig.json
@@ -21,7 +21,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/legacy-compat/tsconfig.json
+++ b/packages/legacy-compat/tsconfig.json
@@ -20,7 +20,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/model/tsconfig.json
+++ b/packages/model/tsconfig.json
@@ -22,7 +22,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/request-utils/tsconfig.json
+++ b/packages/request-utils/tsconfig.json
@@ -31,7 +31,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/request/tsconfig.json
+++ b/packages/request/tsconfig.json
@@ -30,7 +30,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/rest/tsconfig.json
+++ b/packages/rest/tsconfig.json
@@ -20,7 +20,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/serializer/tsconfig.json
+++ b/packages/serializer/tsconfig.json
@@ -21,7 +21,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -21,7 +21,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,

--- a/packages/tracking/tsconfig.json
+++ b/packages/tracking/tsconfig.json
@@ -9,7 +9,6 @@
     "target": "esnext",
     "moduleResolution": "bundler",
     "moduleDetection": "force",
-    "rootDir": "src",
     "declarationDir": "unstable-preview-types",
     "strict": true,
     "downlevelIteration": true,
@@ -22,7 +21,9 @@
 
     // Enable faster builds
     // but causes us to not rebuild properly
+    "composite": true,
     "incremental": true,
+    "rootDir": "src",
 
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
switch to composite mode for tsc to help cut down build/rebuild time. Required for `references`.

progress on #9045 