### PR TITLE
chore: silence deprecation, attempt to fix CI

### DIFF
--- a/packages/build-config/src/index.ts
+++ b/packages/build-config/src/index.ts
@@ -120,9 +120,11 @@ export function setConfig(context: object, appRoot: string, config: WarpDriveCon
 
   // legacy support called prior to user setConfig
   if (isLegacySupport && hasDeprecatedConfig) {
-    console.warn(
-      `You are using the legacy emberData key in your ember-cli-build.js file. This key is deprecated and will be removed in the next major version of EmberData/WarpDrive. Please use \`import { setConfig } from '@warp-drive/build-config';\` instead.`
-    );
+    // We don't want to print this just yet because we are going to re-arrange packages
+    // and this would be come an import from @warp-drive/core. Better to not deprecate twice.
+    // console.warn(
+    //   `You are using the legacy emberData key in your ember-cli-build.js file. This key is deprecated and will be removed in the next major version of EmberData/WarpDrive. Please use \`import { setConfig } from '@warp-drive/build-config';\` instead.`
+    // );
   }
 
   // included hooks run during class initialization of the EmberApp instance

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -42,6 +42,7 @@
   },
   "peerDependencies": {
     "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0",
+    "@ember/test-waiters": "^3.1.0 || ^4.0.0",
     "@ember-data/store": "workspace:*",
     "@ember-data/request": "workspace:*",
     "@ember-data/request-utils": "workspace:*",
@@ -50,7 +51,6 @@
     "@ember-data/tracking": "workspace:*"
   },
   "dependencies": {
-    "@ember/test-waiters": "^3.1.0 || ^4.0.0",
     "@embroider/macros": "^1.16.12",
     "@warp-drive/build-config": "workspace:*"
   },
@@ -79,6 +79,7 @@
     "@ember-data/store": "workspace:*",
     "@ember-data/tracking": "workspace:*",
     "@ember/test-helpers": "5.2.0",
+    "@ember/test-waiters": "^4.1.0",
     "@warp-drive/core-types": "workspace:*",
     "@warp-drive/internal-config": "workspace:*",
     "babel-plugin-ember-template-compilation": "^2.4.1",

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -40,10 +40,10 @@
     }
   },
   "peerDependencies": {
-    "@warp-drive/core-types": "workspace:*"
+    "@warp-drive/core-types": "workspace:*",
+    "@ember/test-waiters": "^3.1.0 || ^4.0.0"
   },
   "dependencies": {
-    "@ember/test-waiters": "^3.1.0 || ^4.0.0",
     "@embroider/macros": "^1.16.12",
     "@warp-drive/build-config": "workspace:*"
   },
@@ -55,6 +55,7 @@
     "@glimmer/component": "^2.0.0",
     "@warp-drive/core-types": "workspace:*",
     "@warp-drive/internal-config": "workspace:*",
+    "@ember/test-waiters": "^4.1.0",
     "ember-source": "~6.3.0",
     "vite": "^5.4.15"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,34 +280,34 @@ importers:
     dependencies:
       '@ember-data/adapter':
         specifier: workspace:*
-        version: file:packages/adapter(e7323f9941802118256d786fcb3ac6a7)
+        version: file:packages/adapter(dc6100bd319db7fe3385ad6ce162d6ca)
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(1761e67250ec2064a77715ad24d24371)
+        version: file:packages/debug(cba9d2d06195261941565e1eaadc849a)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(6ed66525e24805f4167d443950cf8d28)
+        version: file:packages/model(cc762b12c5c802e634c08a54488bf402)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/serializer':
         specifier: workspace:*
-        version: file:packages/serializer(e7323f9941802118256d786fcb3ac6a7)
+        version: file:packages/serializer(dc6100bd319db7fe3385ad6ce162d6ca)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
@@ -494,22 +494,22 @@ importers:
         version: 7.27.0(@babel/core@7.26.10)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
@@ -681,19 +681,19 @@ importers:
         version: 7.27.0(@babel/core@7.26.10)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(3760115784f64fcf3b7d918d0aad87c5)
+        version: file:packages/legacy-compat(1156b12af755d42b97126cf4ace3f85a)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(54c1baeabf96d08a315ebe62a865c45e)
+        version: file:packages/model(90d971b4545ba8070799a40f738f8c67)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
@@ -779,9 +779,6 @@ importers:
 
   packages/ember:
     dependencies:
-      '@ember/test-waiters':
-        specifier: ^3.1.0 || ^4.0.0
-        version: 3.1.0(@babel/core@7.26.10)
       '@embroider/macros':
         specifier: ^1.16.12
         version: 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
@@ -806,19 +803,22 @@ importers:
         version: 7.27.0
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
+        version: file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(c153d55c663e137d50d65695e10cc7e1)
+        version: file:packages/store(1a73f1593c608471af73ba704170923c)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@ember/test-helpers':
         specifier: 5.2.0
         version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(fec7b898d328e52e91c0cf874617af3a)
+      '@ember/test-waiters':
+        specifier: ^4.1.0
+        version: 4.1.0(6b9ab74b27cee7278587f29987a61ec9)
       '@embroider/addon-dev':
         specifier: ^7.1.3
         version: 7.1.3(@glint/template@1.5.2)(rollup@4.38.0)
@@ -1130,19 +1130,19 @@ importers:
         version: 7.27.0(@babel/core@7.26.10)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
@@ -1203,22 +1203,22 @@ importers:
         version: 7.27.0(@babel/core@7.26.10)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
@@ -1252,9 +1252,6 @@ importers:
 
   packages/request:
     dependencies:
-      '@ember/test-waiters':
-        specifier: ^3.1.0 || ^4.0.0
-        version: 3.1.0(@babel/core@7.26.10)
       '@embroider/macros':
         specifier: ^1.16.12
         version: 1.16.12(@babel/core@7.26.10)
@@ -1274,6 +1271,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.27.0
         version: 7.27.0(@babel/core@7.26.10)
+      '@ember/test-waiters':
+        specifier: ^4.1.0
+        version: 4.1.0(@babel/core@7.26.10)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1414,19 +1414,19 @@ importers:
         version: 7.27.0(@babel/core@7.26.10)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(3760115784f64fcf3b7d918d0aad87c5)
+        version: file:packages/legacy-compat(1156b12af755d42b97126cf4ace3f85a)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(54c1baeabf96d08a315ebe62a865c45e)
+        version: file:packages/model(90d971b4545ba8070799a40f738f8c67)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
@@ -1484,19 +1484,19 @@ importers:
         version: 7.27.0(@babel/core@7.26.10)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(3760115784f64fcf3b7d918d0aad87c5)
+        version: file:packages/legacy-compat(1156b12af755d42b97126cf4ace3f85a)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(54c1baeabf96d08a315ebe62a865c45e)
+        version: file:packages/model(90d971b4545ba8070799a40f738f8c67)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
@@ -1708,40 +1708,40 @@ importers:
         version: 7.26.10
       '@ember-data/adapter':
         specifier: workspace:*
-        version: file:packages/adapter(e7323f9941802118256d786fcb3ac6a7)
+        version: file:packages/adapter(dc6100bd319db7fe3385ad6ce162d6ca)
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(1761e67250ec2064a77715ad24d24371)
+        version: file:packages/debug(cba9d2d06195261941565e1eaadc849a)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(6ed66525e24805f4167d443950cf8d28)
+        version: file:packages/model(cc762b12c5c802e634c08a54488bf402)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/serializer':
         specifier: workspace:*
-        version: file:packages/serializer(e7323f9941802118256d786fcb3ac6a7)
+        version: file:packages/serializer(dc6100bd319db7fe3385ad6ce162d6ca)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(e1d286e1c1606b6c285b6b412084952f)
+        version: file:packages/unpublished-test-infra(762baab7aa84058ebe30cd66794b7ae9)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
@@ -1789,40 +1789,40 @@ importers:
         version: 7.27.0
       '@ember-data/active-record':
         specifier: workspace:*
-        version: file:packages/active-record(baf0f64f9531bf85e9d52c971d8e7a5e)
+        version: file:packages/active-record(6b9b24bf6a6289f16eeb5d7c639110f0)
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(dcb073f83595d3904cc2b50faad617db)
+        version: file:packages/debug(98ff3d18c429b6588e3521151ed9506a)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(42cf1093c1d867c103c98f5f248623cf)
+        version: file:packages/graph(2f3970f979a5bcdc56036cb8d3ef5fe0)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(62f006c824c77856925379eaa88fda2b)
+        version: file:packages/json-api(df4ec260642df6134fdc68d76ccd5c52)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(2c65f8541a346f7b284e593a7472ff9e)
+        version: file:packages/legacy-compat(336ee89166c67e5d1f7b6131d92e29e4)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(663b54de9b512efe997729c1b27f1019)
+        version: file:packages/model(764dc834da7ec45afb6eee8a40702239)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
       '@ember-data/rest':
         specifier: workspace:*
