### PR TITLE
chore: remove @types/eslint__js

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3617,9 +3617,6 @@ importers:
       '@tsconfig/ember':
         specifier: ^3.0.9
         version: 3.0.9
-      '@types/eslint__js':
-        specifier: ^8.42.3
-        version: 8.42.3
       '@types/qunit':
         specifier: 2.19.10
         version: 2.19.10
@@ -6282,9 +6279,6 @@ packages:
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
-
-  '@types/eslint__js@8.42.3':
-    resolution: {integrity: sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -17393,10 +17387,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.6
       '@types/json-schema': 7.0.15
-
-  '@types/eslint__js@8.42.3':
-    dependencies:
-      '@types/eslint': 9.6.1
 
   '@types/estree@1.0.6': {}
 

--- a/tests/smoke-tests/dt-types/package.json
+++ b/tests/smoke-tests/dt-types/package.json
@@ -73,7 +73,6 @@
     "@glint/core": "1.5.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^3.0.9",
-    "@types/eslint__js": "^8.42.3",
     "@types/qunit": "2.19.10",
     "@types/rsvp": "^4.0.9",
     "@typescript-eslint/eslint-plugin": "^8.14.0",

--- a/tests/smoke-tests/native-types/package.json
+++ b/tests/smoke-tests/native-types/package.json
@@ -55,7 +55,6 @@
     "@glint/core": "1.5.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^3.0.9",
-    "@types/eslint__js": "^8.42.3",
     "@types/qunit": "2.19.10",
     "@types/rsvp": "^4.0.9",
     "@typescript-eslint/eslint-plugin": "^8.14.0",

--- a/tests/vite-basic-compat/package.json
+++ b/tests/vite-basic-compat/package.json
@@ -51,7 +51,6 @@
     "@glimmer/tracking": "^1.1.2",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^3.0.9",
-    "@types/eslint__js": "^8.42.3",
     "@types/qunit": "2.19.10",
     "@types/rsvp": "^4.0.9",
     "@typescript-eslint/eslint-plugin": "^8.28.0",


### PR DESCRIPTION
deprecated because eslint now provides its own types