### PR TITLE
feat: update SchemaService to reflect RFC updates

### DIFF
--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -1506,7 +1506,7 @@ function getDefaultValue(
 
     // new style transforms
   } else if (schema.kind !== 'attribute' && schema.type) {
-    const transform = store.schema.transformation(schema.type);
+    const transform = store.schema.transformation(schema);
 
     if (transform?.defaultValue) {
       return transform.defaultValue(options || null, identifier);

--- a/packages/model/src/-private/schema-provider.ts
+++ b/packages/model/src/-private/schema-provider.ts
@@ -9,9 +9,14 @@ import type { RecordIdentifier, StableRecordIdentifier } from '@warp-drive/core-
 import type { ObjectValue } from '@warp-drive/core-types/json/raw';
 import type { Derivation, HashFn, Transformation } from '@warp-drive/core-types/schema/concepts';
 import type {
+  ArrayField,
+  DerivedField,
+  GenericField,
+  HashField,
   LegacyAttributeField,
   LegacyFieldSchema,
   LegacyRelationshipSchema,
+  ObjectField,
   ResourceSchema,
 } from '@warp-drive/core-types/schema/fields';
 
@@ -55,14 +60,14 @@ export class ModelSchemaProvider implements SchemaService {
     assert(`resourceHasTrait is not available with @ember-data/model's SchemaService`);
     return false;
   }
-  transformation(name: string): Transformation {
+  transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
     assert(`transformation is not available with @ember-data/model's SchemaService`);
   }
-  hashFn(name: string): HashFn {
-    assert(`hashFn is not available with @ember-data/model's SchemaService`);
-  }
-  derivation(name: string): Derivation {
+  derivation(field: DerivedField | { type: string }): Derivation {
     assert(`derivation is not available with @ember-data/model's SchemaService`);
+  }
+  hashFn(field: HashField | { type: string }): HashFn {
+    assert(`hashFn is not available with @ember-data/model's SchemaService`);
   }
   resource(resource: StableRecordIdentifier | { type: string }): ResourceSchema {
     const type = normalizeModelName(resource.type);

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -7,7 +7,7 @@ import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import { getOrSetGlobal } from '@warp-drive/core-types/-private';
 import type { ObjectValue } from '@warp-drive/core-types/json/raw';
 import type { Derivation, HashFn, Transformation } from '@warp-drive/core-types/schema/concepts';
-import type { FieldSchema, ResourceSchema } from '@warp-drive/core-types/schema/fields';
+import type { ArrayField, DerivedField, FieldSchema, GenericField, HashField, ObjectField, ResourceSchema } from '@warp-drive/core-types/schema/fields';
 import { Type } from '@warp-drive/core-types/symbols';
 import type { WithPartial } from '@warp-drive/core-types/utils';
 
@@ -203,14 +203,14 @@ export class DelegatingSchemaService implements SchemaService {
     }
     return this._secondary.fields(resource);
   }
-  transformation(name: string): Transformation {
-    return this._preferred.transformation(name);
+  transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
+    return this._preferred.transformation(field);
   }
-  hashFn(name: string): HashFn {
-    return this._preferred.hashFn(name);
+  hashFn(field: HashField | { type: string }): HashFn {
+    return this._preferred.hashFn(field);
   }
-  derivation(name: string): Derivation {
-    return this._preferred.derivation(name);
+  derivation(field: DerivedField | { type: string }): Derivation {
+    return this._preferred.derivation(field);
   }
   resource(resource: StableRecordIdentifier | { type: string }): ResourceSchema {
     if (this._preferred.hasResource(resource)) {

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -7,7 +7,15 @@ import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import { getOrSetGlobal } from '@warp-drive/core-types/-private';
 import type { ObjectValue } from '@warp-drive/core-types/json/raw';
 import type { Derivation, HashFn, Transformation } from '@warp-drive/core-types/schema/concepts';
-import type { ArrayField, DerivedField, FieldSchema, GenericField, HashField, ObjectField, ResourceSchema } from '@warp-drive/core-types/schema/fields';
+import type {
+  ArrayField,
+  DerivedField,
+  FieldSchema,
+  GenericField,
+  HashField,
+  ObjectField,
+  ResourceSchema,
+} from '@warp-drive/core-types/schema/fields';
 import { Type } from '@warp-drive/core-types/symbols';
 import type { WithPartial } from '@warp-drive/core-types/utils';
 

--- a/packages/schema-record/src/managed-array.ts
+++ b/packages/schema-record/src/managed-array.ts
@@ -163,8 +163,7 @@ export class ManagedArray {
             subscribe(_SIGNAL);
           }
           if (field.type) {
-            const transform = schema.transformation(field.type);
-            assert(`No '${field.type}' transform defined for use by ${address.type}.${String(prop)}`, transform);
+            const transform = schema.transformation(field);
             return transform.hydrate(val as Value, field.options ?? null, self.owner);
           }
           return val;
@@ -225,8 +224,7 @@ export class ManagedArray {
             return true;
           }
 
-          const transform = schema.transformation(field.type);
-          assert(`No '${field.type}' transform defined for use by ${address.type}.${String(prop)}`, transform);
+          const transform = schema.transformation(field);
           const rawValue = (self[SOURCE] as ArrayValue).map((item) =>
             transform.serialize(item, field.options ?? null, self.owner)
           );

--- a/packages/schema-record/src/managed-object.ts
+++ b/packages/schema-record/src/managed-object.ts
@@ -1,7 +1,6 @@
 import type Store from '@ember-data/store';
 import type { Signal } from '@ember-data/tracking/-private';
 import { addToTransaction, createSignal, subscribe } from '@ember-data/tracking/-private';
-import { assert } from '@warp-drive/build-config/macros';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { Cache } from '@warp-drive/core-types/cache';
 import type { ObjectValue, Value } from '@warp-drive/core-types/json/raw';

--- a/packages/schema-record/src/managed-object.ts
+++ b/packages/schema-record/src/managed-object.ts
@@ -76,8 +76,7 @@ export class ManagedObject {
           let newData = cache.getAttr(self.address, self.key);
           if (newData && newData !== self[SOURCE]) {
             if (field.type) {
-              const transform = schema.transformation(field.type);
-              assert(`No '${field.type}' transform defined for use by ${address.type}.${String(prop)}`, transform);
+              const transform = schema.transformation(field);
               newData = transform.hydrate(newData as ObjectValue, field.options ?? null, self.owner) as ObjectValue;
             }
             self[SOURCE] = { ...(newData as ObjectValue) }; // Add type assertion for newData
@@ -119,8 +118,7 @@ export class ManagedObject {
             return true;
           }
 
-          const transform = schema.transformation(field.type);
-          assert(`No '${field.type}' transform defined for use by ${address.type}.${String(prop)}`, transform);
+          const transform = schema.transformation(field);
           const val = transform.serialize(self[SOURCE], field.options ?? null, self.owner);
           cache.setAttr(self.address, self.key, val);
           _SIGNAL.shouldReset = true;

--- a/packages/schema-record/src/record.ts
+++ b/packages/schema-record/src/record.ts
@@ -81,8 +81,7 @@ function computeField(
   if (!field.type) {
     return rawValue;
   }
-  const transform = schema.transformation(field.type);
-  assert(`No '${field.type}' transform defined for use by ${identifier.type}.${String(prop)}`, transform);
+  const transform = schema.transformation(field);
   return transform.hydrate(rawValue, field.options ?? null, record);
 }
 
@@ -146,8 +145,7 @@ function computeObject(
     }
     if (field.kind === 'object') {
       if (field.type) {
-        const transform = schema.transformation(field.type);
-        assert(`No '${field.type}' transform defined for use by ${identifier.type}.${String(prop)}`, transform);
+        const transform = schema.transformation(field);
         rawValue = transform.hydrate(rawValue as ObjectValue, field.options ?? null, record) as object;
       }
     }
@@ -172,13 +170,7 @@ function computeDerivation(
   field: DerivedField,
   prop: string
 ): unknown {
-  if (!field.type) {
-    throw new Error(`The schema for ${identifier.type}.${String(prop)} is missing the type of the derivation`);
-  }
-
-  const derivation = schema.derivation(field.type);
-  assert(`No '${field.type}' derivation defined for use by ${identifier.type}.${String(prop)}`, derivation);
-  return derivation(record, field.options ?? null, prop);
+  return schema.derivation(field)(record, field.options ?? null, prop);
 }
 
 // TODO probably this should just be a Document
@@ -349,7 +341,7 @@ export class SchemaRecord {
             return identifier.id;
           case '@hash':
             // TODO pass actual cache value not {}
-            return schema.hashFn(field.type)({}, field.options ?? null, field.name ?? null);
+            return schema.hashFn(field)({}, field.options ?? null, field.name ?? null);
           case '@local': {
             const lastValue = computeLocal(receiver, field, prop as string);
             entangleSignal(signals, receiver, prop as string);
@@ -423,9 +415,7 @@ export class SchemaRecord {
               cache.setAttr(identifier, prop as string, value as Value);
               return true;
             }
-            const transform = schema.transformation(field.type);
-            assert(`No '${field.type}' transform defined for use by ${identifier.type}.${String(prop)}`, transform);
-
+            const transform = schema.transformation(field);
             const rawValue = transform.serialize(value, field.options ?? null, target);
             cache.setAttr(identifier, prop as string, rawValue);
             return true;
@@ -448,9 +438,7 @@ export class SchemaRecord {
               return true;
             }
 
-            const transform = schema.transformation(field.type);
-            assert(`No '${field.type}' transform defined for use by ${identifier.type}.${String(prop)}`, transform);
-
+            const transform = schema.transformation(field);
             const rawValue = (value as ArrayValue).map((item) =>
               transform.serialize(item, field.options ?? null, target)
             );
@@ -480,8 +468,7 @@ export class SchemaRecord {
               }
               return true;
             }
-            const transform = schema.transformation(field.type);
-            assert(`No '${field.type}' transform defined for use by ${identifier.type}.${String(prop)}`, transform);
+            const transform = schema.transformation(field);
             const rawValue = transform.serialize({ ...(value as ObjectValue) }, field.options ?? null, target);
 
             cache.setAttr(identifier, prop as string, rawValue);

--- a/packages/schema-record/src/schema.ts
+++ b/packages/schema-record/src/schema.ts
@@ -12,9 +12,14 @@ import { getOrSetGlobal } from '@warp-drive/core-types/-private';
 import type { ObjectValue, Value } from '@warp-drive/core-types/json/raw';
 import type { Derivation, HashFn } from '@warp-drive/core-types/schema/concepts';
 import type {
+  ArrayField,
+  DerivedField,
   FieldSchema,
+  GenericField,
+  HashField,
   LegacyAttributeField,
   LegacyRelationshipSchema,
+  ObjectField,
   ResourceSchema,
 } from '@warp-drive/core-types/schema/fields';
 import { Type } from '@warp-drive/core-types/symbols';
@@ -153,21 +158,33 @@ export class SchemaService implements SchemaServiceInterface {
   resourceHasTrait(resource: StableRecordIdentifier | { type: string }, trait: string): boolean {
     return this._schemas.get(resource.type)!.traits.has(trait);
   }
-  transformation(name: string): Transformation {
-    assert(`No transformation registered with name '${name}'`, this._transforms.has(name));
-    return this._transforms.get(name)!;
+  transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`, !('kind' in field) || ['field', 'object', 'array'].includes(kind));
+    assert(`Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`, field.type);
+    assert(`No transformation registered with name '${field.type}' for '${kind}' field '${name}'`, this._transforms.has(field.type));
+    return this._transforms.get(field.type)!;
   }
-  derivation(name: string): Derivation {
-    assert(`No derivation registered with name '${name}'`, this._derivations.has(name));
-    return this._derivations.get(name)!;
+  derivation(field: DerivedField | { type: string }): Derivation {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`, !('kind' in field) || kind === 'derived');
+    assert(`Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`, field.type);
+    assert(`No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`, this._derivations.has(field.type));
+    return this._derivations.get(field.type)!;
+  }
+  hashFn(field: HashField | { type: string }): HashFn {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`, !('kind' in field) || kind === '@hash');
+    assert(`Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`, field.type);
+    assert(`No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`, this._hashFns.has(field.type));
+    return this._hashFns.get(field.type)!;
   }
   resource(resource: StableRecordIdentifier | { type: string }): ResourceSchema {
     assert(`No resource registered with name '${resource.type}'`, this._schemas.has(resource.type));
     return this._schemas.get(resource.type)!.original;
-  }
-  hashFn(name: string): HashFn {
-    assert(`No hash function registered with name '${name}'`, this._hashFns.has(name));
-    return this._hashFns.get(name)!;
   }
   registerResources(schemas: ResourceSchema[]): void {
     schemas.forEach((schema) => {

--- a/packages/schema-record/src/schema.ts
+++ b/packages/schema-record/src/schema.ts
@@ -161,25 +161,52 @@ export class SchemaService implements SchemaServiceInterface {
   transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`, !('kind' in field) || ['field', 'object', 'array'].includes(kind));
-    assert(`Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`, field.type);
-    assert(`No transformation registered with name '${field.type}' for '${kind}' field '${name}'`, this._transforms.has(field.type));
+    assert(
+      `'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`,
+      !('kind' in field) || ['field', 'object', 'array'].includes(kind)
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`,
+      field.type
+    );
+    assert(
+      `No transformation registered with name '${field.type}' for '${kind}' field '${name}'`,
+      this._transforms.has(field.type)
+    );
     return this._transforms.get(field.type)!;
   }
   derivation(field: DerivedField | { type: string }): Derivation {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`, !('kind' in field) || kind === 'derived');
-    assert(`Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`, field.type);
-    assert(`No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`, this._derivations.has(field.type));
+    assert(
+      `The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`,
+      !('kind' in field) || kind === 'derived'
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`,
+      field.type
+    );
+    assert(
+      `No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`,
+      this._derivations.has(field.type)
+    );
     return this._derivations.get(field.type)!;
   }
   hashFn(field: HashField | { type: string }): HashFn {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`, !('kind' in field) || kind === '@hash');
-    assert(`Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`, field.type);
-    assert(`No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`, this._hashFns.has(field.type));
+    assert(
+      `The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`,
+      !('kind' in field) || kind === '@hash'
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`,
+      field.type
+    );
+    assert(
+      `No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`,
+      this._hashFns.has(field.type)
+    );
     return this._hashFns.get(field.type)!;
   }
   resource(resource: StableRecordIdentifier | { type: string }): ResourceSchema {

--- a/packages/store/src/-types/q/schema-service.ts
+++ b/packages/store/src/-types/q/schema-service.ts
@@ -7,10 +7,15 @@ import type { RecordIdentifier } from '@warp-drive/core-types/identifier';
 import type { ObjectValue } from '@warp-drive/core-types/json/raw';
 import type { Derivation, HashFn, Transformation } from '@warp-drive/core-types/schema/concepts';
 import type {
+  ArrayField,
+  DerivedField,
   FieldSchema,
+  GenericField,
+  HashField,
   LegacyAttributeField,
   LegacyBelongsToField,
   LegacyHasManyField,
+  ObjectField,
   ResourceSchema,
 } from '@warp-drive/core-types/schema/fields';
 
@@ -126,34 +131,37 @@ export interface SchemaService {
   fields(resource: { type: string } | StableRecordIdentifier): Map<string, FieldSchema>;
 
   /**
-   * Returns the transformation registered with the provided name.
+   * Returns the transformation registered with the name provided
+   * by `field.type`. Validates that the field is a valid transformable.
    *
    * @method transformation
    * @public
-   * @param name
+   * @param {TransformableField|{ type: string }} field
    * @returns {Transformation}
    */
-  transformation(name: string): Transformation;
+  transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation;
 
   /**
-   * Returns the hash function registered with the provided name.
+   * Returns the hash function registered with the name provided
+   * by `field.type`. Validates that the field is a valid HashField.
    *
    * @method hashFn
    * @public
-   * @param name
+   * @param {HashField|{ type: string }} field
    * @returns {HashFn}
    */
-  hashFn(name: string): HashFn;
+  hashFn(field: HashField | { type: string }): HashFn;
 
   /**
-   * Returns the derivation registered with the provided name.
+   * Returns the derivation registered with the name provided
+   * by `field.type`. Validates that the field is a valid DerivedField.
    *
    * @method derivation
    * @public
-   * @param name
+   * @param {DerivedField|{ type: string }} field
    * @returns {Derivation}
    */
-  derivation(name: string): Derivation;
+  derivation(field: DerivedField | { type: string }): Derivation;
 
   /**
    * Returns the schema for the provided resource type.

--- a/tests/ember-data__json-api/tests/utils/schema.ts
+++ b/tests/ember-data__json-api/tests/utils/schema.ts
@@ -47,25 +47,52 @@ export class TestSchema implements SchemaService {
   transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`, !('kind' in field) || ['field', 'object', 'array'].includes(kind));
-    assert(`Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`, field.type);
-    assert(`No transformation registered with name '${field.type}' for '${kind}' field '${name}'`, this._transforms.has(field.type));
+    assert(
+      `'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`,
+      !('kind' in field) || ['field', 'object', 'array'].includes(kind)
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`,
+      field.type
+    );
+    assert(
+      `No transformation registered with name '${field.type}' for '${kind}' field '${name}'`,
+      this._transforms.has(field.type)
+    );
     return this._transforms.get(field.type)!;
   }
   derivation(field: DerivedField | { type: string }): Derivation {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`, !('kind' in field) || kind === 'derived');
-    assert(`Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`, field.type);
-    assert(`No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`, this._derivations.has(field.type));
+    assert(
+      `The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`,
+      !('kind' in field) || kind === 'derived'
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`,
+      field.type
+    );
+    assert(
+      `No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`,
+      this._derivations.has(field.type)
+    );
     return this._derivations.get(field.type)!;
   }
   hashFn(field: HashField | { type: string }): HashFn {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`, !('kind' in field) || kind === '@hash');
-    assert(`Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`, field.type);
-    assert(`No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`, this._hashFns.has(field.type));
+    assert(
+      `The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`,
+      !('kind' in field) || kind === '@hash'
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`,
+      field.type
+    );
+    assert(
+      `No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`,
+      this._hashFns.has(field.type)
+    );
     return this._hashFns.get(field.type)!;
   }
   resource(resource: StableRecordIdentifier | { type: string }): ResourceSchema {

--- a/tests/ember-data__json-api/tests/utils/schema.ts
+++ b/tests/ember-data__json-api/tests/utils/schema.ts
@@ -4,9 +4,14 @@ import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { Value } from '@warp-drive/core-types/json/raw';
 import type { Derivation, HashFn, Transformation } from '@warp-drive/core-types/schema/concepts';
 import type {
+  ArrayField,
+  DerivedField,
   FieldSchema,
+  GenericField,
+  HashField,
   LegacyAttributeField,
   LegacyRelationshipSchema,
+  ObjectField,
   ResourceSchema,
 } from '@warp-drive/core-types/schema/fields';
 import { Type } from '@warp-drive/core-types/symbols';
@@ -39,21 +44,33 @@ export class TestSchema implements SchemaService {
   resourceHasTrait(resource: StableRecordIdentifier | { type: string }, trait: string): boolean {
     return this._schemas.get(resource.type)!.traits.has(trait);
   }
-  transformation(name: string): Transformation {
-    assert(`No transformation registered with name ${name}`, this._transforms.has(name));
-    return this._transforms.get(name)!;
+  transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`, !('kind' in field) || ['field', 'object', 'array'].includes(kind));
+    assert(`Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`, field.type);
+    assert(`No transformation registered with name '${field.type}' for '${kind}' field '${name}'`, this._transforms.has(field.type));
+    return this._transforms.get(field.type)!;
   }
-  derivation(name: string): Derivation {
-    assert(`No derivation registered with name ${name}`, this._derivations.has(name));
-    return this._derivations.get(name)!;
+  derivation(field: DerivedField | { type: string }): Derivation {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`, !('kind' in field) || kind === 'derived');
+    assert(`Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`, field.type);
+    assert(`No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`, this._derivations.has(field.type));
+    return this._derivations.get(field.type)!;
+  }
+  hashFn(field: HashField | { type: string }): HashFn {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`, !('kind' in field) || kind === '@hash');
+    assert(`Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`, field.type);
+    assert(`No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`, this._hashFns.has(field.type));
+    return this._hashFns.get(field.type)!;
   }
   resource(resource: StableRecordIdentifier | { type: string }): ResourceSchema {
     assert(`No resource registered with name ${resource.type}`, this._schemas.has(resource.type));
     return this._schemas.get(resource.type)!.original;
-  }
-  hashFn(name: string): HashFn {
-    assert(`No hash function registered with name ${name}`, this._hashFns.has(name));
-    return this._hashFns.get(name)!;
   }
 
   registerTransformation<T extends Value = string, PT = unknown>(transformation: Transformation<T, PT>): void {

--- a/tests/ember-data__model/tests/utils/schema.ts
+++ b/tests/ember-data__model/tests/utils/schema.ts
@@ -47,25 +47,52 @@ export class TestSchema implements SchemaService {
   transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`, !('kind' in field) || ['field', 'object', 'array'].includes(kind));
-    assert(`Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`, field.type);
-    assert(`No transformation registered with name '${field.type}' for '${kind}' field '${name}'`, this._transforms.has(field.type));
+    assert(
+      `'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`,
+      !('kind' in field) || ['field', 'object', 'array'].includes(kind)
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`,
+      field.type
+    );
+    assert(
+      `No transformation registered with name '${field.type}' for '${kind}' field '${name}'`,
+      this._transforms.has(field.type)
+    );
     return this._transforms.get(field.type)!;
   }
   derivation(field: DerivedField | { type: string }): Derivation {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`, !('kind' in field) || kind === 'derived');
-    assert(`Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`, field.type);
-    assert(`No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`, this._derivations.has(field.type));
+    assert(
+      `The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`,
+      !('kind' in field) || kind === 'derived'
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`,
+      field.type
+    );
+    assert(
+      `No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`,
+      this._derivations.has(field.type)
+    );
     return this._derivations.get(field.type)!;
   }
-  hashFn(field: HashField| { type: string }): HashFn {
+  hashFn(field: HashField | { type: string }): HashFn {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`, !('kind' in field) || kind === '@hash');
-    assert(`Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`, field.type);
-    assert(`No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`, this._hashFns.has(field.type));
+    assert(
+      `The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`,
+      !('kind' in field) || kind === '@hash'
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`,
+      field.type
+    );
+    assert(
+      `No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`,
+      this._hashFns.has(field.type)
+    );
     return this._hashFns.get(field.type)!;
   }
   resource(resource: StableRecordIdentifier | { type: string }): ResourceSchema {

--- a/tests/ember-data__model/tests/utils/schema.ts
+++ b/tests/ember-data__model/tests/utils/schema.ts
@@ -4,9 +4,14 @@ import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { Value } from '@warp-drive/core-types/json/raw';
 import type { Derivation, HashFn, Transformation } from '@warp-drive/core-types/schema/concepts';
 import type {
+  ArrayField,
+  DerivedField,
   FieldSchema,
+  GenericField,
+  HashField,
   LegacyAttributeField,
   LegacyRelationshipSchema,
+  ObjectField,
   ResourceSchema,
 } from '@warp-drive/core-types/schema/fields';
 import { Type } from '@warp-drive/core-types/symbols';
@@ -39,21 +44,33 @@ export class TestSchema implements SchemaService {
   resourceHasTrait(resource: StableRecordIdentifier | { type: string }, trait: string): boolean {
     return this._schemas.get(resource.type)!.traits.has(trait);
   }
-  transformation(name: string): Transformation {
-    assert(`No transformation registered with name ${name}`, this._transforms.has(name));
-    return this._transforms.get(name)!;
+  transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`, !('kind' in field) || ['field', 'object', 'array'].includes(kind));
+    assert(`Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`, field.type);
+    assert(`No transformation registered with name '${field.type}' for '${kind}' field '${name}'`, this._transforms.has(field.type));
+    return this._transforms.get(field.type)!;
   }
-  derivation(name: string): Derivation {
-    assert(`No derivation registered with name ${name}`, this._derivations.has(name));
-    return this._derivations.get(name)!;
+  derivation(field: DerivedField | { type: string }): Derivation {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`, !('kind' in field) || kind === 'derived');
+    assert(`Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`, field.type);
+    assert(`No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`, this._derivations.has(field.type));
+    return this._derivations.get(field.type)!;
+  }
+  hashFn(field: HashField| { type: string }): HashFn {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`, !('kind' in field) || kind === '@hash');
+    assert(`Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`, field.type);
+    assert(`No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`, this._hashFns.has(field.type));
+    return this._hashFns.get(field.type)!;
   }
   resource(resource: StableRecordIdentifier | { type: string }): ResourceSchema {
     assert(`No resource registered with name ${resource.type}`, this._schemas.has(resource.type));
     return this._schemas.get(resource.type)!.original;
-  }
-  hashFn(name: string): HashFn {
-    assert(`No hash function registered with name ${name}`, this._hashFns.has(name));
-    return this._hashFns.get(name)!;
   }
 
   registerTransformation<T extends Value = string, PT = unknown>(transformation: Transformation<T, PT>): void {

--- a/tests/main/tests/integration/cache-handler/lifetimes-test.ts
+++ b/tests/main/tests/integration/cache-handler/lifetimes-test.ts
@@ -15,7 +15,15 @@ import type { Cache } from '@warp-drive/core-types/cache';
 import type { StableDocumentIdentifier, StableRecordIdentifier } from '@warp-drive/core-types/identifier';
 import type { ObjectValue } from '@warp-drive/core-types/json/raw';
 import type { Derivation, HashFn, Transformation } from '@warp-drive/core-types/schema/concepts';
-import type { ArrayField, DerivedField, FieldSchema, GenericField, HashField, ObjectField, ResourceSchema } from '@warp-drive/core-types/schema/fields';
+import type {
+  ArrayField,
+  DerivedField,
+  FieldSchema,
+  GenericField,
+  HashField,
+  ObjectField,
+  ResourceSchema,
+} from '@warp-drive/core-types/schema/fields';
 import type { ResourceType } from '@warp-drive/core-types/symbols';
 
 type FakeRecord = { [key: string]: unknown; destroy: () => void };
@@ -23,7 +31,7 @@ type FakeRecord = { [key: string]: unknown; destroy: () => void };
 class BaseTestStore extends Store {
   createSchemaService(): SchemaService {
     const schemaService: SchemaService = {
-      fields(identifier: StableRecordIdentifier | { type: string; }): Map<string, FieldSchema> {
+      fields(identifier: StableRecordIdentifier | { type: string }): Map<string, FieldSchema> {
         return new Map();
       },
       hasResource() {
@@ -32,10 +40,10 @@ class BaseTestStore extends Store {
       hasTrait: function (type: string): boolean {
         throw new Error('Function not implemented.');
       },
-      resourceHasTrait: function (resource: StableRecordIdentifier | { type: string; }, trait: string): boolean {
+      resourceHasTrait: function (resource: StableRecordIdentifier | { type: string }, trait: string): boolean {
         throw new Error('Function not implemented.');
       },
-      resource: function (resource: StableRecordIdentifier | { type: string; }): ResourceSchema {
+      resource: function (resource: StableRecordIdentifier | { type: string }): ResourceSchema {
         throw new Error('Function not implemented.');
       },
       registerResources: function (schemas: ResourceSchema[]): void {
@@ -53,15 +61,15 @@ class BaseTestStore extends Store {
       registerHashFn: function (hashFn: HashFn): void {
         throw new Error('Function not implemented.');
       },
-      transformation: function (field: GenericField | ObjectField | ArrayField | { type: string; }): Transformation {
+      transformation: function (field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
         throw new Error('Function not implemented.');
       },
-      hashFn: function (field: HashField | { type: string; }): HashFn {
+      hashFn: function (field: HashField | { type: string }): HashFn {
         throw new Error('Function not implemented.');
       },
-      derivation: function (field: DerivedField | { type: string; }): Derivation {
+      derivation: function (field: DerivedField | { type: string }): Derivation {
         throw new Error('Function not implemented.');
-      }
+      },
     };
 
     return schemaService;

--- a/tests/main/tests/integration/cache-handler/lifetimes-test.ts
+++ b/tests/main/tests/integration/cache-handler/lifetimes-test.ts
@@ -15,7 +15,7 @@ import type { Cache } from '@warp-drive/core-types/cache';
 import type { StableDocumentIdentifier, StableRecordIdentifier } from '@warp-drive/core-types/identifier';
 import type { ObjectValue } from '@warp-drive/core-types/json/raw';
 import type { Derivation, HashFn, Transformation } from '@warp-drive/core-types/schema/concepts';
-import type { FieldSchema, ResourceSchema } from '@warp-drive/core-types/schema/fields';
+import type { ArrayField, DerivedField, FieldSchema, GenericField, HashField, ObjectField, ResourceSchema } from '@warp-drive/core-types/schema/fields';
 import type { ResourceType } from '@warp-drive/core-types/symbols';
 
 type FakeRecord = { [key: string]: unknown; destroy: () => void };
@@ -23,7 +23,7 @@ type FakeRecord = { [key: string]: unknown; destroy: () => void };
 class BaseTestStore extends Store {
   createSchemaService(): SchemaService {
     const schemaService: SchemaService = {
-      fields(identifier: StableRecordIdentifier | { type: string }): Map<string, FieldSchema> {
+      fields(identifier: StableRecordIdentifier | { type: string; }): Map<string, FieldSchema> {
         return new Map();
       },
       hasResource() {
@@ -32,16 +32,10 @@ class BaseTestStore extends Store {
       hasTrait: function (type: string): boolean {
         throw new Error('Function not implemented.');
       },
-      resourceHasTrait: function (resource: StableRecordIdentifier | { type: string }, trait: string): boolean {
+      resourceHasTrait: function (resource: StableRecordIdentifier | { type: string; }, trait: string): boolean {
         throw new Error('Function not implemented.');
       },
-      transformation: function (name: string): Transformation {
-        throw new Error('Function not implemented.');
-      },
-      derivation: function (name: string): Derivation {
-        throw new Error('Function not implemented.');
-      },
-      resource: function (resource: StableRecordIdentifier | { type: string }): ResourceSchema {
+      resource: function (resource: StableRecordIdentifier | { type: string; }): ResourceSchema {
         throw new Error('Function not implemented.');
       },
       registerResources: function (schemas: ResourceSchema[]): void {
@@ -56,12 +50,18 @@ class BaseTestStore extends Store {
       registerDerivation<R, T, FM extends ObjectValue | null>(derivation: Derivation<R, T, FM>): void {
         throw new Error('Function not implemented.');
       },
-      hashFn: function (name: string): HashFn {
-        throw new Error('Function not implemented.');
-      },
       registerHashFn: function (hashFn: HashFn): void {
         throw new Error('Function not implemented.');
       },
+      transformation: function (field: GenericField | ObjectField | ArrayField | { type: string; }): Transformation {
+        throw new Error('Function not implemented.');
+      },
+      hashFn: function (field: HashField | { type: string; }): HashFn {
+        throw new Error('Function not implemented.');
+      },
+      derivation: function (field: DerivedField | { type: string; }): Derivation {
+        throw new Error('Function not implemented.');
+      }
     };
 
     return schemaService;

--- a/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
+++ b/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
@@ -21,7 +21,7 @@ import type {
 import type { OpaqueRecordInstance } from '@warp-drive/core-types/record';
 import type { RequestContext } from '@warp-drive/core-types/request';
 import type { HashFn } from '@warp-drive/core-types/schema/concepts';
-import type { FieldSchema } from '@warp-drive/core-types/schema/fields';
+import type { FieldSchema, HashField } from '@warp-drive/core-types/schema/fields';
 import type {
   CollectionResourceDataDocument,
   ResourceDataDocument,
@@ -73,7 +73,7 @@ class TestStore extends Store {
       derivation() {
         throw new Error('Method not implemented.');
       },
-      fields(identifier: StableRecordIdentifier | { type: string }): Map<string, FieldSchema> {
+      fields(identifier: StableRecordIdentifier | { type: string; }): Map<string, FieldSchema> {
         return new Map();
       },
       hasTrait() {
@@ -85,12 +85,12 @@ class TestStore extends Store {
       hasResource() {
         return true;
       },
-      hashFn: function (name: string): HashFn {
-        throw new Error('Function not implemented.');
-      },
       registerHashFn: function (hashFn: HashFn): void {
         throw new Error('Function not implemented.');
       },
+      hashFn: function (field: HashField | { type: string; }): HashFn {
+        throw new Error('Function not implemented.');
+      }
     };
 
     return schemaService;

--- a/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
+++ b/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
@@ -73,7 +73,7 @@ class TestStore extends Store {
       derivation() {
         throw new Error('Method not implemented.');
       },
-      fields(identifier: StableRecordIdentifier | { type: string; }): Map<string, FieldSchema> {
+      fields(identifier: StableRecordIdentifier | { type: string }): Map<string, FieldSchema> {
         return new Map();
       },
       hasTrait() {
@@ -88,9 +88,9 @@ class TestStore extends Store {
       registerHashFn: function (hashFn: HashFn): void {
         throw new Error('Function not implemented.');
       },
-      hashFn: function (field: HashField | { type: string; }): HashFn {
+      hashFn: function (field: HashField | { type: string }): HashFn {
         throw new Error('Function not implemented.');
-      }
+      },
     };
 
     return schemaService;

--- a/tests/main/tests/utils/schema.ts
+++ b/tests/main/tests/utils/schema.ts
@@ -51,25 +51,52 @@ export class TestSchema implements SchemaService {
   transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`, !('kind' in field) || ['field', 'object', 'array'].includes(kind));
-    assert(`Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`, field.type);
-    assert(`No transformation registered with name '${field.type}' for '${kind}' field '${name}'`, this._transforms.has(field.type));
+    assert(
+      `'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`,
+      !('kind' in field) || ['field', 'object', 'array'].includes(kind)
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`,
+      field.type
+    );
+    assert(
+      `No transformation registered with name '${field.type}' for '${kind}' field '${name}'`,
+      this._transforms.has(field.type)
+    );
     return this._transforms.get(field.type)!;
   }
   derivation(field: DerivedField | { type: string }): Derivation {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`, !('kind' in field) || kind === 'derived');
-    assert(`Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`, field.type);
-    assert(`No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`, this._derivations.has(field.type));
+    assert(
+      `The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`,
+      !('kind' in field) || kind === 'derived'
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`,
+      field.type
+    );
+    assert(
+      `No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`,
+      this._derivations.has(field.type)
+    );
     return this._derivations.get(field.type)!;
   }
   hashFn(field: HashField | { type: string }): HashFn {
     const kind = 'kind' in field ? field.kind : '<unknown kind>';
     const name = 'name' in field ? field.name : '<unknown name>';
-    assert(`The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`, !('kind' in field) || kind === '@hash');
-    assert(`Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`, field.type);
-    assert(`No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`, this._hashFns.has(field.type));
+    assert(
+      `The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`,
+      !('kind' in field) || kind === '@hash'
+    );
+    assert(
+      `Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`,
+      field.type
+    );
+    assert(
+      `No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`,
+      this._hashFns.has(field.type)
+    );
     return this._hashFns.get(field.type)!;
   }
   resource(resource: StableRecordIdentifier | { type: string }): ResourceSchema {

--- a/tests/main/tests/utils/schema.ts
+++ b/tests/main/tests/utils/schema.ts
@@ -4,9 +4,14 @@ import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { Value } from '@warp-drive/core-types/json/raw';
 import type { Derivation, HashFn, Transformation } from '@warp-drive/core-types/schema/concepts';
 import type {
+  ArrayField,
+  DerivedField,
   FieldSchema,
+  GenericField,
+  HashField,
   LegacyAttributeField,
   LegacyRelationshipSchema,
+  ObjectField,
   ResourceSchema,
 } from '@warp-drive/core-types/schema/fields';
 import { Type } from '@warp-drive/core-types/symbols';
@@ -43,27 +48,35 @@ export class TestSchema implements SchemaService {
     this._assert?.step('TestSchema:resourceHasTrait');
     return this._schemas.get(resource.type)!.traits.has(trait);
   }
-  transformation(name: string): Transformation {
-    this._assert?.step('TestSchema:transformation');
-    assert(`No transformation registered with name ${name}`, this._transforms.has(name));
-    return this._transforms.get(name)!;
+  transformation(field: GenericField | ObjectField | ArrayField | { type: string }): Transformation {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`'${kind}' fields cannot be transformed. Only fields of kind 'field' 'object' or 'array' can specify a transformation. Attempted to find '${field.type ?? '<unknown type>'}' on field '${name}'.`, !('kind' in field) || ['field', 'object', 'array'].includes(kind));
+    assert(`Expected the '${kind}' field '${name}' to specify a transformation via 'field.type', but none was present`, field.type);
+    assert(`No transformation registered with name '${field.type}' for '${kind}' field '${name}'`, this._transforms.has(field.type));
+    return this._transforms.get(field.type)!;
   }
-  derivation(name: string): Derivation {
-    this._assert?.step('TestSchema:derivation');
-    assert(`No derivation registered with name ${name}`, this._derivations.has(name));
-    return this._derivations.get(name)!;
+  derivation(field: DerivedField | { type: string }): Derivation {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`The '${kind}' field '${name}' is not derived and so cannot be used to lookup a derivation`, !('kind' in field) || kind === 'derived');
+    assert(`Expected the '${kind}' field '${name}' to specify a derivation via 'field.type', but no value was present`, field.type);
+    assert(`No '${field.type}' derivation registered for use by the '${kind}' field '${name}'`, this._derivations.has(field.type));
+    return this._derivations.get(field.type)!;
+  }
+  hashFn(field: HashField | { type: string }): HashFn {
+    const kind = 'kind' in field ? field.kind : '<unknown kind>';
+    const name = 'name' in field ? field.name : '<unknown name>';
+    assert(`The '${kind}' field '${name}' is not a HashField and so cannot be used to lookup a hash function`, !('kind' in field) || kind === '@hash');
+    assert(`Expected the '${kind}' field '${name}' to specify a hash function via 'field.type', but no value was present`, field.type);
+    assert(`No '${field.type}' hash function is registered for use by the '${kind}' field '${name}'`, this._hashFns.has(field.type));
+    return this._hashFns.get(field.type)!;
   }
   resource(resource: StableRecordIdentifier | { type: string }): ResourceSchema {
     this._assert?.step('TestSchema:resource');
     assert(`No resource registered with name ${resource.type}`, this._schemas.has(resource.type));
     return this._schemas.get(resource.type)!.original;
   }
-  hashFn(name: string): HashFn {
-    this._assert?.step('TestSchema:hashFn');
-    assert(`No hash function registered with name ${name}`, this._hashFns.has(name));
-    return this._hashFns.get(name)!;
-  }
-
   registerTransformation<T extends Value = string, PT = unknown>(transformation: Transformation<T, PT>): void {
     this._assert?.step('TestSchema:registerTransformation');
     this._transforms.set(transformation[Type], transformation as Transformation);

--- a/tests/warp-drive__schema-record/tests/reads/basic-fields-test.ts
+++ b/tests/warp-drive__schema-record/tests/reads/basic-fields-test.ts
@@ -150,7 +150,7 @@ module('Reads | basic fields', function (hooks) {
     } catch (e) {
       assert.strictEqual(
         (e as Error).message,
-        `No transformation registered with name 'string'`,
+        `No transformation registered with name 'string' for 'field' field 'lastName'`,
         'should error when accessing unknown field transform'
       );
     }

--- a/tests/warp-drive__schema-record/tests/reads/derivation-test.ts
+++ b/tests/warp-drive__schema-record/tests/reads/derivation-test.ts
@@ -112,7 +112,11 @@ module('Reads | derivation', function (hooks) {
       record.fullName;
       assert.ok(false, 'record.fullName should throw');
     } catch (e) {
-      assert.strictEqual((e as Error).message, "No 'concat' derivation registered for use by the 'derived' field 'fullName'", 'record.fullName throws');
+      assert.strictEqual(
+        (e as Error).message,
+        "No 'concat' derivation registered for use by the 'derived' field 'fullName'",
+        'record.fullName throws'
+      );
     }
   });
 });

--- a/tests/warp-drive__schema-record/tests/reads/derivation-test.ts
+++ b/tests/warp-drive__schema-record/tests/reads/derivation-test.ts
@@ -112,7 +112,7 @@ module('Reads | derivation', function (hooks) {
       record.fullName;
       assert.ok(false, 'record.fullName should throw');
     } catch (e) {
-      assert.strictEqual((e as Error).message, "No derivation registered with name 'concat'", 'record.fullName throws');
+      assert.strictEqual((e as Error).message, "No 'concat' derivation registered for use by the 'derived' field 'fullName'", 'record.fullName throws');
     }
   });
 });


### PR DESCRIPTION
RFC emberjs/rfcs#1027

updates the signatures of `transformation()` `hashFn()` and `derivation()` to take a full field, updates error messages to take advantage of the added context.