-        version: file:packages/rest(baf0f64f9531bf85e9d52c971d8e7a5e)
+        version: file:packages/rest(6b9b24bf6a6289f16eeb5d7c639110f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+        version: file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(56c520f81855c43f264af56b00547e03)
+        version: file:packages/unpublished-test-infra(4cfa4c99cb2783cd2fd1f3d5850c3f1a)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
@@ -1967,37 +1967,37 @@ importers:
         version: 7.27.0
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(e5c954c6a704d96554ea9a2c73d27738)
+        version: file:packages/debug(cba9d2d06195261941565e1eaadc849a)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(1fb9ea20d3f98065db69bf1bd75921bb)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(f4ff02b948fcc63f125db7a804b55428)
+        version: file:packages/model(cc762b12c5c802e634c08a54488bf402)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/serializer':
         specifier: workspace:*
-        version: file:packages/serializer(8a485f142e721bd8e8ddc8f57ab0664f)
+        version: file:packages/serializer(dc6100bd319db7fe3385ad6ce162d6ca)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(9c10511edce4e6e36faab49c56f7b2b9)
+        version: file:packages/unpublished-test-infra(05411543d61297c3f7c54af6bbfb9cef)
       '@ember/optional-features':
         specifier: ^2.2.0
         version: 2.2.0
@@ -2005,8 +2005,8 @@ importers:
         specifier: 5.2.0
         version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
       '@ember/test-waiters':
-        specifier: ^3.1.0 || ^4.0.0
-        version: 3.1.0(@babel/core@7.26.10)
+        specifier: ^4.1.0
+        version: 4.1.0(@babel/core@7.26.10)
       '@embroider/addon-shim':
         specifier: ^1.9.0
         version: 1.9.0
@@ -2085,34 +2085,34 @@ importers:
         version: 7.27.0
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(1761e67250ec2064a77715ad24d24371)
+        version: file:packages/debug(cba9d2d06195261941565e1eaadc849a)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(6ed66525e24805f4167d443950cf8d28)
+        version: file:packages/model(cc762b12c5c802e634c08a54488bf402)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(9c10511edce4e6e36faab49c56f7b2b9)
+        version: file:packages/unpublished-test-infra(05411543d61297c3f7c54af6bbfb9cef)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
@@ -2218,34 +2218,34 @@ importers:
         version: 7.27.0
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(1761e67250ec2064a77715ad24d24371)
+        version: file:packages/debug(cba9d2d06195261941565e1eaadc849a)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(6ed66525e24805f4167d443950cf8d28)
+        version: file:packages/model(cc762b12c5c802e634c08a54488bf402)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(9c10511edce4e6e36faab49c56f7b2b9)
+        version: file:packages/unpublished-test-infra(05411543d61297c3f7c54af6bbfb9cef)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
@@ -2281,7 +2281,7 @@ importers:
         version: file:packages/diagnostic(0769fea203e98132438ae0defbe77024)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(2f1166d4bf91c5372f8d84fc36fca6ca)
+        version: file:packages/holodeck(2512a32e8b0d95cd49b7ddd0bab86275)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:config
@@ -2354,28 +2354,28 @@ importers:
         version: 7.27.0
       '@ember-data/adapter':
         specifier: workspace:*
-        version: file:packages/adapter(e7323f9941802118256d786fcb3ac6a7)
+        version: file:packages/adapter(dc6100bd319db7fe3385ad6ce162d6ca)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/serializer':
         specifier: workspace:*
-        version: file:packages/serializer(e7323f9941802118256d786fcb3ac6a7)
+        version: file:packages/serializer(dc6100bd319db7fe3385ad6ce162d6ca)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
@@ -2469,7 +2469,7 @@ importers:
         version: 7.27.0
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
@@ -2505,7 +2505,7 @@ importers:
         version: file:packages/diagnostic(0769fea203e98132438ae0defbe77024)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(2f1166d4bf91c5372f8d84fc36fca6ca)
+        version: file:packages/holodeck(2512a32e8b0d95cd49b7ddd0bab86275)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:config
@@ -2587,37 +2587,37 @@ importers:
         version: 7.27.0
       '@ember-data/adapter':
         specifier: workspace:*
-        version: file:packages/adapter(e7323f9941802118256d786fcb3ac6a7)
+        version: file:packages/adapter(dc6100bd319db7fe3385ad6ce162d6ca)
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(1761e67250ec2064a77715ad24d24371)
+        version: file:packages/debug(cba9d2d06195261941565e1eaadc849a)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(6ed66525e24805f4167d443950cf8d28)
+        version: file:packages/model(cc762b12c5c802e634c08a54488bf402)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(5dee8d774f0af37bbd4814e6d237057e)
+        version: file:packages/unpublished-test-infra(00ef1b17b5212b0c25904aba6070b774)
       '@ember/optional-features':
         specifier: ^2.2.0
         version: 2.2.0
@@ -2701,40 +2701,40 @@ importers:
         version: 7.27.0
       '@ember-data/adapter':
         specifier: workspace:*
-        version: file:packages/adapter(a1ade22c0d9fabfd25a112954714fca6)
+        version: file:packages/adapter(0149a020c8ebae6df594d3e8b68ee55c)
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(dcb073f83595d3904cc2b50faad617db)
+        version: file:packages/debug(98ff3d18c429b6588e3521151ed9506a)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(42cf1093c1d867c103c98f5f248623cf)
+        version: file:packages/graph(2f3970f979a5bcdc56036cb8d3ef5fe0)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(62f006c824c77856925379eaa88fda2b)
+        version: file:packages/json-api(df4ec260642df6134fdc68d76ccd5c52)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(2c65f8541a346f7b284e593a7472ff9e)
+        version: file:packages/legacy-compat(336ee89166c67e5d1f7b6131d92e29e4)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(663b54de9b512efe997729c1b27f1019)
+        version: file:packages/model(764dc834da7ec45afb6eee8a40702239)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
       '@ember-data/serializer':
         specifier: workspace:*
-        version: file:packages/serializer(a1ade22c0d9fabfd25a112954714fca6)
+        version: file:packages/serializer(0149a020c8ebae6df594d3e8b68ee55c)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+        version: file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(ed1f7452463997d3ebd3802a92f753b7)
+        version: file:packages/unpublished-test-infra(4ed69374fc1604d8010e397e5a816a8a)
       '@ember/optional-features':
         specifier: ^2.2.0
         version: 2.2.0
@@ -2849,34 +2849,34 @@ importers:
         version: 7.27.0
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(1761e67250ec2064a77715ad24d24371)
+        version: file:packages/debug(cba9d2d06195261941565e1eaadc849a)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(6ed66525e24805f4167d443950cf8d28)
+        version: file:packages/model(cc762b12c5c802e634c08a54488bf402)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(5dee8d774f0af37bbd4814e6d237057e)
+        version: file:packages/unpublished-test-infra(00ef1b17b5212b0c25904aba6070b774)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
@@ -3017,34 +3017,34 @@ importers:
         version: 7.27.0
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(7f152b03c997c95f1441e71a4aea5913)
+        version: file:packages/debug(a0ec188e0a01f3cad220a8c855ad44f5)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(47b06ed5817314a8a41bd897ca6d0633)
+        version: file:packages/graph(0e0007db8340958cdddaf306d70f5c08)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(aaa51ec56275043781b6e317a1b6c87e)
+        version: file:packages/json-api(06f304c44f4ab5ae511112828e948caa)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(a8538c7b5795e96a949d1e4ff943dd96)
+        version: file:packages/legacy-compat(624b704660c29664a472d97c231c90f4)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(965988fbb16043525d12aaca044e3cab)
+        version: file:packages/model(147553b0a53a74a578944c02fffdf02e)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(867afdadd0634717f2814144a813000f)
+        version: file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(bc56851d569ecd327e50502bbc1a8cfa)
+        version: file:packages/unpublished-test-infra(95bd88ecb233dd27f26167b5ba7f077a)
       '@ember/optional-features':
         specifier: ^2.2.0
         version: 2.2.0
@@ -3217,40 +3217,40 @@ importers:
         version: 7.27.0
       '@ember-data/adapter':
         specifier: workspace:*
-        version: file:packages/adapter(ca4d98ec16688a8c2f8c6501f71ec954)
+        version: file:packages/adapter(5cb5ff665b4e39b3cda054479ba93d07)
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(048445d491a2ee697a4277144616d4d7)
+        version: file:packages/debug(6df2a564e81cc032c01b9011e0cc6d9d)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(9593ad06fabf7e5115a4983944bc9f1c)
+        version: file:packages/graph(1988e180c0805d485b52f53913a6b5ee)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(46020de0037263bee94a91add557af19)
+        version: file:packages/json-api(be64f0619bf23da37ed1bd98df835563)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(f526cd0e174ef5e43334c75f8f74d0c3)
+        version: file:packages/legacy-compat(45bdb77033fe1c7735b6c08439c11db1)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(2de23c88a8c300dca037dfbbb7bba9b3)
+        version: file:packages/model(2f08b1bd604f6cce397049ed21e31fce)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
+        version: file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
       '@ember-data/serializer':
         specifier: workspace:*
-        version: file:packages/serializer(ca4d98ec16688a8c2f8c6501f71ec954)
+        version: file:packages/serializer(5cb5ff665b4e39b3cda054479ba93d07)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
+        version: file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(c6526e773d1bf99de2cc1fe6001ecc05)
+        version: file:packages/unpublished-test-infra(4909b868b92ffb9324e72748d98ee796)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
@@ -3298,13 +3298,13 @@ importers:
         version: file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(00776259705c76f6a3a760b857d69332)
+        version: file:packages/holodeck(50787cdd3314abb44d598f29619a3bcb)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:config(@glint/template@1.5.2)
       '@warp-drive/schema-record':
         specifier: workspace:*
-        version: file:packages/schema-record(4f5c28a5050731017617e2b370d59d94)
+        version: file:packages/schema-record(ac0d71b42e8688b776338d7abcce1756)
       broccoli-concat:
         specifier: ^4.2.5
         version: 4.2.5
@@ -3430,25 +3430,25 @@ importers:
         version: 7.27.0
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(6ed66525e24805f4167d443950cf8d28)
+        version: file:packages/model(cc762b12c5c802e634c08a54488bf402)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
@@ -3559,40 +3559,40 @@ importers:
         version: 7.27.0
       '@ember-data/adapter':
         specifier: workspace:*
-        version: file:packages/adapter(ab2e4a5aa0a0e23281aeaf28af98851a)
+        version: file:packages/adapter(49ff1b1d7550a62c46c5d2638a5a71a9)
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(7f152b03c997c95f1441e71a4aea5913)
+        version: file:packages/debug(a0ec188e0a01f3cad220a8c855ad44f5)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(47b06ed5817314a8a41bd897ca6d0633)
+        version: file:packages/graph(0e0007db8340958cdddaf306d70f5c08)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(aaa51ec56275043781b6e317a1b6c87e)
+        version: file:packages/json-api(06f304c44f4ab5ae511112828e948caa)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(a8538c7b5795e96a949d1e4ff943dd96)
+        version: file:packages/legacy-compat(624b704660c29664a472d97c231c90f4)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(965988fbb16043525d12aaca044e3cab)
+        version: file:packages/model(147553b0a53a74a578944c02fffdf02e)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
       '@ember-data/serializer':
         specifier: workspace:*
-        version: file:packages/serializer(ab2e4a5aa0a0e23281aeaf28af98851a)
+        version: file:packages/serializer(49ff1b1d7550a62c46c5d2638a5a71a9)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(867afdadd0634717f2814144a813000f)
+        version: file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(5093d4034d2acc72a7e37e665125bc0e)
+        version: file:packages/unpublished-test-infra(32c9c6a3717b91bfe1b822bba0666ea1)
       '@ember/optional-features':
         specifier: ^2.2.0
         version: 2.2.0
@@ -3764,34 +3764,34 @@ importers:
         version: 7.27.0
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(3c4488df655673bee6548970bac9ced5)
+        version: file:packages/debug(840fe430b980e3544dbf09b53806ea0d)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(ff4b77fd5c962497e85bcfb6e807f3fe)
+        version: file:packages/graph(30e2608e823c6d3f157a9dddaeabae62)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(5eb0a0db60c03e98bea4d954cb47187c)
+        version: file:packages/json-api(812231e22ded84647161eeef91e55d1d)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(e5b893555cfc0ca1db68c1276aafbb3a)
+        version: file:packages/legacy-compat(cee7afd9aaf3d390a4ebda799e336bba)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(a757e3874bf1cbf9d4deaae542c95c68)
+        version: file:packages/model(23d604913ef990bf67e23c6fad8d6a31)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
+        version: file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(c153d55c663e137d50d65695e10cc7e1)
+        version: file:packages/store(1a73f1593c608471af73ba704170923c)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(382493c97e706a2708c204ee69f0995b)
+        version: file:packages/unpublished-test-infra(ba1e9eb77ffa2ae4bbad7229cb008208)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
@@ -3836,16 +3836,16 @@ importers:
         version: file:packages/diagnostic(a10f3b46fd0a7d21a7d8319d1b6e8f17)
       '@warp-drive/ember':
         specifier: workspace:*
-        version: file:packages/ember(730e82fd9c47f3811ef579a4e3f96233)
+        version: file:packages/ember(e9b3a1cbd3fd9b2cc7e2e94e1e658c85)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(00776259705c76f6a3a760b857d69332)
+        version: file:packages/holodeck(50787cdd3314abb44d598f29619a3bcb)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:config(@glint/template@1.5.2)
       '@warp-drive/schema-record':
         specifier: workspace:*
-        version: file:packages/schema-record(b7fd5c4610be5760615fa8352f5222df)
+        version: file:packages/schema-record(ade3c39e1ebef73bd1b4c5d760dc29c8)
       ember-auto-import:
         specifier: ^2.10.0
         version: 2.10.0(@glint/template@1.5.2)
@@ -3915,34 +3915,34 @@ importers:
         version: 7.27.0
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(1761e67250ec2064a77715ad24d24371)
+        version: file:packages/debug(cba9d2d06195261941565e1eaadc849a)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+        version: file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+        version: file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+        version: file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(6ed66525e24805f4167d443950cf8d28)
+        version: file:packages/model(cc762b12c5c802e634c08a54488bf402)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+        version: file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+        version: file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(9c10511edce4e6e36faab49c56f7b2b9)
+        version: file:packages/unpublished-test-infra(05411543d61297c3f7c54af6bbfb9cef)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
@@ -3984,19 +3984,19 @@ importers:
         version: file:packages/diagnostic(0769fea203e98132438ae0defbe77024)
       '@warp-drive/ember':
         specifier: workspace:*
-        version: file:packages/ember(758f8a2428f0029b3186442228b41a16)
+        version: file:packages/ember(f4560fd7cfb7997691592dd42eaf17e3)
       '@warp-drive/experiments':
         specifier: workspace:*
-        version: file:packages/experiments(e6beeeb8a57db3ecafe80df4e7d03450)
+        version: file:packages/experiments(a37d574ca5e395e4e576e686436d1ddc)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(2f1166d4bf91c5372f8d84fc36fca6ca)
+        version: file:packages/holodeck(2512a32e8b0d95cd49b7ddd0bab86275)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:config
       '@warp-drive/schema-record':
         specifier: workspace:*
-        version: file:packages/schema-record(0d93bbe52cb9c8f81438b6f252a1221d)
+        version: file:packages/schema-record(024b0f285640a155b166c6bf5eb24a63)
       ember-auto-import:
         specifier: ^2.10.0
         version: 2.10.0
@@ -4072,34 +4072,34 @@ importers:
         version: 7.27.0
       '@ember-data/debug':
         specifier: workspace:*
-        version: file:packages/debug(3c4488df655673bee6548970bac9ced5)
+        version: file:packages/debug(840fe430b980e3544dbf09b53806ea0d)
       '@ember-data/graph':
         specifier: workspace:*
-        version: file:packages/graph(ff4b77fd5c962497e85bcfb6e807f3fe)
+        version: file:packages/graph(30e2608e823c6d3f157a9dddaeabae62)
       '@ember-data/json-api':
         specifier: workspace:*
-        version: file:packages/json-api(5eb0a0db60c03e98bea4d954cb47187c)
+        version: file:packages/json-api(812231e22ded84647161eeef91e55d1d)
       '@ember-data/legacy-compat':
         specifier: workspace:*
-        version: file:packages/legacy-compat(e5b893555cfc0ca1db68c1276aafbb3a)
+        version: file:packages/legacy-compat(cee7afd9aaf3d390a4ebda799e336bba)
       '@ember-data/model':
         specifier: workspace:*
-        version: file:packages/model(a757e3874bf1cbf9d4deaae542c95c68)
+        version: file:packages/model(23d604913ef990bf67e23c6fad8d6a31)
       '@ember-data/request':
         specifier: workspace:*
-        version: file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
+        version: file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
       '@ember-data/request-utils':
         specifier: workspace:*
         version: file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
       '@ember-data/store':
         specifier: workspace:*
-        version: file:packages/store(c153d55c663e137d50d65695e10cc7e1)
+        version: file:packages/store(1a73f1593c608471af73ba704170923c)
       '@ember-data/tracking':
         specifier: workspace:*
         version: file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(35ada83424e0f2346a371359b37a502c)
+        version: file:packages/unpublished-test-infra(d9d0015f89bb4e75b3a204db4be6b20d)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
@@ -4144,7 +4144,7 @@ importers:
         version: file:config(@glint/template@1.5.2)
       '@warp-drive/schema-record':
         specifier: workspace:*
-        version: file:packages/schema-record(b7fd5c4610be5760615fa8352f5222df)
+        version: file:packages/schema-record(ade3c39e1ebef73bd1b4c5d760dc29c8)
       ember-auto-import:
         specifier: ^2.10.0
         version: 2.10.0(@glint/template@1.5.2)
@@ -5001,6 +5001,7 @@ packages:
     resolution: {directory: packages/request, type: directory}
     engines: {node: '>= 18.20.8'}
     peerDependencies:
+      '@ember/test-waiters': ^3.1.0 || ^4.0.0
       '@warp-drive/core-types': workspace:*
 
   '@ember-data/rest@file:packages/rest':
@@ -6519,6 +6520,7 @@ packages:
       '@ember-data/request-utils': workspace:*
       '@ember-data/store': workspace:*
       '@ember-data/tracking': workspace:*
+      '@ember/test-waiters': ^3.1.0 || ^4.0.0
       '@warp-drive/core-types': workspace:*
       ember-provide-consume-context: ^0.7.0
       ember-source: 3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0
@@ -14316,10 +14318,10 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@ember-data/active-record@file:packages/active-record(baf0f64f9531bf85e9d52c971d8e7a5e)':
+  '@ember-data/active-record@file:packages/active-record(6b9b24bf6a6289f16eeb5d7c639110f0)':
     dependencies:
       '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
@@ -14328,11 +14330,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/adapter@file:packages/adapter(a1ade22c0d9fabfd25a112954714fca6)':
+  '@ember-data/adapter@file:packages/adapter(0149a020c8ebae6df594d3e8b68ee55c)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(2c65f8541a346f7b284e593a7472ff9e)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(336ee89166c67e5d1f7b6131d92e29e4)
       '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
@@ -14346,11 +14348,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/adapter@file:packages/adapter(ab2e4a5aa0a0e23281aeaf28af98851a)':
+  '@ember-data/adapter@file:packages/adapter(49ff1b1d7550a62c46c5d2638a5a71a9)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(a8538c7b5795e96a949d1e4ff943dd96)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(624b704660c29664a472d97c231c90f4)
       '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
-      '@ember-data/store': file:packages/store(867afdadd0634717f2814144a813000f)
+      '@ember-data/store': file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
@@ -14364,11 +14366,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/adapter@file:packages/adapter(ca4d98ec16688a8c2f8c6501f71ec954)':
+  '@ember-data/adapter@file:packages/adapter(5cb5ff665b4e39b3cda054479ba93d07)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(f526cd0e174ef5e43334c75f8f74d0c3)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(45bdb77033fe1c7735b6c08439c11db1)
       '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
-      '@ember-data/store': file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
+      '@ember-data/store': file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
@@ -14382,11 +14384,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/adapter@file:packages/adapter(e7323f9941802118256d786fcb3ac6a7)':
+  '@ember-data/adapter@file:packages/adapter(dc6100bd319db7fe3385ad6ce162d6ca)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
@@ -14413,11 +14415,11 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@ember-data/debug@file:packages/debug(048445d491a2ee697a4277144616d4d7)':
+  '@ember-data/debug@file:packages/debug(6df2a564e81cc032c01b9011e0cc6d9d)':
     dependencies:
-      '@ember-data/model': file:packages/model(2de23c88a8c300dca037dfbbb7bba9b3)
+      '@ember-data/model': file:packages/model(2f08b1bd604f6cce397049ed21e31fce)
       '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
-      '@ember-data/store': file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
+      '@ember-data/store': file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
@@ -14428,26 +14430,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/debug@file:packages/debug(1761e67250ec2064a77715ad24d24371)':
+  '@ember-data/debug@file:packages/debug(840fe430b980e3544dbf09b53806ea0d)':
     dependencies:
-      '@ember-data/model': file:packages/model(6ed66525e24805f4167d443950cf8d28)
-      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/debug@file:packages/debug(3c4488df655673bee6548970bac9ced5)':
-    dependencies:
-      '@ember-data/model': file:packages/model(a757e3874bf1cbf9d4deaae542c95c68)
+      '@ember-data/model': file:packages/model(23d604913ef990bf67e23c6fad8d6a31)
       '@ember-data/request-utils': file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
-      '@ember-data/store': file:packages/store(c153d55c663e137d50d65695e10cc7e1)
+      '@ember-data/store': file:packages/store(1a73f1593c608471af73ba704170923c)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
@@ -14458,26 +14445,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/debug@file:packages/debug(7f152b03c997c95f1441e71a4aea5913)':
+  '@ember-data/debug@file:packages/debug(98ff3d18c429b6588e3521151ed9506a)':
     dependencies:
-      '@ember-data/model': file:packages/model(965988fbb16043525d12aaca044e3cab)
-      '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
-      '@ember-data/store': file:packages/store(867afdadd0634717f2814144a813000f)
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/debug@file:packages/debug(dcb073f83595d3904cc2b50faad617db)':
-    dependencies:
-      '@ember-data/model': file:packages/model(663b54de9b512efe997729c1b27f1019)
+      '@ember-data/model': file:packages/model(764dc834da7ec45afb6eee8a40702239)
       '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
@@ -14488,11 +14460,26 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/debug@file:packages/debug(e5c954c6a704d96554ea9a2c73d27738)':
+  '@ember-data/debug@file:packages/debug(a0ec188e0a01f3cad220a8c855ad44f5)':
     dependencies:
-      '@ember-data/model': file:packages/model(f4ff02b948fcc63f125db7a804b55428)
+      '@ember-data/model': file:packages/model(147553b0a53a74a578944c02fffdf02e)
+      '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
+      '@ember-data/store': file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/debug@file:packages/debug(cba9d2d06195261941565e1eaadc849a)':
+    dependencies:
+      '@ember-data/model': file:packages/model(cc762b12c5c802e634c08a54488bf402)
       '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
@@ -14503,9 +14490,9 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/graph@file:packages/graph(42cf1093c1d867c103c98f5f248623cf)':
+  '@ember-data/graph@file:packages/graph(0e0007db8340958cdddaf306d70f5c08)':
     dependencies:
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+      '@ember-data/store': file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
@@ -14515,13 +14502,37 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/graph@file:packages/graph(47b06ed5817314a8a41bd897ca6d0633)':
+  '@ember-data/graph@file:packages/graph(1988e180c0805d485b52f53913a6b5ee)':
     dependencies:
-      '@ember-data/store': file:packages/store(867afdadd0634717f2814144a813000f)
+      '@ember-data/store': file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
+      '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
+      '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
+      '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
+      ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/graph@file:packages/graph(2f3970f979a5bcdc56036cb8d3ef5fe0)':
+    dependencies:
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
       ember-source: 6.3.0(@glimmer/component@2.0.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/graph@file:packages/graph(30e2608e823c6d3f157a9dddaeabae62)':
+    dependencies:
+      '@ember-data/store': file:packages/store(1a73f1593c608471af73ba704170923c)
+      '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
+      '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
+      '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
+      ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -14539,35 +14550,53 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/graph@file:packages/graph(9593ad06fabf7e5115a4983944bc9f1c)':
+  '@ember-data/graph@file:packages/graph(a1670e960f653469a6e5cd309fdd011b)':
     dependencies:
-      '@ember-data/store': file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
-      '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
-      '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
-      '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
-      ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/graph@file:packages/graph(ff4b77fd5c962497e85bcfb6e807f3fe)':
+  '@ember-data/json-api@file:packages/json-api(06f304c44f4ab5ae511112828e948caa)':
     dependencies:
-      '@ember-data/store': file:packages/store(c153d55c663e137d50d65695e10cc7e1)
-      '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
-      '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
-      '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
-      ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
+      '@ember-data/graph': file:packages/graph(0e0007db8340958cdddaf306d70f5c08)
+      '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
+      '@ember-data/store': file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      fuse.js: 7.1.0
+      json-to-ast: 2.1.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/json-api@file:packages/json-api(46020de0037263bee94a91add557af19)':
+  '@ember-data/json-api@file:packages/json-api(812231e22ded84647161eeef91e55d1d)':
     dependencies:
-      '@ember-data/graph': file:packages/graph(9593ad06fabf7e5115a4983944bc9f1c)
+      '@ember-data/graph': file:packages/graph(30e2608e823c6d3f157a9dddaeabae62)
+      '@ember-data/request-utils': file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
+      '@ember-data/store': file:packages/store(1a73f1593c608471af73ba704170923c)
+      '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
+      '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
+      '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
+      fuse.js: 7.1.0
+      json-to-ast: 2.1.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/json-api@file:packages/json-api(be64f0619bf23da37ed1bd98df835563)':
+    dependencies:
+      '@ember-data/graph': file:packages/graph(1988e180c0805d485b52f53913a6b5ee)
       '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
-      '@ember-data/store': file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
+      '@ember-data/store': file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
@@ -14578,14 +14607,14 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/json-api@file:packages/json-api(5eb0a0db60c03e98bea4d954cb47187c)':
+  '@ember-data/json-api@file:packages/json-api(c012dbaa50943a60233de13f7afdb431)':
     dependencies:
-      '@ember-data/graph': file:packages/graph(ff4b77fd5c962497e85bcfb6e807f3fe)
-      '@ember-data/request-utils': file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
-      '@ember-data/store': file:packages/store(c153d55c663e137d50d65695e10cc7e1)
-      '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
-      '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
-      '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
+      '@ember-data/graph': file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
+      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
       fuse.js: 7.1.0
       json-to-ast: 2.1.0
     transitivePeerDependencies:
@@ -14593,11 +14622,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/json-api@file:packages/json-api(62f006c824c77856925379eaa88fda2b)':
+  '@ember-data/json-api@file:packages/json-api(df4ec260642df6134fdc68d76ccd5c52)':
     dependencies:
-      '@ember-data/graph': file:packages/graph(42cf1093c1d867c103c98f5f248623cf)
+      '@ember-data/graph': file:packages/graph(2f3970f979a5bcdc56036cb8d3ef5fe0)
       '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
@@ -14608,164 +14637,138 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/json-api@file:packages/json-api(aaa51ec56275043781b6e317a1b6c87e)':
+  '@ember-data/legacy-compat@file:packages/legacy-compat(1156b12af755d42b97126cf4ace3f85a)':
     dependencies:
-      '@ember-data/graph': file:packages/graph(47b06ed5817314a8a41bd897ca6d0633)
-      '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
-      '@ember-data/store': file:packages/store(867afdadd0634717f2814144a813000f)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      fuse.js: 7.1.0
-      json-to-ast: 2.1.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/json-api@file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)':
-    dependencies:
-      '@ember-data/graph': file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      fuse.js: 7.1.0
-      json-to-ast: 2.1.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/legacy-compat@file:packages/legacy-compat(1fb9ea20d3f98065db69bf1bd75921bb)':
-    dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
-      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@ember/test-waiters': 3.1.0(@babel/core@7.26.10)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
+      '@ember/test-waiters': 4.1.0(@babel/core@7.26.10)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
       ember-source: 6.3.0(@glimmer/component@2.0.0)
-    optionalDependencies:
-      '@ember-data/graph': file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
-      '@ember-data/json-api': file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/legacy-compat@file:packages/legacy-compat(2c65f8541a346f7b284e593a7472ff9e)':
+  '@ember-data/legacy-compat@file:packages/legacy-compat(336ee89166c67e5d1f7b6131d92e29e4)':
     dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@ember/test-waiters': 4.1.0(@babel/core@7.26.10)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
       ember-source: 6.3.0(@glimmer/component@2.0.0)
     optionalDependencies:
-      '@ember-data/graph': file:packages/graph(42cf1093c1d867c103c98f5f248623cf)
-      '@ember-data/json-api': file:packages/json-api(62f006c824c77856925379eaa88fda2b)
+      '@ember-data/graph': file:packages/graph(2f3970f979a5bcdc56036cb8d3ef5fe0)
+      '@ember-data/json-api': file:packages/json-api(df4ec260642df6134fdc68d76ccd5c52)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/legacy-compat@file:packages/legacy-compat(3760115784f64fcf3b7d918d0aad87c5)':
+  '@ember-data/legacy-compat@file:packages/legacy-compat(45bdb77033fe1c7735b6c08439c11db1)':
     dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
-      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@ember/test-waiters': 4.1.0(@babel/core@7.26.10)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/legacy-compat@file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)':
-    dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
-      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@ember/test-waiters': 4.1.0(@babel/core@7.26.10)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-    optionalDependencies:
-      '@ember-data/graph': file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
-      '@ember-data/json-api': file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/legacy-compat@file:packages/legacy-compat(a8538c7b5795e96a949d1e4ff943dd96)':
-    dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
-      '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
-      '@ember-data/store': file:packages/store(867afdadd0634717f2814144a813000f)
-      '@ember/test-waiters': 4.1.0(@babel/core@7.26.10)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-    optionalDependencies:
-      '@ember-data/graph': file:packages/graph(47b06ed5817314a8a41bd897ca6d0633)
-      '@ember-data/json-api': file:packages/json-api(aaa51ec56275043781b6e317a1b6c87e)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/legacy-compat@file:packages/legacy-compat(e5b893555cfc0ca1db68c1276aafbb3a)':
-    dependencies:
-      '@ember-data/request': file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
-      '@ember-data/request-utils': file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
-      '@ember-data/store': file:packages/store(c153d55c663e137d50d65695e10cc7e1)
+      '@ember-data/request': file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
+      '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
+      '@ember-data/store': file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
       '@ember/test-waiters': 4.1.0(6b9ab74b27cee7278587f29987a61ec9)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
       ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
     optionalDependencies:
-      '@ember-data/graph': file:packages/graph(ff4b77fd5c962497e85bcfb6e807f3fe)
-      '@ember-data/json-api': file:packages/json-api(5eb0a0db60c03e98bea4d954cb47187c)
+      '@ember-data/graph': file:packages/graph(1988e180c0805d485b52f53913a6b5ee)
+      '@ember-data/json-api': file:packages/json-api(be64f0619bf23da37ed1bd98df835563)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/legacy-compat@file:packages/legacy-compat(f526cd0e174ef5e43334c75f8f74d0c3)':
+  '@ember-data/legacy-compat@file:packages/legacy-compat(624b704660c29664a472d97c231c90f4)':
     dependencies:
-      '@ember-data/request': file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
-      '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
-      '@ember-data/store': file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
+      '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
+      '@ember-data/store': file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
+      '@ember/test-waiters': 4.1.0(@babel/core@7.26.10)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+    optionalDependencies:
+      '@ember-data/graph': file:packages/graph(0e0007db8340958cdddaf306d70f5c08)
+      '@ember-data/json-api': file:packages/json-api(06f304c44f4ab5ae511112828e948caa)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/legacy-compat@file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)':
+    dependencies:
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
+      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
+      '@ember/test-waiters': 4.1.0(@babel/core@7.26.10)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+    optionalDependencies:
+      '@ember-data/graph': file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
+      '@ember-data/json-api': file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/legacy-compat@file:packages/legacy-compat(cee7afd9aaf3d390a4ebda799e336bba)':
+    dependencies:
+      '@ember-data/request': file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
+      '@ember-data/request-utils': file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
+      '@ember-data/store': file:packages/store(1a73f1593c608471af73ba704170923c)
       '@ember/test-waiters': 4.1.0(6b9ab74b27cee7278587f29987a61ec9)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
       ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
     optionalDependencies:
