### PR TITLE
fix: allow decorator syntax in code comments during yui doc processing

### DIFF
--- a/packages/graph/src/-private/-edge-definition.ts
+++ b/packages/graph/src/-private/-edge-definition.ts
@@ -48,6 +48,7 @@ export type EdgeCache = Record<string, Record<string, EdgeDefinition | null>>;
  *   inverseIsCollection: false,
  *   inverseIsPolymorphic: false,
  * }
+ * ```
  *
  * The UpgradeMeta for the LHS would be:
  *

--- a/packages/json-api/src/-private/builders/-utils.ts
+++ b/packages/json-api/src/-private/builders/-utils.ts
@@ -43,6 +43,7 @@ export let ACCEPT_HEADER_VALUE = 'application/vnd.api+json';
  *     pagination: 'https://jsonapi.org/profiles/ethanresnick/cursor-pagination'
  *   }
  * });
+ * ```
  *
  * This also sets the global configuration for `buildBaseURL`
  * for host and namespace values for the application


### PR DESCRIPTION
## Description

This is a fix for decorator handling in code comment blocks. This introduces part of https://github.com/cibernox/ember-cli-yuidoc, a dep of ember.js and is what processes the ember.js docs and allows ember.js yui doc generation to handle decorator syntax. Since we have our own bespoke doc compilation process in EmberData that the addon doesn't address, we are introducing this 1 change here rather than adding `ember-cli-yuidoc` itself as a dependency.

See: https://github.com/cibernox/ember-cli-yuidoc/blob/master/lib/broccoli-yuidoc.js

This also fixes a few code blocks that were unclosed and only became exposed in failing tests once decorators were being handled properly and the docs were fully building (previously we were missing some of the code comments in docs because of the decorator issue).

BEFORE:
<img width="2017" alt="Screenshot 2023-11-12 at 8 49 34 AM" src="https://github.com/emberjs/data/assets/6305935/29f06fec-cb31-4d08-8f31-1c206d76ac78">

AFTER:

<img width="2017" alt="Screenshot 2023-11-12 at 8 41 17 AM" src="https://github.com/emberjs/data/assets/6305935/519ee5cd-8d0b-4a21-adb9-f632290392e1">



