### PR TITLE
Resolve module cycles so that ember-data 4.12 can work with Vite

### DIFF
--- a/packages/model/rollup.config.mjs
+++ b/packages/model/rollup.config.mjs
@@ -41,7 +41,14 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['index.js', 'error.js', 'json-api.js', 'rest.js', '-private.js']),
+    addon.publicEntrypoints([
+      'index.js',
+      'error.js',
+      'json-api.js',
+      'rest.js',
+      '-private.js',
+      '-private/model-for-mixin',
+    ]),
 
     nodeResolve({ extensions: ['.ts', '.js'] }),
     babel({

--- a/packages/model/rollup.config.mjs
+++ b/packages/model/rollup.config.mjs
@@ -47,7 +47,7 @@ export default {
       'json-api.js',
       'rest.js',
       '-private.js',
-      '-private/model-for-mixin',
+      '-private/model-for-mixin.js',
     ]),
 
     nodeResolve({ extensions: ['.ts', '.js'] }),

--- a/packages/model/src/-private.ts
+++ b/packages/model/src/-private.ts
@@ -9,11 +9,14 @@ export { default as PromiseBelongsTo } from './-private/promise-belongs-to';
 export { default as PromiseManyArray } from './-private/promise-many-array';
 // We can't re-export from here, becaues it creates a module cycle
 // (which prevents vite and sometimes webpack from loading)
-// - @ember-data/model/-private
+// - RelatedCollection from @ember-data/model/-private
 //   -> @ember-data/model/has-many-abc123 (private module from rollup)
-//     -> @ember-data/store/-private
+//     -> RecordArray from @ember-data/store/-private
 //       -> @ember-data/store/index-abc123 (private module from rollup)
-//         -> importSync of @ember-data/model/-private
+//         -> _modelForMixin from importSync of @ember-data/model/-private
+//
+// So by pulling out _modelForMixin, we don't use importSync
+// to the same module that our calls stack includes
 //export { default as _modelForMixin } from './-private/model-for-mixin';
 
 // // Used by tests

--- a/packages/model/src/-private.ts
+++ b/packages/model/src/-private.ts
@@ -7,7 +7,14 @@ export { default as Errors } from './-private/errors';
 export { default as ManyArray } from './-private/many-array';
 export { default as PromiseBelongsTo } from './-private/promise-belongs-to';
 export { default as PromiseManyArray } from './-private/promise-many-array';
-export { default as _modelForMixin } from './-private/model-for-mixin';
+// We can't re-export from here, becaues it creates a module cycle
+// (which prevents vite and sometimes webpack from loading)
+// - @ember-data/model/-private
+//   -> @ember-data/model/has-many-abc123 (private module from rollup)
+//     -> @ember-data/store/-private
+//       -> @ember-data/store/index-abc123 (private module from rollup)
+//         -> importSync of @ember-data/model/-private
+//export { default as _modelForMixin } from './-private/model-for-mixin';
 
 // // Used by tests
 export { default as diffArray } from './-private/diff-array';

--- a/packages/store/src/-private/legacy-model-support/schema-definition-service.ts
+++ b/packages/store/src/-private/legacy-model-support/schema-definition-service.ts
@@ -20,7 +20,11 @@ if (HAS_MODEL_PACKAGE) {
   let _found;
   _modelForMixin = function () {
     if (!_found) {
-      _found = (importSync('@ember-data/model/-private') as typeof import('@ember-data/model/-private'))._modelForMixin;
+      _found = (
+        importSync(
+          '@ember-data/model/-private/model-for-mixin'
+        ) as typeof import('@ember-data/model/-private/model-for-mixin')
+      ).default;
     }
     return _found(...arguments);
   };


### PR DESCRIPTION
## Description

under vite, importSync is the same as import, so we need to be careful about accidentally creating module cycles that would prevent a module from being evaluated by the browser.

## Notes for the release

Add vite support for ember-data 4.12.x

