### PR TITLE
feat: implement schema-object for schema-record

### DIFF
--- a/packages/schema-record/src/-private/compute.ts
+++ b/packages/schema-record/src/-private/compute.ts
@@ -16,6 +16,7 @@ import type {
   LocalField,
   ObjectField,
   SchemaArrayField,
+  SchemaObjectField,
 } from '@warp-drive/core-types/schema/fields';
 import type { Link, Links } from '@warp-drive/core-types/spec/json-api-raw';
 import { RecordStore } from '@warp-drive/core-types/symbols';
@@ -120,8 +121,9 @@ export function computeObject(
   cache: Cache,
   record: SchemaRecord,
   identifier: StableRecordIdentifier,
-  field: ObjectField,
-  prop: string
+  field: ObjectField | SchemaObjectField,
+  prop: string,
+  isSchemaObject = false
 ) {
   const managedObjectMapForRecord = ManagedObjectMap.get(record);
   let managedObject;
@@ -141,7 +143,7 @@ export function computeObject(
         rawValue = transform.hydrate(rawValue as ObjectValue, field.options ?? null, record) as object;
       }
     }
-    managedObject = new ManagedObject(store, schema, cache, field, rawValue, identifier, prop, record);
+    managedObject = new ManagedObject(store, schema, cache, field, rawValue, identifier, prop, record, isSchemaObject);
     if (!managedObjectMapForRecord) {
       ManagedObjectMap.set(record, new Map([[field, managedObject]]));
     } else {

--- a/tests/warp-drive__schema-record/tests/-utils/reactive-context.ts
+++ b/tests/warp-drive__schema-record/tests/-utils/reactive-context.ts
@@ -53,6 +53,7 @@ export async function reactiveContext<T extends OpaqueRecordInstance>(
           field.kind === 'array' ||
           field.kind === 'object' ||
           field.kind === 'schema-array' ||
+          field.kind === 'schema-object' ||
           field.kind === '@id' ||
           // @ts-expect-error we secretly allow this
           field.kind === '@hash'

--- a/tests/warp-drive__schema-record/tests/reactivity/object-test.ts
+++ b/tests/warp-drive__schema-record/tests/reactivity/object-test.ts
@@ -1,0 +1,121 @@
+import { rerender } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { setupRenderingTest } from 'ember-qunit';
+
+import type Store from '@ember-data/store';
+import { registerDerivations, withDefaults } from '@warp-drive/schema-record/schema';
+
+import { reactiveContext } from '../-utils/reactive-context';
+
+interface Address {
+  street: string;
+  city: string;
+  state: string;
+  zip: string;
+}
+interface User {
+  id: string | null;
+  $type: 'user';
+  name: string;
+  favoriteNumbers: string[];
+  address: Address;
+  age: number;
+  netWorth: number;
+  coolometer: number;
+  rank: number;
+}
+
+module('Reactivity | object fields can receive remote updates', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('we can use simple fields with no `type`', async function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'address',
+            kind: 'object',
+          },
+        ],
+      })
+    );
+    const resource = schema.resource({ type: 'user' });
+    const record = store.push({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          address: {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+        },
+      },
+    }) as User;
+
+    assert.strictEqual(record.id, '1', 'id is accessible');
+    assert.strictEqual(record.$type, 'user', '$type is accessible');
+    assert.deepEqual(
+      record.address,
+      {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      },
+      'address is accessible'
+    );
+
+    const { counters } = await reactiveContext.call(this, record, resource);
+    // TODO: actually render the address object and verify
+    // const addressIndex = fieldOrder.indexOf('address');
+
+    assert.strictEqual(counters.id, 1, 'idCount is 1');
+    assert.strictEqual(counters.$type, 1, '$typeCount is 1');
+    assert.strictEqual(counters.address, 1, 'addressCount is 1');
+
+    // remote update
+    store.push({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          address: {
+            street: '456 Elm St',
+            city: 'Anytown',
+            state: 'NJ',
+            zip: '23456',
+          },
+        },
+      },
+    });
+
+    assert.strictEqual(record.id, '1', 'id is accessible');
+    assert.strictEqual(record.$type, 'user', '$type is accessible');
+    assert.deepEqual(
+      record.address,
+      {
+        street: '456 Elm St',
+        city: 'Anytown',
+        state: 'NJ',
+        zip: '23456',
+      },
+      'address is accessible'
+    );
+
+    await rerender();
+
+    assert.strictEqual(counters.id, 1, 'idCount is 1');
+    assert.strictEqual(counters.$type, 1, '$typeCount is 1');
+    assert.strictEqual(counters.address, 2, 'addressCount is 2');
+  });
+});

