### PR TITLE
fix: ensure SchemaRecord immutability

### DIFF
--- a/packages/schema-record/src/hooks.ts
+++ b/packages/schema-record/src/hooks.ts
@@ -12,7 +12,7 @@ export function instantiateRecord(
 ): SchemaRecord {
   const schema = store.schema as unknown as SchemaService;
   const isLegacy = schema.resource(identifier)?.legacy ?? false;
-  const isEditable = isLegacy || Boolean(createArgs);
+  const isEditable = isLegacy || store.cache.isNew(identifier);
   const record = new SchemaRecord(store, identifier, {
     [Editable]: isEditable,
     [Legacy]: isLegacy,

--- a/packages/schema-record/src/record.ts
+++ b/packages/schema-record/src/record.ts
@@ -335,7 +335,8 @@ export class SchemaRecord {
       },
       set(target: SchemaRecord, prop: string | number | symbol, value: unknown, receiver: typeof Proxy<SchemaRecord>) {
         if (!IS_EDITABLE) {
-          throw new Error(`Cannot set ${String(prop)} on ${identifier.type} because the record is not editable`);
+          const type = isEmbedded ? embeddedType : identifier.type;
+          throw new Error(`Cannot set ${String(prop)} on ${type} because the record is not editable`);
         }
 
         const maybeField = prop === identityField?.name ? identityField : fields.get(prop as string);

--- a/packages/schema-record/src/record.ts
+++ b/packages/schema-record/src/record.ts
@@ -3,6 +3,7 @@ import { dependencySatisfies, importSync, macroCondition } from '@embroider/macr
 import type { MinimalLegacyRecord } from '@ember-data/model/-private/model-methods';
 import type Store from '@ember-data/store';
 import type { NotificationType } from '@ember-data/store';
+import { recordIdentifierFor, setRecordIdentifier } from '@ember-data/store/-private';
 import { addToTransaction, entangleSignal, getSignal, type Signal, Signals } from '@ember-data/tracking/-private';
 import { assert } from '@warp-drive/build-config/macros';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
@@ -680,7 +681,7 @@ export class SchemaRecord {
       embeddedType,
       embeddedPath
     );
-
+    setRecordIdentifier(editableRecord, recordIdentifierFor(this));
     return Promise.resolve(editableRecord);
   }
 }

--- a/tests/warp-drive__schema-record/tests/writes/array-test.ts
+++ b/tests/warp-drive__schema-record/tests/writes/array-test.ts
@@ -65,6 +65,7 @@ module('Writes | array fields', function (hooks) {
         attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
       },
     });
+
     const record = await immutableRecord[Checkout]();
 
     assert.strictEqual(record.id, '1', 'id is accessible');

--- a/tests/warp-drive__schema-record/tests/writes/array-test.ts
+++ b/tests/warp-drive__schema-record/tests/writes/array-test.ts
@@ -4,18 +4,28 @@ import { setupTest } from 'ember-qunit';
 
 import { recordIdentifierFor } from '@ember-data/store';
 import { Type } from '@warp-drive/core-types/symbols';
+import { Checkout } from '@warp-drive/schema-record/record';
 import type { Transformation } from '@warp-drive/schema-record/schema';
 import { registerDerivations, withDefaults } from '@warp-drive/schema-record/schema';
 
 import type Store from 'warp-drive__schema-record/services/store';
 
-interface User {
+type EditableUser = {
+  readonly id: string;
+  readonly $type: 'user';
+  name: string;
+  favoriteNumbers: string[] | null;
+  readonly [Type]: 'user';
+};
+
+type User = Readonly<{
   id: string;
   $type: 'user';
   name: string;
   favoriteNumbers: string[] | null;
   [Type]: 'user';
-}
+  [Checkout](): Promise<EditableUser>;
+}>;
 interface CreateUserType {
   id: string | null;
   $type: 'user';
@@ -27,7 +37,7 @@ interface CreateUserType {
 module('Writes | array fields', function (hooks) {
   setupTest(hooks);
 
-  test('we can update to a new array', function (assert) {
+  test('we can update to a new array', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -48,13 +58,14 @@ module('Writes | array fields', function (hooks) {
       })
     );
 
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
         attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
       },
     });
+    const record = await immutableRecord[Checkout]();
 
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
@@ -78,7 +89,7 @@ module('Writes | array fields', function (hooks) {
     );
   });
 
-  test('we can update to null', function (assert) {
+  test('we can update to null', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -99,13 +110,14 @@ module('Writes | array fields', function (hooks) {
       })
     );
 
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
         attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
       },
     });
+    const record = await immutableRecord[Checkout]();
 
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
@@ -129,7 +141,7 @@ module('Writes | array fields', function (hooks) {
     assert.deepEqual(record.favoriteNumbers.slice(), ['3', '4'], 'We have the correct array members');
   });
 
-  test('we can update a single value in the array', function (assert) {
+  test('we can update a single value in the array', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -150,13 +162,14 @@ module('Writes | array fields', function (hooks) {
       })
     );
 
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
         attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
       },
     });
+    const record = await immutableRecord[Checkout]();
 
     assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
     const favoriteNumbers = record.favoriteNumbers;
@@ -175,7 +188,7 @@ module('Writes | array fields', function (hooks) {
     );
   });
 
-  test('we can push a new value on to the array', function (assert) {
+  test('we can push a new value on to the array', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -196,13 +209,14 @@ module('Writes | array fields', function (hooks) {
       })
     );
 
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
         attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
       },
     });
+    const record = await immutableRecord[Checkout]();
 
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
@@ -226,7 +240,7 @@ module('Writes | array fields', function (hooks) {
     );
   });
 
-  test('we can pop a value off of the array', function (assert) {
+  test('we can pop a value off of the array', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -247,13 +261,14 @@ module('Writes | array fields', function (hooks) {
       })
     );
 
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
         attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
       },
     });
