### PR TITLE
feat: improve lifetime handling of ad-hoc createRecord requests

### DIFF
--- a/packages/core-types/src/request.ts
+++ b/packages/core-types/src/request.ts
@@ -45,7 +45,12 @@ export type CacheOptions = {
    * provided by `@ember-data/request-utils` for an example.
    *
    * It is recommended to only use this for query/queryRecord requests where
-   * new records created later would affect the results.
+   * new records created later would affect the results, though using it for
+   * findRecord requests is also supported if desired where it may be useful
+   * when a create may affect the result of a sideloaded relationship.
+   *
+   * Generally it is better to patch the cache directly for relationship updates
+   * than to invalidate findRecord requests for one.
    *
    * @typedoc
    */

--- a/packages/store/src/-private/cache-handler.ts
+++ b/packages/store/src/-private/cache-handler.ts
@@ -411,6 +411,47 @@ function cloneError(error: Error & { error: string | object }) {
   return cloned;
 }
 
+/**
+ * A CacheHandler that adds support for using an EmberData Cache with a RequestManager.
+ *
+ * This handler will only run when a request has supplied a `store` instance. Requests
+ * issued by the store via `store.request()` will automatically have the `store` instance
+ * attached to the request.
+ *
+ * ```ts
+ * requestManager.request({
+ *   store: store,
+ *   url: '/api/posts',
+ *   method: 'GET'
+ * });
+ * ```
+ *
+ * When this handler elects to handle a request, it will return the raw `StructuredDocument`
+ * unless the request has `[EnableHydration]` set to `true`. In this case, the handler will
+ * return a `Document` instance that will automatically update the UI when the cache is updated
+ * in the future and will hydrate any identifiers in the StructuredDocument into Record instances.
+ *
+ * When issuing a request via the store, [EnableHydration] is automatically set to `true`. This
+ * means that if desired you can issue requests that utilize the cache without needing to also
+ * utilize Record instances if desired.
+ *
+ * Said differently, you could elect to issue all requests via a RequestManager, without ever using
+ * the store directly, by setting [EnableHydration] to `true` and providing a store instance. Not
+ * necessarily the most useful thing, but the decoupled nature of the RequestManager and incremental-feature
+ * approach of EmberData allows for this flexibility.
+ *
+ * ```ts
+ * import { EnableHydration } from '@warp-drive/core-types/request';
+ *
+ * requestManager.request({
+ *   store: store,
+ *   url: '/api/posts',
+ *   method: 'GET',
+ *   [EnableHydration]: true
+ * });
+ *
+ * @typedoc
+ */
 export const CacheHandler: CacheHandlerType = {
   request<T>(context: StoreRequestContext, next: NextFn<T>): Promise<T | StructuredDataDocument<T>> | Future<T> | T {
     // if we have no cache or no cache-key skip cache handling

--- a/tests/main/tests/integration/cache-handler/lifetimes-test.ts
+++ b/tests/main/tests/integration/cache-handler/lifetimes-test.ts
@@ -300,7 +300,7 @@ module('Store | CacheHandler + Lifetimes', function (hooks) {
 
     assert.verifySteps(['isHardExpired: false', 'isSoftExpired: false'], 'we resolve from cache still');
 
-    const record = store.createRecord('test', {}) as { identifier: StableRecordIdentifier };
+    const record = store.createRecord('test', {});
 
     await store.request({
       url: '/test',
@@ -477,7 +477,7 @@ module('Store | CacheHandler + Lifetimes', function (hooks) {
 
     assert.verifySteps(['isHardExpired: false', 'isSoftExpired: false'], 'we resolve from cache still');
 
-    const record = store.createRecord('test', {}) as { identifier: StableRecordIdentifier };
+    const record = store.createRecord('test', {});
     await store.saveRecord(record);
 
     assert.verifySteps(['adapter:createRecord', 'didRequest'], 'we issue the request since it is a different request');
@@ -538,4 +538,6 @@ module('Store | CacheHandler + Lifetimes', function (hooks) {
       'we are no longer hard expired due to the createRecord response'
     );
   });
+
+  test('An AdHoc createRecord request can invalidate the request cache', async function (assert) {});
 });


### PR DESCRIPTION
- adds support for 204 requests that run through the CacheHandler
- adds support for 201 requests with empty responses that run through the CacheHandler when no records were specified
- adds support for invalidating the cache based on createRecord operations that don't contain any records