### PR TITLE
Add eslint-plugin-n to eslint config for node files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,5 @@
   "files.associations": {
     "turbo.json": "jsonc"
   },
-  "eslint.workingDirectories": ["packages/*", "tests/*"]
+  "eslint.workingDirectories": [{ "mode": "auto" }, "packages/*", "tests/*"]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,34 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "pnpm: lint",
+      "type": "shell",
+      "command": "pnpm lint",
+
+      "problemMatcher": {
+        "owner": "pnpm-lint",
+        "fileLocation": ["absolute"],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^Scope: .* workspace projects$",
+          "endsPattern": "^Summary: .* fails, .* passes$"
+        },
+        "pattern": [
+          {
+            "regexp": "^.+lint: (\\/.+)$",
+            "file": 1
+          },
+          {
+            "regexp": "^.+lint:\\s+(\\d+):(\\d+)\\s+(\\w+)\\s+(.+)$",
+            "line": 1,
+            "column": 2,
+            "severity": 3,
+            "message": 4,
+            "loop": true
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/config/eslint/node.cjs
+++ b/config/eslint/node.cjs
@@ -1,6 +1,6 @@
 function defaults(config) {
   const result = {
-    files: !config?.useModules ? ['./babel.config.js', './.eslintrc.cjs', './index.js', './addon-main.cjs', './addon-main.js'] : [],
+    files: !config?.useModules ? ['./index.js', './addon-main.cjs', './addon-main.js'] : [],
     parserOptions: {
       sourceType: config?.useModules ? 'module' : 'script',
       ecmaVersion: 2022,
@@ -11,6 +11,36 @@ function defaults(config) {
       es6: true,
     },
     globals: config?.globals || {},
+    plugins: ['n'],
+    extends: 'plugin:n/recommended',
+  };
+
+  if (config?.files) {
+    result.files.push(...config.files);
+  }
+
+  return result;
+}
+
+function config(config) {
+  const result = {
+    files: ['./babel.config.js', './.eslintrc.cjs', './rollup.config.mjs'],
+    parserOptions: {
+      sourceType: config?.useModules ? 'module' : 'script',
+      ecmaVersion: 2022,
+    },
+    env: {
+      browser: false,
+      node: true,
+      es6: true,
+    },
+    globals: config?.globals || {},
+    plugins: ['n'],
+    extends: 'plugin:n/recommended',
+    rules: {
+      // It's ok to use unpublished files here since we don't ship these
+      'n/no-unpublished-require': 'off',
+    },
   };
 
   if (config?.files) {
@@ -21,5 +51,6 @@ function defaults(config) {
 }
 
 module.exports = {
-  defaults
+  defaults,
+  config,
 };

--- a/config/eslint/parser.cjs
+++ b/config/eslint/parser.cjs
@@ -6,7 +6,7 @@ function defaults() {
       ecmaVersion: 2022,
       sourceType: 'module',
       babelOptions: {
-        // eslint-disable-next-line node/no-unpublished-require
+        // eslint-disable-next-line n/no-unpublished-require
         plugins: [[require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }]],
       },
       requireConfigFile: false,
@@ -15,5 +15,5 @@ function defaults() {
 }
 
 module.exports = {
-  defaults
+  defaults,
 };

--- a/config/package.json
+++ b/config/package.json
@@ -11,6 +11,7 @@
     "eslint": "^8.52.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "prettier": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepare": "pnpm build",
     "build": "turbo _build --log-order=stream --filter=./packages/*",
     "build:docs": "mkdir -p packages/-ember-data/dist && cd ./docs-generator && node ./compile-docs.js",
-    "lint": "pnpm run -r --workspace-concurrency=-1 --if-present lint",
+    "lint": "FORCE_COLOR=2 pnpm run -r --workspace-concurrency=-1 --if-present --reporter=append-only --no-bail lint",
     "preinstall": "npx only-allow pnpm",
     "check:types": "pnpm run -r --workspace-concurrency=-1 --if-present check:types",
     "test": "pnpm turbo test --concurrency=1",

--- a/packages/-ember-data/.eslintrc.cjs
+++ b/packages/-ember-data/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -12,7 +12,7 @@
     "test": "tests"
   },
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "move-dts": "bun ../../scripts/copy-declarations.mjs addon",
     "build:types": "tsc --build",
     "_build": "bun run build:types && bun run move-dts",

--- a/packages/active-record/.eslintrc.cjs
+++ b/packages/active-record/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/active-record/package.json
+++ b/packages/active-record/package.json
@@ -70,7 +70,7 @@
     }
   },
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:types": "tsc --build",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "_build": "bun run build:client && bun run build:types",

--- a/packages/adapter/.eslintrc.cjs
+++ b/packages/adapter/.eslintrc.cjs
@@ -30,5 +30,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "directories": {},
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:types": "tsc --build",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "_build": "bun run build:client && bun run build:types",

--- a/packages/core-types/.eslintrc.cjs
+++ b/packages/core-types/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:types": "tsc --build",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "_build": "bun run build:client && bun run build:types",

--- a/packages/debug/.eslintrc.cjs
+++ b/packages/debug/.eslintrc.cjs
@@ -21,5 +21,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults()],
+  overrides: [node.config(), node.defaults()],
 };

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "directories": {},
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "_syncPnpm": "bun run sync-dependencies-meta-injected"
   },
   "peerDependencies": {

--- a/packages/diagnostic/.eslintrc.cjs
+++ b/packages/diagnostic/.eslintrc.cjs
@@ -23,8 +23,13 @@ module.exports = {
   ignorePatterns: ignore.ignoreRules(),
 
   overrides: [
+    node.config(),
     node.defaults(),
-    node.defaults({ useModules: true, globals: { Bun: true }, files: ['./server/**'] }),
+    node.defaults({
+      files: ['./server/**'],
+      useModules: true,
+      globals: { Bun: true },
+    }),
     typescript.defaults({
       rules: {
         'no-console': 'off',

--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -60,7 +60,7 @@
     }
   },
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:tests": "rm -rf dist-test && cp -R test dist-test && mkdir -p dist-test/@warp-drive && cp -R dist dist-test/@warp-drive/diagnostic",
     "build:types": "tsc --build",
     "build:runtime": "rollup --config",
@@ -99,6 +99,7 @@
     "@babel/preset-typescript": "^7.23.2",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
+    "@embroider/addon-shim": "^1.8.6",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@warp-drive/internal-config": "workspace:5.5.0-alpha.11",

--- a/packages/diagnostic/server/browsers/index.js
+++ b/packages/diagnostic/server/browsers/index.js
@@ -2,8 +2,8 @@ import os from 'os';
 import path from 'path';
 import tmp from 'tmp';
 
-import { debug } from '../utils/debug';
-import { isWin, platformName } from '../utils/platform';
+import { debug } from '../utils/debug.js';
+import { isWin, platformName } from '../utils/platform.js';
 
 export function getHomeDir() {
   return process.env.HOME || process.env.USERPROFILE;

--- a/packages/diagnostic/server/bun/socket-handler.js
+++ b/packages/diagnostic/server/bun/socket-handler.js
@@ -53,6 +53,11 @@ export function buildHandler(config, state) {
                 await config.cleanup();
                 debug(`Configured cleanup hook completed`);
               }
+              // 1. We expect all cleanup to have happened after
+              //    config.cleanup(), so exiting here should be safe.
+              // 2. We also want to forcibly exit with a success code in this
+              //    case.
+              // eslint-disable-next-line n/no-process-exit
               process.exit(exitCode);
             }
           }

--- a/packages/graph/.eslintrc.cjs
+++ b/packages/graph/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:types": "tsc --build",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "_build": "bun run build:client && bun run build:types",

--- a/packages/holodeck/.eslintrc.cjs
+++ b/packages/holodeck/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/json-api/.eslintrc.cjs
+++ b/packages/json-api/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/json-api/package.json
+++ b/packages/json-api/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "author": "",
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:types": "tsc --build",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "_build": "bun run build:client && bun run build:types",

--- a/packages/legacy-compat/.eslintrc.cjs
+++ b/packages/legacy-compat/.eslintrc.cjs
@@ -23,7 +23,7 @@ const config = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };
 
 module.exports = config;

--- a/packages/legacy-compat/package.json
+++ b/packages/legacy-compat/package.json
@@ -40,7 +40,7 @@
     }
   },
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:types": "tsc --build",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "_build": "bun run build:client && bun run build:types",

