### PR TITLE
feat: persist runtime config

### DIFF
--- a/packages/build-config/src/runtime.ts
+++ b/packages/build-config/src/runtime.ts
@@ -4,7 +4,7 @@ const RuntimeConfig = {
   debug: {},
 };
 
-const settings = sessionStorage.getItem('WarpDriveRuntimeConfig');
+const settings = globalThis.sessionStorage?.getItem('WarpDriveRuntimeConfig');
 if (settings) {
   Object.assign(RuntimeConfig, JSON.parse(settings));
 }
@@ -23,5 +23,5 @@ export function getRuntimeConfig(): typeof RuntimeConfig {
  */
 export function setLogging(config: Partial<LOG_CONFIG>): void {
   Object.assign(RuntimeConfig.debug, config);
-  sessionStorage.setItem('WarpDriveRuntimeConfig', JSON.stringify(RuntimeConfig));
+  globalThis.sessionStorage?.setItem('WarpDriveRuntimeConfig', JSON.stringify(RuntimeConfig));
 }

--- a/packages/build-config/src/runtime.ts
+++ b/packages/build-config/src/runtime.ts
@@ -4,6 +4,11 @@ const RuntimeConfig = {
   debug: {},
 };
 
+const settings = sessionStorage.getItem('WarpDriveRuntimeConfig');
+if (settings) {
+  Object.assign(RuntimeConfig, JSON.parse(settings));
+}
+
 export function getRuntimeConfig(): typeof RuntimeConfig {
   return RuntimeConfig;
 }
@@ -18,4 +23,5 @@ export function getRuntimeConfig(): typeof RuntimeConfig {
  */
 export function setLogging(config: Partial<LOG_CONFIG>): void {
   Object.assign(RuntimeConfig.debug, config);
+  sessionStorage.setItem('WarpDriveRuntimeConfig', JSON.stringify(RuntimeConfig));
 }


### PR DESCRIPTION
persists runtime config into sessionStorage if available

so for instance `setWarpDriveLogging({ LOG_NOTIFICATIONS: true })` will persist for the session across refresh making debugging easier