### PR TITLE
fix: treat uncommitted mutations as local operations when receiving remote updates

### DIFF
--- a/packages/graph/src/-private/operations/replace-related-records.ts
+++ b/packages/graph/src/-private/operations/replace-related-records.ts
@@ -254,7 +254,7 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
           // if we are still in removals at this point then
           // we were not "committed" which means we are present
           // in the remoteMembers. So we "add back" on the inverse.
-          addToInverse(graph, identifier, definition.inverseKey, op.record, isRemote);
+          addToInverse(graph, identifier, definition.inverseKey, op.record, false);
         });
         relationship.removals = null;
       }
@@ -270,7 +270,7 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
             deprecationInfo.additions.push(identifier);
             relationship.isDirty = true;
             relationship.additions!.delete(identifier);
-            removeFromInverse(graph, identifier, definition.inverseKey, op.record, isRemote);
+            removeFromInverse(graph, identifier, definition.inverseKey, op.record, false);
           }
         });
         if (relationship.additions.size === 0) {

--- a/tests/ember-data__graph/tests/test-helper.ts
+++ b/tests/ember-data__graph/tests/test-helper.ts
@@ -17,6 +17,7 @@ configure();
 setApplication(Application.create(config.APP));
 void start({
   tryCatch: true,
+  // debug: true,
   groupLogs: false,
   instrument: true,
   hideReport: true,


### PR DESCRIPTION
We encountered a bug when upgrading to 4.13 (see also #9639) where the following series of steps resulted in an unexpected outcome in the deprecated code-path for handling of remoteState updates. We traced this down to an issue that originates when support for graph-diffing was first added in 5.x

Steps to reproduce:

- `await findRecord (backgroundReload)`
- updated hasMany to a new state
- receive updated payload from backgroundReload with the exact same remote state as before
- [expected] notice new hasMany state has been reverted
- [actual (bug)] graph throws error

This can be more tersely described as

- mutate a hasMany
- receive remote state update for hasMany with exact remote state as before
- [expected] notice hasMany mutation has been cleared
- [actual (bug)] graph throws error

The error occurs because are treating the update to the mutation as an operation on remote state. It will be attempting to find the record added via mutation in the existing remote state of the inverse instead of the local state of the inverse.

