### PR TITLE
[cleanup 4.6] Remove deprecated Ember.Error usage

### DIFF
--- a/packages/-ember-data/tests/unit/adapter-errors-test.js
+++ b/packages/-ember-data/tests/unit/adapter-errors-test.js
@@ -1,5 +1,3 @@
-import EmberError from '@ember/error';
-
 import { module, test } from 'qunit';
 
 import DS from 'ember-data';
@@ -11,7 +9,6 @@ module('unit/adapter-errors - DS.AdapterError', function () {
     let error = new DS.AdapterError();
 
     assert.ok(error instanceof Error);
-    assert.ok(error instanceof EmberError);
     assert.ok(error.isAdapterError);
     assert.strictEqual(error.message, 'Adapter operation failed');
   });

--- a/packages/adapter/addon/error.js
+++ b/packages/adapter/addon/error.js
@@ -2,7 +2,6 @@
   @module @ember-data/adapter/error
  */
 import { assert } from '@ember/debug';
-import EmberError from '@ember/error';
 
 /**
   A `AdapterError` is used by an adapter to signal that an error occurred
@@ -74,7 +73,7 @@ import EmberError from '@ember/error';
 */
 function AdapterError(errors, message = 'Adapter operation failed') {
   this.isAdapterError = true;
-  let error = EmberError.call(this, message);
+  let error = Error.call(this, message);
 
   // in ember 3.8+ Error is a Native Error and we don't
   // gain these automatically from the EmberError.call
@@ -115,7 +114,7 @@ function extend(ParentErrorClass, defaultMessage) {
   return ErrorClass;
 }
 
-AdapterError.prototype = Object.create(EmberError.prototype);
+AdapterError.prototype = Object.create(Error.prototype);
 AdapterError.prototype.code = 'AdapterError';
 AdapterError.extend = extendFn(AdapterError);
 

--- a/packages/model/addon/-private/model.js
+++ b/packages/model/addon/-private/model.js
@@ -3,7 +3,6 @@
  */
 
 import { assert, warn } from '@ember/debug';
-import EmberError from '@ember/error';
 import EmberObject, { get } from '@ember/object';
 import { dependentKeyCompat } from '@ember/object/compat';
 import { run } from '@ember/runloop';
@@ -125,7 +124,7 @@ class Model extends EmberObject {
 
   init(options = {}) {
     if (DEBUG && !options._secretInit && !options._internalModel && !options._createProps) {
-      throw new EmberError(
+      throw new Error(
         'You should not call `create` on a model. Instead, call `store.createRecord` with the attributes you would like to set.'
       );
     }
@@ -2105,7 +2104,7 @@ if (DEBUG) {
       let idDesc = lookupDescriptor(this, 'id');
 
       if (idDesc.get !== ID_DESCRIPTOR.get) {
-        throw new EmberError(
+        throw new Error(
           `You may not set 'id' as an attribute on your model. Please remove any lines that look like: \`id: attr('<type>')\` from ${this.constructor.toString()}`
         );
       }

--- a/packages/model/index.js
+++ b/packages/model/index.js
@@ -24,7 +24,6 @@ module.exports = Object.assign({}, addonBaseConfig, {
       '@ember/array/mutable',
       '@ember/array/proxy',
       '@ember/debug',
-      '@ember/error',
       '@ember/object',
       '@ember/object/compat',
       '@ember/object/computed',

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -19,7 +19,6 @@ module.exports = Object.assign({}, addonBaseConfig, {
       '@ember/array/proxy',
       '@ember/array',
       '@ember/debug',
-      '@ember/error',
       '@ember/object',
       '@ember/object/computed',
       '@ember/object/evented',


### PR DESCRIPTION
## Description

Essentially a port of https://github.com/emberjs/data/pull/8412 to the 4.6 branch. Removes usage of `@ember/error` package which has been deprecated/removed from Ember.

## Notes for the release

Improves compatibility with future Ember.js versions by removing deprecated/removed `@ember/error` usage.


