### PR TITLE
Fix exports for 'ember-data'

### DIFF
--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -54,6 +54,9 @@
       "types": "./unstable-preview-types/test-support/index.d.ts",
       "default": "./dist/test-support/index.js"
     },
+    "./app/*": {
+      "default": "./app/*.js"
+    },
     "./*": {
       "types": "./unstable-preview-types/*.d.ts",
       "default": "./dist/*.js"


### PR DESCRIPTION
Context https://x.com/nullvoxpopuli/status/1798383255718416516

![image](https://github.com/emberjs/data/assets/199018/a9901c78-2bd0-4339-a13a-99007bc48540)


I'm using a patch here: https://github.com/NullVoxPopuli/ember-warpdrive-demo-starwars-api/blob/main/patches/ember-data%405.4.0-alpha.74.patch