--- a/packages/model/.eslintrc.cjs
+++ b/packages/model/.eslintrc.cjs
@@ -35,5 +35,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "directories": {},
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "move-dts": "bun ../../scripts/copy-declarations.mjs src",
     "build:types": "tsc --build && bun run move-dts",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",

--- a/packages/model/src/-private/legacy-relationships-support.ts
+++ b/packages/model/src/-private/legacy-relationships-support.ts
@@ -667,7 +667,6 @@ function handleCompletedRelationshipRequest(
     // has never been accessed
     if (proxy && !isHasMany) {
       // @ts-expect-error unsure why this is not resolving the boolean but async belongsTo is weird
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (proxy.content && proxy.content.isDestroying) {
         (proxy as PromiseBelongsTo).set('content', null);
       }

--- a/packages/model/src/-private/references/belongs-to.ts
+++ b/packages/model/src/-private/references/belongs-to.ts
@@ -393,7 +393,6 @@ export default class BelongsToReference {
     const record = this.store.push(jsonApiDoc);
 
     if (DEBUG) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       assertPolymorphicType(
         this.belongsToRelationship.identifier,
         this.belongsToRelationship.definition,

--- a/packages/model/src/-private/references/has-many.ts
+++ b/packages/model/src/-private/references/has-many.ts
@@ -422,7 +422,6 @@ export default class HasManyReference {
         const relationshipMeta = this.hasManyRelationship.definition;
         const identifier = this.hasManyRelationship.identifier;
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         assertPolymorphicType(identifier, relationshipMeta, recordIdentifierFor(record), store);
       }
       return recordIdentifierFor(record);

--- a/packages/model/tsconfig.json
+++ b/packages/model/tsconfig.json
@@ -1,7 +1,5 @@
 {
-  "include": [
-    "src/**/*",
-  ],
+  "include": ["src/**/*"],
   "baseUrl": ".",
   "compilerOptions": {
     "lib": ["DOM", "ESNext"],
@@ -32,16 +30,14 @@
     "emitDeclarationOnly": true,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "types": [
-      "ember-source/types",
-    ],
+    "types": ["ember-source/types"],
 
     "paths": {
       "@ember-data/deprecations": ["../private-build-infra/virtual-packages/deprecations.d.ts"],
       "@ember-data/packages": ["../private-build-infra/virtual-packages/packages.d.ts"],
       "@ember-data/canary-features": ["../private-build-infra/virtual-packages/canary-features.d.ts"],
       "@ember-data/debugging": ["../private-build-infra/virtual-packages/debugging.d.ts"],
-      "@ember-data/env": ["../private-build-infra/virtual-packages/env.d.ts"],
+      "@ember-data/env": ["../private-build-infra/virtual-packages/env.d.ts"]
     }
   },
   "references": [
@@ -52,6 +48,6 @@
     { "path": "../request-utils" },
     { "path": "../store" },
     { "path": "../tracking" },
-    { "path": "../core-types" },
+    { "path": "../core-types" }
   ]
 }

--- a/packages/private-build-infra/src/utilities/detect-module.js
+++ b/packages/private-build-infra/src/utilities/detect-module.js
@@ -75,7 +75,7 @@ module.exports = function detectModule(require, moduleName, baseDir, pkg) {
         bustCache(require);
         // ember-data brings all packages so if present we are present
         //
-        // eslint-disable-next-line node/no-missing-require
+        // eslint-disable-next-line n/no-missing-require
         require.resolve('ember-data', { paths: [baseDir, path.join(baseDir, '../'), process.cwd()] });
         log('\t✅ FOUND ember-data');
         return true;

--- a/packages/request-utils/.eslintrc.cjs
+++ b/packages/request-utils/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -44,7 +44,7 @@
     }
   },
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:types": "tsc --build",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "_build": "bun run build:client && bun run build:types",

--- a/packages/request/.eslintrc.cjs
+++ b/packages/request/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -15,7 +15,7 @@
     "ember-addon"
   ],
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:types": "tsc --build",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "_build": "bun run build:client && bun run build:types",

--- a/packages/request/src/-private/utils.ts
+++ b/packages/request/src/-private/utils.ts
@@ -138,7 +138,6 @@ export function executeNextHandler<T>(
   try {
     outcome = wares[i].request<T>(context, next);
     if (DEBUG) {
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       if (!outcome || (!(outcome instanceof Promise) && !(typeof outcome === 'object' && 'then' in outcome))) {
         // eslint-disable-next-line no-console
         console.log({ request, handler: wares[i], outcome });

--- a/packages/rest/.eslintrc.cjs
+++ b/packages/rest/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -48,7 +48,7 @@
     }
   },
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:types": "tsc --build",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "_build": "bun run build:client && bun run build:types",

--- a/packages/schema-record/.eslintrc.cjs
+++ b/packages/schema-record/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/schema-record/package.json
+++ b/packages/schema-record/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "author": "",
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:runtime": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "build:types": "tsc --build",
     "_build": "bun run build:runtime && bun run build:types",

--- a/packages/serializer/.eslintrc.cjs
+++ b/packages/serializer/.eslintrc.cjs
@@ -30,5 +30,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "directories": {},
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:types": "tsc --build",
     "build:client": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "_build": "bun run build:client && bun run build:types",

--- a/packages/store/.eslintrc.cjs
+++ b/packages/store/.eslintrc.cjs
@@ -22,5 +22,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -32,7 +32,7 @@
     }
   },
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:runtime": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "build:types": "tsc --build",
     "_build": "bun run build:runtime && bun run build:types",

--- a/packages/store/src/-private/managers/record-array-manager.ts
+++ b/packages/store/src/-private/managers/record-array-manager.ts
@@ -343,7 +343,6 @@ class RecordArrayManager {
     this.clear(false);
     this._live.clear();
     this.isDestroyed = true;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     this.store.notifications.unsubscribe(this._subscription);
   }
 }

--- a/packages/tracking/.eslintrc.cjs
+++ b/packages/tracking/.eslintrc.cjs
@@ -27,5 +27,5 @@ module.exports = {
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.defaults(), typescript.defaults()],
+  overrides: [node.config(), node.defaults(), typescript.defaults()],
 };

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -53,7 +53,7 @@
     }
   },
   "scripts": {
-    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs",
+    "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "build:runtime": "rollup --config && babel ./addon --out-dir addon --plugins=../private-build-infra/src/transforms/babel-plugin-transform-ext.js",
     "build:types": "tsc --build",
     "_build": "bun run build:runtime && bun run build:types",

--- a/packages/tracking/src/-private.ts
+++ b/packages/tracking/src/-private.ts
@@ -320,9 +320,9 @@ export function createSignal<T extends object>(obj: T, key: string): Signal {
 
   if (DEBUG) {
     // @ts-expect-error
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-base-to-string
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const modelName = obj.modelName ?? obj.constructor?.modelName ?? '';
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-base-to-string
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
     const className = obj.constructor?.name ?? obj.toString?.() ?? 'unknown';
     _signal._debug_base = `${className}${modelName ? `:${modelName}` : ''}`;
   }

--- a/packages/unpublished-test-infra/ember-cli-build.js
+++ b/packages/unpublished-test-infra/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint node/no-unpublished-require: 'off' */
+/* eslint n/no-unpublished-require: 'off' */
 
 'use strict';
 

--- a/packages/unpublished-test-infra/index.js
+++ b/packages/unpublished-test-infra/index.js
@@ -1,5 +1,5 @@
 'use strict';
-// eslint-disable-next-line node/no-unpublished-require
+// eslint-disable-next-line n/no-unpublished-require
 const merge = require('broccoli-merge-trees');
 const version = require('@ember-data/private-build-infra/src/create-version-module');
 const addonBuildConfigForDataPackage = require('@ember-data/private-build-infra/src/addon-build-config-for-data-package');

--- a/packages/unpublished-test-infra/src/testem/testem.js
+++ b/packages/unpublished-test-infra/src/testem/testem.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 /* eslint-disable no-console */
 const fs = require('node:fs');
 const path = require('node:path');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.29.0
         version: 2.29.0(@typescript-eslint/parser@6.8.0)(eslint@8.52.0)
+      eslint-plugin-n:
+        specifier: ^16.2.0
+        version: 16.2.0(eslint@8.52.0)
       eslint-plugin-prettier:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.52.0)(prettier@3.0.3)
@@ -673,6 +676,9 @@ importers:
       '@embroider/addon-dev':
         specifier: ^4.1.1
         version: 4.1.1(rollup@4.1.4)
+      '@embroider/addon-shim':
+        specifier: ^1.8.6
+        version: 1.8.6
       '@glimmer/component':
         specifier: ^1.1.2
         version: 1.1.2(@babel/core@7.23.2)
@@ -11665,6 +11671,17 @@ packages:
       - supports-color
     dev: false
 
+  /eslint-plugin-es-x@7.2.0(eslint@8.52.0):
+    resolution: {integrity: sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=8'
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.52.0)
+      '@eslint-community/regexpp': 4.9.1
+      eslint: 8.52.0
+    dev: false
+
   /eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.8.0)(eslint@8.52.0):
     resolution: {integrity: sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==}
     engines: {node: '>=4'}
