### PR TITLE
fix: restore old behavior in deprecation

### DIFF
--- a/packages/graph/src/-private/operations/replace-related-record.ts
+++ b/packages/graph/src/-private/operations/replace-related-record.ts
@@ -165,7 +165,7 @@ export default function replaceRelatedRecord(graph: Graph, op: ReplaceRelatedRec
         localState !== existingState &&
         relationship.definition.resetOnRemoteUpdate !== false
       ) {
-        relationship.localState = existingState;
+        relationship.localState = remoteState;
 
         deprecate(
           `EmberData is changing the default semantics of updates to the remote state of relationships.\n\nThe following local state was cleared from the <${


### PR DESCRIPTION
## Description

This is a fix for the deprecation @ https://deprecations.emberjs.com/ember-data/v5.x/#toc_ember-data-deprecate-relationship-remote-update-clearing-local-state

In the case of a **remote update with a local change**, I think we want to have the remote state as the local state in the old way.

@runspired Does this make sense? Just encountered this issue in our upgrade from v4 => v5. Perhaps this is a copy/paste issue from the deprecation warning in line #89...

---

In v4 we run into this branch:

https://github.com/emberjs/data/blob/v4.12.7/packages/graph/src/-private/graph/operations/replace-related-record.ts#L131

```ts
if (localState !== remoteState) {
  relationship.localState = remoteState;
```

In v5 we run into this branch:

```ts
if (localState !== remoteState && localState === existingState) { // <-- Does not apply as we have a local mutation
  relationship.localState = remoteState;
  notifyChange(graph, relationship.identifier, relationship.definition.key);
} else if (DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE) {
  if (
    localState !== remoteState &&
    localState !== existingState &&
    relationship.definition.resetOnRemoteUpdate !== false
  ) {
    relationship.localState = existingState; // <-- Should be remoteState?
```


https://github.com/emberjs/data/blob/v5.3.3/packages/graph/src/-private/operations/replace-related-record.ts#L168

---

**Example:**

We change a relationship from record "1" to "null" and on save, the server returns a record "99" for this relationship.

In v4 and v5 we have the following state:

```ts
// Before the local change it was '1'
existingState.id; // = '1';

// Local change clears the relationship
relationship.localState; // = null;

// Remote wants to set '99'
op.value.id; // '99'
```

In v4 we end up with '99' as the new local state (`relationship.localState = remoteState`).

In v5 we end up with '1' as the new local state (`relationship.localState = existingState`). But in my understanding it should be '99' in the old way.




## Notes for the release