--- a/tests/warp-drive__schema-record/tests/reactivity/schema-object-test.ts
+++ b/tests/warp-drive__schema-record/tests/reactivity/schema-object-test.ts
@@ -1,0 +1,144 @@
+import { rerender } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { setupRenderingTest } from 'ember-qunit';
+
+import type Store from '@ember-data/store';
+import { registerDerivations, withDefaults } from '@warp-drive/schema-record/schema';
+
+import { reactiveContext } from '../-utils/reactive-context';
+
+interface Address {
+  street: string;
+  city: string;
+  state: string;
+  zip: string;
+}
+interface User {
+  id: string | null;
+  $type: 'user';
+  name: string;
+  favoriteNumbers: string[];
+  address: Address;
+  age: number;
+  netWorth: number;
+  coolometer: number;
+  rank: number;
+}
+
+module('Reactivity | object fields can receive remote updates', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('we can use simple fields with no `type`', async function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      identity: null,
+      type: 'address',
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+        {
+          name: 'state',
+          kind: 'field',
+        },
+        {
+          name: 'zip',
+          kind: 'field',
+        },
+      ],
+    });
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'address',
+            kind: 'schema-object',
+            type: 'address',
+          },
+        ],
+      })
+    );
+    const resource = schema.resource({ type: 'user' });
+    const record = store.push({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          address: {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+        },
+      },
+    }) as User;
+
+    assert.strictEqual(record.id, '1', 'id is accessible');
+    assert.strictEqual(record.$type, 'user', '$type is accessible');
+    assert.deepEqual(
+      record.address,
+      {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      },
+      'address is accessible'
+    );
+
+    const { counters } = await reactiveContext.call(this, record, resource);
+    // TODO: actually render the address object and verify
+    // const addressIndex = fieldOrder.indexOf('address');
+
+    assert.strictEqual(counters.id, 1, 'idCount is 1');
+    assert.strictEqual(counters.$type, 1, '$typeCount is 1');
+    assert.strictEqual(counters.address, 1, 'addressCount is 1');
+
+    // remote update
+    store.push({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          address: {
+            street: '456 Elm St',
+            city: 'Anytown',
+            state: 'NJ',
+            zip: '23456',
+          },
+        },
+      },
+    });
+
+    assert.strictEqual(record.id, '1', 'id is accessible');
+    assert.strictEqual(record.$type, 'user', '$type is accessible');
+    assert.deepEqual(
+      record.address,
+      {
+        street: '456 Elm St',
+        city: 'Anytown',
+        state: 'NJ',
+        zip: '23456',
+      },
+      'address is accessible'
+    );
+
+    await rerender();
+
+    assert.strictEqual(counters.id, 1, 'idCount is 1');
+    assert.strictEqual(counters.$type, 1, '$typeCount is 1');
+    assert.strictEqual(counters.address, 2, 'addressCount is 2');
+  });
+});

--- a/tests/warp-drive__schema-record/tests/reads/schema-object-test.ts
+++ b/tests/warp-drive__schema-record/tests/reads/schema-object-test.ts
@@ -1,0 +1,114 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import { recordIdentifierFor } from '@ember-data/store';
+import type { ResourceType } from '@warp-drive/core-types/symbols';
+import { registerDerivations, withDefaults } from '@warp-drive/schema-record/schema';
+
+import type Store from 'warp-drive__schema-record/services/store';
+
+type address = {
+  street: string;
+  city: string;
+  state: string;
+  zip: string | number;
+};
+
+interface CreateUserType {
+  id: string | null;
+  $type: 'user';
+  name: string | null;
+  address: address | null;
+  [ResourceType]: 'user';
+}
+
+module('Reads | schema-object fields', function (hooks) {
+  setupTest(hooks);
+
+  test('we can use schema-object fields', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      identity: null,
+      type: 'address',
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+        {
+          name: 'state',
+          kind: 'field',
+        },
+        {
+          name: 'zip',
+          kind: 'field',
+        },
+      ],
+    });
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+          {
+            name: 'address',
+            type: 'address',
+            kind: 'schema-object',
+          },
+        ],
+      })
+    );
+
+    const sourceAddress: address = {
+      street: '123 Main St',
+      city: 'Anytown',
+      state: 'NY',
+      zip: '12345',
+    };
+    const record = store.createRecord<CreateUserType>('user', { name: 'Rey Skybarker', address: sourceAddress });
+
+    assert.strictEqual(record.id, null, 'id is accessible');
+    assert.strictEqual(record.$type, 'user', '$type is accessible');
+    assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+    assert.deepEqual(
+      record.address,
+      { street: '123 Main St', city: 'Anytown', state: 'NY', zip: '12345' },
+      'we can access address object'
+    );
+    assert.strictEqual(record.address, record.address, 'We have a stable object reference');
+    assert.notStrictEqual(record.address, sourceAddress);
+
+    // test that the data entered the cache properly
+    const identifier = recordIdentifierFor(record);
+    const cachedResourceData = store.cache.peek(identifier);
+
+    assert.notStrictEqual(
+      cachedResourceData?.attributes?.address,
+      sourceAddress,
+      'with no transform we will still divorce the object reference'
+    );
+    assert.deepEqual(
+      cachedResourceData?.attributes?.address,
+      {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      },
+      'the cache values are correct for the array field'
+    );
+    // @ts-expect-error
+    assert.throws(() => record.address!.notField as unknown, /Field notField does not exist on schema object address/);
+  });
+});

