### PR TITLE
Update strategy.json to mirror publish @warp-drive/schema-record

### DIFF
--- a/release/strategy.json
+++ b/release/strategy.json
@@ -78,7 +78,7 @@
       "stage": "alpha",
       "types": "alpha",
       "typesPublish": false,
-      "mirrorPublish": false
+      "mirrorPublish": true
     }
   }
 }


### PR DESCRIPTION
ensures `@warp-drive-mirror/schema-record` is also published for use with the two-store strategy