### PR TITLE
docs: cleanup usage pattern for RequestManager configuration on store

### DIFF
--- a/guides/requests/examples/0-basic-usage.md
+++ b/guides/requests/examples/0-basic-usage.md
@@ -68,8 +68,7 @@ Lets see how we'd approach this request.
 import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 
-const fetch = new RequestManager();
-manager.use([Fetch]);
+const fetch = new RequestManager().use([Fetch]);
 
 export default fetch;
 ```

--- a/guides/requests/index.md
+++ b/guides/requests/index.md
@@ -323,13 +323,9 @@ import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 
 class extends Store {
-  requestManager = new RequestManager();
-
-  constructor(args) {
-    super(args);
-    this.requestManager.use([Fetch]);
-    this.requestManager.useCache(CacheHandler);
-  }
+  requestManager = new RequestManager()
+    .use([Fetch])
+    .useCache(CacheHandler);
 }
 ```
 
@@ -345,19 +341,16 @@ Additional handlers or a service injection like the above would need to be done 
 consuming application in order to make broader use of `RequestManager`.
 
 ```ts
-import Store, { CacheHandler } from 'ember-data/store';
+import Store from 'ember-data/store';
+import { CacheHandler } from '@ember-data/store';
 import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 
 export default class extends Store {
-  requestManager = new RequestManager();
-
-  constructor(args) {
-    super(args);
-    this.requestManager.use([LegacyNetworkHandler, Fetch]);
-    this.requestManager.useCache(CacheHandler);
-  }
+  requestManager = new RequestManager()
+    .use([LegacyNetworkHandler, Fetch])
+    .useCache(CacheHandler);
 }
 ```
 

