### PR TITLE
Extract qunit ESLint config

### DIFF
--- a/config/eslint/qunit.cjs
+++ b/config/eslint/qunit.cjs
@@ -1,0 +1,18 @@
+const isolation = require('./isolation.cjs');
+
+function defaults(config = {}) {
+  return {
+    files: config.files || ['tests/**/*-test.{js,ts}'],
+    extends: ['plugin:qunit/recommended'],
+    rules: Object.assign(
+      isolation.rules({
+        allowedImports: ['@ember/debug', '@ember/test-helpers', 'qunit'],
+      }),
+      {}
+    ),
+  };
+}
+
+module.exports = {
+  defaults,
+};

--- a/config/package.json
+++ b/config/package.json
@@ -12,6 +12,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-n": "^16.2.0",
+    "eslint-plugin-qunit": "^8.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "typescript": "~5.2.2"
   },

--- a/packages/-ember-data/.eslintrc.cjs
+++ b/packages/-ember-data/.eslintrc.cjs
@@ -5,6 +5,7 @@ const ignore = require('@warp-drive/internal-config/eslint/ignore.cjs');
 const node = require('@warp-drive/internal-config/eslint/node.cjs');
 const base = require('@warp-drive/internal-config/eslint/base.cjs');
 const typescript = require('@warp-drive/internal-config/eslint/typescript.cjs');
+const qunit = require('@warp-drive/internal-config/eslint/qunit.cjs');
 
 module.exports = {
   ...parser.defaults(),
@@ -15,12 +16,19 @@ module.exports = {
     base.rules(),
     imports.rules(),
     isolation.rules({
-      allowedImports: ['@ember/debug', '@ember/test-helpers', 'qunit'],
+      allowedImports: ['@ember/debug'],
     }),
     {}
   ),
 
   ignorePatterns: ignore.ignoreRules(),
 
-  overrides: [node.config(), node.defaults(), typescript.defaults()],
+  overrides: [
+    node.config(),
+    node.defaults(),
+    typescript.defaults(),
+    qunit.defaults({
+      files: ['addon-test-support/**/*.{js,ts}'],
+    }),
+  ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       eslint-plugin-n:
         specifier: ^16.2.0
         version: 16.2.0(eslint@8.52.0)
+      eslint-plugin-qunit:
+        specifier: ^8.0.1
+        version: 8.0.1(eslint@8.52.0)
       eslint-plugin-simple-import-sort:
         specifier: ^10.0.0
         version: 10.0.0(eslint@8.52.0)
@@ -11674,6 +11677,16 @@ packages:
       semver: 7.5.4
     dev: false
 
+  /eslint-plugin-qunit@8.0.1(eslint@8.52.0):
+    resolution: {integrity: sha512-3bFOPryXoQOez95oP/JfWTxHBc/bgDQQZqTuv9uYTwH5sdIvSM2TES1iHDcy/F/LvqiqIpscDAOPAjlqSCnNPg==}
+    engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
+    dependencies:
+      eslint-utils: 3.0.0(eslint@8.52.0)
+      requireindex: 1.2.0
+    transitivePeerDependencies:
+      - eslint
+    dev: false
+
   /eslint-plugin-simple-import-sort@10.0.0(eslint@8.52.0):
     resolution: {integrity: sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==}
     peerDependencies:
@@ -11695,6 +11708,16 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
+
+  /eslint-utils@3.0.0(eslint@8.52.0):
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      eslint: 8.52.0
+      eslint-visitor-keys: 2.1.0
+    dev: false
 
   /eslint-visitor-keys@2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
@@ -16046,6 +16069,11 @@ packages:
       resolve: 1.22.8
     transitivePeerDependencies:
       - supports-color
+
+  /requireindex@1.2.0:
+    resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
+    engines: {node: '>=0.10.5'}
+    dev: false
 
   /requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}


### PR DESCRIPTION
## Description

- Extracts reusable ESLint config for QUnit files
- Uses that config in the one place we currently have QUnit stuff that is linted
- Adds `eslint-plugin-qunit`

Will probably ignore some of the `eslint-plugin-qunit` rules as I use this config on more projects in the monorepo.

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


