### PR TITLE
feat: assert|warn|deprecate macros

### DIFF
--- a/packages/-ember-data/addon-test-support/index.js
+++ b/packages/-ember-data/addon-test-support/index.js
@@ -1,9 +1,9 @@
-import { assert } from '@ember/debug';
 import { render as renderTemplate, settled } from '@ember/test-helpers';
 
 import * as QUnit from 'qunit';
 
 import { PRODUCTION } from '@ember-data/env';
+import { assert } from '@ember-data/macros';
 
 /*
   Temporary replacement for the render test helper

--- a/packages/active-record/src/-private/builders/save-record.ts
+++ b/packages/active-record/src/-private/builders/save-record.ts
@@ -1,8 +1,8 @@
-import { assert } from '@ember/debug';
 import { underscore } from '@ember/string';
 
 import { pluralize } from 'ember-inflector';
 
+import { assert } from '@ember-data/macros';
 import {
   buildBaseURL,
   type CreateRecordUrlOptions,

--- a/packages/adapter/src/-private/utils/fetch.ts
+++ b/packages/adapter/src/-private/utils/fetch.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 type FetchFunction = (input: RequestInfo, init?: RequestInit | undefined) => Promise<Response>;
 

--- a/packages/adapter/src/-private/utils/serialize-into-hash.ts
+++ b/packages/adapter/src/-private/utils/serialize-into-hash.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import { type Snapshot, upgradeStore } from '@ember-data/legacy-compat/-private';
 import type {

--- a/packages/adapter/src/-private/utils/serialize-query-params.ts
+++ b/packages/adapter/src/-private/utils/serialize-query-params.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 const RBRACKET = /\[\]$/;
 

--- a/packages/adapter/src/error.js
+++ b/packages/adapter/src/error.js
@@ -1,7 +1,7 @@
 /**
   @module @ember-data/adapter/error
  */
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 /**
   ## Overview

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -187,7 +187,7 @@ By default when using with Ember you only need to implement this hook if you wan
   @main @ember-data/adapter
 */
 
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 import EmberObject from '@ember/object';
 import { inject as service } from '@ember/service';
 

--- a/packages/adapter/src/json-api.ts
+++ b/packages/adapter/src/json-api.ts
@@ -1,7 +1,7 @@
 /**
   @module @ember-data/adapter/json-api
  */
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 import { dasherize } from '@ember/string';
 
 import { pluralize } from 'ember-inflector';

--- a/packages/debug/addon/index.js
+++ b/packages/debug/addon/index.js
@@ -24,7 +24,7 @@
   @main @ember-data/debug
 */
 import { A } from '@ember/array';
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 import DataAdapter from '@ember/debug/data-adapter';
 import { addObserver, removeObserver } from '@ember/object/observers';
 import { inject as service } from '@ember/service';

--- a/packages/graph/src/-private/-edge-definition.ts
+++ b/packages/graph/src/-private/-edge-definition.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import { DEBUG } from '@ember-data/env';
 import type Store from '@ember-data/store';

--- a/packages/graph/src/-private/debug/assert-polymorphic-type.ts
+++ b/packages/graph/src/-private/debug/assert-polymorphic-type.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 import { DEBUG } from '@ember-data/env';
 import type { UpgradedMeta } from '../-edge-definition';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';

--- a/packages/graph/src/-private/graph.ts
+++ b/packages/graph/src/-private/graph.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import { LOG_GRAPH } from '@ember-data/debugging';
 import { DEBUG } from '@ember-data/env';

--- a/packages/graph/src/-private/operations/add-to-related-records.ts
+++ b/packages/graph/src/-private/operations/add-to-related-records.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { AddToRelatedRecordsOperation } from '@warp-drive/core-types/graph';

--- a/packages/graph/src/-private/operations/remove-from-related-records.ts
+++ b/packages/graph/src/-private/operations/remove-from-related-records.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { RemoveFromRelatedRecordsOperation } from '@warp-drive/core-types/graph';

--- a/packages/json-api/src/-private/builders/save-record.ts
+++ b/packages/json-api/src/-private/builders/save-record.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import { pluralize } from 'ember-inflector';
 

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -1,7 +1,7 @@
 /**
  * @module @ember-data/json-api
  */
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import { LOG_MUTATIONS, LOG_OPERATIONS, LOG_REQUESTS } from '@ember-data/debugging';
 import { DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE } from '@ember-data/deprecations';

