### PR TITLE
feat: whoa debugging

### DIFF
--- a/packages/build-config/src/canary-features.ts
+++ b/packages/build-config/src/canary-features.ts
@@ -89,6 +89,13 @@
 export const SAMPLE_FEATURE_FLAG: boolean | null = null;
 
 /**
+ * This upcoming feature adds a validation step to payloads received
+ * by the JSONAPICache implementation.
+ *
+ * When a request completes and the result is given to the cache via
+ * `cache.put`, the cache will validate the payload against registered
+ * schemas as well as the JSON:API spec.
+ *
  * @property JSON_API_CACHE_VALIDATION_ERRORS
  * @since 5.4
  * @public

--- a/packages/build-config/src/canary-features.ts
+++ b/packages/build-config/src/canary-features.ts
@@ -100,4 +100,4 @@ export const SAMPLE_FEATURE_FLAG: boolean | null = null;
  * @since 5.4
  * @public
  */
-export const JSON_API_CACHE_VALIDATION_ERRORS: boolean | null = null;
+export const JSON_API_CACHE_VALIDATION_ERRORS: boolean | null = false;

--- a/packages/build-config/src/canary-features.ts
+++ b/packages/build-config/src/canary-features.ts
@@ -87,3 +87,10 @@
  * @public
 */
 export const SAMPLE_FEATURE_FLAG: boolean | null = null;
+
+/**
+ * @property JSON_API_CACHE_VALIDATION_ERRORS
+ * @since 5.4
+ * @public
+ */
+export const JSON_API_CACHE_VALIDATION_ERRORS: boolean | null = null;