-      '@ember-data/graph': file:packages/graph(9593ad06fabf7e5115a4983944bc9f1c)
-      '@ember-data/json-api': file:packages/json-api(46020de0037263bee94a91add557af19)
+      '@ember-data/graph': file:packages/graph(30e2608e823c6d3f157a9dddaeabae62)
+      '@ember-data/json-api': file:packages/json-api(812231e22ded84647161eeef91e55d1d)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/model@file:packages/model(2de23c88a8c300dca037dfbbb7bba9b3)':
+  '@ember-data/model@file:packages/model(147553b0a53a74a578944c02fffdf02e)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(f526cd0e174ef5e43334c75f8f74d0c3)
-      '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
-      '@ember-data/store': file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(624b704660c29664a472d97c231c90f4)
+      '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
+      '@ember-data/store': file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
+      '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      ember-cli-string-utils: 1.1.0
+      ember-cli-test-info: 1.0.0
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+      inflection: 3.0.2
+    optionalDependencies:
+      '@ember-data/graph': file:packages/graph(0e0007db8340958cdddaf306d70f5c08)
+      '@ember-data/json-api': file:packages/json-api(06f304c44f4ab5ae511112828e948caa)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/model@file:packages/model(23d604913ef990bf67e23c6fad8d6a31)':
+    dependencies:
+      '@ember-data/legacy-compat': file:packages/legacy-compat(cee7afd9aaf3d390a4ebda799e336bba)
+      '@ember-data/request-utils': file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
+      '@ember-data/store': file:packages/store(1a73f1593c608471af73ba704170923c)
       '@ember-data/tracking': file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
