### PR TITLE
feat: unlock universal 🌌

### DIFF
--- a/packages/ember/src/install.ts
+++ b/packages/ember/src/install.ts
@@ -2,6 +2,7 @@ import { SignalHooks } from '@ember-data/store/-private';
 import { tagForProperty } from '@ember/-internals/metal';
 import { consumeTag, createCache, dirtyTag, getValue, track, updateTag, type UpdatableTag } from '@glimmer/validator';
 
+import { _backburner } from '@ember/runloop';
 // import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
 import { DEPRECATE_COMPUTED_CHAINS } from '@warp-drive/build-config/deprecations';
 import { setupSignals } from '@ember-data/store/configure';
@@ -66,6 +67,10 @@ export function buildSignalConfig(options: {
         const memo = createCache(fn);
         return () => getValue(memo) as F;
       }
+    },
+    willSyncFlushWatchers: () => {
+      //@ts-expect-error
+      return !!_backburner.currentInstance && _backburner._autorun !== true;
     },
   } satisfies SignalHooks<Tag | [Tag, Tag, Tag]>;
 }

--- a/packages/ember/vite.config.mjs
+++ b/packages/ember/vite.config.mjs
@@ -12,6 +12,7 @@ export const externals = [
   '@glimmer/validator',
   '@ember/object/compat',
   '@ember/-internals/metal',
+  '@ember/runloop',
 ];
 export const entryPoints = ['./src/index.ts', './src/install.ts'];
 

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -38,7 +38,6 @@
     }
   },
   "peerDependencies": {
-    "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0",
     "@ember-data/store": "workspace:*",
     "@warp-drive/core-types": "workspace:*"
   },

--- a/packages/graph/src/-private/-utils.ts
+++ b/packages/graph/src/-private/-utils.ts
@@ -1,4 +1,4 @@
-import { inspect, warn } from '@ember/debug';
+import { warn } from '@ember/debug';
 
 import type { Store } from '@ember-data/store/-private';
 import { peekCache } from '@ember-data/store/-private';
@@ -75,6 +75,32 @@ export function assertValidRelationshipPayload(
       }
     }
   }
