### PR TITLE
Improvement: Setting Up The Project

### DIFF
--- a/contributing/setting-up-the-project.md
+++ b/contributing/setting-up-the-project.md
@@ -1,6 +1,6 @@
 # Setting Up The Project
 
-1. Setup Volta
+## Setup Volta
 
 If you are not already using [⚡️ volta](https://volta.sh/) or have a version older than `1.1.1` you will want to begin by [installing it](https://docs.volta.sh/guide/getting-started).
 
@@ -16,29 +16,37 @@ export VOLTA_FEATURE_PNPM=1;
 
 > **Note** if you have previously installed pnpm globally via other means you should uninstall it from all other locations first. You may also need to uninstall nvm or other node version managers if they turn out to conflict.
 
-2. Install bun.sh
+## Install bun.sh
 
-If you don't already have [bun.sh](https://bun.sh/) 
-For MacOS and Linux 
+If you don't already have [bun.sh](https://bun.sh/)
+For MacOS or Linux
 ```sh
 curl -fsSL https://bun.sh/install | bash
 ```
 can be done using homebrew, npm or Docker (User choice) checkout installation [doc](https://bun.sh/docs/installation#macos-and-linux)
 
-For Windows 
+For Windows
 ```sh
 # WARNING: No stability is guaranteed on the experimental Windows builds
 powershell -c "irm bun.sh/install.ps1|iex"
 ```
-Installation [doc](https://bun.sh/docs/installation#windows) 
+Installation [doc](https://bun.sh/docs/installation#windows)
 
-3. Clone the repository
+## Install certificate packages
+
+Using homebrew on MacOS or Linux
+```sh
+brew install mkcert
+```
+can be done using Chocolatey, Scoop or MacPorts (User choice) checkout installation [doc][https://github.com/FiloSottile/mkcert?tab=readme-ov-file#installation]
+
+## Clone the repository
 
 ```sh
 git clone git@github.com:emberjs/data.git
 ```
 
-4. Install the project dependencies
+## Install the project dependencies
 
 ```sh
 cd data && pnpm install
@@ -46,7 +54,13 @@ cd data && pnpm install
 
 Currently the install command is also what builds all of the individual packages in the monorepo and hardlinks them together, so if making changes to one package that need to be used by another you will need to rerun `pnpm install` for the changes to be picked up.
 
-5. Run some commands
+## Create certificates
+
+```sh
+node ./packages/holodeck/server/ensure-cert.js
+```
+
+## Run some commands
 
 Generally test and lint commands can be found in the `"scripts"` section of the root `package.json` manifest. Individual packages or test packages have additional commands in the `"scripts"` section of their own `package.json` manifest as well.
 

--- a/contributing/setting-up-the-project.md
+++ b/contributing/setting-up-the-project.md
@@ -34,11 +34,22 @@ Installation [doc](https://bun.sh/docs/installation#windows)
 
 ## Install certificate packages
 
-Using homebrew on MacOS or Linux
+Install mkcert using homebrew on MacOS or Linux
 ```sh
 brew install mkcert
 ```
 can be done using Chocolatey, Scoop or MacPorts (User choice) checkout installation [doc][https://github.com/FiloSottile/mkcert?tab=readme-ov-file#installation]
+
+For Firefox users, Mozilla NSS is also needed
+Using homebrew on MacOS
+```sh
+brew install nss
+```
+Or apt on Linux
+```sh
+sudo apt install libnss3-tools
+```
+but can also be done using other methods.
 
 ## Clone the repository
 
@@ -57,7 +68,7 @@ Currently the install command is also what builds all of the individual packages
 ## Create certificates
 
 ```sh
-node ./packages/holodeck/server/ensure-cert.js
+pnpx @warp-drive/holodeck ensure-cert
 ```
 
 ## Run some commands

--- a/packages/holodeck/server/ensure-cert.js
+++ b/packages/holodeck/server/ensure-cert.js
@@ -23,18 +23,26 @@ function main() {
   let KEY_PATH = process.env.HOLODECK_SSL_KEY_PATH;
   const configFilePath = getShellConfigFilePath();
 
-  if (!CERT_PATH) {
-    CERT_PATH = path.join(homedir(), 'holodeck-localhost.pem');
-    process.env.HOLODECK_SSL_CERT_PATH = CERT_PATH;
-    execSync(`echo '\nexport HOLODECK_SSL_CERT_PATH="${CERT_PATH}"' >> ${configFilePath}`);
-    console.log(`Added HOLODECK_SSL_CERT_PATH to ${configFilePath}`);
-  }
+  if (!CERT_PATH || !KEY_PATH) {
+    console.log(`Environment variables not found, updating the environment config file...\n`);
 
-  if (!KEY_PATH) {
-    KEY_PATH = path.join(homedir(), 'holodeck-localhost-key.pem');
-    process.env.HOLODECK_SSL_KEY_PATH = KEY_PATH;
-    execSync(`echo '\nexport HOLODECK_SSL_KEY_PATH="${KEY_PATH}"' >> ${configFilePath}`);
-    console.log(`Added HOLODECK_SSL_KEY_PATH to ${configFilePath}`);
+    if (!CERT_PATH) {
+      CERT_PATH = path.join(homedir(), 'holodeck-localhost.pem');
+      process.env.HOLODECK_SSL_CERT_PATH = CERT_PATH;
+      execSync(`echo '\nexport HOLODECK_SSL_CERT_PATH="${CERT_PATH}"' >> ${configFilePath}`);
+      console.log(`Added HOLODECK_SSL_CERT_PATH to ${configFilePath}`);
+    }
+
+    if (!KEY_PATH) {
+      KEY_PATH = path.join(homedir(), 'holodeck-localhost-key.pem');
+      process.env.HOLODECK_SSL_KEY_PATH = KEY_PATH;
+      execSync(`echo '\nexport HOLODECK_SSL_KEY_PATH="${KEY_PATH}"' >> ${configFilePath}`);
+      console.log(`Added HOLODECK_SSL_KEY_PATH to ${configFilePath}`);
+    }
+
+    console.log(
+      `\n*** Please restart your terminal session to apply the changes or run \`source ${configFilePath}\`. ***\n`
+    );
   }
 
   if (!fs.existsSync(CERT_PATH) || !fs.existsSync(KEY_PATH)) {

--- a/packages/holodeck/server/index.js
+++ b/packages/holodeck/server/index.js
@@ -35,24 +35,13 @@ function getShellConfigFilePath() {
 function getCertInfo() {
   let CERT_PATH = process.env.HOLODECK_SSL_CERT_PATH;
   let KEY_PATH = process.env.HOLODECK_SSL_KEY_PATH;
-  const configFilePath = getShellConfigFilePath();
 
-  if (!CERT_PATH) {
-    CERT_PATH = path.join(homedir(), 'holodeck-localhost.pem');
-    process.env.HOLODECK_SSL_CERT_PATH = CERT_PATH;
-    execSync(`echo '\nexport HOLODECK_SSL_CERT_PATH="${CERT_PATH}"' >> ${configFilePath}`);
-    console.log(`Added HOLODECK_SSL_CERT_PATH to ${configFilePath}`);
-  }
-
-  if (!KEY_PATH) {
-    KEY_PATH = path.join(homedir(), 'holodeck-localhost-key.pem');
-    process.env.HOLODECK_SSL_KEY_PATH = KEY_PATH;
-    execSync(`echo '\nexport HOLODECK_SSL_KEY_PATH="${KEY_PATH}"' >> ${configFilePath}`);
-    console.log(`Added HOLODECK_SSL_KEY_PATH to ${configFilePath}`);
-  }
-
-  if (!fs.existsSync(CERT_PATH) || !fs.existsSync(KEY_PATH)) {
-    throw new Error('SSL certificate or key not found, you may need to run `npx -p @warp-drive/holodeck ensure-cert`');
+  if (!CERT_PATH || !KEY_PATH) {
+    throw new Error(
+      'SSL certificate or key paths were not found in your environment, you may need to run `pnpx @warp-drive/holodeck ensure-cert`'
+    );
+  } else if (!fs.existsSync(CERT_PATH) || !fs.existsSync(KEY_PATH)) {
+    throw new Error('SSL certificate or key not found, you may need to run `pnpx @warp-drive/holodeck ensure-cert`');
   }
 
   return {

--- a/packages/holodeck/server/index.js
+++ b/packages/holodeck/server/index.js
@@ -9,6 +9,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import http2 from 'node:http2';
 import zlib from 'node:zlib';
+import { homedir } from 'os';
 import path from 'path';
 
 /** @type {import('bun-types')} */
@@ -20,11 +21,25 @@ function getCertInfo() {
   let CERT_PATH = process.env.HOLODECK_SSL_CERT_PATH;
   let KEY_PATH = process.env.HOLODECK_SSL_KEY_PATH;
 
-  if (!CERT_PATH || !KEY_PATH) {
-    throw new Error(
-      'SSL certificate or key paths were not found in your environment, you may need to run `pnpx @warp-drive/holodeck ensure-cert`'
+  if (!CERT_PATH) {
+    CERT_PATH = path.join(homedir(), 'holodeck-localhost.pem');
+    process.env.HOLODECK_SSL_CERT_PATH = CERT_PATH;
+
+    console.log(
+      `HOLODECK_SSL_CERT_PATH was not found in the current environment. Setting it to default value of ${CERT_PATH}`
     );
-  } else if (!fs.existsSync(CERT_PATH) || !fs.existsSync(KEY_PATH)) {
+  }
+
+  if (!KEY_PATH) {
+    KEY_PATH = path.join(homedir(), 'holodeck-localhost-key.pem');
+    process.env.HOLODECK_SSL_KEY_PATH = KEY_PATH;
+
+    console.log(
+      `HOLODECK_SSL_KEY_PATH was not found in the current environment. Setting it to default value of ${KEY_PATH}`
+    );
+  }
+
+  if (!fs.existsSync(CERT_PATH) || !fs.existsSync(KEY_PATH)) {
     throw new Error('SSL certificate or key not found, you may need to run `pnpx @warp-drive/holodeck ensure-cert`');
   }
 

--- a/packages/holodeck/server/index.js
+++ b/packages/holodeck/server/index.js
@@ -5,32 +5,16 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';
 import { logger } from 'hono/logger';
-import { execSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import http2 from 'node:http2';
 import zlib from 'node:zlib';
-import { homedir, userInfo } from 'os';
 import path from 'path';
 
 /** @type {import('bun-types')} */
 const isBun = typeof Bun !== 'undefined';
 const DEBUG = process.env.DEBUG?.includes('holodeck') || process.env.DEBUG === '*';
 const CURRENT_FILE = new URL(import.meta.url).pathname;
-
-function getShellConfigFilePath() {
-  const shell = userInfo().shell;
-  switch (shell) {
-    case '/bin/zsh':
-      return path.join(homedir(), '.zshrc');
-    case '/bin/bash':
-      return path.join(homedir(), '.bashrc');
-    default:
-      throw Error(
-        `Unable to determine configuration file for shell: ${shell}. Manual SSL Cert Setup Required for Holodeck.`
-      );
-  }
-}
 
 function getCertInfo() {
   let CERT_PATH = process.env.HOLODECK_SSL_CERT_PATH;


### PR DESCRIPTION
## Description

This PR aims to improve the `setting-up-the-project.md` file, based on our findings during the setup of the project on my local environment.

1. Moves to recommending the usage of `pnpx` instead of `npx`
  . Since the project relies on pnpm, recommend running scripts with pnpm commands
  . The only script affected is the holodeck ensure-cert
2. It adds steps related to holodeck certificates
  . Install `mkcert` and `nss` (as needed)
  . Run the ensure-cert script to create the certificates
3. Remove the env manipulation from the holodeck `index.js` file
  . Rely on running the ensure-cert script instead
4. Add more granular log and error messages