### PR TITLE
Handle case when sessionStorage is blocked

### DIFF
--- a/packages/core-types/src/runtime.ts
+++ b/packages/core-types/src/runtime.ts
@@ -6,7 +6,18 @@ const RuntimeConfig: { debug: Partial<LOG_CONFIG> } = getOrSetUniversal('WarpDri
   debug: {},
 });
 
-const settings = globalThis.sessionStorage?.getItem('WarpDriveRuntimeConfig');
+function trySessionStorage() {
+  // This works even when sessionStorage is not available.
+  // See https://github.com/emberjs/data/issues/9784
+  try {
+    return globalThis.sessionStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+const storage = trySessionStorage();
+const settings = storage?.getItem('WarpDriveRuntimeConfig');
 if (settings) {
   Object.assign(RuntimeConfig, JSON.parse(settings));
 }
@@ -25,5 +36,5 @@ export function getRuntimeConfig(): typeof RuntimeConfig {
  */
 export function setLogging(config: Partial<LOG_CONFIG>): void {
   Object.assign(RuntimeConfig.debug, config);
-  globalThis.sessionStorage?.setItem('WarpDriveRuntimeConfig', JSON.stringify(RuntimeConfig));
+  storage?.setItem('WarpDriveRuntimeConfig', JSON.stringify(RuntimeConfig));
 }


### PR DESCRIPTION
This PR attempts to retrieve session storage within a try catch block to handle cases where it is blocked.
This should resolve #9784. 
