### PR TITLE
chore: fix canary chron publishing & release changelog generation

### DIFF
--- a/.github/workflows/release_publish-canary.yml
+++ b/.github/workflows/release_publish-canary.yml
@@ -56,7 +56,7 @@ jobs:
           git config --local user.email ${{ secrets.GH_DEPLOY_EMAIL }}
           git config --local user.name ${{ secrets.GH_DEPLOY_NAME }}
       - name: Publish with script
-        run: bun release canary -i ${{ github.event.inputs.increment }}
+        run: bun release exec canary --increment=${{ github.event.inputs.increment }}
         env:
           FORCE_COLOR: 2
           CI: true

--- a/.github/workflows/release_publish-lts.yml
+++ b/.github/workflows/release_publish-lts.yml
@@ -57,6 +57,7 @@ jobs:
           FORCE_COLOR: 2
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v4
         with:
           name: tarballs

--- a/.github/workflows/release_publish-stable.yml
+++ b/.github/workflows/release_publish-stable.yml
@@ -89,6 +89,7 @@ jobs:
           FORCE_COLOR: 2
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish New Release (Reversion)
         # If we are reversioning
         # Then we increment from the branch with the supplied increment
@@ -99,3 +100,4 @@ jobs:
           FORCE_COLOR: 2
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
the chron does not apply the default value for increment, so we use exec to filter out undefined increment values and use the release script's default instead which is also `patch`.