### PR TITLE
fix: make warnMessageNoModelForKey (and similar) even more safe in prod

### DIFF
--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -204,6 +204,7 @@ const JSONAPISerializer = JSONSerializer.extend({
       return null;
     }
 
+    const modelClass = this.store.modelFor(type);
     const serializer = this.store.serializerFor(type);
     const { data } = serializer.normalize(modelClass, resourceHash);
     return data;

--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -191,9 +191,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     @private
   */
   _normalizeResourceHelper(resourceHash) {
-    if (DEBUG) {
-      assert(this.warnMessageForUndefinedType(), resourceHash.type);
-    }
+    assert(this.warnMessageForUndefinedType(), resourceHash.type);
 
     const type = this.modelNameFromPayloadKey(resourceHash.type);
 
@@ -206,7 +204,6 @@ const JSONAPISerializer = JSONSerializer.extend({
       return null;
     }
 
-    const modelClass = this.store.modelFor(type);
     const serializer = this.store.serializerFor(type);
     const { data } = serializer.normalize(modelClass, resourceHash);
     return data;

--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -191,14 +191,18 @@ const JSONAPISerializer = JSONSerializer.extend({
     @private
   */
   _normalizeResourceHelper(resourceHash) {
-    assert(this.warnMessageForUndefinedType(), resourceHash.type);
+    if (DEBUG) {
+      assert(this.warnMessageForUndefinedType(), resourceHash.type);
+    }
 
     const type = this.modelNameFromPayloadKey(resourceHash.type);
 
     if (!this.store.schema.hasResource({ type })) {
-      warn(this.warnMessageNoModelForType(type, resourceHash.type, 'modelNameFromPayloadKey'), false, {
-        id: 'ds.serializer.model-for-type-missing',
-      });
+      if (DEBUG) {
+        warn(this.warnMessageNoModelForType(type, resourceHash.type, 'modelNameFromPayloadKey'), false, {
+          id: 'ds.serializer.model-for-type-missing',
+        });
+      }
       return null;
     }
 


### PR DESCRIPTION
resolves https://github.com/emberjs/data/issues/9611 even more
https://github.com/emberjs/data/pull/9885 was incomplete