### PR TITLE
fix: config version lookup needs to be project location aware

### DIFF
--- a/packages/build-config/src/-private/utils/features.ts
+++ b/packages/build-config/src/-private/utils/features.ts
@@ -1,9 +1,13 @@
 import fs from 'fs';
+import path from 'path';
 
 import * as CURRENT_FEATURES from '../../canary-features.ts';
 type FEATURE = keyof typeof CURRENT_FEATURES;
 
-const version = JSON.parse(fs.readFileSync('../../package.json', 'utf-8')).version;
+const dirname = new URL(import.meta.url).pathname;
+const relativePkgPath = path.join(dirname, '../../package.json');
+
+const version = JSON.parse(fs.readFileSync(relativePkgPath, 'utf-8')).version;
 const isCanary = version.includes('alpha');
 
 export function getFeatures(isProd: boolean): { [key in FEATURE]: boolean } {

--- a/packages/build-config/vite.config.mjs
+++ b/packages/build-config/vite.config.mjs
@@ -1,6 +1,6 @@
 import { createConfig } from '@warp-drive/internal-config/vite/config.js';
 
-export const externals = ['fs', 'semver'];
+export const externals = ['fs', 'path', 'semver'];
 
 export const entryPoints = [
   './src/index.ts',


### PR DESCRIPTION
enables apps to use `setConfig` correctly