### PR TITLE
feat: fix types for legacy decorator syntax

### DIFF
--- a/packages/model/src/-private/belongs-to.ts
+++ b/packages/model/src/-private/belongs-to.ts
@@ -275,12 +275,12 @@ export function belongsTo(): never;
 export function belongsTo(type: string): never;
 export function belongsTo<T>(
   type: TypeFromInstance<NoNull<T>>,
-  options: RelationshipOptions<T, false>
+  options: RelationshipOptions<T, boolean>
 ): RelationshipDecorator<T>;
-export function belongsTo<K extends Promise<unknown>, T extends Awaited<K> = Awaited<K>>(
-  type: TypeFromInstance<NoNull<T>>,
-  options: RelationshipOptions<T, true>
-): RelationshipDecorator<K>;
+// export function belongsTo<K extends Promise<unknown>, T extends Awaited<K> = Awaited<K>>(
+//   type: TypeFromInstance<NoNull<T>>,
+//   options: RelationshipOptions<T, true>
+// ): RelationshipDecorator<K>;
 export function belongsTo(type: string, options: RelationshipOptions<unknown, boolean>): RelationshipDecorator<unknown>;
 export function belongsTo<T>(
   type?: TypeFromInstance<NoNull<T>>,

--- a/packages/model/src/-private/has-many.ts
+++ b/packages/model/src/-private/has-many.ts
@@ -258,12 +258,12 @@ export function hasMany(): never;
 export function hasMany(type: string): never;
 export function hasMany<T>(
   type: TypeFromInstance<NoNull<T>>,
-  options: RelationshipOptions<T, false>
+  options: RelationshipOptions<T, boolean>
 ): RelationshipDecorator<T>;
-export function hasMany<K extends Promise<unknown>, T extends Awaited<K> = Awaited<K>>(
-  type: TypeFromInstance<NoNull<T>>,
-  options: RelationshipOptions<T, true>
-): RelationshipDecorator<K>;
+// export function hasMany<K extends Promise<unknown>, T extends Awaited<K> = Awaited<K>>(
+//   type: TypeFromInstance<NoNull<T>>,
+//   options: RelationshipOptions<T, true>
+// ): RelationshipDecorator<K>;
 export function hasMany(type: string, options: RelationshipOptions<unknown, boolean>): RelationshipDecorator<unknown>;
 export function hasMany<T>(
   type?: TypeFromInstance<NoNull<T>>,

--- a/packages/model/src/-private/model.type-test.ts
+++ b/packages/model/src/-private/model.type-test.ts
@@ -60,6 +60,33 @@ expectTypeOf(branded.bestFriend).toEqualTypeOf<BrandedUser>();
 expectTypeOf<Awaited<typeof branded.friends>>().toEqualTypeOf<ManyArray<BrandedUser>>();
 expectTypeOf<Awaited<typeof branded.twin>>().toEqualTypeOf<BrandedUser | null>();
 
+class BrandedTypedUser extends Model {
+  @attr('string') declare name: string | null;
+  @hasMany<BrandedTypedUser>('user', { async: false, inverse: null }) declare enemies: ManyArray<BrandedTypedUser>;
+  @belongsTo<BrandedTypedUser>('user', { async: false, inverse: null }) declare bestFriend: BrandedTypedUser;
+  @hasMany<BrandedTypedUser>('user', { async: true, inverse: 'friends' })
+  declare friends: PromiseManyArray<BrandedTypedUser>;
+  @belongsTo<BrandedTypedUser>('user', { async: true, inverse: 'twin' })
+  declare twin: PromiseBelongsTo<BrandedTypedUser>;
+  @hasMany<BrandedTypedUser>('user', { async: false, inverse: 'leader' })
+  declare crew: PromiseManyArray<BrandedTypedUser>;
+  @belongsTo<BrandedTypedUser>('user', { async: false, inverse: 'crew' })
+  declare leader: PromiseBelongsTo<BrandedTypedUser>;
+
+  [ResourceType] = 'user' as const;
+}
+const brandedAndTyped = new BrandedTypedUser();
+
+expectTypeOf<Awaited<PromiseManyArray<BrandedTypedUser>>['modelName']>().toEqualTypeOf<'user'>();
+expectTypeOf<ManyArray<BrandedTypedUser>['modelName']>().toEqualTypeOf<'user'>();
+expectTypeOf<ManyArray<BrandedTypedUser>>().toMatchTypeOf<BrandedTypedUser[]>();
+
+expectTypeOf(brandedAndTyped.name).toEqualTypeOf<string | null>();
+expectTypeOf(brandedAndTyped.enemies).toEqualTypeOf<ManyArray<BrandedTypedUser>>();
+expectTypeOf(brandedAndTyped.bestFriend).toEqualTypeOf<BrandedTypedUser>();
+expectTypeOf<Awaited<typeof brandedAndTyped.friends>>().toEqualTypeOf<ManyArray<BrandedTypedUser>>();
+expectTypeOf<Awaited<typeof brandedAndTyped.twin>>().toEqualTypeOf<BrandedTypedUser | null>();
+
 // ------------------------------
 // References
 // ------------------------------


### PR DESCRIPTION
the types were authored with accessor syntax in mind, but without accessor syntax don't work for async: true properly. This fixes that.