--- a/packages/json-api/src/-private/serialize.ts
+++ b/packages/json-api/src/-private/serialize.ts
@@ -1,7 +1,7 @@
 /**
  * @module @ember-data/json-api/request
  */
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import type { AttributesHash, JsonApiResource } from '@ember-data/store/-types/q/record-data-json-api';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';

--- a/packages/legacy-compat/src/index.ts
+++ b/packages/legacy-compat/src/index.ts
@@ -1,6 +1,6 @@
 import { getOwner } from '@ember/application';
-import { assert } from '@ember/debug';
 
+import { assert } from '@ember-data/macros';
 import type Store from '@ember-data/store';
 import { recordIdentifierFor } from '@ember-data/store';
 import { _deprecatingNormalize } from '@ember-data/store/-private';

--- a/packages/legacy-compat/src/legacy-network-handler/identifier-has-id.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/identifier-has-id.ts
@@ -1,5 +1,4 @@
-import { assert } from '@ember/debug';
-
+import { assert } from '@ember-data/macros';
 import type { StableExistingRecordIdentifier } from '@warp-drive/core-types/identifier';
 
 export function assertIdentifierHasId(identifier: unknown): asserts identifier is StableExistingRecordIdentifier {

--- a/packages/legacy-compat/src/legacy-network-handler/legacy-data-fetch.js
+++ b/packages/legacy-compat/src/legacy-network-handler/legacy-data-fetch.js
@@ -1,6 +1,5 @@
-import { assert } from '@ember/debug';
-
 import { DEBUG } from '@ember-data/env';
+import { assert } from '@ember-data/macros';
 
 import { iterateData, payloadIsNotBlank } from './legacy-data-utils';
 import { normalizeResponseHelper } from './serializer-response';

--- a/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts
@@ -1,9 +1,8 @@
-import { assert } from '@ember/debug';
-
 import { importSync } from '@embroider/macros';
 
 import { LOG_PAYLOADS } from '@ember-data/debugging';
 import { DEBUG, TESTING } from '@ember-data/env';
+import { assert } from '@ember-data/macros';
 import type { Future, Handler, NextFn, StructuredDataDocument } from '@ember-data/request';
 import type Store from '@ember-data/store';
 import type { StoreRequestContext, StoreRequestInfo } from '@ember-data/store/-private/cache-handler';

--- a/packages/legacy-compat/src/legacy-network-handler/serializer-response.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/serializer-response.ts
@@ -1,6 +1,5 @@
-import { assert } from '@ember/debug';
-
 import { DEBUG } from '@ember-data/env';
+import { assert } from '@ember-data/macros';
 import type Store from '@ember-data/store';
 import type { ModelSchema } from '@ember-data/store/-types/q/ds-model';
 import type { JsonApiDocument } from '@warp-drive/core-types/spec/raw';

--- a/packages/legacy-compat/src/legacy-network-handler/snapshot.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/snapshot.ts
@@ -1,13 +1,12 @@
 /**
   @module @ember-data/store
 */
-import { assert } from '@ember/debug';
-
 import { importSync } from '@embroider/macros';
 
 import { DEBUG } from '@ember-data/env';
 import type { CollectionEdge } from '@ember-data/graph/-private/edges/collection';
 import type { ResourceEdge } from '@ember-data/graph/-private/edges/resource';
+import { assert } from '@ember-data/macros';
 import { HAS_JSON_API_PACKAGE } from '@ember-data/packages';
 import type Store from '@ember-data/store';
 import type { RecordInstance } from '@ember-data/store/-types/q/record-instance';

--- a/packages/model/src/-private/attr.js
+++ b/packages/model/src/-private/attr.js
@@ -1,7 +1,7 @@
-import { assert } from '@ember/debug';
 import { computed } from '@ember/object';
 
 import { DEBUG } from '@ember-data/env';
+import { assert } from '@ember-data/macros';
 import { recordIdentifierFor } from '@ember-data/store';
 import { peekCache } from '@ember-data/store/-private';
 

--- a/packages/model/src/-private/debug/assert-polymorphic-type.ts
+++ b/packages/model/src/-private/debug/assert-polymorphic-type.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 import { DEBUG } from '@ember-data/env';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type Store from '@ember-data/store';

--- a/packages/model/src/-private/hooks.ts
+++ b/packages/model/src/-private/hooks.ts
@@ -1,6 +1,6 @@
 import { getOwner, setOwner } from '@ember/application';
-import { assert } from '@ember/debug';
 
+import { assert } from '@ember-data/macros';
 import { setCacheFor, setRecordIdentifier, type Store, StoreMap } from '@ember-data/store/-private';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { Cache } from '@warp-drive/core-types/cache';

--- a/packages/model/src/-private/legacy-relationships-support.ts
+++ b/packages/model/src/-private/legacy-relationships-support.ts
@@ -1,5 +1,3 @@
-import { assert } from '@ember/debug';
-
 import { importSync } from '@embroider/macros';
 
 import { DEBUG } from '@ember-data/env';
@@ -8,6 +6,7 @@ import type { CollectionEdge } from '@ember-data/graph/-private/edges/collection
 import type { ResourceEdge } from '@ember-data/graph/-private/edges/resource';
 import type { Graph, GraphEdge } from '@ember-data/graph/-private/graph';
 import { upgradeStore } from '@ember-data/legacy-compat/-private';
+import { assert } from '@ember-data/macros';
 import { HAS_JSON_API_PACKAGE } from '@ember-data/packages';
 import type Store from '@ember-data/store';
 import {

--- a/packages/model/src/-private/many-array.ts
+++ b/packages/model/src/-private/many-array.ts
@@ -1,7 +1,7 @@
 /**
   @module @ember-data/store
 */
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import type Store from '@ember-data/store';
 import {

--- a/packages/model/src/-private/model-methods.ts
+++ b/packages/model/src/-private/model-methods.ts
@@ -1,8 +1,7 @@
-import { assert } from '@ember/debug';
-
 import { importSync } from '@embroider/macros';
 
 import { upgradeStore } from '@ember-data/legacy-compat/-private';
+import { assert } from '@ember-data/macros';
 import type Store from '@ember-data/store';
 import { recordIdentifierFor } from '@ember-data/store';
 import { peekCache } from '@ember-data/store/-private';

--- a/packages/model/src/-private/notify-changes.ts
+++ b/packages/model/src/-private/notify-changes.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 import { cacheFor } from '@ember/object/internals';
 
 import type Store from '@ember-data/store';

--- a/packages/model/src/-private/promise-belongs-to.ts
+++ b/packages/model/src/-private/promise-belongs-to.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 import { computed } from '@ember/object';
 import type PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import type ObjectProxy from '@ember/object/proxy';

--- a/packages/model/src/-private/promise-many-array.ts
+++ b/packages/model/src/-private/promise-many-array.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import { DEPRECATE_COMPUTED_CHAINS } from '@ember-data/deprecations';
 import type { FindOptions } from '@ember-data/store/-types/q/store';

--- a/packages/model/src/-private/record-state.ts
+++ b/packages/model/src/-private/record-state.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import type Store from '@ember-data/store';
 import { storeFor } from '@ember-data/store';

--- a/packages/model/src/-private/references/has-many.ts
+++ b/packages/model/src/-private/references/has-many.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import { DEBUG } from '@ember-data/env';
 import type { CollectionEdge } from '@ember-data/graph/-private/edges/collection';

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -1,5 +1,4 @@
-import { assert } from '@ember/debug';
-
+import { assert } from '@ember-data/macros';
 import { recordIdentifierFor } from '@ember-data/store';
 import type { FieldSchema } from '@ember-data/store/-types/q/schema-service';
 

--- a/packages/private-build-infra/src/transforms/babel-plugin-transform-debug-macros/index.js
+++ b/packages/private-build-infra/src/transforms/babel-plugin-transform-debug-macros/index.js
@@ -1,0 +1,72 @@
+const { ImportUtil } = require('babel-import-util');
+
+const Utils = new Set(['assert']);
+
+function buildAssertFn(t) {
+  return t.functionDeclaration(
+    t.identifier('assert'),
+    [t.identifier('desc'), t.identifier('test')],
+    t.blockStatement([
+      t.ifStatement(
+        t.unaryExpression('!', t.identifier('test')),
+        t.blockStatement([
+          t.throwStatement(
+            t.newExpression(t.identifier('Error'), [
+              t.identifier('desc')
+            ])
+          ),
+        ])
+      ),
+    ])
+  );
+}
+
+function findInsertionPoint(path) {
+  const program = path.parent;
+  let lastNode = null;
+  for (const node of program.body) {
+    if (node.type !== 'ImportDeclaration') {
+      return lastNode;
+    }
+    lastNode = node;
+  }
+  return lastNode;
+}
+
+module.exports = function (babel) {
+  const { types: t } = babel;
+
+  return {
+    name: 'ast-transform', // not required
+    visitor: {
+      ImportDeclaration(path, state) {
+        const importPath = path.node.source.value;
+
+        if (importPath === '@ember-data/macros') {
+          const specifiers = path.get('specifiers');
+          const insertLocation = findInsertionPoint(path);
+
+          specifiers.forEach((specifier) => {
+            const name = specifier.node.imported.name;
+            if (!Utils.has(name)) {
+              throw new Error(`Unexpected import '${name}' imported from '@ember-data/macros'`);
+            }
+
+            if (name === 'assert') {
+              const fn = buildAssertFn(t);
+              const index = path.parent.body.indexOf(insertLocation) + 1;
+              path.parent.body.splice(index, 0, fn);
+              specifier.remove();
+            }
+          });
+
+          if (specifiers.length === 0) path.remove();
+        }
+      },
+
+      Program(path, state) {
+        state.importer = new ImportUtil(t, path);
+      },
+    },
+  };
+};

--- a/packages/private-build-infra/virtual-packages/macros.d.ts
+++ b/packages/private-build-infra/virtual-packages/macros.d.ts
@@ -1,0 +1,24 @@
+
+export function assert(message: string): never;
+export function assert(message: string, condition: unknown): asserts condition;
+
+interface Available {
+  available: string;
+}
+interface Enabled extends Available {
+  enabled: string;
+}
+interface DeprecationOptions {
+  id: string;
+  until: string;
+  url?: string;
+  for: string;
+  since: Available | Enabled;
+}
+
+// not available yet so not exported
+function deprecate(
+  message: string,
+  test?: boolean,
+  options?: DeprecationOptions
+): void;

--- a/packages/request-utils/src/index.ts
+++ b/packages/request-utils/src/index.ts
@@ -1,5 +1,6 @@
-import { assert, deprecate } from '@ember/debug';
+import { deprecate } from '@ember/debug';
 
+import { assert } from '@ember-data/macros';
 import type { Cache } from '@warp-drive/core-types/cache';
 import type { StableDocumentIdentifier } from '@warp-drive/core-types/identifier';
 import type { QueryParamsSerializationOptions, QueryParamsSource, Serializable } from '@warp-drive/core-types/params';

--- a/packages/rest/src/-private/builders/save-record.ts
+++ b/packages/rest/src/-private/builders/save-record.ts
@@ -1,8 +1,8 @@
-import { assert } from '@ember/debug';
 import { camelize } from '@ember/string';
 
 import { pluralize } from 'ember-inflector';
 
+import { assert } from '@ember-data/macros';
 import {
   buildBaseURL,
   type CreateRecordUrlOptions,

--- a/packages/schema-record/src/-base-fields.ts
+++ b/packages/schema-record/src/-base-fields.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import { recordIdentifierFor } from '@ember-data/store';
 import type { RecordInstance } from '@ember-data/store/-types/q/record-instance';

--- a/packages/schema-record/src/record.ts
+++ b/packages/schema-record/src/record.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import { DEBUG } from '@ember-data/env';
 import type { Future } from '@ember-data/request';

--- a/packages/schema-record/src/schema.ts
+++ b/packages/schema-record/src/schema.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 
 import type { FieldSchema } from '@ember-data/store/-types/q/schema-service';
 import { createCache, getValue } from '@ember-data/tracking';

--- a/packages/store/src/-private/cache-handler.ts
+++ b/packages/store/src/-private/cache-handler.ts
@@ -1,8 +1,7 @@
 /**
  * @module @ember-data/store
  */
-import { assert } from '@ember/debug';
-
+import { assert } from '@ember-data/macros';
 import type { Future, Handler, NextFn } from '@ember-data/request/-private/types';
 import type { Cache } from '@warp-drive/core-types/cache';
 import type { StableDocumentIdentifier } from '@warp-drive/core-types/identifier';

--- a/packages/store/src/-private/caches/cache-utils.ts
+++ b/packages/store/src/-private/caches/cache-utils.ts
@@ -1,5 +1,4 @@
-import { assert } from '@ember/debug';
-
+import { assert } from '@ember-data/macros';
 import type { StableRecordIdentifier } from '@warp-drive/core-types/identifier';
 
 import type { Cache } from '../../-types/q/cache';

--- a/packages/store/src/-private/document.ts
+++ b/packages/store/src/-private/document.ts
@@ -1,8 +1,7 @@
 /**
  * @module @ember-data/store
  */
-import { assert } from '@ember/debug';
-
+import { assert } from '@ember-data/macros';
 import { defineSignal } from '@ember-data/tracking/-private';
 import type { StableDocumentIdentifier } from '@warp-drive/core-types/identifier';
 import type { RequestInfo } from '@warp-drive/core-types/request';

--- a/packages/store/src/-private/legacy-model-support/record-reference.ts
+++ b/packages/store/src/-private/legacy-model-support/record-reference.ts
@@ -1,5 +1,4 @@
-import { assert } from '@ember/debug';
-
+import { assert } from '@ember-data/macros';
 import { defineSignal } from '@ember-data/tracking/-private';
 import type { StableRecordIdentifier } from '@warp-drive/core-types/identifier';
 /**

--- a/packages/store/src/-private/managers/cache-capabilities-manager.ts
+++ b/packages/store/src/-private/managers/cache-capabilities-manager.ts
@@ -1,5 +1,4 @@
-import { assert } from '@ember/debug';
-
+import { assert } from '@ember-data/macros';
 import type { StableDocumentIdentifier, StableRecordIdentifier } from '@warp-drive/core-types/identifier';
 
 import type { CacheCapabilitiesManager as StoreWrapper } from '../../-types/q/cache-store-wrapper';

--- a/packages/store/src/-private/managers/notification-manager.ts
+++ b/packages/store/src/-private/managers/notification-manager.ts
@@ -1,12 +1,12 @@
 /**
  * @module @ember-data/store
  */
-import { assert } from '@ember/debug';
 // eslint-disable-next-line no-restricted-imports
 import { _backburner } from '@ember/runloop';
 
 import { LOG_NOTIFICATIONS } from '@ember-data/debugging';
 import { DEBUG } from '@ember-data/env';
+import { assert } from '@ember-data/macros';
 import type { StableDocumentIdentifier, StableRecordIdentifier } from '@warp-drive/core-types/identifier';
 
 import { isDocumentIdentifier, isStableIdentifier } from '../caches/identifier-cache';

--- a/packages/store/src/-private/network/request-cache.ts
+++ b/packages/store/src/-private/network/request-cache.ts
@@ -1,9 +1,8 @@
 /**
  * @module @ember-data/store
  */
-import { assert } from '@ember/debug';
-
 import { DEBUG } from '@ember-data/env';
+import { assert } from '@ember-data/macros';
 import type { StableRecordIdentifier } from '@warp-drive/core-types/identifier';
 
 import type { FindOptions } from '../../-types/q/store';

--- a/packages/store/src/-private/record-arrays/identifier-array.ts
+++ b/packages/store/src/-private/record-arrays/identifier-array.ts
@@ -1,8 +1,7 @@
 /**
   @module @ember-data/store
 */
-import { assert } from '@ember/debug';
-
+import { assert } from '@ember-data/macros';
 import { compat } from '@ember-data/tracking';
 import type { Signal } from '@ember-data/tracking/-private';
 import {

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -2,11 +2,11 @@
   @module @ember-data/store
  */
 // this import location is deprecated but breaks in 4.8 and older
-import { assert } from '@ember/debug';
 import EmberObject from '@ember/object';
 
 import { LOG_PAYLOADS, LOG_REQUESTS } from '@ember-data/debugging';
 import { DEBUG, TESTING } from '@ember-data/env';
+import { assert } from '@ember-data/macros';
 import type RequestManager from '@ember-data/request';
 import type { Future } from '@ember-data/request/-private/types';
 import type { Graph } from '@warp-drive/core-types/graph';

--- a/packages/store/src/-private/utils/construct-resource.ts
+++ b/packages/store/src/-private/utils/construct-resource.ts
@@ -1,5 +1,4 @@
-import { assert } from '@ember/debug';
-
+import { assert } from '@ember-data/macros';
 import type { ExistingResourceIdentifierObject, ResourceIdentifierObject } from '@warp-drive/core-types/spec/raw';
 
 import { isStableIdentifier } from '../caches/identifier-cache';

--- a/packages/tracking/src/index.ts
+++ b/packages/tracking/src/index.ts
@@ -1,5 +1,6 @@
-import { assert } from '@ember/debug';
 import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
+
+import { assert } from '@ember-data/macros';
 
 export { transact, memoTransact, untracked } from './-private';
 

--- a/tests/recommended-json-api/app/utils/pagination-links.ts
+++ b/tests/recommended-json-api/app/utils/pagination-links.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert } from '@ember-data/macros';
 import { tracked } from '@glimmer/tracking';
 
 type ApiMeta = {


### PR DESCRIPTION
partially resolves #9066 

Replaces `@ember/debug` with `@ember-data/macros`

Currently only handles `assert` as we will need to introduce deprecation infra for `warn` and `deprecate`.