### PR TITLE
Fix trailing `?` in URL  of query builder

### DIFF
--- a/packages/active-record/src/-private/builders/query.ts
+++ b/packages/active-record/src/-private/builders/query.ts
@@ -76,12 +76,14 @@ export function query(
 
   copyForwardUrlOptions(urlOptions, options);
 
-  const url = buildBaseURL(urlOptions);
+  const url = new URL(buildBaseURL(urlOptions));
+  url.search = buildQueryParams(query, options.urlParamsSettings);
+
   const headers = new Headers();
   headers.append('Accept', 'application/json;charset=utf-8');
 
   return {
-    url: `${url}?${buildQueryParams(query, options.urlParamsSettings)}`,
+    url: url.toString(),
     method: 'GET',
     headers,
     cacheOptions,

--- a/packages/json-api/src/-private/builders/query.ts
+++ b/packages/json-api/src/-private/builders/query.ts
@@ -83,12 +83,14 @@ export function query(
 
   copyForwardUrlOptions(urlOptions, options);
 
-  const url = buildBaseURL(urlOptions);
+  const url = new URL(buildBaseURL(urlOptions));
+  url.search = buildQueryParams(query, options.urlParamsSettings);
+
   const headers = new Headers();
   headers.append('Accept', ACCEPT_HEADER_VALUE);
 
   return {
-    url: `${url}?${buildQueryParams(query, options.urlParamsSettings)}`,
+    url: url.toString(),
     method: 'GET',
     headers,
     cacheOptions,

--- a/packages/rest/src/-private/builders/query.ts
+++ b/packages/rest/src/-private/builders/query.ts
@@ -76,12 +76,14 @@ export function query(
 
   copyForwardUrlOptions(urlOptions, options);
 
-  const url = buildBaseURL(urlOptions);
+  const url = new URL(buildBaseURL(urlOptions));
+  url.search = buildQueryParams(query, options.urlParamsSettings);
+
   const headers = new Headers();
   headers.append('Accept', 'application/json;charset=utf-8');
 
   return {
-    url: `${url}?${buildQueryParams(query, options.urlParamsSettings)}`,
+    url: url.toString(),
     method: 'GET',
     headers,
     cacheOptions,

--- a/tests/builders/tests/unit/active-record-builder-test.ts
+++ b/tests/builders/tests/unit/active-record-builder-test.ts
@@ -117,6 +117,22 @@ module('ActiveRecord | Request Builders', function (hooks) {
     assert.deepEqual(headersToObject(result.headers), ACTIVE_RECORD_HEADERS);
   });
 
+  test('query with empty params [used to be findAll]', function (this: TestContext, assert) {
+    const result = query('user-setting', {}, { reload: true, backgroundReload: false });
+    assert.deepEqual(
+      result,
+      {
+        url: 'https://api.example.com/api/v1/user_settings',
+        method: 'GET',
+        headers: new Headers(ACTIVE_RECORD_HEADERS),
+        cacheOptions: { reload: true, backgroundReload: false },
+        op: 'query',
+      },
+      `query works with type and empty options, does not leave a trailing ?`
+    );
+    assert.deepEqual(headersToObject(result.headers), ACTIVE_RECORD_HEADERS);
+  });
+
   test('createRecord passing store record', function (this: TestContext, assert) {
     const store = this.owner.lookup('service:store') as Store;
     const userSetting = store.createRecord('user-setting', {

--- a/tests/builders/tests/unit/json-api-builder-test.ts
+++ b/tests/builders/tests/unit/json-api-builder-test.ts
@@ -117,6 +117,22 @@ module('JSON:API | Request Builders', function (hooks) {
     assert.deepEqual(headersToObject(result.headers), JSON_API_HEADERS);
   });
 
+  test('query with empty params [used to be findAll]', function (this: TestContext, assert) {
+    const result = query('user-setting', {}, { reload: true, backgroundReload: false });
+    assert.deepEqual(
+      result,
+      {
+        url: 'https://api.example.com/api/v1/user-settings',
+        method: 'GET',
+        headers: new Headers(JSON_API_HEADERS),
+        cacheOptions: { reload: true, backgroundReload: false },
+        op: 'query',
+      },
+      `query works with type and empty options, does not leave a trailing ?`
+    );
+    assert.deepEqual(headersToObject(result.headers), JSON_API_HEADERS);
+  });
+
   test('postQuery', function (this: TestContext, assert) {
     const result = postQuery(
       'user-setting',

--- a/tests/builders/tests/unit/rest-builder-test.ts
+++ b/tests/builders/tests/unit/rest-builder-test.ts
@@ -117,6 +117,22 @@ module('REST | Request Builders', function (hooks) {
     assert.deepEqual(headersToObject(result.headers), REST_HEADERS);
   });
 
+  test('query with empty params [used to be findAll]', function (this: TestContext, assert) {
+    const result = query('user-setting', {}, { reload: true, backgroundReload: false });
+    assert.deepEqual(
+      result,
+      {
+        url: 'https://api.example.com/api/v1/userSettings',
+        method: 'GET',
+        headers: new Headers(REST_HEADERS),
+        cacheOptions: { reload: true, backgroundReload: false },
+        op: 'query',
+      },
+      `query works with type and empty options, does not leave a trailing ?`
+    );
+    assert.deepEqual(headersToObject(result.headers), REST_HEADERS);
+  });
+
   test('createRecord passing store record', function (this: TestContext, assert) {
     const store = this.owner.lookup('service:store') as Store;
     const userSetting = store.createRecord('user-setting', {


### PR DESCRIPTION
## Description

Fix trailing ? in built url for query builder across json-api/rest/active-record

Mirage have troubles recognizing URL with trailing `?` 
I think other routers might have problems as well

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


