### PR TITLE
feat: preserve lids returned by the API in legacy normalization

### DIFF
--- a/packages/serializer/src/-private/embedded-records-mixin.js
+++ b/packages/serializer/src/-private/embedded-records-mixin.js
@@ -585,6 +585,9 @@ export default Mixin.create({
       }
 
       hasMany[i] = { id: data.id, type: data.type };
+      if (data.lid) {
+        hasMany[i].lid = data.lid;
+      }
     }
 
     const relationship = { data: hasMany };
@@ -610,6 +613,10 @@ export default Mixin.create({
 
     const belongsTo = { id: data.id, type: data.type };
     const relationship = { data: belongsTo };
+
+    if (data.lid) {
+      belongsTo.lid = data.lid;
+    }
 
     hash.data.relationships[key] = relationship;
   },

--- a/packages/serializer/src/json.js
+++ b/packages/serializer/src/json.js
@@ -617,6 +617,10 @@ const JSONSerializer = Serializer.extend({
         relationships: this.extractRelationships(modelClass, resourceHash),
       };
 
+      if (resourceHash.lid) {
+        data.lid = resourceHash.lid;
+      }
+
       this.applyTransforms(modelClass, data.attributes);
     }
 


### PR DESCRIPTION
extension of #7956 

We don't want to automatically include `lid` in the payloads generated to be sent to the server as this would probably be a breaking change, but we can at least attempt to preserve any lid the API reflects back to us.

cc @amk221 