### PR TITLE
feat (internal): support legacy model behaviors in SchemaRecord legacy mode

### DIFF
--- a/config/eslint/qunit.cjs
+++ b/config/eslint/qunit.cjs
@@ -15,7 +15,9 @@ function defaults(config = {}) {
         ],
       }),
       config?.rules,
-      {}
+      {
+        'qunit/no-ok-equality': 'off',
+      }
     ),
   };
 }

--- a/config/rollup/external.js
+++ b/config/rollup/external.js
@@ -6,9 +6,30 @@ function external(manual = []) {
   const peers = Object.keys(pkg.peerDependencies || {});
   const all = new Set([...deps, ...peers, ...manual]);
 
-  const result = [...all.keys()];
   // console.log({ externals: result });
-  return result;
+  return function (id) {
+    if (all.has(id)) {
+      return true;
+    }
+
+    for (const dep of deps) {
+      if (id.startsWith(dep + '/')) {
+        return true;
+      }
+    }
+
+    for (const dep of peers) {
+      if (id.startsWith(dep + '/')) {
+        return true;
+      }
+    }
+
+    if (id.startsWith('@ember/') || id.startsWith('@ember-data/') || id.startsWith('@warp-drive/')) {
+      throw new Error(`Unexpected import: ${id}`);
+    }
+
+    return false;
+  };
 }
 
 module.exports = {

--- a/packages/core-types/rollup.config.mjs
+++ b/packages/core-types/rollup.config.mjs
@@ -19,7 +19,7 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['index.js', 'identifier.js', 'request.js']),
+    addon.publicEntrypoints(['index.js', 'identifier.js', 'request.js', 'symbols.js']),
 
     nodeResolve({ extensions: ['.ts'] }),
     babel({

--- a/packages/core-types/src/symbols.ts
+++ b/packages/core-types/src/symbols.ts
@@ -1,0 +1,1 @@
+export const RecordStore = Symbol('Store');

--- a/packages/legacy-compat/rollup.config.mjs
+++ b/packages/legacy-compat/rollup.config.mjs
@@ -14,7 +14,7 @@ export default {
   // You can augment this if you need to.
   output: addon.output(),
 
-  external: external(['@ember/debug', '@embroider/macros', '@ember-data/store/-private']),
+  external: external(['@ember/debug', '@ember/application', '@embroider/macros', '@ember-data/store/-private']),
 
   plugins: [
     // These are the modules that users should be able to import from your

--- a/packages/model/rollup.config.mjs
+++ b/packages/model/rollup.config.mjs
@@ -35,7 +35,7 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['index.js', '-private.js', 'hooks.js']),
+    addon.publicEntrypoints(['index.js', '-private.js', 'hooks.js', 'migration-support.js']),
 
     nodeResolve({ extensions: ['.ts', '.js'] }),
     babel({

--- a/packages/model/src/-private.ts
+++ b/packages/model/src/-private.ts
@@ -8,5 +8,5 @@ export { default as ManyArray } from './-private/many-array';
 export { default as PromiseBelongsTo } from './-private/promise-belongs-to';
 export { default as PromiseManyArray } from './-private/promise-many-array';
 
-// // Used by tests
-export { LEGACY_SUPPORT } from './-private/model';
+// // Used by tests, migration support
+export { lookupLegacySupport, LEGACY_SUPPORT } from './-private/legacy-relationships-support';

--- a/packages/model/src/-private/belongs-to.js
+++ b/packages/model/src/-private/belongs-to.js
@@ -3,7 +3,7 @@ import { computed } from '@ember/object';
 
 import { DEBUG } from '@ember-data/env';
 
-import { lookupLegacySupport } from './model';
+import { lookupLegacySupport } from './legacy-relationships-support';
 import { computedMacroWithOptionalParams, normalizeModelName } from './util';
 
 /**

--- a/packages/model/src/-private/has-many.js
+++ b/packages/model/src/-private/has-many.js
@@ -10,7 +10,7 @@ import { singularize } from 'ember-inflector';
 import { DEPRECATE_NON_STRICT_TYPES } from '@ember-data/deprecations';
 import { DEBUG } from '@ember-data/env';
 
-import { lookupLegacySupport } from './model';
+import { lookupLegacySupport } from './legacy-relationships-support';
 import { computedMacroWithOptionalParams } from './util';
 
 function normalizeType(type) {

--- a/packages/model/src/-private/legacy-relationships-support.ts
+++ b/packages/model/src/-private/legacy-relationships-support.ts
@@ -28,11 +28,11 @@ import type { LocalRelationshipOperation } from '@warp-drive/core-types/graph';
 import type { CollectionResourceRelationship, SingleResourceRelationship } from '@warp-drive/core-types/spec/raw';
 
 import RelatedCollection from './many-array';
+import type { MinimalLegacyRecord } from './model-methods';
 import type { BelongsToProxyCreateArgs, BelongsToProxyMeta } from './promise-belongs-to';
 import PromiseBelongsTo from './promise-belongs-to';
 import type { HasManyProxyCreateArgs } from './promise-many-array';
 import PromiseManyArray from './promise-many-array';
-import type { MinimalLegacyRecord } from './record-state';
 import BelongsToReference from './references/belongs-to';
 import HasManyReference from './references/has-many';
 

--- a/packages/model/src/-private/model-methods.ts
+++ b/packages/model/src/-private/model-methods.ts
@@ -1,0 +1,135 @@
+import { assert } from '@ember/debug';
+
+import { importSync } from '@embroider/macros';
+
+import { upgradeStore } from '@ember-data/legacy-compat/-private';
+import Store, { recordIdentifierFor } from '@ember-data/store';
+import { peekCache } from '@ember-data/store/-private';
+import { RecordStore } from '@warp-drive/core-types/symbols';
+
+import Errors from './errors';
+import { lookupLegacySupport } from './legacy-relationships-support';
+import RecordState from './record-state';
+
+export interface MinimalLegacyRecord {
+  errors: Errors;
+  ___recordState: RecordState;
+  currentState: RecordState;
+  isDestroyed: boolean;
+  isDestroying: boolean;
+  isReloading: boolean;
+  [RecordStore]: Store;
+
+  deleteRecord(): void;
+  unloadRecord(): void;
+  save<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): Promise<T>;
+  destroyRecord<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): Promise<T>;
+}
+
+export function rollbackAttributes(this: MinimalLegacyRecord) {
+  const { currentState } = this;
+  const { isNew } = currentState;
+
+  this[RecordStore]._join(() => {
+    peekCache(this).rollbackAttrs(recordIdentifierFor(this));
+    this.errors.clear();
+    currentState.cleanErrorRequests();
+    if (isNew) {
+      this.unloadRecord();
+    }
+  });
+}
+
+export function unloadRecord(this: MinimalLegacyRecord) {
+  if (this.currentState.isNew && (this.isDestroyed || this.isDestroying)) {
+    return;
+  }
+  this[RecordStore].unloadRecord(this);
+}
+
+export function belongsTo(this: MinimalLegacyRecord, prop: string) {
+  return lookupLegacySupport(this).referenceFor('belongsTo', prop);
+}
+
+export function hasMany(this: MinimalLegacyRecord, prop: string) {
+  return lookupLegacySupport(this).referenceFor('hasMany', prop);
+}
+
+export function reload(this: MinimalLegacyRecord, options: Record<string, unknown> = {}) {
+  options.isReloading = true;
+  options.reload = true;
+
+  const identifier = recordIdentifierFor(this);
+  assert(`You cannot reload a record without an ID`, identifier.id);
+
+  this.isReloading = true;
+  const promise = this[RecordStore].request({
+    op: 'findRecord',
+    data: {
+      options,
+      record: identifier,
+    },
+    cacheOptions: { [Symbol.for('wd:skip-cache')]: true },
+  })
+    .then(() => this)
+    .finally(() => {
+      this.isReloading = false;
+    });
+
+  return promise;
+}
+
+export function changedAttributes(this: MinimalLegacyRecord) {
+  return peekCache(this).changedAttrs(recordIdentifierFor(this));
+}
+
+export function serialize(this: MinimalLegacyRecord, options?: Record<string, unknown>) {
+  upgradeStore(this[RecordStore]);
+  return this[RecordStore].serializeRecord(this, options);
+}
+
+export function deleteRecord(this: MinimalLegacyRecord) {
+  // ensure we've populated currentState prior to deleting a new record
+  if (this.currentState) {
+    this[RecordStore].deleteRecord(this);
+  }
+}
+
+export function save<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): Promise<T> {
+  let promise: Promise<T>;
+
+  if (this.currentState.isNew && this.currentState.isDeleted) {
+    promise = Promise.resolve(this);
+  } else {
+    this.errors.clear();
+    promise = this[RecordStore].saveRecord(this, options) as Promise<T>;
+  }
+
+  return promise;
+}
+
+export function destroyRecord(this: MinimalLegacyRecord, options?: Record<string, unknown>) {
+  const { isNew } = this.currentState;
+  this.deleteRecord();
+  if (isNew) {
+    return Promise.resolve(this);
+  }
+  return this.save(options).then((_) => {
+    this.unloadRecord();
+    return this;
+  });
+}
+
+export function createSnapshot(this: MinimalLegacyRecord) {
+  const store = this[RecordStore];
+
+  upgradeStore(store);
+  if (!store._fetchManager) {
+    const FetchManager = (
+      importSync('@ember-data/legacy-compat/-private') as typeof import('@ember-data/legacy-compat/-private')
+    ).FetchManager;
+    store._fetchManager = new FetchManager(store);
+  }
+
+  return store._fetchManager.createSnapshot(recordIdentifierFor(this));
+}

--- a/packages/model/src/-private/model.js
+++ b/packages/model/src/-private/model.js
@@ -15,25 +15,9 @@ import { compat } from '@ember-data/tracking';
 import { defineSignal } from '@ember-data/tracking/-private';
 
 import Errors from './errors';
-import { LegacySupport } from './legacy-relationships-support';
+import { LEGACY_SUPPORT, lookupLegacySupport } from './legacy-relationships-support';
 import notifyChanges from './notify-changes';
 import RecordState, { notifySignal, tagged } from './record-state';
-
-export const LEGACY_SUPPORT = new Map();
-
-export function lookupLegacySupport(record) {
-  const identifier = recordIdentifierFor(record);
-  let support = LEGACY_SUPPORT.get(identifier);
-
-  if (!support) {
-    assert(`Memory Leak Detected`, !record.isDestroyed && !record.isDestroying);
-    support = new LegacySupport(record);
-    LEGACY_SUPPORT.set(identifier, support);
-    LEGACY_SUPPORT.set(record, support);
-  }
-
-  return support;
-}
 
 function findPossibleInverses(type, inverseType, name, relationshipsSoFar) {
   const possibleRelationships = relationshipsSoFar || [];

--- a/packages/model/src/-private/model.js
+++ b/packages/model/src/-private/model.js
@@ -8,7 +8,7 @@ import EmberObject from '@ember/object';
 import { DEBUG } from '@ember-data/env';
 import { HAS_DEBUG_PACKAGE } from '@ember-data/packages';
 import { recordIdentifierFor, storeFor } from '@ember-data/store';
-import { coerceId, peekCache } from '@ember-data/store/-private';
+import { coerceId } from '@ember-data/store/-private';
 import { compat } from '@ember-data/tracking';
 import { defineSignal } from '@ember-data/tracking/-private';
 import { RecordStore } from '@warp-drive/core-types/symbols';

--- a/packages/model/src/-private/model.js
+++ b/packages/model/src/-private/model.js
@@ -5,17 +5,29 @@
 import { assert, warn } from '@ember/debug';
 import EmberObject from '@ember/object';
 
-import { importSync } from '@embroider/macros';
-
 import { DEBUG } from '@ember-data/env';
 import { HAS_DEBUG_PACKAGE } from '@ember-data/packages';
 import { recordIdentifierFor, storeFor } from '@ember-data/store';
 import { coerceId, peekCache } from '@ember-data/store/-private';
 import { compat } from '@ember-data/tracking';
 import { defineSignal } from '@ember-data/tracking/-private';
+import { RecordStore } from '@warp-drive/core-types/symbols';
 
 import Errors from './errors';
-import { LEGACY_SUPPORT, lookupLegacySupport } from './legacy-relationships-support';
+import { LEGACY_SUPPORT } from './legacy-relationships-support';
+import {
+  belongsTo,
+  changedAttributes,
+  createSnapshot,
+  deleteRecord,
+  destroyRecord,
+  hasMany,
+  reload,
+  rollbackAttributes,
+  save,
+  serialize,
+  unloadRecord,
+} from './model-methods';
 import notifyChanges from './notify-changes';
 import RecordState, { notifySignal, tagged } from './record-state';
 
@@ -111,6 +123,8 @@ class Model extends EmberObject {
 
     const store = (this.store = _secretInit.store);
     super.init(options);
+
+    this[RecordStore] = store;
 
     const identity = _secretInit.identifier;
     _secretInit.cb(this, _secretInit.cache, identity, _secretInit.store);
@@ -602,9 +616,6 @@ class Model extends EmberObject {
     @param {Object} options
     @return {Object} an object whose values are primitive JSON values only
   */
-  serialize(options) {
-    return storeFor(this).serializeRecord(this, options);
-  }
 
   /*
     We hook the default implementation to ensure
@@ -648,12 +659,6 @@ class Model extends EmberObject {
     @method deleteRecord
     @public
   */
-  deleteRecord() {
-    // ensure we've populated currentState prior to deleting a new record
-    if (this.currentState) {
-      storeFor(this).deleteRecord(this);
-    }
-  }
 
   /**
     Same as `deleteRecord`, but saves the record immediately.
@@ -698,17 +703,6 @@ class Model extends EmberObject {
     @return {Promise} a promise that will be resolved when the adapter returns
     successfully or rejected if the adapter returns with an error.
   */
-  destroyRecord(options) {
-    const { isNew } = this.currentState;
-    this.deleteRecord();
-    if (isNew) {
-      return Promise.resolve(this);
-    }
-    return this.save(options).then((_) => {
-      this.unloadRecord();
-      return this;
-    });
-  }
 
   /**
     Unloads the record from the store. This will not send a delete request
@@ -717,12 +711,6 @@ class Model extends EmberObject {
     @method unloadRecord
     @public
   */
-  unloadRecord() {
-    if (this.currentState.isNew && (this.isDestroyed || this.isDestroying)) {
-      return;
-    }
-    storeFor(this).unloadRecord(this);
-  }
 
   /**
     Returns an object, whose keys are changed properties, and value is
@@ -770,9 +758,6 @@ class Model extends EmberObject {
     @return {Object} an object, whose keys are changed properties,
       and value is an [oldProp, newProp] array.
   */
-  changedAttributes() {
-    return peekCache(this).changedAttrs(recordIdentifierFor(this));
-  }
 
   /**
     If the model `hasDirtyAttributes` this function will discard any unsaved
@@ -792,35 +777,12 @@ class Model extends EmberObject {
     @method rollbackAttributes
     @public
   */
-  rollbackAttributes() {
-    const { currentState } = this;
-    const { isNew } = currentState;
-
-    storeFor(this)._join(() => {
-      peekCache(this).rollbackAttrs(recordIdentifierFor(this));
-      this.errors.clear();
-      currentState.cleanErrorRequests();
-      if (isNew) {
-        this.unloadRecord();
-      }
-    });
-  }
 
   /**
     @method _createSnapshot
     @private
   */
   // TODO @deprecate in favor of a public API or examples of how to test successfully
-  _createSnapshot() {
-    const store = storeFor(this);
-
-    if (!store._fetchManager) {
-      const FetchManager = importSync('@ember-data/legacy-compat/-private').FetchManager;
-      store._fetchManager = new FetchManager(store);
-    }
-
-    return store._fetchManager.createSnapshot(recordIdentifierFor(this));
-  }
 
   /**
     Save the record and persist any changes to the record to an
@@ -863,18 +825,6 @@ class Model extends EmberObject {
     @return {Promise} a promise that will be resolved when the adapter returns
     successfully or rejected if the adapter returns with an error.
   */
-  save(options) {
-    let promise;
-
-    if (this.currentState.isNew && this.currentState.isDeleted) {
-      promise = Promise.resolve(this);
-    } else {
-      this.errors.clear();
-      promise = storeFor(this).saveRecord(this, options);
-    }
-
-    return promise;
-  }
 
   /**
     Reload the record from the adapter.
@@ -902,30 +852,6 @@ class Model extends EmberObject {
     adapter returns successfully or rejected if the adapter returns
     with an error.
   */
-  reload(options = {}) {
-    options.isReloading = true;
-    options.reload = true;
-
-    const identifier = recordIdentifierFor(this);
-    assert(`You cannot reload a record without an ID`, identifier.id);
-
-    this.isReloading = true;
-    const promise = storeFor(this)
-      .request({
-        op: 'findRecord',
-        data: {
-          options,
-          record: identifier,
-        },
-        cacheOptions: { [Symbol.for('wd:skip-cache')]: true },
-      })
-      .then(() => this)
-      .finally(() => {
-        this.isReloading = false;
-      });
-
-    return promise;
-  }
 
   attr() {
     assert(
@@ -998,9 +924,6 @@ class Model extends EmberObject {
     @since 2.5.0
     @return {BelongsToReference} reference for this relationship
   */
-  belongsTo(name) {
-    return lookupLegacySupport(this).referenceFor('belongsTo', name);
-  }
 
   /**
     Get the reference for the specified hasMany relationship.
@@ -1061,9 +984,6 @@ class Model extends EmberObject {
     @since 2.5.0
     @return {HasManyReference} reference for this relationship
   */
-  hasMany(name) {
-    return lookupLegacySupport(this).referenceFor('hasMany', name);
-  }
 
   /**
    Given a callback, iterates over each of the relationships in the model,
@@ -2069,6 +1989,18 @@ class Model extends EmberObject {
     return `model:${this.modelName}`;
   }
 }
+
+Model.prototype.save = save;
+Model.prototype.destroyRecord = destroyRecord;
+Model.prototype.unloadRecord = unloadRecord;
+Model.prototype.hasMany = hasMany;
+Model.prototype.belongsTo = belongsTo;
+Model.prototype.serialize = serialize;
+Model.prototype._createSnapshot = createSnapshot;
+Model.prototype.deleteRecord = deleteRecord;
+Model.prototype.changedAttributes = changedAttributes;
+Model.prototype.rollbackAttributes = rollbackAttributes;
+Model.prototype.reload = reload;
 
 defineSignal(Model.prototype, 'isReloading', false);
 

--- a/packages/model/src/-private/notify-changes.ts
+++ b/packages/model/src/-private/notify-changes.ts
@@ -6,8 +6,8 @@ import type { NotificationType } from '@ember-data/store/-private/managers/notif
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import { RelationshipSchema } from '@warp-drive/core-types/schema';
 
+import { LEGACY_SUPPORT } from './legacy-relationships-support';
 import type Model from './model';
-import { LEGACY_SUPPORT } from './model';
 
 export default function notifyChanges(
   identifier: StableRecordIdentifier,

--- a/packages/model/src/-private/record-state.ts
+++ b/packages/model/src/-private/record-state.ts
@@ -10,9 +10,9 @@ import type { Cache } from '@ember-data/store/-types/q/cache';
 import { cached, compat } from '@ember-data/tracking';
 import { addToTransaction, defineSignal, getSignal, peekSignal, subscribe } from '@ember-data/tracking/-private';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
+import type { RecordStore } from '@warp-drive/core-types/symbols';
 
 import type Errors from './errors';
-import type Model from './model';
 
 const SOURCE_POINTER_REGEXP = /^\/?data\/(attributes|relationships)\/(.*)/;
 const SOURCE_POINTER_PRIMARY_REGEXP = /^\/?data/;
@@ -70,6 +70,15 @@ export function notifySignal<T extends object, K extends keyof T & string>(obj: 
   }
 }
 
+export interface MinimalLegacyRecord {
+  errors: Errors;
+  ___recordState: RecordState;
+  currentState: RecordState;
+  isDestroyed: boolean;
+  isDestroying: boolean;
+  [RecordStore]: Store;
+}
+
 /**
 Historically EmberData managed a state machine
 for each record, the localState for which
@@ -112,7 +121,7 @@ root
 export default class RecordState {
   declare store: Store;
   declare identifier: StableRecordIdentifier;
-  declare record: Model;
+  declare record: MinimalLegacyRecord;
   declare rs: RequestStateService;
 
   declare pendingCount: number;
@@ -123,7 +132,7 @@ export default class RecordState {
   declare _lastError: RequestState | null;
   declare handler: object;
 
-  constructor(record: Model) {
+  constructor(record: MinimalLegacyRecord) {
     const store = storeFor(record)!;
     const identity = recordIdentifierFor(record);
 

--- a/packages/model/src/-private/record-state.ts
+++ b/packages/model/src/-private/record-state.ts
@@ -10,9 +10,9 @@ import type { Cache } from '@ember-data/store/-types/q/cache';
 import { cached, compat } from '@ember-data/tracking';
 import { addToTransaction, defineSignal, getSignal, peekSignal, subscribe } from '@ember-data/tracking/-private';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
-import type { RecordStore } from '@warp-drive/core-types/symbols';
 
 import type Errors from './errors';
+import type { MinimalLegacyRecord } from './model-methods';
 
 const SOURCE_POINTER_REGEXP = /^\/?data\/(attributes|relationships)\/(.*)/;
 const SOURCE_POINTER_PRIMARY_REGEXP = /^\/?data/;
@@ -68,15 +68,6 @@ export function notifySignal<T extends object, K extends keyof T & string>(obj: 
     signal.shouldReset = true;
     addToTransaction(signal);
   }
-}
-
-export interface MinimalLegacyRecord {
-  errors: Errors;
-  ___recordState: RecordState;
-  currentState: RecordState;
-  isDestroyed: boolean;
-  isDestroying: boolean;
-  [RecordStore]: Store;
 }
 
 /**

--- a/packages/model/src/-private/record-state.ts
+++ b/packages/model/src/-private/record-state.ts
@@ -224,7 +224,6 @@ export default class RecordState {
             this.notify('isDirty');
             break;
           case 'errors':
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.updateInvalidErrors(this.record.errors);
             this.notify('isValid');
             break;
@@ -333,7 +332,6 @@ export default class RecordState {
 
   @tagged
   get isValid() {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     return this.record.errors.length === 0;
   }
 

--- a/packages/model/src/-private/references/belongs-to.ts
+++ b/packages/model/src/-private/references/belongs-to.ts
@@ -17,8 +17,7 @@ import type {
 } from '@warp-drive/core-types/spec/raw';
 
 import { assertPolymorphicType } from '../debug/assert-polymorphic-type';
-import { areAllInverseRecordsLoaded, LegacySupport } from '../legacy-relationships-support';
-import { LEGACY_SUPPORT } from '../model';
+import { areAllInverseRecordsLoaded, LEGACY_SUPPORT, LegacySupport } from '../legacy-relationships-support';
 
 /**
   @module @ember-data/model

--- a/packages/model/src/-private/references/has-many.ts
+++ b/packages/model/src/-private/references/has-many.ts
@@ -21,9 +21,8 @@ import type {
 } from '@warp-drive/core-types/spec/raw';
 
 import { assertPolymorphicType } from '../debug/assert-polymorphic-type';
-import { areAllInverseRecordsLoaded, LegacySupport } from '../legacy-relationships-support';
+import { areAllInverseRecordsLoaded, LEGACY_SUPPORT, LegacySupport  } from '../legacy-relationships-support';
 import type ManyArray from '../many-array';
-import { LEGACY_SUPPORT } from '../model';
 
 /**
   @module @ember-data/model

--- a/packages/model/src/-private/references/has-many.ts
+++ b/packages/model/src/-private/references/has-many.ts
@@ -21,7 +21,7 @@ import type {
 } from '@warp-drive/core-types/spec/raw';
 
 import { assertPolymorphicType } from '../debug/assert-polymorphic-type';
-import { areAllInverseRecordsLoaded, LEGACY_SUPPORT, LegacySupport  } from '../legacy-relationships-support';
+import { areAllInverseRecordsLoaded, LEGACY_SUPPORT, LegacySupport } from '../legacy-relationships-support';
 import type ManyArray from '../many-array';
 
 /**

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -1,0 +1,62 @@
+import { assert } from '@ember/debug';
+
+import { recordIdentifierFor } from '@ember-data/store';
+import { RecordStore } from '@warp-drive/core-types/symbols';
+
+import RecordState, { MinimalLegacyRecord } from './-private/record-state';
+
+interface FieldSchema {
+  type: string | null;
+  name: string;
+  kind: 'attribute' | 'resource' | 'collection' | 'derived' | 'object' | 'array' | '@id';
+  options?: Record<string, unknown>;
+}
+
+type Derivation<R, T> = (record: R, options: Record<string, unknown> | null, prop: string) => T;
+type SchemaService = {
+  registerDerivation(name: string, derivation: Derivation<unknown, unknown>): void;
+};
+
+const LegacyFields = ['constructor', 'currentState', 'unloadRecord'];
+
+function unloadRecord(this: MinimalLegacyRecord) {
+  if (this.currentState.isNew && (this.isDestroyed || this.isDestroying)) {
+    return;
+  }
+  this[RecordStore].unloadRecord(this);
+}
+
+function legacySupport(record: MinimalLegacyRecord, options: Record<string, unknown> | null, prop: string): unknown {
+  switch (prop) {
+    case 'constructor':
+      return {
+        modelName: recordIdentifierFor(record).type,
+      };
+    case 'currentState':
+      return (record.___recordState = record.___recordState || new RecordState(record));
+    case 'unloadRecord':
+      return unloadRecord;
+    default:
+      assert(`${prop} is not a supported legacy field`, false);
+  }
+}
+
+export function withFields(fields: FieldSchema[]) {
+  LegacyFields.forEach((field) => {
+    fields.push({
+      type: '@legacy',
+      name: field,
+      kind: 'derived',
+    });
+  });
+  fields.push({
+    name: 'id',
+    kind: '@id',
+    type: null,
+  });
+  return fields;
+}
+
+export function registerDerivations(schema: SchemaService) {
+  schema.registerDerivation('@legacy', legacySupport as Derivation<unknown, unknown>);
+}

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -6,7 +6,7 @@ import { upgradeStore } from '@ember-data/legacy-compat/-private';
 import { recordIdentifierFor } from '@ember-data/store';
 import { RecordStore } from '@warp-drive/core-types/symbols';
 
-import { Errors } from './-private';
+import { Errors , lookupLegacySupport } from './-private';
 import RecordState, { MinimalLegacyRecord } from './-private/record-state';
 
 interface FieldSchema {
@@ -56,6 +56,14 @@ function unloadRecord(this: MinimalLegacyRecord) {
   this[RecordStore].unloadRecord(this);
 }
 
+function belongsTo(this: MinimalLegacyRecord, prop: string) {
+  return lookupLegacySupport(this).referenceFor('belongsTo', prop);
+}
+
+function hasMany(this: MinimalLegacyRecord, prop: string) {
+  return lookupLegacySupport(this).referenceFor('hasMany', prop);
+}
+
 function serialize(this: MinimalLegacyRecord, options?: Record<string, unknown>) {
   upgradeStore(this[RecordStore]);
   return this[RecordStore].serializeRecord(this, options);
@@ -88,7 +96,7 @@ function legacySupport(record: MinimalLegacyRecord, options: Record<string, unkn
     case 'adapterError':
       return record.currentState.adapterError;
     case 'belongsTo':
-      throw new Error('not implemented');
+      return belongsTo;
     case 'changedAttributes':
       throw new Error('not implemented');
     case 'constructor':
@@ -111,7 +119,7 @@ function legacySupport(record: MinimalLegacyRecord, options: Record<string, unkn
     case 'hasDirtyAttributes':
       return record.currentState.isDirty;
     case 'hasMany':
-      throw new Error('not implemented');
+      return hasMany;
     case 'isDeleted':
       return record.currentState.isDeleted;
     case 'isEmpty':

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -1,5 +1,8 @@
 import { assert } from '@ember/debug';
 
+import { importSync } from '@embroider/macros';
+
+import { upgradeStore } from '@ember-data/legacy-compat/-private';
 import { recordIdentifierFor } from '@ember-data/store';
 import { RecordStore } from '@warp-drive/core-types/symbols';
 
@@ -17,14 +20,57 @@ type Derivation<R, T> = (record: R, options: Record<string, unknown> | null, pro
 type SchemaService = {
   registerDerivation(name: string, derivation: Derivation<unknown, unknown>): void;
 };
-
-const LegacyFields = ['constructor', 'currentState', 'unloadRecord', 'errors'];
+// 'isDestroying', 'isDestroyed'
+const LegacyFields = [
+  '_createSnapshot',
+  'adapterError',
+  'belongsTo',
+  'changedAttributes',
+  'constructor',
+  'currentState',
+  'deleteRecord',
+  'destroyRecord',
+  'dirtyType',
+  'errors',
+  'hasDirtyAttributes',
+  'hasMany',
+  'isDeleted',
+  'isEmpty',
+  'isError',
+  'isLoaded',
+  'isLoading',
+  'isNew',
+  'isSaving',
+  'isValid',
+  'reload',
+  'rollbackAttributes',
+  'save',
+  'serialize',
+  'unloadRecord',
+];
 
 function unloadRecord(this: MinimalLegacyRecord) {
   if (this.currentState.isNew && (this.isDestroyed || this.isDestroying)) {
     return;
   }
   this[RecordStore].unloadRecord(this);
+}
+
+function serialize(this: MinimalLegacyRecord, options?: Record<string, unknown>) {
+  upgradeStore(this[RecordStore]);
+  return this[RecordStore].serializeRecord(this, options);
+}
+
+function createSnapshot(this: MinimalLegacyRecord) {
+  const store = this[RecordStore];
+
+  upgradeStore(store);
+  if (!store._fetchManager) {
+    const FetchManager = (importSync('@ember-data/legacy-compat/-private') as typeof import('@ember-data/legacy-compat/-private')).FetchManager;
+    store._fetchManager = new FetchManager(store);
+  }
+
+  return store._fetchManager.createSnapshot(recordIdentifierFor(this));
 }
 
 const LegacySupport = new WeakMap<MinimalLegacyRecord, Record<string, unknown>>();
@@ -37,18 +83,61 @@ function legacySupport(record: MinimalLegacyRecord, options: Record<string, unkn
   }
 
   switch (prop) {
+    case '_createSnapshot':
+      return createSnapshot;
+    case 'adapterError':
+      return record.currentState.adapterError;
+    case 'belongsTo':
+      throw new Error('not implemented');
+    case 'changedAttributes':
+      throw new Error('not implemented');
     case 'constructor':
       return (state._constructor = state._constructor || {
+        isModel: true,
         modelName: recordIdentifierFor(record).type,
       });
     case 'currentState':
       return (state.recordState = state.recordState || new RecordState(record));
-    case 'unloadRecord':
-      return unloadRecord;
+    case 'deleteRecord':
+      throw new Error('not implemented');
+    case 'destroyRecord':
+      throw new Error('not implemented');
+    case 'dirtyType':
+      return record.currentState.dirtyType;
     case 'errors':
       // @ts-expect-error
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       return (state.errors = state.errors || Errors.create({ __record: record }));
+    case 'hasDirtyAttributes':
+      return record.currentState.isDirty;
+    case 'hasMany':
+      throw new Error('not implemented');
+    case 'isDeleted':
+      return record.currentState.isDeleted;
+    case 'isEmpty':
+      return record.currentState.isEmpty;
+    case 'isError':
+      return record.currentState.isError;
+    case 'isLoaded':
+      return record.currentState.isLoaded;
+    case 'isLoading':
+      return record.currentState.isLoading;
+    case 'isNew':
+      return record.currentState.isNew;
+    case 'isSaving':
+      return record.currentState.isSaving;
+    case 'isValid':
+      return record.currentState.isValid;
+    case 'reload':
+      throw new Error('not implemented');
+    case 'rollbackAttributes':
+      throw new Error('not implemented');
+    case 'save':
+      throw new Error('not implemented');
+    case 'serialize':
+      return serialize;
+    case 'unloadRecord':
+      return unloadRecord;
     default:
       assert(`${prop} is not a supported legacy field`, false);
   }

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -148,6 +148,18 @@ export function withFields(fields: FieldSchema[]) {
     type: 'boolean',
     options: { defaultValue: false },
   });
+  fields.push({
+    name: 'isDestroying',
+    kind: '@local',
+    type: 'boolean',
+    options: { defaultValue: false },
+  });
+  fields.push({
+    name: 'isDestroyed',
+    kind: '@local',
+    type: 'boolean',
+    options: { defaultValue: false },
+  });
   return fields;
 }
 

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -22,7 +22,7 @@ import RecordState from './-private/record-state';
 interface FieldSchema {
   type: string | null;
   name: string;
-  kind: 'attribute' | 'resource' | 'collection' | 'derived' | 'object' | 'array' | '@id';
+  kind: 'attribute' | 'resource' | 'collection' | 'derived' | 'object' | 'array' | '@id' | '@local';
   options?: Record<string, unknown>;
 }
 
@@ -141,6 +141,12 @@ export function withFields(fields: FieldSchema[]) {
     name: 'id',
     kind: '@id',
     type: null,
+  });
+  fields.push({
+    name: 'isReloading',
+    kind: '@local',
+    type: 'boolean',
+    options: { defaultValue: false },
   });
   return fields;
 }

--- a/packages/schema-record/package.json
+++ b/packages/schema-record/package.json
@@ -41,6 +41,11 @@
       "default": "./addon/*.js"
     }
   },
+  "peerDependencies": {
+    "@ember-data/store": "workspace:5.5.0-alpha.11",
+    "@warp-drive/core-types": "workspace:5.5.0-alpha.11",
+    "@ember-data/tracking": "workspace:5.5.0-alpha.11"
+  },
   "dependenciesMeta": {
     "@ember-data/private-build-infra": {
       "injected": true

--- a/packages/schema-record/rollup.config.mjs
+++ b/packages/schema-record/rollup.config.mjs
@@ -14,7 +14,7 @@ export default {
   // You can augment this if you need to.
   output: addon.output(),
 
-  external: external(['@embroider/macros']),
+  external: external(['@embroider/macros', '@ember/debug']),
 
   plugins: [
     // These are the modules that users should be able to import from your

--- a/packages/schema-record/src/-base-fields.ts
+++ b/packages/schema-record/src/-base-fields.ts
@@ -1,0 +1,52 @@
+import { assert } from '@ember/debug';
+
+import type { StableRecordIdentifier } from '@warp-drive/core-types';
+
+import { Identifier, type SchemaRecord } from './record';
+import type { Derivation, FieldSchema, SchemaService } from './schema';
+
+export const SchemaRecordFields: FieldSchema[] = [
+  {
+    name: 'id',
+    kind: '@id',
+    type: null,
+  },
+  {
+    type: '@identity',
+    name: '$type',
+    kind: 'derived',
+    options: { key: 'type' },
+  },
+];
+
+export function withFields(fields: FieldSchema[]) {
+  fields.push(...SchemaRecordFields);
+  return fields;
+}
+
+export function fromIdentity(record: SchemaRecord, options: null, key: string): asserts options;
+export function fromIdentity(record: SchemaRecord, options: { key: 'lid' }, key: string): string;
+export function fromIdentity(record: SchemaRecord, options: { key: 'type' }, key: string): string;
+export function fromIdentity(record: SchemaRecord, options: { key: 'id' }, key: string): string | null;
+export function fromIdentity(record: SchemaRecord, options: { key: '^' }, key: string): StableRecordIdentifier;
+export function fromIdentity(
+  record: SchemaRecord,
+  options: { key: 'id' | 'lid' | 'type' | '^' } | null,
+  key: string
+): StableRecordIdentifier | string | null {
+  const identifier = record[Identifier];
+  assert(`Cannot compute @identity for a record without an identifier`, identifier);
+  assert(
+    `Expected to receive a key to compute @identity, but got ${String(options)}`,
+    options?.key && ['lid', 'id', 'type', '^'].includes(options.key)
+  );
+
+  return options.key === '^' ? identifier : identifier[options.key];
+}
+
+export function registerDerivations(schema: SchemaService) {
+  schema.registerDerivation(
+    '@identity',
+    fromIdentity as Derivation<SchemaRecord, StableRecordIdentifier | string | null>
+  );
+}

--- a/packages/schema-record/src/record.ts
+++ b/packages/schema-record/src/record.ts
@@ -211,6 +211,10 @@ export class SchemaRecord {
           return target[prop as keyof SchemaRecord];
         }
 
+        if (prop === '___notifications') {
+          return target.___notifications;
+        }
+
         // SchemaRecord reserves use of keys that begin with these characters
         // for its own usage.
         // _, @, $, *

--- a/packages/schema-record/src/schema.ts
+++ b/packages/schema-record/src/schema.ts
@@ -11,7 +11,7 @@ export { withFields, registerDerivations } from './-base-fields';
 export interface FieldSchema {
   type: string | null;
   name: string;
-  kind: 'attribute' | 'resource' | 'collection' | 'derived' | 'object' | 'array' | '@id';
+  kind: 'attribute' | 'resource' | 'collection' | 'derived' | 'object' | 'array' | '@id' | '@local';
   options?: Record<string, unknown>;
 }
 
@@ -103,7 +103,7 @@ export class SchemaService {
           kind: field.kind === 'resource' ? 'belongsTo' : 'hasMany',
         }) as unknown as RelationshipSchema;
         fieldSpec.relationships[field.name] = relSchema;
-      } else if (field.kind !== 'derived') {
+      } else if (field.kind !== 'derived' && field.kind !== '@local') {
         throw new Error(`Unknown field kind ${field.kind}`);
       }
     });

--- a/packages/schema-record/src/schema.ts
+++ b/packages/schema-record/src/schema.ts
@@ -1,13 +1,17 @@
+import { assert } from '@ember/debug';
+
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { Value } from '@warp-drive/core-types/json/raw';
 import type { AttributeSchema, RelationshipSchema } from '@warp-drive/core-types/schema';
 
 import type { SchemaRecord } from './record';
 
+export { withFields, registerDerivations } from './-base-fields';
+
 export interface FieldSchema {
   type: string | null;
   name: string;
-  kind: 'attribute' | 'resource' | 'collection' | 'derived' | 'object' | 'array';
+  kind: 'attribute' | 'resource' | 'collection' | 'derived' | 'object' | 'array' | '@id';
   options?: Record<string, unknown>;
 }
 
@@ -18,6 +22,7 @@ export interface FieldSchema {
  * @internal
  */
 type FieldSpec = {
+  '@id': FieldSchema | null;
   /**
    * legacy schema service separated attribute
    * from relationship lookup
@@ -72,16 +77,26 @@ export class SchemaService {
   defineSchema(name: string, schema: { legacy?: boolean; fields: FieldSchema[] }): void {
     const { legacy, fields } = schema;
     const fieldSpec: FieldSpec = {
+      '@id': null,
       attributes: {},
       relationships: {},
       fields: new Map(),
       legacy: legacy ?? false,
     };
 
+    assert(
+      `Only one field can be defined as @id, ${name} has more than one: ${fields
+        .filter((f) => f.kind === '@id')
+        .map((f) => f.name)
+        .join(' ')}`,
+      fields.filter((f) => f.kind === '@id').length <= 1
+    );
     fields.forEach((field) => {
       fieldSpec.fields.set(field.name, field);
 
-      if (field.kind === 'attribute') {
+      if (field.kind === '@id') {
+        fieldSpec['@id'] = field;
+      } else if (field.kind === 'attribute') {
         fieldSpec.attributes[field.name] = field as AttributeSchema;
       } else if (field.kind === 'resource' || field.kind === 'collection') {
         const relSchema = Object.assign({}, field, {

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -2060,7 +2060,7 @@ class Store extends EmberObject {
     if (!identifier) {
       // this commonly means we're disconnected
       // but just in case we reject here to prevent bad things.
-      return Promise.reject(`Record Is Disconnected`);
+      return Promise.reject(new Error(`Record Is Disconnected`));
     }
     // TODO we used to check if the record was destroyed here
     assert(

--- a/packages/unpublished-test-infra/addon-test-support/asserts/assert-assertion.ts
+++ b/packages/unpublished-test-infra/addon-test-support/asserts/assert-assertion.ts
@@ -59,7 +59,7 @@ async function expectAssertion(
     }
     outcome = verifyAssertion('', matcher, label);
   } catch (e) {
-    outcome = verifyAssertion(e instanceof Error ? e.message : e as string, matcher, label);
+    outcome = verifyAssertion(e instanceof Error ? e.message : (e as string), matcher, label);
   }
 
   if (!DEBUG) {

--- a/packages/unpublished-test-infra/addon-test-support/asserts/assert-assertion.ts
+++ b/packages/unpublished-test-infra/addon-test-support/asserts/assert-assertion.ts
@@ -59,7 +59,7 @@ async function expectAssertion(
     }
     outcome = verifyAssertion('', matcher, label);
   } catch (e) {
-    outcome = verifyAssertion((e as Error).message, matcher, label);
+    outcome = verifyAssertion(e instanceof Error ? e.message : e as string, matcher, label);
   }
 
   if (!DEBUG) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4142,6 +4142,12 @@ importers:
       '@ember-data/json-api':
         specifier: workspace:5.5.0-alpha.11
         version: file:packages/json-api(@babel/core@7.23.2)(@ember-data/graph@5.5.0-alpha.11)(@ember-data/request-utils@5.5.0-alpha.11)(@ember-data/store@5.5.0-alpha.11)(@warp-drive/core-types@5.5.0-alpha.11)(ember-inflector@4.0.2)
+      '@ember-data/legacy-compat':
+        specifier: workspace:5.5.0-alpha.11
+        version: file:packages/legacy-compat(@babel/core@7.23.2)(@ember-data/graph@5.5.0-alpha.11)(@ember-data/json-api@5.5.0-alpha.11)(@ember-data/request@5.5.0-alpha.11)(@ember-data/store@5.5.0-alpha.11)(@warp-drive/core-types@5.5.0-alpha.11)
+      '@ember-data/model':
+        specifier: workspace:5.5.0-alpha.11
+        version: file:packages/model(@babel/core@7.23.2)(@ember-data/debug@5.5.0-alpha.11)(@ember-data/graph@5.5.0-alpha.11)(@ember-data/json-api@5.5.0-alpha.11)(@ember-data/legacy-compat@5.5.0-alpha.11)(@ember-data/store@5.5.0-alpha.11)(@ember-data/tracking@5.5.0-alpha.11)(@ember/string@3.1.1)(@warp-drive/core-types@5.5.0-alpha.11)(ember-inflector@4.0.2)
       '@ember-data/private-build-infra':
         specifier: workspace:5.5.0-alpha.11
         version: file:packages/private-build-infra
@@ -4260,6 +4266,10 @@ importers:
       '@ember-data/graph':
         injected: true
       '@ember-data/json-api':
+        injected: true
+      '@ember-data/legacy-compat':
+        injected: true
+      '@ember-data/model':
         injected: true
       '@ember-data/private-build-infra':
         injected: true

--- a/tests/warp-drive__schema-record/package.json
+++ b/tests/warp-drive__schema-record/package.json
@@ -29,6 +29,12 @@
     "@ember-data/store": {
       "injected": true
     },
+    "@ember-data/model": {
+      "injected": true
+    },
+    "@ember-data/legacy-compat": {
+      "injected": true
+    },
     "@ember-data/request": {
       "injected": true
     },
@@ -71,6 +77,8 @@
     "@ember-data/store": "workspace:5.5.0-alpha.11",
     "@ember-data/tracking": "workspace:5.5.0-alpha.11",
     "@ember-data/unpublished-test-infra": "workspace:5.5.0-alpha.11",
+    "@ember-data/model": "workspace:5.5.0-alpha.11",
+    "@ember-data/legacy-compat": "workspace:5.5.0-alpha.11",
     "@ember/edition-utils": "^1.2.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "3.1.1",

--- a/tests/warp-drive__schema-record/tests/-utils/reactive-context.ts
+++ b/tests/warp-drive__schema-record/tests/-utils/reactive-context.ts
@@ -8,7 +8,7 @@ import type { ResourceRelationship } from '@warp-drive/core-types/cache/relation
 import type { FieldSchema } from '@warp-drive/schema-record/schema';
 
 export async function reactiveContext<T extends RecordInstance>(this: TestContext, record: T, fields: FieldSchema[]) {
-  const _fields: string[] = ['idCount', 'id', '$typeCount', '$type'];
+  const _fields: string[] = [];
   fields.forEach((field) => {
     _fields.push(field.name + 'Count');
     _fields.push(field.name);
@@ -19,36 +19,7 @@ export async function reactiveContext<T extends RecordInstance>(this: TestContex
       return _fields;
     }
   }
-
   const counters: Record<string, number> = {};
-  counters['id'] = 0;
-  counters['$type'] = 0;
-
-  Object.defineProperty(ReactiveComponent.prototype, 'idCount', {
-    get() {
-      return counters['id'];
-    },
-  });
-  Object.defineProperty(ReactiveComponent.prototype, '$typeCount', {
-    get() {
-      return counters['$type'];
-    },
-  });
-
-  Object.defineProperty(ReactiveComponent.prototype, 'id', {
-    get() {
-      counters['id']++;
-      // @ts-expect-error RecordInstance isn't typed yet
-      return record['id'] as unknown;
-    },
-  });
-  Object.defineProperty(ReactiveComponent.prototype, '$type', {
-    get() {
-      counters['$type']++;
-      // @ts-expect-error RecordInstance isn't typed yet
-      return record['$type'] as unknown;
-    },
-  });
 
   fields.forEach((field) => {
     counters[field.name] = 0;

--- a/tests/warp-drive__schema-record/tests/legacy/mode-test.ts
+++ b/tests/warp-drive__schema-record/tests/legacy/mode-test.ts
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 
 import { setupRenderingTest } from 'ember-qunit';
 
+import { registerDerivations, withFields } from '@ember-data/model/migration-support';
 import type Store from '@ember-data/store';
 import { Editable, Legacy } from '@warp-drive/schema-record/record';
 import { SchemaService } from '@warp-drive/schema-record/schema';
@@ -25,16 +26,17 @@ module('Legacy Mode', function (hooks) {
     const store = this.owner.lookup('service:store') as Store;
     const schema = new SchemaService();
     store.registerSchema(schema);
+    registerDerivations(schema);
 
     schema.defineSchema('user', {
       legacy: true,
-      fields: [
+      fields: withFields([
         {
           name: 'name',
           type: null,
           kind: 'attribute',
         },
-      ],
+      ]),
     });
 
     const record = store.push({
@@ -54,11 +56,7 @@ module('Legacy Mode', function (hooks) {
       record.$type;
       assert.ok(false, 'record.$type should throw');
     } catch (e) {
-      assert.strictEqual(
-        (e as Error).message,
-        'Assertion Failed: SchemaRecord.$type is not available in legacy mode',
-        'record.$type throws'
-      );
+      assert.strictEqual((e as Error).message, 'No field named $type on user', 'record.$type throws');
     }
   });
 
@@ -66,6 +64,7 @@ module('Legacy Mode', function (hooks) {
     const store = this.owner.lookup('service:store') as Store;
     const schema = new SchemaService();
     store.registerSchema(schema);
+    registerDerivations(schema);
 
     schema.defineSchema('user', {
       legacy: false,
@@ -87,7 +86,6 @@ module('Legacy Mode', function (hooks) {
     }) as User;
 
     assert.false(record[Legacy], 'record is in legacy mode');
-    assert.strictEqual(record.$type, 'user', '$type is accessible');
 
     try {
       (record.constructor as { modelName?: string }).modelName;
@@ -95,7 +93,7 @@ module('Legacy Mode', function (hooks) {
     } catch (e) {
       assert.strictEqual(
         (e as Error).message,
-        'Assertion Failed: SchemaRecord.constructor.modelName is not available ouside of legacy mode',
+        'No field named constructor on user',
         'record.constructor.modelName throws'
       );
     }
@@ -105,16 +103,17 @@ module('Legacy Mode', function (hooks) {
     const store = this.owner.lookup('service:store') as Store;
     const schema = new SchemaService();
     store.registerSchema(schema);
+    registerDerivations(schema);
 
     schema.defineSchema('user', {
       legacy: true,
-      fields: [
+      fields: withFields([
         {
           name: 'name',
           type: null,
           kind: 'attribute',
         },
-      ],
+      ]),
     });
 
     const record = store.push({

--- a/tests/warp-drive__schema-record/tests/legacy/mode-test.ts
+++ b/tests/warp-drive__schema-record/tests/legacy/mode-test.ts
@@ -13,7 +13,17 @@ import { SchemaService } from '@warp-drive/schema-record/schema';
 interface User {
   [Legacy]: boolean;
   [Editable]: boolean;
+  hasDirtyAttributes: boolean;
   isDeleted: boolean;
+  isEmpty: boolean;
+  isError: boolean;
+  isLoaded: boolean;
+  isLoading: boolean;
+  isNew: boolean;
+  isSaving: boolean;
+  isValid: boolean;
+  dirtyType: string;
+  adapterError: unknown;
   deleteRecord(): void;
   id: string | null;
   $type: 'user';
@@ -312,5 +322,72 @@ module('Legacy Mode', function (hooks) {
     assert.strictEqual(snapshot.id, '1', 'snapshot id is correct');
     assert.strictEqual(snapshot.modelName, 'user', 'snapshot modelName is correct');
     assert.strictEqual(snapshot.attributes().name, 'Rey Pupatine', 'snapshot attribute is correct');
+  });
+
+  test('we can access state flags', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const schema = new SchemaService();
+    store.registerSchema(schema);
+    registerDerivations(schema);
+
+    schema.defineSchema('user', {
+      legacy: true,
+      fields: withFields([
+        {
+          name: 'name',
+          type: null,
+          kind: 'attribute',
+        },
+      ]),
+    });
+
+    const record = store.push({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    }) as User;
+
+    assert.strictEqual(record.dirtyType, '', 'dirtyType is correct');
+    assert.strictEqual(record.adapterError, null, 'adapterError is correct');
+    assert.false(record.hasDirtyAttributes, 'hasDirtyAttributes is correct');
+    assert.false(record.isDeleted, 'isDeleted is correct');
+    assert.false(record.isEmpty, 'isEmpty is correct');
+    assert.false(record.isError, 'isError is correct');
+    assert.true(record.isLoaded, 'isLoaded is correct');
+    assert.false(record.isLoading, 'isReloading is correct');
+    assert.false(record.isNew, 'isNew is correct');
+    assert.false(record.isSaving, 'isSaving is correct');
+    assert.true(record.isValid, 'isValid is correct');
+  });
+
+  test('we can access object lifecycle flags', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const schema = new SchemaService();
+    store.registerSchema(schema);
+    registerDerivations(schema);
+
+    schema.defineSchema('user', {
+      legacy: true,
+      fields: withFields([
+        {
+          name: 'name',
+          type: null,
+          kind: 'attribute',
+        },
+      ]),
+    });
+
+    const record = store.push({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    }) as User;
+
+    assert.false(record.isDestroying, 'isDestroying is correct');
+    assert.false(record.isDestroyed, 'isDestroyed is correct');
   });
 });

--- a/tests/warp-drive__schema-record/tests/reactivity/basic-fields-test.ts
+++ b/tests/warp-drive__schema-record/tests/reactivity/basic-fields-test.ts
@@ -8,7 +8,7 @@ import type Store from '@ember-data/store';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { SchemaRecord } from '@warp-drive/schema-record/record';
 import type { FieldSchema, Transform } from '@warp-drive/schema-record/schema';
-import { SchemaService } from '@warp-drive/schema-record/schema';
+import { registerDerivations, SchemaService, withFields } from '@warp-drive/schema-record/schema';
 
 import { reactiveContext } from '../-utils/reactive-context';
 
@@ -29,15 +29,16 @@ module('Reactivity | basic fields can receive remote updates', function (hooks) 
     const store = this.owner.lookup('service:store') as Store;
     const schema = new SchemaService();
     store.registerSchema(schema);
+    registerDerivations(schema);
 
     schema.defineSchema('user', {
-      fields: [
+      fields: withFields([
         {
           name: 'name',
           type: null,
           kind: 'attribute',
         },
-      ],
+      ]),
     });
     const fieldsMap = schema.schemas.get('user')!.fields;
     const fields: FieldSchema[] = [...fieldsMap.values()];
@@ -89,6 +90,7 @@ module('Reactivity | basic fields can receive remote updates', function (hooks) 
     const store = this.owner.lookup('service:store') as Store;
     const schema = new SchemaService();
     store.registerSchema(schema);
+    registerDerivations(schema);
 
     const FloatTransform: Transform<string | number, number> = {
       serialize(value: string | number, options: { precision?: number } | null, _record: SchemaRecord): string {
@@ -111,7 +113,7 @@ module('Reactivity | basic fields can receive remote updates', function (hooks) 
     schema.registerTransform('float', FloatTransform);
 
     schema.defineSchema('user', {
-      fields: [
+      fields: withFields([
         {
           name: 'name',
           type: null,
@@ -140,7 +142,7 @@ module('Reactivity | basic fields can receive remote updates', function (hooks) 
           type: 'float',
           kind: 'attribute',
         },
-      ],
+      ]),
     });
 
     const fieldsMap = schema.schemas.get('user')!.fields;

--- a/tests/warp-drive__schema-record/tests/reactivity/derivation-test.ts
+++ b/tests/warp-drive__schema-record/tests/reactivity/derivation-test.ts
@@ -6,7 +6,7 @@ import { setupRenderingTest } from 'ember-qunit';
 
 import type Store from '@ember-data/store';
 import { SchemaRecord } from '@warp-drive/schema-record/record';
-import { FieldSchema, SchemaService } from '@warp-drive/schema-record/schema';
+import { FieldSchema, registerDerivations, SchemaService, withFields } from '@warp-drive/schema-record/schema';
 
 import { reactiveContext } from '../-utils/reactive-context';
 
@@ -37,9 +37,10 @@ module('Reactivity | derivation', function (hooks) {
     }
 
     schema.registerDerivation('concat', concat);
+    registerDerivations(schema);
 
     schema.defineSchema('user', {
-      fields: [
+      fields: withFields([
         {
           name: 'firstName',
           type: null,
@@ -56,7 +57,7 @@ module('Reactivity | derivation', function (hooks) {
           options: { fields: ['firstName', 'lastName'], separator: ' ' },
           kind: 'derived',
         },
-      ],
+      ]),
     });
 
     const fieldsMap = schema.schemas.get('user')!.fields;

--- a/tests/warp-drive__schema-record/tests/reads/basic-fields-test.ts
+++ b/tests/warp-drive__schema-record/tests/reads/basic-fields-test.ts
@@ -8,7 +8,7 @@ import type { JsonApiResource } from '@ember-data/store/-types/q/record-data-jso
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { SchemaRecord } from '@warp-drive/schema-record/record';
 import type { Transform } from '@warp-drive/schema-record/schema';
-import { SchemaService } from '@warp-drive/schema-record/schema';
+import { registerDerivations, SchemaService, withFields } from '@warp-drive/schema-record/schema';
 
 interface User {
   id: string | null;
@@ -27,15 +27,16 @@ module('Reads | basic fields', function (hooks) {
     const store = this.owner.lookup('service:store') as Store;
     const schema = new SchemaService();
     store.registerSchema(schema);
+    registerDerivations(schema);
 
     schema.defineSchema('user', {
-      fields: [
+      fields: withFields([
         {
           name: 'name',
           type: null,
           kind: 'attribute',
         },
-      ],
+      ]),
     });
 
     const record = store.createRecord('user', { name: 'Rey Skybarker' }) as User;
@@ -82,9 +83,10 @@ module('Reads | basic fields', function (hooks) {
     };
 
     schema.registerTransform('float', FloatTransform);
+    registerDerivations(schema);
 
     schema.defineSchema('user', {
-      fields: [
+      fields: withFields([
         {
           name: 'name',
           type: null,
@@ -118,7 +120,7 @@ module('Reads | basic fields', function (hooks) {
           type: 'float',
           kind: 'attribute',
         },
-      ],
+      ]),
     });
 
     const record = store.createRecord('user', {

--- a/tests/warp-drive__schema-record/tests/reads/derivation-test.ts
+++ b/tests/warp-drive__schema-record/tests/reads/derivation-test.ts
@@ -4,7 +4,7 @@ import { setupTest } from 'ember-qunit';
 
 import type Store from '@ember-data/store';
 import { SchemaRecord } from '@warp-drive/schema-record/record';
-import { SchemaService } from '@warp-drive/schema-record/schema';
+import { registerDerivations, SchemaService, withFields } from '@warp-drive/schema-record/schema';
 
 interface User {
   id: string | null;
@@ -33,9 +33,10 @@ module('Reads | derivation', function (hooks) {
     }
 
     schema.registerDerivation('concat', concat);
+    registerDerivations(schema);
 
     schema.defineSchema('user', {
-      fields: [
+      fields: withFields([
         {
           name: 'firstName',
           type: null,
@@ -52,7 +53,7 @@ module('Reads | derivation', function (hooks) {
           options: { fields: ['firstName', 'lastName'], separator: ' ' },
           kind: 'derived',
         },
-      ],
+      ]),
     });
 
     const record = store.createRecord('user', { firstName: 'Rey', lastName: 'Skybarker' }) as User;

--- a/tests/warp-drive__schema-record/tests/reads/resource-test.ts
+++ b/tests/warp-drive__schema-record/tests/reads/resource-test.ts
@@ -7,7 +7,7 @@ import { setupTest } from 'ember-qunit';
 import type Store from '@ember-data/store';
 import { Document } from '@ember-data/store/-private/document';
 import { SchemaRecord } from '@warp-drive/schema-record/record';
-import { SchemaService } from '@warp-drive/schema-record/schema';
+import { registerDerivations, SchemaService, withFields } from '@warp-drive/schema-record/schema';
 
 interface User {
   id: string | null;
@@ -35,9 +35,10 @@ module('Reads | resource', function (hooks) {
     }
 
     schema.registerDerivation('concat', concat);
+    registerDerivations(schema);
 
     schema.defineSchema('user', {
-      fields: [
+      fields: withFields([
         {
           name: 'name',
           type: null,
@@ -49,7 +50,7 @@ module('Reads | resource', function (hooks) {
           kind: 'resource',
           options: { inverse: 'bestFriend', async: true },
         },
-      ],
+      ]),
     });
 
     const record = store.push({

--- a/tests/warp-drive__schema-record/tsconfig.json
+++ b/tests/warp-drive__schema-record/tsconfig.json
@@ -27,6 +27,8 @@
   "references": [
     { "path": "../../packages/schema-record" },
     { "path": "../../packages/core-types" },
-    { "path": "../../packages/store" }
+    { "path": "../../packages/store" },
+    { "path": "../../packages/legacy-compat" },
+    { "path": "../../packages/model" }
   ]
 }


### PR DESCRIPTION
- [x] id
- [x] constructor.modelName
- [x] currentState
- [x] errors
- [x] state flags
- [x] object lifecycle flags
- [x] serialize
- [x] _createSnapshot
- [x] reload
- [x] changedAttributes
- [x] rollbackAttributes
- [x] unloadRecord
- [x] deleteRecord
- [x] save
- [x] belongsTo references
- [x] hasMany references
- [x] destroyRecord

Tests
- [x] id
- [x] constructor.modelName
- [x] currentState
- [x] errors
- [x] state flags
- [x] object lifecycle flags
- [x] serialize
- [x] _createSnapshot
- [x] reload
- [x] changedAttributes
- [x] rollbackAttributes
- [x] unloadRecord
- [x] deleteRecord
- [x] save
- [-] belongsTo references (test once legacy belongsTo support is done)
- [-] hasMany references (test once legacy hasMany support is done)
- [x] destroyRecord

TBD
- schema methods on instance
- schema methods on constructor

Note: only superficially tested. We're largely just copying model code over in a non-diverging manner so as long as the basic mechanics work we should be fine. So for instance we don't need to test every behavior around state flags.