### PR TITLE
docs: fix readme links in @warp-drive/ember

### DIFF
--- a/packages/ember/README.md
+++ b/packages/ember/README.md
@@ -38,10 +38,10 @@ Documentation
 
 - [PromiseState](#promisestate)
   - [getPromiseState](#getpromisestate)
-  - [\<Await />](#await)
+  - [\<Await />](#await-)
 - [RequestState](#requeststate)
   - [getRequestState](#getrequeststate)
-  - [\<Request />](#request)
+  - [\<Request />](#request-)
 
 ---
 


### PR DESCRIPTION
`<name/>` apparently results in `name-`