### PR TITLE
feat: make setKeyInfoForResource public

### DIFF
--- a/packages/store/src/-private.ts
+++ b/packages/store/src/-private.ts
@@ -8,6 +8,8 @@ export { recordIdentifierFor } from './-private/caches/instance-cache';
 
 export { CacheHandler, type LifetimesService } from './-private/cache-handler';
 
+export { isStableIdentifier } from './-private/caches/identifier-cache';
+
 export { default as constructResource } from './-private/utils/construct-resource';
 
 // TODO this should be a deprecated helper but we have so much usage of it

--- a/packages/store/src/-private.ts
+++ b/packages/store/src/-private.ts
@@ -8,14 +8,6 @@ export { recordIdentifierFor } from './-private/caches/instance-cache';
 
 export { CacheHandler, type LifetimesService } from './-private/cache-handler';
 
-export {
-  setIdentifierGenerationMethod,
-  setIdentifierUpdateMethod,
-  setIdentifierForgetMethod,
-  setIdentifierResetMethod,
-  isStableIdentifier,
-} from './-private/caches/identifier-cache';
-
 export { default as constructResource } from './-private/utils/construct-resource';
 
 // TODO this should be a deprecated helper but we have so much usage of it

--- a/packages/store/src/-private/caches/identifier-cache.ts
+++ b/packages/store/src/-private/caches/identifier-cache.ts
@@ -25,6 +25,8 @@ import type { ExistingResourceObject, ResourceIdentifierObject } from '@warp-dri
 import type {
   ForgetMethod,
   GenerationMethod,
+  KeyInfo,
+  KeyInfoMethod,
   ResetMethod,
   ResourceData,
   UpdateMethod,
@@ -76,18 +78,13 @@ type TypeMap = { [key: string]: KeyOptions };
 // type IdentifierTypeLookup = { all: Set<StableRecordIdentifier>; id: Map<string, StableRecordIdentifier> };
 // type IdentifiersByType = Map<string, IdentifierTypeLookup>;
 type IdentifierMap = Map<string, StableRecordIdentifier>;
-type KeyInfo = {
-  id: string | null;
-  type: string;
-};
+
 type StableCache = {
   resources: IdentifierMap;
   documents: Map<string, StableDocumentIdentifier>;
   resourcesByType: TypeMap;
   polymorphicLidBackMap: Map<string, string[]>;
 };
-
-export type KeyInfoMethod = (resource: unknown, known: StableRecordIdentifier | null) => KeyInfo;
 
 export type MergeMethod = (
   targetIdentifier: StableRecordIdentifier,

--- a/packages/store/src/-types/q/identifier.ts
+++ b/packages/store/src/-types/q/identifier.ts
@@ -171,3 +171,28 @@ export type ForgetMethod = (identifier: StableIdentifier | StableRecordIdentifie
   @static
 */
 export type ResetMethod = () => void;
+
+/**
+ Configure a callback for when the identifier cache is generating a new
+ StableRecordIdentifier for a resource.
+
+ This method controls the `type` and `id` that will be assigned to the
+ `StableRecordIdentifier` that is created.
+
+ This configuration MUST occur prior to the store instance being created.
+
+ ```js
+ import { setKeyInfoForResource } from '@ember-data/store';
+ ```
+
+  @method setKeyInfoForResource
+  @for @ember-data/store
+  @param method
+  @public
+  @static
+ */
+export type KeyInfo = {
+  id: string | null;
+  type: string;
+};
+export type KeyInfoMethod = (resource: unknown, known: StableRecordIdentifier | null) => KeyInfo;

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -187,10 +187,14 @@ export {
   CacheHandler,
   type LifetimesService,
   type StoreRequestInput,
+  recordIdentifierFor,
+  storeFor,
+} from './-private';
+
+export {
   setIdentifierGenerationMethod,
   setIdentifierUpdateMethod,
   setIdentifierForgetMethod,
   setIdentifierResetMethod,
-  recordIdentifierFor,
-  storeFor,
-} from './-private';
+  setKeyInfoForResource,
+} from './-private/caches/identifier-cache';

--- a/tests/docs/fixtures/expected.js
+++ b/tests/docs/fixtures/expected.js
@@ -467,6 +467,7 @@ module.exports = {
     '(public) @ember-data/store @ember-data/store#setIdentifierGenerationMethod',
     '(public) @ember-data/store @ember-data/store#setIdentifierResetMethod',
     '(public) @ember-data/store @ember-data/store#setIdentifierUpdateMethod',
+    '(public) @ember-data/store @ember-data/store#setKeyInfoForResource',
     '(public) @ember-data/store CacheManager#changedAttrs',
     '(public) @ember-data/store CacheManager#clientDidCreate',
     '(public) @ember-data/store CacheManager#commitWasRejected',


### PR DESCRIPTION
This hooks is required if you want to fully utilize a non `id` primary key