### PR TITLE
docs: Update ISSUE_TEMPLATE.md to follow latest pnpm

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,7 +23,7 @@ If a previous version of `ember-data` worked as `expected`, which was the most r
 
 ### Versions
 
-Run the following command and paste the output below: `pnpm list ember-source && pnpm list ember-cli && pnpm list --pattern ember-data`.
+Run the following command and paste the output below: `pnpm list ember-source && pnpm list ember-cli && pnpm list "*ember-data*"`.
 
 ```cli
 [Replace this line with the output]


### PR DESCRIPTION
## Description

- Looking at the [pnpm list docs](https://pnpm.io/cli/list) I can't see `--pattern` option.
- My `pnpm` version complains about this: ` ERROR  Unknown option: 'pattern'`
- My `pnpm` version is: `8.15.6`
