### PR TITLE
fix: keep core-type peer-deps

### DIFF
--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -50,7 +50,8 @@
     "@ember-data/legacy-compat": "workspace:5.4.0-alpha.27",
     "@ember-data/store": "workspace:5.4.0-alpha.27",
     "@ember/string": "^3.1.1",
-    "ember-inflector": "^4.0.2"
+    "ember-inflector": "^4.0.2",
+    "@warp-drive/core-types": "workspace:0.0.0-alpha.13"
   },
   "dependenciesMeta": {
     "@ember-data/private-build-infra": {

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@ember-data/store": "workspace:5.4.0-alpha.27",
-    "@ember/string": "^3.1.1"
+    "@ember/string": "^3.1.1",
+    "@warp-drive/core-types": "workspace:0.0.0-alpha.13"
   },
   "dependenciesMeta": {
     "@ember-data/private-build-infra": {

--- a/release/core/publish/steps/generate-tarballs.ts
+++ b/release/core/publish/steps/generate-tarballs.ts
@@ -117,8 +117,8 @@ async function makeTypesPrivate(pkg: Package) {
   }
 
   // remove @warp-drive/core-types from dependencies and peerDependencies
-  delete pkg.pkgData.dependencies?.['@warp-drive/core-types'];
-  delete pkg.pkgData.peerDependencies?.['@warp-drive/core-types'];
+  pkg.pkgData.dependencies?.['@warp-drive/core-types'];
+  pkg.pkgData.peerDependencies?.['@warp-drive/core-types'];
 
   // deactivate build types command
   if (pkg.pkgData.scripts?.['build:types']) {


### PR DESCRIPTION
we rely on symbols provided by core-types (the intersection of symbols and types is otherwise hard to break out of cycles), thus we do need access to a published version even if its the alpha and we don't use the types.