### PR TITLE
Use vite's built-in package.json loading to inline names and versions

### DIFF
--- a/packages/-ember-data/addon-main.cjs
+++ b/packages/-ember-data/addon-main.cjs
@@ -3,12 +3,7 @@
 const { addonShim } = require('@warp-drive/build-config/addon-shim.cjs');
 
 const addon = addonShim(__dirname);
-addon.options = addon.options || {};
-addon.options['@embroider/macros'] = addon.options['@embroider/macros'] || {};
 const pkg = require('./package.json');
-addon.options['@embroider/macros'].setOwnConfig = {
-  VERSION: pkg.version,
-};
 if (pkg['ember-addon'].version === 1) {
   delete addon.treeForApp;
 }

--- a/packages/-ember-data/src/version.ts
+++ b/packages/-ember-data/src/version.ts
@@ -1,4 +1,1 @@
-import { getOwnConfig } from '@embroider/macros';
-
-const VERSION = getOwnConfig<{ VERSION: string }>().VERSION;
-export default VERSION;
+export { version as default } from '../package.json';

--- a/packages/core-types/addon-main.cjs
+++ b/packages/core-types/addon-main.cjs
@@ -1,13 +1,4 @@
 'use strict';
 
 const { addonShim } = require('@warp-drive/build-config/addon-shim.cjs');
-const { version, name } = require('./package.json');
-
-const addon = addonShim(__dirname);
-addon.options = addon.options || {};
-addon.options['@embroider/macros'] = addon.options['@embroider/macros'] || {};
-addon.options['@embroider/macros'].setOwnConfig = {
-  PKG: { name, version },
-};
-
-module.exports = addon;
+module.exports = addonShim(__dirname);

--- a/packages/core-types/src/-private.ts
+++ b/packages/core-types/src/-private.ts
@@ -1,8 +1,8 @@
 // in testing mode, we utilize globals to ensure only one copy exists of
 // these maps, due to bugs in ember-auto-import
-import { getOwnConfig } from '@embroider/macros';
-
 import { DEBUG, TESTING } from '@warp-drive/build-config/env';
+
+import { name, version } from '../package.json';
 
 type UniversalTransientKey =
   // @ember-data/request
@@ -118,12 +118,11 @@ const UniversalCache = (GlobalRef.__warpDrive_universalCache =
 
 // in order to support mirror packages, we ensure that each
 // unique package name has its own global cache
-const PkgInfo = getOwnConfig<{ PKG: { name: string; version: string } }>().PKG;
-GlobalRef[PkgInfo.name] = GlobalRef[PkgInfo.name] ?? { __version: PkgInfo.version };
-const GlobalSink = GlobalRef[PkgInfo.name];
+GlobalRef[name] = GlobalRef[name] ?? { __version: version };
+const GlobalSink = GlobalRef[name];
 
 if (DEBUG) {
-  if (GlobalSink.__version !== PkgInfo.version) {
+  if (GlobalSink.__version !== version) {
     throw new Error('Multiple versions of WarpDrive detected, the application will malfunction.');
   }
 }


### PR DESCRIPTION
This eliminates the need for embroider macros to provide packages their own name and version. That is not a good use case for macros, since it can never change post-publication. The prepublication Vite build here has built-in support for reading from package.json.

(Also, this is being motivated  by the fact that addon-main.js in v2 addons in not guaranteed to be run by embroider. It's a classic file that does nothing under our Vite build. Having an alternative that allows apps to manipulate the macros config is planned as a blocker for releasing the vite blueprint.)

This PR is only a WIP, because I suspect the package publication process here needs to change to ensure that `vite build` gets run after each of the mirror package names and/or versions gets set. There's a lot going on in the publication step, so I figured it would be best to just open this for discussion first.



