### PR TITLE
doc: don't mention unexisting ESA auth handler

### DIFF
--- a/packages/request/README.md
+++ b/packages/request/README.md
@@ -410,7 +410,7 @@ Most applications will desire to have a single `RequestManager` instance, which 
 ```ts
 import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
-import Auth from 'ember-simple-auth/ember-data-handler';
+import Auth from 'app/services/auth-handler';
 
 export default class extends RequestManager {
   constructor(createArgs) {


### PR DESCRIPTION
## Description

I think this could be confusing, and unless I miss something such handler does not exist, and I didn't see any open issue/PR in the ESA repo mentionning it
