### PR TITLE
feat: immutable records should show only remote state, make builder types more useful

### DIFF
--- a/packages/core-types/src/request.ts
+++ b/packages/core-types/src/request.ts
@@ -93,7 +93,7 @@ export type PostQueryRequestOptions<T = unknown, RT = unknown> = {
   url: string;
   method: 'POST' | 'QUERY';
   headers: Headers;
-  body: string;
+  body?: string | BodyInit | FormData;
   cacheOptions: CacheOptions<T> & { key: string };
   op: 'query';
   [RequestSignature]?: RT;
@@ -104,6 +104,7 @@ export type DeleteRequestOptions<T = unknown, RT = unknown> = {
   method: 'DELETE';
   headers: Headers;
   op: 'deleteRecord';
+  body?: string | BodyInit | FormData;
   data: {
     record: StableRecordIdentifier<TypeFromInstanceOrString<T>>;
   };
@@ -121,6 +122,7 @@ export type UpdateRequestOptions<T = unknown, RT = unknown> = {
   method: 'PATCH' | 'PUT';
   headers: Headers;
   op: 'updateRecord';
+  body?: string | BodyInit | FormData;
   data: {
     record: StableRecordIdentifier<TypeFromInstanceOrString<T>>;
   };
@@ -133,6 +135,7 @@ export type CreateRequestOptions<T = unknown, RT = unknown> = {
   method: 'POST';
   headers: Headers;
   op: 'createRecord';
+  body?: string | BodyInit | FormData;
   data: {
     record: StableRecordIdentifier<TypeFromInstanceOrString<T>>;
   };

--- a/packages/json-api/src/-private/builders/save-record.ts
+++ b/packages/json-api/src/-private/builders/save-record.ts
@@ -8,12 +8,14 @@ import { pluralize } from '@ember-data/request-utils/string';
 import { recordIdentifierFor } from '@ember-data/store';
 import { assert } from '@warp-drive/build-config/macros';
 import type { StableExistingRecordIdentifier, StableRecordIdentifier } from '@warp-drive/core-types/identifier';
+import type { TypedRecordInstance } from '@warp-drive/core-types/record';
 import type {
   ConstrainedRequestOptions,
   CreateRequestOptions,
   DeleteRequestOptions,
   UpdateRequestOptions,
 } from '@warp-drive/core-types/request';
+import type { SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
 
 import { ACCEPT_HEADER_VALUE, copyForwardUrlOptions } from './-utils';
 
@@ -221,10 +223,10 @@ export function createRecord(record: unknown, options: ConstrainedRequestOptions
  * @param record
  * @param options
  */
-export function updateRecord<T>(
+export function updateRecord<T extends TypedRecordInstance, RT extends TypedRecordInstance = T>(
   record: T,
   options?: ConstrainedRequestOptions & { patch?: boolean }
-): UpdateRequestOptions<T>;
+): UpdateRequestOptions<T, SingleResourceDataDocument<RT>>;
 export function updateRecord(
   record: unknown,
   options?: ConstrainedRequestOptions & { patch?: boolean }

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -1256,6 +1256,8 @@ export default class JSONAPICache implements Cache {
 
       if (cached.remoteAttrs && attribute in cached.remoteAttrs) {
         return cached.remoteAttrs[attribute];
+
+        // we still show defaultValues in the case of a remoteAttr access
       } else if (cached.defaultAttrs && attribute in cached.defaultAttrs) {
         return cached.defaultAttrs[attribute];
       } else {

--- a/packages/store/src/-private/managers/notification-manager.ts
+++ b/packages/store/src/-private/managers/notification-manager.ts
@@ -48,22 +48,6 @@ export interface DocumentOperationCallback {
   (identifier: StableDocumentIdentifier, notificationType: DocumentCacheOperation): void;
 }
 
-if (LOG_METRIC_COUNTS) {
-  // @ts-expect-error
-  // eslint-disable-next-line
-  globalThis.__WarpDriveMetricCountData = globalThis.__WarpDriveMetricCountData || {};
-  // @ts-expect-error
-  // eslint-disable-next-line
-  globalThis.counts[label] = (globalThis.counts[label] || 0) + 1;
-
-  // @ts-expect-error
-  globalThis.getWarpDriveMetricCounts = () => {
-    // @ts-expect-error
-    // eslint-disable-next-line
-    return globalThis.__WarpDriveMetricCountData;
-  };
-}
-
 function count(label: string) {
   // @ts-expect-error
   // eslint-disable-next-line

--- a/packages/store/src/-private/managers/notification-manager.ts
+++ b/packages/store/src/-private/managers/notification-manager.ts
@@ -48,13 +48,26 @@ export interface DocumentOperationCallback {
   (identifier: StableDocumentIdentifier, notificationType: DocumentCacheOperation): void;
 }
 
-function count(label: string) {
+if (LOG_METRIC_COUNTS) {
   // @ts-expect-error
   // eslint-disable-next-line
-  globalThis.counts = globalThis.counts || {};
+  globalThis.__WarpDriveMetricCountData = globalThis.__WarpDriveMetricCountData || {};
   // @ts-expect-error
   // eslint-disable-next-line
   globalThis.counts[label] = (globalThis.counts[label] || 0) + 1;
+
+  // @ts-expect-error
+  globalThis.getWarpDriveMetricCounts = () => {
+    // @ts-expect-error
+    // eslint-disable-next-line
+    return globalThis.__WarpDriveMetricCountData;
+  };
+}
+
+function count(label: string) {
+  // @ts-expect-error
+  // eslint-disable-next-line
+  globalThis.__WarpDriveMetricCountData[label] = (globalThis.__WarpDriveMetricCountData[label] || 0) + 1;
 }
 
 function _unsubscribe(

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -8,7 +8,7 @@ import { dependencySatisfies, importSync, macroCondition } from '@embroider/macr
 
 import type RequestManager from '@ember-data/request';
 import type { Future } from '@ember-data/request';
-import { LOG_PAYLOADS, LOG_REQUESTS } from '@warp-drive/build-config/debugging';
+import { LOG_METRIC_COUNTS, LOG_PAYLOADS, LOG_REQUESTS } from '@warp-drive/build-config/debugging';
 import {
   DEPRECATE_STORE_EXTENDS_EMBER_OBJECT,
   ENABLE_LEGACY_SCHEMA_SERVICE,
@@ -68,6 +68,22 @@ globalThis.setWarpDriveLogging = setLogging;
 
 // @ts-expect-error adding to globalThis
 globalThis.getWarpDriveRuntimeConfig = getRuntimeConfig;
+
+if (LOG_METRIC_COUNTS) {
+  // @ts-expect-error
+  // eslint-disable-next-line
+  globalThis.__WarpDriveMetricCountData = globalThis.__WarpDriveMetricCountData || {};
+  // @ts-expect-error
+  // eslint-disable-next-line
+  globalThis.counts[label] = (globalThis.counts[label] || 0) + 1;
+
+  // @ts-expect-error
+  globalThis.getWarpDriveMetricCounts = () => {
+    // @ts-expect-error
+    // eslint-disable-next-line
+    return globalThis.__WarpDriveMetricCountData;
+  };
+}
 
 export { storeFor };
 

--- a/tests/warp-drive__schema-record/tests/edit-workflow-test.ts
+++ b/tests/warp-drive__schema-record/tests/edit-workflow-test.ts
@@ -1,0 +1,151 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import { serializePatch, serializeResources, updateRecord } from '@ember-data/json-api/request';
+import RequestManager from '@ember-data/request';
+import { CacheHandler, recordIdentifierFor } from '@ember-data/store';
+import type { SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
+import type { Type } from '@warp-drive/core-types/symbols';
+import { Checkout } from '@warp-drive/schema-record/record';
+import { registerDerivations, withDefaults } from '@warp-drive/schema-record/schema';
+
+import type Store from '../app/services/store';
+
+const UserSchema = withDefaults({
+  type: 'user',
+  fields: [
+    {
+      name: 'name',
+      kind: 'field',
+    },
+  ],
+});
+type User = Readonly<{
+  id: string;
+  name: string;
+  $type: 'user';
+  [Type]: 'user';
+  [Checkout](): Promise<EditableUser>;
+}>;
+
+type EditableUser = {
+  readonly id: string;
+  name: string;
+  readonly $type: 'user';
+  readonly [Type]: 'user';
+};
+
+module('WarpDrive | SchemaRecord | Edit Workflow', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    store.schema.registerResource(UserSchema);
+    registerDerivations(store.schema);
+    store.requestManager = new RequestManager()
+      .use([
+        {
+          request({ request }) {
+            const { url, method, body } = request;
+            assert.step(`${method} ${url}`);
+            return Promise.resolve(JSON.parse(body as string));
+          },
+        },
+      ])
+      .useCache(CacheHandler);
+  });
+
+  test('we can edit a record', async function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const user = store.push<User>({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: { name: 'Rey Skybarker' },
+      },
+    });
+    const editableUser = await user[Checkout]();
+    assert.strictEqual(editableUser.name, 'Rey Skybarker', 'name is accessible');
+    editableUser.name = 'Rey Skywalker';
+    assert.strictEqual(editableUser.name, 'Rey Skywalker', 'name is updated');
+    assert.strictEqual(user.name, 'Rey Skybarker', 'immutable record shows original value');
+
+    // ensure identifier works as expected
+    const identifier = recordIdentifierFor(editableUser);
+    assert.strictEqual(identifier.id, '1', 'id is accessible');
+    assert.strictEqual(identifier.type, 'user', 'type is accessible');
+
+    // ensure save works as expected
+    const saveInit = updateRecord(editableUser);
+    const patch = serializePatch(store.cache, recordIdentifierFor(editableUser));
+    saveInit.body = JSON.stringify(patch);
+
+    const saveResult = await store.request(saveInit);
+    assert.deepEqual(saveResult.content.data, user, 'we get the immutable version back from the request');
+    assert.verifySteps(['PUT /users/1']);
+    assert.strictEqual(user.name, 'Rey Skywalker', 'name is updated in the cache and shows in the immutable record');
+  });
+
+  test('we can serialize an editable record', async function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const user = store.push<User>({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: { name: 'Rey Skybarker' },
+      },
+    });
+    const editableUser = await user[Checkout]();
+    assert.strictEqual(editableUser.name, 'Rey Skybarker', 'name is accessible');
+    editableUser.name = 'Rey Skywalker';
+    assert.strictEqual(editableUser.name, 'Rey Skywalker', 'name is updated');
+    assert.strictEqual(user.name, 'Rey Skybarker', 'immutable record shows original value');
+
+    // ensure identifier works as expected
+    const identifier = recordIdentifierFor(editableUser);
+    assert.strictEqual(identifier.id, '1', 'id is accessible');
+    assert.strictEqual(identifier.type, 'user', 'type is accessible');
+
+    // ensure save works as expected
+    const saveInit = updateRecord(editableUser);
+    const body = serializeResources(store.cache, saveInit.data.record);
+    saveInit.body = JSON.stringify(body);
+
+    const saveResult = await store.request(saveInit);
+    assert.deepEqual(saveResult.content.data, user, 'we get the immutable version back from the request');
+    assert.verifySteps(['PUT /users/1']);
+    assert.strictEqual(user.name, 'Rey Skywalker', 'name is updated in the cache and shows in the immutable record');
+  });
+
+  test('serializing the immutable record serializes the edits', async function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const user = store.push<User>({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: { name: 'Rey Skybarker' },
+      },
+    });
+    const editableUser = await user[Checkout]();
+    assert.strictEqual(editableUser.name, 'Rey Skybarker', 'name is accessible');
+    editableUser.name = 'Rey Skywalker';
+    assert.strictEqual(editableUser.name, 'Rey Skywalker', 'name is updated');
+    assert.strictEqual(user.name, 'Rey Skybarker', 'immutable record shows original value');
+
+    // ensure identifier works as expected
+    const identifier = recordIdentifierFor(editableUser);
+    assert.strictEqual(identifier.id, '1', 'id is accessible');
+    assert.strictEqual(identifier.type, 'user', 'type is accessible');
+
+    // ensure save works as expected
+    const saveInit = updateRecord(user);
+    const body = serializeResources(store.cache, saveInit.data.record);
+    saveInit.body = JSON.stringify(body);
+
+    const saveResult = await store.request(saveInit);
+    assert.deepEqual(saveResult.content.data, user, 'we get the immutable version back from the request');
+    assert.verifySteps(['PUT /users/1']);
+    assert.strictEqual(user.name, 'Rey Skywalker', 'name is updated in the cache and shows in the immutable record');
+  });
+});

--- a/tests/warp-drive__schema-record/tests/edit-workflow-test.ts
+++ b/tests/warp-drive__schema-record/tests/edit-workflow-test.ts
@@ -5,7 +5,6 @@ import { setupTest } from 'ember-qunit';
 import { serializePatch, serializeResources, updateRecord } from '@ember-data/json-api/request';
 import RequestManager from '@ember-data/request';
 import { CacheHandler, recordIdentifierFor } from '@ember-data/store';
-import type { SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
 import type { Type } from '@warp-drive/core-types/symbols';
 import { Checkout } from '@warp-drive/schema-record/record';
 import { registerDerivations, withDefaults } from '@warp-drive/schema-record/schema';


### PR DESCRIPTION
Also add more tests around edit workflows,

[x] requires editable vs immutable record PRs to land first such as #9624 