### PR TITLE
chore: cleanup @ember/service deprecation from shipped library code

### DIFF
--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -188,7 +188,7 @@ By default when using with Ember you only need to implement this hook if you wan
 */
 
 import EmberObject from '@ember/object';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 
 import type { AdapterPayload, MinimumAdapterInterface, SerializerOptions } from '@ember-data/legacy-compat';
 import type { Snapshot, SnapshotRecordArray } from '@ember-data/legacy-compat/-private';
@@ -197,6 +197,7 @@ import type { ModelSchema } from '@ember-data/store/types';
 import { DEBUG } from '@warp-drive/build-config/env';
 import { assert } from '@warp-drive/build-config/macros';
 
+const service = s.service ?? s.inject;
 /**
   An adapter is an object that receives requests from a store and
   translates them into the appropriate action to take against your

--- a/packages/debug/src/data-adapter.ts
+++ b/packages/debug/src/data-adapter.ts
@@ -27,7 +27,7 @@ import type { NativeArray } from '@ember/array';
 import { A } from '@ember/array';
 import DataAdapter from '@ember/debug/data-adapter';
 import { addObserver, removeObserver } from '@ember/object/observers';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 
 import { getGlobalConfig, macroCondition } from '@embroider/macros';
 
@@ -38,6 +38,7 @@ import { recordIdentifierFor } from '@ember-data/store';
 import type { ModelSchema } from '@ember-data/store/types';
 import { assert } from '@warp-drive/build-config/macros';
 
+const service = s.service ?? s.inject;
 const StoreTypesMap = new WeakMap<Store, Map<string, boolean>>();
 
 type RecordColor = 'black' | 'red' | 'blue' | 'green';

--- a/packages/serializer/src/index.ts
+++ b/packages/serializer/src/index.ts
@@ -108,11 +108,13 @@
 */
 
 import EmberObject from '@ember/object';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 
 import type Store from '@ember-data/store';
 import type { ModelSchema } from '@ember-data/store/types';
 import type { EmptyResourceDocument, SingleResourceDocument } from '@warp-drive/core-types/spec/json-api-raw';
+
+const service = s.service ?? s.inject;
 
 /**
   > ⚠️ CAUTION you likely want the docs for [<Interface> Serializer](/ember-data/release/classes/%3CInterface%3E%20Serializer)


### PR DESCRIPTION
We will still need to do similar anywhere it is in the test suite

resolves #9772 