### PR TITLE
fix: code snippet in json-api/request api docs

### DIFF
--- a/packages/json-api/src/request.ts
+++ b/packages/json-api/src/request.ts
@@ -31,8 +31,8 @@ import { findRecord } from '@ember-data/json-api/request';
 
 const options = findRecord('ember-developer', '1', { include: ['pets', 'friends'] });
 
-/\*
-  => {
+/*
+  {
     url: 'https://api.example.com/v1/ember-developers/1?include=friends,pets',
     method: 'GET',
     headers: <Headers>,
@@ -41,7 +41,7 @@ const options = findRecord('ember-developer', '1', { include: ['pets', 'friends'
     op: 'findRecord';
     records: [{ type: 'ember-developer', id: '1' }]
   }
-*\/
+*\
 ```
 
 Request builder output may be used with either `requestManager.request` or `store.request`.


### PR DESCRIPTION
## Description
In the JSON API request documentation, there's an issue with a code snippet. The snippet is intended to be displayed as a comment, but it instead shows up with unwanted characters.

resolves: 
<img width="783" alt="Screenshot 2024-06-10 at 11 14 11 PM" src="https://github.com/emberjs/data/assets/55375534/91c1bfa8-f5a4-4d6c-9969-07040056e2fb">



## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


