### PR TITLE
fix: Resolve promise types for props passed to `store.createRecord()`

### DIFF
--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -66,7 +66,10 @@ type CompatStore = Store & {
 };
 function upgradeStore(store: Store): asserts store is CompatStore {}
 
-type FilteredKeys<T> = Omit<T, typeof ResourceType | keyof EmberObject | 'constructor'>;
+type AwaitedKeys<T> = { [K in keyof T]: Awaited<T[K]> };
+
+// `AwaitedKeys` is needed here to resolve any promise types like `PromiseBelongsTo`.
+type FilteredKeys<T> = AwaitedKeys<Omit<T, typeof ResourceType | keyof EmberObject | 'constructor'>>;
 
 type MaybeHasId = { id?: string | null };
 /**

--- a/packages/store/src/-private/store-service.type-test.ts
+++ b/packages/store/src/-private/store-service.type-test.ts
@@ -1,9 +1,13 @@
+import EmberObject from '@ember/object';
+
 import { expectTypeOf } from 'expect-type';
 
-import type { ResourceType } from '@warp-drive/core-types/symbols';
+import { ResourceType } from '@warp-drive/core-types/symbols';
 
 import type { IdentifierArray } from '../-private';
+import ShimModelClass from './legacy-model-support/shim-model-class';
 import type { Collection } from './record-arrays/identifier-array';
+import type { CreateRecordProperties } from './store-service';
 import Store from './store-service';
 
 //////////////////////////////////
@@ -370,4 +374,28 @@ import Store from './store-service';
   expectTypeOf<Collection>(result);
   expectTypeOf<Collection>(result3);
   expectTypeOf<Collection<MyThing>>(result2);
+}
+
+//////////////////////////////////
+//////////////////////////////////
+// type CreateRecordProperties
+//////////////////////////////////
+//////////////////////////////////
+{
+  class MockModel extends EmberObject {
+    [ResourceType] = 'user' as const;
+    asyncProp = Promise.resolve('async');
+    syncProp = 'sync';
+  }
+
+  const mock = new MockModel();
+
+  expectTypeOf(mock.asyncProp).toEqualTypeOf<Promise<string>>();
+  expectTypeOf(mock.syncProp).toEqualTypeOf<string>();
+
+  const result: CreateRecordProperties<typeof mock> = {};
+
+  // Only `asyncProp` and `syncProp` should be present in the type, they should be optional and
+  // any Promise types should be awaited.
+  expectTypeOf(result).toEqualTypeOf<{ asyncProp?: string; syncProp?: string }>();
 }

--- a/packages/store/src/-private/store-service.type-test.ts
+++ b/packages/store/src/-private/store-service.type-test.ts
@@ -5,7 +5,6 @@ import { expectTypeOf } from 'expect-type';
 import { ResourceType } from '@warp-drive/core-types/symbols';
 
 import type { IdentifierArray } from '../-private';
-import ShimModelClass from './legacy-model-support/shim-model-class';
 import type { Collection } from './record-arrays/identifier-array';
 import type { CreateRecordProperties } from './store-service';
 import Store from './store-service';


### PR DESCRIPTION
## Description

Fix incorrect types being expected by the store service’s `createRecord()` method. This could happen when the record being created had, for example, a `belongsTo` relationship, in which case the type for the property with the relationship was `PromiseBelongsTo<SomeModel>` rather than `SomeModel`.

## Cause

When determining the TS type for properties that can be passed to `createRecord()` a `CreateRecordProperties` utility type is used. It in turn uses a `FilteredKeys` type to narrow the properties to only the model attributes. Promise types were not being handled here and only filtered, leading to the issue.

## Fix

To resolve any promise types like `PromiseBelongsTo`, a new `AwaitedKeys<Type>` utiltity type was added that wraps `FilteredKeys`. It’s a mapped type that applies [`Awaited`](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) to all keys, resolving promise types.

## Notes for the release

N/A


