### PR TITLE
fix: prevent rollbackRelationships from setting remoteState and localState to the same array reference

### DIFF
--- a/packages/graph/src/-private/-diff.ts
+++ b/packages/graph/src/-private/-diff.ts
@@ -398,7 +398,7 @@ export function rollbackRelationship(
         op: 'replaceRelatedRecords',
         record: identifier,
         field,
-        value: relationship.remoteState,
+        value: relationship.remoteState.slice(),
       },
       false
     );

--- a/tests/main/tests/integration/relationships/rollback-test.ts
+++ b/tests/main/tests/integration/relationships/rollback-test.ts
@@ -1,9 +1,12 @@
+import { settled } from '@ember/test-helpers';
+
 import { module, test } from 'qunit';
 
 import { setupTest } from 'ember-qunit';
 
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import type Store from '@ember-data/store';
+import { recordIdentifierFor } from '@ember-data/store';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 
 class App extends Model {
@@ -397,6 +400,58 @@ module('Integration | Relationships | Rollback', function (hooks) {
       const changed = store.cache.rollbackRelationships(configIdentifier);
       assert.arrayStrictEquals(changed, [], 'belongsTo has rolled back');
       assert.strictEqual(config.app, store.peekRecord('app', '1') as App, 'belongsTo has rolled back');
+    });
+
+    test('relationship rollback can be repeated', async function (assert) {
+      class Message extends Model {
+        @attr declare msg: string;
+      }
+      class Job extends Model {
+        @attr declare name: string;
+        @hasMany('message', { async: false, inverse: null }) declare messages: Message[];
+      }
+
+      this.owner.register('model:job', Job);
+      this.owner.register('model:message', Message);
+      const store = this.owner.lookup('service:store') as Store;
+
+      const job = store.push({
+        data: {
+          id: '1',
+          type: 'job',
+          attributes: {
+            name: 'First Job',
+          },
+        },
+      }) as Job;
+
+      const msg1 = store.push({
+        data: {
+          id: '1',
+          type: 'message',
+          attributes: {
+            msg: 'First Message',
+          },
+        },
+      }) as Message;
+      assert.strictEqual(job.messages.length, 0, 'job has 0 messages');
+      const jobIdentifier = recordIdentifierFor(job);
+
+      // add message, assert state, rollback, assert state is clean
+      job.messages.push(msg1);
+      assert.strictEqual(job.messages.length, 1, 'job has 1 message');
+
+      const rollbackResult = store.cache.rollbackRelationships(jobIdentifier);
+      assert.strictEqual(rollbackResult.length, 1, '1 rollbackRelations');
+      assert.strictEqual(job.messages.length, 0, 'job has no message');
+
+      // repeat the scenario to add a message and rollback
+      job.messages.push(msg1);
+      assert.strictEqual(job.messages.length, 1, 'job has 1 message');
+
+      const rollbackResult2 = store.cache.rollbackRelationships(jobIdentifier);
+      assert.strictEqual(rollbackResult2.length, 1, '1 rollbackRelations');
+      assert.strictEqual(job.messages.length, 0, 'job has no message');
     });
   });
 

--- a/tests/main/tests/integration/relationships/rollback-test.ts
+++ b/tests/main/tests/integration/relationships/rollback-test.ts
@@ -1,5 +1,3 @@
-import { settled } from '@ember/test-helpers';
-
 import { module, test } from 'qunit';
 
 import { setupTest } from 'ember-qunit';
@@ -402,7 +400,7 @@ module('Integration | Relationships | Rollback', function (hooks) {
       assert.strictEqual(config.app, store.peekRecord('app', '1') as App, 'belongsTo has rolled back');
     });
 
-    test('relationship rollback can be repeated', async function (assert) {
+    test('relationship rollback can be repeated', function (assert) {
       class Message extends Model {
         @attr declare msg: string;
       }


### PR DESCRIPTION
fixes #9207 

Adds the test from that PR. Root cause is that typically we can presume `replaceRelatedRecords` is receiving an array reference it can safely re-use for localState/remoteState as appropriate. However in this case we generate the operation from the existing remoteState array and so this led to the two arrays having the same reference.

This meant that the next mutation on localState was then partially reflected into remoteState, preventing rollbackRelationships from working properly. Only partially reflected because the bookkeeping sets would still see this relationship as empty remotely.