### PR TITLE
feat: make documents react to cache updates

### DIFF
--- a/packages/core-types/src/utils.ts
+++ b/packages/core-types/src/utils.ts
@@ -1,1 +1,3 @@
 export type WithPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+export type Mutable<T> = { -readonly [P in keyof T]: T[P] };

--- a/packages/model/src/-private/model.ts
+++ b/packages/model/src/-private/model.ts
@@ -9,8 +9,8 @@ import type Store from '@ember-data/store';
 import type { NotificationType } from '@ember-data/store';
 import { recordIdentifierFor, storeFor } from '@ember-data/store';
 import { coerceId } from '@ember-data/store/-private';
-import { compat } from '@ember-data/tracking';
-import { defineSignal } from '@ember-data/tracking/-private';
+import { compat, notifySignal } from '@ember-data/tracking';
+import { defineSignal, subscribed as tagged } from '@ember-data/tracking/-private';
 import { DEBUG } from '@warp-drive/build-config/env';
 import { assert } from '@warp-drive/build-config/macros';
 import type { StableRecordIdentifier } from '@warp-drive/core-types';
@@ -35,7 +35,7 @@ import {
   unloadRecord,
 } from './model-methods';
 import notifyChanges from './notify-changes';
-import RecordState, { notifySignal, tagged } from './record-state';
+import RecordState from './record-state';
 import type BelongsToReference from './references/belongs-to';
 import type HasManyReference from './references/has-many';
 import type {

--- a/packages/store/src/-private.ts
+++ b/packages/store/src/-private.ts
@@ -13,7 +13,7 @@ export { isStableIdentifier } from './-private/caches/identifier-cache';
 
 export { constructResource } from './-private/utils/construct-resource';
 
-export type { Document } from './-private/document';
+export type { ReactiveDocument as Document } from './-private/document';
 export type { InstanceCache } from './-private/caches/instance-cache';
 
 export type {

--- a/packages/store/src/-private/cache-handler/utils.ts
+++ b/packages/store/src/-private/cache-handler/utils.ts
@@ -48,18 +48,6 @@ export function isMutation(
   return Boolean(request.op && MUTATION_OPS.has(request.op));
 }
 
-export function copyDocumentProperties(target: { links?: unknown; meta?: unknown; errors?: unknown }, source: object) {
-  if ('links' in source) {
-    target.links = source.links;
-  }
-  if ('meta' in source) {
-    target.meta = source.meta;
-  }
-  if ('errors' in source) {
-    target.errors = source.errors;
-  }
-}
-
 export function isCacheAffecting<T>(document: StructuredDataDocument<T>): boolean {
   if (!isMutation(document.request)) {
     return true;

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -56,7 +56,7 @@ import {
   resourceIsFullyDeleted,
   storeFor,
 } from './caches/instance-cache';
-import type { Document } from './document';
+import type { ReactiveDocument } from './document';
 import type RecordReference from './legacy-model-support/record-reference';
 import { getShimClass } from './legacy-model-support/shim-model-class';
 import { CacheManager } from './managers/cache-manager';
@@ -658,7 +658,7 @@ export class Store extends BaseClass {
   declare _instanceCache: InstanceCache;
   declare _documentCache: Map<
     StableDocumentIdentifier,
-    Document<OpaqueRecordInstance | OpaqueRecordInstance[] | null | undefined>
+    ReactiveDocument<OpaqueRecordInstance | OpaqueRecordInstance[] | null | undefined>
   >;
 
   declare _cbs: { coalesce?: () => void; sync?: () => void; notify?: () => void } | null;

--- a/packages/tracking/src/index.ts
+++ b/packages/tracking/src/index.ts
@@ -2,11 +2,7 @@ import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
 
 import { assert } from '@warp-drive/build-config/macros';
 
-export { transact, memoTransact, untracked } from './-private';
-
-// temporary so we can remove the glimmer and ember imports elsewhere
-// eslint-disable-next-line no-restricted-imports
-export { dependentKeyCompat as compat } from '@ember/object/compat';
+export { transact, memoTransact, untracked, compat, notifySignal } from './-private';
 
 export function cached<T extends object, K extends keyof T & string>(
   target: T,


### PR DESCRIPTION
This refactor ensures that the reactive properties on document update based on updates in the cache instead of their state being managed by the request lifecycle.

This is a key pre-req for

- giving documents their own schemas
- adding document patch operations to the cache
- adding document mutations to the cache
- ensuring `cache.put` updates any associated reactive documents
- using documents for relationships