### PR TITLE
fix: Don't notify changes for attributes not registered with the schema

### DIFF
--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -1710,7 +1710,7 @@ function notifyAttributes(
 function calculateChangedKeys(
   cached: CachedResource,
   updates: Exclude<ExistingResourceObject['attributes'], undefined>,
-  schema: ReturnType<Store['schema']['fields']>
+  fields: ReturnType<Store['schema']['fields']>
 ): Set<string> {
   const changedKeys = new Set<string>();
   const keys = Object.keys(updates);
@@ -1725,7 +1725,7 @@ function calculateChangedKeys(
 
   for (let i = 0; i < length; i++) {
     const key = keys[i];
-    if (!schema.has(key)) {
+    if (!fields.has(key)) {
       continue;
     }
 

--- a/packages/model/src/-private/model.ts
+++ b/packages/model/src/-private/model.ts
@@ -1740,7 +1740,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     this.eachComputedProperty((name, meta) => {
       if (isAttributeSchema(meta)) {
         assert(
-          "You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: attr('<type>')` from " +
+          "You may not set 'id' as an attribute on your model. Please remove any lines that look like: `id: attr('<type>')` from " +
             this.toString(),
           name !== 'id'
         );

--- a/tests/main/eslint.config.mjs
+++ b/tests/main/eslint.config.mjs
@@ -23,6 +23,7 @@ const AllowedImports = [
   '@ember/test-helpers',
   '@ember/test-waiters',
   '@glimmer/component',
+  '@glimmer/tracking',
   'qunit',
 ];
 

--- a/tests/main/tests/acceptance/relationships/tracking-record-state-test.js
+++ b/tests/main/tests/acceptance/relationships/tracking-record-state-test.js
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import { inject } from '@ember/service';
 import { click, findAll, render } from '@ember/test-helpers';
 import Component from '@glimmer/component';
-// eslint-disable-next-line no-restricted-imports
 import { tracked } from '@glimmer/tracking';
 
 import { module, test } from 'qunit';

--- a/tests/main/tests/acceptance/tracking-create-record-test.js
+++ b/tests/main/tests/acceptance/tracking-create-record-test.js
@@ -2,7 +2,6 @@ import { setComponentTemplate } from '@ember/component';
 import { inject as service } from '@ember/service';
 import { render, settled } from '@ember/test-helpers';
 import Component from '@glimmer/component';
-// eslint-disable-next-line no-restricted-imports
 import { tracked } from '@glimmer/tracking';
 
 import { module, test } from 'qunit';

--- a/tests/main/tests/helpers/create-tracking-context.gjs
+++ b/tests/main/tests/helpers/create-tracking-context.gjs
@@ -1,6 +1,5 @@
 import { render, settled } from '@ember/test-helpers';
 import Component from '@glimmer/component';
-// eslint-disable-next-line no-restricted-imports
 import { tracked } from '@glimmer/tracking';
 
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/tests/main/tests/integration/cache/json-api-cache-2-test.ts
+++ b/tests/main/tests/integration/cache/json-api-cache-2-test.ts
@@ -1,0 +1,69 @@
+import { settled } from '@ember/test-helpers';
+import { tracked } from '@glimmer/tracking';
+
+import { module, test } from 'qunit';
+
+import { setupRenderingTest } from 'ember-qunit';
+
+import Model, { attr } from '@ember-data/model';
+import type Store from '@ember-data/store';
+import { Type } from '@warp-drive/core-types/symbols';
+
+import { reactiveContext } from '../../helpers/reactive-context';
+
+class User extends Model {
+  @attr declare name: string;
+
+  // Not an attr, so shouldn't notify if a similarly named attribute changes.
+  @tracked brotherName: string | undefined;
+
+  declare [Type]: 'user';
+}
+
+module('@ember-data/json-api | Cache (2)', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('model:user', User);
+  });
+
+  test('Does not notify for attributes not in schema', async function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const user = store.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          name: 'Aino',
+        },
+      },
+    });
+
+    const rc = await reactiveContext.call(this, user, {
+      type: 'user',
+      fields: [
+        { name: 'name', kind: 'field' },
+        { name: 'brotherName', kind: 'field' },
+      ],
+    });
+
+    const { counters } = rc;
+
+    assert.deepEqual(counters, { name: 1, brotherName: 1 }, 'Test setup: counters initialized');
+
+    store.push({
+      data: {
+        id: '1',
+        type: 'user',
+        attributes: {
+          name: 'Aino',
+          brotherName: 'Ellis',
+        },
+      },
+    });
+
+    await settled();
+
+    assert.deepEqual(counters, { name: 1, brotherName: 1 }, 'brotherName did not notify');
+  });
+});

