### PR TITLE
feat: improve debuggability of SchemaRecord, RecordArray and Identifier

### DIFF
--- a/guides/relationships/features/links-mode.md
+++ b/guides/relationships/features/links-mode.md
@@ -60,6 +60,8 @@ interface LinksModeRelationship {
 }
 ```
 
+<br>
+
 ### Related Links May Be Provided by Handlers
 
 This means that, in order to use links mode, a relationship payload given to the cache MUST contain this related link. 
@@ -67,6 +69,8 @@ This means that, in order to use links mode, a relationship payload given to the
 If your API does not provide this link, a [request handler](https://api.emberjs.com/ember-data/release/classes/%3Cinterface%3E%20handler/) could be utilized to decorate an API response to add them provided that your handlers (or your API) are able to understand that link.
 
 Note that this approach can even work if your API requires you to send a POST request to fetch the relationship. [This blog post](https://runspired.com/2025/02/26/exploring-advanced-handlers.html) contains an overview of advanced request handling to achieve a similar aim for pagination.
+
+<br>
 
 ### When a Relationship Is Fetched, the Related Link Is Used
 
@@ -106,11 +110,17 @@ relationship as well.
 
 Sideloads (included records) are valid to include in these responses.
 
+<br>
+
+---
+
 ## Activating LinksMode
 
 LinksMode is activated by adding `linksMode: true` to the relationship's options.
 
 Read on below for examples and nuances specific to Model vs SchemaRecord
+
+<br>
 
 ### For a Relationship on a Model
 
@@ -128,6 +138,8 @@ export default class User extends Model {
 ```
 
 This works for both `async` and `non-async` relationships and only changes the fetching behavior of the field it is defined on. For instance, in the example above, `homeAddress` is fetched in links mode while `<Address>.residents` might still be using the legacy adapter experience.
+
+<br>
 
 ### For a SchemaRecord in LegacyMode
 
