### PR TITLE
feat: universal consts

### DIFF
--- a/packages/core-types/src/request.ts
+++ b/packages/core-types/src/request.ts
@@ -1,4 +1,4 @@
-import { getOrSetGlobal } from './-private';
+import { getOrSetGlobal, getOrSetUniversal } from './-private';
 import type { StableRecordIdentifier } from './identifier';
 import type { QueryParamsSerializationOptions } from './params';
 import type { ExtractSuggestedCacheTypes, Includes, TypedRecordInstance, TypeFromInstanceOrString } from './record';
@@ -7,8 +7,8 @@ import type { RequestSignature } from './symbols';
 
 type Store = unknown;
 
-export const SkipCache = getOrSetGlobal('SkipCache', Symbol.for('wd:skip-cache'));
-export const EnableHydration = getOrSetGlobal('EnableHydration', Symbol.for('wd:enable-hydration'));
+export const SkipCache = getOrSetUniversal('SkipCache', Symbol.for('wd:skip-cache'));
+export const EnableHydration = getOrSetUniversal('EnableHydration', Symbol.for('wd:enable-hydration'));
 export const IS_FUTURE = getOrSetGlobal('IS_FUTURE', Symbol('IS_FUTURE'));
 export const STRUCTURED = getOrSetGlobal('DOC', Symbol('DOC'));
 

--- a/packages/request/src/-private/manager.ts
+++ b/packages/request/src/-private/manager.ts
@@ -435,7 +435,7 @@ For usage of the store's `requestManager` via `store.request(<req>)` see the
 import { importSync } from '@embroider/macros';
 
 import { DEBUG, TESTING } from '@warp-drive/build-config/env';
-import { peekTransient, setTransient } from '@warp-drive/core-types/-private';
+import { peekUniversalTransient, setUniversalTransient } from '@warp-drive/core-types/-private';
 import type { RequestInfo, StructuredErrorDocument } from '@warp-drive/core-types/request';
 
 import { assertValidRequest } from './debug';
@@ -616,8 +616,8 @@ export class RequestManager {
       delete request.controller;
     }
 
-    const requestId = peekTransient<number>('REQ_ID') ?? 0;
-    setTransient('REQ_ID', requestId + 1);
+    const requestId = peekUniversalTransient<number>('REQ_ID') ?? 0;
+    setUniversalTransient('REQ_ID', requestId + 1);
 
     const promise = executeNextHandler<RT>(handlers, request, 0, {
       controller,

--- a/packages/request/src/-private/promise-cache.ts
+++ b/packages/request/src/-private/promise-cache.ts
@@ -1,4 +1,4 @@
-import { getOrSetGlobal } from '@warp-drive/core-types/-private';
+import { getOrSetUniversal } from '@warp-drive/core-types/-private';
 
 export type CacheResult<T = unknown, E = unknown> = { isError: true; result: E } | { isError: false; result: T };
 
@@ -8,8 +8,8 @@ export type Awaitable<T = unknown, E = unknown> = {
   finally: (onFinally: () => unknown) => unknown;
 };
 
-export const PromiseCache = getOrSetGlobal('PromiseCache', new WeakMap<Awaitable, CacheResult>());
-export const RequestMap = getOrSetGlobal('RequestMap', new Map<number, CacheResult>());
+export const PromiseCache = getOrSetUniversal('PromiseCache', new WeakMap<Awaitable, CacheResult>());
+export const RequestMap = getOrSetUniversal('RequestMap', new Map<number, CacheResult>());
 
 export function setRequestResult(requestId: number, result: CacheResult) {
   RequestMap.set(requestId, result);


### PR DESCRIPTION
In order for `@warp-drive/ember` to be directly compatible with both mirror and non-mirror versions of Ember, a few global concepts need to be universal (shared even across EmberData versions)