### PR TITLE
perf: dont notify for attrs on insertions or committed changes that are referentially equal

### DIFF
--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get Browser Flags
         id: browser-flags
         run: |
-          node ./scripts/perf-tracking/get-browser-flags.mjs >> $BROWSER_FLAGS
+          BROWSER_FLAGS=$(node ./scripts/perf-tracking/get-browser-flags.mjs)
           echo "BROWSER_FLAGS=$BROWSER_FLAGS" >> $GITHUB_OUTPUT
       - uses: tracerbench/tracerbench-compare-action@53cd4adeab84ad03bac3276d378fcf322a00f870
         with:

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           BROWSER_FLAGS=$(node ./scripts/perf-tracking/browser-flags.mjs)
           echo "BROWSER_FLAGS=$BROWSER_FLAGS" >> $GITHUB_OUTPUT
-      - uses: tracerbench/tracerbench-compare-action@53cd4adeab84ad03bac3276d378fcf322a00f870
+      - uses: tracerbench/tracerbench-compare-action@38085ba17b09de10a9824fac85ae50c3c3a9ae50
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           BROWSER_FLAGS=(node ./scripts/perf-tracking/get-browser-flags.mjs)
           echo "::set-output name=BROWSER_FLAGS::${BROWSER_FLAGS}"
-      - uses: tracerbench/tracerbench-compare-action@a02576756fdf716e14e116f9861712173a276bed
+      - uses: tracerbench/tracerbench-compare-action@53cd4adeab84ad03bac3276d378fcf322a00f870
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -48,6 +48,11 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
+      - name: Get Browser Flags
+        id: browser-flags
+        run: |
+          BROWSER_FLAGS=(node ./scripts/perf-tracking/get-browser-flags.mjs)
+          echo "::set-output name=BROWSER_FLAGS::${BROWSER_FLAGS}"
       - uses: tracerbench/tracerbench-compare-action@a02576756fdf716e14e116f9861712173a276bed
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
@@ -57,6 +62,7 @@ jobs:
           control-sha: origin/main
           sample-timeout: 60
           use-pnpm: true
