### PR TITLE
Update the paths in the canary tsconfig example

### DIFF
--- a/guides/typescript/1-configuration.md
+++ b/guides/typescript/1-configuration.md
@@ -26,18 +26,18 @@ potential volatility.
    "compilerOptions": {
 +   "types": [
 +      "ember-source/types",
-+      "ember-data/unstable-preview-types",
-+      "@ember-data/store/unstable-preview-types",
-+      "@ember-data/adapter/unstable-preview-types",
-+      "@ember-data/graph/unstable-preview-types",
-+      "@ember-data/json-api/unstable-preview-types",
-+      "@ember-data/legacy-compat/unstable-preview-types",
-+      "@ember-data/request/unstable-preview-types",
-+      "@ember-data/request-utils/unstable-preview-types",
-+      "@ember-data/model/unstable-preview-types",
-+      "@ember-data/serializer//unstable-preview-types",
-+      "@ember-data/tracking/unstable-preview-types",
-+      "@warp-drive/core-types/unstable-preview-types"
++      "./node_modules/ember-data/unstable-preview-types",
++      "./node_modules/@ember-data/store/unstable-preview-types",
++      "./node_modules/@ember-data/adapter/unstable-preview-types",
++      "./node_modules/@ember-data/graph/unstable-preview-types",
++      "./node_modules/@ember-data/json-api/unstable-preview-types",
++      "./node_modules/@ember-data/legacy-compat/unstable-preview-types",
++      "./node_modules/@ember-data/request/unstable-preview-types",
++      "./node_modules/@ember-data/request-utils/unstable-preview-types",
++      "./node_modules/@ember-data/model/unstable-preview-types",
++      "./node_modules/@ember-data/serializer/unstable-preview-types",
++      "./node_modules/@ember-data/tracking/unstable-preview-types",
++      "./node_modules/@warp-drive/core-types/unstable-preview-types"
 +    ]
    }
  }
@@ -64,7 +64,7 @@ potential volatility.
 +      "@ember-data-types/request/unstable-preview-types",
 +      "@ember-data-types/request-utils/unstable-preview-types",
 +      "@ember-data-types/model/unstable-preview-types",
-+      "@ember-data-types/serializer//unstable-preview-types",
++      "@ember-data-types/serializer/unstable-preview-types",
 +      "@ember-data-types/tracking/unstable-preview-types",
 +      "@warp-drive-types/core-types/unstable-preview-types"
 +    ]


### PR DESCRIPTION
Without the `./node_modules/` prefix, TS can't find the types. This is also what the warp-drive retrofit command does: https://github.com/emberjs/data/blob/536192b15822c49226b462a905fa39e47a790fea/packages/-warp-drive/src/-private/warp-drive/commands/retrofit.ts#L408

Related to the changes in https://github.com/ember-cli/ember-cli/pull/10507