### PR TITLE
spec: JSON:API Graphs

### DIFF
--- a/packages/json-api-graph-spec/README.md
+++ b/packages/json-api-graph-spec/README.md
@@ -1,5 +1,8 @@
 # :electron: JSON:API Graphs
 
+> **Note**
+> Users of this specification must also utilize the [Atomic Operations Extension](https://jsonapi.org/ext/atomic/) and [Cursor Pagination Profile](https://jsonapi.org/profiles/ethanresnick/cursor-pagination/)
+
 The `JSON:API Graphs` Specification provides three things
 
 - A [profile](https://jsonapi.org/format/1.2/#profile-rules) which adds support for linkage via `*` members

--- a/packages/json-api-graph-spec/README.md
+++ b/packages/json-api-graph-spec/README.md
@@ -1,0 +1,10 @@
+# :electron: JSON:API Graphs
+
+The `JSON:API Graphs` Specification provides three things
+
+- A [profile](https://jsonapi.org/format/1.2/#profile-rules) which adds support for linkage via `*` members
+  - [Profile URI](./src/profile-references.md)
+- An [extension](https://jsonapi.org/format/1.2/#extension-rules) which adds support for `QUERY` via `POST` and the `X-HTTP-Method-Override` header
+  - [Ext URI](./src/ext-query.md)
+- A query syntax and a parser spec for it.
+  - [Spec URI](./src/spec-query-parser.md)

--- a/packages/json-api-graph-spec/src/ext-query.md
+++ b/packages/json-api-graph-spec/src/ext-query.md
@@ -1,0 +1,3 @@
+# :electron: JSON:API Graphs
+
+## QUERY Extension

--- a/packages/json-api-graph-spec/src/profile-references.md
+++ b/packages/json-api-graph-spec/src/profile-references.md
@@ -1,0 +1,4 @@
+# :electron: JSON:API Graphs
+
+## References Profile
+

--- a/packages/json-api-graph-spec/src/spec-query-parser.md
+++ b/packages/json-api-graph-spec/src/spec-query-parser.md
@@ -1,0 +1,5 @@
+# :electron: JSON:API Graphs
+
+## QUERY Parse Spec
+
+


### PR DESCRIPTION
As EmberData builds out its JSON:API support and Schema driven behaviors, we've noticed that some useful capabilities are less usable by JSON:API users due to that spec not yet considering the overall ergonomics of querying and consuming graphs.

This adds a specification with an extension and profile that APIs may implement to make use of these capabilities.

[Rendered]()