### PR TITLE
chore: make tests more splittable

### DIFF
--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-1-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-1-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 0);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-10-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-10-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 9);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-11-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-11-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 10);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-12-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-12-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 11);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-13-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-13-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 12);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-14-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-14-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 13);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-15-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-15-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 14);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-16-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-16-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 15);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-17-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-17-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 16);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-18-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-18-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 17);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-19-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-19-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 18);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-2-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-2-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 1);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-20-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-20-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 19);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-3-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-3-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 2);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-4-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-4-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 3);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-5-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-5-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 4);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-6-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-6-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 5);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-7-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-7-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 6);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-8-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-8-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 7);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-9-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-partition-9-test.ts
@@ -1,0 +1,3 @@
+import { runTestGroup } from './mutating-has-many-test-infra';
+
+runTestGroup(20, 8);

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-test-infra.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-test-infra.ts
@@ -395,8 +395,27 @@ function getMutations(): Mutation[] {
   ];
 }
 
+const STATES: Array<{
+  startingState: { name: string; cb: (store: Store) => User };
+  mutation: Mutation;
+}> = [];
+
 getStartingState().forEach((startingState) => {
   getMutations().forEach((mutation) => {
+    STATES.push({
+      startingState,
+      mutation,
+    });
+  });
+});
+
+export function runTestGroup(splitNum: number, offset: number) {
+  STATES.forEach(({ startingState, mutation }, index) => {
+    // Run only every Nth test, offset by 0
+    if (index % splitNum !== offset) {
+      return;
+    }
+
     module(
       `Integration | Relationships | Collection | Mutation > Starting state: ${startingState.name} > Mutation: ${mutation.name}`,
       function (hooks) {
@@ -424,4 +443,4 @@ getStartingState().forEach((startingState) => {
       }
     );
   });
-});
+}

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-test.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-test.ts
@@ -395,34 +395,33 @@ function getMutations(): Mutation[] {
   ];
 }
 
-module('Integration | Relationships | Collection | Mutation', function (hooks) {
-  setupRenderingTest(hooks);
+getStartingState().forEach((startingState) => {
+  getMutations().forEach((mutation) => {
+    module(
+      `Integration | Relationships | Collection | Mutation > Starting state: ${startingState.name} > Mutation: ${mutation.name}`,
+      function (hooks) {
+        setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    this.owner.register('model:user', User);
-  });
+        hooks.beforeEach(function () {
+          this.owner.register('model:user', User);
+        });
 
-  getStartingState().forEach((startingState) => {
-    module(`Starting state: ${startingState.name}`, function () {
-      getMutations().forEach((mutation) => {
-        module(`Mutation: ${mutation.name}`, function () {
-          getMutations().forEach((mutation2) => {
-            test(`followed by Mutation: ${mutation2.name}`, async function (assert) {
-              const store = this.owner.lookup('service:store') as Store;
-              const user = startingState.cb(store);
-              const rc = await reactiveContext.call(this, user, {
-                identity: null,
-                type: 'user',
-                fields: [{ name: 'friends', kind: 'hasMany', type: 'user', options: { async: false, inverse: null } }],
-              });
-              rc.reset();
-
-              await applyMutation(assert, store, user, mutation, rc);
-              await applyMutation(assert, store, user, mutation2, rc);
+        getMutations().forEach((mutation2) => {
+          test(`followed by Mutation: ${mutation2.name}`, async function (assert) {
+            const store = this.owner.lookup('service:store') as Store;
+            const user = startingState.cb(store);
+            const rc = await reactiveContext.call(this, user, {
+              identity: null,
+              type: 'user',
+              fields: [{ name: 'friends', kind: 'hasMany', type: 'user', options: { async: false, inverse: null } }],
             });
+            rc.reset();
+
+            await applyMutation(assert, store, user, mutation, rc);
+            await applyMutation(assert, store, user, mutation2, rc);
           });
         });
-      });
-    });
+      }
+    );
   });
 });


### PR DESCRIPTION
I think this should let us split and parallelize these tests across all 4 available browser instances

appears to be ~6-7min faster on just the "test chrome" scenario, let alone all the try scenarios