### PR TITLE
feat: improve typing around Model and createRecord

### DIFF
--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content --report-unused-disable-directives",
     "build:pkg": "vite build;",
-    "prepack": "bun run _build && cd ../../ && bun run build:docs"
+    "prepack": "bun run build:pkg && cd ../../ && bun run build:docs",
+    "sync-hardlinks": "bun run sync-dependencies-meta-injected"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/-ember-data/src/store.ts
+++ b/packages/-ember-data/src/store.ts
@@ -38,11 +38,11 @@ export default class Store extends BaseStore {
     this.registerSchema(buildSchema(this));
   }
 
-  override createCache(storeWrapper: CacheCapabilitiesManager): Cache {
+  createCache(storeWrapper: CacheCapabilitiesManager): Cache {
     return new JSONAPICache(storeWrapper);
   }
 
-  override instantiateRecord(
+  instantiateRecord(
     this: ModelStore,
     identifier: StableRecordIdentifier,
     createRecordArgs: Record<string, unknown>
@@ -50,13 +50,13 @@ export default class Store extends BaseStore {
     return instantiateRecord.call(this, identifier, createRecordArgs);
   }
 
-  override teardownRecord(record: Model): void {
+  teardownRecord(record: Model): void {
     teardownRecord.call(this, record);
   }
 
-  override modelFor<T>(type: TypeFromInstance<T>): ModelSchema<T>;
-  override modelFor(type: string): ModelSchema;
-  override modelFor(type: string): ModelSchema {
+  modelFor<T>(type: TypeFromInstance<T>): ModelSchema<T>;
+  modelFor(type: string): ModelSchema;
+  modelFor(type: string): ModelSchema {
     return (modelFor.call(this, type) as ModelSchema) || super.modelFor(type);
   }
 
@@ -66,7 +66,7 @@ export default class Store extends BaseStore {
   normalize = normalize;
   serializeRecord = serializeRecord;
 
-  override destroy() {
+  destroy() {
     cleanup.call(this);
     super.destroy();
   }

--- a/packages/adapter/src/json-api.ts
+++ b/packages/adapter/src/json-api.ts
@@ -162,7 +162,7 @@ import RESTAdapter from './rest';
   @extends RESTAdapter
 */
 class JSONAPIAdapter extends RESTAdapter {
-  override _defaultContentType = 'application/vnd.api+json';
+  _defaultContentType = 'application/vnd.api+json';
 
   /**
     @method ajaxOptions
@@ -172,7 +172,7 @@ class JSONAPIAdapter extends RESTAdapter {
     @param {Object} options
     @return {Object}
   */
-  override ajaxOptions(
+  ajaxOptions(
     url: string,
     type: HTTPMethod,
     options: JQueryAjaxSettings | RequestInit = {}
@@ -240,7 +240,7 @@ class JSONAPIAdapter extends RESTAdapter {
     @public
     @type {boolean}
   */
-  override get coalesceFindRequests() {
+  get coalesceFindRequests() {
     const coalesceFindRequests = this._coalesceFindRequests;
     if (typeof coalesceFindRequests === 'boolean') {
       return coalesceFindRequests;
@@ -248,21 +248,21 @@ class JSONAPIAdapter extends RESTAdapter {
     return (this._coalesceFindRequests = false);
   }
 
-  override set coalesceFindRequests(value: boolean) {
+  set coalesceFindRequests(value: boolean) {
     this._coalesceFindRequests = value;
   }
 
-  override findMany(store: Store, type: ModelSchema, ids: string[], snapshots: Snapshot[]): Promise<AdapterPayload> {
+  findMany(store: Store, type: ModelSchema, ids: string[], snapshots: Snapshot[]): Promise<AdapterPayload> {
     const url = this.buildURL(type.modelName, ids, snapshots, 'findMany');
     return this.ajax(url, 'GET', { data: { filter: { id: ids.join(',') } } });
   }
 
-  override pathForType(modelName: string): string {
+  pathForType(modelName: string): string {
     const dasherized = dasherize(modelName);
     return pluralize(dasherized);
   }
 
-  override updateRecord(store: Store, schema: ModelSchema, snapshot: Snapshot): Promise<AdapterPayload> {
+  updateRecord(store: Store, schema: ModelSchema, snapshot: Snapshot): Promise<AdapterPayload> {
     const data = serializeIntoHash(store, schema, snapshot);
     const type = snapshot.modelName;
     const id = snapshot.id;

--- a/packages/adapter/src/rest.ts
+++ b/packages/adapter/src/rest.ts
@@ -433,7 +433,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @public
     @type {boolean}
   */
-  override get coalesceFindRequests() {
+  get coalesceFindRequests() {
     const coalesceFindRequests = this._coalesceFindRequests;
     if (typeof coalesceFindRequests === 'boolean') {
       return coalesceFindRequests;
@@ -441,7 +441,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     return (this._coalesceFindRequests = false);
   }
 
-  override set coalesceFindRequests(value: boolean) {
+  set coalesceFindRequests(value: boolean) {
     this._coalesceFindRequests = value;
   }
 
@@ -526,7 +526,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @param {Snapshot} snapshot
     @return {Promise} promise
   */
-  override findRecord(store: Store, type: ModelSchema, id: string, snapshot: Snapshot): Promise<AdapterPayload> {
+  findRecord(store: Store, type: ModelSchema, id: string, snapshot: Snapshot): Promise<AdapterPayload> {
     const url = this.buildURL(type.modelName, id, snapshot, 'findRecord');
     const query: QueryState = this.buildQuery(snapshot);
 
@@ -548,7 +548,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @param {SnapshotRecordArray} snapshotRecordArray
     @return {Promise} promise
   */
-  override findAll(
+  findAll(
     store: Store,
     type: ModelSchema,
     sinceToken: null,
@@ -584,7 +584,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @param {Object} adapterOptions
     @return {Promise} promise
   */
-  override query(store: Store, type: ModelSchema, query: Record<string, unknown>): Promise<AdapterPayload> {
+  query(store: Store, type: ModelSchema, query: Record<string, unknown>): Promise<AdapterPayload> {
     const url = this.buildURL(type.modelName, null, null, 'query', query);
 
     if (this.sortQueryParams) {
@@ -614,7 +614,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @param {Object} adapterOptions
     @return {Promise} promise
   */
-  override queryRecord(
+  queryRecord(
     store: Store,
     type: ModelSchema,
     query: Record<string, unknown>,
@@ -789,7 +789,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @param {Snapshot} snapshot
     @return {Promise} promise
   */
-  override createRecord(store: Store, type: ModelSchema, snapshot: Snapshot): Promise<AdapterPayload> {
+  createRecord(store: Store, type: ModelSchema, snapshot: Snapshot): Promise<AdapterPayload> {
     const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
 
     const data = serializeIntoHash(store, type, snapshot);
@@ -814,7 +814,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @param {Snapshot} snapshot
     @return {Promise} promise
   */
-  override updateRecord(store: Store, schema: ModelSchema, snapshot: Snapshot): Promise<AdapterPayload> {
+  updateRecord(store: Store, schema: ModelSchema, snapshot: Snapshot): Promise<AdapterPayload> {
     const data = serializeIntoHash(store, schema, snapshot, {});
     const type = snapshot.modelName;
     const id = snapshot.id;
@@ -836,7 +836,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @param {Snapshot} snapshot
     @return {Promise} promise
   */
-  override deleteRecord(store: Store, schema: ModelSchema, snapshot: Snapshot): Promise<AdapterPayload> {
+  deleteRecord(store: Store, schema: ModelSchema, snapshot: Snapshot): Promise<AdapterPayload> {
     const type = snapshot.modelName;
     const id = snapshot.id;
     assert(`Attempted to delete the ${type} record, but the record has no id`, typeof id === 'string' && id.length > 0);
@@ -897,7 +897,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     @return {Array}  an array of arrays of records, each of which is to be
                       loaded separately by `findMany`.
   */
-  override groupRecordsForFindMany(store: Store, snapshots: Snapshot[]): Snapshot[][] {
+  groupRecordsForFindMany(store: Store, snapshots: Snapshot[]): Snapshot[][] {
     const groups: Map<string, Snapshot[]> = new Map();
     const maxURLLength = this.maxURLLength;
 

--- a/packages/debug/src/data-adapter.ts
+++ b/packages/debug/src/data-adapter.ts
@@ -35,6 +35,7 @@ import type Store from '@ember-data/store';
 import { recordIdentifierFor } from '@ember-data/store';
 import type { ModelSchema } from '@ember-data/store/types';
 import { assert } from '@warp-drive/build-config/macros';
+import { isSubClass } from '@ember-data/model/-private/type-utils';
 
 const StoreTypesMap = new WeakMap<Store, Map<string, boolean>>();
 
@@ -330,7 +331,7 @@ export default class extends DataAdapter<Model> {
     @param {Model} record to get values from
     @return {Object} Keys should match column names defined by the model type
   */
-  getRecordColumnValues(record: Model) {
+  getRecordColumnValues<T extends Model>(record: T) {
     let count = 0;
     const columnValues: Record<string, unknown> = { id: record.id };
 
@@ -338,7 +339,7 @@ export default class extends DataAdapter<Model> {
       if (count++ > this.attributeLimit) {
         return false;
       }
-      columnValues[key] = record[key];
+      columnValues[key] = record[key as keyof T];
     });
     return columnValues;
   }
@@ -351,13 +352,13 @@ export default class extends DataAdapter<Model> {
     @param {Model} record
     @return {Array} Relevant keywords for search based on the record's attribute values
   */
-  getRecordKeywords(record: Model): NativeArray<unknown> {
+  getRecordKeywords<T extends Model>(record: T): NativeArray<unknown> {
     const keywords: unknown[] = [record.id];
     const keys = ['id'];
 
     record.eachAttribute((key) => {
       keys.push(key);
-      keywords.push(record[key]);
+      keywords.push(record[key as keyof T]);
     });
 
     return A(keywords);

--- a/packages/debug/src/data-adapter.ts
+++ b/packages/debug/src/data-adapter.ts
@@ -35,7 +35,6 @@ import type Store from '@ember-data/store';
 import { recordIdentifierFor } from '@ember-data/store';
 import type { ModelSchema } from '@ember-data/store/types';
 import { assert } from '@warp-drive/build-config/macros';
-import { isSubClass } from '@ember-data/model/-private/type-utils';
 
 const StoreTypesMap = new WeakMap<Store, Map<string, boolean>>();
 

--- a/packages/debug/src/data-adapter.ts
+++ b/packages/debug/src/data-adapter.ts
@@ -161,7 +161,7 @@ export default class extends DataAdapter<Model> {
     @return {Array} List of objects defining filters
      The object should have a `name` and `desc` property
   */
-  override getFilters() {
+  getFilters() {
     return [
       { name: 'isNew', desc: 'New' },
       { name: 'isModified', desc: 'Modified' },
@@ -169,7 +169,7 @@ export default class extends DataAdapter<Model> {
     ];
   }
 
-  override _nameToClass(type: string) {
+  _nameToClass(type: string) {
     return this.store.modelFor(type);
   }
 
@@ -185,7 +185,7 @@ export default class extends DataAdapter<Model> {
     Takes an array of objects containing wrapped types.
     @return {Function} Method to call to remove all observers
   */
-  override watchModelTypes(typesAdded: WrappedTypeCallback, typesUpdated: WrappedTypeCallback) {
+  watchModelTypes(typesAdded: WrappedTypeCallback, typesUpdated: WrappedTypeCallback) {
     const { store } = this;
 
     const discoveredTypes = typesMapFor(store);
@@ -277,7 +277,7 @@ export default class extends DataAdapter<Model> {
      name: {String} The name of the column
      desc: {String} Humanized description (what would show in a table column name)
   */
-  override columnsForType(typeClass: ModelSchema) {
+  columnsForType(typeClass: ModelSchema) {
     const columns = [
       {
         name: 'id',
@@ -306,7 +306,7 @@ export default class extends DataAdapter<Model> {
      This array will be observed for changes,
      so it should update when new records are added/removed
   */
-  override getRecords(modelClass: ModelSchema, modelName: string) {
+  getRecords(modelClass: ModelSchema, modelName: string) {
     if (arguments.length < 2) {
       // Legacy Ember.js < 1.13 support
       const containerKey = (modelClass as unknown as { _debugContainerKey?: string })._debugContainerKey;
@@ -330,7 +330,7 @@ export default class extends DataAdapter<Model> {
     @param {Model} record to get values from
     @return {Object} Keys should match column names defined by the model type
   */
-  override getRecordColumnValues(record: Model) {
+  getRecordColumnValues(record: Model) {
     let count = 0;
     const columnValues: Record<string, unknown> = { id: record.id };
 
@@ -351,7 +351,7 @@ export default class extends DataAdapter<Model> {
     @param {Model} record
     @return {Array} Relevant keywords for search based on the record's attribute values
   */
-  override getRecordKeywords(record: Model): NativeArray<unknown> {
+  getRecordKeywords(record: Model): NativeArray<unknown> {
     const keywords: unknown[] = [record.id];
     const keys = ['id'];
 
@@ -372,7 +372,7 @@ export default class extends DataAdapter<Model> {
     @param {Model} record
     @return {Object} The record state filter values
   */
-  override getRecordFilterValues(record: Model) {
+  getRecordFilterValues(record: Model) {
     return {
       isNew: record.isNew,
       isModified: record.hasDirtyAttributes && !record.isNew,
@@ -389,7 +389,7 @@ export default class extends DataAdapter<Model> {
     @param {Model} record
     @return {String} The record color
   */
-  override getRecordColor(record: Model) {
+  getRecordColor(record: Model) {
     let color = 'black';
     if (record.isNew) {
       color = 'green';

--- a/packages/model/src/-private/errors.ts
+++ b/packages/model/src/-private/errors.ts
@@ -176,7 +176,7 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
     @private
   */
   @computed()
-  override get content(): NativeArray<ValidationError> {
+  get content(): NativeArray<ValidationError> {
     return A();
   }
 
@@ -374,7 +374,7 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
    @method clear
    @public
    */
-  override clear(): void {
+  clear(): void {
     if (this.isEmpty) {
       return;
     }

--- a/packages/model/src/-private/many-array.ts
+++ b/packages/model/src/-private/many-array.ts
@@ -452,7 +452,7 @@ export class RelatedCollection<T = unknown> extends LiveArray<T> {
     return record;
   }
 
-  override destroy() {
+  destroy() {
     super.destroy(false);
   }
 }

--- a/packages/model/src/-private/model-methods.ts
+++ b/packages/model/src/-private/model-methods.ts
@@ -14,6 +14,7 @@ import { lookupLegacySupport } from './legacy-relationships-support';
 import type RecordState from './record-state';
 import type BelongsToReference from './references/belongs-to';
 import type HasManyReference from './references/has-many';
+import type { MaybeBelongsToFields, MaybeHasManyFields } from './type-utils';
 
 export interface MinimalLegacyRecord {
   errors: Errors;
@@ -52,14 +53,14 @@ export function unloadRecord<T extends MinimalLegacyRecord>(this: T) {
   this[RecordStore].unloadRecord(this);
 }
 
-export function belongsTo<T extends MinimalLegacyRecord, K extends keyof T & string>(
+export function belongsTo<T extends MinimalLegacyRecord, K extends MaybeBelongsToFields<T>>(
   this: T,
   prop: K
 ): BelongsToReference<T, K> {
   return lookupLegacySupport(this).referenceFor('belongsTo', prop) as BelongsToReference<T, K>;
 }
 
-export function hasMany<T extends MinimalLegacyRecord, K extends keyof T & string>(
+export function hasMany<T extends MinimalLegacyRecord, K extends MaybeHasManyFields<T>>(
   this: T,
   prop: K
 ): HasManyReference<T, K> {

--- a/packages/model/src/-private/model-methods.ts
+++ b/packages/model/src/-private/model-methods.ts
@@ -27,8 +27,8 @@ export interface MinimalLegacyRecord {
 
   deleteRecord(): void;
   unloadRecord(): void;
-  save<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): Promise<T>;
-  destroyRecord<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): Promise<T>;
+  save<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): Promise<this>;
+  destroyRecord<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): Promise<this>;
 }
 
 export function rollbackAttributes<T extends MinimalLegacyRecord>(this: T) {

--- a/packages/model/src/-private/model.ts
+++ b/packages/model/src/-private/model.ts
@@ -133,7 +133,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
   declare ___private_notifications: object;
   declare [RecordStore]: Store;
 
-  override init(options: ModelCreateArgs) {
+  init(options: ModelCreateArgs) {
     if (DEBUG) {
       if (!options?._secretInit && !options?._createProps) {
         throw new Error(
@@ -170,7 +170,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
   }
 
   // @ts-expect-error destroy should not return a value, but ember's types force it to
-  override destroy(): this {
+  destroy(): this {
     const identifier = recordIdentifierFor(this);
     this.___recordState?.destroy();
     const store = storeFor(this)!;
@@ -523,7 +523,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     }
   }
 
-  override toString() {
+  toString() {
     return `<model::${(this.constructor as unknown as { modelName: string }).modelName}:${this.id}>`;
   }
 
@@ -657,7 +657,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     super in 4.0+ where sync observers are removed.
    */
   // @ts-expect-error no return is necessary, but Ember's types are forcing it
-  override notifyPropertyChange(prop: string): this {
+  notifyPropertyChange(prop: string): this {
     notifySignal(this, prop as keyof this & string);
     super.notifyPropertyChange(prop);
   }
@@ -1924,7 +1924,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @public
    @static
    */
-  static override toString() {
+  static toString() {
     assert(
       `Accessing schema information on Models without looking up the model via the store is disallowed.`,
       this.modelName

--- a/packages/model/src/-private/model.ts
+++ b/packages/model/src/-private/model.ts
@@ -38,7 +38,13 @@ import notifyChanges from './notify-changes';
 import RecordState, { notifySignal, tagged } from './record-state';
 import type BelongsToReference from './references/belongs-to';
 import type HasManyReference from './references/has-many';
-import type { MaybeAttrFields, MaybeBelongsToFields, MaybeHasManyFields, MaybeRelationshipFields } from './type-utils';
+import type {
+  isSubClass,
+  MaybeAttrFields,
+  MaybeBelongsToFields,
+  MaybeHasManyFields,
+  MaybeRelationshipFields,
+} from './type-utils';
 
 export type ModelCreateArgs = {
   _createProps: Record<string, unknown>;
@@ -1067,7 +1073,11 @@ class Model extends EmberObject implements MinimalLegacyRecord {
   }
 
   eachAttribute<T>(
-    callback: (this: NoInfer<T> | undefined, key: MaybeAttrFields<this>, meta: LegacyAttributeField) => void,
+    callback: (
+      this: NoInfer<T> | undefined,
+      key: isSubClass<this> extends true ? MaybeAttrFields<this> : string,
+      meta: LegacyAttributeField
+    ) => void,
     binding?: T
   ): void {
     (this.constructor as typeof Model).eachAttribute<T, this>(callback, binding);

--- a/packages/model/src/-private/model.ts
+++ b/packages/model/src/-private/model.ts
@@ -39,6 +39,7 @@ import RecordState, { notifySignal, tagged } from './record-state';
 import type BelongsToReference from './references/belongs-to';
 import type HasManyReference from './references/has-many';
 import type {
+  _MaybeBelongsToFields,
   isSubClass,
   MaybeAttrFields,
   MaybeBelongsToFields,
@@ -121,14 +122,11 @@ interface Model {
   save<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): Promise<this>;
   reload<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): Promise<T>;
 
-  belongsTo<T extends MinimalLegacyRecord, K extends MaybeBelongsToFields<T>>(
-    this: T,
-    prop: K
-  ): BelongsToReference<T, K>;
-  // belongsTo<T extends MinimalLegacyRecord, K extends keyof T & string>(
+  // belongsTo<T extends MinimalLegacyRecord, K extends MaybeBelongsToFields<T>>(
   //   this: T,
-  //   prop: K extends MaybeBelongsToFields<T> ? K : string
+  //   prop: K
   // ): BelongsToReference<T, K>;
+  belongsTo<K extends _MaybeBelongsToFields<this>>(prop: K): BelongsToReference<this, K>;
   hasMany<T extends MinimalLegacyRecord, K extends MaybeHasManyFields<T>>(this: T, prop: K): HasManyReference<T, K>;
   deleteRecord<T extends MinimalLegacyRecord>(this: T): void;
 }

--- a/packages/model/src/-private/model.ts
+++ b/packages/model/src/-private/model.ts
@@ -42,7 +42,6 @@ import type {
   _MaybeBelongsToFields,
   isSubClass,
   MaybeAttrFields,
-  MaybeBelongsToFields,
   MaybeHasManyFields,
   MaybeRelationshipFields,
 } from './type-utils';

--- a/packages/model/src/-private/model.ts
+++ b/packages/model/src/-private/model.ts
@@ -126,7 +126,10 @@ interface Model {
   //   this: T,
   //   prop: K
   // ): BelongsToReference<T, K>;
-  belongsTo<K extends _MaybeBelongsToFields<this>>(prop: K): BelongsToReference<this, K>;
+  belongsTo<T extends Model, K extends keyof T & string>(
+    this: T,
+    prop: K & (K extends _MaybeBelongsToFields<T> ? K : never)
+  ): BelongsToReference<T, K>;
   hasMany<T extends MinimalLegacyRecord, K extends MaybeHasManyFields<T>>(this: T, prop: K): HasManyReference<T, K>;
   deleteRecord<T extends MinimalLegacyRecord>(this: T): void;
 }

--- a/packages/model/src/-private/model.type-test.ts
+++ b/packages/model/src/-private/model.type-test.ts
@@ -13,6 +13,7 @@ import type { PromiseBelongsTo } from './promise-belongs-to';
 import type { PromiseManyArray } from './promise-many-array';
 import type BelongsToReference from './references/belongs-to';
 import type HasManyReference from './references/has-many';
+import type { isSubClass, MaybeAttrFields } from './type-utils';
 
 // ------------------------------
 //              💚
@@ -22,14 +23,20 @@ import type HasManyReference from './references/has-many';
 //              🐹
 // ⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇
 
+expectTypeOf<MaybeAttrFields<Model>>().toEqualTypeOf<never>();
+expectTypeOf<isSubClass<Model>>().toEqualTypeOf<false>();
+
 class UnbrandedUser extends Model {
   @attr('string') declare name: string | null;
   @hasMany('user', { async: false, inverse: null }) declare enemies: ManyArray<UnbrandedUser>;
-  @belongsTo('user', { async: false, inverse: null }) declare bestFriend: UnbrandedUser;
+  @belongsTo('user', { async: false, inverse: null }) declare bestFriend: UnbrandedUser | null;
   @hasMany('user', { async: true, inverse: 'friends' }) declare friends: PromiseManyArray<UnbrandedUser>;
   @belongsTo('user', { async: true, inverse: 'twin' }) declare twin: PromiseBelongsTo<UnbrandedUser>;
 }
 const user = new UnbrandedUser();
+
+expectTypeOf<MaybeAttrFields<UnbrandedUser>>().toEqualTypeOf<'name' | 'bestFriend'>();
+expectTypeOf<isSubClass<UnbrandedUser>>().toEqualTypeOf<true>();
 
 type DoesExtend = UnbrandedUser extends Model ? true : false;
 function takeModel<T extends Model>(model: T): T {
@@ -45,7 +52,7 @@ expectTypeOf<ManyArray<UnbrandedUser>>().toMatchTypeOf<UnbrandedUser[]>();
 
 expectTypeOf(user.name).toEqualTypeOf<string | null>();
 expectTypeOf(user.enemies).toEqualTypeOf<ManyArray<UnbrandedUser>>();
-expectTypeOf(user.bestFriend).toEqualTypeOf<UnbrandedUser>();
+expectTypeOf(user.bestFriend).toEqualTypeOf<UnbrandedUser | null>();
 expectTypeOf<Awaited<typeof user.friends>>().toEqualTypeOf<ManyArray<UnbrandedUser>>();
 expectTypeOf<Awaited<typeof user.twin>>().toEqualTypeOf<UnbrandedUser | null>();
 
@@ -59,6 +66,9 @@ class BrandedUser extends Model {
   [ResourceType] = 'user' as const;
 }
 const branded = new BrandedUser();
+
+expectTypeOf<MaybeAttrFields<BrandedUser>>().toEqualTypeOf<'name'>();
+expectTypeOf<isSubClass<BrandedUser>>().toEqualTypeOf<true>();
 
 expectTypeOf<Awaited<PromiseManyArray<BrandedUser>>['modelName']>().toEqualTypeOf<'user'>();
 expectTypeOf<ManyArray<BrandedUser>['modelName']>().toEqualTypeOf<'user'>();

--- a/packages/model/src/-private/model.type-test.ts
+++ b/packages/model/src/-private/model.type-test.ts
@@ -13,7 +13,7 @@ import type { PromiseBelongsTo } from './promise-belongs-to';
 import type { PromiseManyArray } from './promise-many-array';
 import type BelongsToReference from './references/belongs-to';
 import type HasManyReference from './references/has-many';
-import type { _MaybeBelongsToFields, isSubClass, MaybeAttrFields, MaybeBelongsToFields } from './type-utils';
+import type { isSubClass, MaybeAttrFields, MaybeBelongsToFields } from './type-utils';
 
 // ------------------------------
 //              💚

--- a/packages/model/src/-private/model.type-test.ts
+++ b/packages/model/src/-private/model.type-test.ts
@@ -1,5 +1,4 @@
 import { expectTypeOf } from 'expect-type';
-import { has } from 'require';
 
 import Store from '@ember-data/store';
 import type { LegacyAttributeField, LegacyRelationshipSchema } from '@warp-drive/core-types/schema/fields';
@@ -14,7 +13,7 @@ import type { PromiseBelongsTo } from './promise-belongs-to';
 import type { PromiseManyArray } from './promise-many-array';
 import type BelongsToReference from './references/belongs-to';
 import type HasManyReference from './references/has-many';
-import type { isSubClass, MaybeAttrFields, MaybeBelongsToFields } from './type-utils';
+import type { _MaybeBelongsToFields, isSubClass, MaybeAttrFields, MaybeBelongsToFields } from './type-utils';
 
 // ------------------------------
 //              💚
@@ -290,8 +289,7 @@ class HasGetter extends Model {
   @belongsTo('user', { async: false, inverse: null }) declare bestFriend: BrandedUser | null;
 
   get bestFriendId(): string | null {
-    // @ts-expect-error apparently TS can't infer keys on this types when exclude is used
-    return this.belongsTo('bestFriend').id();
+    return this.belongsTo<HasGetter, 'bestFriend'>('bestFriend').id();
   }
 }
 const hasGetter = new HasGetter();

--- a/packages/model/src/-private/model.type-test.ts
+++ b/packages/model/src/-private/model.type-test.ts
@@ -1,4 +1,5 @@
 import { expectTypeOf } from 'expect-type';
+import { has } from 'require';
 
 import Store from '@ember-data/store';
 import type { LegacyAttributeField, LegacyRelationshipSchema } from '@warp-drive/core-types/schema/fields';
@@ -13,7 +14,7 @@ import type { PromiseBelongsTo } from './promise-belongs-to';
 import type { PromiseManyArray } from './promise-many-array';
 import type BelongsToReference from './references/belongs-to';
 import type HasManyReference from './references/has-many';
-import type { isSubClass, MaybeAttrFields } from './type-utils';
+import type { isSubClass, MaybeAttrFields, MaybeBelongsToFields } from './type-utils';
 
 // ------------------------------
 //              💚
@@ -284,3 +285,15 @@ store.createRecord<BrandedUser>('user', {
   // @ts-expect-error is an EmberObject field
   isDestroyed: true,
 });
+
+class HasGetter extends Model {
+  @belongsTo('user', { async: false, inverse: null }) declare bestFriend: BrandedUser | null;
+
+  get bestFriendId(): string | null {
+    // @ts-expect-error apparently TS can't infer keys on this types when exclude is used
+    return this.belongsTo('bestFriend').id();
+  }
+}
+const hasGetter = new HasGetter();
+expectTypeOf<MaybeBelongsToFields<typeof hasGetter>>().toEqualTypeOf<'bestFriend'>();
+expectTypeOf(hasGetter.belongsTo('bestFriend').id()).toEqualTypeOf<string | null>();

--- a/packages/model/src/-private/references/belongs-to.ts
+++ b/packages/model/src/-private/references/belongs-to.ts
@@ -19,6 +19,7 @@ import type { IsUnknown } from '../belongs-to';
 import { assertPolymorphicType } from '../debug/assert-polymorphic-type';
 import type { LegacySupport } from '../legacy-relationships-support';
 import { areAllInverseRecordsLoaded, LEGACY_SUPPORT } from '../legacy-relationships-support';
+import type { MaybeBelongsToFields } from '../type-utils';
 import { isMaybeResource } from './has-many';
 
 /**
@@ -68,8 +69,8 @@ function isResourceIdentiferWithRelatedLinks(
  */
 export default class BelongsToReference<
   T = unknown,
-  K extends string = IsUnknown<T> extends true ? string : keyof T & string,
-  Related = K extends keyof T ? Awaited<T[K]> : unknown,
+  K extends string = IsUnknown<T> extends true ? string : MaybeBelongsToFields<T>,
+  Related = K extends keyof T ? Exclude<Awaited<T[K]>, null> : unknown,
 > {
   declare graph: Graph;
   declare store: Store;

--- a/packages/model/src/-private/references/has-many.ts
+++ b/packages/model/src/-private/references/has-many.ts
@@ -23,6 +23,7 @@ import { assertPolymorphicType } from '../debug/assert-polymorphic-type';
 import type { LegacySupport } from '../legacy-relationships-support';
 import { areAllInverseRecordsLoaded, LEGACY_SUPPORT } from '../legacy-relationships-support';
 import type { RelatedCollection as ManyArray } from '../many-array';
+import type { MaybeHasManyFields } from '../type-utils';
 
 /**
   @module @ember-data/model
@@ -71,7 +72,7 @@ function isResourceIdentiferWithRelatedLinks(
  */
 export default class HasManyReference<
   T = unknown,
-  K extends string = IsUnknown<T> extends true ? string : keyof T & string,
+  K extends string = IsUnknown<T> extends true ? string : MaybeHasManyFields<T>,
   Related = K extends keyof T ? ArrayItemType<Awaited<T[K]>> : unknown,
 > {
   declare graph: Graph;

--- a/packages/model/src/-private/type-utils.ts
+++ b/packages/model/src/-private/type-utils.ts
@@ -64,5 +64,7 @@ type _TrueKeys<ThisType> = Exclude<keyof ThisType & string, (keyof Model & strin
 /**
  * Get the keys of all fields defined on the given subclass of Model
  * that don't exist on EmberObject or Model.
+ *
+ * @typedoc
  */
 export type SubclassKeys<ThisType> = _TrueKeys<ThisType> extends never ? string : _TrueKeys<ThisType>;

--- a/packages/model/src/-private/type-utils.ts
+++ b/packages/model/src/-private/type-utils.ts
@@ -19,7 +19,7 @@ type GetMappedKey<M, V> = { [K in keyof M]-?: ExcludeNull<M[K]> extends V ? K : 
  */
 export type MaybeBelongsToFields<ThisType> =
   _TrueKeys<ThisType> extends never ? string : _MaybeBelongsToFields<ThisType>;
-type _MaybeBelongsToFields<ThisType> = GetMappedKey<ThisType, PromiseBelongsTo | TypedRecordInstance>;
+export type _MaybeBelongsToFields<ThisType> = GetMappedKey<ThisType, PromiseBelongsTo | TypedRecordInstance>;
 
 /**
  * Get the keys of fields that are maybe defined as `hasMany` relationships

--- a/packages/model/src/-private/type-utils.ts
+++ b/packages/model/src/-private/type-utils.ts
@@ -43,10 +43,10 @@ type _MaybeHasManyFields<ThisType> = GetMappedKey<ThisType, RelatedCollection | 
  *
  * @typedoc
  */
-export type MaybeAttrFields<ThisType> =
-  _TrueKeys<ThisType> extends never
-    ? string
-    : Exclude<_TrueKeys<ThisType>, _MaybeBelongsToFields<ThisType> | _MaybeHasManyFields<ThisType>>;
+export type MaybeAttrFields<ThisType> = Exclude<
+  _TrueKeys<ThisType>,
+  _MaybeBelongsToFields<ThisType> | _MaybeHasManyFields<ThisType>
+>;
 
 /**
  * Get the keys of fields that are maybe defined as relationships
@@ -60,7 +60,7 @@ export type MaybeRelationshipFields<ThisType> =
   _TrueKeys<ThisType> extends never ? string : _MaybeBelongsToFields<ThisType> | _MaybeHasManyFields<ThisType>;
 
 type _TrueKeys<ThisType> = Exclude<keyof ThisType & string, (keyof Model & string) | typeof ResourceType>;
-
+export type isSubClass<ThisType> = _TrueKeys<ThisType> extends never ? false : true;
 /**
  * Get the keys of all fields defined on the given subclass of Model
  * that don't exist on EmberObject or Model.

--- a/packages/model/src/-private/type-utils.ts
+++ b/packages/model/src/-private/type-utils.ts
@@ -1,0 +1,67 @@
+import type { TypedRecordInstance } from '@warp-drive/core-types/record';
+import type { ResourceType } from '@warp-drive/core-types/symbols';
+
+import type { RelatedCollection } from './many-array';
+import type { Model } from './model';
+import type { PromiseBelongsTo } from './promise-belongs-to';
+import type { PromiseManyArray } from './promise-many-array';
+
+type GetMappedKey<M, V> = { [K in keyof M]-?: M[K] extends V ? K : never }[keyof M] & string;
+
+/**
+ * Get the keys of fields that are maybe defined as `belongsTo` relationships
+ *
+ * "Maybe" because getter/computed fields might be returning values that look
+ * like relationships, but are not.
+ *
+ * @typedoc
+ */
+export type MaybeBelongsToFields<ThisType extends Model> = GetMappedKey<
+  ThisType,
+  PromiseBelongsTo | TypedRecordInstance
+>;
+
+/**
+ * Get the keys of fields that are maybe defined as `hasMany` relationships
+ *
+ * "Maybe" because getter/computed fields might be returning values that look
+ * like relationships, but are not.
+ *
+ * @typedoc
+ */
+export type MaybeHasManyFields<ThisType extends Model> = GetMappedKey<ThisType, RelatedCollection | PromiseManyArray>;
+
+/**
+ * Get the keys of fields that are maybe defined as `attr` fields
+ *
+ * "Maybe" because getter/computed fields might be returning values that look
+ * like attributes, but are not.
+ *
+ * This is computed by excluding the keys that are defined as `belongsTo` or `hasMany`
+ * as well as the keys on EmberObject and the Model base class
+ *
+ * @typedoc
+ */
+export type MaybeAttrFields<ThisType extends Model> =
+  _TrueKeys<ThisType> extends never
+    ? string
+    : Exclude<_TrueKeys<ThisType>, MaybeBelongsToFields<ThisType> | MaybeHasManyFields<ThisType>>;
+
+/**
+ * Get the keys of fields that are maybe defined as relationships
+ *
+ * "Maybe" because getter/computed fields might be returning values that look
+ * like relationships, but are not.
+ *
+ * @typedoc
+ */
+export type MaybeRelationshipFields<ThisType extends Model> =
+  _TrueKeys<ThisType> extends never ? string : MaybeBelongsToFields<ThisType> | MaybeHasManyFields<ThisType>;
+
+type _TrueKeys<ThisType extends Model> = Exclude<keyof ThisType & string, (keyof Model & string) | typeof ResourceType>;
+
+/**
+ * Get the keys of all fields defined on the given subclass of Model
+ * that don't exist on EmberObject or Model.
+ */
+export type SubclassKeys<ThisType extends Model> = _TrueKeys<ThisType> extends never ? string : _TrueKeys<ThisType>;

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -103,7 +103,6 @@ type DSModelKeys =
   | 'errors'
   | 'hasDirtyAttributes'
   | 'hasMany'
-  | 'id'
   | 'inverseFor'
   | 'isDeleted'
   | 'isEmpty'

--- a/packages/store/src/-private/store-service.type-test.ts
+++ b/packages/store/src/-private/store-service.type-test.ts
@@ -1,5 +1,3 @@
-import EmberObject from '@ember/object';
-
 import { expectTypeOf } from 'expect-type';
 
 import { ResourceType } from '@warp-drive/core-types/symbols';
@@ -380,10 +378,20 @@ import { Store } from './store-service';
 //////////////////////////////////
 //////////////////////////////////
 {
-  class MockModel extends EmberObject {
+  class MockModel {
     [ResourceType] = 'user' as const;
     asyncProp = Promise.resolve('async');
     syncProp = 'sync';
+
+    // some fake Model properties
+
+    // some fake EmberObject properties
+    reopen(): void {}
+    destroy(): void {}
+    init(): void {}
+    isDestroyed = false;
+    isDestroying = false;
+    willDestroy(): void {}
   }
 
   const mock = new MockModel();
@@ -391,9 +399,22 @@ import { Store } from './store-service';
   expectTypeOf(mock.asyncProp).toEqualTypeOf<Promise<string>>();
   expectTypeOf(mock.syncProp).toEqualTypeOf<string>();
 
-  const result: CreateRecordProperties<typeof mock> = {};
+  const result: CreateRecordProperties<MockModel> = {};
 
   // Only `asyncProp` and `syncProp` should be present in the type, they should be optional and
   // any Promise types should be awaited.
-  expectTypeOf(result).toEqualTypeOf<{ asyncProp?: string; syncProp?: string }>();
+  expectTypeOf(result).toEqualTypeOf<{
+    asyncProp?: string;
+    syncProp?: string;
+  }>();
+
+  const fullResult: Required<CreateRecordProperties<MockModel>> = {
+    asyncProp: 'async',
+    syncProp: 'sync',
+  };
+
+  expectTypeOf(fullResult).toEqualTypeOf<{
+    asyncProp: string;
+    syncProp: string;
+  }>();
 }

--- a/tests/fastboot/app/models/person.ts
+++ b/tests/fastboot/app/models/person.ts
@@ -12,7 +12,8 @@ export default class Person extends Model {
   @belongsTo('person', { async: true, inverse: 'children' })
   declare parent: AsyncBelongsTo<Person>;
 
-  get parentId() {
+  get parentId(): string | null {
+    // @ts-expect-error apparently TS can't infer that `this` is a Person :/
     return this.belongsTo('parent').id();
   }
 

--- a/tests/fastboot/app/models/person.ts
+++ b/tests/fastboot/app/models/person.ts
@@ -13,8 +13,7 @@ export default class Person extends Model {
   declare parent: AsyncBelongsTo<Person>;
 
   get parentId(): string | null {
-    // @ts-expect-error apparently TS can't infer that `this` is a Person :/
-    return this.belongsTo('parent').id();
+    return this.belongsTo<Person, 'parent'>('parent').id();
   }
 
   toNode() {

--- a/tests/main/tests/integration/cache-handler/lifetimes-test.ts
+++ b/tests/main/tests/integration/cache-handler/lifetimes-test.ts
@@ -210,7 +210,7 @@ module('Store | CacheHandler + Lifetimes', function (hooks) {
 
   test('@ember-data/request-utils CachePolicy handles createRecord requests', async function (assert) {
     class InterceptLifetimes extends CachePolicy {
-      override didRequest(
+      didRequest(
         request: ImmutableRequestInfo,
         response: Response | ResponseInfo | null,
         identifier: StableDocumentIdentifier | null,
@@ -219,18 +219,14 @@ module('Store | CacheHandler + Lifetimes', function (hooks) {
         assert.step('didRequest');
         super.didRequest(request, response, identifier, store);
       }
-      override isHardExpired(identifier: StableDocumentIdentifier, store: Store): boolean {
+      isHardExpired(identifier: StableDocumentIdentifier, store: Store): boolean {
         const result = super.isHardExpired(identifier, store);
         assert.step(`isHardExpired: ${result}`);
         return result;
       }
-      override isSoftExpired(identifier: StableDocumentIdentifier, store: Store): boolean {
+      isSoftExpired(identifier: StableDocumentIdentifier, store: Store): boolean {
         const result = super.isSoftExpired(identifier, store);
         assert.step(`isSoftExpired: ${result}`);
-        if (result) {
-          // debugger;
-          super.isSoftExpired(identifier, store);
-        }
         return result;
       }
     }

--- a/tests/main/tests/integration/identifiers/lid-reflection-test.ts
+++ b/tests/main/tests/integration/identifiers/lid-reflection-test.ts
@@ -6,6 +6,7 @@ import { setupTest } from 'ember-qunit';
 
 import Adapter from '@ember-data/adapter';
 import type { Snapshot } from '@ember-data/legacy-compat/-private';
+import type { ManyArray } from '@ember-data/model';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { createDeferred } from '@ember-data/request';
 import type Store from '@ember-data/store';
@@ -151,11 +152,15 @@ module('Integration | Identifiers - lid reflection', function (hooks: NestedHook
     class Ingredient extends Model {
       @attr name;
       @belongsTo('cake', { async: true, inverse: null }) cake;
+
+      [ResourceType] = 'ingredient' as const;
     }
 
     class Cake extends Model {
       @attr name;
-      @hasMany('ingredient', { inverse: null, async: false }) declare ingredients: Ingredient[];
+      @hasMany('ingredient', { inverse: null, async: false }) declare ingredients: ManyArray<Ingredient>;
+
+      [ResourceType] = 'cake' as const;
     }
 
     this.owner.register('model:ingredient', Ingredient);
@@ -218,8 +223,8 @@ module('Integration | Identifiers - lid reflection', function (hooks: NestedHook
     this.owner.register('adapter:application', TestAdapter);
 
     const store = this.owner.lookup('service:store') as Store;
-    const cheese = store.createRecord('ingredient', { name: 'Cheese' }) as Ingredient;
-    const cake = store.createRecord('cake', { name: 'Cheesecake', ingredients: [cheese] }) as Cake;
+    const cheese = store.createRecord<Ingredient>('ingredient', { name: 'Cheese' });
+    const cake = store.createRecord<Cake>('cake', { name: 'Cheesecake', ingredients: [cheese] });
 
     // Consume ids before save() to check for update errors
     assert.strictEqual(cake.id, null, 'cake id is initially null');
@@ -237,11 +242,15 @@ module('Integration | Identifiers - lid reflection', function (hooks: NestedHook
   test('belongsTo() has correct state after .save() on a newly created record with sideposted child record when lid is provided in the response payload', async function (assert: Assert) {
     class Topping extends Model {
       @attr name;
+
+      [ResourceType] = 'topping' as const;
     }
 
     class Cake extends Model {
       @attr name;
       @belongsTo('topping', { inverse: null, async: false }) declare topping: Topping;
+
+      [ResourceType] = 'cake' as const;
     }
 
     this.owner.register('model:topping', Topping);
@@ -299,8 +308,8 @@ module('Integration | Identifiers - lid reflection', function (hooks: NestedHook
     this.owner.register('adapter:application', TestAdapter);
 
     const store = this.owner.lookup('service:store') as Store;
-    const cheese = store.createRecord('topping', { name: 'Cheese' }) as Topping;
-    const cake = store.createRecord('cake', { name: 'Cheesecake', topping: cheese }) as Cake;
+    const cheese = store.createRecord<Topping>('topping', { name: 'Cheese' });
+    const cake = store.createRecord<Cake>('cake', { name: 'Cheesecake', topping: cheese });
 
     await cake.save();
 

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-test.ts
@@ -4,6 +4,7 @@ import { module, test } from 'qunit';
 
 import { setupRenderingTest } from 'ember-qunit';
 
+import type { ManyArray } from '@ember-data/model';
 import Model, { attr, hasMany } from '@ember-data/model';
 import type Store from '@ember-data/store';
 import { recordIdentifierFor } from '@ember-data/store';
@@ -22,7 +23,7 @@ if (DEPRECATE_MANY_ARRAY_DUPLICATES) {
 
 class User extends Model {
   @attr declare name: string;
-  @hasMany('user', { async: false, inverse: 'friends' }) declare friends: User[];
+  @hasMany('user', { async: false, inverse: 'friends' }) declare friends: ManyArray<User>;
 
   [ResourceType] = 'user' as const;
 }

--- a/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -75,10 +75,10 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
       super(args);
       this.registerSchema(new TestSchema());
     }
-    override instantiateRecord(identifier, createOptions) {
+    instantiateRecord(identifier, createOptions) {
       return new Person(this);
     }
-    override teardownRecord(record) {}
+    teardownRecord(record) {}
   }
   setupTest(hooks);
 
@@ -102,7 +102,7 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
     let notificationCount = 0;
     let identifier: StableRecordIdentifier;
     class CreationStore extends CustomStore {
-      override instantiateRecord(id: StableRecordIdentifier, createRecordArgs): object {
+      instantiateRecord(id: StableRecordIdentifier, createRecordArgs): object {
         identifier = id;
         this.notifications.subscribe(identifier, (passedId, key) => {
           notificationCount++;
@@ -137,13 +137,13 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
     assert.expect(5);
     let returnValue: unknown;
     class CreationStore extends CustomStore {
-      override instantiateRecord(identifier: StableRecordIdentifier, createRecordArgs) {
+      instantiateRecord(identifier: StableRecordIdentifier, createRecordArgs) {
         assert.strictEqual(identifier.type, 'person', 'Identifier type passed in correctly');
         assert.deepEqual(createRecordArgs, { name: 'chris', otherProp: 'unk' }, 'createRecordArg passed in');
         returnValue = {};
         return returnValue;
       }
-      override teardownRecord(record) {
+      teardownRecord(record) {
         assert.strictEqual(record, person, 'Passed in person to teardown');
       }
     }
@@ -232,10 +232,10 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
     );
     // eslint-disable-next-line @typescript-eslint/no-shadow
     class CustomStore extends Store {
-      override instantiateRecord(identifier, createOptions) {
+      instantiateRecord(identifier, createOptions) {
         return new Person(this);
       }
-      override teardownRecord(record) {}
+      teardownRecord(record) {}
     }
     this.owner.register('service:store', CustomStore);
     const store = this.owner.lookup('service:store') as Store;
@@ -380,7 +380,7 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
     );
     const subscribedValues: string[] = [];
     class CreationStore extends CustomStore {
-      override instantiateRecord(identifier: StableRecordIdentifier, createRecordArgs) {
+      instantiateRecord(identifier: StableRecordIdentifier, createRecordArgs) {
         ident = identifier;
         assert.false(this.cache.isDeleted(identifier), 'we are not deleted when we start');
         this.notifications.subscribe(identifier, (passedId, key: string) => {
@@ -389,7 +389,7 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
         });
         return {};
       }
-      override teardownRecord(record) {
+      teardownRecord(record) {
         assert.strictEqual(record, person, 'Passed in person to teardown');
       }
     }
@@ -419,10 +419,10 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
     );
     // eslint-disable-next-line @typescript-eslint/no-shadow
     class CustomStore extends Store {
-      override instantiateRecord(identifier, createOptions) {
+      instantiateRecord(identifier, createOptions) {
         return new Person(this);
       }
-      override teardownRecord(record) {}
+      teardownRecord(record) {}
     }
     this.owner.register('service:store', CustomStore);
     const store = this.owner.lookup('service:store') as Store;


### PR DESCRIPTION
- disentangles EmberObject type from @ember-data/store
- fixes #9404 by changing how the types get merged into Model
- fixes #9405 by falling back to `string` when keys resolves to `never`
- fixes #9402 by reducing any array-like to array
- improves createRecord type by filtering Model properties