### PR TITLE
fix: Doc for query.ts

### DIFF
--- a/packages/rest/src/-private/builders/query.ts
+++ b/packages/rest/src/-private/builders/query.ts
@@ -43,7 +43,7 @@ import { copyForwardUrlOptions, extractCacheOptions } from './-utils';
  * - `backgroundReload` - Whether to reload the request if it is already in the store, but to also resolve the
  *      promise with the cached value, not supplying this option will delegate to the store's CachePolicy,
  *      defaulting to `false` if none is configured.
- * - `urlParamsSetting` - an object containing options for how to serialize the query params (see `buildQueryParams`)
+ * - `urlParamsSettings` - an object containing options for how to serialize the query params (see `buildQueryParams`)
  *
  * ```ts
  * import { query } from '@ember-data/rest/request';


### PR DESCRIPTION
## Description

Previously it was suggested that one of the parameters is `urlParamsSetting` (singular), but [looking at this line](https://github.com/emberjs/data/blob/eb9e8a9213d1dc74a132c36646929974d7acc742/packages/rest/src/-private/builders/query.ts#L93) (and experimenting with my code) I concluded that it should be `urlParamsSettings` (plural).
