### PR TITLE
[WIP] fix: resolve and unwrap `AsyncHasMany` for `store.createRecord()`

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -62,6 +62,7 @@
     }
   },
   "peerDependencies": {
+    "@ember-data/model": "workspace:5.4.0-alpha.64",
     "@ember-data/request": "workspace:5.4.0-alpha.64",
     "@ember-data/tracking": "workspace:5.4.0-alpha.64",
     "@ember/string": "^3.1.1",
@@ -78,6 +79,7 @@
     "@babel/preset-env": "^7.24.4",
     "@babel/preset-typescript": "^7.24.1",
     "@babel/runtime": "^7.24.4",
+    "@ember-data/model": "workspace:5.4.0-alpha.64",
     "@ember-data/request": "workspace:5.4.0-alpha.64",
     "@ember-data/tracking": "workspace:5.4.0-alpha.64",
     "@ember/string": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2096,6 +2096,9 @@ importers:
       '@babel/runtime':
         specifier: ^7.24.4
         version: 7.24.4
+      '@ember-data/model':
+        specifier: workspace:5.4.0-alpha.62
+        version: link:../model
       '@ember-data/request':
         specifier: workspace:5.4.0-alpha.64
         version: file:packages/request(@babel/core@7.24.4)(@glint/template@1.4.0)(@warp-drive/core-types@0.0.0-alpha.50)


### PR DESCRIPTION
_This is a WIP. The code works as expected but a cyclical dependency was introduced that needs to be resolved._

## Description

In #9396 the prop types expected by `store.createRecord()` were updated to resolve `AsyncBelongsTo` to the underlying model.

`AsyncHasMany` wasn't handled though, so this PR addresses that. To do so the `CreateRecordProperties` type util was updated to look for `RelatedCollection`s (which are the result of `Awaited`-ing the `AsyncHasMany` type) and then the model used in the collection is turned into a plain array of that model type. This allows the following:

```ts
const parentModel = store.createRecord<ParentModel>('parent', { children: [existingChildModel] })
```

Previously this would error because `[existingChildModel]` in the model props wasn't of type `RelatedCollection<ChildModel>`.

## Notes for the release

N/A


