### PR TITLE
fix: be more specific in files in case .npmignore is ignored

### DIFF
--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -20,7 +20,7 @@
     "_syncPnpm": "bun run sync-dependencies-meta-injected"
   },
   "files": [
-    "dist/docs",
+    "dist/docs/data.json",
     "ember-data-logo-dark.svg",
     "ember-data-logo-light.svg",
     "LICENSE.md",


### PR DESCRIPTION
potential resolution for #9255 since `npm pack` also seems to have recently gone crazy