@@ -11698,6 +11715,24 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: false
+
+  /eslint-plugin-n@16.2.0(eslint@8.52.0):
+    resolution: {integrity: sha512-AQER2jEyQOt1LG6JkGJCCIFotzmlcCZFur2wdKrp1JX2cNotC7Ae0BcD/4lLv3lUAArM9uNS8z/fsvXTd0L71g==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.52.0)
+      builtins: 5.0.1
+      eslint: 8.52.0
+      eslint-plugin-es-x: 7.2.0(eslint@8.52.0)
+      get-tsconfig: 4.7.2
+      ignore: 5.2.4
+      is-core-module: 2.13.1
+      minimatch: 3.1.2
+      resolve: 1.22.8
+      semver: 7.5.4
     dev: false
 
   /eslint-plugin-prettier@5.0.1(eslint-config-prettier@9.0.0)(eslint@8.52.0)(prettier@3.0.3):
@@ -12694,6 +12729,12 @@ packages:
     dependencies:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
+
+  /get-tsconfig@4.7.2:
+    resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: false
 
   /get-uri@6.0.2:
     resolution: {integrity: sha512-5KLucCJobh8vBY1K07EFV4+cPZH3mrV9YeAruUseCQKHB58SGjjT2l9/eA9LD082IiuMjSlFJEcdJ27TXvbZNw==}
