### PR TITLE
feat: add expectId util

### DIFF
--- a/packages/legacy-compat/src/utils.ts
+++ b/packages/legacy-compat/src/utils.ts
@@ -199,8 +199,6 @@ export function expectId(id: string | number | null): string {
   return formattedId(id);
 }
 
-
-
 /**
  * Compares two types for strict equality, converting them to
  * the format expected by the EmberData Cache to ensure

--- a/packages/legacy-compat/src/utils.ts
+++ b/packages/legacy-compat/src/utils.ts
@@ -191,6 +191,16 @@ export function formattedId(id: string | number | null): string | null {
   return id === null ? null : String(id);
 }
 
+export function expectId(id: string | number): string;
+export function expectId(id: null): never;
+export function expectId(id: string | number | null): string {
+  AssertFn('expectId: id must not be null', id !== null);
+
+  return formattedId(id);
+}
+
+
+
 /**
  * Compares two types for strict equality, converting them to
  * the format expected by the EmberData Cache to ensure


### PR DESCRIPTION
adds `expectId` which is useful when you expect to only have existing records and may accidentally encounter a record in the isNew state