+    const record = await immutableRecord[Checkout]();
 
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
@@ -274,7 +289,7 @@ module('Writes | array fields', function (hooks) {
     assert.deepEqual(cachedResourceData?.attributes?.favoriteNumbers, ['1'], 'the cache values are correctly updated');
   });
 
-  test('we can unshift a value on to the array', function (assert) {
+  test('we can unshift a value on to the array', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -295,13 +310,14 @@ module('Writes | array fields', function (hooks) {
       })
     );
 
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
         attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
       },
     });
+    const record = await immutableRecord[Checkout]();
 
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
@@ -325,7 +341,7 @@ module('Writes | array fields', function (hooks) {
     );
   });
 
-  test('we can shift a value off of the array', function (assert) {
+  test('we can shift a value off of the array', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -346,13 +362,14 @@ module('Writes | array fields', function (hooks) {
       })
     );
 
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
         attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
       },
     });
+    const record = await immutableRecord[Checkout]();
 
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
@@ -373,7 +390,7 @@ module('Writes | array fields', function (hooks) {
     assert.deepEqual(cachedResourceData?.attributes?.favoriteNumbers, ['2'], 'the cache values are correctly updated');
   });
 
-  test('we can assign an array value to another record', function (assert) {
+  test('we can assign an array value to another record', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -402,13 +419,14 @@ module('Writes | array fields', function (hooks) {
       },
     });
 
-    const record2 = store.push<User>({
+    const record2Immutable = store.push<User>({
       data: {
         type: 'user',
         id: '2',
         attributes: { name: 'Luke Skybarker' },
       },
     });
+    const record2 = await record2Immutable[Checkout]();
 
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');

--- a/tests/warp-drive__schema-record/tests/writes/array-test.ts
+++ b/tests/warp-drive__schema-record/tests/writes/array-test.ts
@@ -37,6 +37,591 @@ interface CreateUserType {
 module('Writes | array fields', function (hooks) {
   setupTest(hooks);
 
+  module('Immutability', function () {
+    test('we cannot update to a new array', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+      assert.throws(() => {
+        // @ts-expect-error we're testing the immutability of the array
+        record.favoriteNumbers = ['3', '4'];
+      }, /Error: Cannot set favoriteNumbers on user because the record is not editable/);
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+    });
+
+    test('we cannot update to null', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+      assert.throws(() => {
+        // @ts-expect-error we're testing the immutability of the array
+        record.favoriteNumbers = null;
+      }, /Error: Cannot set favoriteNumbers on user because the record is not editable/);
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+    });
+
+    test('we cannot update a single value in the array', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
+        },
+      });
+
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+      assert.throws(() => {
+        record.favoriteNumbers![0] = '3';
+      }, /Error: Cannot set 0 on favoriteNumbers because the record is not editable/);
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+    });
+
+    test('we cannot push a new value on to the array', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+      assert.throws(() => {
+        record.favoriteNumbers?.push('3');
+      }, /Error: Mutating this array via push is not allowed because the record is not editable/);
+
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+    });
+
+    test('we cannot pop a value off of the array', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+      assert.throws(() => {
+        record.favoriteNumbers?.pop();
+      }, /Error: Mutating this array via pop is not allowed because the record is not editable/);
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+    });
+
+    test('we cannot unshift a value on to the array', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+      assert.throws(() => {
+        record.favoriteNumbers?.unshift('3');
+      }, /Error: Mutating this array via unshift is not allowed because the record is not editable/);
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+    });
+
+    test('we cannot shift a value off of the array', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+      assert.throws(() => {
+        record.favoriteNumbers?.shift();
+      }, /Error: Mutating this array via shift is not allowed because the record is not editable/);
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+    });
+
+    test('we cannot assign an array value to another record', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Pupatine', favoriteNumbers: ['1', '2'] },
+        },
+      });
+
+      const record2 = store.push<User>({
+        data: {
+          type: 'user',
+          id: '2',
+          attributes: { name: 'Luke Skybarker' },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.strictEqual(record2.id, '2', 'id is accessible');
+      assert.strictEqual(record2.$type, 'user', '$type is accessible');
+      assert.strictEqual(record2.name, 'Luke Skybarker', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+      assert.throws(() => {
+        // @ts-expect-error we're testing the immutability of the array
+        record2.favoriteNumbers = record.favoriteNumbers;
+      }, /Error: Cannot set favoriteNumbers on user because the record is not editable/);
+
+      assert.strictEqual(record2.favoriteNumbers, null, 'the second record array has not been updated');
+    });
+
+    test('we cannot edit simple array fields with a `type`', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              type: 'string-from-int',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const StringFromIntTransform: Transformation<number, string> = {
+        serialize(value: string, options, _record): number {
+          return parseInt(value);
+        },
+        hydrate(value: number, _options, _record): string {
+          return value.toString();
+        },
+        defaultValue(_options, _identifier) {
+          assert.ok(false, 'unexpected defaultValue');
+          throw new Error('unexpected defaultValue');
+        },
+        [Type]: 'string-from-int',
+      };
+
+      schema.registerTransformation(StringFromIntTransform);
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Skybarker', favoriteNumbers: [1, 2] },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers!.slice(), ['1', '2'], 'We have the correct array members');
+
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+
+      assert.throws(() => {
+        // @ts-expect-error we're testing the immutability of the array
+        record.favoriteNumbers = ['3', '4'];
+      }, /Error: Cannot set favoriteNumbers on user because the record is not editable/);
+
+      assert.deepEqual(record.favoriteNumbers!.slice(), ['1', '2'], 'We have the correct array members');
+    });
+
+    test('we cannot edit single values in array fields with a `type`', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              type: 'string-from-int',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const StringFromIntTransform: Transformation<number, string> = {
+        serialize(value: string, options, _record): number {
+          return parseInt(value);
+        },
+        hydrate(value: number, _options, _record): string {
+          return value.toString();
+        },
+        defaultValue(_options, _identifier) {
+          assert.ok(false, 'unexpected defaultValue');
+          throw new Error('unexpected defaultValue');
+        },
+        [Type]: 'string-from-int',
+      };
+
+      schema.registerTransformation(StringFromIntTransform);
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Skybarker', favoriteNumbers: [1, 2] },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+
+      assert.throws(() => {
+        record.favoriteNumbers![0] = '3';
+      }, /Error: Cannot set 0 on favoriteNumbers because the record is not editable/);
+
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+    });
+
+    test('we cannot push a new value on to array fields with a `type`', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              type: 'string-from-int',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const StringFromIntTransform: Transformation<number, string> = {
+        serialize(value: string, options, _record): number {
+          return parseInt(value);
+        },
+        hydrate(value: number, _options, _record): string {
+          return value.toString();
+        },
+        defaultValue(_options, _identifier) {
+          assert.ok(false, 'unexpected defaultValue');
+          throw new Error('unexpected defaultValue');
+        },
+        [Type]: 'string-from-int',
+      };
+
+      schema.registerTransformation(StringFromIntTransform);
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Skybarker', favoriteNumbers: [1, 2] },
+        },
+      });
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+
+      assert.throws(() => {
+        record.favoriteNumbers?.push('3');
+      }, /Error: Mutating this array via push is not allowed because the record is not editable/);
+
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+    });
+
+    test('we can pop a value off of an array fields with a `type`', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'favoriteNumbers',
+              type: 'string-from-int',
+              kind: 'array',
+            },
+          ],
+        })
+      );
+
+      const StringFromIntTransform: Transformation<number, string> = {
+        serialize(value: string, options, _record): number {
+          return parseInt(value);
+        },
+        hydrate(value: number, _options, _record): string {
+          return value.toString();
+        },
+        defaultValue(_options, _identifier) {
+          assert.ok(false, 'unexpected defaultValue');
+          throw new Error('unexpected defaultValue');
+        },
+        [Type]: 'string-from-int',
+      };
+
+      schema.registerTransformation(StringFromIntTransform);
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: { name: 'Rey Skybarker', favoriteNumbers: [1, 2] },
+        },
+      });
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.true(Array.isArray(record.favoriteNumbers), 'we can access favoriteNumber array');
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+
+      assert.strictEqual(record.favoriteNumbers, record.favoriteNumbers, 'We have a stable array reference');
+
+      assert.throws(() => {
+        record.favoriteNumbers?.pop();
+      }, /Error: Mutating this array via pop is not allowed because the record is not editable/);
+
+      assert.deepEqual(record.favoriteNumbers?.slice(), ['1', '2'], 'We have the correct array members');
+    });
+  });
+
+  // Editable tests
   test('we can update to a new array', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;

--- a/tests/warp-drive__schema-record/tests/writes/object-test.ts
+++ b/tests/warp-drive__schema-record/tests/writes/object-test.ts
@@ -46,6 +46,447 @@ interface CreateUserType {
 module('Writes | object fields', function (hooks) {
   setupTest(hooks);
 
+  module('Immutability', function () {
+    test('we cannot update to a new object', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              kind: 'object',
+            },
+          ],
+        })
+      );
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Pupatine',
+            address: {
+              street: '123 Main Street',
+              city: 'Anytown',
+              state: 'NY',
+              zip: '12345',
+            },
+          },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.deepEqual(
+        record.address,
+        { street: '123 Main Street', city: 'Anytown', state: 'NY', zip: '12345' },
+        'We have the correct address object'
+      );
+      assert.throws(() => {
+        // @ts-expect-error we're testing the immutability of the object
+        record.address = { street: '456 Elm Street', city: 'Sometown', state: 'NJ', zip: '23456' };
+      }, /Error: Cannot set address on user because the record is not editable/);
+
+      assert.deepEqual(
+        record.address,
+        { street: '123 Main Street', city: 'Anytown', state: 'NY', zip: '12345' },
+        'We have the correct address object'
+      );
+    });
+
+    test('we cannot update to null', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              kind: 'object',
+            },
+          ],
+        })
+      );
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Pupatine',
+            address: {
+              street: '123 Main Street',
+              city: 'Anytown',
+              state: 'NY',
+              zip: '12345',
+            },
+          },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.deepEqual(
+        record.address,
+        {
+          street: '123 Main Street',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct address object'
+      );
+      assert.throws(() => {
+        // @ts-expect-error we're testing the immutability of the object
+        record.address = null;
+      }, /Error: Cannot set address on user because the record is not editable/);
+
+      assert.deepEqual(
+        record.address,
+        {
+          street: '123 Main Street',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct address object'
+      );
+    });
+
+    test('we cannot update a single value in the object', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              kind: 'object',
+            },
+          ],
+        })
+      );
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Pupatine',
+            address: { street: '123 Main Street', city: 'Anytown', state: 'NY', zip: '12345' },
+          },
+        },
+      });
+
+      assert.deepEqual(
+        record.address,
+        {
+          street: '123 Main Street',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct address object'
+      );
+      assert.throws(() => {
+        record.address!.state = 'NJ';
+      }, /Error: Cannot set read-only property 'state' on ManagedObject/);
+      assert.deepEqual(
+        record.address,
+        {
+          street: '123 Main Street',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct address object'
+      );
+    });
+
+    test('we cannot assign an object value to another record', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              kind: 'object',
+            },
+          ],
+        })
+      );
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Pupatine',
+            address: {
+              street: '123 Main Street',
+              city: 'Anytown',
+              state: 'NY',
+              zip: '12345',
+            },
+          },
+        },
+      });
+      const record2 = store.push<User>({
+        data: {
+          type: 'user',
+          id: '2',
+          attributes: { name: 'Luke Skybarker' },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.strictEqual(record2.id, '2', 'id is accessible');
+      assert.strictEqual(record2.$type, 'user', '$type is accessible');
+      assert.strictEqual(record2.name, 'Luke Skybarker', 'name is accessible');
+      assert.deepEqual(
+        record.address,
+        {
+          street: '123 Main Street',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct address object'
+      );
+      assert.strictEqual(record.address, record.address, 'We have a stable object reference');
+      assert.throws(() => {
+        // @ts-expect-error we're testing the immutability of the object
+        record2.address = record.address;
+      }, /Error: Cannot set address on user because the record is not editable/);
+      assert.strictEqual(record2.address, null, 'Record2 address object is not updated');
+    });
+
+    test('we cannot edit simple object fields with a `type`', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              type: 'zip-string-from-int',
+              kind: 'object',
+            },
+          ],
+        })
+      );
+
+      const ZipStringFromIntTransform: Transformation<address, address> = {
+        serialize(value: address, options, _record): address {
+          if (typeof value.zip === 'string') {
+            return {
+              street: value.street,
+              city: value.city,
+              state: value.state,
+              zip: parseInt(value.zip),
+            };
+          }
+          return value;
+        },
+        hydrate(value: address, _options, _record): address {
+          return {
+            street: value.street,
+            city: value.city,
+            state: value.state,
+            zip: value.zip?.toString(),
+          };
+        },
+        defaultValue(_options, _identifier) {
+          assert.ok(false, 'unexpected defaultValue');
+          throw new Error('unexpected defaultValue');
+        },
+        [Type]: 'zip-string-from-int',
+      };
+      schema.registerTransformation(ZipStringFromIntTransform);
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Skybarker',
+            address: {
+              street: '123 Main St',
+              city: 'Anytown',
+              state: 'NY',
+              zip: 12345,
+            },
+          },
+        },
+      });
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.deepEqual(
+        record.address,
+        {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct object members'
+      );
+      assert.strictEqual(record.address, record.address, 'We have a stable object reference');
+      assert.throws(() => {
+        // @ts-expect-error we're testing the immutability of the object
+        record.address = {
+          street: '456 Elm St',
+          city: 'Sometown',
+          state: 'NJ',
+          zip: '23456',
+        };
+      }, /Error: Cannot set address on user because the record is not editable/);
+
+      assert.deepEqual(
+        record.address,
+        {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct object members'
+      );
+    });
+
+    test('we cannot edit single values in object fields with a `type`', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              type: 'zip-string-from-int',
+              kind: 'object',
+            },
+          ],
+        })
+      );
+
+      const ZipStringFromIntTransform: Transformation<address, address> = {
+        serialize(value: address, options, _record): address {
+          if (typeof value.zip === 'string') {
+            return {
+              street: value.street,
+              city: value.city,
+              state: value.state,
+              zip: parseInt(value.zip),
+            };
+          }
+          return value;
+        },
+        hydrate(value: address, _options, _record): address {
+          return {
+            street: value.street,
+            city: value.city,
+            state: value.state,
+            zip: value.zip?.toString(),
+          };
+        },
+        defaultValue(_options, _identifier) {
+          assert.ok(false, 'unexpected defaultValue');
+          throw new Error('unexpected defaultValue');
+        },
+        [Type]: 'zip-string-from-int',
+      };
+      schema.registerTransformation(ZipStringFromIntTransform);
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Skybarker',
+            address: {
+              street: '123 Main St',
+              city: 'Anytown',
+              state: 'NY',
+              zip: 12345,
+            },
+          },
+        },
+      });
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.deepEqual(
+        record.address,
+        {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct object members'
+      );
+      assert.strictEqual(record.address, record.address, 'We have a stable object reference');
+      assert.strictEqual(record.address?.zip, '12345', 'zip is accessible');
+      assert.throws(() => {
+        record.address!.zip = '23456';
+      }, /Error: Cannot set read-only property 'zip' on ManagedObject/);
+
+      assert.deepEqual(
+        record.address,
+        {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct object members'
+      );
+    });
+  });
+
+  // Editable tests
   test('we can update to a new object', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;

--- a/tests/warp-drive__schema-record/tests/writes/schema-array-test.ts
+++ b/tests/warp-drive__schema-record/tests/writes/schema-array-test.ts
@@ -6,6 +6,7 @@ import type Store from '@ember-data/store';
 import { recordIdentifierFor } from '@ember-data/store';
 import type { JsonApiResource } from '@ember-data/store/-types/q/record-data-json-api';
 import type { Type } from '@warp-drive/core-types/symbols';
+import { Checkout } from '@warp-drive/schema-record/record';
 import { registerDerivations, withDefaults } from '@warp-drive/schema-record/schema';
 
 interface address {
@@ -23,9 +24,505 @@ interface CreateUserType {
   [Type]: 'user';
 }
 
+type User = Readonly<{
+  id: string | null;
+  $type: 'user';
+  name: string | null;
+  addresses: Array<address | null> | null;
+  [Type]: 'user';
+  [Checkout](): Promise<EditableUser>;
+}>;
+
+type EditableUser = {
+  readonly id: string | null;
+  readonly $type: 'user';
+  name: string | null;
+  addresses: Array<address | null> | null;
+  readonly [Type]: 'user';
+};
+
 module('Writes | schema-array fields', function (hooks) {
   setupTest(hooks);
 
+  module('Immutability', function () {
+    test('we cannot update to a new array', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource({
+        identity: null,
+        type: 'address',
+        fields: [
+          {
+            name: 'street',
+            kind: 'field',
+          },
+          {
+            name: 'city',
+            kind: 'field',
+          },
+          {
+            name: 'state',
+            kind: 'field',
+          },
+          {
+            name: 'zip',
+            kind: 'field',
+          },
+        ],
+      });
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'addresses',
+              type: 'address',
+              kind: 'schema-array',
+            },
+          ],
+        })
+      );
+
+      const sourceArray = [
+        {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        {
+          street: '456 Elm St',
+          city: 'Othertown',
+          state: 'CA',
+          zip: '54321',
+        },
+      ];
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Skybarker',
+            addresses: sourceArray,
+          },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.true(Array.isArray(record.addresses), 'we can access favoriteNumber array');
+      assert.propContains(
+        record.addresses?.slice(),
+        [
+          {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+          {
+            street: '456 Elm St',
+            city: 'Othertown',
+            state: 'CA',
+            zip: '54321',
+          },
+        ],
+        'We have the correct array members'
+      );
+      assert.throws(() => {
+        // @ts-expect-error we're testing the immutability of the array
+        record.addresses = [
+          {
+            street: '789 Maple St',
+            city: 'Thistown',
+            state: 'TX',
+            zip: '67890',
+          },
+          {
+            street: '012 Oak St',
+            city: 'ThatTown',
+            state: 'FL',
+            zip: '09876',
+          },
+        ];
+      }, /Error: Cannot set addresses on user because the record is not editable/);
+
+      assert.propContains(
+        record.addresses?.slice(),
+        [
+          {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+          {
+            street: '456 Elm St',
+            city: 'Othertown',
+            state: 'CA',
+            zip: '54321',
+          },
+        ],
+        'We have the correct array members'
+      );
+    });
+
+    test('we cannot update individual objects in the array to new objects', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource({
+        identity: null,
+        type: 'address',
+        fields: [
+          {
+            name: 'street',
+            kind: 'field',
+          },
+          {
+            name: 'city',
+            kind: 'field',
+          },
+          {
+            name: 'state',
+            kind: 'field',
+          },
+          {
+            name: 'zip',
+            kind: 'field',
+          },
+        ],
+      });
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'addresses',
+              type: 'address',
+              kind: 'schema-array',
+            },
+          ],
+        })
+      );
+
+      const sourceArray = [
+        {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        {
+          street: '456 Elm St',
+          city: 'Othertown',
+          state: 'CA',
+          zip: '54321',
+        },
+      ];
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Skybarker',
+            addresses: sourceArray,
+          },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.true(Array.isArray(record.addresses), 'we can access favoriteNumber array');
+      assert.propContains(
+        record.addresses?.slice(),
+        [
+          {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+          {
+            street: '456 Elm St',
+            city: 'Othertown',
+            state: 'CA',
+            zip: '54321',
+          },
+        ],
+        'We have the correct array members'
+      );
+      assert.throws(() => {
+        record.addresses![0] = {
+          street: '789 Maple St',
+          city: 'Thistown',
+          state: 'TX',
+          zip: '67890',
+        };
+      }, /Error: Cannot set 0 on addresses because the record is not editable/);
+
+      assert.propContains(
+        record.addresses?.slice(),
+        [
+          {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+          {
+            street: '456 Elm St',
+            city: 'Othertown',
+            state: 'CA',
+            zip: '54321',
+          },
+        ],
+        'We have the correct array members'
+      );
+    });
+
+    test('we cannot update individual objects in the array to null', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource({
+        identity: null,
+        type: 'address',
+        fields: [
+          {
+            name: 'street',
+            kind: 'field',
+          },
+          {
+            name: 'city',
+            kind: 'field',
+          },
+          {
+            name: 'state',
+            kind: 'field',
+          },
+          {
+            name: 'zip',
+            kind: 'field',
+          },
+        ],
+      });
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'addresses',
+              type: 'address',
+              kind: 'schema-array',
+            },
+          ],
+        })
+      );
+
+      const sourceArray = [
+        {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        {
+          street: '456 Elm St',
+          city: 'Othertown',
+          state: 'CA',
+          zip: '54321',
+        },
+      ];
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Skybarker',
+            addresses: sourceArray,
+          },
+        },
+      });
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.true(Array.isArray(record.addresses), 'we can access favoriteNumber array');
+      assert.propContains(
+        record.addresses?.slice(),
+        [
+          {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+          {
+            street: '456 Elm St',
+            city: 'Othertown',
+            state: 'CA',
+            zip: '54321',
+          },
+        ],
+        'We have the correct array members'
+      );
+      assert.throws(() => {
+        record.addresses![0] = null;
+      }, /Error: Cannot set 0 on addresses because the record is not editable/);
+
+      assert.propContains(
+        record.addresses?.slice(),
+        [
+          {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+          {
+            street: '456 Elm St',
+            city: 'Othertown',
+            state: 'CA',
+            zip: '54321',
+          },
+        ],
+        'We have the correct array members'
+      );
+    });
+
+    test('we cannot update individual fields in objects in the array to new values', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource({
+        identity: null,
+        type: 'address',
+        fields: [
+          {
+            name: 'street',
+            kind: 'field',
+          },
+          {
+            name: 'city',
+            kind: 'field',
+          },
+          {
+            name: 'state',
+            kind: 'field',
+          },
+          {
+            name: 'zip',
+            kind: 'field',
+          },
+        ],
+      });
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'addresses',
+              type: 'address',
+              kind: 'schema-array',
+            },
+          ],
+        })
+      );
+
+      const sourceArray = [
+        {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        {
+          street: '456 Elm St',
+          city: 'Othertown',
+          state: 'CA',
+          zip: '54321',
+        },
+      ];
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Skybarker',
+            addresses: sourceArray,
+          },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.true(Array.isArray(record.addresses), 'we can access favoriteNumber array');
+      assert.propContains(
+        record.addresses?.slice(),
+        [
+          {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+          {
+            street: '456 Elm St',
+            city: 'Othertown',
+            state: 'CA',
+            zip: '54321',
+          },
+        ],
+        'We have the correct array members'
+      );
+      assert.throws(() => {
+        record.addresses![0]!.street = '789 Maple St';
+      }, /Error: Cannot set street on address because the record is not editable/);
+
+      assert.propContains(
+        record.addresses?.slice(),
+        [
+          {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+          {
+            street: '456 Elm St',
+            city: 'Othertown',
+            state: 'CA',
+            zip: '54321',
+          },
+        ],
+        'We have the correct array members'
+      );
+    });
+  });
   test('we can update to a new array', function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;

--- a/tests/warp-drive__schema-record/tests/writes/schema-object-test.ts
+++ b/tests/warp-drive__schema-record/tests/writes/schema-object-test.ts
@@ -4,6 +4,7 @@ import { setupTest } from 'ember-qunit';
 
 import { recordIdentifierFor } from '@ember-data/store';
 import type { Type } from '@warp-drive/core-types/symbols';
+import { Checkout } from '@warp-drive/schema-record/record';
 import { registerDerivations, withDefaults } from '@warp-drive/schema-record/schema';
 
 import type Store from 'warp-drive__schema-record/services/store';
@@ -20,19 +21,29 @@ type business = {
   address?: address;
   addresses?: address[];
 };
-interface User {
+type User = Readonly<{
   id: string;
   $type: 'user';
   name: string;
   address: address | null;
   business: business | null;
   [Type]: 'user';
-}
+  [Checkout](): Promise<EditableUser>;
+}>;
+
+type EditableUser = {
+  readonly id: string;
+  readonly $type: 'user';
+  name: string;
+  address: address | null;
+  business: business | null;
+  [Type]: 'user';
+};
 
 module('Writes | schema-object fields', function (hooks) {
   setupTest(hooks);
 
-  test('we can update to a new object', function (assert) {
+  test('we can update to a new object', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -76,7 +87,7 @@ module('Writes | schema-object fields', function (hooks) {
       })
     );
 
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
@@ -92,6 +103,7 @@ module('Writes | schema-object fields', function (hooks) {
       },
     });
 
+    const record = await immutableRecord[Checkout]();
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
     assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
@@ -120,7 +132,7 @@ module('Writes | schema-object fields', function (hooks) {
     );
   });
 
-  test('we can update to null', function (assert) {
+  test('we can update to null', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -162,7 +174,7 @@ module('Writes | schema-object fields', function (hooks) {
         ],
       })
     );
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
@@ -177,6 +189,7 @@ module('Writes | schema-object fields', function (hooks) {
         },
       },
     });
+    const record = await immutableRecord[Checkout]();
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
     assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
@@ -214,7 +227,7 @@ module('Writes | schema-object fields', function (hooks) {
     );
   });
 
-  test('we can update a single value in the object', function (assert) {
+  test('we can update a single value in the object', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -256,7 +269,7 @@ module('Writes | schema-object fields', function (hooks) {
         ],
       })
     );
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
@@ -266,6 +279,7 @@ module('Writes | schema-object fields', function (hooks) {
         },
       },
     });