--- a/tests/warp-drive__schema-record/tests/writes/schema-object-test.ts
+++ b/tests/warp-drive__schema-record/tests/writes/schema-object-test.ts
@@ -1,0 +1,492 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import { recordIdentifierFor } from '@ember-data/store';
+import type { ResourceType } from '@warp-drive/core-types/symbols';
+import { registerDerivations, withDefaults } from '@warp-drive/schema-record/schema';
+
+import type Store from 'warp-drive__schema-record/services/store';
+
+type address = {
+  street: string;
+  city: string;
+  state: string;
+  zip: string | number;
+};
+interface User {
+  id: string;
+  $type: 'user';
+  name: string;
+  address: address | null;
+  [ResourceType]: 'user';
+}
+
+module('Writes | schema-object fields', function (hooks) {
+  setupTest(hooks);
+
+  test('we can update to a new object', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      identity: null,
+      type: 'address',
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+        {
+          name: 'state',
+          kind: 'field',
+        },
+        {
+          name: 'zip',
+          kind: 'field',
+        },
+      ],
+    });
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+          {
+            name: 'address',
+            kind: 'schema-object',
+            type: 'address',
+          },
+        ],
+      })
+    );
+
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Rey Pupatine',
+          address: {
+            street: '123 Main Street',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+        },
+      },
+    });
+
+    assert.strictEqual(record.id, '1', 'id is accessible');
+    assert.strictEqual(record.$type, 'user', '$type is accessible');
+    assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+    assert.deepEqual(
+      record.address,
+      { street: '123 Main Street', city: 'Anytown', state: 'NY', zip: '12345' },
+      'We have the correct address object'
+    );
+    const address = record.address;
+    record.address = { street: '456 Elm Street', city: 'Sometown', state: 'NJ', zip: '23456' };
+    assert.deepEqual(
+      record.address,
+      { street: '456 Elm Street', city: 'Sometown', state: 'NJ', zip: '23456' },
+      'we have the correct Object members'
+    );
+    assert.strictEqual(address, record.address, 'Object reference does not change');
+
+    // test that the data entered the cache properly
+    const identifier = recordIdentifierFor(record);
+    const cachedResourceData = store.cache.peek(identifier);
+
+    assert.deepEqual(
+      cachedResourceData?.attributes?.address,
+      { street: '456 Elm Street', city: 'Sometown', state: 'NJ', zip: '23456' },
+      'the cache values are correctly updated'
+    );
+  });
+
+  test('we can update to null', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+    schema.registerResource({
+      identity: null,
+      type: 'address',
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+        {
+          name: 'state',
+          kind: 'field',
+        },
+        {
+          name: 'zip',
+          kind: 'field',
+        },
+      ],
+    });
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+          {
+            name: 'address',
+            kind: 'schema-object',
+            type: 'address',
+          },
+        ],
+      })
+    );
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Rey Pupatine',
+          address: {
+            street: '123 Main Street',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+        },
+      },
+    });
+    assert.strictEqual(record.id, '1', 'id is accessible');
+    assert.strictEqual(record.$type, 'user', '$type is accessible');
+    assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+    assert.deepEqual(
+      record.address,
+      {
+        street: '123 Main Street',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      },
+      'We have the correct address object'
+    );
+    record.address = null;
+    assert.strictEqual(record.address, null, 'The object is correctly set to null');
+    // test that the data entered the cache properly
+    const identifier = recordIdentifierFor(record);
+    const cachedResourceData = store.cache.peek(identifier);
+    assert.deepEqual(cachedResourceData?.attributes?.address, null, 'the cache values are correctly updated');
+    record.address = {
+      street: '123 Main Street',
+      city: 'Anytown',
+      state: 'NY',
+      zip: '12345',
+    };
+    assert.deepEqual(
+      record.address,
+      {
+        street: '123 Main Street',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      },
+      'We have the correct address object'
+    );
+  });
+
+  test('we can update a single value in the object', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+    schema.registerResource({
+      identity: null,
+      type: 'address',
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+        {
+          name: 'state',
+          kind: 'field',
+        },
+        {
+          name: 'zip',
+          kind: 'field',
+        },
+      ],
+    });
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+          {
+            name: 'address',
+            kind: 'schema-object',
+            type: 'address',
+          },
+        ],
+      })
+    );
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Rey Pupatine',
+          address: { street: '123 Main Street', city: 'Anytown', state: 'NY', zip: '12345' },
+        },
+      },
+    });
+    assert.deepEqual(
+      record.address,
+      {
+        street: '123 Main Street',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      },
+      'We have the correct address object'
+    );
+    const address = record.address;
+    record.address!.state = 'NJ';
+    assert.deepEqual(
+      record.address,
+      {
+        street: '123 Main Street',
+        city: 'Anytown',
+        state: 'NJ',
+        zip: '12345',
+      },
+      'We have the correct address object'
+    );
+    assert.strictEqual(address, record.address, 'Object reference does not change');
+    // test that the data entered the cache properly
+    const identifier = recordIdentifierFor(record);
+    const cachedResourceData = store.cache.peek(identifier);
+    assert.deepEqual(
+      cachedResourceData?.attributes?.address,
+      { street: '123 Main Street', city: 'Anytown', state: 'NJ', zip: '12345' },
+      'the cache values are correctly updated'
+    );
+  });
+
+  test('we can assign an object value to another record', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+    schema.registerResource({
+      identity: null,
+      type: 'address',
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+        {
+          name: 'state',
+          kind: 'field',
+        },
+        {
+          name: 'zip',
+          kind: 'field',
+        },
+      ],
+    });
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+          {
+            name: 'address',
+            kind: 'schema-object',
+            type: 'address',
+          },
+        ],
+      })
+    );
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Rey Pupatine',
+          address: {
+            street: '123 Main Street',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+        },
+      },
+    });
+    const record2 = store.push<User>({
+      data: {
+        type: 'user',
+        id: '2',
+        attributes: { name: 'Luke Skybarker' },
+      },
+    });
+    assert.strictEqual(record.id, '1', 'id is accessible');
+    assert.strictEqual(record.$type, 'user', '$type is accessible');
+    assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+    assert.strictEqual(record2.id, '2', 'id is accessible');
+    assert.strictEqual(record2.$type, 'user', '$type is accessible');
+    assert.strictEqual(record2.name, 'Luke Skybarker', 'name is accessible');
+    assert.deepEqual(
+      record.address,
+      {
+        street: '123 Main Street',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      },
+      'We have the correct address object'
+    );
+    assert.strictEqual(record.address, record.address, 'We have a stable object reference');
+    const address = record.address;
+    record2.address = record.address;
+    assert.deepEqual(
+      record2.address,
+      {
+        street: '123 Main Street',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      },
+      'We have the correct address object'
+    );
+
+    assert.strictEqual(address, record.address, 'Object reference does not change');
+    assert.notStrictEqual(address, record2.address, 'We have a new object reference');
+    // test that the data entered the cache properly
+    const identifier = recordIdentifierFor(record2);
+    const cachedResourceData = store.cache.peek(identifier);
+    assert.deepEqual(
+      cachedResourceData?.attributes?.address,
+      {
+        street: '123 Main Street',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      },
+      'the cache values are correctly updated'
+    );
+  });
+
+  test('throws errors when trying to set non-schema fields', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+    schema.registerResource({
+      identity: null,
+      type: 'address',
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+        {
+          name: 'state',
+          kind: 'field',
+        },
+        {
+          name: 'zip',
+          kind: 'field',
+        },
+      ],
+    });
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+          {
+            name: 'address',
+            kind: 'schema-object',
+            type: 'address',
+          },
+        ],
+      })
+    );
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Rey Pupatine',
+          address: {
+            street: '123 Main Street',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+        },
+      },
+    });
+    assert.strictEqual(record.id, '1', 'id is accessible');
+    assert.strictEqual(record.$type, 'user', '$type is accessible');
+    assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+    assert.deepEqual(
+      record.address,
+      {
+        street: '123 Main Street',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      },
+      'We have the correct address object'
+    );
+    assert.strictEqual(record.address, record.address, 'We have a stable object reference');
+    assert.throws(() => {
+      //@ts-expect-error
+      record.address!.notAField = 'This should throw';
+    }, /Field notAField does not exist on schema object address/);
+    assert.throws(() => {
+      record.address = {
+        street: '456 Elm Street',
+        city: 'Sometown',
+        state: 'NJ',
+        zip: '23456',
+        //@ts-expect-error
+        notAField: 'This should throw',
+      };
+    }, /Field notAField does not exist on schema object address/);
+  });
+});


### PR DESCRIPTION
## Description

Implements schema-object features in keeping with definitions in the [Schema Service RFC](https://github.com/emberjs/rfcs/pull/1027).

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


