### PR TITLE
Fix: @attr defaultValue() results should persist after init (#9355)

### DIFF
--- a/tests/json-api/tests/integration/cache/resource-data-documents-test.ts
+++ b/tests/json-api/tests/integration/cache/resource-data-documents-test.ts
@@ -472,7 +472,7 @@ module('Integration | @ember-data/json-api Cache.put(<ResourceDataDocument>)', f
             name: {
               kind: 'attribute',
               name: 'name',
-              type: null,
+              type: 'string',
               options: {
                 defaultValue: () => {
                   i++;
@@ -500,21 +500,21 @@ module('Integration | @ember-data/json-api Cache.put(<ResourceDataDocument>)', f
     const identifier = store.identifierCache.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
 
     const name1 = store.cache.getAttr(identifier, 'name');
-    assert.equal(name1, 'Name 1', 'The default value was generated');
+    assert.strictEqual(name1, 'Name 1', 'The default value was generated');
     const name2 = store.cache.getAttr(identifier, 'name');
-    assert.equal(name2, 'Name 1', 'The default value was cached');
+    assert.strictEqual(name2, 'Name 1', 'The default value was cached');
 
     store.cache.setAttr(identifier, 'name', 'Chris');
     const name3 = store.cache.getAttr(identifier, 'name');
-    assert.equal(name3, 'Chris', 'The value was updated');
+    assert.strictEqual(name3, 'Chris', 'The value was updated');
 
     store.cache.setAttr(identifier, 'name', null);
     const name4 = store.cache.getAttr(identifier, 'name');
-    assert.equal(name4, null, 'Null was set and maintained');
+    assert.strictEqual(name4, null, 'Null was set and maintained');
 
     store.cache.rollbackAttrs(identifier);
     const name5 = store.cache.getAttr(identifier, 'name');
-    assert.equal(name5, 'Name 2', 'The default value was regenerated');
+    assert.strictEqual(name5, 'Name 2', 'The default value was regenerated');
 
     store._run(() => {
       store.cache.put({
@@ -531,6 +531,6 @@ module('Integration | @ember-data/json-api Cache.put(<ResourceDataDocument>)', f
     });
 
     const name6 = store.cache.getAttr(identifier, 'name');
-    assert.equal(name6, 'Tomster', 'The value was updated on put');
+    assert.strictEqual(name6, 'Tomster', 'The value was updated on put');
   });
 });


### PR DESCRIPTION
* Backport of #9355

* defaultValue function results should persist after initialization

* clear default values on patch changes

* defaultValue caching test

---------

## Description

<!-- insert description here -->

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