@@ -14776,103 +14779,18 @@ snapshots:
       ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
       inflection: 3.0.2
     optionalDependencies:
-      '@ember-data/graph': file:packages/graph(9593ad06fabf7e5115a4983944bc9f1c)
-      '@ember-data/json-api': file:packages/json-api(46020de0037263bee94a91add557af19)
+      '@ember-data/graph': file:packages/graph(30e2608e823c6d3f157a9dddaeabae62)
+      '@ember-data/json-api': file:packages/json-api(812231e22ded84647161eeef91e55d1d)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/model@file:packages/model(54c1baeabf96d08a315ebe62a865c45e)':
+  '@ember-data/model@file:packages/model(2f08b1bd604f6cce397049ed21e31fce)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(3760115784f64fcf3b7d918d0aad87c5)
-      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-cli-string-utils: 1.1.0
-      ember-cli-test-info: 1.0.0
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-      inflection: 3.0.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/model@file:packages/model(663b54de9b512efe997729c1b27f1019)':
-    dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(2c65f8541a346f7b284e593a7472ff9e)
-      '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
-      '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-cli-string-utils: 1.1.0
-      ember-cli-test-info: 1.0.0
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-      inflection: 3.0.2
-    optionalDependencies:
-      '@ember-data/graph': file:packages/graph(42cf1093c1d867c103c98f5f248623cf)
-      '@ember-data/json-api': file:packages/json-api(62f006c824c77856925379eaa88fda2b)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/model@file:packages/model(6ed66525e24805f4167d443950cf8d28)':
-    dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
-      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-cli-string-utils: 1.1.0
-      ember-cli-test-info: 1.0.0
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-      inflection: 3.0.2
-    optionalDependencies:
-      '@ember-data/graph': file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
-      '@ember-data/json-api': file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/model@file:packages/model(965988fbb16043525d12aaca044e3cab)':
-    dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(a8538c7b5795e96a949d1e4ff943dd96)
-      '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
-      '@ember-data/store': file:packages/store(867afdadd0634717f2814144a813000f)
-      '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-cli-string-utils: 1.1.0
-      ember-cli-test-info: 1.0.0
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-      inflection: 3.0.2
-    optionalDependencies:
-      '@ember-data/graph': file:packages/graph(47b06ed5817314a8a41bd897ca6d0633)
-      '@ember-data/json-api': file:packages/json-api(aaa51ec56275043781b6e317a1b6c87e)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/model@file:packages/model(a757e3874bf1cbf9d4deaae542c95c68)':
-    dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(e5b893555cfc0ca1db68c1276aafbb3a)
-      '@ember-data/request-utils': file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
-      '@ember-data/store': file:packages/store(c153d55c663e137d50d65695e10cc7e1)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(45bdb77033fe1c7735b6c08439c11db1)
+      '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
+      '@ember-data/store': file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
       '@ember-data/tracking': file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
