### PR TITLE
fix: dont notify during population if the array is a collection

### DIFF
--- a/packages/store/src/-private/managers/record-array-manager.ts
+++ b/packages/store/src/-private/managers/record-array-manager.ts
@@ -332,9 +332,11 @@ export class RecordArrayManager {
     fastPush(source, identifiers);
     this._set.set(array, new Set(identifiers));
 
-    notifyArray(array);
-    array.meta = payload?.meta || null;
-    array.links = payload?.links || null;
+    if (!isCollection(array)) {
+      notifyArray(array);
+      array.meta = payload?.meta || null;
+      array.links = payload?.links || null;
+    }
     array.isLoaded = true;
 
     disassociate(this._identifiers, array, old);


### PR DESCRIPTION
This resolves #9945, confirmed in the reproduction via patch