### PR TITLE
feat: v2 addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
       }
     },
     "overrides": {
-      "ember-auto-import": "^2.7.2",
+      "ember-auto-import": "^2.7.3",
       "@embroider/macros": "^1.16.1",
       "broccoli-funnel": "^3.0.8",
       "broccoli-merge-trees": "^4.2.0",

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -23,7 +23,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1,
+    "version": 2,
     "app-js": {
       "./initializers/ember-data.js": "./app/initializers/ember-data.js",
       "./services/store.js": "./app/services/store.js",
@@ -124,8 +124,7 @@
     "@embroider/macros": "^1.16.1",
     "@warp-drive/core-types": "workspace:0.0.0-alpha.58",
     "ember-inflector": "^4.0.2",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "peerDependencies": {
     "@ember/string": "^3.1.1",

--- a/packages/active-record/package.json
+++ b/packages/active-record/package.json
@@ -42,12 +42,11 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "dependencies": {
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "peerDependencies": {
     "@ember-data/request-utils": "workspace:5.4.0-alpha.72",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -22,7 +22,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "files": [
     "unstable-preview-types",
@@ -92,8 +92,7 @@
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-path-utils": "^1.0.0",
     "@ember/edition-utils": "1.2.0",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -39,8 +39,7 @@
   },
   "dependencies": {
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",
@@ -61,7 +60,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "ember": {
     "edition": "octane"

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -74,8 +74,7 @@
   "dependencies": {
     "@ember/edition-utils": "^1.2.0",
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",
@@ -105,7 +104,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -64,8 +64,7 @@
   "dependencies": {
     "@ember/edition-utils": "^1.2.0",
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",
@@ -94,7 +93,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "ember": {
     "edition": "octane"

--- a/packages/json-api/package.json
+++ b/packages/json-api/package.json
@@ -21,7 +21,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "files": [
     "unstable-preview-types",
@@ -86,8 +86,7 @@
   "dependencies": {
     "@ember/edition-utils": "^1.2.0",
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/packages/legacy-compat/package.json
+++ b/packages/legacy-compat/package.json
@@ -48,7 +48,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "dependenciesMeta": {
     "@ember-data/request": {
@@ -95,8 +95,7 @@
   },
   "dependencies": {
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "peerDependencies": {
     "@ember-data/graph": "workspace:5.4.0-alpha.72",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -22,7 +22,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "files": [
     "unstable-preview-types",
@@ -103,8 +103,7 @@
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-test-info": "^1.0.0",
     "inflection": "~3.0.0",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -45,15 +45,14 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "peerDependencies": {
     "@warp-drive/core-types": "workspace:0.0.0-alpha.58"
   },
   "dependencies": {
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@ember/test-waiters": "^3.1.0",
     "@embroider/macros": "^1.16.1",
-    "ember-cli-babel": "^8.2.0",
     "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "devDependencies": {
@@ -78,7 +77,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "ember": {
     "edition": "octane"

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -23,8 +23,7 @@
   },
   "dependencies": {
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "peerDependencies": {
     "@ember-data/request-utils": "workspace:5.4.0-alpha.72",
@@ -57,7 +56,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/packages/schema-record/package.json
+++ b/packages/schema-record/package.json
@@ -21,7 +21,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "files": [
     "addon-main.cjs",
@@ -67,8 +67,7 @@
   "dependencies": {
     "@ember/edition-utils": "^1.2.0",
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -22,7 +22,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "files": [
     "unstable-preview-types",
@@ -83,8 +83,7 @@
     "ember-cli-string-utils": "^1.1.0",
     "ember-cli-path-utils": "^1.0.0",
     "@ember/edition-utils": "1.2.0",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -56,8 +56,7 @@
   },
   "dependencies": {
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "peerDependencies": {
     "@ember-data/request": "workspace:5.4.0-alpha.72",
@@ -93,7 +92,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1
+    "version": 2
   },
   "ember": {
     "edition": "octane"

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -31,8 +31,7 @@
   },
   "dependencies": {
     "@embroider/macros": "^1.16.1",
-    "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-cli-babel": "^8.2.0"
+    "@warp-drive/build-config": "workspace:0.0.0-alpha.9"
   },
   "peerDependencies": {
     "ember-source": ">= 3.28.12",
@@ -66,7 +65,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 1,
+    "version": 2,
     "externals": [
       "@ember/-internals",
       "@ember/-internals/metal",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  ember-auto-import: ^2.7.2
+  ember-auto-import: ^2.7.3
   '@embroider/macros': ^1.16.1
   broccoli-funnel: ^3.0.8
   broccoli-merge-trees: ^4.2.0
@@ -237,9 +237,6 @@ importers:
       '@warp-drive/core-types':
         specifier: workspace:0.0.0-alpha.58
         version: file:packages/core-types(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
       ember-inflector:
         specifier: ^4.0.2
         version: 4.0.2(@babel/core@7.24.5)
@@ -335,9 +332,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -416,9 +410,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
       ember-cli-path-utils:
         specifier: ^1.0.0
         version: 1.0.0
@@ -619,9 +610,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -659,9 +647,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -930,9 +915,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -1055,9 +1037,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -1144,9 +1123,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -1241,9 +1217,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
       ember-cli-string-utils:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1358,9 +1331,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -1409,9 +1379,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -1460,9 +1427,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -1550,9 +1514,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -1624,9 +1585,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
       ember-cli-path-utils:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1720,9 +1678,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -1792,9 +1747,6 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:0.0.0-alpha.9
         version: file:packages/build-config(@babel/core@7.24.5)(@glint/template@1.4.0)
-      ember-cli-babel:
-        specifier: ^8.2.0
-        version: 8.2.0(@babel/core@7.24.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -2137,8 +2089,8 @@ importers:
         specifier: workspace:5.4.0-alpha.72
         version: link:../../config
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -2356,8 +2308,8 @@ importers:
         specifier: workspace:5.4.0-alpha.72
         version: link:../../config
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -2521,8 +2473,8 @@ importers:
         specifier: workspace:5.4.0-alpha.72
         version: link:../../config
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -2694,8 +2646,8 @@ importers:
         specifier: workspace:5.4.0-alpha.72
         version: link:../../config
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -2857,8 +2809,8 @@ importers:
         specifier: workspace:5.4.0-alpha.72
         version: link:../../config
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -2992,8 +2944,8 @@ importers:
         specifier: ^1.1.8
         version: 1.1.8
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -3145,8 +3097,8 @@ importers:
         specifier: workspace:5.4.0-alpha.72
         version: link:../../config
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -3308,8 +3260,8 @@ importers:
         specifier: workspace:5.4.0-alpha.72
         version: link:../../config
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -3494,8 +3446,8 @@ importers:
         specifier: workspace:5.4.0-alpha.72
         version: link:../../config
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -3622,8 +3574,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(@babel/core@7.24.5)
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-data:
         specifier: workspace:5.4.0-alpha.72
         version: file:packages/-ember-data(@babel/core@7.24.5)(@ember/string@3.1.1)(@ember/test-helpers@3.3.0)(@ember/test-waiters@3.1.0)(ember-source@5.8.0)(qunit@2.19.4)
@@ -3788,8 +3740,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -3944,8 +3896,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cached-decorator-polyfill:
         specifier: ^1.0.2
         version: 1.0.2(@babel/core@7.24.5)(ember-source@5.8.0)
@@ -4074,8 +4026,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(@babel/core@7.24.5)
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-data:
         specifier: workspace:5.4.0-alpha.72
         version: file:packages/-ember-data(@babel/core@7.24.5)(@ember/string@3.1.1)(@ember/test-helpers@3.3.0)(@ember/test-waiters@3.1.0)(ember-source@5.8.0)(qunit@2.19.4)
@@ -4252,8 +4204,8 @@ importers:
         specifier: workspace:0.0.0-alpha.58
         version: file:packages/schema-record(@babel/core@7.24.5)(@ember-data/request@5.4.0-alpha.72)(@ember-data/store@5.4.0-alpha.72)(@ember-data/tracking@5.4.0-alpha.72)(@glint/template@1.4.0)(@warp-drive/core-types@0.0.0-alpha.58)
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -4431,8 +4383,8 @@ importers:
         specifier: workspace:0.0.0-alpha.58
         version: file:packages/schema-record(@babel/core@7.24.5)(@ember-data/request@5.4.0-alpha.72)(@ember-data/store@5.4.0-alpha.72)(@ember-data/tracking@5.4.0-alpha.72)(@glint/template@1.4.0)(@warp-drive/core-types@0.0.0-alpha.58)
       ember-auto-import:
-        specifier: ^2.7.2
-        version: 2.7.2(@glint/template@1.4.0)
+        specifier: ^2.7.3
+        version: 2.7.3(@glint/template@1.4.0)
       ember-cli:
         specifier: ~5.8.1
         version: 5.8.1
@@ -5899,7 +5851,7 @@ packages:
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       dom-element-descriptors: 0.5.0
-      ember-auto-import: 2.7.2(@glint/template@1.4.0)
+      ember-auto-import: 2.7.3(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.24.5)
       ember-cli-htmlbars: 6.3.0
       ember-source: 5.8.0(@babel/core@7.24.5)(@glimmer/component@1.1.2)(@glint/template@1.4.0)
@@ -10977,6 +10929,53 @@ packages:
       - uglify-js
       - webpack-cli
 
+  /ember-auto-import@2.7.3(@glint/template@1.4.0):
+    resolution: {integrity: sha512-EQzStGYxNvTPYWCFh0X57HFAzAvA2rHHRgBeWNDKHQ/rENNlHw0c0e0i1XebwEfv+yGHOodE4dN+f/mrYkQXLw==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@babel/core': 7.24.5(supports-color@8.1.1)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-class-static-block': 7.24.4(@babel/core@7.24.5)
+      '@babel/preset-env': 7.24.5(@babel/core@7.24.5)(supports-color@8.1.1)
+      '@embroider/macros': 1.16.1(@babel/core@7.24.5)(@glint/template@1.4.0)
+      '@embroider/shared-internals': 2.6.0(supports-color@8.1.1)
+      babel-loader: 8.3.0(@babel/core@7.24.5)(webpack@5.91.0)
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-ember-template-compilation: 2.2.5
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      css-loader: 5.2.7(webpack@5.91.0)
+      debug: 4.3.4(supports-color@8.1.1)
+      fs-extra: 10.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.8
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.0(webpack@5.91.0)
+      minimatch: 3.1.2
+      parse5: 6.0.1
+      resolve: 1.22.8
+      resolve-package-path: 4.0.3
+      semver: 7.6.2
+      style-loader: 2.0.0(webpack@5.91.0)
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+      webpack: 5.91.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - uglify-js
+      - webpack-cli
+
   /ember-cache-primitive-polyfill@1.0.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==}
     engines: {node: 10.* || >= 12}
@@ -11095,7 +11094,7 @@ packages:
     dependencies:
       '@ember/test-helpers': 3.3.0(patch_hash=gppmtiox6pymwamrfimkbxfrsm)(@babel/core@7.24.5)(@glint/template@1.4.0)(ember-source@5.8.0)
       body-parser: 1.20.2
-      ember-auto-import: 2.7.2(@glint/template@1.4.0)
+      ember-auto-import: 2.7.3(@glint/template@1.4.0)
       ember-cli: 5.8.1
       ember-cli-babel: 8.2.0(@babel/core@7.24.5)
       ember-cli-fastboot: 4.1.4(@babel/core@7.24.5)(ember-cli@5.8.1)(ember-source@5.8.0)
@@ -11527,7 +11526,7 @@ packages:
       chalk: 5.3.0
       cli-table3: 0.6.4
       debug: 4.3.4(supports-color@8.1.1)
-      ember-auto-import: 2.7.2(@glint/template@1.4.0)
+      ember-auto-import: 2.7.3(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.24.5)
       ember-qunit: 8.0.2(@babel/core@7.24.5)(@ember/test-helpers@3.3.0)(ember-source@5.8.0)(qunit@2.19.4)
       ember-source: 5.8.0(@babel/core@7.24.5)(@glimmer/component@1.1.2)(@glint/template@1.4.0)
@@ -11723,7 +11722,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.7.2(@glint/template@1.4.0)
+      ember-auto-import: 2.7.3(@glint/template@1.4.0)
       ember-cli-babel: 8.2.0(@babel/core@7.24.5)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0

--- a/tests/builders/package.json
+++ b/tests/builders/package.json
@@ -103,7 +103,7 @@
     "@warp-drive/diagnostic": "workspace:0.0.0-alpha.58",
     "@warp-drive/internal-config": "workspace:5.4.0-alpha.72",
     "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",

--- a/tests/ember-data__adapter/package.json
+++ b/tests/ember-data__adapter/package.json
@@ -101,7 +101,7 @@
     "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
     "@warp-drive/internal-config": "workspace:5.4.0-alpha.72",
     "@warp-drive/diagnostic": "workspace:0.0.0-alpha.58",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",

--- a/tests/ember-data__graph/package.json
+++ b/tests/ember-data__graph/package.json
@@ -96,7 +96,7 @@
     "@warp-drive/core-types": "workspace:0.0.0-alpha.58",
     "@warp-drive/internal-config": "workspace:5.4.0-alpha.72",
     "@warp-drive/diagnostic": "workspace:0.0.0-alpha.58",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",

--- a/tests/ember-data__json-api/package.json
+++ b/tests/ember-data__json-api/package.json
@@ -101,7 +101,7 @@
     "@warp-drive/holodeck": "workspace:0.0.0-alpha.58",
     "@warp-drive/internal-config": "workspace:5.4.0-alpha.72",
     "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",

--- a/tests/ember-data__model/package.json
+++ b/tests/ember-data__model/package.json
@@ -88,7 +88,7 @@
     "@warp-drive/diagnostic": "workspace:0.0.0-alpha.58",
     "@warp-drive/internal-config": "workspace:5.4.0-alpha.72",
     "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",

--- a/tests/ember-data__request/package.json
+++ b/tests/ember-data__request/package.json
@@ -69,7 +69,7 @@
     "@warp-drive/holodeck": "workspace:0.0.0-alpha.58",
     "@warp-drive/internal-config": "workspace:5.4.0-alpha.72",
     "bun-types": "^1.1.8",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",

--- a/tests/ember-data__serializer/package.json
+++ b/tests/ember-data__serializer/package.json
@@ -92,7 +92,7 @@
     "@warp-drive/core-types": "workspace:0.0.0-alpha.58",
     "@warp-drive/internal-config": "workspace:5.4.0-alpha.72",
     "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",

--- a/tests/embroider-basic-compat/package.json
+++ b/tests/embroider-basic-compat/package.json
@@ -87,7 +87,7 @@
     "@embroider/core": "^3.4.9",
     "@embroider/webpack": "^4.0.0",
     "@ember/string": "3.1.1",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-data": "workspace:5.4.0-alpha.72",
     "ember-inflector": "^4.0.2",
     "pnpm-sync-dependencies-meta-injected": "0.0.14",

--- a/tests/example-json-api/package.json
+++ b/tests/example-json-api/package.json
@@ -93,7 +93,7 @@
     "@types/morgan": "^1.9.9",
     "@warp-drive/core-types": "workspace:0.0.0-alpha.58",
     "@warp-drive/internal-config": "workspace:5.4.0-alpha.72",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",

--- a/tests/fastboot/package.json
+++ b/tests/fastboot/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@ember-data/unpublished-test-infra": "workspace:5.4.0-alpha.72",
     "@ember/string": "3.1.1",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-data": "workspace:5.4.0-alpha.72",
     "ember-inflector": "^4.0.2",
     "pnpm-sync-dependencies-meta-injected": "0.0.14",

--- a/tests/full-data-asset-size-app/package.json
+++ b/tests/full-data-asset-size-app/package.json
@@ -34,7 +34,7 @@
     "@ember/string": "3.1.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",

--- a/tests/main/package.json
+++ b/tests/main/package.json
@@ -119,7 +119,7 @@
     "broccoli-string-replace": "^0.1.2",
     "broccoli-test-helper": "^2.0.0",
     "broccoli-uglify-sourcemap": "^4.0.0",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cached-decorator-polyfill": "^1.0.2",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",

--- a/tests/performance/package.json
+++ b/tests/performance/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@ember/string": "3.1.1",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-data": "workspace:5.4.0-alpha.72",
     "pnpm-sync-dependencies-meta-injected": "0.0.14",
     "webpack": "^5.91.0"

--- a/tests/warp-drive__ember/package.json
+++ b/tests/warp-drive__ember/package.json
@@ -110,7 +110,7 @@
     "@warp-drive/diagnostic": "workspace:0.0.0-alpha.58",
     "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
     "@warp-drive/holodeck": "workspace:0.0.0-alpha.58",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",

--- a/tests/warp-drive__schema-record/package.json
+++ b/tests/warp-drive__schema-record/package.json
@@ -94,7 +94,7 @@
     "@warp-drive/internal-config": "workspace:5.4.0-alpha.72",
     "@warp-drive/schema-record": "workspace:0.0.0-alpha.58",
     "@warp-drive/build-config": "workspace:0.0.0-alpha.9",
-    "ember-auto-import": "^2.7.2",
+    "ember-auto-import": "^2.7.3",
     "ember-cli": "~5.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.3.2",


### PR DESCRIPTION
monitoring to see if v2 addons are feasible yet

In our work in #9292 we discovered that

- rolling up types(`.d.ts`) is not yet feasible, though `dts-buddy` approach was not yet explored (vite, rollup, tsc, and api-extractor approaches were)
- EmberData can't ship v2 addons (yet) due to webpack bugs in production builds improperly dropping various exports. This may (or may not) be related the auto-import layering issue, though is likely distinct.

We merged the big PR with all the work but turned off type rollup and configured most of the packages to continue to ship as v1 addons with a simple switch to upgrade them to v2 if possible. This PR triggered that switch so that we can debug these issues.