@@ -16212,6 +16253,10 @@ packages:
     dependencies:
       http-errors: 1.6.3
       path-is-absolute: 1.0.1
+
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: false
 
   /resolve-url@0.2.1:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}

--- a/tests/builders/ember-cli-build.js
+++ b/tests/builders/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');

--- a/tests/docs/index.js
+++ b/tests/docs/index.js
@@ -25,7 +25,7 @@ function linkItem(item) {
 
 QUnit.module('Docs coverage', function (hooks) {
   // data.json is generated and not always present. So this disable needs to be preserved.
-  const docs = require('../../packages/-ember-data/dist/docs/data.json'); // eslint-disable-line node/no-missing-require
+  const docs = require('../../packages/-ember-data/dist/docs/data.json'); // eslint-disable-line n/no-missing-require
   const expected = require('./fixtures/expected');
 
   function classIsPublic(className) {

--- a/tests/ember-data__adapter/ember-cli-build.js
+++ b/tests/ember-data__adapter/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint node/no-unpublished-require: 'off' */
+/* eslint n/no-unpublished-require: 'off' */
 
 'use strict';
 

--- a/tests/ember-data__graph/ember-cli-build.js
+++ b/tests/ember-data__graph/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');

--- a/tests/ember-data__json-api/ember-cli-build.js
+++ b/tests/ember-data__json-api/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');

--- a/tests/ember-data__model/ember-cli-build.js
+++ b/tests/ember-data__model/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint node/no-unpublished-require: 'off' */
+/* eslint n/no-unpublished-require: 'off' */
 
 'use strict';
 

--- a/tests/ember-data__request/ember-cli-build.js
+++ b/tests/ember-data__request/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');

--- a/tests/ember-data__serializer/ember-cli-build.js
+++ b/tests/ember-data__serializer/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint node/no-unpublished-require: 'off' */
+/* eslint n/no-unpublished-require: 'off' */
 
 'use strict';
 

--- a/tests/ember-data__serializer/testem.js
+++ b/tests/ember-data__serializer/testem.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line node/no-unpublished-require
+// eslint-disable-next-line n/no-unpublished-require
 const customDotReporter = require('@ember-data/unpublished-test-infra/src/testem/custom-dot-reporter');
 
 // eslint-disable-next-line no-console

--- a/tests/embroider-basic-compat/ember-cli-build.js
+++ b/tests/embroider-basic-compat/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint node/no-unpublished-require: 'off' */
+/* eslint n/no-unpublished-require: 'off' */
 
 'use strict';
 

--- a/tests/embroider-basic-compat/testem.js
+++ b/tests/embroider-basic-compat/testem.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line node/no-unpublished-require
+// eslint-disable-next-line n/no-unpublished-require
 const customDotReporter = require('@ember-data/unpublished-test-infra/src/testem/custom-dot-reporter');
 
 // eslint-disable-next-line no-console

--- a/tests/fastboot/ember-cli-build.js
+++ b/tests/fastboot/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint node/no-unpublished-require: 'off' */
+/* eslint n/no-unpublished-require: 'off' */
 
 'use strict';
 

--- a/tests/fastboot/testem.js
+++ b/tests/fastboot/testem.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line node/no-unpublished-require
+// eslint-disable-next-line n/no-unpublished-require
 const customDotReporter = require('@ember-data/unpublished-test-infra/src/testem/custom-dot-reporter');
 
 // eslint-disable-next-line no-console

--- a/tests/full-data-asset-size-app/ember-cli-build.js
+++ b/tests/full-data-asset-size-app/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');

--- a/tests/main/config/ember-try.js
+++ b/tests/main/config/ember-try.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');

--- a/tests/main/ember-cli-build.js
+++ b/tests/main/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');

--- a/tests/main/testem.js
+++ b/tests/main/testem.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 const TestemConfig = require('@ember-data/unpublished-test-infra/src/testem/testem');
 
 module.exports = TestemConfig;

--- a/tests/performance/ember-cli-build.js
+++ b/tests/performance/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint node/no-unpublished-require: 'off' */
+/* eslint n/no-unpublished-require: 'off' */
 
 'use strict';
 

--- a/tests/recommended-json-api/ember-cli-build.js
+++ b/tests/recommended-json-api/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');

--- a/tests/recommended-json-api/server/index.js
+++ b/tests/recommended-json-api/server/index.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 
 // To use it create some files under `mocks/`

--- a/tests/recommended-json-api/server/mocks/book.js
+++ b/tests/recommended-json-api/server/mocks/book.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 const RAW_BOOKS = require('./MOCK_DATA.json');
 

--- a/tests/recommended-json-api/testem.js
+++ b/tests/recommended-json-api/testem.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 const customDotReporter = require('@ember-data/unpublished-test-infra/src/testem/custom-dot-reporter');
 
 // eslint-disable-next-line no-console

--- a/tests/warp-drive__schema-record/ember-cli-build.js
+++ b/tests/warp-drive__schema-record/ember-cli-build.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');

--- a/tests/warp-drive__schema-record/testem.js
+++ b/tests/warp-drive__schema-record/testem.js
@@ -1,4 +1,4 @@
-/* eslint-disable node/no-unpublished-require */
+/* eslint-disable n/no-unpublished-require */
 const customDotReporter = require('@ember-data/unpublished-test-infra/src/testem/custom-dot-reporter');
 
 // eslint-disable-next-line no-console


### PR DESCRIPTION
## Description

- Tweak `.vscode/settings.json` so that VSCode ESLint server finds TSConfig files as expected
- Add `eslint-plugin-n` to ESLint config for Node files
- Splits ESLint config for "config" type Node files (e.g. babel, eslint, rollup config files) from project Node files, which have slightly different rules
- Enables the `--report-unused-disable-directives` so that ESLint will error in that case
- Fixes all of the resulting lint errors
- Adds a VSCode task config for running `pnpm lint` and populating the VSCode Problems panel

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


