### PR TITLE
fix: Make IS_MAYBE_MIRAGE simplified

### DIFF
--- a/packages/request/src/fetch.ts
+++ b/packages/request/src/fetch.ts
@@ -40,8 +40,7 @@ if (DEBUG) {
     Boolean(
       typeof window !== 'undefined' &&
         ((window as { server?: { pretender: unknown } }).server?.pretender ||
-          (window.fetch.toString() !== 'function fetch() { [native code] }' &&
-            window.fetch.toString() !== 'function fetch() {\n    [native code]\n}'))
+          window.fetch.toString().replace(/\s+/g, '') !== 'function fetch() { [native code] }'.replace(/\s+/g, ''))
     );
 }
 


### PR DESCRIPTION
## Description

- In previous version we fixed the code for FireFox that can now work in FireFox which has different `.toString()` implementation
- This change should make it more error prone as it completely removes whitespace from the strings and then compares them
- Follow-up for #9360

## Notes for the release