+          browserArgs: ${{ steps.browser-flags.outputs.BROWSER_FLAGS }}
           scenarios: |
             {
               "basic-record-materialization": {

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get Browser Flags
         id: browser-flags
         run: |
-          BROWSER_FLAGS=$(node ./scripts/perf-tracking/get-browser-flags.mjs)
+          BROWSER_FLAGS=$(node ./scripts/perf-tracking/browser-flags.mjs)
           echo "BROWSER_FLAGS=$BROWSER_FLAGS" >> $GITHUB_OUTPUT
       - uses: tracerbench/tracerbench-compare-action@53cd4adeab84ad03bac3276d378fcf322a00f870
         with:

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - uses: tracerbench/tracerbench-compare-action@e281985200519c70303e7ddbbeb6151ba13c2e5b
+      - uses: tracerbench/tracerbench-compare-action@a02576756fdf716e14e116f9861712173a276bed
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Get Browser Flags
         id: browser-flags
         run: |
-          BROWSER_FLAGS=(node ./scripts/perf-tracking/get-browser-flags.mjs)
-          echo "::set-output name=BROWSER_FLAGS::${BROWSER_FLAGS}"
+          node ./scripts/perf-tracking/get-browser-flags.mjs >> $BROWSER_FLAGS
+          echo "BROWSER_FLAGS=$BROWSER_FLAGS" >> $GITHUB_OUTPUT
       - uses: tracerbench/tracerbench-compare-action@53cd4adeab84ad03bac3276d378fcf322a00f870
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -62,7 +62,7 @@ jobs:
           control-sha: origin/main
           sample-timeout: 60
           use-pnpm: true
-          browserArgs: ${{ steps.browser-flags.outputs.BROWSER_FLAGS }}
+          browser-args: ${{ steps.browser-flags.outputs.BROWSER_FLAGS }}
           scenarios: |
             {
               "basic-record-materialization": {

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - uses: tracerbench/tracerbench-compare-action@89a8b657a4ff4e6e266a0079545449523efac130
+      - uses: tracerbench/tracerbench-compare-action@e281985200519c70303e7ddbbeb6151ba13c2e5b
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - uses: tracerbench/tracerbench-compare-action@4d8df6162994be1e5fa30f63d53b241befb0496b
+      - uses: tracerbench/tracerbench-compare-action@89a8b657a4ff4e6e266a0079545449523efac130
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -61,7 +61,7 @@ jobs:
           control-serve-command: pnpm --filter performance-test-app exec ember s --path dist-control
           sample-timeout: 60
           use-pnpm: true
-          browserArgs: ${{ steps.browser-flags.outputs.BROWSER_FLAGS }}
+          browser-args: ${{ steps.browser-flags.outputs.BROWSER_FLAGS }}
           scenarios: |
             {
               "basic-record-materialization": {

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get Browser Flags
         id: browser-flags
         run: |
-          node ./scripts/perf-tracking/get-browser-flags.mjs >> $BROWSER_FLAGS
+          BROWSER_FLAGS=$(node ./scripts/perf-tracking/get-browser-flags.mjs)
           echo "BROWSER_FLAGS=$BROWSER_FLAGS" >> $GITHUB_OUTPUT
       - uses: tracerbench/tracerbench-compare-action@53cd4adeab84ad03bac3276d378fcf322a00f870
         with:

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           BROWSER_FLAGS=$(node ./scripts/perf-tracking/browser-flags.mjs)
           echo "BROWSER_FLAGS=$BROWSER_FLAGS" >> $GITHUB_OUTPUT
-      - uses: tracerbench/tracerbench-compare-action@53cd4adeab84ad03bac3276d378fcf322a00f870
+      - uses: tracerbench/tracerbench-compare-action@38085ba17b09de10a9824fac85ae50c3c3a9ae50
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           node-version: 19.x
           cache: 'pnpm'
-      - uses: tracerbench/tracerbench-compare-action@master
+      - uses: tracerbench/tracerbench-compare-action@4d8df6162994be1e5fa30f63d53b241befb0496b
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get Browser Flags
         id: browser-flags
         run: |
-          BROWSER_FLAGS=$(node ./scripts/perf-tracking/get-browser-flags.mjs)
+          BROWSER_FLAGS=$(node ./scripts/perf-tracking/browser-flags.mjs)
           echo "BROWSER_FLAGS=$BROWSER_FLAGS" >> $GITHUB_OUTPUT
       - uses: tracerbench/tracerbench-compare-action@53cd4adeab84ad03bac3276d378fcf322a00f870
         with:

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - uses: tracerbench/tracerbench-compare-action@e281985200519c70303e7ddbbeb6151ba13c2e5b
+      - uses: tracerbench/tracerbench-compare-action@a02576756fdf716e14e116f9861712173a276bed
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Get Browser Flags
         id: browser-flags
         run: |
-          BROWSER_FLAGS=(node ./scripts/perf-tracking/get-browser-flags.mjs)
-          echo "::set-output name=BROWSER_FLAGS::${BROWSER_FLAGS}"
+          node ./scripts/perf-tracking/get-browser-flags.mjs >> $BROWSER_FLAGS
+          echo "BROWSER_FLAGS=$BROWSER_FLAGS" >> $GITHUB_OUTPUT
       - uses: tracerbench/tracerbench-compare-action@53cd4adeab84ad03bac3276d378fcf322a00f870
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -42,8 +42,12 @@ jobs:
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 19.x
+          registry-url: 'https://registry.npmjs.org'
+          node-version-file: 'package.json'
           cache: 'pnpm'
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
       - uses: tracerbench/tracerbench-compare-action@4d8df6162994be1e5fa30f63d53b241befb0496b
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - uses: tracerbench/tracerbench-compare-action@89a8b657a4ff4e6e266a0079545449523efac130
+      - uses: tracerbench/tracerbench-compare-action@e281985200519c70303e7ddbbeb6151ba13c2e5b
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -48,7 +48,12 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - uses: tracerbench/tracerbench-compare-action@a02576756fdf716e14e116f9861712173a276bed
+      - name: Get Browser Flags
+        id: browser-flags
+        run: |
+          BROWSER_FLAGS=(node ./scripts/perf-tracking/get-browser-flags.mjs)
+          echo "::set-output name=BROWSER_FLAGS::${BROWSER_FLAGS}"
+      - uses: tracerbench/tracerbench-compare-action@53cd4adeab84ad03bac3276d378fcf322a00f870
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201
@@ -56,6 +61,7 @@ jobs:
           control-serve-command: pnpm --filter performance-test-app exec ember s --path dist-control
           sample-timeout: 60
           use-pnpm: true
+          browserArgs: ${{ steps.browser-flags.outputs.BROWSER_FLAGS }}
           scenarios: |
             {
               "basic-record-materialization": {

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - uses: tracerbench/tracerbench-compare-action@4d8df6162994be1e5fa30f63d53b241befb0496b
+      - uses: tracerbench/tracerbench-compare-action@89a8b657a4ff4e6e266a0079545449523efac130
         with:
           experiment-build-command: pnpm install && pnpm --filter performance-test-app exec ember build -e production --output-path dist-experiment --suppress-sizes
           experiment-serve-command: pnpm --filter performance-test-app exec ember s --path dist-experiment --port 4201

--- a/packages/core-types/src/identifier.ts
+++ b/packages/core-types/src/identifier.ts
@@ -2,13 +2,19 @@
   @module @ember-data/store
 */
 
+import { DEBUG } from '@warp-drive/build-config/env';
+
 // provided for additional debuggability
 export const DEBUG_CLIENT_ORIGINATED: unique symbol = Symbol('record-originated-on-client');
 export const DEBUG_IDENTIFIER_BUCKET: unique symbol = Symbol('identifier-bucket');
 export const DEBUG_STALE_CACHE_OWNER: unique symbol = Symbol('warpDriveStaleCache');
 
+function ProdSymbol<T extends string>(str: T): T {
+  return DEBUG ? (Symbol(str) as unknown as T) : str;
+}
+
 // also present in production
-export const CACHE_OWNER: unique symbol = Symbol('warpDriveCache');
+export const CACHE_OWNER = ProdSymbol('__$co');
 
 export type IdentifierBucket = 'record' | 'document';
 

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -334,7 +334,7 @@ export default class JSONAPICache implements Cache {
       const hasExisting = this.__documents.has(identifier.lid);
       this.__documents.set(identifier.lid, doc as StructuredDocument<ResourceDocument>);
 
-      this._capabilities.notifyChange(identifier, hasExisting ? 'updated' : 'added');
+      this._capabilities.notifyChange(identifier, hasExisting ? 'updated' : 'added', null);
     }
 
     return resourceDocument;
@@ -537,8 +537,8 @@ export default class JSONAPICache implements Cache {
 
     if (cached.isNew) {
       cached.isNew = false;
-      this._capabilities.notifyChange(identifier, 'identity');
-      this._capabilities.notifyChange(identifier, 'state');
+      this._capabilities.notifyChange(identifier, 'identity', null);
+      this._capabilities.notifyChange(identifier, 'state', null);
     }
 
     // if no cache entry existed, no record exists / property has been accessed
@@ -554,12 +554,12 @@ export default class JSONAPICache implements Cache {
 
     if (cached.localAttrs) {
       if (patchLocalAttributes(cached, changedKeys)) {
-        this._capabilities.notifyChange(identifier, 'state');
+        this._capabilities.notifyChange(identifier, 'state', null);
       }
     }
 
     if (!isUpdate) {
-      this._capabilities.notifyChange(identifier, 'added');
+      this._capabilities.notifyChange(identifier, 'added', null);
     }
 
     if (data.id) {
@@ -766,7 +766,7 @@ export default class JSONAPICache implements Cache {
       }
     }
 
-    this._capabilities.notifyChange(identifier, 'added');
+    this._capabilities.notifyChange(identifier, 'added', null);
 
     return createOptions;
   }
@@ -872,7 +872,7 @@ export default class JSONAPICache implements Cache {
         isNew: false,
       });
       cached.isDeletionCommitted = true;
-      this._capabilities.notifyChange(identifier, 'removed');
+      this._capabilities.notifyChange(identifier, 'removed', null);
       // TODO @runspired should we early exit here?
     }
 
@@ -894,7 +894,7 @@ export default class JSONAPICache implements Cache {
         cached.id = data.id;
       }
       if (identifier === committedIdentifier && identifier.id !== existingId) {
-        this._capabilities.notifyChange(identifier, 'identity');
+        this._capabilities.notifyChange(identifier, 'identity', null);
       }
 
       assert(
@@ -949,11 +949,11 @@ export default class JSONAPICache implements Cache {
 
     if (cached.errors) {
       cached.errors = null;
-      this._capabilities.notifyChange(identifier, 'errors');
+      this._capabilities.notifyChange(identifier, 'errors', null);
     }
 
     if (changedKeys?.size) notifyAttributes(this._capabilities, identifier, changedKeys);
-    this._capabilities.notifyChange(identifier, 'state');
+    this._capabilities.notifyChange(identifier, 'state', null);
 
     const included = payload && payload.included;
     if (included) {
@@ -994,7 +994,7 @@ export default class JSONAPICache implements Cache {
     if (errors) {
       cached.errors = errors;
     }
-    this._capabilities.notifyChange(identifier, 'errors');
+    this._capabilities.notifyChange(identifier, 'errors', null);
   }
 
   /**
@@ -1044,7 +1044,7 @@ export default class JSONAPICache implements Cache {
     if (areAllModelsUnloaded(storeWrapper, relatedIdentifiers)) {
       for (let i = 0; i < relatedIdentifiers.length; ++i) {
         const relatedIdentifier = relatedIdentifiers[i];
-        storeWrapper.notifyChange(relatedIdentifier, 'removed');
+        storeWrapper.notifyChange(relatedIdentifier, 'removed', null);
         removed = true;
         storeWrapper.disconnectRecord(relatedIdentifier);
       }
@@ -1074,7 +1074,7 @@ export default class JSONAPICache implements Cache {
     }
 
     if (!removed && removeFromRecordArray) {
-      storeWrapper.notifyChange(identifier, 'removed');
+      storeWrapper.notifyChange(identifier, 'removed', null);
     }
   }
 
@@ -1361,10 +1361,10 @@ export default class JSONAPICache implements Cache {
 
     if (cached.errors) {
       cached.errors = null;
-      this._capabilities.notifyChange(identifier, 'errors');
+      this._capabilities.notifyChange(identifier, 'errors', null);
     }
 
-    this._capabilities.notifyChange(identifier, 'state');
+    this._capabilities.notifyChange(identifier, 'state', null);
 
     if (dirtyKeys && dirtyKeys.length) {
       notifyAttributes(this._capabilities, identifier, new Set(dirtyKeys));
@@ -1468,7 +1468,7 @@ export default class JSONAPICache implements Cache {
     const cached = this.__peek(identifier, false);
     cached.isDeleted = isDeleted;
     // > Note: Graph removal for isNew handled by unloadRecord
-    this._capabilities.notifyChange(identifier, 'state');
+    this._capabilities.notifyChange(identifier, 'state', null);
   }
 
   /**
@@ -1670,7 +1670,7 @@ function notifyAttributes(
   keys?: Set<string>
 ) {
   if (!keys) {
-    storeWrapper.notifyChange(identifier, 'attributes');
+    storeWrapper.notifyChange(identifier, 'attributes', null);
     return;
   }
 

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -4,6 +4,7 @@
 import type { CollectionEdge, Graph, GraphEdge, ImplicitEdge, ResourceEdge } from '@ember-data/graph/-private';
 import { graphFor, isBelongsTo, peekGraph } from '@ember-data/graph/-private';
 import type Store from '@ember-data/store';
+import { logGroup } from '@ember-data/store/-private';
 import type { CacheCapabilitiesManager } from '@ember-data/store/types';
 import { LOG_MUTATIONS, LOG_OPERATIONS, LOG_REQUESTS } from '@warp-drive/build-config/debugging';
 import { DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE } from '@warp-drive/build-config/deprecations';
@@ -525,14 +526,25 @@ export default class JSONAPICache implements Cache {
     const isUpdate = /*#__NOINLINE__*/ !_isEmpty(peeked) && !isLoading;
 
     if (LOG_OPERATIONS) {
+      logGroup(
+        'cache',
+        'upsert',
+        identifier.type,
+        identifier.lid,
+        existed ? 'merged' : 'inserted',
+        calculateChanges ? 'has-subscription' : ''
+      );
       try {
         const _data = JSON.parse(JSON.stringify(data)) as object;
+
         // eslint-disable-next-line no-console
-        console.log(`EmberData | Operation - upsert (${existed ? 'merge' : 'insert'})`, _data);
+        console.log(_data);
       } catch {
         // eslint-disable-next-line no-console
-        console.log(`EmberData | Operation - upsert (${existed ? 'merge' : 'insert'})`, data);
+        console.log(data);
       }
+      // eslint-disable-next-line no-console
+      console.groupEnd();
     }
 
     if (cached.isNew) {

--- a/packages/model/src/-private/notify-changes.ts
+++ b/packages/model/src/-private/notify-changes.ts
@@ -16,26 +16,33 @@ export default function notifyChanges(
   record: Model,
   store: Store
 ) {
-  if (value === 'attributes') {
-    if (key) {
-      notifyAttribute(store, identifier, key, record);
-    } else {
-      record.eachAttribute((name) => {
-        notifyAttribute(store, identifier, name, record);
-      });
-    }
-  } else if (value === 'relationships') {
-    if (key) {
-      const meta = (record.constructor as typeof Model).relationshipsByName.get(key);
-      assert(`Expected to find a relationship for ${key} on ${identifier.type}`, meta);
-      notifyRelationship(identifier, key, record, meta);
-    } else {
-      record.eachRelationship((name, meta) => {
-        notifyRelationship(identifier, name, record, meta);
-      });
-    }
-  } else if (value === 'identity') {
-    record.notifyPropertyChange('id');
+  switch (value) {
+    case 'added':
+    case 'attributes':
+      if (key) {
+        notifyAttribute(store, identifier, key, record);
+      } else {
+        record.eachAttribute((name) => {
+          notifyAttribute(store, identifier, name, record);
+        });
+      }
+      break;
+
+    case 'relationships':
+      if (key) {
+        const meta = (record.constructor as typeof Model).relationshipsByName.get(key);
+        assert(`Expected to find a relationship for ${key} on ${identifier.type}`, meta);
+        notifyRelationship(identifier, key, record, meta);
+      } else {
+        record.eachRelationship((name, meta) => {
+          notifyRelationship(identifier, name, record, meta);
+        });
+      }
+      break;
+
+    case 'identity':
+      record.notifyPropertyChange('id');
+      break;
   }
 }
 

--- a/packages/store/src/-private.ts
+++ b/packages/store/src/-private.ts
@@ -49,3 +49,5 @@ export { setRecordIdentifier, StoreMap } from './-private/caches/instance-cache'
 export { setCacheFor } from './-private/caches/cache-utils';
 export { normalizeModelName as _deprecatingNormalize } from './-private/utils/normalize-model-name';
 export type { StoreRequestInput } from './-private/cache-handler/handler';
+
+export { log, logGroup } from './-private/debug/utils';

--- a/packages/store/src/-private/caches/identifier-cache.ts
+++ b/packages/store/src/-private/caches/identifier-cache.ts
@@ -39,11 +39,10 @@ import { hasId, hasLid, hasType } from './resource-utils';
 
 type ResourceData = unknown;
 
-const IDENTIFIERS = getOrSetGlobal('IDENTIFIERS', new Set());
 const DOCUMENTS = getOrSetGlobal('DOCUMENTS', new Set());
 
 export function isStableIdentifier(identifier: unknown): identifier is StableRecordIdentifier {
-  return (identifier as StableRecordIdentifier)[CACHE_OWNER] !== undefined || IDENTIFIERS.has(identifier);
+  return (identifier as StableRecordIdentifier)[CACHE_OWNER] !== undefined;
 }
 
 export function isDocumentIdentifier(identifier: unknown): identifier is StableDocumentIdentifier {
@@ -622,7 +621,6 @@ export class IdentifierCache {
       identifier[DEBUG_STALE_CACHE_OWNER] = identifier[CACHE_OWNER];
     }
     identifier[CACHE_OWNER] = undefined;
-    IDENTIFIERS.delete(identifier);
     this._forget(identifier, 'record');
     if (LOG_IDENTIFIERS) {
       // eslint-disable-next-line no-console
@@ -649,8 +647,6 @@ function makeStableRecordIdentifier(
   bucket: IdentifierBucket,
   clientOriginated: boolean
 ): StableRecordIdentifier {
-  IDENTIFIERS.add(recordIdentifier);
-
   if (DEBUG) {
     // we enforce immutability in dev
     //  but preserve our ability to do controlled updates to the reference
@@ -693,7 +689,6 @@ function makeStableRecordIdentifier(
     });
     wrapper[DEBUG_CLIENT_ORIGINATED] = clientOriginated;
     wrapper[DEBUG_IDENTIFIER_BUCKET] = bucket;
-    IDENTIFIERS.add(wrapper);
     DEBUG_MAP.set(wrapper, recordIdentifier);
     wrapper = freeze(wrapper);
     return wrapper;

--- a/packages/store/src/-private/caches/instance-cache.ts
+++ b/packages/store/src/-private/caches/instance-cache.ts
@@ -16,6 +16,7 @@ import type {
 } from '@warp-drive/core-types/spec/json-api-raw';
 
 import type { OpaqueRecordInstance } from '../../-types/q/record-instance';
+import { log, logGroup } from '../debug/utils';
 import RecordReference from '../legacy-model-support/record-reference';
 import { CacheCapabilitiesManager } from '../managers/cache-capabilities-manager';
 import type { CacheManager } from '../managers/cache-manager';
@@ -206,8 +207,11 @@ export class InstanceCache {
       this.__instances.record.set(identifier, record);
 
       if (LOG_INSTANCE_CACHE) {
+        logGroup('reactive-ui', '', identifier.type, identifier.lid, 'created', '');
         // eslint-disable-next-line no-console
-        console.log(`InstanceCache: created Record for ${String(identifier)}`, properties);
+        console.log({ properties });
+        // eslint-disable-next-line no-console
+        console.groupEnd();
       }
     }
 
@@ -260,8 +264,7 @@ export class InstanceCache {
     removeRecordDataFor(identifier);
     this.store._requestCache._clearEntries(identifier);
     if (LOG_INSTANCE_CACHE) {
-      // eslint-disable-next-line no-console
-      console.log(`InstanceCache: disconnected ${String(identifier)}`);
+      log('reactive-ui', '', identifier.type, identifier.lid, 'disconnected', '');
     }
   }
 

--- a/packages/store/src/-private/debug/utils.ts
+++ b/packages/store/src/-private/debug/utils.ts
@@ -1,0 +1,156 @@
+type SCOPE = 'notify' | 'reactive-ui' | 'graph' | 'request' | 'cache';
+
+const TEXT_COLORS = {
+  TEXT: 'inherit',
+  notify: ['white', 'white', 'inherit', 'magenta', 'inherit'],
+  'reactive-ui': ['white', 'white', 'inherit', 'magenta', 'inherit'],
+  graph: ['white', 'white', 'inherit', 'magenta', 'inherit'],
+  request: ['white', 'white', 'inherit', 'magenta', 'inherit'],
+  cache: ['white', 'white', 'inherit', 'magenta', 'inherit'],
+};
+const BG_COLORS = {
+  TEXT: 'transparent',
+  notify: ['dimgray', 'cadetblue', 'transparent', 'transparent', 'transparent'],
+  'reactive-ui': ['dimgray', 'cadetblue', 'transparent', 'transparent', 'transparent'],
+  graph: ['dimgray', 'cadetblue', 'transparent', 'transparent', 'transparent'],
+  request: ['dimgray', 'cadetblue', 'transparent', 'transparent', 'transparent'],
+  cache: ['dimgray', 'cadetblue', 'transparent', 'transparent', 'transparent'],
+};
+const NOTIFY_BORDER = {
+  TEXT: 0,
+  notify: [3, 2, 0, 0, 0],
+  'reactive-ui': [3, 2, 0, 0, 0],
+  graph: [3, 2, 0, 0, 0],
+  request: [3, 2, 0, 0, 0],
+  cache: [3, 2, 0, 0, 0],
+};
+
+const LIGHT_DARK_ALT: Record<string, string> = {
+  lightgreen: 'green',
+  green: 'lightgreen',
+};
+
+function badge(isLight: boolean, color: string, bgColor: string, border: number) {
+  return [
+    `color: ${correctColor(isLight, color)}; background-color: ${correctColor(isLight, bgColor)}; padding: ${border}px ${2 * border}px; border-radius: ${border}px;`,
+    `color: ${TEXT_COLORS.TEXT}; background-color: ${BG_COLORS.TEXT};`,
+  ];
+}
+
+function colorForBucket(isLight: boolean, scope: SCOPE, bucket: string) {
+  if (scope === 'notify') {
+    return bucket === 'added'
+      ? badge(isLight, 'lightgreen', 'transparent', 0)
+      : bucket === 'removed'
+        ? badge(isLight, 'red', 'transparent', 0)
+        : badge(isLight, TEXT_COLORS[scope][2], BG_COLORS[scope][2], NOTIFY_BORDER[scope][2]);
+  }
+  if (scope === 'reactive-ui') {
+    return bucket === 'created'
+      ? badge(isLight, 'lightgreen', 'transparent', 0)
+      : bucket === 'disconnected'
+        ? badge(isLight, 'red', 'transparent', 0)
+        : badge(isLight, TEXT_COLORS[scope][2], BG_COLORS[scope][2], NOTIFY_BORDER[scope][2]);
+  }
+  if (scope === 'cache') {
+    return bucket === 'inserted'
+      ? badge(isLight, 'lightgreen', 'transparent', 0)
+      : bucket === 'removed'
+        ? badge(isLight, 'red', 'transparent', 0)
+        : badge(isLight, TEXT_COLORS[scope][2], BG_COLORS[scope][2], NOTIFY_BORDER[scope][2]);
+  }
+
+  return badge(isLight, TEXT_COLORS[scope][3], BG_COLORS[scope][3], NOTIFY_BORDER[scope][3]);
+}
+
+export function logGroup(scope: 'cache', prefix: string, type: string, lid: string, bucket: string, key: string): void;
+export function logGroup(
+  scope: 'reactive-ui',
+  prefix: string,
+  type: string,
+  lid: string,
+  bucket: string,
+  key: ''
+): void;
+export function logGroup(scope: 'notify', prefix: string, type: string, lid: string, bucket: string, key: string): void;
+export function logGroup(
+  scope: SCOPE,
+  prefix: string,
+  subScop1: string,
+  subScop2: string,
+  subScop3: string,
+  subScop4: string
+): void {
+  // eslint-disable-next-line no-console
+  console.groupCollapsed(..._log(scope, prefix, subScop1, subScop2, subScop3, subScop4));
+}
+
+export function log(scope: 'cache', prefix: string, type: string, lid: string, bucket: string, key: string): void;
+export function log(scope: 'reactive-ui', prefix: string, type: string, lid: string, bucket: string, key: ''): void;
+export function log(scope: 'notify', prefix: string, type: string, lid: string, bucket: string, key: string): void;
+export function log(
+  scope: SCOPE,
+  prefix: string,
+  subScop1: string,
+  subScop2: string,
+  subScop3: string,
+  subScop4: string
+): void {
+  // eslint-disable-next-line no-console
+  console.log(..._log(scope, prefix, subScop1, subScop2, subScop3, subScop4));
+}
+
+function correctColor(isLight: boolean, color: string) {
+  if (!isLight) {
+    return color;
+  }
+  return color in LIGHT_DARK_ALT ? LIGHT_DARK_ALT[color] : color;
+}
+
+function isLightMode() {
+  if (window?.matchMedia?.('(prefers-color-scheme: light)').matches) {
+    return true;
+  }
+  return false;
+}
+
+function _log(
+  scope: SCOPE,
+  prefix: string,
+  subScop1: string,
+  subScop2: string,
+  subScop3: string,
+  subScop4: string
+): string[] {
+  const isLight = isLightMode();
+  switch (scope) {
+    case 'reactive-ui':
+    case 'notify': {
+      const scopePath = prefix ? `[${prefix}] ${scope}` : scope;
+      const path = subScop4 ? `${subScop3}.${subScop4}` : subScop3;
+      return [
+        `%c@warp%c-%cdrive%c %c${scopePath}%c %c${subScop1}%c %c${subScop2}%c %c${path}%c`,
+        ...badge(isLight, 'lightgreen', 'transparent', 0),
+        ...badge(isLight, 'magenta', 'transparent', 0),
+        ...badge(isLight, TEXT_COLORS[scope][0], BG_COLORS[scope][0], NOTIFY_BORDER[scope][0]),
+        ...badge(isLight, TEXT_COLORS[scope][1], BG_COLORS[scope][1], NOTIFY_BORDER[scope][1]),
+        ...badge(isLight, TEXT_COLORS[scope][2], BG_COLORS[scope][2], NOTIFY_BORDER[scope][2]),
+        ...colorForBucket(isLight, scope, path),
+      ];
+    }
+    case 'cache': {
+      const scopePath = prefix ? `${scope} (${prefix})` : scope;
+      return [
+        `%c@warp%c-%cdrive%c %c${scopePath}%c %c${subScop1}%c %c${subScop2}%c %c${subScop3}%c %c${subScop4}%c`,
+        ...badge(isLight, 'lightgreen', 'transparent', 0),
+        ...badge(isLight, 'magenta', 'transparent', 0),
+        ...badge(isLight, TEXT_COLORS[scope][0], BG_COLORS[scope][0], NOTIFY_BORDER[scope][0]),
+        ...badge(isLight, TEXT_COLORS[scope][1], BG_COLORS[scope][1], NOTIFY_BORDER[scope][1]),
+        ...badge(isLight, TEXT_COLORS[scope][2], BG_COLORS[scope][2], NOTIFY_BORDER[scope][2]),
+        ...colorForBucket(isLight, scope, subScop3),
+        ...badge(isLight, TEXT_COLORS[scope][4], BG_COLORS[scope][4], NOTIFY_BORDER[scope][4]),
+      ];
+    }
+  }
+  return [];
+}

--- a/packages/store/src/-private/managers/cache-capabilities-manager.ts
+++ b/packages/store/src/-private/managers/cache-capabilities-manager.ts
@@ -72,13 +72,13 @@ export class CacheCapabilitiesManager implements StoreWrapper {
     });
   }
 
-  notifyChange(identifier: StableRecordIdentifier, namespace: 'added' | 'removed'): void;
-  notifyChange(identifier: StableDocumentIdentifier, namespace: 'added' | 'updated' | 'removed'): void;
-  notifyChange(identifier: StableRecordIdentifier, namespace: NotificationType, key?: string): void;
+  notifyChange(identifier: StableRecordIdentifier, namespace: 'added' | 'removed', key: null): void;
+  notifyChange(identifier: StableDocumentIdentifier, namespace: 'added' | 'updated' | 'removed', key: null): void;
+  notifyChange(identifier: StableRecordIdentifier, namespace: NotificationType, key: string | null): void;
   notifyChange(
     identifier: StableRecordIdentifier | StableDocumentIdentifier,
     namespace: NotificationType | 'added' | 'removed' | 'updated',
-    key?: string
+    key: string | null
   ): void {
     assert(`Expected a stable identifier`, isStableIdentifier(identifier) || isDocumentIdentifier(identifier));
 

--- a/packages/store/src/-types/q/cache-capabilities-manager.ts
+++ b/packages/store/src/-types/q/cache-capabilities-manager.ts
@@ -108,12 +108,12 @@ export type CacheCapabilitiesManager = {
    * @param {string|undefined} key
    * @public
    */
-  notifyChange(identifier: StableRecordIdentifier, namespace: 'added' | 'removed'): void;
-  notifyChange(identifier: StableDocumentIdentifier, namespace: 'added' | 'updated' | 'removed'): void;
-  notifyChange(identifier: StableRecordIdentifier, namespace: NotificationType, key?: string): void;
+  notifyChange(identifier: StableRecordIdentifier, namespace: 'added' | 'removed', key: null): void;
+  notifyChange(identifier: StableDocumentIdentifier, namespace: 'added' | 'updated' | 'removed', key: null): void;
+  notifyChange(identifier: StableRecordIdentifier, namespace: NotificationType, key: string | null): void;
   notifyChange(
     identifier: StableRecordIdentifier | StableDocumentIdentifier,
     namespace: NotificationType | 'added' | 'removed' | 'updated',
-    key?: string
+    key: string | null
   ): void;
 };

--- a/scripts/perf-tracking/browser-flags.mjs
+++ b/scripts/perf-tracking/browser-flags.mjs
@@ -1,0 +1,140 @@
+import process from 'process';
+
+const DEBUG = Boolean(process.env.DEBUG) || false;
+const DEBUG_MEMORY = Boolean(process.env.DEBUG_MEMORY) || false;
+const DISABLE_HEADLESS = Boolean(process.env.DISABLE_HEADLESS) || false;
+
+const flags = [
+  // '--user-data-dir=' + getTmpDir(browser),
+  DISABLE_HEADLESS ? false : '--headless=new',
+  '--no-sandbox',
+  // these prevent user account
+  // and extensions from mucking with things
+  '--incognito',
+  '--bwsi',
+  '--enable-automation',
+
+  // potentially needed to enable multi-tab
+  '--allow-http-background-page',
+  // '--silent-debugger-extension-api',
+  '--disable-throttle-non-visible-cross-origin-iframes',
+  // '--memory-saver-multi-state-mode=discarded',
+  // '--disable-battery-saver-mode',
+  // '--disable-memory-saver-mode',
+  // '--enable-background-thread-pool',
+  // '--disable-background-media-suspend',
+  // '--disable-tab-discarding',
+  // '--disable-aggressive-tab-discard',
+  // disabled because already enabled elsewhere
+  // '--disable-backgrounding-occluded-windows',
+
+  // Enable Debugging Output
+  DEBUG ? '--enable-logging=stderr' : '--disable-logging',
+  DEBUG ? '--v=2' : false,
+
+  // when debugging memory usage this gives us better data
+  DEBUG_MEMORY ? '--enable-precise-memory-info' : false,
+  DEBUG_MEMORY ? '--js-flags="--allow-natives-syntax --expose-gc"' : false,
+
+  // Disable Browser Features we don't want
+  // =====================================
+  '--ash-no-nudges',
+  '--autoplay-policy=user-gesture-required',
+  '--disable-add-to-shelf',
+  '--disable-client-side-phishing-detection',
+  '--disable-component-extensions-with-background-pages',
+  '--disable-default-apps',
+  '--disable-desktop-notifications',
+  '--disable-popup-blocking',
+  '--disable-domain-reliability',
+  '--disable-extensions',
+  '--disable-infobars',
+  '--disable-notifications',
+  '--disable-search-engine-choice-screen',
+  '--disable-setuid-sandbox',
+  '--disable-site-isolation-trials',
+  '--disable-sync',
+  '--force-color-profile=srgb',
+  '--force-device-scale-factor=1',
+  // This can cause a test to flake
+  // '--hide-scrollbars',
+  '--ignore-certificate-errors',
+  '--disable-proxy-certificate-handler',
+  // useful in some situations when you trust that
+  // your tests won't call out to the internet
+  // '--disable-content-security-policy',
+  '--mute-audio',
+  '--no-default-browser-check',
+  '--no-first-run',
+  '--test-type',
+
+  // disable specific features
+  // =====================================
+  `--disable-features=${[
+    'ChromeEOLPowerSaveMode',
+    'AutofillServerCommunication',
+    'AvoidUnnecessaryBeforeUnloadCheckSync',
+    'BackForwardCache',
+    'BlinkGenPropertyTrees',
+    'CalculateNativeWinOcclusion',
+    'CertificateTransparencyComponentUpdater',
+    'DialMediaRouteProvider',
+    // 'HeavyAdPrivacyMitigation',
+    'InterestFeedContentSuggestions',
+    'IsolateOrigins',
+    'LazyFrameLoading',
+    'MediaRouter',
+    'OptimizationHints',
+    // 'ScriptStreaming',
+    'Translate',
+  ]
+    .filter(Boolean)
+    .join(',')}`,
+
+  // Adjust Task Throttling
+  // =====================================
+  '--disable-background-timer-throttling',
+  '--disable-backgrounding-occluded-windows',
+  '--disable-hang-monitor',
+  '--disable-ipc-flooding-protection',
+  '--disable-renderer-backgrounding',
+
+  // Disable Background Networking
+  // =====================================
+  '--disable-background-networking',
+  DEBUG ? false : '--disable-breakpad',
+  '--disable-component-update',
+  '--disable-domain-reliability',
+  '--no-pings',
+
+  // On Ubuntu this dev-shm-usage speeds you up on bigger machines
+  // and slows you down on smaller. If you are on a larger CI box
+  // you should consider re-enabling this.
+  // off because ubuntu vms currently seem to crash without this
+  // due to missing drivers
+  // '--disable-dev-shm-usage',
+
+  // Potentially no longer needed settings
+  // =====================================
+  '--disable-gpu',
+  '--disable-3d-apis',
+  '--disable-software-rasterizer',
+  '--disable-webgl',
+  // disable-web-security seems to cause browser not able to connect issues
+  // '--disable-web-security',
+  '--disable-remote-fonts',
+  '--blink-settings=imagesEnabled=false',
+
+  // ubuntu-16-core seems to be unhappy with this being set to a non-zero port
+  // throws: ERROR:socket_posix.cc(147)] bind() failed: Address already in use (98)
+  // options.useEventSimulation ? '--remote-debugging-port=0' : false,
+  // options.useEventSimulation ? '--remote-debugging-address=0.0.0.0' : false,
+  '--window-size=1440,900',
+  // no-proxy seems to cause browser not able to connect issues
+  // '--no-proxy-server',
+  // '--proxy-bypass-list=*',
+  // "--proxy-server='direct://'",
+].filter(Boolean);
+
+process.stdout.write(JSON.stringify(flags) + '\n');
+process.exit(0);

--- a/tests/main/ember-cli-build.js
+++ b/tests/main/ember-cli-build.js
@@ -57,6 +57,17 @@ module.exports = async function (defaults) {
 
   setConfig(app, __dirname, {
     compatWith: process.env.EMBER_DATA_FULL_COMPAT ? '99.0' : null,
+    debug: {
+      // LOG_GRAPH: true,
+      // LOG_IDENTIFIERS: true,
+      // LOG_NOTIFICATIONS: true,
+      // LOG_INSTANCE_CACHE: true,
+      // LOG_MUTATIONS: true,
+      // LOG_PAYLOADS: true,
+      // LOG_REQUESTS: true,
+      // LOG_REQUEST_STATUS: true,
+      // LOG_OPERATIONS: true,
+    },
   });
 
   return app.toTree();

--- a/tests/main/tests/integration/cache/spec-cache-errors-test.ts
+++ b/tests/main/tests/integration/cache/spec-cache-errors-test.ts
@@ -114,11 +114,11 @@ class TestCache implements Cache {
     calculateChanges?: boolean
   ): void | string[] {
     if (!this._data.has(identifier)) {
-      this.wrapper.notifyChange(identifier, 'added');
+      this.wrapper.notifyChange(identifier, 'added', null);
     }
     this._data.set(identifier, data);
-    this.wrapper.notifyChange(identifier, 'attributes');
-    this.wrapper.notifyChange(identifier, 'relationships');
+    this.wrapper.notifyChange(identifier, 'attributes', null);
+    this.wrapper.notifyChange(identifier, 'relationships', null);
   }
   clientDidCreate(identifier: StableRecordIdentifier, options?: Record<string, unknown>): Record<string, unknown> {
     this._isNew = true;
@@ -354,7 +354,7 @@ module('integration/record-data Custom Cache (v2) Errors', function (hooks) {
         },
       },
     ];
-    storeWrapper.notifyChange(identifier, 'errors');
+    storeWrapper.notifyChange(identifier, 'errors', null);
 
     nameError = person.errors.errorsFor('firstName').objectAt(0);
 
@@ -362,7 +362,7 @@ module('integration/record-data Custom Cache (v2) Errors', function (hooks) {
     assert.false(person.isValid, 'person is not valid');
 
     errorsToReturn = [];
-    storeWrapper.notifyChange(identifier, 'errors');
+    storeWrapper.notifyChange(identifier, 'errors', null);
 
     assert.strictEqual(person.errors.errorsFor('firstName').length, 0, 'no errors on name');
     assert.true(person.isValid, 'person is valid');
@@ -376,7 +376,7 @@ module('integration/record-data Custom Cache (v2) Errors', function (hooks) {
         },
       },
     ];
-    storeWrapper.notifyChange(identifier, 'errors');
+    storeWrapper.notifyChange(identifier, 'errors', null);
 
     assert.false(person.isValid, 'person is not valid');
 

--- a/tests/main/tests/integration/cache/spec-cache-state-test.ts
+++ b/tests/main/tests/integration/cache/spec-cache-state-test.ts
@@ -129,11 +129,11 @@ class TestCache implements Cache {
     calculateChanges?: boolean
   ): void | string[] {
     if (!this._data.has(identifier)) {
-      this._storeWrapper.notifyChange(identifier, 'added');
+      this._storeWrapper.notifyChange(identifier, 'added', null);
     }
     this._data.set(identifier, data);
-    this._storeWrapper.notifyChange(identifier, 'attributes');
-    this._storeWrapper.notifyChange(identifier, 'relationships');
+    this._storeWrapper.notifyChange(identifier, 'attributes', null);
+    this._storeWrapper.notifyChange(identifier, 'relationships', null);
   }
   mutate(operation: LocalRelationshipOperation): void {
     throw new Error('Method not implemented.');
@@ -145,7 +145,7 @@ class TestCache implements Cache {
 
   clientDidCreate(identifier: StableRecordIdentifier, options?: Record<string, unknown>): Record<string, unknown> {
     this._isNew = true;
-    this._storeWrapper.notifyChange(identifier, 'added');
+    this._storeWrapper.notifyChange(identifier, 'added', null);
     return {};
   }
   willCommit(identifier: StableRecordIdentifier): void {}
@@ -374,14 +374,14 @@ module('integration/record-data - Record Data State', function (hooks) {
     assert.strictEqual(people.length, 1, 'live array starting length is 1');
 
     isNew = true;
-    storeWrapper.notifyChange(personIdentifier, 'state');
+    storeWrapper.notifyChange(personIdentifier, 'state', null);
     await settled();
     assert.true(person.isNew, 'person is new');
     assert.strictEqual(people.length, 1, 'live array starting length is 1');
 
     isNew = false;
     isDeleted = true;
-    storeWrapper.notifyChange(personIdentifier, 'state');
+    storeWrapper.notifyChange(personIdentifier, 'state', null);
     await settled();
     assert.false(person.isNew, 'person is not new');
     assert.true(person.isDeleted, 'person is deleted');
@@ -389,7 +389,7 @@ module('integration/record-data - Record Data State', function (hooks) {
 
     isNew = false;
     isDeleted = false;
-    storeWrapper.notifyChange(personIdentifier, 'state');
+    storeWrapper.notifyChange(personIdentifier, 'state', null);
     await settled();
     assert.false(person.isNew, 'person is not new');
     assert.false(person.isDeleted, 'person is not deleted');
@@ -401,7 +401,7 @@ module('integration/record-data - Record Data State', function (hooks) {
     assert.true(calledSetIsDeleted, 'called setIsDeleted');
 
     isDeletionCommitted = true;
-    storeWrapper.notifyChange(personIdentifier, 'state');
+    storeWrapper.notifyChange(personIdentifier, 'state', null);
     await settled();
     assert.strictEqual(people.length, 0, 'committing a deletion updates the live array');
   });

--- a/tests/main/tests/integration/cache/spec-cache-test.ts
+++ b/tests/main/tests/integration/cache/spec-cache-test.ts
@@ -143,11 +143,11 @@ class TestCache implements Cache {
     calculateChanges?: boolean
   ): void | string[] {
     if (!this._data.has(identifier)) {
-      this._storeWrapper.notifyChange(identifier, 'added');
+      this._storeWrapper.notifyChange(identifier, 'added', null);
     }
     this._data.set(identifier, data);
-    this._storeWrapper.notifyChange(identifier, 'attributes');
-    this._storeWrapper.notifyChange(identifier, 'relationships');
+    this._storeWrapper.notifyChange(identifier, 'attributes', null);
+    this._storeWrapper.notifyChange(identifier, 'relationships', null);
   }
 
   clientDidCreate(identifier: StableRecordIdentifier, options?: Record<string, unknown>): Record<string, unknown> {

--- a/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -96,8 +96,8 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
     store._join(() => {
       capabilities.notifyChange(identifier, 'relationships', 'key');
       capabilities.notifyChange(identifier, 'relationships', 'key');
-      capabilities.notifyChange(identifier, 'state');
-      capabilities.notifyChange(identifier, 'errors');
+      capabilities.notifyChange(identifier, 'state', null);
+      capabilities.notifyChange(identifier, 'errors', null);
     });
 
     assert.strictEqual(notificationCount, 3, 'called notification callback');


### PR DESCRIPTION
While debugging 4.13 with @gitKrystan I noticed that the attribute notifications were noisier than I would have expected, this will reduce that noise especially for newly created records.

This PR also fixes a few invariant method signatures and drops use of the global IDENTIFIERS set as it is no longer required.

This PR also improves the logging output, and updates our perf-test harness. However, due to an issue somewhere with chrome+tracerbench I've not been able to get it to run yet.