### PR TITLE
backport fix: make warnMessageNoModelForKey (and similar) even more safe in prod

### DIFF
--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -196,9 +196,11 @@ const JSONAPISerializer = JSONSerializer.extend({
     const type = this.modelNameFromPayloadKey(resourceHash.type);
 
     if (!this.store.schema.hasResource({ type })) {
-      warn(this.warnMessageNoModelForType(type, resourceHash.type, 'modelNameFromPayloadKey'), false, {
-        id: 'ds.serializer.model-for-type-missing',
-      });
+      if (DEBUG) {
+        warn(this.warnMessageNoModelForType(type, resourceHash.type, 'modelNameFromPayloadKey'), false, {
+          id: 'ds.serializer.model-for-type-missing',
+        });
+      }
       return null;
     }
 


### PR DESCRIPTION
backport https://github.com/emberjs/data/pull/9894