### PR TITLE
Allow `@ember/string` v4 as dependency & allow `ember-inflector` v5

### DIFF
--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -52,9 +52,9 @@
     "version": 2
   },
   "peerDependencies": {
-    "@ember/string": "3.1.1",
+    "@ember/string": "^3.1.1 || ^4.0.0",
     "@warp-drive/core-types": "workspace:0.0.0-beta.11",
-    "ember-inflector": "4.0.2"
+    "ember-inflector": "^4.0.2"
   },
   "peerDependenciesMeta": {
     "ember-inflector": {

--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "@ember/string": "^3.1.1 || ^4.0.0",
     "@warp-drive/core-types": "workspace:0.0.0-beta.11",
-    "ember-inflector": "^4.0.2"
+    "ember-inflector": "^4.0.2 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "ember-inflector": {


### PR DESCRIPTION
- Some week ago there was released `@ember/string` v4. We should also allow v4 as peerDependency
- Allow `ember-inflector` v5 as peerDependency