### PR TITLE
Add @ember/string v4 to peerDependencies

### DIFF
--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -52,7 +52,7 @@
     "version": 2
   },
   "peerDependencies": {
-    "@ember/string": "3.1.1",
+    "@ember/string": "^3.1.1 || ^4.0.0",
     "@warp-drive/core-types": "workspace:0.0.0-alpha.77",
     "ember-inflector": "4.0.2"
   },


### PR DESCRIPTION
## Description

@ember/string v4 was recently published https://github.com/emberjs/ember-string/releases/tag/v4.0.0-%40ember%2Fstring

it's not possible to upgrade as `@ember-data/store` still requires v3.

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


