### PR TITLE
Don't set isDirty to true in diff callbacks

### DIFF
--- a/packages/graph/src/-private/operations/replace-related-records.ts
+++ b/packages/graph/src/-private/operations/replace-related-records.ts
@@ -226,7 +226,6 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
             );
           }
         }
-        relationship.isDirty = true;
       }
       addToInverse(graph, identifier, definition.inverseKey, op.record, isRemote);
     },
@@ -245,7 +244,6 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
             );
           }
         }
-        relationship.isDirty = true;
       }
       removeFromInverse(graph, identifier, definition.inverseKey, op.record, isRemote);
     }
@@ -273,7 +271,8 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
       // because we want to clear local changes even if
       // no change has occurred to preserve the legacy behavior
       relationship.definition.kind === 'hasMany' &&
-      relationship.definition.resetOnRemoteUpdate !== false
+      relationship.definition.resetOnRemoteUpdate !== false &&
+      diff.changed
     ) {
       const deprecationInfo: {
         removals: StableRecordIdentifier[];

--- a/packages/graph/src/-private/operations/replace-related-records.ts
+++ b/packages/graph/src/-private/operations/replace-related-records.ts
@@ -272,7 +272,7 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
       // no change has occurred to preserve the legacy behavior
       relationship.definition.kind === 'hasMany' &&
       relationship.definition.resetOnRemoteUpdate !== false &&
-      diff.changed
+      (diff.changed || wasDirty)
     ) {
       const deprecationInfo: {
         removals: StableRecordIdentifier[];

--- a/tests/ember-data__graph/tests/integration/graph/diff-preservation-test.ts
+++ b/tests/ember-data__graph/tests/integration/graph/diff-preservation-test.ts
@@ -747,7 +747,7 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
         class App extends Model {
           @attr declare name: string;
           @hasMany('config', { async: false, inverse: 'app' }) declare configs: Config[];
-          @hasMany('namespace', { async: false, inverse: 'apps' }) declare namespaces: Namespace | null;
+          @hasMany('namespace', { async: false, inverse: 'apps' }) declare namespaces: Namespace[];
         }
 
         class Namespace extends Model {
@@ -777,7 +777,7 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
         // each namespace has the app and 2 more apps
         store._join(() => {
           // setup primary app relationships
-          // this also convers the belongsTo side on config
+          // this also converts the belongsTo side on config
           graph.push({
             op: 'updateRelationship',
             field: 'configs',
@@ -821,6 +821,12 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
           });
         });
 
+        // we access these relationships so that we do not fall victim
+        // in this test to laziness optimizations where calcs are not made
+        // if the data is not accessed
+        graph.getData(appIdentifier, 'configs');
+        graph.getData(appIdentifier, 'namespaces');
+
         // mutate app:1.configs, adding config:5
         // mutate app:1.namespaces, adding namespace:5
         store._join(() => {
@@ -842,7 +848,7 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
         // for app:1
         store._join(() => {
           // setup primary app relationships
-          // this also convers the belongsTo side on config
+          // this also converts the belongsTo side on config
           graph.push({
             op: 'updateRelationship',
             field: 'configs',

--- a/tests/ember-data__graph/tests/integration/graph/diff-preservation-test.ts
+++ b/tests/ember-data__graph/tests/integration/graph/diff-preservation-test.ts
@@ -821,12 +821,6 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
           });
         });
 
-        // we access these relationships so that we do not fall victim
-        // in this test to laziness optimizations where calcs are not made
-        // if the data is not accessed
-        graph.getData(appIdentifier, 'configs');
-        graph.getData(appIdentifier, 'namespaces');
-
         // mutate app:1.configs, adding config:5
         // mutate app:1.namespaces, adding namespace:5
         store._join(() => {

--- a/tests/ember-data__graph/tests/test-helper.ts
+++ b/tests/ember-data__graph/tests/test-helper.ts
@@ -4,6 +4,7 @@ import Application from 'ember-data__graph/app';
 import config from 'ember-data__graph/config/environment';
 
 import configureAsserts from '@ember-data/unpublished-test-infra/test-support/asserts/index';
+import { IS_CI } from '@warp-drive/build-config/env';
 import { setupGlobalHooks } from '@warp-drive/diagnostic';
 import { configure } from '@warp-drive/diagnostic/ember';
 import { start } from '@warp-drive/diagnostic/runners/dom';
@@ -17,9 +18,9 @@ configure();
 setApplication(Application.create(config.APP));
 void start({
   tryCatch: false,
-  debug: false,
+  debug: IS_CI ? false : true,
   groupLogs: false,
   instrument: true,
-  hideReport: true,
+  hideReport: IS_CI ? true : false,
   useDiagnostic: true,
 });


### PR DESCRIPTION
Theoretically the diff function is smart enough for this to no longer be necessary. Reduces overnotification.

## Description

<!-- insert description here -->

## Notes for the release

<!-- If this PR should be described in the Ember release blog post please briefly describe what should be shared. -->