+    const record = await immutableRecord[Checkout]();
     assert.propEqual(
       record.address,
       {
@@ -299,7 +313,7 @@ module('Writes | schema-object fields', function (hooks) {
     );
   });
 
-  test('we can assign an object value to another record', function (assert) {
+  test('we can assign an object value to another record', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -341,7 +355,7 @@ module('Writes | schema-object fields', function (hooks) {
         ],
       })
     );
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
@@ -356,13 +370,15 @@ module('Writes | schema-object fields', function (hooks) {
         },
       },
     });
-    const record2 = store.push<User>({
+    const immutableRecord2 = store.push<User>({
       data: {
         type: 'user',
         id: '2',
         attributes: { name: 'Luke Skybarker' },
       },
     });
+    const record = await immutableRecord[Checkout]();
+    const record2 = await immutableRecord2[Checkout]();
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
     assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
@@ -410,7 +426,7 @@ module('Writes | schema-object fields', function (hooks) {
     );
   });
 
-  test('throws errors when trying to set non-schema fields', function (assert) {
+  test('throws errors when trying to set non-schema fields', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -452,7 +468,7 @@ module('Writes | schema-object fields', function (hooks) {
         ],
       })
     );
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
@@ -467,6 +483,7 @@ module('Writes | schema-object fields', function (hooks) {
         },
       },
     });
