### PR TITLE
feat: SchemaRecord guide

### DIFF
--- a/guides/manual/1-overview.md
+++ b/guides/manual/1-overview.md
@@ -18,9 +18,12 @@ We see this as one of the keys to scalability. Providing a stable framework
 for how data is requested, cached, mutated, and mocked allows developers to
 focus more time on the product requirements that matter.
 
-This also means that a single WarpDrive configuration can power multiple web-apps
-using varying frameworks sharing a single domain: bridging the gap between MPA
-and SPA.
+A single WarpDrive configuration can power multiple web-apps using differing
+frameworks all sharing a single domain: bridging the gap between MPA and SPA.
+
+<br>
+
+## A Very Brief History
 
 WarpDrive began in ~2006 as a suite of ORM-like data utilities in SproutCore that
 later evolved into EmberData. Beginning in ~2017 the team plotted a course towards
@@ -51,14 +54,15 @@ quick to pickup the basics. Our patterns are portable and scalable, meaning that
 your app, team and data needs evolve we'll be right there with you.
 
 Because we are universal and also not tied to any API Format or backend architecture,
-there's no lock-in. The data patterns you learn, the code you write is portable
-between frontend frameworks and backends and can help smooth the evolution of both.
+there's no lock-in. The data patterns you learn and the code you write is portable
+between frontend frameworks and backend APIs and can help smooth the evolution of both.
 
 We're also not specific to a given frontend architecture. When serving on the same
 domain, you can dedupe and cache requests across multiple apps and tabs at once!
 This means we are as good for embedded content and MPAs as we are for SPAs.
 
-Our core philosophy is to deliver value that lasts decades and evolves with your app.
+Our core philosophy is to deliver value that lasts decades and evolves with your app,
+helping you ship, iterate and deliver to your customers.
 
 <br>
 

--- a/guides/manual/3-data.md
+++ b/guides/manual/3-data.md
@@ -18,7 +18,33 @@ at each layer, making your application faster.
 
 Misalignment tends to occur when API and Application developers don't work together to understand
 requirements, or when the format in use is "lossy" (unable to accurately convey the full scope of
-information being serialized)
+information being serialized).
+
+We encourage the use of [JSON:API](https://jsonapi.org/) as the wire and cache format because unlike
+most other formats in use today it encodes information about your data in a near-lossless and easily-cacheable manner.
+
+For the presentation format, we encourage applications to limit the amount of manual transformation
+done. Applications should wherever possible align the interfaces of the data components expect to
+the shape of the data available, rather than transforming data to fit into the component. This said,
+WarpDrive offers powerful schema-defined transformation and derivation capabilities built-in to the
+reactivity layer for presenting data from the cache. Handling transformation universally via schema
+enables apps to align to component interfaces where needed in a safer, more performant manner.
+
+We'll explore these capabilities later on in the manual in the sections on [Presentation](./5-presentation.md) and [Schemas](./6-schemas.md). But first, lets take some time to look at some key
+concepts surrounding the wire and cache format.
+
+
+### StructuredDocuments
+
+### ResourceDocuments
+
+### Resources
+
+### CacheKeys
+
+### Membership
+
+### Fields
 
 <br>
 


### PR DESCRIPTION
This PR is a Mega Guides/Docs Push for the 5.4 release.

Roughly speaking we probably want to ensure we have coverage of

- How to author a resource/object schema
- kinds of FieldSchema and what they do
- which FieldSchema kinds / features are not yet supported in standard mode
- configuring SchemaRecord
- configuring SchemaRecord AND Model
- immutability/remoteState expectations of SchemaRecord
- editing and saving an immutable SchemaRecord
- editing and saving deep-object changes
- using legacy mode for SchemaRecord (and its expectations)
- linksMode with Model relationships
- linksMode with SchemaRecord relationships
- using Types with SchemaRecord
- registering and using transformations
- registering and using derivations
- registering and using hash functions
- registering and using default derivations for legacy mode
- registering and using default derivations for standard mode
- "rules" for registering schema information
- withDefaults for legacy mode
- withDefaults for standard mode
- migrating between Model and SchemaRecord
- advanced migration via Proxy + legacy mode
- ??