### PR TITLE
docs: fix note notation to make use of github formatting

### DIFF
--- a/packages/adapter/README.md
+++ b/packages/adapter/README.md
@@ -35,7 +35,8 @@ pnpm add @ember-data/adapter
 
 If using `ember-data` no additional setup is necesssary.
 
-> **Note** When using [ember-data](https://github.com/emberjs/data/blob/main/packages/-ember-data) the below
+> **Note**
+> When using [ember-data](https://github.com/emberjs/data/blob/main/packages/-ember-data) the below
 > configuration is handled for you automatically.
 
 To use legacy adapters you will need to have installed and configured the LegacyNetworkHandler from [@ember-data/legacy-compat](https://github.com/emberjs/data/blob/main/packages/-ember-data)

--- a/packages/debug/README.md
+++ b/packages/debug/README.md
@@ -3,7 +3,8 @@
 Provides ember-inspector support for Ember apps built with EmberData
 ## Installation
 
-> **Note** If using `ember-data`, this library comes pre-installed.
+> **Note**
+> If using `ember-data`, this library comes pre-installed.
 
 ```
 pnpm install @ember-data/debug

--- a/packages/diagnostic/README.md
+++ b/packages/diagnostic/README.md
@@ -143,9 +143,11 @@ module('My Module', function(hooks) {
 
 ### Running Tests
 
-> **Note** This section is about how to setup your tests to run once launched. To learn about launching tests, read [Using The Launcher](#using-the-launcher)
+> **Note**
+> This section is about how to setup your tests to run once launched. To learn about launching tests, read [Using The Launcher](#using-the-launcher)
 
-> **Note** This section is nuanced, read carefully!
+> **Warning**
+> This section is nuanced, read carefully!
 
 
 To run your tests, import and run `start`.
@@ -350,7 +352,8 @@ callback.
 `@warp-drive/diagnostic` runs tests as microtasks. Yielding out of the microtask queue only occurs if
 the test itself needs to do so.
 
-> **Note** soon we will elect to periodically yield just to allow the DOMReporter to show results, currently its so fast though that the tests are done before you'd care.
+> **Note**
+> soon we will elect to periodically yield just to allow the DOMReporter to show results, currently its so fast though that the tests are done before you'd care.
 
 Next, diagnostic, uses several singleton patterns internally to keep allocations to a minimum while
 running tests.

--- a/packages/json-api/README.md
+++ b/packages/json-api/README.md
@@ -33,7 +33,8 @@ If this package is how you are first learning about EmberData, we recommend star
 
 ## 🚀 Setup
 
-> **Note** When using [ember-data](https://github.com/emberjs/data/blob/main/packages/-ember-data) the below
+> **Note**
+> When using [ember-data](https://github.com/emberjs/data/blob/main/packages/-ember-data) the below
 > configuration is handled for you automatically.
 
 ```ts

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -172,7 +172,8 @@ export default class JSONAPICache implements Cache {
    * })
    * ```
    *
-   * > **Note:** The nested `content` and `data` members are not a mistake. This is because
+   * > **Note**
+   * > The nested `content` and `data` members are not a mistake. This is because
    * > there are two separate concepts involved here, the `StructuredDocument` which contains
    * > the context of a given Request that has been issued with the returned contents as its
    * > `content` property, and a `JSON:API Document` which is the json contents returned by

--- a/packages/json-api/src/index.ts
+++ b/packages/json-api/src/index.ts
@@ -23,7 +23,8 @@ pnpm add @ember-data/json-api
 
 ## 🚀 Setup
 
-> **Note** When using [ember-data](https://github.com/emberjs/data/blob/main/packages/-ember-data) the below
+> **Note**
+> When using [ember-data](https://github.com/emberjs/data/blob/main/packages/-ember-data) the below
 > configuration is handled for you automatically.
 
 ```ts

--- a/packages/serializer/README.md
+++ b/packages/serializer/README.md
@@ -35,7 +35,8 @@ pnpm add @ember-data/serializer
 
 If using `ember-data` no additional setup is necesssary.
 
-> **Note** When using [ember-data](https://github.com/emberjs/data/blob/main/packages/-ember-data) the below
+> **Note**
+> When using [ember-data](https://github.com/emberjs/data/blob/main/packages/-ember-data) the below
 > configuration is handled for you automatically.
 
 To use legacy serializers you will need to have installed and configured the LegacyNetworkHandler from [@ember-data/legacy-compat](https://github.com/emberjs/data/blob/main/packages/-ember-data)

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -60,7 +60,8 @@ After installing you will want to configure your first `Store`. Read more below 
 
 To use a `Store` we will need to do few things: add a [Cache](https://api.emberjs.com/ember-data/release/classes/%3CInterface%3E%20Cache) to store data **in-memory**, add a [Handler](https://github.com/emberjs/data/tree/main/packages/request#handling-requests) to fetch data from a source, and implement `instantiateRecord` to tell the store how to display the data for individual resources. 
 
-> **Note** If you are using the package `ember-data` then a `JSON:API` cache and `instantiateRecord` are configured for you by default.
+> **Note**
+> If you are using the package `ember-data` then a `JSON:API` cache and `instantiateRecord` are configured for you by default.
 
 ### Configuring A Cache
 
@@ -81,7 +82,8 @@ class extends Store {
 
 Now that we have a `cache` let's setup something to handle fetching and saving data via our API.
 
-> **Note** The `ember-data` package automatically includes and configures the `@ember-data/json-api` cache for you.
+> **Note**
+> The `ember-data` package automatically includes and configures the `@ember-data/json-api` cache for you.
 
 ### Handling Requests
 
@@ -89,7 +91,8 @@ When *Ember***Data** needs to fetch or save data it will pass that request to yo
 
 To start, let's install the `RequestManager` from `@ember-data/request` and the basic `Fetch` handler from ``@ember-data/request/fetch`.
 
-> **Note** If your app uses `GraphQL`, `REST` or different conventions for `JSON:API` than your cache expects, other handlers may better fit your data. You can author your own handler by creating one that conforms to the [handler interface](https://github.com/emberjs/data/tree/main/packages/request#handling-requests).
+> **Note**
+> If your app uses `GraphQL`, `REST` or different conventions for `JSON:API` than your cache expects, other handlers may better fit your data. You can author your own handler by creating one that conforms to the [handler interface](https://github.com/emberjs/data/tree/main/packages/request#handling-requests).
 
 ```ts
 import Store, { CacheHandler } from '@ember-data/store';
@@ -185,5 +188,6 @@ Typically you will choose an existing record implementation such as `@ember-data
 
 Because of the boundaries around instantiation and the cache, record implementations should be capable of interop both with each other and with any `Cache`. Due to this, if needed an application can utilize multiple record implementations and multiple cache implementations either to support enhanced features for only a subset of records or to be able to incrementally migrate from one record/cache to another record or cache.
 
-> **Note:** The `ember-data` package automatically includes the `@ember-data/model`
+> **Note**
+> The `ember-data` package automatically includes the `@ember-data/model`
 > package and configures it for you.

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -36,7 +36,8 @@
  * to store data **in-memory**, add a [Handler](https://api.emberjs.com/ember-data/release/classes/%3CInterface%3E%20Cache) to fetch data from a source,
  * and implement `instantiateRecord` to tell the store how to display the data for individual resources.
  *
- * > **Note** If you are using the package `ember-data` then a JSON:API cache, RequestManager, LegacyNetworkHandler,
+ * > **Note**
+ * > If you are using the package `ember-data` then a JSON:API cache, RequestManager, LegacyNetworkHandler,
  * > and `instantiateRecord` are configured for you by default.
  *
  * ### Configuring A Cache
@@ -62,7 +63,8 @@
  * Now that we have a `cache` let's setup something to handle fetching
  * and saving data via our API.
  *
- * > **Note** The `ember-data` package automatically includes and configures
+ * > **Note**
+ * > The `ember-data` package automatically includes and configures
  * > the `@ember-data/json-api` cache for you.
  *
  * ### Handling Requests
@@ -71,7 +73,8 @@
  *
  * To start, let's install the `RequestManager` from `@ember-data/request` and the basic `Fetch` handler from ``@ember-data/request/fetch`.
  *
- * > **Note** If your app uses `GraphQL`, `REST` or different conventions for `JSON:API` than your cache expects, other handlers may better fit your data. You can author your own handler by creating one that conforms to the [handler interface](https://github.com/emberjs/data/tree/main/packages/request#handling-requests).
+ * > **Note**
+ * > If your app uses `GraphQL`, `REST` or different conventions for `JSON:API` than your cache expects, other handlers may better fit your data. You can author your own handler by creating one that conforms to the [handler interface](https://github.com/emberjs/data/tree/main/packages/request#handling-requests).
  *
  * ```ts
  * import Store from '@ember-data/store';
@@ -171,7 +174,8 @@
  * implementations either to support enhanced features for only a subset of records or to
  * be able to incrementally migrate from one record/cache to another record or cache.
  *
- * > **Note:** The `ember-data` package automatically includes the `@ember-data/model`
+ * > **Note**
+ * > The `ember-data` package automatically includes the `@ember-data/model`
  * > package and configures it for you.
  *
  * @module @ember-data/store


### PR DESCRIPTION
ensures notes are formatted nicely in markdown