+    const record = await immutableRecord[Checkout]();
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
     assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
@@ -497,7 +514,7 @@ module('Writes | schema-object fields', function (hooks) {
     }, /Field notAField does not exist on schema object address/);
   });
 
-  test('we can edit nested schema-object fields', function (assert) {
+  test('we can edit nested schema-object fields', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -573,7 +590,7 @@ module('Writes | schema-object fields', function (hooks) {
       state: 'NY',
       zip: '12345',
     };
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
@@ -585,6 +602,7 @@ module('Writes | schema-object fields', function (hooks) {
       },
     });
 
+    const record = await immutableRecord[Checkout]();
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
     assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
@@ -649,7 +667,7 @@ module('Writes | schema-object fields', function (hooks) {
     );
   });
 
-  test('we can edit nested nest schema-array fields inside a schema-object', function (assert) {
+  test('we can edit nested nest schema-array fields inside a schema-object', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);
@@ -730,7 +748,7 @@ module('Writes | schema-object fields', function (hooks) {
       state: 'NJ',
       zip: '23456',
     };
-    const record = store.push<User>({
+    const immutableRecord = store.push<User>({
       data: {
         type: 'user',
         id: '1',
@@ -742,6 +760,7 @@ module('Writes | schema-object fields', function (hooks) {
       },
     });
 
+    const record = await immutableRecord[Checkout]();
     assert.strictEqual(record.id, '1', 'id is accessible');
     assert.strictEqual(record.$type, 'user', '$type is accessible');
     assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');

--- a/tests/warp-drive__schema-record/tests/writes/schema-object-test.ts
+++ b/tests/warp-drive__schema-record/tests/writes/schema-object-test.ts
@@ -43,6 +43,600 @@ type EditableUser = {
 module('Writes | schema-object fields', function (hooks) {
   setupTest(hooks);
 
+  module('immutability', function () {
+    test('we cannot update to a new object', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource({
+        identity: null,
+        type: 'address',
+        fields: [
+          {
+            name: 'street',
+            kind: 'field',
+          },
+          {
+            name: 'city',
+            kind: 'field',
+          },
+          {
+            name: 'state',
+            kind: 'field',
+          },
+          {
+            name: 'zip',
+            kind: 'field',
+          },
+        ],
+      });
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              kind: 'schema-object',
+              type: 'address',
+            },
+          ],
+        })
+      );
+
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Pupatine',
+            address: {
+              street: '123 Main Street',
+              city: 'Anytown',
+              state: 'NY',
+              zip: '12345',
+            },
+          },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.propEqual(
+        record.address,
+        { street: '123 Main Street', city: 'Anytown', state: 'NY', zip: '12345' },
+        'We have the correct address object'
+      );
+      assert.throws(() => {
+        // @ts-expect-error we are testing the immutability of the object
+        record.address = { street: '456 Elm Street', city: 'Sometown', state: 'NJ', zip: '23456' };
+      }, /Error: Cannot set address on user because the record is not editable/);
+      assert.propEqual(
+        record.address,
+        { street: '123 Main Street', city: 'Anytown', state: 'NY', zip: '12345' },
+        'we have the correct Object members'
+      );
+    });
+
+    test('we cannot update to null', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource({
+        identity: null,
+        type: 'address',
+        fields: [
+          {
+            name: 'street',
+            kind: 'field',
+          },
+          {
+            name: 'city',
+            kind: 'field',
+          },
+          {
+            name: 'state',
+            kind: 'field',
+          },
+          {
+            name: 'zip',
+            kind: 'field',
+          },
+        ],
+      });
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              kind: 'schema-object',
+              type: 'address',
+            },
+          ],
+        })
+      );
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Pupatine',
+            address: {
+              street: '123 Main Street',
+              city: 'Anytown',
+              state: 'NY',
+              zip: '12345',
+            },
+          },
+        },
+      });
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.propEqual(
+        record.address,
+        {
+          street: '123 Main Street',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct address object'
+      );
+      assert.throws(() => {
+        // @ts-expect-error we are testing the immutability of the object
+        record.address = null;
+      }, /Error: Cannot set address on user because the record is not editable/);
+
+      assert.propEqual(
+        record.address,
+        {
+          street: '123 Main Street',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct address object'
+      );
+    });
+
+    test('we cannot update a single value in the object', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource({
+        identity: null,
+        type: 'address',
+        fields: [
+          {
+            name: 'street',
+            kind: 'field',
+          },
+          {
+            name: 'city',
+            kind: 'field',
+          },
+          {
+            name: 'state',
+            kind: 'field',
+          },
+          {
+            name: 'zip',
+            kind: 'field',
+          },
+        ],
+      });
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              kind: 'schema-object',
+              type: 'address',
+            },
+          ],
+        })
+      );
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Pupatine',
+            address: { street: '123 Main Street', city: 'Anytown', state: 'NY', zip: '12345' },
+          },
+        },
+      });
+      assert.propEqual(
+        record.address,
+        {
+          street: '123 Main Street',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct address object'
+      );
+      assert.throws(() => {
+        record.address!.state = 'NJ';
+      }, /Error: Cannot set state on address because the record is not editable/);
+      assert.propEqual(
+        record.address,
+        {
+          street: '123 Main Street',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct address object'
+      );
+    });
+
+    test('we cannot assign an object value to another record', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+      schema.registerResource({
+        identity: null,
+        type: 'address',
+        fields: [
+          {
+            name: 'street',
+            kind: 'field',
+          },
+          {
+            name: 'city',
+            kind: 'field',
+          },
+          {
+            name: 'state',
+            kind: 'field',
+          },
+          {
+            name: 'zip',
+            kind: 'field',
+          },
+        ],
+      });
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              kind: 'schema-object',
+              type: 'address',
+            },
+          ],
+        })
+      );
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Pupatine',
+            address: {
+              street: '123 Main Street',
+              city: 'Anytown',
+              state: 'NY',
+              zip: '12345',
+            },
+          },
+        },
+      });
+      const record2 = store.push<User>({
+        data: {
+          type: 'user',
+          id: '2',
+          attributes: { name: 'Luke Skybarker' },
+        },
+      });
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Pupatine', 'name is accessible');
+      assert.strictEqual(record2.id, '2', 'id is accessible');
+      assert.strictEqual(record2.$type, 'user', '$type is accessible');
+      assert.strictEqual(record2.name, 'Luke Skybarker', 'name is accessible');
+      assert.propEqual(
+        record.address,
+        {
+          street: '123 Main Street',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'We have the correct address object'
+      );
+      assert.strictEqual(record.address, record.address, 'We have a stable object reference');
+      assert.throws(() => {
+        // @ts-expect-error we are testing the immutability of the object
+        record2.address = record.address;
+      }, /Error: Cannot set address on user because the record is not editable/);
+
+      assert.strictEqual(record2.address, null, 'We have the correct address object');
+    });
+
+    test('we cannot edit nested schema-object fields', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource({
+        identity: null,
+        type: 'address',
+        fields: [
+          {
+            name: 'street',
+            kind: 'field',
+          },
+          {
+            name: 'city',
+            kind: 'field',
+          },
+          {
+            name: 'state',
+            kind: 'field',
+          },
+          {
+            name: 'zip',
+            kind: 'field',
+          },
+        ],
+      });
+      schema.registerResource({
+        identity: null,
+        type: 'business',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+          {
+            name: 'address',
+            type: 'address',
+            kind: 'schema-object',
+          },
+        ],
+      });
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              type: 'address',
+              kind: 'schema-object',
+            },
+            {
+              name: 'business',
+              type: 'business',
+              kind: 'schema-object',
+            },
+          ],
+        })
+      );
+
+      const sourceAddress: address = {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      };
+      const sourceBusinessAddress: address = {
+        street: '456 Elm St',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      };
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Skybarker',
+            address: sourceAddress,
+            business: { name: 'Acme', address: sourceBusinessAddress },
+          },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.propEqual(
+        record.address,
+        { street: '123 Main St', city: 'Anytown', state: 'NY', zip: '12345' },
+        'we can access address object'
+      );
+      assert.strictEqual(record.address, record.address, 'We have a stable object reference');
+      assert.notStrictEqual(record.address, sourceAddress);
+      assert.strictEqual(record.business?.name, 'Acme');
+      assert.propEqual(record.business?.address, { street: '456 Elm St', city: 'Anytown', state: 'NY', zip: '12345' });
+
+      // test that the data entered the cache properly
+      const identifier = recordIdentifierFor(record);
+      const cachedResourceData = store.cache.peek(identifier);
+
+      assert.deepEqual(
+        cachedResourceData?.attributes?.address,
+        {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        'the cache values are correct for the object field'
+      );
+      assert.deepEqual(
+        cachedResourceData?.attributes?.business,
+        {
+          name: 'Acme',
+          address: {
+            street: '456 Elm St',
+            city: 'Anytown',
+            state: 'NY',
+            zip: '12345',
+          },
+        },
+        'the cache values are correct for a nested object field'
+      );
+      assert.throws(() => {
+        record.business!.address = { street: '789 Oak St', city: 'Sometown', state: 'NJ', zip: '23456' };
+      }, /Error: Cannot set address on business because the record is not editable/);
+
+      assert.propEqual(
+        record.business?.address,
+        { street: '456 Elm St', city: 'Anytown', state: 'NY', zip: '12345' },
+        'we can access nested address object'
+      );
+    });
+
+    test('we cannot edit nested schema-array fields inside a schema-object', function (assert) {
+      const store = this.owner.lookup('service:store') as Store;
+      const { schema } = store;
+      registerDerivations(schema);
+
+      schema.registerResource({
+        identity: null,
+        type: 'address',
+        fields: [
+          {
+            name: 'street',
+            kind: 'field',
+          },
+          {
+            name: 'city',
+            kind: 'field',
+          },
+          {
+            name: 'state',
+            kind: 'field',
+          },
+          {
+            name: 'zip',
+            kind: 'field',
+          },
+        ],
+      });
+      schema.registerResource({
+        identity: null,
+        type: 'business',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+          {
+            name: 'addresses',
+            type: 'address',
+            kind: 'schema-array',
+          },
+        ],
+      });
+      schema.registerResource(
+        withDefaults({
+          type: 'user',
+          fields: [
+            {
+              name: 'name',
+              kind: 'field',
+            },
+            {
+              name: 'address',
+              type: 'address',
+              kind: 'schema-object',
+            },
+            {
+              name: 'business',
+              type: 'business',
+              kind: 'schema-object',
+            },
+          ],
+        })
+      );
+      const sourceAddress: address = {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      };
+      const sourceBusinessAddress1: address = {
+        street: '456 Elm St',
+        city: 'Anytown',
+        state: 'NY',
+        zip: '12345',
+      };
+      const sourceBusinessAddress2: address = {
+        street: '789 Oak St',
+        city: 'Sometown',
+        state: 'NJ',
+        zip: '23456',
+      };
+      const record = store.push<User>({
+        data: {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Rey Skybarker',
+            address: sourceAddress,
+            business: { name: 'Acme', addresses: [sourceBusinessAddress1, sourceBusinessAddress2] },
+          },
+        },
+      });
+
+      assert.strictEqual(record.id, '1', 'id is accessible');
+      assert.strictEqual(record.$type, 'user', '$type is accessible');
+      assert.strictEqual(record.name, 'Rey Skybarker', 'name is accessible');
+      assert.propEqual(
+        record.address,
+        { street: '123 Main St', city: 'Anytown', state: 'NY', zip: '12345' },
+        'we can access address object'
+      );
+      assert.strictEqual(record.address, record.address, 'We have a stable object reference');
+      assert.strictEqual(record.business?.name, 'Acme');
+      assert.propEqual(record.business?.addresses, [
+        { street: '456 Elm St', city: 'Anytown', state: 'NY', zip: '12345' },
+        { street: '789 Oak St', city: 'Sometown', state: 'NJ', zip: '23456' },
+      ]);
+      assert.strictEqual(record.business?.addresses, record.business?.addresses, 'We have a stable array reference');
+      assert.throws(() => {
+        record.business!.addresses![0] = { street: '123 Main St', city: 'Anytown', state: 'NY', zip: '12345' };
+      }, /Error: Cannot set 0 on addresses because the record is not editable/);
+      assert.propEqual(
+        record.business?.addresses,
+        [
+          { street: '456 Elm St', city: 'Anytown', state: 'NY', zip: '12345' },
+          { street: '789 Oak St', city: 'Sometown', state: 'NJ', zip: '23456' },
+        ],
+        'we can access nested address object'
+      );
+    });
+  });
+
   test('we can update to a new object', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
@@ -667,7 +1261,7 @@ module('Writes | schema-object fields', function (hooks) {
     );
   });
 
-  test('we can edit nested nest schema-array fields inside a schema-object', async function (assert) {
+  test('we can edit nested schema-array fields inside a schema-object', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
     const { schema } = store;
     registerDerivations(schema);


### PR DESCRIPTION
spike with @richgt of ensuring immutability. We will want some tests that we are in fact (deeply) immutable when in read-only mode, and to continue to build out tests that we are (deeply) mutable once we checkout.

