### PR TITLE
feat: paginated relationships

### DIFF
--- a/packages/graph/src/-private/edges/paginated-collection.ts
+++ b/packages/graph/src/-private/edges/paginated-collection.ts
@@ -1,0 +1,148 @@
+import { assert } from '@ember/debug';
+
+import type { StableRecordIdentifier } from '@warp-drive/core-types';
+import type { CollectionRelationship } from '@warp-drive/core-types/cache/relationship';
+import type { Meta, PaginationLinks } from '@warp-drive/core-types/spec/raw';
+
+import type { UpgradedMeta } from '../-edge-definition';
+
+const Unpaged = Symbol('Unpaged');
+const Local = Symbol('Local');
+
+interface CollectionPage {
+  links: PaginationLinks | null;
+  meta: Meta | null;
+  remoteMembers: Set<StableRecordIdentifier>;
+  isDirty: boolean;
+  localState: StableRecordIdentifier[] | null;
+}
+
+export interface PaginatedCollectionEdge {
+  definition: UpgradedMeta;
+  identifier: StableRecordIdentifier;
+  // state: RelationshipState;
+
+  pages: Map<string, CollectionPage>;
+
+  // remote state added via inverse that is not yet in a page
+  remoteMembers: Set<StableRecordIdentifier>;
+
+  // locally added records to add to unpaged
+  additions: Set<StableRecordIdentifier> | null;
+
+  // locally removed records to remove from all pages
+  removals: Set<StableRecordIdentifier> | null;
+
+  // relationshipObject meta & links
+  // (as opposed to the meta & links of a specific page)
+  meta: Meta | null;
+  links: PaginationLinks | null;
+
+  // a cache of the unpaged data with removals applied
+  localState: StableRecordIdentifier[] | null;
+  // whether localState is up-to-date
+  isDirty: boolean;
+  transactionRef: number;
+
+  // TODO: this should likely be per-page
+  _diff?: {
+    add: Set<StableRecordIdentifier>;
+    del: Set<StableRecordIdentifier>;
+  };
+}
+
+export function createPaginatedCollectionEdge(
+  definition: UpgradedMeta,
+  identifier: StableRecordIdentifier
+): PaginatedCollectionEdge {
+  return {
+    definition,
+    identifier,
+
+    pages: new Map(),
+    remoteMembers: new Set(),
+
+    additions: null,
+    removals: null,
+
+    meta: null,
+    links: null,
+
+    isDirty: true,
+    localState: null,
+    transactionRef: 0,
+    _diff: undefined,
+  };
+}
+
+type PaginatedCollectionRelationship = {
+  links?: PaginationLinks;
+  meta?: Meta;
+  pages: Map<string | typeof Unpaged | typeof Local, CollectionRelationship>;
+};
+
+function computePageState(
+  storage: CollectionPage | PaginatedCollectionEdge,
+  source: PaginatedCollectionEdge
+): StableRecordIdentifier[] {
+  if (!storage.isDirty) {
+    assert(`Expected localState to be present`, Array.isArray(storage.localState));
+    return storage.localState;
+  }
+
+  let result: StableRecordIdentifier[];
+  if (!source.removals?.size) {
+    result = Array.from(storage.remoteMembers);
+  } else {
+    const state = new Set(storage.remoteMembers);
+    source.removals?.forEach((v) => {
+      state.delete(v);
+    });
+    result = Array.from(state);
+  }
+
+  storage.localState = result;
+  storage.isDirty = false;
+
+  return result;
+}
+
+export function getPaginatedCollectionData(source: PaginatedCollectionEdge): PaginatedCollectionRelationship {
+  const payload: PaginatedCollectionRelationship = {
+    pages: new Map(),
+  };
+
+  // primary pages
+  source.pages.forEach((page, key) => {
+    const collectionRelationship: CollectionRelationship = {};
+    collectionRelationship.data = computePageState(page, source);
+
+    if (page.links) {
+      collectionRelationship.links = page.links;
+    }
+
+    if (page.meta) {
+      collectionRelationship.meta = page.meta;
+    }
+
+    payload.pages.set(key, collectionRelationship);
+  });
+
+  // specialized pages
+  payload.pages.set(Unpaged, {
+    data: computePageState(source, source),
+  });
+  payload.pages.set(Local, {
+    data: source.additions ? Array.from(source.additions) : [],
+  });
+
+  if (source.links) {
+    payload.links = source.links;
+  }
+
+  if (source.meta) {
+    payload.meta = source.meta;
+  }
+
+  return payload;
+}


### PR DESCRIPTION
Once complete, this removes what is probably the largest blocker to us quickly shipping `@warp-drive/schema-record` and/or building decorators for `@ember-data/model` to replace `belongsTo` and `hasMany` with new semantics.

There are two paths forward with this PR:

1. Replace the storage for all collection relationships with the paginated version
2. Add `isPaginated` somewhere in the schema (either via `kind` or via something on options)
   and switch handling in the graph based on schema.

There's a case to be made for either, though I have a preference for the first as it likely offers the largest amount of test coverage by default *and* a single set of codepaths is simpler to maintain in the long run.

However, for the unpaginated case, performance may be slightly better in the old storage mechanism. I suspect though this will be easily offset by a couple of perf gains I noticed while implementing the storage for pagination in this PR: (1) we no longer need a separate array for remoteState and (2) construction of localState is ~15% faster if we use copy the set, delete the removals, and the Array.from the result.