### PR TITLE
fix: remove unused turbo key

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,4 @@
 {
-  "baseBranch": "origin/main",
   // Additive to package.json and turbo.json
   //
   // https://turbo.build/repo/docs/core-concepts/caching/file-inputs#specifying-additional-inputs


### PR DESCRIPTION
removes an unused key that's been preventing us from upgrading