@@ -14883,18 +14801,18 @@ snapshots:
       ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
       inflection: 3.0.2
     optionalDependencies:
-      '@ember-data/graph': file:packages/graph(ff4b77fd5c962497e85bcfb6e807f3fe)
-      '@ember-data/json-api': file:packages/json-api(5eb0a0db60c03e98bea4d954cb47187c)
+      '@ember-data/graph': file:packages/graph(1988e180c0805d485b52f53913a6b5ee)
+      '@ember-data/json-api': file:packages/json-api(be64f0619bf23da37ed1bd98df835563)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/model@file:packages/model(f4ff02b948fcc63f125db7a804b55428)':
+  '@ember-data/model@file:packages/model(764dc834da7ec45afb6eee8a40702239)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(1fb9ea20d3f98065db69bf1bd75921bb)
-      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(336ee89166c67e5d1f7b6131d92e29e4)
+      '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
@@ -14905,8 +14823,49 @@ snapshots:
       ember-source: 6.3.0(@glimmer/component@2.0.0)
       inflection: 3.0.2
     optionalDependencies:
-      '@ember-data/graph': file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
-      '@ember-data/json-api': file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
+      '@ember-data/graph': file:packages/graph(2f3970f979a5bcdc56036cb8d3ef5fe0)
+      '@ember-data/json-api': file:packages/json-api(df4ec260642df6134fdc68d76ccd5c52)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/model@file:packages/model(90d971b4545ba8070799a40f738f8c67)':
+    dependencies:
+      '@ember-data/legacy-compat': file:packages/legacy-compat(1156b12af755d42b97126cf4ace3f85a)
+      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
+      '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      ember-cli-string-utils: 1.1.0
+      ember-cli-test-info: 1.0.0
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+      inflection: 3.0.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/model@file:packages/model(cc762b12c5c802e634c08a54488bf402)':
+    dependencies:
+      '@ember-data/legacy-compat': file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
+      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
+      '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      ember-cli-string-utils: 1.1.0
+      ember-cli-test-info: 1.0.0
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+      inflection: 3.0.2
+    optionalDependencies:
+      '@ember-data/graph': file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
+      '@ember-data/json-api': file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -14975,7 +14934,17 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/request@file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)':
+  '@ember-data/request@file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)':
+    dependencies:
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/request@file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)':
     dependencies:
       '@ember/test-waiters': 4.1.0(6b9ab74b27cee7278587f29987a61ec9)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
