### PR TITLE
Widen Peer Range for ember-inflector

### DIFF
--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -55,7 +55,7 @@
     "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0",
     "@ember/string": "^3.1.1 || ^4.0.0",
     "@warp-drive/core-types": "workspace:*",
-    "ember-inflector": "^4.0.2 || ^5.0.0"
+    "ember-inflector": "^4.0.2 || ^5.0.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "ember-inflector": {


### PR DESCRIPTION
## Description

Supports the [6.0.0 release](https://github.com/emberjs/ember-inflector/releases/tag/v6.0.0-ember-inflector) of inflector which had a very minimal breaking change to make `meta` uncountable.