--- a/packages/json-api/package.json
+++ b/packages/json-api/package.json
@@ -50,13 +50,16 @@
   },
   "dependencies": {
     "@embroider/macros": "^1.16.12",
-    "@warp-drive/build-config": "workspace:*"
+    "@warp-drive/build-config": "workspace:*",
+    "json-to-ast": "2.1.0",
+    "fuse.js": "7.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",
     "@babel/plugin-transform-typescript": "^7.27.0",
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-typescript": "^7.27.0",
+    "@types/json-to-ast": "^2.1.4",
     "@ember-data/graph": "workspace:*",
     "@ember-data/request": "workspace:*",
     "@ember-data/request-utils": "workspace:*",

--- a/packages/json-api/src/-private/validator/1.1/7.1_top-level-document-members.ts
+++ b/packages/json-api/src/-private/validator/1.1/7.1_top-level-document-members.ts
@@ -19,7 +19,7 @@ export function validateTopLevelDocumentMembers(reporter: Reporter, doc: Resourc
   for (const key of keys) {
     if (!VALID_TOP_LEVEL_MEMBERS.includes(key)) {
       if (key.includes(':')) {
-        // TODO enable folks to add validation for their own extensions
+        // TODO @runspired expose the API to enable folks to add validation for their own extensions
         const extensionName = key.split(':')[0];
 
         if (reporter.hasExtension(extensionName)) {

--- a/packages/json-api/src/-private/validator/1.1/7.1_top-level-document-members.ts
+++ b/packages/json-api/src/-private/validator/1.1/7.1_top-level-document-members.ts
@@ -1,0 +1,142 @@
+import type { ResourceDocument } from '@warp-drive/core-types/spec/document';
+
+import { inspectType, isSimpleObject, type Reporter } from '../utils';
+
+const VALID_TOP_LEVEL_MEMBERS = ['data', 'included', 'meta', 'jsonapi', 'links'];
+
+/**
+ * Reports issues which violate the JSON:API spec for top-level members.
+ *
+ * Version: 1.1
+ * Section: 7.1
+ * Link: https://jsonapi.org/format/#document-top-level
+ *
+ * @internal
+ */
+export function validateTopLevelDocumentMembers(reporter: Reporter, doc: ResourceDocument) {
+  const keys = Object.keys(doc);
+
+  for (const key of keys) {
+    if (!VALID_TOP_LEVEL_MEMBERS.includes(key)) {
+      if (key.includes(':')) {
+        // TODO enable folks to add validation for their own extensions
+        const extensionName = key.split(':')[0];
+
+        if (reporter.hasExtension(extensionName)) {
+          const extension = reporter.getExtension(extensionName)!;
+          extension(reporter, [key]);
+        } else {
+          reporter.warn(
+            [key],
+            `Unrecognized extension ${extensionName}. The data provided by "${key}" will be ignored as it is not a valid {JSON:API} member`
+          );
+        }
+      } else {
+        reporter.error(
+          [key],
+          `Unrecognized top-level member. The data it provides is ignored as it is not a valid {JSON:API} member`
+        );
+      }
+    }
+  }
+
+  // additional rules for top-level members
+  // ======================================
+
+  // 1. MUST have either `data`, `errors`, or `meta`
+  if (!('data' in doc) && !('errors' in doc) && !('meta' in doc)) {
+    reporter.error([], 'A {JSON:API} Document must contain one-of `data` `errors` or `meta`');
+  }
+
+  // 2. MUST NOT have both `data` and `errors`
+  if ('data' in doc && 'errors' in doc) {
+    reporter.error(['data'], 'A {JSON:API} Document MUST NOT contain both `data` and `errors` members');
+  }
+
+  // 3. MUST NOT have both `included` and `errors`
+  // while not explicitly stated in the spec, this is a logical extension of the above rule
+  // since `included` is only valid when `data` is present.
+  if ('included' in doc && 'errors' in doc) {
+    reporter.error(['included'], 'A {JSON:API} Document MUST NOT contain both `included` and `errors` members');
+  }
+
+  // 4. MUST NOT have `included` if `data` is not present
+  if ('included' in doc && !('data' in doc)) {
+    reporter.error(['included'], 'A {JSON:API} Document MUST NOT contain `included` if `data` is not present');
+  }
+
+  // 5. MUST NOT have `included` if `data` is null
+  // when strictly enforcing full linkage, we need to ensure that `included` is not present if `data` is null
+  // however, most APIs will ignore this rule for DELETE requests, so unless strict linkage is enabled, we will only warn
+  // about this issue.
+  if ('included' in doc && doc.data === null) {
+    const isMaybeDelete =
+      reporter.contextDocument.request?.method?.toUpperCase() === 'DELETE' ||
+      reporter.contextDocument.request?.op === 'deleteRecord';
+    const method = !reporter.strict.linkage && isMaybeDelete ? 'warn' : 'error';
+    reporter[method](['included'], 'A {JSON:API} Document MUST NOT contain `included` if `data` is null');
+  }
+
+  // Simple Validation of Top-Level Members
+  // ==========================================
+  // 1. `data` MUST be a single resource object or an array of resource objects or `null`
+  if ('data' in doc) {
+    const dataMemberHasAppropriateForm = doc.data === null || Array.isArray(doc.data) || isSimpleObject(doc.data);
+    if (!dataMemberHasAppropriateForm) {
+      reporter.error(
+        ['data'],
+        `The 'data' member MUST be a single resource object or an array of resource objects or null. Received data of type "${inspectType(doc.data)}"`
+      );
+    }
+  }
+
+  // 2. `included` MUST be an array of resource objects
+  if ('included' in doc) {
+    if (!Array.isArray(doc.included)) {
+      reporter.error(
+        ['included'],
+        `The 'included' member MUST be an array of resource objects. Received data of type "${inspectType(doc.included)}"`
+      );
+    }
+  }
+
+  // 3. `meta` MUST be a simple object
+  if ('meta' in doc) {
+    if (!isSimpleObject(doc.meta)) {
+      reporter.error(
+        ['meta'],
+        `The 'meta' member MUST be a simple object. Received data of type "${inspectType(doc.meta)}"`
+      );
+    }
+  }
+
+  // 4. `jsonapi` MUST be a simple object
+  if ('jsonapi' in doc) {
+    if (!isSimpleObject(doc.jsonapi)) {
+      reporter.error(
+        ['jsonapi'],
+        `The 'jsonapi' member MUST be a simple object. Received data of type "${inspectType(doc.jsonapi)}"`
+      );
+    }
+  }
+
+  // 5. `links` MUST be a simple object
+  if ('links' in doc) {
+    if (!isSimpleObject(doc.links)) {
+      reporter.error(
+        ['links'],
+        `The 'links' member MUST be a simple object. Received data of type "${inspectType(doc.links)}"`
+      );
+    }
+  }
+
+  // 6. `errors` MUST be an array of error objects
+  if ('errors' in doc) {
+    if (!Array.isArray(doc.errors)) {
+      reporter.error(
+        ['errors'],
+        `The 'errors' member MUST be an array of error objects. Received data of type "${inspectType(doc.errors)}"`
+      );
+    }
+  }
+}

--- a/packages/json-api/src/-private/validator/1.1/7.2_resource-objects.ts
+++ b/packages/json-api/src/-private/validator/1.1/7.2_resource-objects.ts
@@ -1,0 +1,193 @@
+import type { ResourceDocument } from '@warp-drive/core-types/spec/document';
+
+import { inspectType, isSimpleObject, type Reporter } from '../utils';
+import { validateLinks } from './links';
+
+const SINGULAR_OPS = ['createRecord', 'updateRecord', 'deleteRecord', 'findRecord', 'queryRecord'];
+
+/**
+ * Validates the resource objects in either the `data` or `included` members of
+ * JSON:API document.
+ *
+ * Version: 1.1
+ * Section: 7.2
+ * Link: https://jsonapi.org/format/#document-resource-objects
+ *
+ * @internal
+ */
+export function validateDocumentResources(reporter: Reporter, doc: ResourceDocument) {
+  if ('data' in doc) {
+    // scan for common mistakes of single vs multiple resource objects
+    const op = reporter.contextDocument.request?.op;
+    if (op && SINGULAR_OPS.includes(op)) {
+      if (Array.isArray(doc.data)) {
+        reporter.error(
+          ['data'],
+          `"${op}" requests expect a single resource object in the returned data, but received an array`
+        );
+      }
+    }
+
+    // guard for a common mistake around deleteRecord
+    if (op === 'deleteRecord') {
+      if (doc.data !== null) {
+        reporter.warn(
+          ['data'],
+          `"deleteRecord" requests expect the data member to be null, but received ${inspectType(doc.data)}. This can sometimes cause unexpected resurrection of the deleted record.`
+        );
+      }
+    }
+
+    if (Array.isArray(doc.data)) {
+      doc.data.forEach((resource, index) => {
+        if (!isSimpleObject(resource)) {
+          reporter.error(['data', String(index)], `Expected a resource object, but received ${inspectType(resource)}`);
+        } else {
+          validateResourceObject(reporter, resource, ['data', String(index)]);
+        }
+      });
+    } else if (doc.data !== null) {
+      if (!isSimpleObject(doc.data)) {
+        reporter.error(['data'], `Expected a resource object, but received ${inspectType(doc.data)}`);
+      } else {
+        validateResourceObject(reporter, doc.data, ['data']);
+      }
+    }
+  }
+
+  if ('included' in doc && Array.isArray(doc.included)) {
+    doc.included.forEach((resource, index) => {
+      if (!isSimpleObject(resource)) {
+        reporter.error(
+          ['included', String(index)],
+          `Expected a resource object, but received ${inspectType(resource)}`
+        );
+      } else {
+        validateResourceObject(reporter, resource, ['included', String(index)]);
+      }
+    });
+  }
+}
+
+function validateResourceObject(reporter: Reporter, resource: Record<string, unknown>, path: string[]) {
+  validateTopLevelResourceShape(reporter, resource, path);
+}
+
+const VALID_TOP_LEVEL_RESOURCE_KEYS = ['lid', 'id', 'type', 'attributes', 'relationships', 'meta', 'links'];
+function validateTopLevelResourceShape(reporter: Reporter, resource: Record<string, unknown>, path: string[]) {
+  // a resource MUST have a string type
+  if (!('type' in resource)) {
+    reporter.error(path, `Expected a ResourceObjectto have a type property`);
+  } else if (typeof resource.type !== 'string') {
+    reporter.error(
+      [...path, 'type'],
+      `Expected a string value for the type property, but received ${inspectType(resource.type)}`
+    );
+  } else if (resource.type.length === 0) {
+    reporter.error(
+      [...path, 'type'],
+      `Expected a non-empty string value for the type property, but received an empty string`
+    );
+  } else if (!reporter.schema.hasResource({ type: resource.type })) {
+    const method = reporter.strict.unknownType ? 'error' : 'warn';
+    reporter[method](
+      [...path, 'type'],
+      `Expected a schema to be available for the resource type "${resource.type}" but none was found`
+    );
+  }
+
+  // a resource MUST have a string ID
+  if (!('id' in resource)) {
+    reporter.error(path, `Expected a resource object to have an id property`);
+  } else if (typeof resource.id !== 'string') {
+    reporter.error(
+      [...path, 'id'],
+      `Expected a string value for the id property, but received ${inspectType(resource.id)}`
+    );
+  } else if (resource.id.length === 0) {
+    reporter.error(
+      [...path, 'id'],
+      `Expected a non-empty string value for the id property, but received an empty string`
+    );
+  }
+
+  // a resource MAY have a lid property
+  if ('lid' in resource && typeof resource.lid !== 'string') {
+    reporter.error(
+      [...path, 'lid'],
+      `Expected a string value for the lid property, but received ${inspectType(resource.lid)}`
+    );
+  } else {
+    // We MAY want to validate in the future that the lid is a valid local ID
+    // and not just a string. For now, we will just check that it is a string.
+  }
+
+  // a resource MAY have a meta property
+  if ('meta' in resource && !isSimpleObject(resource.meta)) {
+    reporter.error(
+      [...path, 'meta'],
+      `Expected a simple object for the meta property, but received ${inspectType(resource.meta)}`
+    );
+  }
+
+  // a resource MAY have a links property
+  if ('links' in resource && !isSimpleObject(resource.links)) {
+    reporter.error(
+      [...path, 'links'],
+      `Expected a simple object for the links property, but received ${inspectType(resource.links)}`
+    );
+  } else if ('links' in resource) {
+    validateLinks(reporter, resource, 'resource', [...path, 'links']);
+  }
+
+  const hasAttributes = 'attributes' in resource && isSimpleObject(resource.attributes);
+  const hasRelationships = 'relationships' in resource && isSimpleObject(resource.relationships);
+
+  // We expect at least one of attributes or relationships to be present
+  if (!hasAttributes && !hasRelationships) {
+    reporter.warn(path, `Expected a ResourceObject to have either attributes or relationships`);
+  }
+
+  // we expect at least one of attributes or relationships to be non-empty
+  const attributesLength = hasAttributes ? Object.keys(resource.attributes as object).length : 0;
+  const relationshipsLength = hasRelationships ? Object.keys(resource.relationships as object).length : 0;
+
+  if (attributesLength === 0 && relationshipsLength === 0) {
+    reporter.warn(
+      [...path, hasAttributes ? 'attributes' : hasRelationships ? 'relationships' : 'attributes'],
+      `Expected a ResourceObject to have either attributes or relationships`
+    );
+  }
+
+  // check for unknown keys on the resource object
+  const keys = Object.keys(resource);
+  for (const key of keys) {
+    if (!VALID_TOP_LEVEL_RESOURCE_KEYS.includes(key)) {
+      // check for extension keys
+      if (key.includes(':')) {
+        const extensionName = key.split(':')[0];
+        if (reporter.hasExtension(extensionName)) {
+          const extension = reporter.getExtension(extensionName)!;
+          extension(reporter, [...path, key]);
+        } else {
+          reporter.warn(
+            [...path, key],
+            `Unrecognized extension ${extensionName}. The data provided by "${key}" will be ignored as it is not a valid {JSON:API} ResourceObject member`
+          );
+        }
+      } else {
+        reporter.error(
+          [...path, key],
+          `Unrecognized ResourceObject member. The data it provides is ignored as it is not a valid {JSON:API} ResourceObject member`
+        );
+      }
+    }
+  }
+
+  // if we have a schema, validate the attributes and relationships
+  // validate linksMode requirements
+  // validate polymorphic requirements
+  // fuzzy-search missing/unexpected keys
+  // fuzzy-search missing/unexpected resource-types
+  // FIXME
+}

--- a/packages/json-api/src/-private/validator/1.1/7.2_resource-objects.ts
+++ b/packages/json-api/src/-private/validator/1.1/7.2_resource-objects.ts
@@ -1,6 +1,14 @@
 import type { ResourceDocument } from '@warp-drive/core-types/spec/document';
 
-import { inspectType, isSimpleObject, type Reporter } from '../utils';
+import {
+  getRemoteField,
+  inspectType,
+  isSimpleObject,
+  logPotentialMatches,
+  type PathLike,
+  RELATIONSHIP_FIELD_KINDS,
+  type Reporter,
+} from '../utils';
 import { validateLinks } from './links';
 
 const SINGULAR_OPS = ['createRecord', 'updateRecord', 'deleteRecord', 'findRecord', 'queryRecord'];
@@ -41,9 +49,9 @@ export function validateDocumentResources(reporter: Reporter, doc: ResourceDocum
     if (Array.isArray(doc.data)) {
       doc.data.forEach((resource, index) => {
         if (!isSimpleObject(resource)) {
-          reporter.error(['data', String(index)], `Expected a resource object, but received ${inspectType(resource)}`);
+          reporter.error(['data', index], `Expected a resource object, but received ${inspectType(resource)}`);
         } else {
-          validateResourceObject(reporter, resource, ['data', String(index)]);
+          validateResourceObject(reporter, resource, ['data', index]);
         }
       });
     } else if (doc.data !== null) {
@@ -58,56 +66,59 @@ export function validateDocumentResources(reporter: Reporter, doc: ResourceDocum
   if ('included' in doc && Array.isArray(doc.included)) {
     doc.included.forEach((resource, index) => {
       if (!isSimpleObject(resource)) {
-        reporter.error(
-          ['included', String(index)],
-          `Expected a resource object, but received ${inspectType(resource)}`
-        );
+        reporter.error(['included', index], `Expected a resource object, but received ${inspectType(resource)}`);
       } else {
-        validateResourceObject(reporter, resource, ['included', String(index)]);
+        validateResourceObject(reporter, resource, ['included', index]);
       }
     });
   }
 }
 
-function validateResourceObject(reporter: Reporter, resource: Record<string, unknown>, path: string[]) {
+function validateResourceObject(reporter: Reporter, resource: Record<string, unknown>, path: PathLike) {
   validateTopLevelResourceShape(reporter, resource, path);
 }
 
 const VALID_TOP_LEVEL_RESOURCE_KEYS = ['lid', 'id', 'type', 'attributes', 'relationships', 'meta', 'links'];
-function validateTopLevelResourceShape(reporter: Reporter, resource: Record<string, unknown>, path: string[]) {
+function validateTopLevelResourceShape(reporter: Reporter, resource: Record<string, unknown>, path: PathLike) {
   // a resource MUST have a string type
   if (!('type' in resource)) {
-    reporter.error(path, `Expected a ResourceObjectto have a type property`);
+    reporter.error([...path, 'type'], `Expected a ResourceObject to have a type property`);
   } else if (typeof resource.type !== 'string') {
     reporter.error(
       [...path, 'type'],
-      `Expected a string value for the type property, but received ${inspectType(resource.type)}`
+      `Expected a string value for the type property, but received ${inspectType(resource.type)}`,
+      'value'
     );
   } else if (resource.type.length === 0) {
     reporter.error(
       [...path, 'type'],
-      `Expected a non-empty string value for the type property, but received an empty string`
+      `Expected a non-empty string value for the type property, but received an empty string`,
+      'value'
     );
   } else if (!reporter.schema.hasResource({ type: resource.type })) {
     const method = reporter.strict.unknownType ? 'error' : 'warn';
+    const potentialTypes = reporter.searchTypes(resource.type);
     reporter[method](
       [...path, 'type'],
-      `Expected a schema to be available for the resource type "${resource.type}" but none was found`
+      `Expected a schema to be available for the ResourceType "${resource.type}" but none was found.${logPotentialMatches(potentialTypes, 'ResourceType')}`,
+      'value'
     );
   }
 
   // a resource MUST have a string ID
   if (!('id' in resource)) {
-    reporter.error(path, `Expected a resource object to have an id property`);
+    reporter.error([...path, 'id'], `Expected a ResourceObject to have an id property`);
   } else if (typeof resource.id !== 'string') {
     reporter.error(
       [...path, 'id'],
-      `Expected a string value for the id property, but received ${inspectType(resource.id)}`
+      `Expected a string value for the id property, but received ${inspectType(resource.id)}`,
+      'value'
     );
   } else if (resource.id.length === 0) {
     reporter.error(
       [...path, 'id'],
-      `Expected a non-empty string value for the id property, but received an empty string`
+      `Expected a non-empty string value for the id property, but received an empty string`,
+      'value'
     );
   }
 
@@ -115,7 +126,8 @@ function validateTopLevelResourceShape(reporter: Reporter, resource: Record<stri
   if ('lid' in resource && typeof resource.lid !== 'string') {
     reporter.error(
       [...path, 'lid'],
-      `Expected a string value for the lid property, but received ${inspectType(resource.lid)}`
+      `Expected a string value for the lid property, but received ${inspectType(resource.lid)}`,
+      'value'
     );
   } else {
     // We MAY want to validate in the future that the lid is a valid local ID
@@ -126,7 +138,8 @@ function validateTopLevelResourceShape(reporter: Reporter, resource: Record<stri
   if ('meta' in resource && !isSimpleObject(resource.meta)) {
     reporter.error(
       [...path, 'meta'],
-      `Expected a simple object for the meta property, but received ${inspectType(resource.meta)}`
+      `Expected a simple object for the meta property, but received ${inspectType(resource.meta)}`,
+      'value'
     );
   }
 
@@ -134,7 +147,8 @@ function validateTopLevelResourceShape(reporter: Reporter, resource: Record<stri
   if ('links' in resource && !isSimpleObject(resource.links)) {
     reporter.error(
       [...path, 'links'],
-      `Expected a simple object for the links property, but received ${inspectType(resource.links)}`
+      `Expected a simple object for the links property, but received ${inspectType(resource.links)}`,
+      'value'
     );
   } else if ('links' in resource) {
     validateLinks(reporter, resource, 'resource', [...path, 'links']);
@@ -152,10 +166,10 @@ function validateTopLevelResourceShape(reporter: Reporter, resource: Record<stri
   const attributesLength = hasAttributes ? Object.keys(resource.attributes as object).length : 0;
   const relationshipsLength = hasRelationships ? Object.keys(resource.relationships as object).length : 0;
 
-  if (attributesLength === 0 && relationshipsLength === 0) {
+  if ((hasAttributes || hasRelationships) && attributesLength === 0 && relationshipsLength === 0) {
     reporter.warn(
       [...path, hasAttributes ? 'attributes' : hasRelationships ? 'relationships' : 'attributes'],
-      `Expected a ResourceObject to have either attributes or relationships`
+      `Expected a ResourceObject to have either non-empty attributes or non-empty relationships`
     );
   }
 
@@ -176,18 +190,163 @@ function validateTopLevelResourceShape(reporter: Reporter, resource: Record<stri
           );
         }
       } else {
+        // check if this is an attribute or relationship
+        let didYouMean = '  Likely this field should have been inside of either "attributes" or "relationships"';
+
+        const type = 'type' in resource ? (resource.type as string) : undefined;
+        if (type && reporter.schema.hasResource({ type })) {
+          const fields = reporter.schema.fields({ type });
+          const field = getRemoteField(fields, key);
+
+          if (field) {
+            const isRelationship = RELATIONSHIP_FIELD_KINDS.includes(field.kind);
+            didYouMean = `  Based on the ResourceSchema for "${type}" this field is likely a ${field.kind} and belongs inside of ${isRelationship ? 'relationships' : 'attributes'}, e.g. "${isRelationship ? 'relationships' : 'attributes'}": { "${key}": { ... } }`;
+          } else {
+            const fieldMatches = reporter.searchFields(type, key);
+
+            if (fieldMatches.length === 1) {
+              const matchedField = fields.get(fieldMatches[0].item)!;
+              const isRelationship = RELATIONSHIP_FIELD_KINDS.includes(matchedField.kind);
+              didYouMean = `  Based on the ResourceSchema for "${type}" this field is likely a ${matchedField.kind} and belongs inside of ${isRelationship ? 'relationships' : 'attributes'}, e.g. "${isRelationship ? 'relationships' : 'attributes'}": { "${matchedField.name}": { ... } }`;
+            } else if (fieldMatches.length > 1) {
+              const matchedField = fields.get(fieldMatches[0].item)!;
+              const isRelationship = RELATIONSHIP_FIELD_KINDS.includes(matchedField.kind);
+              didYouMean = `  Based on the ResourceSchema for "${type}" this field is likely one of "${fieldMatches.map((v) => v.item).join('", "')}" and belongs inside of either "attributes" or "relationships", e.g. "${isRelationship ? 'relationships' : 'attributes'}": { "${matchedField.name}": { ... } }`;
+            }
+          }
+        }
+
         reporter.error(
           [...path, key],
-          `Unrecognized ResourceObject member. The data it provides is ignored as it is not a valid {JSON:API} ResourceObject member`
+          `Unrecognized ResourceObject member. The data it provides is ignored as it is not a valid {JSON:API} ResourceObject member.${didYouMean}`
         );
       }
     }
   }
 
-  // if we have a schema, validate the attributes and relationships
-  // validate linksMode requirements
-  // validate polymorphic requirements
-  // fuzzy-search missing/unexpected keys
-  // fuzzy-search missing/unexpected resource-types
-  // FIXME
+  // if we have a schema, validate the individual attributes and relationships
+  const type = 'type' in resource ? (resource.type as string) : undefined;
+  if (type && reporter.schema.hasResource({ type })) {
+    if ('attributes' in resource) {
+      validateResourceAttributes(reporter, type, resource.attributes as Record<string, unknown>, [
+        ...path,
+        'attributes',
+      ]);
+    }
+
+    if ('relationships' in resource) {
+      validateResourceRelationships(reporter, type, resource.relationships as Record<string, unknown>, [
+        ...path,
+        'relationships',
+      ]);
+    }
+  }
+}
+
+function validateResourceAttributes(
+  reporter: Reporter,
+  type: string,
+  resource: Record<string, unknown>,
+  path: PathLike
+) {
+  const schema = reporter.schema.fields({ type });
+  for (const [key] of Object.entries(resource)) {
+    const field = getRemoteField(schema, key);
+    const actualField = schema.get(key);
+    if (!field && actualField) {
+      reporter.warn(
+        [...path, key],
+        `Expected the ${actualField.kind} field to not have its own resource data. Likely this field should either not be returned in this payload or the field definition should be updated in the schema.`
+      );
+    } else if (!field) {
+      if (key.includes(':')) {
+        const extensionName = key.split(':')[0];
+        if (reporter.hasExtension(extensionName)) {
+          const extension = reporter.getExtension(extensionName)!;
+          extension(reporter, [...path, key]);
+        } else {
+          reporter.warn(
+            [...path, key],
+            `Unrecognized extension ${extensionName}. The data provided by "${key}" will be ignored as it is not a valid {JSON:API} ResourceObject member`
+          );
+        }
+      } else {
+        const method = reporter.strict.unknownAttribute ? 'error' : 'warn';
+
+        // TODO @runspired when we check for fuzzy matches we can adjust the message to say
+        // whether the expected field is an attribute or a relationship
+        const potentialFields = reporter.searchFields(type, key);
+        reporter[method](
+          [...path, key],
+          `Unrecognized attribute. The data it provides is ignored as it is not part of the ResourceSchema for "${type}".${logPotentialMatches(
+            potentialFields,
+            'field'
+          )}`
+        );
+      }
+    } else if (field && RELATIONSHIP_FIELD_KINDS.includes(field.kind)) {
+      reporter.error(
+        [...path, key],
+        `Expected the "${key}" field to be in "relationships" as it has kind "${field.kind}", but received data for it in "attributes".`
+      );
+    }
+  }
+
+  // TODO @runspired we should also deep-validate the field value
+  // TODO @runspired we should validate that field values are valid JSON and not instances
+}
+
+function validateResourceRelationships(
+  reporter: Reporter,
+  type: string,
+  resource: Record<string, unknown>,
+  path: PathLike
+) {
+  const schema = reporter.schema.fields({ type });
+  for (const [key] of Object.entries(resource)) {
+    const field = getRemoteField(schema, key);
+    const actualField = schema.get(key);
+    if (!field && actualField) {
+      reporter.warn(
+        [...path, key],
+        `Expected the ${actualField.kind} field to not have its own resource data. Likely this field should either not be returned in this payload or the field definition should be updated in the schema.`
+      );
+    } else if (!field) {
+      if (key.includes(':')) {
+        const extensionName = key.split(':')[0];
+        if (reporter.hasExtension(extensionName)) {
+          const extension = reporter.getExtension(extensionName)!;
+          extension(reporter, [...path, key]);
+        } else {
+          reporter.warn(
+            [...path, key],
+            `Unrecognized extension ${extensionName}. The data provided by "${key}" will be ignored as it is not a valid {JSON:API} ResourceObject member`
+          );
+        }
+      } else {
+        const method = reporter.strict.unknownRelationship ? 'error' : 'warn';
+
+        // TODO @runspired when we check for fuzzy matches we can adjust the message to say
+        // whether the expected field is an attribute or a relationship
+        const potentialFields = reporter.searchFields(type, key);
+        reporter[method](
+          [...path, key],
+          `Unrecognized relationship. The data it provides is ignored as it is not part of the ResourceSchema for "${type}".${logPotentialMatches(
+            potentialFields,
+            'field'
+          )}`
+        );
+      }
+    } else if (field && !RELATIONSHIP_FIELD_KINDS.includes(field.kind)) {
+      reporter.error(
+        [...path, key],
+        `Expected the "${key}" field to be in "attributes" as it has kind "${field.kind}", but received data for it in "relationships".`
+      );
+    }
+  }
+
+  // TODO @runspired we should also deep-validate the relationship payload
+  // TODO @runspired we should validate linksMode requirements for both Polaris and Legacy modes
+  // TODO @runspired we should warn if the discovered resource-type in a relationship is the abstract
+  //   type instead of the concrete type.
 }

--- a/packages/json-api/src/-private/validator/1.1/links.ts
+++ b/packages/json-api/src/-private/validator/1.1/links.ts
@@ -1,0 +1,114 @@
+import type { ResourceDocument } from '@warp-drive/core-types/spec/document';
+import type {
+  CollectionResourceRelationship,
+  ResourceObject,
+  SingleResourceRelationship,
+} from '@warp-drive/core-types/spec/json-api-raw';
+
+import { inspectType, isSimpleObject, type Reporter } from '../utils';
+
+const VALID_COLLECTION_LINKS = ['self', 'related', 'first', 'last', 'prev', 'next'];
+const VALID_RESOURCE_RELATIONSHIP_LINKS = ['self', 'related'];
+const VALID_RESOURCE_LINKS = ['self'];
+
+/**
+ * Validates the links object in a top-level JSON API document or resource object
+ *
+ * Version: 1.1
+ *
+ * Section: 7.1 Top Level
+ * Link: https://jsonapi.org/format/#document-top-level
+ *
+ * Section: 7.2.3 Resource Objects
+ * Link: https://jsonapi.org/format/#document-resource-object-links
+ *
+ * Section: 7.2.2.2 Resource Relationships
+ * Link: https://jsonapi.org/format/#document-resource-object-relationships
+ *
+ * Section: 7.6 Document Links
+ * Link: https://jsonapi.org/format/#document-links
+ *
+ * @internal
+ */
+export function validateLinks(
+  reporter: Reporter,
+  doc: ResourceDocument | ResourceObject | SingleResourceRelationship | CollectionResourceRelationship,
+  type: 'collection-document' | 'resource-document' | 'resource' | 'resource-relationship' | 'collection-relationship',
+  path: string[] = ['links']
+) {
+  if (!('links' in doc)) {
+    return;
+  }
+
+  if (!isSimpleObject(doc.links)) {
+    // this is a violation but we report it when validating section 7.1
+    return;
+  }
+
+  // prettier-ignore
+  const VALID_TOP_LEVEL_LINKS =
+    type === 'collection-document' || type === 'collection-relationship' ? VALID_COLLECTION_LINKS
+    : type === 'resource-document' || type === 'resource-relationship' ? VALID_RESOURCE_RELATIONSHIP_LINKS
+    : type === 'resource' ? VALID_RESOURCE_LINKS
+    : [];
+
+  const links = doc.links;
+  const keys = Object.keys(links);
+  for (const key of keys) {
+    if (!VALID_TOP_LEVEL_LINKS.includes(key)) {
+      reporter.warn(
+        [...path, key],
+        `Unrecognized top-level link. The data it provides may be ignored as it is not a valid {JSON:API} link for a ${type}`
+      );
+    }
+    // links may be either a string or an object with an href property or null
+    if (links[key] === null) {
+      // valid
+    } else if (typeof links[key] === 'string') {
+      if (links[key].length === 0) {
+        reporter.warn([...path, key], `Expected a non-empty string, but received an empty string`);
+      }
+      // valid, though we should potentially validate the URL here
+    } else if (isSimpleObject(links[key])) {
+      if ('href' in links[key]) {
+        const linksKeys = Object.keys(links[key]);
+        if (linksKeys.length > 1) {
+          reporter.warn(
+            [...path, key],
+            `Expected the links object to only have an href property, but received unknown keys ${linksKeys.filter((k) => k !== 'href').join(', ')}`
+          );
+        }
+
+        if (typeof links[key].href !== 'string') {
+          reporter.error(
+            [...path, key, 'href'],
+            `Expected a string value, but received ${inspectType(links[key].href)}`
+          );
+        } else {
+          if (links[key].href.length === 0) {
+            reporter.warn([...path, key, 'href'], `Expected a non-empty string, but received an empty string`);
+          }
+          // valid, though we should potentially validate the URL here
+        }
+      } else {
+        const linksKeys = Object.keys(links[key]);
+        if (linksKeys.length > 0) {
+          reporter.error(
+            [...path, key],
+            `Expected the links object to have an href property, but received only the unknown keys ${linksKeys.join(', ')}`
+          );
+        } else {
+          reporter.error([...path, key], `Expected the links object to have an href property`);
+        }
+      }
+    } else {
+      // invalid
+      reporter.error(
+        [...path, key],
+        `Expected a string, null, or an object with an href property for the link "${key}", but received ${inspectType(
+          links[key]
+        )}`
+      );
+    }
+  }
+}

--- a/packages/json-api/src/-private/validator/1.1/links.ts
+++ b/packages/json-api/src/-private/validator/1.1/links.ts
@@ -5,7 +5,7 @@ import type {
   SingleResourceRelationship,
 } from '@warp-drive/core-types/spec/json-api-raw';
 
-import { inspectType, isSimpleObject, type Reporter } from '../utils';
+import { inspectType, isSimpleObject, type PathLike, type Reporter } from '../utils';
 
 const VALID_COLLECTION_LINKS = ['self', 'related', 'first', 'last', 'prev', 'next'];
 const VALID_RESOURCE_RELATIONSHIP_LINKS = ['self', 'related'];
@@ -34,7 +34,7 @@ export function validateLinks(
   reporter: Reporter,
   doc: ResourceDocument | ResourceObject | SingleResourceRelationship | CollectionResourceRelationship,
   type: 'collection-document' | 'resource-document' | 'resource' | 'resource-relationship' | 'collection-relationship',
-  path: string[] = ['links']
+  path: PathLike = ['links']
 ) {
   if (!('links' in doc)) {
     return;

--- a/packages/json-api/src/-private/validator/index.ts
+++ b/packages/json-api/src/-private/validator/index.ts
@@ -45,24 +45,22 @@ function validateResourceDocument(reporter: Reporter, doc: StructuredDataDocumen
   // validateMeta on document
   // validateMeta on resource
   // validateMeta on resource relationships
-  // validateMeta on links
-  // validate links objects more deeply
   // validate no-meta on resource identifiers
-  //
-  // fuzzy-search missing/unexpected resource-types
   //
   // ---------------------------------
   // super-strict-mode
   //
-  // validate full-linkage requirement
+  // TODO @runspired - validate that all referenced resource identifiers are present in the document (full linkage)
+  // TODO @runspired - validate that all included resources have a path back to `data` (full linkage)
   //
   // ---------------------------------
-  // nice-to-have
+  // nice-to-haves
   //
-  // validate includes
-  // validate sparse fieldsets
-  // validate sort ?
-  // validate pagination profile ?
+  // TODO @runspired - validate links objects more thoroughly for spec props we don't use
+  // TODO @runspired - validate request includes are in fact included
+  // TODO @runspired - validate request fields are in fact present
+  // TODO @runspired - MAYBE validate request sort is in fact sorted? (useful for catching Mocking bugs)
+  // TODO @runspired - MAYBE validate request pagination is in fact paginated? (useful for catching Mocking bugs)
 
-  // PRINT ERRORS AND WARNINGS gated by a LOGGING flag (for now)
+  reporter.report();
 }

--- a/packages/json-api/src/-private/validator/index.ts
+++ b/packages/json-api/src/-private/validator/index.ts
@@ -1,9 +1,9 @@
-import type { StructuredDataDocument, StructuredDocument, StructuredErrorDocument } from '@ember-data/request';
+import type { StructuredDataDocument, StructuredDocument } from '@ember-data/request';
 import type { CacheCapabilitiesManager } from '@ember-data/store/types';
 import { JSON_API_CACHE_VALIDATION_ERRORS } from '@warp-drive/build-config/canary-features';
 import { LOG_PAYLOADS } from '@warp-drive/build-config/debugging';
 import { assert } from '@warp-drive/build-config/macros';
-import type { ResourceDocument, ResourceMetaDocument } from '@warp-drive/core-types/spec/document';
+import type { ResourceDocument } from '@warp-drive/core-types/spec/document';
 
 import { validateTopLevelDocumentMembers } from './1.1/7.1_top-level-document-members';
 import { validateDocumentResources } from './1.1/7.2_resource-objects';
@@ -24,24 +24,23 @@ export function validateDocument(capabilities: CacheCapabilitiesManager, doc: St
     }
   }
 
-  const reporter = new Reporter(capabilities, doc);
-
   if (isErrorDocument(doc)) {
-    return validateErrorDocument(reporter, doc);
+    return; // return validateErrorDocument(reporter, doc);
   } else if (isMetaDocument(doc)) {
-    return validateMetaDocument(reporter, doc);
+    return; // return validateMetaDocument(reporter, doc);
   } else if (isPushedDocument(doc)) {
-    return validatePushedDocument(reporter, doc);
+    return; // return validatePushedDocument(reporter, doc);
   }
 
+  const reporter = new Reporter(capabilities, doc);
   return validateResourceDocument(reporter, doc as StructuredDataDocument<ResourceDocument>);
 }
 
-function validateErrorDocument(reporter: Reporter, doc: StructuredErrorDocument) {}
+// function validateErrorDocument(reporter: Reporter, doc: StructuredErrorDocument) {}
 
-function validateMetaDocument(reporter: Reporter, doc: StructuredDataDocument<ResourceMetaDocument>) {}
+// function validateMetaDocument(reporter: Reporter, doc: StructuredDataDocument<ResourceMetaDocument>) {}
 
-function validatePushedDocument(reporter: Reporter, doc: StructuredDataDocument<ResourceDocument>) {}
+// function validatePushedDocument(reporter: Reporter, doc: StructuredDataDocument<ResourceDocument>) {}
 
 function validateResourceDocument(reporter: Reporter, doc: StructuredDataDocument<ResourceDocument>) {
   validateTopLevelDocumentMembers(reporter, doc.content);

--- a/packages/json-api/src/-private/validator/index.ts
+++ b/packages/json-api/src/-private/validator/index.ts
@@ -1,5 +1,7 @@
 import type { StructuredDataDocument, StructuredDocument, StructuredErrorDocument } from '@ember-data/request';
 import type { CacheCapabilitiesManager } from '@ember-data/store/types';
+import { JSON_API_CACHE_VALIDATION_ERRORS } from '@warp-drive/build-config/canary-features';
+import { LOG_PAYLOADS } from '@warp-drive/build-config/debugging';
 import { assert } from '@warp-drive/build-config/macros';
 import type { ResourceDocument, ResourceMetaDocument } from '@warp-drive/core-types/spec/document';
 
@@ -13,6 +15,15 @@ export function validateDocument(capabilities: CacheCapabilitiesManager, doc: St
     `Expected a JSON:API Document as the content provided to the cache, received ${typeof doc.content}`,
     doc instanceof Error || (typeof doc.content === 'object' && doc.content !== null)
   );
+
+  // if the feature is not active and the payloads are not being logged
+  // we don't need to validate the payloads
+  if (!JSON_API_CACHE_VALIDATION_ERRORS) {
+    if (!LOG_PAYLOADS) {
+      return;
+    }
+  }
+
   const reporter = new Reporter(capabilities, doc);
 
   if (isErrorDocument(doc)) {

--- a/packages/json-api/src/-private/validator/index.ts
+++ b/packages/json-api/src/-private/validator/index.ts
@@ -1,0 +1,68 @@
+import type { StructuredDataDocument, StructuredDocument, StructuredErrorDocument } from '@ember-data/request';
+import type { CacheCapabilitiesManager } from '@ember-data/store/types';
+import { assert } from '@warp-drive/build-config/macros';
+import type { ResourceDocument, ResourceMetaDocument } from '@warp-drive/core-types/spec/document';
+
+import { validateTopLevelDocumentMembers } from './1.1/7.1_top-level-document-members';
+import { validateDocumentResources } from './1.1/7.2_resource-objects';
+import { validateLinks } from './1.1/links';
+import { isErrorDocument, isMetaDocument, isPushedDocument, Reporter } from './utils';
+
+export function validateDocument(capabilities: CacheCapabilitiesManager, doc: StructuredDocument<ResourceDocument>) {
+  assert(
+    `Expected a JSON:API Document as the content provided to the cache, received ${typeof doc.content}`,
+    doc instanceof Error || (typeof doc.content === 'object' && doc.content !== null)
+  );
+  const reporter = new Reporter(capabilities, doc);
+
+  if (isErrorDocument(doc)) {
+    return validateErrorDocument(reporter, doc);
+  } else if (isMetaDocument(doc)) {
+    return validateMetaDocument(reporter, doc);
+  } else if (isPushedDocument(doc)) {
+    return validatePushedDocument(reporter, doc);
+  }
+
+  return validateResourceDocument(reporter, doc as StructuredDataDocument<ResourceDocument>);
+}
+
+function validateErrorDocument(reporter: Reporter, doc: StructuredErrorDocument) {}
+
+function validateMetaDocument(reporter: Reporter, doc: StructuredDataDocument<ResourceMetaDocument>) {}
+
+function validatePushedDocument(reporter: Reporter, doc: StructuredDataDocument<ResourceDocument>) {}
+
+function validateResourceDocument(reporter: Reporter, doc: StructuredDataDocument<ResourceDocument>) {
+  validateTopLevelDocumentMembers(reporter, doc.content);
+  validateLinks(
+    reporter,
+    doc.content,
+    'data' in doc.content && Array.isArray(doc.content?.data) ? 'collection-document' : 'resource-document'
+  );
+  validateDocumentResources(reporter, doc.content);
+
+  // FIXME
+  // validateMeta on document
+  // validateMeta on resource
+  // validateMeta on resource relationships
+  // validateMeta on links
+  // validate links objects more deeply
+  // validate no-meta on resource identifiers
+  //
+  // fuzzy-search missing/unexpected resource-types
+  //
+  // ---------------------------------
+  // super-strict-mode
+  //
+  // validate full-linkage requirement
+  //
+  // ---------------------------------
+  // nice-to-have
+  //
+  // validate includes
+  // validate sparse fieldsets
+  // validate sort ?
+  // validate pagination profile ?
+
+  // PRINT ERRORS AND WARNINGS gated by a LOGGING flag (for now)
+}

--- a/packages/json-api/src/-private/validator/utils.ts
+++ b/packages/json-api/src/-private/validator/utils.ts
@@ -5,7 +5,6 @@ import jsonToAst from 'json-to-ast';
 
 import type { CacheCapabilitiesManager } from '@ember-data/store/types';
 import { JSON_API_CACHE_VALIDATION_ERRORS } from '@warp-drive/build-config/canary-features';
-import { LOG_PAYLOADS } from '@warp-drive/build-config/debugging';
 import { assert } from '@warp-drive/build-config/macros';
 import type {
   StructuredDataDocument,
@@ -308,16 +307,14 @@ export class Reporter {
 
     const contextStr = `${counts.error} errors and ${counts.warning} warnings found in the {JSON:API} document returned by ${this.contextDocument.request?.method} ${this.contextDocument.request?.url}`;
     const errorString = contextStr + `\n\n` + errorLines.join('\n');
-    if (JSON_API_CACHE_VALIDATION_ERRORS) {
-      // eslint-disable-next-line no-console, @typescript-eslint/no-unused-expressions
-      colorize ? console.log(errorString, ...colors) : console.log(errorString);
 
+    // eslint-disable-next-line no-console, @typescript-eslint/no-unused-expressions
+    colorize ? console.log(errorString, ...colors) : console.log(errorString);
+
+    if (JSON_API_CACHE_VALIDATION_ERRORS) {
       if (counts.error > 0) {
         throw new Error(contextStr);
       }
-    } else if (LOG_PAYLOADS) {
-      // eslint-disable-next-line no-console, @typescript-eslint/no-unused-expressions
-      colorize ? console.log(errorString, ...colors) : console.log(errorString);
     }
   }
 }

--- a/packages/json-api/src/-private/validator/utils.ts
+++ b/packages/json-api/src/-private/validator/utils.ts
@@ -1,9 +1,18 @@
-import type { CacheCapabilitiesManager, SchemaService } from '@ember-data/store/types';
+import type { FuseResult } from 'fuse.js';
+import Fuse from 'fuse.js';
+import type { ArrayNode, ObjectNode } from 'json-to-ast';
+import jsonToAst from 'json-to-ast';
+
+import type { CacheCapabilitiesManager } from '@ember-data/store/types';
+import { JSON_API_CACHE_VALIDATION_ERRORS } from '@warp-drive/build-config/canary-features';
+import { LOG_PAYLOADS } from '@warp-drive/build-config/debugging';
+import { assert } from '@warp-drive/build-config/macros';
 import type {
   StructuredDataDocument,
   StructuredDocument,
   StructuredErrorDocument,
 } from '@warp-drive/core-types/request';
+import type { FieldSchema } from '@warp-drive/core-types/schema/fields';
 import type {
   ResourceDataDocument,
   ResourceDocument,
@@ -73,17 +82,27 @@ export function isSimpleObject(obj: unknown): obj is Record<string, unknown> {
   return false;
 }
 
+export const RELATIONSHIP_FIELD_KINDS = ['belongsTo', 'hasMany', 'resource', 'collection'];
+export type PathLike = Array<string | number>;
 interface ErrorReport {
-  path: string[];
+  path: PathLike;
   message: string;
+  loc: {
+    start: { line: number; column: number; offset: number };
+    end: { line: number; column: number; offset: number };
+  };
+  type: 'error' | 'warning' | 'info';
+  kind: 'key' | 'value';
 }
 export class Reporter {
   capabilities: CacheCapabilitiesManager;
   contextDocument: StructuredDocument<ResourceDocument>;
   errors: ErrorReport[] = [];
-  warnings: ErrorReport[] = [];
-  infos: ErrorReport[] = [];
+  ast: ReturnType<typeof jsonToAst>;
+  jsonStr: string;
 
+  // TODO @runspired make this configurable to consuming apps before
+  // activating by default
   strict = {
     linkage: true,
     unknownType: true,
@@ -94,22 +113,118 @@ export class Reporter {
   constructor(capabilities: CacheCapabilitiesManager, doc: StructuredDocument<ResourceDocument>) {
     this.capabilities = capabilities;
     this.contextDocument = doc;
+
+    this.jsonStr = JSON.stringify(doc.content, null, 2);
+    this.ast = jsonToAst(this.jsonStr, { loc: true });
+  }
+
+  declare _typeFilter: Fuse<string> | undefined;
+  searchTypes(type: string) {
+    if (!this._typeFilter) {
+      const allTypes = this.schema.resourceTypes();
+      this._typeFilter = new Fuse(allTypes);
+    }
+    const result = this._typeFilter.search(type);
+    return result;
+  }
+
+  _fieldFilters: Map<string, Fuse<string>> = new Map();
+  searchFields(type: string, field: string) {
+    if (!this._fieldFilters.has(type)) {
+      const allFields = this.schema.fields({ type });
+      const attrs = Array.from(allFields.values())
+        .filter(isRemoteField)
+        .map((v) => v.name);
+      this._fieldFilters.set(type, new Fuse(attrs));
+    }
+    const result = this._fieldFilters.get(type)!.search(field);
+    return result;
   }
 
   get schema() {
     return this.capabilities.schema;
   }
 
-  error(path: string[], message: string) {
-    this.errors.push({ path, message });
+  getLocation(
+    path: PathLike,
+    kind: 'key' | 'value'
+  ): {
+    start: { line: number; column: number; offset: number };
+    end: { line: number; column: number; offset: number };
+  } {
+    if (path.length === 0) {
+      return this.ast.loc!;
+    }
+
+    let priorNode = this.ast as ObjectNode | ArrayNode;
+    let node = this.ast as ObjectNode | ArrayNode;
+    for (const segment of path) {
+      //
+      // handle array paths
+      //
+      if (typeof segment === 'number') {
+        assert(`Because the segment is a number, expected a node of type Array`, node.type === 'Array');
+
+        if (node.children && node.children[segment]) {
+          priorNode = node;
+          const childNode = node.children[segment];
+
+          if (childNode.type === 'Object' || childNode.type === 'Array') {
+            node = childNode;
+          } else {
+            // set to the closest node we can find
+            return node.loc!;
+          }
+        } else {
+          // set to the closest node we can find
+          // as we had no children
+          return priorNode.loc!;
+        }
+
+        //
+        // handle object paths
+        //
+      } else {
+        assert(`Because the segment is a string, expected a node of type Object`, node.type === 'Object');
+
+        const child = node.children.find((childCandidate) => {
+          if (childCandidate.type === 'Property') {
+            return childCandidate.key.type === 'Identifier' && childCandidate.key.value === segment;
+          }
+          return false;
+        });
+
+        if (child) {
+          if (child.value.type === 'Object' || child.value.type === 'Array') {
+            priorNode = node;
+            node = child.value;
+          } else {
+            // set to the closest node we can find
+            return kind === 'key' ? child.key.loc! : child.value.loc!;
+          }
+        } else {
+          // set to the closest node we can find
+          return priorNode.loc!;
+        }
+      }
+    }
+
+    return node.loc!;
   }
 
-  warn(path: string[], message: string) {
-    this.warnings.push({ path, message });
+  error(path: PathLike, message: string, kind: 'key' | 'value' = 'key') {
+    const loc = this.getLocation(path, kind);
+    this.errors.push({ path, message, loc, type: 'error', kind });
   }
 
-  info(path: string[], message: string) {
-    this.infos.push({ path, message });
+  warn(path: PathLike, message: string, kind: 'key' | 'value' = 'key') {
+    const loc = this.getLocation(path, kind);
+    this.errors.push({ path, message, loc, type: 'warning', kind });
+  }
+
+  info(path: PathLike, message: string, kind: 'key' | 'value' = 'key') {
+    const loc = this.getLocation(path, kind);
+    this.errors.push({ path, message, loc, type: 'info', kind });
   }
 
   hasExtension(extensionName: string) {
@@ -119,9 +234,115 @@ export class Reporter {
   getExtension(extensionName: string) {
     return REGISTERED_EXTENSIONS.get(extensionName);
   }
+
+  report(colorize = true): void {
+    const lines = this.jsonStr.split('\n');
+
+    // sort the errors by line, then by column, then by type
+    const { errors } = this;
+
+    if (!errors.length) {
+      return;
+    }
+
+    errors.sort((a, b) => {
+      return a.loc.end.line < b.loc.end.line
+        ? -1
+        : a.loc.end.column < b.loc.end.column
+          ? -1
+          : compareType(a.type, b.type);
+    });
+
+    // store the errors in a map by line
+    const errorMap = new Map<number, ErrorReport[]>();
+    for (const error of errors) {
+      const line = error.loc.end.line;
+      if (!errorMap.has(line)) {
+        errorMap.set(line, []);
+      }
+      errorMap.get(line)!.push(error);
+    }
+
+    // splice the errors into the lines
+    const errorLines: string[] = [];
+    const colors: string[] = [];
+    const counts = {
+      error: 0,
+      warning: 0,
+      info: 0,
+    };
+
+    const LINE_SIZE = String(lines.length).length;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      errorLines.push(
+        colorize
+          ? `${String(i + 1).padEnd(LINE_SIZE, ' ')}  \t%c${line}%c`
+          : `${String(i + 1).padEnd(LINE_SIZE, ' ')}  \t${line}`
+      );
+      colors.push(
+        `color: grey; background-color: transparent;`, // first color sets color
+        `color: inherit; background-color: transparent;` // second color resets the color profile
+      );
+      if (errorMap.has(i + 1)) {
+        const errorsForLine = errorMap.get(i + 1)!;
+        for (const error of errorsForLine) {
+          counts[error.type]++;
+          const { loc, message } = error;
+          const start = loc.end.line === loc.start.line ? loc.start.column - 1 : loc.end.column - 1;
+          const end = loc.end.column - 1;
+          const symbol = error.type === 'error' ? '❌' : error.type === 'warning' ? '⚠️' : 'ℹ️';
+          const errorLine = colorize
+            ? `${''.padStart(LINE_SIZE, ' ') + symbol}\t${' '.repeat(start)}%c^${'~'.repeat(end - start)} %c//%c ${message}%c`
+            : `${''.padStart(LINE_SIZE, ' ') + symbol}\t${' '.repeat(start)}^${'~'.repeat(end - start)} // ${message}`;
+          errorLines.push(errorLine);
+          colors.push(
+            error.type === 'error' ? 'color: red;' : error.type === 'warning' ? 'color: orange;' : 'color: blue;',
+            'color: grey;',
+            error.type === 'error' ? 'color: red;' : error.type === 'warning' ? 'color: orange;' : 'color: blue;',
+            'color: inherit; background-color: transparent;' // reset color
+          );
+        }
+      }
+    }
+
+    const contextStr = `${counts.error} errors and ${counts.warning} warnings found in the {JSON:API} document returned by ${this.contextDocument.request?.method} ${this.contextDocument.request?.url}`;
+    const errorString = contextStr + `\n\n` + errorLines.join('\n');
+    if (JSON_API_CACHE_VALIDATION_ERRORS) {
+      // eslint-disable-next-line no-console, @typescript-eslint/no-unused-expressions
+      colorize ? console.log(errorString, ...colors) : console.log(errorString);
+
+      if (counts.error > 0) {
+        throw new Error(contextStr);
+      }
+    } else if (LOG_PAYLOADS) {
+      // eslint-disable-next-line no-console, @typescript-eslint/no-unused-expressions
+      colorize ? console.log(errorString, ...colors) : console.log(errorString);
+    }
+  }
 }
 
-type ReporterFn = (reporter: Reporter, path: string[]) => void;
+// we always want to sort errors first, then warnings, then info
+function compareType(a: 'error' | 'warning' | 'info', b: 'error' | 'warning' | 'info') {
+  if (a === b) {
+    return 0;
+  }
+  if (a === 'error') {
+    return -1;
+  }
+  if (b === 'error') {
+    return 1;
+  }
+  if (a === 'warning') {
+    return -1;
+  }
+  if (b === 'warning') {
+    return 1;
+  }
+  return 0;
+}
+
+type ReporterFn = (reporter: Reporter, path: PathLike) => void;
 const REGISTERED_EXTENSIONS = new Map<string, ReporterFn>();
 
 export function isMetaDocument(
@@ -144,4 +365,32 @@ export function isErrorDocument(
 
 export function isPushedDocument(doc: unknown): doc is { content: ResourceDataDocument } {
   return false;
+}
+
+export function logPotentialMatches(matches: FuseResult<string>[], kind: string): string {
+  if (matches.length === 0) {
+    return '';
+  }
+
+  if (matches.length === 1) {
+    return `  Did you mean this available ${kind} "${matches[0].item}"?`;
+  }
+
+  const potentialMatches = matches.map((match) => match.item).join('", "');
+  return `  Did you mean one of these available ${kind}s: "${potentialMatches}"?`;
+}
+
+function isRemoteField(v: FieldSchema): boolean {
+  return !(v.kind === '@local' || v.kind === 'alias' || v.kind === 'derived');
+}
+
+export function getRemoteField(fields: Map<string, FieldSchema>, key: string) {
+  const field = fields.get(key);
+  if (!field) {
+    return undefined;
+  }
+  if (!isRemoteField(field)) {
+    return undefined;
+  }
+  return field;
 }

--- a/packages/json-api/src/-private/validator/utils.ts
+++ b/packages/json-api/src/-private/validator/utils.ts
@@ -1,0 +1,147 @@
+import type { CacheCapabilitiesManager, SchemaService } from '@ember-data/store/types';
+import type {
+  StructuredDataDocument,
+  StructuredDocument,
+  StructuredErrorDocument,
+} from '@warp-drive/core-types/request';
+import type {
+  ResourceDataDocument,
+  ResourceDocument,
+  ResourceErrorDocument,
+  ResourceMetaDocument,
+} from '@warp-drive/core-types/spec/document';
+
+export function inspectType(obj: unknown): string {
+  if (obj === null) {
+    return 'null';
+  }
+  if (Array.isArray(obj)) {
+    return 'array';
+  }
+  if (typeof obj === 'object') {
+    const proto = Object.getPrototypeOf(obj) as unknown;
+    if (proto === null) {
+      return 'object';
+    }
+    if (proto === Object.prototype) {
+      return 'object';
+    }
+    return `object (${(proto as object).constructor?.name})`;
+  }
+  if (typeof obj === 'function') {
+    return 'function';
+  }
+  if (typeof obj === 'string') {
+    return 'string';
+  }
+  if (typeof obj === 'number') {
+    return 'number';
+  }
+  if (typeof obj === 'boolean') {
+    return 'boolean';
+  }
+  if (typeof obj === 'symbol') {
+    return 'symbol';
+  }
+  if (typeof obj === 'bigint') {
+    return 'bigint';
+  }
+  if (typeof obj === 'undefined') {
+    return 'undefined';
+  }
+  return 'unknown';
+}
+
+export function isSimpleObject(obj: unknown): obj is Record<string, unknown> {
+  if (obj === null) {
+    return false;
+  }
+  if (Array.isArray(obj)) {
+    return false;
+  }
+  if (typeof obj !== 'object') {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(obj) as unknown;
+  if (proto === null) {
+    return true;
+  }
+  if (proto === Object.prototype) {
+    return true;
+  }
+  return false;
+}
+
+interface ErrorReport {
+  path: string[];
+  message: string;
+}
+export class Reporter {
+  capabilities: CacheCapabilitiesManager;
+  contextDocument: StructuredDocument<ResourceDocument>;
+  errors: ErrorReport[] = [];
+  warnings: ErrorReport[] = [];
+  infos: ErrorReport[] = [];
+
+  strict = {
+    linkage: true,
+    unknownType: true,
+    unknownAttribute: true,
+    unknownRelationship: true,
+  };
+
+  constructor(capabilities: CacheCapabilitiesManager, doc: StructuredDocument<ResourceDocument>) {
+    this.capabilities = capabilities;
+    this.contextDocument = doc;
+  }
+
+  get schema() {
+    return this.capabilities.schema;
+  }
+
+  error(path: string[], message: string) {
+    this.errors.push({ path, message });
+  }
+
+  warn(path: string[], message: string) {
+    this.warnings.push({ path, message });
+  }
+
+  info(path: string[], message: string) {
+    this.infos.push({ path, message });
+  }
+
+  hasExtension(extensionName: string) {
+    return REGISTERED_EXTENSIONS.has(extensionName);
+  }
+
+  getExtension(extensionName: string) {
+    return REGISTERED_EXTENSIONS.get(extensionName);
+  }
+}
+
+type ReporterFn = (reporter: Reporter, path: string[]) => void;
+const REGISTERED_EXTENSIONS = new Map<string, ReporterFn>();
+
+export function isMetaDocument(
+  doc: StructuredDocument<ResourceDocument>
+): doc is StructuredDataDocument<ResourceMetaDocument> {
+  return (
+    !(doc instanceof Error) &&
+    doc.content &&
+    !('data' in doc.content) &&
+    !('included' in doc.content) &&
+    'meta' in doc.content
+  );
+}
+
+export function isErrorDocument(
+  doc: StructuredDocument<ResourceDocument>
+): doc is StructuredErrorDocument<ResourceErrorDocument> {
+  return doc instanceof Error;
+}
+
+export function isPushedDocument(doc: unknown): doc is { content: ResourceDataDocument } {
+  return false;
+}

--- a/packages/json-api/src/-private/validator/utils.ts
+++ b/packages/json-api/src/-private/validator/utils.ts
@@ -361,7 +361,7 @@ export function isErrorDocument(
 }
 
 export function isPushedDocument(doc: unknown): doc is { content: ResourceDataDocument } {
-  return false;
+  return !!doc && typeof doc === 'object' && 'content' in doc && !('request' in doc) && !('response' in doc);
 }
 
 export function logPotentialMatches(matches: FuseResult<string>[], kind: string): string {

--- a/packages/model/src/-private/schema-provider.ts
+++ b/packages/model/src/-private/schema-provider.ts
@@ -53,7 +53,7 @@ export class ModelSchemaProvider implements SchemaService {
     this._typeMisses = new Set();
   }
 
-  resourceTypes(): string[] {
+  resourceTypes(): Readonly<string[]> {
     return Array.from(this._schemas.keys());
   }
 

--- a/packages/model/src/-private/schema-provider.ts
+++ b/packages/model/src/-private/schema-provider.ts
@@ -53,6 +53,10 @@ export class ModelSchemaProvider implements SchemaService {
     this._typeMisses = new Set();
   }
 
+  resourceTypes(): string[] {
+    return Array.from(this._schemas.keys());
+  }
+
   hasTrait(type: string): boolean {
     assert(`hasTrait is not available with @ember-data/model's SchemaService`);
     return false;

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -199,7 +199,7 @@ export class DelegatingSchemaService implements SchemaService {
     this._secondary = buildSchema(store);
   }
 
-  resourceTypes(): string[] {
+  resourceTypes(): Readonly<string[]> {
     return Array.from(new Set(this._preferred.resourceTypes().concat(this._secondary.resourceTypes())));
   }
 

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -198,6 +198,11 @@ export class DelegatingSchemaService implements SchemaService {
     this._preferred = schema;
     this._secondary = buildSchema(store);
   }
+
+  resourceTypes(): string[] {
+    return Array.from(new Set(this._preferred.resourceTypes().concat(this._secondary.resourceTypes())));
+  }
+
   hasResource(resource: StableRecordIdentifier | { type: string }): boolean {
     return this._preferred.hasResource(resource) || this._secondary.hasResource(resource);
   }

--- a/packages/schema-record/src/-private/schema.ts
+++ b/packages/schema-record/src/-private/schema.ts
@@ -212,6 +212,11 @@ export class SchemaService implements SchemaServiceInterface {
     this._hashFns = new Map();
     this._derivations = new Map();
   }
+
+  resourceTypes(): string[] {
+    return Array.from(this._schemas.keys());
+  }
+
   hasTrait(type: string): boolean {
     return this._traits.has(type);
   }

--- a/packages/schema-record/src/-private/schema.ts
+++ b/packages/schema-record/src/-private/schema.ts
@@ -213,7 +213,7 @@ export class SchemaService implements SchemaServiceInterface {
     this._derivations = new Map();
   }
 
-  resourceTypes(): string[] {
+  resourceTypes(): Readonly<string[]> {
     return Array.from(this._schemas.keys());
   }
 

--- a/packages/store/src/-types/q/schema-service.ts
+++ b/packages/store/src/-types/q/schema-service.ts
@@ -362,4 +362,9 @@ export interface SchemaService {
    * @return {RelationshipsSchema}
    */
   relationshipsDefinitionFor?(identifier: RecordIdentifier | { type: string }): RelationshipsSchema;
+
+  /**
+   * Returns all known resource types
+   */
+  resourceTypes(): Readonly<string[]>;
 }

--- a/packages/store/src/-types/q/schema-service.ts
+++ b/packages/store/src/-types/q/schema-service.ts
@@ -365,6 +365,10 @@ export interface SchemaService {
 
   /**
    * Returns all known resource types
+   *
+   * @method resourceTypes
+   * @public
+   * @return {string[]}
    */
   resourceTypes(): Readonly<string[]>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1051,6 +1051,12 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:*
         version: file:packages/build-config(@babel/core@7.26.10)
+      fuse.js:
+        specifier: 7.1.0
+        version: 7.1.0
+      json-to-ast:
+        specifier: 2.1.0
+        version: 2.1.0
     devDependencies:
       '@babel/core':
         specifier: ^7.26.10
@@ -1082,6 +1088,9 @@ importers:
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
+      '@types/json-to-ast':
+        specifier: ^2.1.4
+        version: 2.1.4
       '@warp-drive/core-types':
         specifier: workspace:*
         version: file:packages/core-types(@babel/core@7.26.10)
@@ -6319,6 +6328,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/json-to-ast@2.1.4':
+    resolution: {integrity: sha512-131wOmuwDg8ypYCSQ437bGdP+K2lJ8GJUu+ng4iQQxAc3irRnb7mGHbexsPChBcKWLctTR9V5LJdX5A8WWk44A==}
+
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
@@ -7559,6 +7571,10 @@ packages:
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  code-error-fragment@0.0.230:
+    resolution: {integrity: sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw==}
+    engines: {node: '>= 4'}
 
   collection-visit@1.0.0:
     resolution: {integrity: sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==}
@@ -9410,6 +9426,9 @@ packages:
   graceful-readlink@1.0.1:
     resolution: {integrity: sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==}
 
+  grapheme-splitter@1.0.4:
+    resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
@@ -10081,6 +10100,10 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json-to-ast@2.1.0:
+    resolution: {integrity: sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==}
+    engines: {node: '>= 4'}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -14467,6 +14490,8 @@ snapshots:
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
+      fuse.js: 7.1.0
+      json-to-ast: 2.1.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -14480,6 +14505,8 @@ snapshots:
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
+      fuse.js: 7.1.0
+      json-to-ast: 2.1.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -14493,6 +14520,8 @@ snapshots:
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      fuse.js: 7.1.0
+      json-to-ast: 2.1.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -14506,6 +14535,8 @@ snapshots:
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      fuse.js: 7.1.0
+      json-to-ast: 2.1.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -14519,6 +14550,8 @@ snapshots:
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      fuse.js: 7.1.0
+      json-to-ast: 2.1.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -17326,6 +17359,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/json-to-ast@2.1.4': {}
+
   '@types/json5@0.0.29': {}
 
   '@types/keyv@3.1.4':
@@ -19329,6 +19364,8 @@ snapshots:
   clone@2.1.2: {}
 
   co@4.6.0: {}
+
+  code-error-fragment@0.0.230: {}
 
   collection-visit@1.0.0:
     dependencies:
@@ -22202,6 +22239,8 @@ snapshots:
 
   graceful-readlink@1.0.1: {}
 
+  grapheme-splitter@1.0.4: {}
+
   graphemer@1.4.0: {}
 
   growly@1.3.0: {}
@@ -22972,6 +23011,11 @@ snapshots:
       object-keys: 1.1.1
 
   json-stringify-safe@5.0.1: {}
+
+  json-to-ast@2.1.0:
+    dependencies:
+      code-error-fragment: 0.0.230
+      grapheme-splitter: 1.0.4
 
   json5@1.0.2:
     dependencies:

--- a/tests/docs/fixtures/expected.js
+++ b/tests/docs/fixtures/expected.js
@@ -801,5 +801,7 @@ module.exports = {
     '(public) @warp-drive/core-types <Type> ResourceField#options',
     '(public) @warp-drive/core-types <Type> SchemaArrayField#options',
     '(public) @warp-drive/core-types <Type> SchemaObjectField#options',
+    '(public) @ember-data/store <Interface> SchemaService#resourceTypes',
+    '(public) @warp-drive/build-config CanaryFeatures#JSON_API_CACHE_VALIDATION_ERRORS',
   ],
 };

--- a/tests/ember-data__json-api/tests/integration/cache/collection-data-documents-test.ts
+++ b/tests/ember-data__json-api/tests/integration/cache/collection-data-documents-test.ts
@@ -22,7 +22,16 @@ type FakeRecord = { [key: string]: unknown; destroy: () => void };
 
 class TestStore extends Store {
   createSchemaService() {
-    return new TestSchema();
+    const schema = new TestSchema();
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        { name: 'name', kind: 'field' },
+        { name: 'username', kind: 'field' },
+      ],
+    });
+    return schema;
   }
 
   override createCache(wrapper: CacheCapabilitiesManager) {

--- a/tests/ember-data__json-api/tests/integration/cache/meta-documents-test.ts
+++ b/tests/ember-data__json-api/tests/integration/cache/meta-documents-test.ts
@@ -18,7 +18,16 @@ function asStructuredDocument<T>(doc: {
 
 class TestStore extends Store {
   createSchemaService() {
-    return new TestSchema();
+    const schema = new TestSchema();
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        { name: 'name', kind: 'field' },
+        { name: 'username', kind: 'field' },
+      ],
+    });
+    return schema;
   }
   override createCache(wrapper: CacheCapabilitiesManager) {
     return new Cache(wrapper);

--- a/tests/ember-data__json-api/tests/integration/cache/resource-data-documents-test.ts
+++ b/tests/ember-data__json-api/tests/integration/cache/resource-data-documents-test.ts
@@ -19,7 +19,16 @@ type FakeRecord = { [key: string]: unknown; destroy: () => void };
 
 class TestStore extends Store {
   createSchemaService() {
-    return new TestSchema();
+    const schema = new TestSchema();
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        { name: 'name', kind: 'field' },
+        { name: 'username', kind: 'field' },
+      ],
+    });
+    return schema;
   }
 
   override createCache(wrapper: CacheCapabilitiesManager) {

--- a/tests/ember-data__json-api/tests/integration/cache/validation-errors-test.ts
+++ b/tests/ember-data__json-api/tests/integration/cache/validation-errors-test.ts
@@ -2,6 +2,7 @@ import Cache from '@ember-data/json-api';
 import RequestManager from '@ember-data/request';
 import Store, { CacheHandler } from '@ember-data/store';
 import type { CacheCapabilitiesManager } from '@ember-data/store/types';
+import { JSON_API_CACHE_VALIDATION_ERRORS } from '@warp-drive/build-config/canary-features';
 import { module, test } from '@warp-drive/diagnostic';
 
 import { TestSchema } from '../../utils/schema';
@@ -18,116 +19,118 @@ class TestStore extends Store {
   }
 }
 
-module('Cache | Validation Errors', function (hooks) {
-  test('It reports errors for invalid documents', function (assert) {
-    const store = new TestStore();
-    store.schema.registerResources([
-      {
-        type: 'user',
-        legacy: true,
-        identity: { kind: '@id', name: 'id' },
-        fields: [
-          { name: 'fullName', kind: 'derived', type: 'concat', options: { fields: ['firstName', 'lastName'] } },
-          { name: 'firstName', kind: 'field' },
-          { name: 'lastName', kind: 'field' },
-          { name: 'username', kind: 'field' },
-          { name: 'email', kind: 'field' },
-          {
-            name: 'friends',
-            kind: 'hasMany',
-            type: 'user',
-            options: {
-              inverse: 'friends',
-              async: false,
+if (JSON_API_CACHE_VALIDATION_ERRORS) {
+  module('Cache | Validation Errors', function (hooks) {
+    test('It reports errors for invalid documents', function (assert) {
+      const store = new TestStore();
+      store.schema.registerResources([
+        {
+          type: 'user',
+          legacy: true,
+          identity: { kind: '@id', name: 'id' },
+          fields: [
+            { name: 'fullName', kind: 'derived', type: 'concat', options: { fields: ['firstName', 'lastName'] } },
+            { name: 'firstName', kind: 'field' },
+            { name: 'lastName', kind: 'field' },
+            { name: 'username', kind: 'field' },
+            { name: 'email', kind: 'field' },
+            {
+              name: 'friends',
+              kind: 'hasMany',
+              type: 'user',
+              options: {
+                inverse: 'friends',
+                async: false,
+              },
             },
-          },
-          {
-            name: 'bestFriend',
-            kind: 'belongsTo',
-            type: 'user',
-            options: {
-              inverse: 'friend',
-              async: false,
+            {
+              name: 'bestFriend',
+              kind: 'belongsTo',
+              type: 'user',
+              options: {
+                inverse: 'friend',
+                async: false,
+              },
             },
-          },
-        ],
-      },
-      {
-        type: 'outdoor-pet',
-        identity: { kind: '@id', name: 'id' },
-        fields: [{ name: 'name', kind: 'field' }],
-      },
-      {
-        type: 'indoor-pet',
-        identity: { kind: '@id', name: 'id' },
-        fields: [{ name: 'name', kind: 'field' }],
-      },
-    ]);
+          ],
+        },
+        {
+          type: 'outdoor-pet',
+          identity: { kind: '@id', name: 'id' },
+          fields: [{ name: 'name', kind: 'field' }],
+        },
+        {
+          type: 'indoor-pet',
+          identity: { kind: '@id', name: 'id' },
+          fields: [{ name: 'name', kind: 'field' }],
+        },
+      ]);
 
-    try {
-      store.cache.put({
-        request: {
-          op: 'findRecord',
-          url: '/users/1',
-          method: 'GET',
-        },
-        content: {
-          data: [
-            {
-              type: 'user',
-              id: '1',
-              attributes: {
+      try {
+        store.cache.put({
+          request: {
+            op: 'findRecord',
+            url: '/users/1',
+            method: 'GET',
+          },
+          content: {
+            data: [
+              {
+                type: 'user',
+                id: '1',
+                attributes: {
+                  name: 'Chris',
+                  fullName: 'Chris Thoburn',
+                  userName: 'runspired',
+                },
+                relationships: {},
+              },
+            ],
+            meta: {},
+            links: {},
+            jsonapi: {},
+            included: [
+              {
+                type: 'users',
+                id: 2,
+                attributes: {
+                  firstName: 'Chris',
+                  lastName: 'Thoburn',
+                  user_name: 'cthoburn',
+                },
+                relationships: {},
+              },
+              {
+                type: 'users',
+                id: 3,
+                attributes: {},
+              },
+              {
+                type: 'pet',
+                id: '4',
+                attributes: {
+                  name: 'Fluffy',
+                },
+              },
+              {
+                type: 'user',
+                id: '4',
                 name: 'Chris',
-                fullName: 'Chris Thoburn',
-                userName: 'runspired',
               },
-              relationships: {},
-            },
-          ],
-          meta: {},
-          links: {},
-          jsonapi: {},
-          included: [
-            {
-              type: 'users',
-              id: 2,
-              attributes: {
-                firstName: 'Chris',
-                lastName: 'Thoburn',
-                user_name: 'cthoburn',
-              },
-              relationships: {},
-            },
-            {
-              type: 'users',
-              id: 3,
-              attributes: {},
-            },
-            {
-              type: 'pet',
-              id: '4',
-              attributes: {
-                name: 'Fluffy',
-              },
-            },
-            {
-              type: 'user',
-              id: '4',
-              name: 'Chris',
-            },
-          ],
-          'invalid_ext:custom': {},
-          INVALID_KEY: 'invalid',
-        },
-        response: new Response(),
-      });
-      assert.ok(false, 'we should error when the document has invalid keys');
-    } catch (e: unknown) {
-      assert.true(e instanceof Error, 'We throw an error when the document has invalid keys');
-      assert.true(
-        (e as Error).message.includes('warnings found in the {JSON:API} document returned by'),
-        'We throw an error when the document has invalid keys'
-      );
-    }
+            ],
+            'invalid_ext:custom': {},
+            INVALID_KEY: 'invalid',
+          },
+          response: new Response(),
+        });
+        assert.ok(false, 'we should error when the document has invalid keys');
+      } catch (e: unknown) {
+        assert.true(e instanceof Error, 'We throw an error when the document has invalid keys');
+        assert.true(
+          (e as Error).message.includes('warnings found in the {JSON:API} document returned by'),
+          'We throw an error when the document has invalid keys'
+        );
+      }
+    });
   });
-});
+}

--- a/tests/ember-data__json-api/tests/integration/cache/validation-errors-test.ts
+++ b/tests/ember-data__json-api/tests/integration/cache/validation-errors-test.ts
@@ -122,9 +122,12 @@ module('Cache | Validation Errors', function (hooks) {
         response: new Response(),
       });
       assert.ok(false, 'we should error when the document has invalid keys');
-    } catch (e) {
-      console.log(e);
+    } catch (e: unknown) {
       assert.true(e instanceof Error, 'We throw an error when the document has invalid keys');
+      assert.true(
+        (e as Error).message.includes('warnings found in the {JSON:API} document returned by'),
+        'We throw an error when the document has invalid keys'
+      );
     }
   });
 });

--- a/tests/ember-data__json-api/tests/integration/cache/validation-errors-test.ts
+++ b/tests/ember-data__json-api/tests/integration/cache/validation-errors-test.ts
@@ -1,0 +1,130 @@
+import Cache from '@ember-data/json-api';
+import RequestManager from '@ember-data/request';
+import Store, { CacheHandler } from '@ember-data/store';
+import type { CacheCapabilitiesManager } from '@ember-data/store/types';
+import { module, test } from '@warp-drive/diagnostic';
+
+import { TestSchema } from '../../utils/schema';
+
+class TestStore extends Store {
+  requestManager = new RequestManager().useCache(CacheHandler);
+
+  createSchemaService() {
+    return new TestSchema();
+  }
+
+  createCache(capabilities: CacheCapabilitiesManager) {
+    return new Cache(capabilities);
+  }
+}
+
+module('Cache | Validation Errors', function (hooks) {
+  test('It reports errors for invalid documents', function (assert) {
+    const store = new TestStore();
+    store.schema.registerResources([
+      {
+        type: 'user',
+        legacy: true,
+        identity: { kind: '@id', name: 'id' },
+        fields: [
+          { name: 'fullName', kind: 'derived', type: 'concat', options: { fields: ['firstName', 'lastName'] } },
+          { name: 'firstName', kind: 'field' },
+          { name: 'lastName', kind: 'field' },
+          { name: 'username', kind: 'field' },
+          { name: 'email', kind: 'field' },
+          {
+            name: 'friends',
+            kind: 'hasMany',
+            type: 'user',
+            options: {
+              inverse: 'friends',
+              async: false,
+            },
+          },
+          {
+            name: 'bestFriend',
+            kind: 'belongsTo',
+            type: 'user',
+            options: {
+              inverse: 'friend',
+              async: false,
+            },
+          },
+        ],
+      },
+      {
+        type: 'outdoor-pet',
+        identity: { kind: '@id', name: 'id' },
+        fields: [{ name: 'name', kind: 'field' }],
+      },
+      {
+        type: 'indoor-pet',
+        identity: { kind: '@id', name: 'id' },
+        fields: [{ name: 'name', kind: 'field' }],
+      },
+    ]);
+
+    try {
+      store.cache.put({
+        request: {
+          op: 'findRecord',
+          url: '/users/1',
+          method: 'GET',
+        },
+        content: {
+          data: [
+            {
+              type: 'user',
+              id: '1',
+              attributes: {
+                name: 'Chris',
+                fullName: 'Chris Thoburn',
+                userName: 'runspired',
+              },
+              relationships: {},
+            },
+          ],
+          meta: {},
+          links: {},
+          jsonapi: {},
+          included: [
+            {
+              type: 'users',
+              id: 2,
+              attributes: {
+                firstName: 'Chris',
+                lastName: 'Thoburn',
+                user_name: 'cthoburn',
+              },
+              relationships: {},
+            },
+            {
+              type: 'users',
+              id: 3,
+              attributes: {},
+            },
+            {
+              type: 'pet',
+              id: '4',
+              attributes: {
+                name: 'Fluffy',
+              },
+            },
+            {
+              type: 'user',
+              id: '4',
+              name: 'Chris',
+            },
+          ],
+          'invalid_ext:custom': {},
+          INVALID_KEY: 'invalid',
+        },
+        response: new Response(),
+      });
+      assert.ok(false, 'we should error when the document has invalid keys');
+    } catch (e) {
+      console.log(e);
+      assert.true(e instanceof Error, 'We throw an error when the document has invalid keys');
+    }
+  });
+});

--- a/tests/ember-data__json-api/tests/utils/schema.ts
+++ b/tests/ember-data__json-api/tests/utils/schema.ts
@@ -40,6 +40,9 @@ export class TestSchema implements SchemaService {
     this._hashFns = new Map();
     this._derivations = new Map();
   }
+  resourceTypes(): string[] {
+    return Array.from(this._schemas.keys());
+  }
   hasTrait(type: string): boolean {
     return this._traits.has(type);
   }

--- a/tests/ember-data__json-api/tests/utils/schema.ts
+++ b/tests/ember-data__json-api/tests/utils/schema.ts
@@ -40,7 +40,7 @@ export class TestSchema implements SchemaService {
     this._hashFns = new Map();
     this._derivations = new Map();
   }
-  resourceTypes(): string[] {
+  resourceTypes(): Readonly<string[]> {
     return Array.from(this._schemas.keys());
   }
   hasTrait(type: string): boolean {

--- a/tests/ember-data__model/tests/utils/schema.ts
+++ b/tests/ember-data__model/tests/utils/schema.ts
@@ -40,6 +40,9 @@ export class TestSchema implements SchemaService {
     this._hashFns = new Map();
     this._derivations = new Map();
   }
+  resourceTypes(): string[] {
+    return Array.from(this._schemas.keys());
+  }
   hasTrait(type: string): boolean {
     return this._traits.has(type);
   }

--- a/tests/ember-data__model/tests/utils/schema.ts
+++ b/tests/ember-data__model/tests/utils/schema.ts
@@ -40,7 +40,7 @@ export class TestSchema implements SchemaService {
     this._hashFns = new Map();
     this._derivations = new Map();
   }
-  resourceTypes(): string[] {
+  resourceTypes(): Readonly<string[]> {
     return Array.from(this._schemas.keys());
   }
   hasTrait(type: string): boolean {

--- a/tests/main/tests/integration/cache-handler/lifetimes-test.ts
+++ b/tests/main/tests/integration/cache-handler/lifetimes-test.ts
@@ -30,6 +30,9 @@ type FakeRecord = { [key: string]: unknown; destroy: () => void };
 class BaseTestStore extends Store {
   createSchemaService(): SchemaService {
     const schemaService: SchemaService = {
+      resourceTypes() {
+        return [];
+      },
       fields(identifier: StableRecordIdentifier | { type: string }): Map<string, FieldSchema> {
         return new Map();
       },

--- a/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
+++ b/tests/main/tests/integration/cache-handler/store-package-setup-test.ts
@@ -54,6 +54,9 @@ class TestStore extends Store {
 
   createSchemaService(): SchemaService {
     const schemaService: SchemaService = {
+      resourceTypes() {
+        return [];
+      },
       registerDerivation() {
         throw new Error('Method not implemented.');
       },

--- a/tests/main/tests/utils/schema.ts
+++ b/tests/main/tests/utils/schema.ts
@@ -46,6 +46,10 @@ export class TestSchema implements SchemaService {
     this._assert?.step('TestSchema:hasTrait');
     return this._traits.has(type);
   }
+  resourceTypes(): string[] {
+    this._assert?.step('TestSchema:resourceTypes');
+    return [...this._schemas.keys()];
+  }
   resourceHasTrait(resource: StableRecordIdentifier | { type: string }, trait: string): boolean {
     this._assert?.step('TestSchema:resourceHasTrait');
     return this._schemas.get(resource.type)!.traits.has(trait);

--- a/tests/main/tests/utils/schema.ts
+++ b/tests/main/tests/utils/schema.ts
@@ -46,7 +46,7 @@ export class TestSchema implements SchemaService {
     this._assert?.step('TestSchema:hasTrait');
     return this._traits.has(type);
   }
-  resourceTypes(): string[] {
+  resourceTypes(): Readonly<string[]> {
     this._assert?.step('TestSchema:resourceTypes');
     return [...this._schemas.keys()];
   }


### PR DESCRIPTION
resolves #4727 

There's a huge amount of trivial errors we could catch and help folks with by validating the data that gets inserted into the cache against the expected format.

This adds that. It will always run, but initially it will log its output only when asked to:

```ts
setWarpDriveLogging({ LOG_PAYLOADS: true })
```

but eventually we will set it to not only always log, but also to throw if more than a warning is present.

The validation will be *slightly* configurable, specifics forthcoming, with two kinds of supported configuration:

- extensions, to support json:api extensions, will pass any fields for a registered extension to a validator registered for that extension.
- strict mode, which has a number of specific settings
  - linkage: whether to validate the full-linkage requirement json:api specifies (but is often violated)
  - unknownType: whether to error or merely warn when unknown resource types are encountered
  - unknownAttribute: whether to error or merely warn when unknown attribute fields are encountered
  - unknownRelationship: whether to error or merely warn when unknown relationship fields are encountered
  
  
Example report:

<img width="1123" alt="image" src="https://github.com/user-attachments/assets/527d123b-1956-406b-bda5-f92d56185b8a" />

  
  