### PR TITLE
Allow RequestState.abort to be used with on modifier

### DIFF
--- a/packages/ember/src/-private/request-state.ts
+++ b/packages/ember/src/-private/request-state.ts
@@ -214,9 +214,9 @@ export class RequestLoadingState {
     this._future = future;
   }
 
-  abort(): void {
+  abort = (): void => {
     this._future.abort();
-  }
+  };
 }
 
 export class RequestState<T = unknown, RT = unknown> {


### PR DESCRIPTION
## Description

Fixes the following error encountered when using `state.abort` (yielded by the `Request` component) with the `on` modifier:

```
util.js:579 Uncaught Error: You accessed `this._future` from a function passed to the `on` modifier, but the function itself was not bound to a valid `this` context. Consider updating to use a bound function (for instance, use an arrow function, `() => {}`).
    at assertOnProperty (util.js:579:1)
    at Object.get (util.js:583:1)
    at Proxy.abort (index.js:30:1364)
```

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