@@ -14986,7 +14955,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/request@file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)':
+  '@ember-data/request@file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)':
     dependencies:
       '@ember/test-waiters': 4.1.0(@babel/core@7.26.10)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
@@ -14997,10 +14966,10 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/rest@file:packages/rest(baf0f64f9531bf85e9d52c971d8e7a5e)':
+  '@ember-data/rest@file:packages/rest(6b9b24bf6a6289f16eeb5d7c639110f0)':
     dependencies:
       '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
@@ -15011,29 +14980,11 @@ snapshots:
 
   '@ember-data/rfc395-data@0.0.4': {}
 
-  '@ember-data/serializer@file:packages/serializer(8a485f142e721bd8e8ddc8f57ab0664f)':
+  '@ember-data/serializer@file:packages/serializer(0149a020c8ebae6df594d3e8b68ee55c)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(1fb9ea20d3f98065db69bf1bd75921bb)
-      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-cli-path-utils: 1.0.0
-      ember-cli-string-utils: 1.1.0
-      ember-cli-test-info: 1.0.0
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/serializer@file:packages/serializer(a1ade22c0d9fabfd25a112954714fca6)':
-    dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(2c65f8541a346f7b284e593a7472ff9e)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(336ee89166c67e5d1f7b6131d92e29e4)
       '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
@@ -15047,11 +14998,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/serializer@file:packages/serializer(ab2e4a5aa0a0e23281aeaf28af98851a)':
+  '@ember-data/serializer@file:packages/serializer(49ff1b1d7550a62c46c5d2638a5a71a9)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(a8538c7b5795e96a949d1e4ff943dd96)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(624b704660c29664a472d97c231c90f4)
       '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
-      '@ember-data/store': file:packages/store(867afdadd0634717f2814144a813000f)
+      '@ember-data/store': file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
@@ -15065,11 +15016,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/serializer@file:packages/serializer(ca4d98ec16688a8c2f8c6501f71ec954)':
+  '@ember-data/serializer@file:packages/serializer(5cb5ff665b4e39b3cda054479ba93d07)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(f526cd0e174ef5e43334c75f8f74d0c3)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(45bdb77033fe1c7735b6c08439c11db1)
       '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
-      '@ember-data/store': file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
+      '@ember-data/store': file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
@@ -15083,11 +15034,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/serializer@file:packages/serializer(e7323f9941802118256d786fcb3ac6a7)':
+  '@ember-data/serializer@file:packages/serializer(dc6100bd319db7fe3385ad6ce162d6ca)':
     dependencies:
-      '@ember-data/legacy-compat': file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
       '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
@@ -15101,29 +15052,29 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/store@file:packages/store(867afdadd0634717f2814144a813000f)':
+  '@ember-data/store@file:packages/store(1a73f1593c608471af73ba704170923c)':
     dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
-      '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
-      '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/store@file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)':
-    dependencies:
-      '@ember-data/request': file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
-      '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
+      '@ember-data/request': file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
+      '@ember-data/request-utils': file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
       '@ember-data/tracking': file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
       ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/store@file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)':
+    dependencies:
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
+      '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
+      '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -15143,10 +15094,24 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/store@file:packages/store(c153d55c663e137d50d65695e10cc7e1)':
+  '@ember-data/store@file:packages/store(9f6a5ed80a09cb037a21bc3805915870)':
     dependencies:
-      '@ember-data/request': file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
-      '@ember-data/request-utils': file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
+      '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
+      '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/store@file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)':
+    dependencies:
+      '@ember-data/request': file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
+      '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
       '@ember-data/tracking': file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
@@ -15157,9 +15122,9 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/store@file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)':
+  '@ember-data/store@file:packages/store(cbce6a688577e3cca5b72a1a86187833)':
     dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
       '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
@@ -15193,9 +15158,60 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(35ada83424e0f2346a371359b37a502c)':
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(00ef1b17b5212b0c25904aba6070b774)':
     dependencies:
-      '@ember-data/store': file:packages/store(c153d55c663e137d50d65695e10cc7e1)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      chalk: 4.1.2
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+      semver: 7.7.1
+    optionalDependencies:
+      qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(05411543d61297c3f7c54af6bbfb9cef)':
+    dependencies:
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      chalk: 4.1.2
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+      semver: 7.7.1
+    optionalDependencies:
+      '@warp-drive/diagnostic': file:packages/diagnostic(0769fea203e98132438ae0defbe77024)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(32c9c6a3717b91bfe1b822bba0666ea1)':
+    dependencies:
+      '@ember-data/store': file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      chalk: 4.1.2
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+      semver: 7.7.1
+    optionalDependencies:
+      qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(4909b868b92ffb9324e72748d98ee796)':
+    dependencies:
+      '@ember-data/store': file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
       '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(fec7b898d328e52e91c0cf874617af3a)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
@@ -15211,9 +15227,77 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(382493c97e706a2708c204ee69f0995b)':
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(4cfa4c99cb2783cd2fd1f3d5850c3f1a)':
     dependencies:
-      '@ember-data/store': file:packages/store(c153d55c663e137d50d65695e10cc7e1)
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      chalk: 4.1.2
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+      semver: 7.7.1
+    optionalDependencies:
+      '@warp-drive/diagnostic': file:packages/diagnostic(0769fea203e98132438ae0defbe77024)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(4ed69374fc1604d8010e397e5a816a8a)':
+    dependencies:
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      chalk: 4.1.2
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+      semver: 7.7.1
+    optionalDependencies:
+      qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
+      testem: 3.11.0(patch_hash=cf147865cff81f2d0f3ed51d274f9fdee7b4ad675a902248aa317c07272fbea5)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(762baab7aa84058ebe30cd66794b7ae9)':
+    dependencies:
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      chalk: 4.1.2
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(95bd88ecb233dd27f26167b5ba7f077a)':
+    dependencies:
+      '@ember-data/store': file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
+      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
+      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      chalk: 4.1.2
+      ember-source: 6.3.0(@glimmer/component@2.0.0)
+      semver: 7.7.1
+    optionalDependencies:
+      qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
+      testem: 3.11.0(patch_hash=cf147865cff81f2d0f3ed51d274f9fdee7b4ad675a902248aa317c07272fbea5)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(ba1e9eb77ffa2ae4bbad7229cb008208)':
+    dependencies:
+      '@ember-data/store': file:packages/store(1a73f1593c608471af73ba704170923c)
       '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(fec7b898d328e52e91c0cf874617af3a)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
