### PR TITLE
internal: fixup diagnostic reporting

### DIFF
--- a/packages/diagnostic/server/bun/socket-handler.js
+++ b/packages/diagnostic/server/bun/socket-handler.js
@@ -63,6 +63,7 @@ export function buildHandler(config, state) {
                 await config.cleanup();
                 debug(`Configured cleanup hook completed`);
               }
+              debug(`\n\nExiting with code ${exitCode}`);
               // 1. We expect all cleanup to have happened after
               //    config.cleanup(), so exiting here should be safe.
               // 2. We also want to forcibly exit with a success code in this
@@ -70,6 +71,8 @@ export function buildHandler(config, state) {
               // eslint-disable-next-line n/no-process-exit
               process.exit(exitCode);
             }
+          } else {
+            console.log(`Waiting for ${state.expected - state.completed} more browsers to finish`);
           }
 
           break;

--- a/packages/diagnostic/server/reporters/default.js
+++ b/packages/diagnostic/server/reporters/default.js
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
+import { exit } from 'process';
 
 const SLOW_TEST_COUNT = 50;
 const DEFAULT_TIMEOUT = 8_000;
@@ -219,9 +220,10 @@ export default class CustomDotReporter {
       )} ms\n${HEADER_STR}\n\n`
     );
 
+    const exitCode = this.globalFailures.length || this.failedTests.length ? 1 : 0;
     this.clearState();
 
-    return this.globalFailures.length || this.failedTests.length ? 1 : 0;
+    return exitCode;
   }
 
   addLauncher(data) {

--- a/packages/diagnostic/server/reporters/default.js
+++ b/packages/diagnostic/server/reporters/default.js
@@ -184,6 +184,13 @@ export default class CustomDotReporter {
         )
       );
     }
+    if (this.globalFailures.length) {
+      this.write(
+        chalk.red(
+          `\n\n${this.globalFailures.length} Global Failures were detected.. Complete stack traces for failures will print at the end.`
+        )
+      );
+    }
     this.write(`\n\n`);
 
     this.reportPendingTests();
@@ -214,7 +221,7 @@ export default class CustomDotReporter {
 
     this.clearState();
 
-    return this.failedTests.length ? 1 : 0;
+    return this.globalFailures.length || this.failedTests.length ? 1 : 0;
   }
 
   addLauncher(data) {


### PR DESCRIPTION
I noticed there were some failing tests on main that aren't causing the test suite to fail when using diagnostic. I suspect the exit code for global failures wasn't being applied.