### PR TITLE
Add a URL to the deprecate Store extends EmberObject

### DIFF
--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -343,6 +343,7 @@ const app = new EmberApp(defaults, {
       id: 'ember-data:deprecate-store-extends-ember-object',
       until: '6.0',
       for: 'ember-data',
+      url: 'https://deprecations.emberjs.com/id/ember-data-deprecate-store-extends-ember-object',
       since: {
         available: '4.13',
         enabled: '5.4',


### PR DESCRIPTION
Deprecation guide will exist with https://github.com/ember-learn/deprecation-app/pull/1400

URL is knowable as it is based on the id.