### PR TITLE
fix: keep a backreference for previously merged identifiers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,43 @@
 {
+  "eslint.format.enable": true,
+  "eslint.workingDirectories": [{ "mode": "auto" }, "packages/*", "tests/*"],
+  "eslint.options": { "reportUnusedDisableDirectives": "error" },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
   "files.associations": {
     "turbo.json": "jsonc"
   },
-  "eslint.workingDirectories": [{ "mode": "auto" }, "packages/*", "tests/*"],
-  "editor.formatOnSave": true
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[handlebars]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[glimmer-js]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[glimmer-ts]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[markdown]": {
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": false,
+    "editor.tabSize": 4
+  },
+  "typescript.preferences.importModuleSpecifier": "project-relative"
 }

--- a/tests/main/tests/integration/identifiers/configuration-test.ts
+++ b/tests/main/tests/integration/identifiers/configuration-test.ts
@@ -382,6 +382,10 @@ module('Integration | Identifiers - configuration', function (hooks) {
       if (bucket !== 'record') {
         throw new Error('Test cannot generate an lid for a non-record');
       }
+      if (typeof resource === 'object' && resource !== null && 'lid' in resource && typeof resource.lid === 'string') {
+        generateLidCalls++;
+        return resource.lid;
+      }
       if (typeof resource !== 'object' || resource === null || !('type' in resource)) {
         throw new Error('Test cannot generate an lid for a non-object');
       }
@@ -393,12 +397,12 @@ module('Integration | Identifiers - configuration', function (hooks) {
       return `${resource.type}:${resource.id}`;
     });
     let forgetMethodCalls = 0;
-    // eslint-disable-next-line prefer-const
+
     let expectedIdentifier;
 
     let testMethod = (identifier) => {
       forgetMethodCalls++;
-      assert.strictEqual(expectedIdentifier, identifier, `We forgot the expected identifier ${expectedIdentifier}`);
+      assert.strictEqual(identifier, expectedIdentifier, `We forgot the expected identifier ${expectedIdentifier}`);
     };
 
     setIdentifierForgetMethod((identifier) => {
@@ -434,7 +438,11 @@ module('Integration | Identifiers - configuration', function (hooks) {
     const finalUserByIdIdentifier = recordIdentifierFor(userById);
 
     assert.strictEqual(generateLidCalls, 2, 'We generated no new lids when we looked up the originals');
-    assert.strictEqual(store.identifierCache._cache.resources.size, 1, 'We now have only 1 identifier in the cache');
+    assert.strictEqual(
+      store.identifierCache._cache.resources.size,
+      2,
+      'We keep a back reference identifier in the cache'
+    );
     assert.strictEqual(forgetMethodCalls, 1, 'We abandoned an identifier');
 
     assert.notStrictEqual(
@@ -451,6 +459,36 @@ module('Integration | Identifiers - configuration', function (hooks) {
       finalUserByUsernameIdentifier,
       finalUserByIdIdentifier,
       'We are using the identifier by id for the result of findRecord with username'
+    );
+
+    const recordA = store.peekRecord({ lid: finalUserByUsernameIdentifier.lid });
+    const recordB = store.peekRecord({ lid: finalUserByIdIdentifier.lid });
+    const recordC = store.peekRecord({ lid: originalUserByUsernameIdentifier.lid });
+    const recordD = store.peekRecord('user', '@runspired');
+    const recordE = store.peekRecord('user', '1');
+
+    assert.strictEqual(recordA, recordB, 'We have a single record for both identifiers');
+    assert.strictEqual(recordA, recordC, 'We have a single record for both identifiers');
+    assert.strictEqual(recordA, recordD, 'We have a single record for both identifiers');
+    assert.strictEqual(recordA, recordE, 'We have a single record for both identifiers');
+
+    const regeneratedIdentifier = store.identifierCache.getOrCreateRecordIdentifier({
+      lid: finalUserByUsernameIdentifier.lid,
+    });
+    const regeneratedIdentifier2 = store.identifierCache.getOrCreateRecordIdentifier({
+      id: '@runspired',
+      type: 'user',
+    });
+    assert.strictEqual(regeneratedIdentifier, finalUserByUsernameIdentifier, 'We regenerate the same identifier');
+    assert.strictEqual(regeneratedIdentifier2, finalUserByUsernameIdentifier, 'We regenerate the same identifier');
+
+    expectedIdentifier = finalUserByIdIdentifier;
+    store.unloadRecord(recordA);
+    await settled();
+    assert.strictEqual(
+      store.identifierCache._cache.resources.size,
+      0,
+      'We have no identifiers or backreferences in the cache'
     );
 
     // end test before store teardown

--- a/tests/main/tests/integration/identifiers/scenarios-test.ts
+++ b/tests/main/tests/integration/identifiers/scenarios-test.ts
@@ -468,12 +468,14 @@ module('Integration | Identifiers - scenarios', function (hooks) {
 
       // ensure we truly are in a good state internally
       const lidCache = store.identifierCache._cache.resources;
-      const lids = [...lidCache.values()];
-      assert.strictEqual(
-        lidCache.size,
-        1,
-        `We only have the lid '${identifierByUsername.lid}' in ['${lids.join("', '")}']`
+      assert.strictEqual(lidCache.size, 2, `We should have both lids in the cache still since one is a backreference`);
+      assert.deepEqual(
+        [...lidCache.keys()],
+        ['remote:user:1:9001', 'remote:user:@runspired:9000'],
+        'We have the expected keys'
       );
+      const lids = [...lidCache.values()];
+      assert.arrayStrictEquals(lids, [identifierById, identifierById], 'We have the expected values');
 
       // ensure we still use secondary caching for @runspired post-merging of the identifiers
       const recordByUsernameAgain = (await store.findRecord('user', '@runspired')) as User;

--- a/tests/main/tests/integration/records/polymorphic-find-record-test.ts
+++ b/tests/main/tests/integration/records/polymorphic-find-record-test.ts
@@ -1,0 +1,53 @@
+import { settled } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import Model, { attr } from '@ember-data/model';
+import type Store from '@ember-data/store';
+import { recordIdentifierFor } from '@ember-data/store';
+
+class Person extends Model {
+  @attr declare name: string;
+}
+class Employee extends Person {}
+
+module('integration/records/polymorphic-find-record - Polymorphic findRecord', function (hooks) {
+  setupTest(hooks);
+
+  test('when findRecord with abstract type returns concrete type', async function (assert) {
+    this.owner.register('model:person', Person);
+    this.owner.register('model:employee', Employee);
+
+    const store = this.owner.lookup('service:store') as Store;
+    const adapter = store.adapterFor('application');
+
+    adapter.findRecord = () => {
+      return {
+        data: {
+          id: '1',
+          type: 'employee',
+          attributes: {
+            name: 'Rey Skybarker',
+          },
+        },
+      };
+    };
+
+    const person = await store.findRecord('person', '1') as Employee;
+    assert.ok(person instanceof Employee, 'record is an instance of Employee');
+    assert.strictEqual(person.name, 'Rey Skybarker', 'name is correct');
+    assert.strictEqual(recordIdentifierFor(person).type, 'employee', 'identifier has the concrete type');
+
+    const employee = store.peekRecord('employee', '1');
+    const person2 = store.peekRecord('person', '1');
+    assert.strictEqual(employee, person, 'peekRecord returns the same instance for concrete type');
+    assert.strictEqual(person2, person, 'peekRecord returns the same instance for abstract type');
+    assert.strictEqual(store.identifierCache._cache.resources.size, 2, 'identifier cache contains backreferences');
+
+    person.unloadRecord();
+    await settled();
+    assert.strictEqual(store.identifierCache._cache.resources.size, 0, 'identifier cache is empty');
+  });
+});

--- a/tests/main/tests/integration/records/polymorphic-find-record-test.ts
+++ b/tests/main/tests/integration/records/polymorphic-find-record-test.ts
@@ -2,10 +2,10 @@ import { settled } from '@ember/test-helpers';
 
 import { module, test } from 'qunit';
 
+import type Store from 'ember-data/store';
 import { setupTest } from 'ember-qunit';
 
 import Model, { attr } from '@ember-data/model';
-import type Store from '@ember-data/store';
 import { recordIdentifierFor } from '@ember-data/store';
 
 class Person extends Model {
@@ -24,7 +24,7 @@ module('integration/records/polymorphic-find-record - Polymorphic findRecord', f
     const adapter = store.adapterFor('application');
 
     adapter.findRecord = () => {
-      return {
+      return Promise.resolve({
         data: {
           id: '1',
           type: 'employee',
@@ -32,10 +32,10 @@ module('integration/records/polymorphic-find-record - Polymorphic findRecord', f
             name: 'Rey Skybarker',
           },
         },
-      };
+      });
     };
 
-    const person = await store.findRecord('person', '1') as Employee;
+    const person = (await store.findRecord('person', '1')) as Employee;
     assert.ok(person instanceof Employee, 'record is an instance of Employee');
     assert.strictEqual(person.name, 'Rey Skybarker', 'name is correct');
     assert.strictEqual(recordIdentifierFor(person).type, 'employee', 'identifier has the concrete type');


### PR DESCRIPTION
resolves #9168 