### PR TITLE
chore: bump timeout for floating dep check in CI

### DIFF
--- a/.github/workflows/compat-tests.yml
+++ b/.github/workflows/compat-tests.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           UV_USE_IO_URING: 0
   floating-dependencies:
-    timeout-minutes: 8
+    timeout-minutes: 9
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4


### PR DESCRIPTION
## Description

<!-- insert description here -->

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