@@ -154,6 +166,8 @@ const UserSchema = {
 
 The behavior of a relationship for a SchemaRecord in LegacyMode is always identical to that of a the same
 relationship defined on a Model.
+
+<br>
 
 ### For a SchemaRecord in PolarisMode
 
@@ -198,6 +212,10 @@ In the meantime, we've enabled synchronous linksMode relationships in order to a
 
 If this limitation is too great we would recommend continuing to use `LegacyMode` until the full story for 
 relationships in PolarisMode is shipped.
+
+<br>
+
+---
 
 #### What To Expect from PolarisMode Relationships in the Future
 

--- a/guides/relationships/features/polymorphism.md
+++ b/guides/relationships/features/polymorphism.md
@@ -68,6 +68,10 @@ interface Human {
 }
 ```
 
+<br>
+
+---
+
 ## How To Implement
 
 WarpDrive implements polymorphism structurally: as long as records on both sides of the relationship agree
@@ -78,6 +82,8 @@ There are two polymorphic modes in WarpDrive:
 
 - **open** - any type of record can be a value (this is like our last example above of `pets: unknown[]`)
 - **closed** - only types of records that conform to a specific contract can be a value
+
+<br>
 
 ### Open Polymorphism
 
@@ -116,6 +122,8 @@ store.schema.registerResource({
   ]
 })
 ```
+
+<br>
 
 ### Closed/Structural Polymorphism
 
@@ -218,6 +226,10 @@ schema:
   }
 }
 ```
+
+<br>
+
+---
 
 ## Fetching Polymorphic Data
 

--- a/packages/core-types/src/identifier.ts
+++ b/packages/core-types/src/identifier.ts
@@ -9,12 +9,12 @@ export const DEBUG_CLIENT_ORIGINATED: unique symbol = Symbol('record-originated-
 export const DEBUG_IDENTIFIER_BUCKET: unique symbol = Symbol('identifier-bucket');
 export const DEBUG_STALE_CACHE_OWNER: unique symbol = Symbol('warpDriveStaleCache');
 
-function ProdSymbol<T extends string>(str: T): T {
-  return DEBUG ? (Symbol(str) as unknown as T) : str;
+function ProdSymbol<T extends string>(str: T, debugStr: string): T {
+  return DEBUG ? (Symbol(debugStr) as unknown as T) : str;
 }
 
 // also present in production
-export const CACHE_OWNER: '__$co' = ProdSymbol('__$co');
+export const CACHE_OWNER: '__$co' = ProdSymbol('__$co', 'CACHE_OWNER');
 
 export type IdentifierBucket = 'record' | 'document';
 

--- a/packages/schema-record/src/-private/record.ts
+++ b/packages/schema-record/src/-private/record.ts
@@ -690,7 +690,9 @@ export class SchemaRecord {
     );
 
     if (DEBUG) {
-      Object.defineProperty(proxy, '__SHOW_ME_THE_DATA_(debug mode only)__', {
+      Object.defineProperty(this, '__SHOW_ME_THE_DATA_(debug mode only)__', {
+        enumerable: false,
+        configurable: true,
         get() {
           const data: Record<string, unknown> = {};
           for (const key of fields.keys()) {

--- a/packages/schema-record/src/-private/record.ts
+++ b/packages/schema-record/src/-private/record.ts
@@ -6,6 +6,7 @@ import type { NotificationType } from '@ember-data/store';
 import type { RelatedCollection as ManyArray } from '@ember-data/store/-private';
 import { recordIdentifierFor, setRecordIdentifier } from '@ember-data/store/-private';
 import { addToTransaction, entangleSignal, getSignal, type Signal, Signals } from '@ember-data/tracking/-private';
+import { DEBUG } from '@warp-drive/build-config/env';
 import { assert } from '@warp-drive/build-config/macros';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
 import type { ArrayValue, ObjectValue, Value } from '@warp-drive/core-types/json/raw';
@@ -687,6 +688,19 @@ export class SchemaRecord {
         }
       }
     );
+
+    if (DEBUG) {
+      Object.defineProperty(proxy, '__SHOW_ME_THE_DATA_(debug mode only)__', {
+        get() {
+          const data: Record<string, unknown> = {};
+          for (const key of fields.keys()) {
+            data[key] = proxy[key as keyof SchemaRecord];
+          }
+
+          return data;
+        },
+      });
+    }
 
     return proxy;
   }

--- a/packages/store/src/-private/caches/identifier-cache.ts
+++ b/packages/store/src/-private/caches/identifier-cache.ts
@@ -676,15 +676,21 @@ function makeStableRecordIdentifier(
       get [DEBUG_IDENTIFIER_BUCKET]() {
         return bucket;
       },
-      toString() {
+    };
+    Object.defineProperty(proto, 'toString', {
+      enumerable: false,
+      value: () => {
         const { type, id, lid } = recordIdentifier;
         return `${clientOriginated ? '[CLIENT_ORIGINATED] ' : ''}${String(type)}:${String(id)} (${lid})`;
       },
-      toJSON() {
+    });
+    Object.defineProperty(proto, 'toJSON', {
+      enumerable: false,
+      value: () => {
         const { type, id, lid } = recordIdentifier;
         return { type, id, lid };
       },
-    };
+    });
     Object.setPrototypeOf(wrapper, proto);
     DEBUG_MAP.set(wrapper, recordIdentifier);
     wrapper = freeze(wrapper);

--- a/packages/store/src/-private/caches/identifier-cache.ts
+++ b/packages/store/src/-private/caches/identifier-cache.ts
@@ -650,16 +650,14 @@ function makeStableRecordIdentifier(
   if (DEBUG) {
     // we enforce immutability in dev
     //  but preserve our ability to do controlled updates to the reference
-    let wrapper: StableRecordIdentifier = {
-      get lid() {
-        return recordIdentifier.lid;
-      },
+    let wrapper = {
+      type: recordIdentifier.type,
+      lid: recordIdentifier.lid,
       get id() {
         return recordIdentifier.id;
       },
-      get type() {
-        return recordIdentifier.type;
-      },
+    } as StableRecordIdentifier;
+    const proto = {
       get [CACHE_OWNER](): number | undefined {
         return recordIdentifier[CACHE_OWNER];
       },
@@ -672,23 +670,22 @@ function makeStableRecordIdentifier(
       set [DEBUG_STALE_CACHE_OWNER](value: number | undefined) {
         (recordIdentifier as StableRecordIdentifier)[DEBUG_STALE_CACHE_OWNER] = value;
       },
-    };
-    Object.defineProperty(wrapper, 'toString', {
-      enumerable: false,
-      value: () => {
+      get [DEBUG_CLIENT_ORIGINATED]() {
+        return clientOriginated;
+      },
+      get [DEBUG_IDENTIFIER_BUCKET]() {
+        return bucket;
+      },
+      toString() {
         const { type, id, lid } = recordIdentifier;
         return `${clientOriginated ? '[CLIENT_ORIGINATED] ' : ''}${String(type)}:${String(id)} (${lid})`;
       },
-    });
-    Object.defineProperty(wrapper, 'toJSON', {
-      enumerable: false,
-      value: () => {
+      toJSON() {
         const { type, id, lid } = recordIdentifier;
         return { type, id, lid };
       },
-    });
-    wrapper[DEBUG_CLIENT_ORIGINATED] = clientOriginated;
-    wrapper[DEBUG_IDENTIFIER_BUCKET] = bucket;
+    };
+    Object.setPrototypeOf(wrapper, proto);
     DEBUG_MAP.set(wrapper, recordIdentifier);
     wrapper = freeze(wrapper);
     return wrapper;

--- a/packages/store/src/-private/record-arrays/identifier-array.ts
+++ b/packages/store/src/-private/record-arrays/identifier-array.ts
@@ -450,7 +450,9 @@ export class IdentifierArray<T = unknown> {
     }) as IdentifierArray<T>;
 
     if (DEBUG) {
-      Object.defineProperty(proxy, '__SHOW_ME_THE_DATA_(debug mode only)__', {
+      Object.defineProperty(this, '__SHOW_ME_THE_DATA_(debug mode only)__', {
+        enumerable: false,
+        configurable: true,
         get() {
           return proxy.slice();
         },

--- a/packages/store/src/-private/record-arrays/identifier-array.ts
+++ b/packages/store/src/-private/record-arrays/identifier-array.ts
@@ -11,6 +11,7 @@ import {
   subscribe,
 } from '@ember-data/tracking/-private';
 import { DEPRECATE_COMPUTED_CHAINS } from '@warp-drive/build-config/deprecations';
+import { DEBUG } from '@warp-drive/build-config/env';
 import { assert } from '@warp-drive/build-config/macros';
 import { getOrSetGlobal } from '@warp-drive/core-types/-private';
 import type { LocalRelationshipOperation } from '@warp-drive/core-types/graph';
@@ -447,6 +448,14 @@ export class IdentifierArray<T = unknown> {
         return Array.prototype as unknown as IdentifierArray<T>;
       },
     }) as IdentifierArray<T>;
+
+    if (DEBUG) {
+      Object.defineProperty(proxy, '__SHOW_ME_THE_DATA_(debug mode only)__', {
+        get() {
+          return proxy.slice();
+        },
+      });
+    }
 
     createArrayTags(proxy, _SIGNAL);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2871,6 +2871,9 @@ importers:
       '@types/morgan':
         specifier: ^1.9.9
         version: 1.9.9
+      '@warp-drive/build-config':
+        specifier: workspace:*
+        version: file:packages/build-config(@babel/core@7.26.9)
       '@warp-drive/core-types':
         specifier: workspace:*
         version: file:packages/core-types(@babel/core@7.26.9)
@@ -4063,7 +4066,7 @@ importers:
         version: file:packages/tracking(705310b48e66482cebd843ac2ea54e02)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(8441b4bfd934185a340cab6c3a01dfe9)
+        version: file:packages/unpublished-test-infra(7241f0a96f636f80bc83a4e93ea05f4f)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
@@ -4169,6 +4172,9 @@ importers:
       silent-error:
         specifier: ^1.1.1
         version: 1.1.1
+      testem:
+        specifier: ~3.11.0
+        version: 3.11.0(patch_hash=cf147865cff81f2d0f3ed51d274f9fdee7b4ad675a902248aa317c07272fbea5)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -6501,6 +6507,7 @@ packages:
 
   '@warp-drive/internal-tooling@file:internal-tooling':
     resolution: {directory: internal-tooling, type: directory}
+    engines: {node: '>= 18.20.7'}
     hasBin: true
 
   '@warp-drive/schema-record@file:packages/schema-record':
@@ -15083,7 +15090,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(8441b4bfd934185a340cab6c3a01dfe9)':
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(7241f0a96f636f80bc83a4e93ea05f4f)':
     dependencies:
       '@ember-data/store': file:packages/store(d46a3222a0b206b3d019d022c547e343)
       '@ember/test-helpers': 5.1.0(patch_hash=ed8cc42d8dc0ec69d7f3c00f5c943370ae4b36fe4fa06afd3b5658bbf75bc421)(6bdc1548f7ec55b645542e5984f71664)
@@ -15095,6 +15102,7 @@ snapshots:
       semver: 7.7.1
     optionalDependencies:
       qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
+      testem: 3.11.0(patch_hash=cf147865cff81f2d0f3ed51d274f9fdee7b4ad675a902248aa317c07272fbea5)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'

--- a/tests/example-json-api/package.json
+++ b/tests/example-json-api/package.json
@@ -45,6 +45,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@html-next/vertical-collection": "^4.0.2",
     "@types/morgan": "^1.9.9",
+    "@warp-drive/build-config": "workspace:*",
     "@warp-drive/core-types": "workspace:*",
     "@warp-drive/internal-config": "workspace:*",
     "ember-auto-import": "2.10.0",

--- a/tests/warp-drive__schema-record/package.json
+++ b/tests/warp-drive__schema-record/package.json
@@ -69,6 +69,7 @@
     "qunit-console-grouper": "^0.3.0",
     "qunit-dom": "^3.1.1",
     "silent-error": "^1.1.1",
+    "testem": "^3.12.0",
     "typescript": "^5.8.2",
     "webpack": "^5.98.0"
   },


### PR DESCRIPTION
Adds a better debugging experience in dev mode to SchemaRecord, RecordArray and Identifier
allowing more visibility through these proxies more quickly.

Also cleans up spacing in some of the guides and fixes two missing deps in test apps

Note: SchemaRecord's getter for debugging will show the value of EVERYTHING in the schema including derived fields, which is why the model in legacy mode shows all the legacy APIs when expanded in the screenshot below.

<img width="1116" alt="Screenshot 2025-03-13 at 1 53 59 AM" src="https://github.com/user-attachments/assets/f48ba975-cb8f-4c26-b31c-8a017dd40a54" />
<img width="461" alt="Screenshot 2025-03-13 at 1 54 14 AM" src="https://github.com/user-attachments/assets/e3779598-7e29-47bc-bbb0-f44551aa5436" />
<img width="311" alt="Screenshot 2025-03-13 at 1 54 26 AM" src="https://github.com/user-attachments/assets/1ae1c851-441f-4dc1-b55b-ab49bc9746ff" />
<img width="340" alt="Screenshot 2025-03-13 at 1 55 14 AM" src="https://github.com/user-attachments/assets/53244d0a-beda-4069-8d6b-3138d49b13af" />
<img width="756" alt="Screenshot 2025-03-13 at 1 55 36 AM" src="https://github.com/user-attachments/assets/5f10c136-fef5-4485-aed9-6c9328a7468f" />
