### PR TITLE
feat: ensure objects behave amazeballs

### DIFF
--- a/internal-tooling/src/tasks/sync-scripts.ts
+++ b/internal-tooling/src/tasks/sync-scripts.ts
@@ -135,6 +135,15 @@ export async function main() {
     // ensure that the package.json scripts are up to date with defaults
     /////////////////////////////////////////////////////////////////////
 
+    if (project.isTest) {
+      if (!('private' in project.pkg)) {
+        project.pkg.private = true;
+        project.isPrivate = true;
+        pkgEdited = true;
+        log(`\t\t🔧 Added private flag to package.json`);
+      }
+    }
+
     if (!project.isPrivate) {
       if (!project.pkg.scripts) {
         project.pkg.scripts = {};

--- a/packages/schema-record/src/-private/fields/managed-object.ts
+++ b/packages/schema-record/src/-private/fields/managed-object.ts
@@ -83,7 +83,7 @@ export class ManagedObject {
         }
 
         if (prop === Symbol.toPrimitive) {
-          return null;
+          return () => null;
         }
         if (prop === Symbol.toStringTag) {
           return `ManagedObject<${identifier.type}:${identifier.id} (${identifier.lid})>`;
@@ -98,7 +98,12 @@ export class ManagedObject {
         }
         if (prop === 'toHTML') {
           return function () {
-            return '<div>ManagedObject</div>';
+            return '<span>ManagedObject</span>';
+          };
+        }
+        if (prop === 'toJSON') {
+          return function () {
+            return structuredClone(self[SOURCE]);
           };
         }
 

--- a/packages/schema-record/src/-private/record.ts
+++ b/packages/schema-record/src/-private/record.ts
@@ -79,7 +79,8 @@ function isNonEnumerableProp(prop: string | number | symbol) {
     prop === '__proto__' ||
     prop === 'toString' ||
     prop === 'toJSON' ||
-    prop === 'toHTML'
+    prop === 'toHTML' ||
+    typeof prop === 'symbol'
   );
 }
 
@@ -117,18 +118,15 @@ export class SchemaRecord {
 
     const schema = store.schema as unknown as SchemaService;
     const cache = store.cache;
-    const identityField = schema.resource(identifier).identity;
+    const identityField = schema.resource(isEmbedded ? { type: embeddedType as string } : identifier).identity;
     const BoundFns = new Map<string | symbol, ProxiedMethod>();
 
     this[EmbeddedType] = embeddedType;
     this[EmbeddedPath] = embeddedPath;
 
-    let fields: Map<string, FieldSchema>;
-    if (isEmbedded) {
-      fields = schema.fields({ type: embeddedType as string });
-    } else {
-      fields = schema.fields(identifier);
-    }
+    const fields: Map<string, FieldSchema> = isEmbedded
+      ? schema.fields({ type: embeddedType as string })
+      : schema.fields(identifier);
 
     const signals: Map<string, Signal> = new Map();
     this[Signals] = signals;

--- a/packages/schema-record/src/-private/record.ts
+++ b/packages/schema-record/src/-private/record.ts
@@ -66,6 +66,7 @@ const symbolList = [
 const RecordSymbols = new Set(symbolList);
 
 type RecordSymbol = (typeof symbolList)[number];
+type ProxiedMethod = (...args: unknown[]) => unknown;
 
 function isPathMatch(a: string[], b: string[]) {
   return a.length === b.length && a.every((v, i) => v === b[i]);
@@ -106,6 +107,7 @@ export class SchemaRecord {
     const schema = store.schema as unknown as SchemaService;
     const cache = store.cache;
     const identityField = schema.resource(identifier).identity;
+    const BoundFns = new Map<string | symbol, ProxiedMethod>();
 
     this[EmbeddedType] = embeddedType;
     this[EmbeddedPath] = embeddedPath;
@@ -136,11 +138,17 @@ export class SchemaRecord {
         if (!fields.has(prop as string)) {
           throw new Error(`No field named ${String(prop)} on ${identifier.type}`);
         }
-        const schemaForField = fields.get(prop as string)!;
+        const schemaForField = prop === identityField?.name ? identityField : fields.get(prop as string)!;
         switch (schemaForField.kind) {
           case 'derived':
             return {
               writable: false,
+              enumerable: true,
+              configurable: true,
+            };
+          case '@id':
+            return {
+              writable: identifier.id === null,
               enumerable: true,
               configurable: true,
             };
@@ -161,32 +169,18 @@ export class SchemaRecord {
               enumerable: true,
               configurable: true,
             };
+          default:
+            return {
+              writable: false,
+              enumerable: false,
+              configurable: false,
+            };
         }
       },
 
       get(target: SchemaRecord, prop: string | number | symbol, receiver: typeof Proxy<SchemaRecord>) {
         if (RecordSymbols.has(prop as RecordSymbol)) {
           return target[prop as keyof SchemaRecord];
-        }
-
-        if (prop === Symbol.toStringTag) {
-          return `SchemaRecord<${identifier.type}:${identifier.id} (${identifier.lid})>`;
-        }
-
-        if (prop === 'toString') {
-          return function () {
-            return `SchemaRecord<${identifier.type}:${identifier.id} (${identifier.lid})>`;
-          };
-        }
-
-        if (prop === 'toHTML') {
-          return function () {
-            return `<div>SchemaRecord<${identifier.type}:${identifier.id} (${identifier.lid})></div>`;
-          };
-        }
-
-        if (prop === Symbol.toPrimitive) {
-          return null;
         }
 
         // TODO make this a symbol
@@ -203,19 +197,65 @@ export class SchemaRecord {
           if (IgnoredGlobalFields.has(prop as string)) {
             return undefined;
           }
+
+          /////////////////////////////////////////////////////////////
+          //// Note these bound function behaviors are essentially ////
+          //// built-in but overrideable derivations.              ////
+          ////                                                     ////
+          //// The bar for this has to be "basic expectations of   ////
+          ///  an object" – very, very high                        ////
+          /////////////////////////////////////////////////////////////
+
+          if (prop === Symbol.toStringTag || prop === 'toString') {
+            let fn = BoundFns.get('toString');
+            if (!fn) {
+              fn = function () {
+                entangleSignal(signals, receiver, '@identity');
+                return `Record<${identifier.type}:${identifier.id} (${identifier.lid})>`;
+              };
+              BoundFns.set(prop, fn);
+            }
+            return fn;
+          }
+
+          if (prop === 'toHTML') {
+            let fn = BoundFns.get('toHTML');
+            if (!fn) {
+              fn = function () {
+                entangleSignal(signals, receiver, '@identity');
+                return `<span>Record<${identifier.type}:${identifier.id} (${identifier.lid})></span>`;
+              };
+              BoundFns.set(prop, fn);
+            }
+            return fn;
+          }
+
+          if (prop === 'toJSON') {
+            let fn = BoundFns.get('toJSON');
+            if (!fn) {
+              fn = function () {
+                const json: Record<string, unknown> = {};
+                for (const key in receiver) {
+                  json[key] = receiver[key as keyof typeof receiver];
+                }
+
+                return json;
+              };
+              BoundFns.set(prop, fn);
+            }
+            return fn;
+          }
+
+          if (prop === Symbol.toPrimitive) return () => null;
+
           if (prop === 'constructor') {
             return SchemaRecord;
           }
           // too many things check for random symbols
-          if (typeof prop === 'symbol') {
-            return undefined;
-          }
-          let type = identifier.type;
-          if (isEmbedded) {
-            type = embeddedType!;
-          }
+          if (typeof prop === 'symbol') return undefined;
 
-          throw new Error(`No field named ${String(prop)} on ${type}`);
+          assert(`No field named ${String(prop)} on ${isEmbedded ? embeddedType! : identifier.type}`);
+          return undefined;
         }
 
         const field = maybeField.kind === 'alias' ? maybeField.options : maybeField;

--- a/packages/schema-record/src/-private/schema.ts
+++ b/packages/schema-record/src/-private/schema.ts
@@ -55,6 +55,10 @@ function _constructor(record: SchemaRecord) {
 
   return (state._constructor = state._constructor || {
     name: `SchemaRecord<${recordIdentifierFor(record).type}>`,
+    get modelName() {
+      assert(`record.constructor.modelName is not available outside of legacy mode`, false);
+      return undefined;
+    },
   });
 }
 _constructor[Type] = '@constructor';
@@ -65,7 +69,12 @@ _constructor[Type] = '@constructor';
  */
 export function withDefaults(schema: WithPartial<ResourceSchema, 'identity'>): ResourceSchema {
   schema.identity = schema.identity || DefaultIdentityField;
-  schema.fields.push(TypeField, ConstructorField);
+
+  // because fields gets iterated in definition order,
+  // we add TypeField to the beginning so that it will
+  // appear right next to the identity field
+  schema.fields.unshift(TypeField);
+  schema.fields.push(ConstructorField);
   return schema as ResourceSchema;
 }
 

--- a/tests/warp-drive__schema-record/package.json
+++ b/tests/warp-drive__schema-record/package.json
@@ -18,8 +18,9 @@
     "build:tests": "IS_TESTING=true EMBER_CLI_TEST_COMMAND=true ember build --output-path=dist-test --suppress-sizes",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "glint",
-    "start": "ember test --test-port=0 --serve --no-launch",
-    "test": "ember test --test-port=0 --path=dist-test"
+    "start": "bun run build:tests --watch",
+    "test": "ember test --test-port=0 --path=dist-test",
+    "test:start": "bun run test --serve --no-launch"
   },
   "devDependencies": {
     "@babel/core": "^7.26.9",

--- a/tests/warp-drive__schema-record/tests/legacy/legacy-mode-activation-test.ts
+++ b/tests/warp-drive__schema-record/tests/legacy/legacy-mode-activation-test.ts
@@ -135,8 +135,8 @@ module('Legacy Mode', function (hooks) {
     } catch (e) {
       assert.strictEqual(
         (e as Error).message,
-        'Cannot access record.constructor.modelName on non-Legacy Schema Records.',
-        'record.constructor.modelName throws'
+        'record.constructor.modelName is not available outside of legacy mode',
+        `record.constructor.modelName throws: ${(e as Error).message}`
       );
     }
     assert.strictEqual(record.constructor.name, 'SchemaRecord<user>', 'it has a useful constructor name');

--- a/tests/warp-drive__schema-record/tests/polaris/managed-array-iterable-test.ts
+++ b/tests/warp-drive__schema-record/tests/polaris/managed-array-iterable-test.ts
@@ -1,0 +1,194 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import type Store from '@ember-data/store';
+import type { Type } from '@warp-drive/core-types/symbols';
+import { registerDerivations } from '@warp-drive/schema-record';
+
+interface User {
+  id: string;
+  $type: 'user';
+  name: string;
+  qualities: string[];
+  [Type]: 'user';
+}
+
+module('ManagedArray | Iterable Behaviors', function (hooks) {
+  setupTest(hooks);
+
+  test('we can use `JSON.stringify` on a ManagedArray', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+        {
+          name: 'qualities',
+          kind: 'array',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Wesley Thoburn',
+          qualities: ['smart', 'funny', 'cool'],
+        },
+      },
+    });
+
+    try {
+      const serialized = JSON.stringify(record);
+      assert.true(true, 'JSON.stringify should not throw');
+
+      const value = JSON.parse(serialized) as object;
+      assert.deepEqual(
+        value,
+        {
+          id: '1',
+          name: 'Wesley Thoburn',
+          qualities: ['smart', 'funny', 'cool'],
+        },
+        'stringify should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `JSON.stringify should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `[ ...record.qualties ]` on a ManagedArray', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+        {
+          name: 'qualities',
+          kind: 'array',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Wesley Thoburn',
+          qualities: ['smart', 'funny', 'cool'],
+        },
+      },
+    });
+
+    try {
+      const value = [...record.qualities] as string[];
+      assert.true(true, 'spread should not throw');
+      assert.arrayStrictEquals(
+        value,
+        ['smart', 'funny', 'cool'],
+        'spread should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `spread should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `for (const value of record.qualities)` on a record', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+        {
+          name: 'qualities',
+          kind: 'array',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Wesley Thoburn',
+          qualities: ['smart', 'funny', 'cool'],
+        },
+      },
+    });
+
+    try {
+      const value = [] as string[];
+
+      for (const val of record.qualities) {
+        value.push(val);
+      }
+
+      assert.true(true, 'for...of should not throw');
+      assert.arrayStrictEquals(value, ['smart', 'funny', 'cool'], 'for...of should work');
+    } catch (e: unknown) {
+      assert.true(false, `for...of should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `Array.from(record.qualities)` as expected', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+        {
+          name: 'qualities',
+          kind: 'array',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Wesley Thoburn',
+          qualities: ['smart', 'funny', 'cool'],
+        },
+      },
+    });
+
+    try {
+      const value = Array.from(record.qualities);
+      assert.true(true, 'Array.from should not throw');
+      assert.arrayStrictEquals(value, ['smart', 'funny', 'cool'], 'Array.from should work');
+    } catch (e: unknown) {
+      assert.true(false, `Array.from should not throw: ${(e as Error).message}`);
+    }
+  });
+});

--- a/tests/warp-drive__schema-record/tests/polaris/object-iterable-test.gts
+++ b/tests/warp-drive__schema-record/tests/polaris/object-iterable-test.gts
@@ -8,18 +8,19 @@ import type Store from '@ember-data/store';
 import type { Type } from '@warp-drive/core-types/symbols';
 import { registerDerivations } from '@warp-drive/schema-record';
 
-interface User {
-  id: string | null;
-  $type: 'user';
+interface ChatRelay {
+  id: string;
+  $type: 'chat-relay';
+  config: {
+    instanceName: string;
+    host: string;
+  };
+  activeUsers: Record<string, string>;
   name: string;
-  age: number;
-  netWorth: number;
-  coolometer: number;
-  rank: number;
-  [Type]: 'user';
+  [Type]: 'chat-relay';
 }
 
-module('SchemaRecord | Iterable Behaviors', function (hooks) {
+module('ManagedObject | Iterable Behaviors', function (hooks) {
   setupTest(hooks);
 
   test('we can use `JSON.stringify` on a record without providing toJSON in the schema', function (assert) {
@@ -28,7 +29,16 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
     registerDerivations(schema);
 
     schema.registerResource({
-      type: 'user',
+      type: 'config',
+      identity: null,
+      fields: [
+        { kind: 'field', name: 'instanceName' },
+        { kind: 'field', name: 'host' },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'chat-relay',
       identity: { kind: '@id', name: 'id' },
       fields: [
         {
@@ -43,16 +53,29 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
           options: { key: 'type' },
         },
         {
+          name: 'config',
+          kind: 'schema-object',
+          type: 'config',
+        },
+        {
+          name: 'activeUsers',
+          kind: 'object',
+        },
+        {
           name: 'name',
           kind: 'field',
         },
       ],
     });
-    const record = store.push<User>({
+    const record = store.push<ChatRelay>({
       data: {
-        type: 'user',
+        type: 'chat-relay',
         id: '1',
-        attributes: { name: 'Rey Pupatine' },
+        attributes: {
+          name: 'discord.com',
+          config: { instanceName: 'discord', host: 'discord.com' },
+          activeUsers: { acf4g1: 'Rey Pupatine' },
+        },
       },
     });
 
@@ -65,8 +88,15 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
         value,
         {
           id: '1',
-          $type: 'user',
-          name: 'Rey Pupatine',
+          $type: 'chat-relay',
+          activeUsers: {
+            acf4g1: 'Rey Pupatine',
+          },
+          config: {
+            host: 'discord.com',
+            instanceName: 'discord',
+          },
+          name: 'discord.com',
         },
         'stringify should remove constructor and include all other fields in the schema'
       );
@@ -81,7 +111,16 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
     registerDerivations(schema);
 
     schema.registerResource({
-      type: 'user',
+      type: 'config',
+      identity: null,
+      fields: [
+        { kind: 'field', name: 'instanceName' },
+        { kind: 'field', name: 'host' },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'chat-relay',
       identity: { kind: '@id', name: 'id' },
       fields: [
         {
@@ -96,16 +135,29 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
           options: { key: 'type' },
         },
         {
+          name: 'config',
+          kind: 'schema-object',
+          type: 'config',
+        },
+        {
+          name: 'activeUsers',
+          kind: 'object',
+        },
+        {
           name: 'name',
           kind: 'field',
         },
       ],
     });
-    const record = store.push<User>({
+    const record = store.push<ChatRelay>({
       data: {
-        type: 'user',
+        type: 'chat-relay',
         id: '1',
-        attributes: { name: 'Rey Pupatine' },
+        attributes: {
+          name: 'discord.com',
+          config: { instanceName: 'discord', host: 'discord.com' },
+          activeUsers: { acf4g1: 'Rey Pupatine' },
+        },
       },
     });
 
@@ -116,8 +168,11 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
         value,
         {
           id: '1',
-          $type: 'user',
-          name: 'Rey Pupatine',
+          $type: 'chat-relay',
+          // spread will preserve the original object references
+          activeUsers: record['activeUsers'],
+          config: record['config'],
+          name: 'discord.com',
         },
         'spread should remove constructor and include all other fields in the schema'
       );
@@ -132,7 +187,16 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
     registerDerivations(schema);
 
     schema.registerResource({
-      type: 'user',
+      type: 'config',
+      identity: null,
+      fields: [
+        { kind: 'field', name: 'instanceName' },
+        { kind: 'field', name: 'host' },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'chat-relay',
       identity: { kind: '@id', name: 'id' },
       fields: [
         {
@@ -147,16 +211,29 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
           options: { key: 'type' },
         },
         {
+          name: 'config',
+          kind: 'schema-object',
+          type: 'config',
+        },
+        {
+          name: 'activeUsers',
+          kind: 'object',
+        },
+        {
           name: 'name',
           kind: 'field',
         },
       ],
     });
-    const record = store.push<User>({
+    const record = store.push<ChatRelay>({
       data: {
-        type: 'user',
+        type: 'chat-relay',
         id: '1',
-        attributes: { name: 'Rey Pupatine' },
+        attributes: {
+          name: 'discord.com',
+          config: { instanceName: 'discord', host: 'discord.com' },
+          activeUsers: { acf4g1: 'Rey Pupatine' },
+        },
       },
     });
 
@@ -164,7 +241,7 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
       const value = {} as Record<string, unknown>;
 
       for (const key in record) {
-        value[key] = record[key as keyof User];
+        value[key] = record[key as keyof ChatRelay];
       }
 
       assert.true(true, 'for...in should not throw');
@@ -172,8 +249,11 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
         value,
         {
           id: '1',
-          $type: 'user',
-          name: 'Rey Pupatine',
+          $type: 'chat-relay',
+          // for...in will preserve the original object references
+          activeUsers: record['activeUsers'],
+          config: record['config'],
+          name: 'discord.com',
         },
         'for...in should remove constructor and include all other fields in the schema'
       );
@@ -188,7 +268,16 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
     registerDerivations(schema);
 
     schema.registerResource({
-      type: 'user',
+      type: 'config',
+      identity: null,
+      fields: [
+        { kind: 'field', name: 'instanceName' },
+        { kind: 'field', name: 'host' },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'chat-relay',
       identity: { kind: '@id', name: 'id' },
       fields: [
         {
@@ -203,16 +292,29 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
           options: { key: 'type' },
         },
         {
+          name: 'config',
+          kind: 'schema-object',
+          type: 'config',
+        },
+        {
+          name: 'activeUsers',
+          kind: 'object',
+        },
+        {
           name: 'name',
           kind: 'field',
         },
       ],
     });
-    const record = store.push<User>({
+    const record = store.push<ChatRelay>({
       data: {
-        type: 'user',
+        type: 'chat-relay',
         id: '1',
-        attributes: { name: 'Rey Pupatine' },
+        attributes: {
+          name: 'discord.com',
+          config: { instanceName: 'discord', host: 'discord.com' },
+          activeUsers: { acf4g1: 'Rey Pupatine' },
+        },
       },
     });
 
@@ -229,8 +331,11 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
         value,
         {
           id: '1',
-          $type: 'user',
-          name: 'Rey Pupatine',
+          $type: 'chat-relay',
+          // for...of will preserve the original object references
+          activeUsers: record['activeUsers'],
+          config: record['config'],
+          name: 'discord.com',
         },
         'for...of should remove constructor and include all other fields in the schema'
       );
@@ -245,7 +350,16 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
     registerDerivations(schema);
 
     schema.registerResource({
-      type: 'user',
+      type: 'config',
+      identity: null,
+      fields: [
+        { kind: 'field', name: 'instanceName' },
+        { kind: 'field', name: 'host' },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'chat-relay',
       identity: { kind: '@id', name: 'id' },
       fields: [
         {
@@ -260,16 +374,29 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
           options: { key: 'type' },
         },
         {
+          name: 'config',
+          kind: 'schema-object',
+          type: 'config',
+        },
+        {
+          name: 'activeUsers',
+          kind: 'object',
+        },
+        {
           name: 'name',
           kind: 'field',
         },
       ],
     });
-    const record = store.push<User>({
+    const record = store.push<ChatRelay>({
       data: {
-        type: 'user',
+        type: 'chat-relay',
         id: '1',
-        attributes: { name: 'Rey Pupatine' },
+        attributes: {
+          name: 'discord.com',
+          config: { instanceName: 'discord', host: 'discord.com' },
+          activeUsers: { acf4g1: 'Rey Pupatine' },
+        },
       },
     });
 
@@ -278,7 +405,7 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
       assert.true(true, 'Object.keys should not throw');
       assert.arrayStrictEquals(
         keys,
-        ['id', '$type', 'name'],
+        ['id', '$type', 'config', 'activeUsers', 'name'],
         'Object.keys should remove constructor and include all other fields in the schema'
       );
     } catch (e: unknown) {
@@ -292,7 +419,16 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
     registerDerivations(schema);
 
     schema.registerResource({
-      type: 'user',
+      type: 'config',
+      identity: null,
+      fields: [
+        { kind: 'field', name: 'instanceName' },
+        { kind: 'field', name: 'host' },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'chat-relay',
       identity: { kind: '@id', name: 'id' },
       fields: [
         {
@@ -307,16 +443,29 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
           options: { key: 'type' },
         },
         {
+          name: 'config',
+          kind: 'schema-object',
+          type: 'config',
+        },
+        {
+          name: 'activeUsers',
+          kind: 'object',
+        },
+        {
           name: 'name',
           kind: 'field',
         },
       ],
     });
-    const record = store.push<User>({
+    const record = store.push<ChatRelay>({
       data: {
-        type: 'user',
+        type: 'chat-relay',
         id: '1',
-        attributes: { name: 'Rey Pupatine' },
+        attributes: {
+          name: 'discord.com',
+          config: { instanceName: 'discord', host: 'discord.com' },
+          activeUsers: { acf4g1: 'Rey Pupatine' },
+        },
       },
     });
 
@@ -325,7 +474,7 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
       assert.true(true, 'Object.values should not throw');
       assert.arrayStrictEquals(
         values,
-        ['1', 'user', 'Rey Pupatine'],
+        ['1', 'chat-relay', record.config, record.activeUsers, 'discord.com'],
         'Object.values should remove constructor and include all other fields in the schema'
       );
     } catch (e: unknown) {
@@ -339,7 +488,16 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
     registerDerivations(schema);
 
     schema.registerResource({
-      type: 'user',
+      type: 'config',
+      identity: null,
+      fields: [
+        { kind: 'field', name: 'instanceName' },
+        { kind: 'field', name: 'host' },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'chat-relay',
       identity: { kind: '@id', name: 'id' },
       fields: [
         {
@@ -354,16 +512,29 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
           options: { key: 'type' },
         },
         {
+          name: 'config',
+          kind: 'schema-object',
+          type: 'config',
+        },
+        {
+          name: 'activeUsers',
+          kind: 'object',
+        },
+        {
           name: 'name',
           kind: 'field',
         },
       ],
     });
-    const record = store.push<User>({
+    const record = store.push<ChatRelay>({
       data: {
-        type: 'user',
+        type: 'chat-relay',
         id: '1',
-        attributes: { name: 'Rey Pupatine' },
+        attributes: {
+          name: 'discord.com',
+          config: { instanceName: 'discord', host: 'discord.com' },
+          activeUsers: { acf4g1: 'Rey Pupatine' },
+        },
       },
     });
 
@@ -374,8 +545,10 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
         entries,
         [
           ['id', '1'],
-          ['$type', 'user'],
-          ['name', 'Rey Pupatine'],
+          ['$type', 'chat-relay'],
+          ['config', record.config],
+          ['activeUsers', record.activeUsers],
+          ['name', 'discord.com'],
         ],
         'Object.entries should remove constructor and include all other fields in the schema'
       );
@@ -385,7 +558,7 @@ module('SchemaRecord | Iterable Behaviors', function (hooks) {
   });
 });
 
-module('SchemaRecord | Iterable Behaviors | Rendering', function (hooks) {
+module('ManagedObject | Iterable Behaviors | Rendering', function (hooks) {
   setupRenderingTest(hooks);
 
   test('we can use `{{#each-in record as |key value|}}` in a template', async function (assert) {
@@ -394,7 +567,16 @@ module('SchemaRecord | Iterable Behaviors | Rendering', function (hooks) {
     registerDerivations(schema);
 
     schema.registerResource({
-      type: 'user',
+      type: 'config',
+      identity: null,
+      fields: [
+        { kind: 'field', name: 'instanceName' },
+        { kind: 'field', name: 'host' },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'chat-relay',
       identity: { kind: '@id', name: 'id' },
       fields: [
         {
@@ -409,31 +591,47 @@ module('SchemaRecord | Iterable Behaviors | Rendering', function (hooks) {
           options: { key: 'type' },
         },
         {
+          name: 'config',
+          kind: 'schema-object',
+          type: 'config',
+        },
+        {
+          name: 'activeUsers',
+          kind: 'object',
+        },
+        {
           name: 'name',
           kind: 'field',
         },
       ],
     });
-
-    const record = store.push<User>({
+    const record = store.push<ChatRelay>({
       data: {
-        type: 'user',
+        type: 'chat-relay',
         id: '1',
-        attributes: { name: 'Rey Pupatine' },
+        attributes: {
+          name: 'discord.com',
+          config: { instanceName: 'discord', host: 'discord.com' },
+          activeUsers: { acf4g1: 'Rey Pupatine' },
+        },
       },
     });
+
+    const stringify = (value: unknown) => JSON.stringify(value);
 
     await render(
       <template>
         {{#each-in record as |key value|}}
-          <div data-test-key={{key}}>{{value}}</div>
+          <div data-test-key={{key}}>{{stringify value}}</div>
         {{/each-in}}
       </template>
     );
 
-    assert.dom('[data-test-key="id"]').hasText('1');
-    assert.dom('[data-test-key="$type"]').hasText('user');
-    assert.dom('[data-test-key="name"]').hasText('Rey Pupatine');
+    assert.dom('[data-test-key="id"]').hasText('"1"');
+    assert.dom('[data-test-key="$type"]').hasText('"chat-relay"');
+    assert.dom('[data-test-key="name"]').hasText('"discord.com"');
+    assert.dom('[data-test-key="config"]').hasText('{"instanceName":"discord","host":"discord.com"}');
+    assert.dom('[data-test-key="activeUsers"]').hasText('{"acf4g1":"Rey Pupatine"}');
   });
 
   test('we can use `{{#each record as |entry|}}` in a template', async function (assert) {
@@ -442,7 +640,16 @@ module('SchemaRecord | Iterable Behaviors | Rendering', function (hooks) {
     registerDerivations(schema);
 
     schema.registerResource({
-      type: 'user',
+      type: 'config',
+      identity: null,
+      fields: [
+        { kind: 'field', name: 'instanceName' },
+        { kind: 'field', name: 'host' },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'chat-relay',
       identity: { kind: '@id', name: 'id' },
       fields: [
         {
@@ -457,32 +664,51 @@ module('SchemaRecord | Iterable Behaviors | Rendering', function (hooks) {
           options: { key: 'type' },
         },
         {
+          name: 'config',
+          kind: 'schema-object',
+          type: 'config',
+        },
+        {
+          name: 'activeUsers',
+          kind: 'object',
+        },
+        {
           name: 'name',
           kind: 'field',
         },
       ],
     });
-
-    const record = store.push<User & { [Symbol.iterator]: () => Iterator<[string, string]> }>({
+    const record = store.push<ChatRelay & { [Symbol.iterator]: () => Iterator<[string, unknown]> }>({
       data: {
-        type: 'user',
+        type: 'chat-relay',
         id: '1',
-        attributes: { name: 'Rey Pupatine' },
+        attributes: {
+          name: 'discord.com',
+          config: { instanceName: 'discord', host: 'discord.com' },
+          activeUsers: { acf4g1: 'Rey Pupatine' },
+        },
       },
     });
 
-    const get = (entry: [string, string], index: number) => entry[index];
+    interface get {
+      (entry: [string, unknown], index: 0): string;
+      (entry: [string, unknown], index: 1): unknown;
+    }
+    const get = ((entry: [string, unknown], index: 0 | 1) => entry[index]) as get;
+    const stringify = (value: unknown) => JSON.stringify(value);
 
     await render(
       <template>
         {{#each record as |entry|}}
-          <div data-test-key={{get entry 0}}>{{get entry 1}}</div>
+          <div data-test-key={{get entry 0}}>{{stringify (get entry 1)}}</div>
         {{/each}}
       </template>
     );
 
-    assert.dom('[data-test-key="id"]').hasText('1');
-    assert.dom('[data-test-key="$type"]').hasText('user');
-    assert.dom('[data-test-key="name"]').hasText('Rey Pupatine');
+    assert.dom('[data-test-key="id"]').hasText('"1"');
+    assert.dom('[data-test-key="$type"]').hasText('"chat-relay"');
+    assert.dom('[data-test-key="name"]').hasText('"discord.com"');
+    assert.dom('[data-test-key="config"]').hasText('{"instanceName":"discord","host":"discord.com"}');
+    assert.dom('[data-test-key="activeUsers"]').hasText('{"acf4g1":"Rey Pupatine"}');
   });
 });

--- a/tests/warp-drive__schema-record/tests/polaris/record-array-iterable-test.ts
+++ b/tests/warp-drive__schema-record/tests/polaris/record-array-iterable-test.ts
@@ -1,0 +1,214 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import type Store from '@ember-data/store';
+import type { Type } from '@warp-drive/core-types/symbols';
+import { registerDerivations } from '@warp-drive/schema-record';
+
+interface User {
+  id: string;
+  $type: 'user';
+  name: string;
+  [Type]: 'user';
+}
+
+module('RecordArray | Iterable Behaviors', function (hooks) {
+  setupTest(hooks);
+
+  test('we can use `JSON.stringify` on a RecordArray', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: [
+        {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Wesley Thoburn',
+          },
+        },
+        {
+          type: 'user',
+          id: '2',
+          attributes: {
+            name: 'Rey Pupatine',
+          },
+        },
+      ],
+    });
+
+    try {
+      const serialized = JSON.stringify(record);
+      assert.true(true, 'JSON.stringify should not throw');
+
+      const value = JSON.parse(serialized) as object;
+      assert.deepEqual(
+        value,
+        [
+          {
+            id: '1',
+            name: 'Wesley Thoburn',
+          },
+          {
+            id: '2',
+            name: 'Rey Pupatine',
+          },
+        ],
+        'stringify should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `JSON.stringify should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `[ ...record ]` on a RecordArray', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const records = store.push<User>({
+      data: [
+        {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Wesley Thoburn',
+          },
+        },
+        {
+          type: 'user',
+          id: '2',
+          attributes: {
+            name: 'Rey Pupatine',
+          },
+        },
+      ],
+    });
+
+    try {
+      const value = [...records] as Partial<User>[];
+      assert.true(true, 'spread should not throw');
+      assert.deepEqual(
+        value,
+        [records[0], records[1]],
+        'spread should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `spread should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `for (const value of record)` on a record', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const records = store.push<User>({
+      data: [
+        {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Wesley Thoburn',
+          },
+        },
+        {
+          type: 'user',
+          id: '2',
+          attributes: {
+            name: 'Rey Pupatine',
+          },
+        },
+      ],
+    });
+
+    try {
+      const value = [] as User[];
+
+      for (const val of records) {
+        value.push(val);
+      }
+
+      assert.true(true, 'for...of should not throw');
+      assert.deepEqual(value, [records[0], records[1]], 'for...of should work');
+    } catch (e: unknown) {
+      assert.true(false, `for...of should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `Array.from(records)` as expected', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const records = store.push<User>({
+      data: [
+        {
+          type: 'user',
+          id: '1',
+          attributes: {
+            name: 'Wesley Thoburn',
+          },
+        },
+        {
+          type: 'user',
+          id: '2',
+          attributes: {
+            name: 'Rey Pupatine',
+          },
+        },
+      ],
+    });
+
+    try {
+      const value = Array.from(records);
+      assert.true(true, 'Array.from should not throw');
+      assert.deepEqual(value, [records[0], records[1]], 'Array.from should work');
+    } catch (e: unknown) {
+      assert.true(false, `Array.from should not throw: ${(e as Error).message}`);
+    }
+  });
+});

--- a/tests/warp-drive__schema-record/tests/polaris/record-iterable-test.gts
+++ b/tests/warp-drive__schema-record/tests/polaris/record-iterable-test.gts
@@ -1,0 +1,488 @@
+import { render } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { setupRenderingTest, setupTest } from 'ember-qunit';
+
+import type Store from '@ember-data/store';
+import type { Type } from '@warp-drive/core-types/symbols';
+import { registerDerivations } from '@warp-drive/schema-record';
+
+interface User {
+  id: string | null;
+  $type: 'user';
+  name: string;
+  age: number;
+  netWorth: number;
+  coolometer: number;
+  rank: number;
+  [Type]: 'user';
+}
+
+module('SchemaRecord | Behaviors', function (hooks) {
+  setupTest(hooks);
+
+  test('we can use `JSON.stringify` on a record without providing toJSON in the schema', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          type: '@constructor',
+          name: 'constructor',
+          kind: 'derived',
+        },
+        {
+          type: '@identity',
+          name: '$type',
+          kind: 'derived',
+          options: { key: 'type' },
+        },
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    });
+
+    try {
+      const serialized = JSON.stringify(record);
+      assert.true(true, 'JSON.stringify should not throw');
+
+      const value = JSON.parse(serialized) as object;
+      assert.deepEqual(
+        value,
+        {
+          id: '1',
+          $type: 'user',
+          name: 'Rey Pupatine',
+        },
+        'stringify should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `JSON.stringify should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `{ ...record }` on a record', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          type: '@constructor',
+          name: 'constructor',
+          kind: 'derived',
+        },
+        {
+          type: '@identity',
+          name: '$type',
+          kind: 'derived',
+          options: { key: 'type' },
+        },
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    });
+
+    try {
+      const value = { ...record } as object;
+      assert.true(true, 'spread should not throw');
+      assert.deepEqual(
+        value,
+        {
+          id: '1',
+          $type: 'user',
+          name: 'Rey Pupatine',
+        },
+        'spread should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `spread should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `for (let key in record)` on a record', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          type: '@constructor',
+          name: 'constructor',
+          kind: 'derived',
+        },
+        {
+          type: '@identity',
+          name: '$type',
+          kind: 'derived',
+          options: { key: 'type' },
+        },
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    });
+
+    try {
+      const value = {} as Record<string, unknown>;
+
+      for (const key in record) {
+        value[key] = record[key as keyof User];
+      }
+
+      assert.true(true, 'for...in should not throw');
+      assert.deepEqual(
+        value,
+        {
+          id: '1',
+          $type: 'user',
+          name: 'Rey Pupatine',
+        },
+        'for...in should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `for...in should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `for (const [key, value] of record)` on a record', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          type: '@constructor',
+          name: 'constructor',
+          kind: 'derived',
+        },
+        {
+          type: '@identity',
+          name: '$type',
+          kind: 'derived',
+          options: { key: 'type' },
+        },
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    });
+
+    try {
+      const value = {} as Record<string, unknown>;
+
+      // @ts-expect-error we dont type the iterator
+      for (const [key, val] of record) {
+        value[key as string] = val;
+      }
+
+      assert.true(true, 'for...of should not throw');
+      assert.deepEqual(
+        value,
+        {
+          id: '1',
+          $type: 'user',
+          name: 'Rey Pupatine',
+        },
+        'for...of should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `for...of should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `Object.keys(record)` on a record', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          type: '@constructor',
+          name: 'constructor',
+          kind: 'derived',
+        },
+        {
+          type: '@identity',
+          name: '$type',
+          kind: 'derived',
+          options: { key: 'type' },
+        },
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    });
+
+    try {
+      const keys = Object.keys(record);
+      assert.true(true, 'Object.keys should not throw');
+      assert.arrayStrictEquals(
+        keys,
+        ['id', '$type', 'name'],
+        'Object.keys should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `Object.keys should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `Object.value(record)` on a record', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          type: '@constructor',
+          name: 'constructor',
+          kind: 'derived',
+        },
+        {
+          type: '@identity',
+          name: '$type',
+          kind: 'derived',
+          options: { key: 'type' },
+        },
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    });
+
+    try {
+      const values = Object.values(record);
+      assert.true(true, 'Object.values should not throw');
+      assert.arrayStrictEquals(
+        values,
+        ['1', 'user', 'Rey Pupatine'],
+        'Object.values should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `Object.values should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `Object.entries(record)` on a record', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          type: '@constructor',
+          name: 'constructor',
+          kind: 'derived',
+        },
+        {
+          type: '@identity',
+          name: '$type',
+          kind: 'derived',
+          options: { key: 'type' },
+        },
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    });
+
+    try {
+      const entries = Object.entries(record);
+      assert.true(true, 'Object.entries should not throw');
+      assert.deepEqual(
+        entries,
+        [
+          ['id', '1'],
+          ['$type', 'user'],
+          ['name', 'Rey Pupatine'],
+        ],
+        'Object.entries should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `Object.entries should not throw: ${(e as Error).message}`);
+    }
+  });
+});
+
+module('SchemaRecord | Behaviors | Rendering', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('we can use `{{#each-in record as |key value|}}` in a template', async function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          type: '@constructor',
+          name: 'constructor',
+          kind: 'derived',
+        },
+        {
+          type: '@identity',
+          name: '$type',
+          kind: 'derived',
+          options: { key: 'type' },
+        },
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    });
+
+    await render(
+      <template>
+        {{#each-in record as |key value|}}
+          <div data-test-key={{key}}>{{value}}</div>
+        {{/each-in}}
+      </template>
+    );
+
+    assert.dom('[data-test-key="id"]').hasText('1');
+    assert.dom('[data-test-key="$type"]').hasText('user');
+    assert.dom('[data-test-key="name"]').hasText('Rey Pupatine');
+  });
+
+  test('we can use `{{#each record as |entry|}}` in a template', async function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          type: '@constructor',
+          name: 'constructor',
+          kind: 'derived',
+        },
+        {
+          type: '@identity',
+          name: '$type',
+          kind: 'derived',
+          options: { key: 'type' },
+        },
+        {
+          name: 'name',
+          kind: 'field',
+        },
+      ],
+    });
+
+    const record = store.push<User & { [Symbol.iterator]: () => Iterator<[string, string]> }>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Rey Pupatine' },
+      },
+    });
+
+    const get = (entry: [string, string], index: number) => entry[index];
+
+    await render(
+      <template>
+        {{#each record as |entry|}}
+          <div data-test-key={{get entry 0}}>{{get entry 1}}</div>
+        {{/each}}
+      </template>
+    );
+
+    assert.dom('[data-test-key="id"]').hasText('1');
+    assert.dom('[data-test-key="$type"]').hasText('user');
+    assert.dom('[data-test-key="name"]').hasText('Rey Pupatine');
+  });
+});

--- a/tests/warp-drive__schema-record/tests/polaris/schema-array-iterable-test.ts
+++ b/tests/warp-drive__schema-record/tests/polaris/schema-array-iterable-test.ts
@@ -1,0 +1,308 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import type Store from '@ember-data/store';
+import type { Type } from '@warp-drive/core-types/symbols';
+import { registerDerivations } from '@warp-drive/schema-record';
+
+interface Address {
+  street: string;
+  city: string;
+}
+
+interface User {
+  id: string;
+  $type: 'user';
+  name: string;
+  addresses: Address[];
+  [Type]: 'user';
+}
+
+module('SchemaArray | Iterable Behaviors', function (hooks) {
+  setupTest(hooks);
+
+  test('we can use `JSON.stringify` on a SchemaArray', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'address',
+      identity: null,
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+        {
+          name: 'addresses',
+          kind: 'schema-array',
+          type: 'address',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Wesley Thoburn',
+          addresses: [
+            {
+              street: '123 Area St',
+              city: 'Baytown',
+            },
+            {
+              street: '456 Land St',
+              city: 'Oaktown',
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      const serialized = JSON.stringify(record);
+      assert.true(true, 'JSON.stringify should not throw');
+
+      const value = JSON.parse(serialized) as object;
+      assert.deepEqual(
+        value,
+        {
+          id: '1',
+          name: 'Wesley Thoburn',
+          addresses: [
+            {
+              street: '123 Area St',
+              city: 'Baytown',
+            },
+            {
+              street: '456 Land St',
+              city: 'Oaktown',
+            },
+          ],
+        },
+        'stringify should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `JSON.stringify should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `[ ...record.addresses ]` on a SchemaArray', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'address',
+      identity: null,
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+        {
+          name: 'addresses',
+          kind: 'schema-array',
+          type: 'address',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Wesley Thoburn',
+          addresses: [
+            {
+              street: '123 Area St',
+              city: 'Baytown',
+            },
+            {
+              street: '456 Land St',
+              city: 'Oaktown',
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      const value = [...record.addresses] as Address[];
+      assert.true(true, 'spread should not throw');
+      assert.deepEqual(
+        value,
+        [record.addresses[0], record.addresses[1]],
+        'spread should remove constructor and include all other fields in the schema'
+      );
+    } catch (e: unknown) {
+      assert.true(false, `spread should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `for (const value of record.addresses)` on a record', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'address',
+      identity: null,
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+        {
+          name: 'addresses',
+          kind: 'schema-array',
+          type: 'address',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Wesley Thoburn',
+          addresses: [
+            {
+              street: '123 Area St',
+              city: 'Baytown',
+            },
+            {
+              street: '456 Land St',
+              city: 'Oaktown',
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      const value = [] as Address[];
+
+      for (const val of record.addresses) {
+        value.push(val);
+      }
+
+      assert.true(true, 'for...of should not throw');
+      assert.deepEqual(value, [record.addresses[0], record.addresses[1]], 'for...of should work');
+    } catch (e: unknown) {
+      assert.true(false, `for...of should not throw: ${(e as Error).message}`);
+    }
+  });
+
+  test('we can use `Array.from(record.addresses)` as expected', function (assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+    registerDerivations(schema);
+
+    schema.registerResource({
+      type: 'address',
+      identity: null,
+      fields: [
+        {
+          name: 'street',
+          kind: 'field',
+        },
+        {
+          name: 'city',
+          kind: 'field',
+        },
+      ],
+    });
+
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        {
+          name: 'name',
+          kind: 'field',
+        },
+        {
+          name: 'addresses',
+          kind: 'schema-array',
+          type: 'address',
+        },
+      ],
+    });
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Wesley Thoburn',
+          addresses: [
+            {
+              street: '123 Area St',
+              city: 'Baytown',
+            },
+            {
+              street: '456 Land St',
+              city: 'Oaktown',
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      const value = Array.from(record.addresses);
+      assert.true(true, 'Array.from should not throw');
+      assert.deepEqual(value, [record.addresses[0], record.addresses[1]], 'Array.from should work');
+    } catch (e: unknown) {
+      assert.true(false, `Array.from should not throw: ${(e as Error).message}`);
+    }
+  });
+});


### PR DESCRIPTION
With SchemaRecord we want to ensure we support by-default in an overridable manner the following:

- JSON.stringify(record)
- JSON.stringify(managedObject)
- JSON.stringify(managedArray)
- JSON.stringify(recordArray)
- `{ ...record }`
- `{ ...managedObject }`
- `[ ...managedArray]`
- `[ ...recordArray]`
- `for (const key in record) {}`
- `for (const key in managedObject) {}`
- `for (const [key, value] of record) {}`
- `for (const [key, value] of managedObject) {}`
- `for (const value of managedArray) {}`
- `for (const value of recordArray) {}`
- `{{#each-in record as |key value|}}`
- `{{#each record as |entry|}}`
- `{{#each-in managedObject as |key value|}}`
- `{{#each managedObject as |entry|}}`
- `Object.keys(record)`
- `Object.keys(managedObject)`
- `Object.values(record)`
- `Object.values(managedObject)`
- `Object.entries(record)`
- `Object.entries(managedObject)`

iterating an object should iterate all its fields unless that field is a reserved name or a symbol. Reserved names include:

- 'constructor'
- 'prototype'
- '\_\_proto\_\_'
- 'toString'
- 'toJSON'
- 'toHTML'