### PR TITLE
perf: fix teardown perf

### DIFF
--- a/packages/model/src/-private/belongs-to.ts
+++ b/packages/model/src/-private/belongs-to.ts
@@ -94,6 +94,10 @@ function _belongsTo<T, Async extends boolean>(
       return support.getBelongsTo(key);
     },
     set<R extends MinimalLegacyRecord>(this: R, key: string, value: unknown) {
+      assert(`Cannot set belongsTo relationship ${key} on a destroyed record`, !this.isDestroying && !this.isDestroyed);
+      if (this.isDestroying || this.isDestroyed) {
+        return null;
+      }
       const support = lookupLegacySupport(this);
       if (DEBUG) {
         if (['currentState'].includes(key)) {

--- a/packages/model/src/-private/model.ts
+++ b/packages/model/src/-private/model.ts
@@ -179,12 +179,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     this.___recordState?.destroy();
     const store = storeFor(this)!;
     store.notifications.unsubscribe(this.___private_notifications);
-    // Legacy behavior is to notify the relationships on destroy
-    // such that they "clear". It's uncertain this behavior would
-    // be good for a new model paradigm, likely cheaper and safer
-    // to simply not notify, for this reason the store does not itself
-    // notify individual changes once the delete has been signaled,
-    // this decision is left to model instances.
+
     LEGACY_SUPPORT.get(this as unknown as MinimalLegacyRecord)?.destroy();
     LEGACY_SUPPORT.delete(this as unknown as MinimalLegacyRecord);
     LEGACY_SUPPORT.delete(identifier);

--- a/packages/model/src/-private/model.ts
+++ b/packages/model/src/-private/model.ts
@@ -185,12 +185,6 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     // to simply not notify, for this reason the store does not itself
     // notify individual changes once the delete has been signaled,
     // this decision is left to model instances.
-
-    this.eachRelationship((name, meta) => {
-      if (meta.kind === 'belongsTo') {
-        this.notifyPropertyChange(name);
-      }
-    });
     LEGACY_SUPPORT.get(this as unknown as MinimalLegacyRecord)?.destroy();
     LEGACY_SUPPORT.delete(this as unknown as MinimalLegacyRecord);
     LEGACY_SUPPORT.delete(identifier);

--- a/tests/main/tests/integration/records/create-record-test.js
+++ b/tests/main/tests/integration/records/create-record-test.js
@@ -85,7 +85,8 @@ module('Store.createRecord() coverage', function (hooks) {
 
     pet.unloadRecord();
     await settled();
-    assert.strictEqual(pet.owner, null, 'Shen no longer has an owner');
+
+    assert.strictEqual(pet.owner, chris, 'We leave shen behind disconnected');
     // check that the relationship has been dissolved
     pets = chris.pets.slice().map((pet) => pet.name);
     assert.deepEqual(pets, [], 'Chris no longer has any pets');


### PR DESCRIPTION
A few of our recent efforts (reactivity hooks, granular patches / signal updates to relationships and attrs) have surprisingly shown perf regressions in the `unloadAll` scenario. This scenario mostly matters for test suite performance and not app performance, but this PR is one of a few that seeks to diagnose underlying causes and fix/improve the perf in that area.

This particular change removes notification of belongsTo relationships during record teardown, resulting in their values being stale if accessed. This has been a long standing thing we've thought of changing and has some risks for test suites so I'm making this as a stand alone change in case we need to revert it.

I suspect quite a bit of the regression was that this notification resulted in a bunch of work that we weren't doing before due to other improvements in the graph. Profiling still shows a series of over-notifications during teardown - so there will likely be followups to this.