### PR TITLE
Improve query types for legacy-compat/builders

### DIFF
--- a/packages/legacy-compat/src/builders/find-all.ts
+++ b/packages/legacy-compat/src/builders/find-all.ts
@@ -19,7 +19,7 @@ type FindAllRequestInput<T extends string = string, RT = unknown[]> = StoreReque
   [RequestSignature]?: RT;
 };
 
-type FindAllBuilderOptions = FindAllOptions;
+type FindAllBuilderOptions<T = unknown> = FindAllOptions<T>;
 
 /**
   This function builds a request config to perform a `findAll` request for the given type.
@@ -42,7 +42,7 @@ type FindAllBuilderOptions = FindAllOptions;
 */
 export function findAllBuilder<T extends TypedRecordInstance>(
   type: TypeFromInstance<T>,
-  options?: FindAllBuilderOptions
+  options?: FindAllBuilderOptions<T>
 ): FindAllRequestInput<TypeFromInstance<T>, T[]>;
 export function findAllBuilder(type: string, options?: FindAllBuilderOptions): FindAllRequestInput;
 export function findAllBuilder(type: string, options: FindAllBuilderOptions = {}): FindAllRequestInput {

--- a/packages/legacy-compat/src/builders/find-record.ts
+++ b/packages/legacy-compat/src/builders/find-record.ts
@@ -55,21 +55,17 @@ type FindRecordBuilderOptions = Omit<FindRecordOptions, 'preload'>;
   @public
   @static
   @for @ember-data/legacy-compat/builders
-  @param {string|object} type - either a string representing the name of the resource or a ResourceIdentifier object containing both the type (a string) and the id (a string) for the record or an lid (a string) of an existing record
+  @param {string|object} resource - either a string representing the name of the resource or a ResourceIdentifier object containing both the type (a string) and the id (a string) for the record or an lid (a string) of an existing record
   @param {string|number|object} id - optional object with options for the request only if the first param is a ResourceIdentifier, else the string id of the record to be retrieved
   @param {FindRecordBuilderOptions} [options] - if the first param is a string this will be the optional options for the request. See examples for available options.
   @return {FindRecordRequestInput} request config
 */
 export function findRecordBuilder<T extends TypedRecordInstance>(
-  resource: TypeFromInstance<T>,
+  type: TypeFromInstance<T>,
   id: string,
   options?: FindRecordBuilderOptions
 ): FindRecordRequestInput<TypeFromInstance<T>, T>;
-export function findRecordBuilder(
-  resource: string,
-  id: string,
-  options?: FindRecordBuilderOptions
-): FindRecordRequestInput;
+export function findRecordBuilder(type: string, id: string, options?: FindRecordBuilderOptions): FindRecordRequestInput;
 export function findRecordBuilder<T extends TypedRecordInstance>(
   resource: ResourceIdentifierObject<TypeFromInstance<T>>,
   options?: FindRecordBuilderOptions

--- a/packages/legacy-compat/src/builders/query.ts
+++ b/packages/legacy-compat/src/builders/query.ts
@@ -2,7 +2,7 @@
  * @module @ember-data/legacy-compat/builders
  */
 import type { StoreRequestInput } from '@ember-data/store';
-import type { QueryOptions } from '@ember-data/store/types';
+import type { LegacyResourceQuery, QueryOptions } from '@ember-data/store/types';
 import { assert } from '@warp-drive/build-config/macros';
 import type { TypedRecordInstance, TypeFromInstance } from '@warp-drive/core-types/record';
 import { SkipCache } from '@warp-drive/core-types/request';
@@ -14,7 +14,7 @@ type QueryRequestInput<T extends string = string, RT = unknown[]> = StoreRequest
   op: 'query';
   data: {
     type: T;
-    query: Record<string, unknown>;
+    query: LegacyResourceQuery;
     options: QueryBuilderOptions;
   };
   [RequestSignature]?: RT;
@@ -43,17 +43,17 @@ type QueryBuilderOptions = QueryOptions;
 */
 export function queryBuilder<T extends TypedRecordInstance>(
   type: TypeFromInstance<T>,
-  query: Record<string, unknown>,
+  query: LegacyResourceQuery<T>,
   options?: QueryBuilderOptions
 ): QueryRequestInput<TypeFromInstance<T>, T[]>;
 export function queryBuilder(
   type: string,
-  query: Record<string, unknown>,
+  query: LegacyResourceQuery,
   options?: QueryBuilderOptions
 ): QueryRequestInput;
 export function queryBuilder(
   type: string,
-  query: Record<string, unknown>,
+  query: LegacyResourceQuery,
   options: QueryBuilderOptions = {}
 ): QueryRequestInput {
   assert(`You need to pass a model name to the query builder`, type);
@@ -78,7 +78,7 @@ type QueryRecordRequestInput<T extends string = string, RT = unknown> = StoreReq
   op: 'queryRecord';
   data: {
     type: T;
-    query: Record<string, unknown>;
+    query: LegacyResourceQuery;
     options: QueryBuilderOptions;
   };
   [RequestSignature]?: RT;
@@ -105,17 +105,17 @@ type QueryRecordRequestInput<T extends string = string, RT = unknown> = StoreReq
 */
 export function queryRecordBuilder<T extends TypedRecordInstance>(
   type: TypeFromInstance<T>,
-  query: Record<string, unknown>,
+  query: LegacyResourceQuery<T>,
   options?: QueryBuilderOptions
 ): QueryRecordRequestInput<TypeFromInstance<T>, T | null>;
 export function queryRecordBuilder(
   type: string,
-  query: Record<string, unknown>,
+  query: LegacyResourceQuery,
   options?: QueryBuilderOptions
 ): QueryRecordRequestInput;
 export function queryRecordBuilder(
   type: string,
-  query: Record<string, unknown>,
+  query: LegacyResourceQuery,
   options?: QueryBuilderOptions
 ): QueryRecordRequestInput {
   assert(`You need to pass a model name to the queryRecord builder`, type);

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -1,4 +1,10 @@
 export type { CacheCapabilitiesManager } from './-types/q/cache-capabilities-manager';
 export type { ModelSchema } from './-types/q/ds-model';
 export type { SchemaService } from './-types/q/schema-service';
-export type { BaseFinderOptions, FindRecordOptions, QueryOptions, FindAllOptions } from './-types/q/store';
+export type {
+  BaseFinderOptions,
+  FindRecordOptions,
+  LegacyResourceQuery,
+  QueryOptions,
+  FindAllOptions,
+} from './-types/q/store';


### PR DESCRIPTION
## Description

Pulls legacy store method type improvements from https://github.com/emberjs/data/pull/9387 into the legacy-compat/builders, which should accept the same params.

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