--- a/packages/adapter/README.md
+++ b/packages/adapter/README.md
@@ -60,13 +60,9 @@ import RequestManager from '@ember-data/request';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 
 export default class extends Store {
-  requestManager = new RequestManager();
-
-  constructor(args) {
-    super(args);
-    this.requestManager.use([LegacyNetworkHandler]);
-    this.requestManager.useCache(CacheHandler);
-  }
+  requestManager = new RequestManager()
+    .use([LegacyNetworkHandler])
+    .useCache(CacheHandler);
 }
 ```
 

--- a/packages/experiments/src/data-worker/README.md
+++ b/packages/experiments/src/data-worker/README.md
@@ -99,12 +99,10 @@ import type { CacheCapabilitiesManager } from '@ember-data/store/types';
 import { CachePolicy } from '@ember-data/request-utils';
 import { SchemaService } from '@warp-drive/schema-record/schema';
 
-const requestManager = new RequestManager();
-requestManager.use([Fetch]);
-requestManager.useCache(CacheHandler);
-
 class WorkerStore extends Store {
-  requestManager = requestManager;
+  requestManager = new RequestManager()
+    .use([Fetch])
+    .useCache(CacheHandler);
 
   lifetimes = new CachePolicy({
     apiCacheHardExpires: 600_000,

--- a/packages/experiments/src/persisted-cache/README.md
+++ b/packages/experiments/src/persisted-cache/README.md
@@ -30,12 +30,9 @@ Or use favorite your javascript package manager.
 
 ```ts
 class Store {
-  constructor() {
-    const rm = new RequestManager();
-    rm.use([new PersistedFetch(), Fetch]);
-    rm.useCache(CacheHandler);
-    this.requestManager = rm;
-  }
+  requestManager = new RequestManager()
+    .use([new PersistedFetch(), Fetch])
+    .useCache(CacheHandler);
 
   createCache() {
     const jsonapi = new JSONAPICache();

--- a/packages/holodeck/README.md
+++ b/packages/holodeck/README.md
@@ -107,8 +107,8 @@ import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 import { MockServerHandler } from '@warp-drive/holodeck';
 
-const manager = new RequestManager();
-manager.use([new MockServerHandler(testContext), Fetch]);
+const manager = new RequestManager()
+  .use([new MockServerHandler(testContext), Fetch]);
 ```
 
 From within a test this might look like:
@@ -121,8 +121,8 @@ import { module, test } from 'qunit';
 
 module('my module', function() {
   test('my test', async function() {
-    const manager = new RequestManager();
-    manager.use([new MockServerHandler(this), Fetch]);
+    const manager = new RequestManager()
+      .use([new MockServerHandler(this), Fetch]);
   });
 });
 ```

--- a/packages/request/README.md
+++ b/packages/request/README.md
@@ -63,8 +63,8 @@ import Fetch from '@ember-data/request/fetch';
 import { apiUrl } from './config';
 
 // ... create manager and add our Fetch handler
-const manager = new RequestManager();
-manager.use([Fetch]);
+const manager = new RequestManager()
+  .use([Fetch]);
 
 // ... execute a request
 const response = await manager.request({
@@ -441,13 +441,9 @@ import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 
 class extends Store {
-  requestManager = new RequestManager();
-
-  constructor(args) {
-    super(args);
-    this.requestManager.use([Fetch]);
-    this.requestManager.useCache(CacheHandler);
-  }
+  requestManager = new RequestManager()
+    .use([Fetch])
+    .useCache(CacheHandler);
 }
 ```
 
@@ -463,19 +459,16 @@ Additional handlers or a service injection like the above would need to be done 
 consuming application in order to make broader use of `RequestManager`.
 
 ```ts
-import Store, { CacheHandler } from 'ember-data/store';
+import Store from 'ember-data/store';
+import { CacheHandler } from '@ember-data/store';
 import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 
 export default class extends Store {
-  requestManager = new RequestManager();
-
-  constructor(args) {
-    super(args);
-    this.requestManager.use([LegacyNetworkHandler, Fetch]);
-    this.requestManager.useCache(CacheHandler);
-  }
+  requestManager = new RequestManager()
+    .use([LegacyNetworkHandler, Fetch])
+    .useCache(CacheHandler);
 }
 ```
 

--- a/packages/request/src/-private/manager.ts
+++ b/packages/request/src/-private/manager.ts
@@ -54,8 +54,8 @@ import Fetch from '@ember-data/request/fetch';
 import { apiUrl } from './config';
 
 // ... create manager and add our Fetch handler
-const manager = new RequestManager();
-manager.use([Fetch]);
+const manager = new RequestManager()
+  .use([Fetch]);
 
 // ... execute a request
 const response = await manager.request({
@@ -383,13 +383,9 @@ import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 
 class extends Store {
-  requestManager = new RequestManager();
-
-  constructor(args) {
-    super(args);
-    this.requestManager.use([Fetch]);
-    this.requestManager.useCache(CacheHandler);
-  }
+  requestManager = new RequestManager()
+    .use([Fetch])
+    .useCache(CacheHandler);
 }
 ```
 
@@ -405,19 +401,16 @@ Additional handlers or a service injection like the above would need to be done 
 consuming application in order to make broader use of `RequestManager`.
 
 ```ts
-import Store, { CacheHandler } from 'ember-data/store';
+import Store from 'ember-data/store';
+import { CacheHandler } from '@ember-data/store';
 import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 
 export default class extends Store {
-  requestManager = new RequestManager();
-
-  constructor(args) {
-    super(args);
-    this.requestManager.use([LegacyNetworkHandler, Fetch]);
-    this.requestManager.useCache(CacheHandler);
-  }
+  requestManager = new RequestManager()
+    .use([LegacyNetworkHandler, Fetch])
+    .useCache(CacheHandler);
 }
 ```
 

--- a/packages/request/src/-private/types.ts
+++ b/packages/request/src/-private/types.ts
@@ -205,9 +205,8 @@ In the case of the `Future` being returned, `Stream` proxying is automatic and i
 Request handlers are registered by configuring the manager via `use`
 
 ```ts
-const manager = new RequestManager();
-
-manager.use([Handler1, Handler2]);
+const manager = new RequestManager()
+  .use([Handler1, Handler2]);
 ```
 
 Handlers will be invoked in the order they are registered ("fifo", first-in first-out), and may only be registered up until the first request is made. It is recommended but not required to register all handlers at one time in order to ensure explicitly visible handler ordering.

--- a/packages/serializer/README.md
+++ b/packages/serializer/README.md
@@ -60,13 +60,9 @@ import RequestManager from '@ember-data/request';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 
 export default class extends Store {
-  requestManager = new RequestManager();
-
-  constructor(args) {
-    super(args);
-    this.requestManager.use([LegacyNetworkHandler]);
-    this.requestManager.useCache(CacheHandler);
-  }
+  requestManager = new RequestManager()
+    .use([LegacyNetworkHandler])
+    .useCache(CacheHandler);
 }
 ```
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -108,12 +108,9 @@ import RequestManager from '@ember-data/request';
 import Fetch from '@ember-data/request/fetch';
 
 export default class extends Store {
-  constructor() {
-    super(...arguments);
-    this.requestManager = new RequestManager();
-    this.requestManager.use([Fetch]);
-    this.requestManager.useCache(CacheHandler);
-  }
+  requestManager = new RequestManager()
+    .use([Fetch])
+    .useCache(CacheHandler);
 }
 ```
 

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -486,12 +486,9 @@ export class Store extends BaseClass {
    * import Fetch from '@ember-data/request/fetch';
    *
    * class extends Store {
-   *   constructor() {
-   *     super(...arguments);
-   *     this.requestManager = new RequestManager();
-   *     this.requestManager.use([Fetch]);
-   *     this.requestManager.useCache(CacheHandler);
-   *   }
+   *   requestManager = new RequestManager()
+   *    .use([Fetch])
+   *    .useCache(CacheHandler);
    * }
    * ```
    *

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -82,11 +82,8 @@
  * import Fetch from '@ember-data/request/fetch';
  *
  * export default class extends Store {
- *   constructor() {
- *     super(...arguments);
- *     this.requestManager = new RequestManager();
- *     this.requestManager.use([Fetch]);
- *   }
+ *   requestManager = new RequestManager()
+ *    .use([Fetch]);
  * }
  * ```
  *

--- a/tests/ember-data__adapter/app/services/store.ts
+++ b/tests/ember-data__adapter/app/services/store.ts
@@ -18,12 +18,7 @@ import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { TypeFromInstance } from '@warp-drive/core-types/record';
 
 export default class Store extends BaseStore {
-  constructor(args: unknown) {
-    super(args);
-    this.requestManager = new RequestManager();
-    this.requestManager.use([LegacyNetworkHandler, Fetch]);
-    this.requestManager.useCache(CacheHandler);
-  }
+  requestManager = new RequestManager().use([LegacyNetworkHandler, Fetch]).useCache(CacheHandler);
 
   createSchemaService(): ReturnType<typeof buildSchema> {
     return buildSchema(this);


### PR DESCRIPTION
Fixes an issue with docs where an import was wrong noted by `subone` in discord and cleans up docs for RequestManager config to use the nicer syntax