+}
+
+function inspect(value: unknown) {
+  const type = typeof value;
+  if (value === null) {
+    return 'null';
+  }
+  if (type !== 'object') {
+    return type;
+  }
+  if (Array.isArray(value)) {
+    return 'Array';
+  }
+  if (value instanceof Date) {
+    return 'Date';
+  }
+  if (value instanceof RegExp) {
+    return 'RegExp';
+  }
+  if (value instanceof Map) {
+    return 'Map';
+  }
+  if (value instanceof Set) {
+    return 'Set';
+  }
+  return 'object';
 }
 
 export function isNew(identifier: StableRecordIdentifier): boolean {

--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -52,7 +52,6 @@
     "version": 2
   },
   "peerDependencies": {
-    "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0",
     "@ember/string": "^3.1.1 || ^4.0.0",
     "@warp-drive/core-types": "workspace:*",
     "ember-inflector": "^4.0.2 || ^5.0.0 || ^6.0.0"

--- a/packages/schema-record/package.json
+++ b/packages/schema-record/package.json
@@ -43,7 +43,6 @@
     }
   },
   "peerDependencies": {
-    "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0",
     "@ember-data/request": "workspace:*",
     "@ember-data/model": "workspace:*",
     "@ember-data/store": "workspace:*",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -51,6 +51,9 @@
   "peerDependenciesMeta": {
     "@ember-data/tracking": {
       "optional": true
+    },
+    "ember-source": {
+      "optional": true
     }
   },
   "devDependencies": {

--- a/packages/store/src/-private/new-core-tmp/reactivity/configure.ts
+++ b/packages/store/src/-private/new-core-tmp/reactivity/configure.ts
@@ -64,6 +64,7 @@ export interface SignalHooks<T = SignalRef> {
   consumeSignal: (signal: T) => void;
   notifySignal: (signal: T) => void;
   createMemo: <F>(obj: object, key: string | symbol, fn: () => F) => () => F;
+  willSyncFlushWatchers: () => boolean;
 }
 
 export interface HooksOptions {
@@ -128,6 +129,12 @@ export function createMemo<T>(object: object, key: string | symbol, fn: () => T)
   const signalHooks: SignalHooks | null = peekTransient('signalHooks');
   assert(`Signal hooks not configured`, signalHooks);
   return signalHooks.createMemo(object, key, fn);
+}
+
+export function willSyncFlushWatchers(): boolean {
+  const signalHooks: SignalHooks | null = peekTransient('signalHooks');
+  assert(`Signal hooks not configured`, signalHooks);
+  return signalHooks.willSyncFlushWatchers();
 }
 
 if (DEPRECATE_TRACKING_PACKAGE) {

--- a/packages/store/vite.config.mjs
+++ b/packages/store/vite.config.mjs
@@ -1,6 +1,6 @@
 import { createConfig } from '@warp-drive/internal-config/vite/config.js';
 
-export const externals = ['@ember/-internals/metal', '@ember/runloop', '@ember/object', '@ember/debug'];
+export const externals = ['@ember/-internals/metal', '@ember/object', '@ember/debug'];
 export const entryPoints = ['./src/index.ts', './src/types.ts', './src/-private.ts', './src/configure.ts'];
 
 export default createConfig(

--- a/packages/tracking/eslint.config.mjs
+++ b/packages/tracking/eslint.config.mjs
@@ -2,6 +2,7 @@
 import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
+import { externals } from './vite.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [
@@ -11,7 +12,7 @@ export default [
   // browser (js/ts) ================
   typescript.browser({
     srcDirs: ['src'],
-    allowedImports: ['@glimmer/tracking/primitives/cache', '@ember/-internals/metal', '@glimmer/validator'],
+    allowedImports: externals,
   }),
 
   // node (module) ================

--- a/packages/tracking/src/index.ts
+++ b/packages/tracking/src/index.ts
@@ -1,4 +1,5 @@
 import { tagForProperty } from '@ember/-internals/metal';
+import { _backburner } from '@ember/runloop';
 import { consumeTag, createCache, dirtyTag, getValue, track, type UpdatableTag, updateTag } from '@glimmer/validator';
 
 // import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
@@ -64,6 +65,10 @@ export function buildSignalConfig(options: {
         const memo = createCache(fn);
         return () => getValue(memo) as F;
       }
+    },
+    willSyncFlushWatchers: () => {
+      //@ts-expect-error
+      return !!_backburner.currentInstance && _backburner._autorun !== true;
     },
   };
 }

--- a/packages/tracking/vite.config.mjs
+++ b/packages/tracking/vite.config.mjs
@@ -5,6 +5,7 @@ export const externals = [
   '@ember/-internals/metal',
   '@glimmer/tracking/primitives/cache',
   '@ember/object/compat',
+  '@ember/runloop',
 ];
 export const entryPoints = ['src/index.ts'];
 


### PR DESCRIPTION
🎉 With this PR, WarpDrive becomes usable by any signals-compatible framework or library.

To do so still requires the following constraints:

- Use SchemaRecord in Polaris Mode only (no Legacy Mode)
- Use zero legacy features (no model, legacy-compat, adapter, serializer packages)
- Do not install ember-inspector support (`@ember-data/debug`)
- Set all deprecations (especially for store extending EmberObject) as resolved. This is most easily done via `compatWith: 5.5`

- There are 3 uses of `await import()` to wrap async calls with `@ember/test-waiters`. Either use a version of this package that does not require ember-source, or set requests to deactivate test waiter behaviors to avoid the async import.

- There are 16 uses of `warn` and `deprecate` from `@ember/debug`, we will eventually remove these but they can also be compiled to framework-agnostic code via a babel plugin: https://github.com/emberjs/data/issues/9651

- `ember-source` and `@ember-data/tracking` are still optional peers of `@ember-data/store`, you will want to set your package manager to not install them

- You will need to configure the reactivity system for the framework of your choosing (or to use TC39 Signals), see Ember's here: https://github.com/emberjs/data/blob/main/packages/ember/src/install.ts See the interface required here: https://github.com/emberjs/data/blob/main/packages/store/src/-private/new-core-tmp/reactivity/configure.ts#L62
