### PR TITLE
perf: reduce notifications on relationship remote state updates

### DIFF
--- a/packages/core-types/src/spec/document.ts
+++ b/packages/core-types/src/spec/document.ts
@@ -9,13 +9,13 @@ export interface ResourceMetaDocument {
   links?: Links | PaginationLinks;
 }
 
-export interface SingleResourceDataDocument<T = StableExistingRecordIdentifier> {
+export interface SingleResourceDataDocument<T = StableExistingRecordIdentifier, R = StableExistingRecordIdentifier> {
   // the url or cache-key associated with the structured document
   lid?: string;
   links?: Links | PaginationLinks;
   meta?: Meta;
   data: T | null;
-  included?: T[];
+  included?: R[];
 }
 
 export interface CollectionResourceDataDocument<T = StableExistingRecordIdentifier> {

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -384,16 +384,22 @@ export default class JSONAPICache implements Cache {
    */
   mutate(mutation: LocalRelationshipOperation): void {
     if (LOG_MUTATIONS) {
+      logGroup('cache', 'mutate', mutation.record.type, mutation.record.lid, mutation.field, mutation.op);
       try {
         const _data = JSON.parse(JSON.stringify(mutation)) as object;
         // eslint-disable-next-line no-console
-        console.log(`EmberData | Mutation - update ${mutation.op}`, _data);
+        console.log(_data);
       } catch {
         // eslint-disable-next-line no-console
-        console.log(`EmberData | Mutation - update ${mutation.op}`, mutation);
+        console.log(mutation);
       }
     }
     this.__graph.update(mutation, false);
+
+    if (LOG_MUTATIONS) {
+      // eslint-disable-next-line no-console
+      console.groupEnd();
+    }
   }
 
   /**
@@ -543,8 +549,6 @@ export default class JSONAPICache implements Cache {
         // eslint-disable-next-line no-console
         console.log(data);
       }
-      // eslint-disable-next-line no-console
-      console.groupEnd();
     }
 
     if (cached.isNew) {
@@ -584,6 +588,11 @@ export default class JSONAPICache implements Cache {
 
     if (changedKeys?.size) {
       notifyAttributes(this._capabilities, identifier, changedKeys);
+    }
+
+    if (LOG_OPERATIONS) {
+      // eslint-disable-next-line no-console
+      console.groupEnd();
     }
 
     return changedKeys?.size ? Array.from(changedKeys) : undefined;

--- a/tests/main/tests/integration/relationships/collection/mutating-has-many-test-infra.ts
+++ b/tests/main/tests/integration/relationships/collection/mutating-has-many-test-infra.ts
@@ -1,3 +1,4 @@
+import type { TestContext } from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
 
 import { module, test } from 'qunit';
@@ -201,7 +202,14 @@ function generateAppliedMutation(store: Store, record: User, mutation: Mutation)
   };
 }
 
-async function applyMutation(assert: Assert, store: Store, record: User, mutation: Mutation, rc: ReactiveContext) {
+async function applyMutation(
+  this: TestContext,
+  assert: Assert,
+  store: Store,
+  record: User,
+  mutation: Mutation,
+  rc: ReactiveContext
+) {
   assert.ok(true, `LOG: applying "${mutation.name}" with ids [${mutation.values.map((v) => v.id).join(',')}]`);
 
   const { counters, fieldOrder } = rc;
@@ -436,8 +444,8 @@ export function runTestGroup(splitNum: number, offset: number) {
             });
             rc.reset();
 
-            await applyMutation(assert, store, user, mutation, rc);
-            await applyMutation(assert, store, user, mutation2, rc);
+            await applyMutation.call(this, assert, store, user, mutation, rc);
+            await applyMutation.call(this, assert, store, user, mutation2, rc);
           });
         });
       }

--- a/tests/main/tests/integration/relationships/not-overly-reactive-test.ts
+++ b/tests/main/tests/integration/relationships/not-overly-reactive-test.ts
@@ -1,0 +1,536 @@
+import { rerender } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { setupRenderingTest, setupTest } from 'ember-qunit';
+
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import type Store from '@ember-data/store';
+import { deprecatedTest } from '@ember-data/unpublished-test-infra/test-support/deprecated-test';
+import { Type } from '@warp-drive/core-types/symbols';
+
+import { reactiveContext } from '../../helpers/reactive-context';
+
+module('Integration | Not Overly Reactive', function (hooks) {
+  setupTest(hooks);
+
+  test('pushing an identical relationship state should not clear local mutations (inverse specified)', function (assert) {
+    class Post extends Model {
+      declare [Type]: 'post';
+      @attr declare title: string;
+      @hasMany('comment', { async: false, inverse: 'post', resetOnRemoteUpdate: false }) declare comments: Comment[];
+    }
+
+    class Comment extends Model {
+      declare [Type]: 'comment';
+      @attr declare text: string;
+      @belongsTo('post', { async: false, inverse: 'comments' }) declare post: Post;
+    }
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    const store = this.owner.lookup('service:store') as Store;
+
+    const post = store.push<Post>({
+      data: {
+        id: '1',
+        type: 'post',
+        attributes: {
+          title: 'Post 1',
+        },
+        relationships: {
+          comments: {
+            data: [
+              { id: '1', type: 'comment' },
+              { id: '2', type: 'comment' },
+              { id: '3', type: 'comment' },
+            ],
+          },
+        },
+      },
+      included: [
+        {
+          id: '1',
+          type: 'comment',
+          attributes: {
+            text: 'Comment 1',
+          },
+          relationships: {
+            post: {
+              data: { id: '1', type: 'post' },
+            },
+          },
+        },
+        {
+          id: '2',
+          type: 'comment',
+          attributes: {
+            text: 'Comment 2',
+          },
+          relationships: {
+            post: {
+              data: { id: '1', type: 'post' },
+            },
+          },
+        },
+        {
+          id: '3',
+          type: 'comment',
+          attributes: {
+            text: 'Comment 3',
+          },
+          relationships: {
+            post: {
+              data: { id: '1', type: 'post' },
+            },
+          },
+        },
+      ],
+    });
+    const comment4 = store.push<Comment>({
+      data: {
+        id: '4',
+        type: 'comment',
+        attributes: {
+          text: 'Comment 4',
+        },
+        relationships: {
+          post: {
+            data: null,
+          },
+        },
+      },
+    });
+
+    assert.arrayStrictEquals(
+      post.comments.map((v) => v.id),
+      ['1', '2', '3'],
+      'initial comments are present'
+    );
+    assert.strictEqual(comment4.post, null, 'initial comment 4 has no post');
+
+    post.comments.push(comment4);
+
+    assert.arrayStrictEquals(
+      post.comments.map((v) => v.id),
+      ['1', '2', '3', '4'],
+      'comments are updated'
+    );
+    assert.strictEqual(comment4.post?.id, post?.id, 'comment 4 is updated');
+
+    store.push<Post>({
+      data: {
+        id: '1',
+        type: 'post',
+        attributes: {
+          title: 'Post 1',
+        },
+        relationships: {
+          comments: {
+            data: [
+              { id: '1', type: 'comment' },
+              { id: '2', type: 'comment' },
+              { id: '3', type: 'comment' },
+            ],
+          },
+        },
+      },
+    });
+
+    assert.arrayStrictEquals(
+      post.comments.map((v) => v.id),
+      ['1', '2', '3', '4'],
+      'comments are NOT updated'
+    );
+    assert.strictEqual(comment4.post?.id, post.id, 'comment 4 is NOT updated');
+  });
+
+  test('pushing an identical relationship state should not clear local mutations (inverse not specified)', function (assert) {
+    class Post extends Model {
+      declare [Type]: 'post';
+      @attr declare title: string;
+      @hasMany('comment', { async: false, inverse: 'post', resetOnRemoteUpdate: false }) declare comments: Comment[];
+    }
+
+    class Comment extends Model {
+      declare [Type]: 'comment';
+      @attr declare text: string;
+      @belongsTo('post', { async: false, inverse: 'comments' }) declare post: Post;
+    }
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    const store = this.owner.lookup('service:store') as Store;
+
+    const post = store.push<Post>({
+      data: {
+        id: '1',
+        type: 'post',
+        attributes: {
+          title: 'Post 1',
+        },
+        relationships: {
+          comments: {
+            data: [
+              { id: '1', type: 'comment' },
+              { id: '2', type: 'comment' },
+              { id: '3', type: 'comment' },
+            ],
+          },
+        },
+      },
+      included: [
+        {
+          id: '1',
+          type: 'comment',
+          attributes: {
+            text: 'Comment 1',
+          },
+          relationships: {
+            post: {
+              data: { id: '1', type: 'post' },
+            },
+          },
+        },
+        {
+          id: '2',
+          type: 'comment',
+          attributes: {
+            text: 'Comment 2',
+          },
+          relationships: {
+            post: {
+              data: { id: '1', type: 'post' },
+            },
+          },
+        },
+        {
+          id: '3',
+          type: 'comment',
+          attributes: {
+            text: 'Comment 3',
+          },
+          relationships: {
+            post: {
+              data: { id: '1', type: 'post' },
+            },
+          },
+        },
+      ],
+    });
+    const comment4 = store.push<Comment>({
+      data: {
+        id: '4',
+        type: 'comment',
+        attributes: {
+          text: 'Comment 4',
+        },
+        relationships: {
+          post: {
+            data: null,
+          },
+        },
+      },
+    });
+
+    assert.arrayStrictEquals(
+      post.comments.map((v) => v.id),
+      ['1', '2', '3'],
+      'initial comments are present'
+    );
+    assert.strictEqual(comment4.post, null, 'initial comment 4 has no post');
+
+    post.comments.push(comment4);
+
+    assert.arrayStrictEquals(
+      post.comments.map((v) => v.id),
+      ['1', '2', '3', '4'],
+      'comments are updated'
+    );
+    assert.strictEqual(comment4.post?.id, post?.id, 'comment 4 is updated');
+
+    store.push<Post>({
+      data: {
+        id: '1',
+        type: 'post',
+        attributes: {
+          title: 'Post 1',
+        },
+        relationships: {
+          comments: {
+            data: [
+              { id: '1', type: 'comment' },
+              { id: '2', type: 'comment' },
+              { id: '3', type: 'comment' },
+            ],
+          },
+        },
+      },
+    });
+
+    assert.arrayStrictEquals(
+      post.comments.map((v) => v.id),
+      ['1', '2', '3', '4'],
+      'comments are NOT updated'
+    );
+    assert.strictEqual(comment4.post?.id, post.id, 'comment 4 is NOT updated');
+  });
+});
+
+module('Integration | Not Overly Reactive (rendering)', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('pushing a relationship state identical to the local state should not notify (inverse specified)', async function (assert) {
+    class Post extends Model {
+      declare [Type]: 'post';
+      @attr declare title: string;
+      @hasMany('comment', { async: false, inverse: 'post', resetOnRemoteUpdate: false }) declare comments: Comment[];
+    }
+
+    class Comment extends Model {
+      declare [Type]: 'comment';
+      @attr declare text: string;
+      @belongsTo('post', { async: false, inverse: 'comments' }) declare post: Post;
+    }
+
+    this.owner.register('model:post', Post);
+    this.owner.register('model:comment', Comment);
+    const store = this.owner.lookup('service:store') as Store;
+
+    const post = store.push<Post>({
+      data: {
+        id: '1',
+        type: 'post',
+        attributes: {
+          title: 'Post 1',
+        },
+        relationships: {
+          comments: {
+            data: [],
+          },
+        },
+      },
+      included: [
+        {
+          id: '1',
+          type: 'comment',
+          attributes: {
+            text: 'Comment 1',
+          },
+          relationships: {
+            post: {
+              data: null,
+            },
+          },
+        },
+        {
+          id: '2',
+          type: 'comment',
+          attributes: {
+            text: 'Comment 2',
+          },
+          relationships: {
+            post: {
+              data: null,
+            },
+          },
+        },
+        {
+          id: '3',
+          type: 'comment',
+          attributes: {
+            text: 'Comment 3',
+          },
+          relationships: {
+            post: {
+              data: null,
+            },
+          },
+        },
+      ],
+    });
+    const comment1 = store.peekRecord<Comment>('comment', '1')!;
+    const comment2 = store.peekRecord<Comment>('comment', '2')!;
+    const comment3 = store.peekRecord<Comment>('comment', '3')!;
+
+    const postSchema = Object.assign({}, store.schema.resource({ type: 'post' }));
+    postSchema.fields = postSchema.fields.filter((field) => field.name === 'comments');
+    postSchema.identity = null;
+
+    const context = await reactiveContext.call(this, post, postSchema);
+    assert.strictEqual(context.counters.comments, 1, 'rendered comments once');
+
+    assert.arrayStrictEquals(
+      post.comments.map((v) => v.id),
+      [],
+      'initially no comments are present'
+    );
+
+    post.comments = [comment1, comment2, comment3];
+
+    await rerender();
+    assert.strictEqual(context.counters.comments, 2, 'rendered comments twice');
+
+    assert.arrayStrictEquals(
+      post.comments.map((v) => v.id),
+      ['1', '2', '3'],
+      'comments are updated'
+    );
+
+    store.push<Post>({
+      data: {
+        id: '1',
+        type: 'post',
+        attributes: {
+          title: 'Post 1',
+        },
+        relationships: {
+          comments: {
+            data: [
+              { id: '1', type: 'comment' },
+              { id: '2', type: 'comment' },
+              { id: '3', type: 'comment' },
+            ],
+          },
+        },
+      },
+    });
+
+    assert.arrayStrictEquals(
+      post.comments.map((v) => v.id),
+      ['1', '2', '3'],
+      'comments are NOT updated'
+    );
+
+    assert.strictEqual(context.counters.comments, 2, 'did not rerender comments');
+  });
+
+  deprecatedTest(
+    'pushing a relationship state identical to the local state should not notify (inverse specified)',
+    { id: 'ember-data:deprecate-relationship-remote-update-clearing-local-state', count: 0, until: '6.0.0' },
+    async function (assert) {
+      class Post extends Model {
+        declare [Type]: 'post';
+        @attr declare title: string;
+        @hasMany('comment', { async: false, inverse: 'post' }) declare comments: Comment[];
+      }
+
+      class Comment extends Model {
+        declare [Type]: 'comment';
+        @attr declare text: string;
+        @belongsTo('post', { async: false, inverse: 'comments' }) declare post: Post;
+      }
+
+      this.owner.register('model:post', Post);
+      this.owner.register('model:comment', Comment);
+      const store = this.owner.lookup('service:store') as Store;
+
+      const post = store.push<Post>({
+        data: {
+          id: '1',
+          type: 'post',
+          attributes: {
+            title: 'Post 1',
+          },
+          relationships: {
+            comments: {
+              data: [],
+            },
+          },
+        },
+        included: [
+          {
+            id: '1',
+            type: 'comment',
+            attributes: {
+              text: 'Comment 1',
+            },
+            relationships: {
+              post: {
+                data: null,
+              },
+            },
+          },
+          {
+            id: '2',
+            type: 'comment',
+            attributes: {
+              text: 'Comment 2',
+            },
+            relationships: {
+              post: {
+                data: null,
+              },
+            },
+          },
+          {
+            id: '3',
+            type: 'comment',
+            attributes: {
+              text: 'Comment 3',
+            },
+            relationships: {
+              post: {
+                data: null,
+              },
+            },
+          },
+        ],
+      });
+      const comment1 = store.peekRecord<Comment>('comment', '1')!;
+      const comment2 = store.peekRecord<Comment>('comment', '2')!;
+      const comment3 = store.peekRecord<Comment>('comment', '3')!;
+
+      const postSchema = Object.assign({}, store.schema.resource({ type: 'post' }));
+      postSchema.fields = postSchema.fields.filter((field) => field.name === 'comments');
+      postSchema.identity = null;
+
+      const context = await reactiveContext.call(this, post, postSchema);
+      assert.strictEqual(context.counters.comments, 1, 'rendered comments once');
+
+      assert.arrayStrictEquals(
+        post.comments.map((v) => v.id),
+        [],
+        'initially no comments are present'
+      );
+
+      post.comments = [comment1, comment2, comment3];
+
+      await rerender();
+      assert.strictEqual(context.counters.comments, 2, 'rendered comments twice');
+
+      assert.arrayStrictEquals(
+        post.comments.map((v) => v.id),
+        ['1', '2', '3'],
+        'comments are updated'
+      );
+
+      store.push<Post>({
+        data: {
+          id: '1',
+          type: 'post',
+          attributes: {
+            title: 'Post 1',
+          },
+          relationships: {
+            comments: {
+              data: [
+                { id: '1', type: 'comment' },
+                { id: '2', type: 'comment' },
+                { id: '3', type: 'comment' },
+              ],
+            },
+          },
+        },
+      });
+
+      assert.arrayStrictEquals(
+        post.comments.map((v) => v.id),
+        ['1', '2', '3'],
+        'comments are NOT updated'
+      );
+
+      assert.strictEqual(context.counters.comments, 2, 'did not rerender comments');
+    }
+  );
+});


### PR DESCRIPTION
If this works, this would fix one issue we noticed in 4.13-canary