### PR TITLE
chore: dont --compile during prepack

### DIFF
--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -14,8 +14,6 @@
   },
   "scripts": {
     "build:cli": "bun build bin/codemods.ts --compile --target node --outfile codemods --sourcemap",
-    "_build": "bun run build:cli",
-    "prepack": "bun run _build",
     "check:types": "tsc --noEmit",
     "lint": "eslint . --quiet --cache --cache-strategy=content --ext .js,.ts,.mjs,.cjs --report-unused-disable-directives",
     "_syncPnpm": "bun run sync-dependencies-meta-injected"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -23,8 +23,7 @@
   "scripts": {
     "build:parse": "bun build src/parse.ts --compile --outfile parse",
     "build:scaffold": "bun build src/scaffold.ts --compile --outfile scaffold",
-    "_build": "bun run build:parse && bun run build:scaffold",
-    "prepack": "bun run _build"
+    "build:cli": "bun run build:parse && bun run build:scaffold"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
will help make the binaries more stable until a tool exists to pin bun version