@@ -15228,134 +15312,15 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(5093d4034d2acc72a7e37e665125bc0e)':
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(d9d0015f89bb4e75b3a204db4be6b20d)':
     dependencies:
-      '@ember-data/store': file:packages/store(867afdadd0634717f2814144a813000f)
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      chalk: 4.1.2
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-      semver: 7.7.1
-    optionalDependencies:
-      qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(56c520f81855c43f264af56b00547e03)':
-    dependencies:
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      chalk: 4.1.2
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-      semver: 7.7.1
-    optionalDependencies:
-      '@warp-drive/diagnostic': file:packages/diagnostic(0769fea203e98132438ae0defbe77024)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(5dee8d774f0af37bbd4814e6d237057e)':
-    dependencies:
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      chalk: 4.1.2
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-      semver: 7.7.1
-    optionalDependencies:
-      qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(9c10511edce4e6e36faab49c56f7b2b9)':
-    dependencies:
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      chalk: 4.1.2
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-      semver: 7.7.1
-    optionalDependencies:
-      '@warp-drive/diagnostic': file:packages/diagnostic(0769fea203e98132438ae0defbe77024)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(bc56851d569ecd327e50502bbc1a8cfa)':
-    dependencies:
-      '@ember-data/store': file:packages/store(867afdadd0634717f2814144a813000f)
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      chalk: 4.1.2
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-      semver: 7.7.1
-    optionalDependencies:
-      qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
-      testem: 3.11.0(patch_hash=cf147865cff81f2d0f3ed51d274f9fdee7b4ad675a902248aa317c07272fbea5)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(c6526e773d1bf99de2cc1fe6001ecc05)':
-    dependencies:
-      '@ember-data/store': file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
+      '@ember-data/store': file:packages/store(1a73f1593c608471af73ba704170923c)
       '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(fec7b898d328e52e91c0cf874617af3a)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
       chalk: 4.1.2
       ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
-      semver: 7.7.1
-    optionalDependencies:
-      qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
-      testem: 3.11.0(patch_hash=cf147865cff81f2d0f3ed51d274f9fdee7b4ad675a902248aa317c07272fbea5)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(e1d286e1c1606b6c285b6b412084952f)':
-    dependencies:
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      chalk: 4.1.2
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
-      semver: 7.7.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(ed1f7452463997d3ebd3802a92f753b7)':
-    dependencies:
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(93bf39883543dd297f5f9130e917efdd)
-      '@embroider/macros': 1.16.12(@babel/core@7.26.10)
-      '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
-      chalk: 4.1.2
-      ember-source: 6.3.0(@glimmer/component@2.0.0)
       semver: 7.7.1
     optionalDependencies:
       qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
@@ -17728,11 +17693,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/ember@file:packages/ember(730e82fd9c47f3811ef579a4e3f96233)':
+  '@warp-drive/ember@file:packages/ember(e9b3a1cbd3fd9b2cc7e2e94e1e658c85)':
     dependencies:
-      '@ember-data/request': file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
+      '@ember-data/request': file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
       '@ember-data/request-utils': file:packages/request-utils(f1344c43f56730eefe18cf43866ada59)
-      '@ember-data/store': file:packages/store(c153d55c663e137d50d65695e10cc7e1)
+      '@ember-data/store': file:packages/store(1a73f1593c608471af73ba704170923c)
       '@ember-data/tracking': file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@ember/test-waiters': 4.1.0(6b9ab74b27cee7278587f29987a61ec9)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
@@ -17744,11 +17709,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/ember@file:packages/ember(758f8a2428f0029b3186442228b41a16)':
+  '@warp-drive/ember@file:packages/ember(f4560fd7cfb7997691592dd42eaf17e3)':
     dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember/test-waiters': 4.1.0(@babel/core@7.26.10)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
@@ -17760,11 +17725,11 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/experiments@file:packages/experiments(e6beeeb8a57db3ecafe80df4e7d03450)':
+  '@warp-drive/experiments@file:packages/experiments(a37d574ca5e395e4e576e686436d1ddc)':
     dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
@@ -17773,19 +17738,19 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/holodeck@file:packages/holodeck(00776259705c76f6a3a760b857d69332)':
+  '@warp-drive/holodeck@file:packages/holodeck(2512a32e8b0d95cd49b7ddd0bab86275)':
     dependencies:
-      '@ember-data/request': file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@hono/node-server': 1.14.0(hono@4.7.5)
-      '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
+      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
       chalk: 5.4.1
       hono: 4.7.5
 
-  '@warp-drive/holodeck@file:packages/holodeck(2f1166d4bf91c5372f8d84fc36fca6ca)':
+  '@warp-drive/holodeck@file:packages/holodeck(50787cdd3314abb44d598f29619a3bcb)':
     dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+      '@ember-data/request': file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
       '@hono/node-server': 1.14.0(hono@4.7.5)
-      '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
+      '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
       chalk: 5.4.1
       hono: 4.7.5
 
@@ -17990,49 +17955,49 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@warp-drive/schema-record@file:packages/schema-record(0d93bbe52cb9c8f81438b6f252a1221d)':
+  '@warp-drive/schema-record@file:packages/schema-record(024b0f285640a155b166c6bf5eb24a63)':
     dependencies:
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.26.10)
       '@warp-drive/core-types': file:packages/core-types(@babel/core@7.26.10)
       ember-source: 6.3.0(@glimmer/component@2.0.0)
     optionalDependencies:
-      '@ember-data/model': file:packages/model(6ed66525e24805f4167d443950cf8d28)
+      '@ember-data/model': file:packages/model(cc762b12c5c802e634c08a54488bf402)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/schema-record@file:packages/schema-record(4f5c28a5050731017617e2b370d59d94)':
+  '@warp-drive/schema-record@file:packages/schema-record(ac0d71b42e8688b776338d7abcce1756)':
     dependencies:
-      '@ember-data/request': file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
-      '@ember-data/store': file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
+      '@ember-data/request': file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
+      '@ember-data/store': file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
       '@ember-data/tracking': file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
       ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
     optionalDependencies:
-      '@ember-data/model': file:packages/model(2de23c88a8c300dca037dfbbb7bba9b3)
+      '@ember-data/model': file:packages/model(2f08b1bd604f6cce397049ed21e31fce)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/schema-record@file:packages/schema-record(b7fd5c4610be5760615fa8352f5222df)':
+  '@warp-drive/schema-record@file:packages/schema-record(ade3c39e1ebef73bd1b4c5d760dc29c8)':
     dependencies:
-      '@ember-data/request': file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
-      '@ember-data/store': file:packages/store(c153d55c663e137d50d65695e10cc7e1)
+      '@ember-data/request': file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
+      '@ember-data/store': file:packages/store(1a73f1593c608471af73ba704170923c)
       '@ember-data/tracking': file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/build-config': file:packages/build-config(6b9ab74b27cee7278587f29987a61ec9)
       '@warp-drive/core-types': file:packages/core-types(6b9ab74b27cee7278587f29987a61ec9)
       ember-source: 6.3.0(807cfcd3020ea8ad8edb1795de9ad08f)
     optionalDependencies:
-      '@ember-data/model': file:packages/model(a757e3874bf1cbf9d4deaae542c95c68)
+      '@ember-data/model': file:packages/model(23d604913ef990bf67e23c6fad8d6a31)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -20483,16 +20448,16 @@ snapshots:
 
   ember-data@file:packages/-ember-data(1d6e4f9248e166cc60951041d7055852):
     dependencies:
-      '@ember-data/adapter': file:packages/adapter(ca4d98ec16688a8c2f8c6501f71ec954)
-      '@ember-data/debug': file:packages/debug(048445d491a2ee697a4277144616d4d7)
-      '@ember-data/graph': file:packages/graph(9593ad06fabf7e5115a4983944bc9f1c)
-      '@ember-data/json-api': file:packages/json-api(46020de0037263bee94a91add557af19)
-      '@ember-data/legacy-compat': file:packages/legacy-compat(f526cd0e174ef5e43334c75f8f74d0c3)
-      '@ember-data/model': file:packages/model(2de23c88a8c300dca037dfbbb7bba9b3)
-      '@ember-data/request': file:packages/request(6a8de57fb39c7c8949898f6f14ae1fdb)
+      '@ember-data/adapter': file:packages/adapter(5cb5ff665b4e39b3cda054479ba93d07)
+      '@ember-data/debug': file:packages/debug(6df2a564e81cc032c01b9011e0cc6d9d)
+      '@ember-data/graph': file:packages/graph(1988e180c0805d485b52f53913a6b5ee)
+      '@ember-data/json-api': file:packages/json-api(be64f0619bf23da37ed1bd98df835563)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(45bdb77033fe1c7735b6c08439c11db1)
+      '@ember-data/model': file:packages/model(2f08b1bd604f6cce397049ed21e31fce)
+      '@ember-data/request': file:packages/request(cf9ff2a698b78c0a36c4a22cb9e0368a)
       '@ember-data/request-utils': file:packages/request-utils(de61eeb412b6fedef9cbe7ab3ce562fd)
