### PR TITLE
chore: fix publishing of core-types when strategy is private

### DIFF
--- a/release/core/publish/steps/generate-tarballs.ts
+++ b/release/core/publish/steps/generate-tarballs.ts
@@ -94,6 +94,10 @@ async function makeTypesPrivate(pkg: Package) {
   // scrub the package.json of any types fields in exports
   scrubTypesFromExports(pkg);
 
+  // remove @warp-drive/core-types from dependencies and peerDependencies
+  delete pkg.pkgData.dependencies?.['@warp-drive/core-types'];
+  delete pkg.pkgData.peerDependencies?.['@warp-drive/core-types'];
+
   // deactivate build types command
   if (pkg.pkgData.scripts?.['build:types']) {
     pkg.pkgData.scripts['build:types'] = 'echo "Types are private" && exit 0';


### PR DESCRIPTION
if the types strategy is private, avoid installation of core-types as a dep or peer-dep