--- a/tests/main/tests/integration/cache/json-api-cache-2-test.ts
+++ b/tests/main/tests/integration/cache/json-api-cache-2-test.ts
@@ -29,7 +29,7 @@ module('@ember-data/json-api | Cache (2)', function (hooks) {
 
   test('Does not notify for attributes not in schema', async function (assert) {
     const store = this.owner.lookup('service:store') as Store;
-    const user = store.push({
+    const user: User = store.push({
       data: {
         id: '1',
         type: 'user',

--- a/tests/main/tests/integration/cache/json-api-cache-2-test.ts
+++ b/tests/main/tests/integration/cache/json-api-cache-2-test.ts
@@ -41,6 +41,7 @@ module('@ember-data/json-api | Cache (2)', function (hooks) {
 
     const rc = await reactiveContext.call(this, user, {
       type: 'user',
+      identity: null,
       fields: [
         { name: 'name', kind: 'field' },
         { name: 'brotherName', kind: 'field' },

--- a/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -259,7 +259,6 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
             'TestSchema:fields',
             'TestSchema:fields',
             'TestSchema:fields',
-            'TestSchema:fields',
           ]
         : ['TestSchema:hasResource', 'TestSchema:fields', 'TestSchema:fields', 'TestSchema:fields'],
       'update of record on save completion'

--- a/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -259,6 +259,7 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
             'TestSchema:fields',
             'TestSchema:fields',
             'TestSchema:fields',
+            'TestSchema:fields',
           ]
         : ['TestSchema:hasResource', 'TestSchema:fields', 'TestSchema:fields', 'TestSchema:fields'],
       'update of record on save completion'

--- a/tests/main/tests/unit/model-test.js
+++ b/tests/main/tests/unit/model-test.js
@@ -210,7 +210,7 @@ module('unit/model - Model', function (hooks) {
       assert.expectAssertion(() => {
         const ModelClass = store.modelFor('test-model');
         get(ModelClass, 'attributes');
-      }, /You may not set `id` as an attribute on your model/);
+      }, /You may not set 'id' as an attribute on your model/);
 
       assert.expectAssertion(() => {
         store.push({

--- a/tests/main/tests/unit/store/push-test.js
+++ b/tests/main/tests/unit/store/push-test.js
@@ -527,24 +527,6 @@ module('unit/store/push - Store#push', function (hooks) {
     assert.notOk(store._instanceCache.peek(pushResult, { bucket: 'record' }), 'record is not materialized');
   });
 
-  test('_push does not require a modelName to resolve to a modelClass', function (assert) {
-    const store = this.owner.lookup('service:store');
-    const originalCall = store.modelFor;
-    store.modelFor = function () {
-      assert.notOk('modelFor was triggered as a result of a call to store._push');
-    };
-
-    store._push({
-      data: {
-        id: '1',
-        type: 'person',
-      },
-    });
-
-    store.modelFor = originalCall;
-    assert.ok('We made it');
-  });
-
   test('_push returns an array of identifiers if an array is pushed', function (assert) {
     const store = this.owner.lookup('service:store');
     const pushResult = store._push({


### PR DESCRIPTION
## Description

Fixes a bug where we would notify changes to data that wasn't actually registered with the schema. This seems to only cause issues if the data is coincidentally tracked for some other reason (e.g. `id` or a tracked property with the same name).

NOTE:
Currently (including with this change), we do not discard this data in the cache. So when you get the resource data out of the cache, we include it. Since some APIs are dependent on payloads being complete when you send them back, some users may rely on the current behavior. So we don't delete the value itself so that it's still merged in. We should probably deprecate this eventually.

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