-      '@ember-data/serializer': file:packages/serializer(ca4d98ec16688a8c2f8c6501f71ec954)
-      '@ember-data/store': file:packages/store(8a2d6dcc0b5160aedae17a39f5819526)
+      '@ember-data/serializer': file:packages/serializer(5cb5ff665b4e39b3cda054479ba93d07)
+      '@ember-data/store': file:packages/store(a70d5c75590cc99dad9ad93e1ab51719)
       '@ember-data/tracking': file:packages/tracking(f1344c43f56730eefe18cf43866ada59)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(6b9ab74b27cee7278587f29987a61ec9)
@@ -20512,16 +20477,16 @@ snapshots:
 
   ember-data@file:packages/-ember-data(26bca8ed48f01ac332b64674e206eeee):
     dependencies:
-      '@ember-data/adapter': file:packages/adapter(a1ade22c0d9fabfd25a112954714fca6)
-      '@ember-data/debug': file:packages/debug(dcb073f83595d3904cc2b50faad617db)
-      '@ember-data/graph': file:packages/graph(42cf1093c1d867c103c98f5f248623cf)
-      '@ember-data/json-api': file:packages/json-api(62f006c824c77856925379eaa88fda2b)
-      '@ember-data/legacy-compat': file:packages/legacy-compat(2c65f8541a346f7b284e593a7472ff9e)
-      '@ember-data/model': file:packages/model(663b54de9b512efe997729c1b27f1019)
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+      '@ember-data/adapter': file:packages/adapter(0149a020c8ebae6df594d3e8b68ee55c)
+      '@ember-data/debug': file:packages/debug(98ff3d18c429b6588e3521151ed9506a)
+      '@ember-data/graph': file:packages/graph(2f3970f979a5bcdc56036cb8d3ef5fe0)
+      '@ember-data/json-api': file:packages/json-api(df4ec260642df6134fdc68d76ccd5c52)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(336ee89166c67e5d1f7b6131d92e29e4)
+      '@ember-data/model': file:packages/model(764dc834da7ec45afb6eee8a40702239)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils': file:packages/request-utils(db7e1e396756e03871d2f588a53fca79)
-      '@ember-data/serializer': file:packages/serializer(a1ade22c0d9fabfd25a112954714fca6)
-      '@ember-data/store': file:packages/store(e198dafb0e59c5ceb93567e827e19b8a)
+      '@ember-data/serializer': file:packages/serializer(0149a020c8ebae6df594d3e8b68ee55c)
+      '@ember-data/store': file:packages/store(cbce6a688577e3cca5b72a1a86187833)
       '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
@@ -20541,16 +20506,16 @@ snapshots:
 
   ember-data@file:packages/-ember-data(366978058d3aedd6c2f5b937b6f76106):
     dependencies:
-      '@ember-data/adapter': file:packages/adapter(ab2e4a5aa0a0e23281aeaf28af98851a)
-      '@ember-data/debug': file:packages/debug(7f152b03c997c95f1441e71a4aea5913)
-      '@ember-data/graph': file:packages/graph(47b06ed5817314a8a41bd897ca6d0633)
-      '@ember-data/json-api': file:packages/json-api(aaa51ec56275043781b6e317a1b6c87e)
-      '@ember-data/legacy-compat': file:packages/legacy-compat(a8538c7b5795e96a949d1e4ff943dd96)
-      '@ember-data/model': file:packages/model(965988fbb16043525d12aaca044e3cab)
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+      '@ember-data/adapter': file:packages/adapter(49ff1b1d7550a62c46c5d2638a5a71a9)
+      '@ember-data/debug': file:packages/debug(a0ec188e0a01f3cad220a8c855ad44f5)
+      '@ember-data/graph': file:packages/graph(0e0007db8340958cdddaf306d70f5c08)
+      '@ember-data/json-api': file:packages/json-api(06f304c44f4ab5ae511112828e948caa)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(624b704660c29664a472d97c231c90f4)
+      '@ember-data/model': file:packages/model(147553b0a53a74a578944c02fffdf02e)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils': file:packages/request-utils(06d407bf65139b9ce15d21fb9daee195)
-      '@ember-data/serializer': file:packages/serializer(ab2e4a5aa0a0e23281aeaf28af98851a)
-      '@ember-data/store': file:packages/store(867afdadd0634717f2814144a813000f)
+      '@ember-data/serializer': file:packages/serializer(49ff1b1d7550a62c46c5d2638a5a71a9)
+      '@ember-data/store': file:packages/store(9f6a5ed80a09cb037a21bc3805915870)
       '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
@@ -20570,16 +20535,16 @@ snapshots:
 
   ember-data@file:packages/-ember-data(48d72b54fb19e3ebebeaf790f4040d6a):
     dependencies:
-      '@ember-data/adapter': file:packages/adapter(e7323f9941802118256d786fcb3ac6a7)
-      '@ember-data/debug': file:packages/debug(1761e67250ec2064a77715ad24d24371)
-      '@ember-data/graph': file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
-      '@ember-data/json-api': file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
-      '@ember-data/legacy-compat': file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
-      '@ember-data/model': file:packages/model(6ed66525e24805f4167d443950cf8d28)
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+      '@ember-data/adapter': file:packages/adapter(dc6100bd319db7fe3385ad6ce162d6ca)
+      '@ember-data/debug': file:packages/debug(cba9d2d06195261941565e1eaadc849a)
+      '@ember-data/graph': file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
+      '@ember-data/json-api': file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
+      '@ember-data/model': file:packages/model(cc762b12c5c802e634c08a54488bf402)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/serializer': file:packages/serializer(e7323f9941802118256d786fcb3ac6a7)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+      '@ember-data/serializer': file:packages/serializer(dc6100bd319db7fe3385ad6ce162d6ca)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)
@@ -20599,16 +20564,16 @@ snapshots:
 
   ember-data@file:packages/-ember-data(c91eabc240b5554ad38b7ffbab52a86d):
     dependencies:
-      '@ember-data/adapter': file:packages/adapter(e7323f9941802118256d786fcb3ac6a7)
-      '@ember-data/debug': file:packages/debug(1761e67250ec2064a77715ad24d24371)
-      '@ember-data/graph': file:packages/graph(48a8e98c3326df445a8b5f0c42274556)
-      '@ember-data/json-api': file:packages/json-api(c98cf8cd1024d9cd8ce05b0ed1173f9f)
-      '@ember-data/legacy-compat': file:packages/legacy-compat(41c3fc39cd2b286956705894421a74ec)
-      '@ember-data/model': file:packages/model(6ed66525e24805f4167d443950cf8d28)
-      '@ember-data/request': file:packages/request(a27b62f034eb7f7c405fb1ae64d3764e)
+      '@ember-data/adapter': file:packages/adapter(dc6100bd319db7fe3385ad6ce162d6ca)
+      '@ember-data/debug': file:packages/debug(cba9d2d06195261941565e1eaadc849a)
+      '@ember-data/graph': file:packages/graph(a1670e960f653469a6e5cd309fdd011b)
+      '@ember-data/json-api': file:packages/json-api(c012dbaa50943a60233de13f7afdb431)
+      '@ember-data/legacy-compat': file:packages/legacy-compat(a0d739c6f69dd78cd94154b4fde77eb0)
+      '@ember-data/model': file:packages/model(cc762b12c5c802e634c08a54488bf402)
+      '@ember-data/request': file:packages/request(dd9be7e7e88b25e309856ff6e0a8c90d)
       '@ember-data/request-utils': file:packages/request-utils(afb989cb1a1da16ca1e783f2ffc555f0)
-      '@ember-data/serializer': file:packages/serializer(e7323f9941802118256d786fcb3ac6a7)
-      '@ember-data/store': file:packages/store(8bc4dbfb1950a249ddc44cd41b2cefd1)
+      '@ember-data/serializer': file:packages/serializer(dc6100bd319db7fe3385ad6ce162d6ca)
+      '@ember-data/store': file:packages/store(22f36de19f9593cdc921ab5f5b1c0aa4)
       '@ember-data/tracking': file:packages/tracking(afb989cb1a1da16ca1e783f2ffc555f0)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.12(@babel/core@7.26.10)

--- a/tests/ember-data__adapter/package.json
+++ b/tests/ember-data__adapter/package.json
@@ -40,7 +40,7 @@
     "@ember-data/unpublished-test-infra": "workspace:*",
     "@ember/optional-features": "^2.2.0",
     "@ember/test-helpers": "5.2.0",
-    "@ember/test-waiters": "^3.1.0 || ^4.0.0",
+    "@ember/test-waiters": "^4.1.0",
     "@embroider/addon-shim": "^1.9.0",
     "@glimmer/component": "^2.0.0",
     "@glimmer/tracking": "^1.1.2",


### PR DESCRIPTION
attempts shifting install of test-waiters to avoid 3.1 to address recent rise in timeouts