### PR TITLE
chore: improve output of typedoc

### DIFF
--- a/contributing/writing-api-docs.md
+++ b/contributing/writing-api-docs.md
@@ -47,10 +47,8 @@ When compiling the API documentation, several categories of comments will be ign
 
 - `@internal` - signifies internal documentation for contributors for a non-public API
 - `@feature` - signifies documentation for an unreleased feature gated by a canary flag
-- `@typedoc` - signifies typescript-only (in-editor) documentation that should not be compiled into the API docs
 
-Additionally, use of the following tags will cause a doc comment to be ignored due to intended use primarily being docs
-written for in-editor experience similar to `@typedoc`
+Additionally, use of the following tags will cause a doc comment to be ignored due to intended use primarily being docs written for in-editor experience.
 
 - `@see`
 - `@link`
@@ -211,7 +209,6 @@ Classes are documented using `@class`.
  * @main @ember-data/adapter/json-api
  * @public
  * @constructor
- * @extends RESTAdapter
 */
 ```
 
@@ -226,7 +223,6 @@ Note: the use of non-typescript types here means that these doc comments cannot/
 /**
  * Some documentation
  * 
- * @method myMethod
  * @public
  * @param {AType} myParam explanation of the param
  * @return {AnotherType} explanation of the return value
@@ -266,8 +262,6 @@ imported from `@ember-data/store` would be done like the below
  * Description of the function
  *
  * @public
- * @static
- * @for @ember-data/store
  * @param {Object} record a record instance previously obstained from the store.
  * @return {StableRecordIdentifier}
  */

--- a/docs-viewer/docs.warp-drive.io/.vitepress/config.mts
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/config.mts
@@ -111,20 +111,15 @@ export default defineConfig({
       { text: 'API', link: '/api' },
     ],
 
-    sidebar: {
-      // This sidebar gets displayed when a user
-      // is on `api-docs` directory.
-      '/api/': [
-        {
-          text: 'API Documentation',
-          items: typedocSidebar,
-        },
-      ],
-
-      // This sidebar gets displayed when a user
-      // is on `guides` directory.
-      '/guide/': GuidesStructure.paths,
-    },
+    sidebar: [
+      ...GuidesStructure.paths,
+      {
+        text: 'API Docs',
+        collapsed: true,
+        link: '/api/',
+        items: typedocSidebar,
+      },
+    ],
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/emberjs/data' },

--- a/docs-viewer/package.json
+++ b/docs-viewer/package.json
@@ -13,9 +13,9 @@
     "_tsc": "./src/tsc.ts"
   },
   "scripts": {
-    "prepare": "bun src/prepare-website.ts; typedoc;",
+    "prepare": "bun src/prepare-website.ts",
     "dev": "vitepress dev docs.warp-drive.io",
-    "build": "vitepress build docs.warp-drive.io",
+    "build": " typedoc; vitepress build docs.warp-drive.io",
     "preview": "vitepress preview docs.warp-drive.io"
   },
   "dependencies": {

--- a/docs-viewer/package.json
+++ b/docs-viewer/package.json
@@ -13,9 +13,9 @@
     "_tsc": "./src/tsc.ts"
   },
   "scripts": {
-    "prepare": "bun src/prepare-website.ts",
-    "dev": "typedoc; vitepress dev docs.warp-drive.io",
-    "build": "typedoc; vitepress build docs.warp-drive.io",
+    "prepare": "bun src/prepare-website.ts; typedoc;",
+    "dev": "vitepress dev docs.warp-drive.io",
+    "build": "vitepress build docs.warp-drive.io",
     "preview": "vitepress preview docs.warp-drive.io"
   },
   "dependencies": {
@@ -28,6 +28,7 @@
     "@types/debug": "4.1.12",
     "typedoc": "^0.28.4",
     "typedoc-plugin-markdown": "^4.6.3",
+    "typedoc-plugin-no-inherit": "^1.6.1",
     "typedoc-vitepress-theme": "^1.1.2",
     "vitepress-plugin-llms": "^1.1.4",
     "vitepress-plugin-group-icons": "^1.5.2",

--- a/docs-viewer/typedoc.cjs
+++ b/docs-viewer/typedoc.cjs
@@ -29,14 +29,23 @@ const config = {
   packageOptions: {
     entryFileName: 'index',
     readme: 'none',
+    excludeInternal: true,
+    // inheritNone: true,
   },
-  plugin: [require.resolve('typedoc-plugin-markdown'), require.resolve('typedoc-vitepress-theme')],
+  plugin: [
+    require.resolve('typedoc-plugin-markdown'),
+    require.resolve('typedoc-vitepress-theme'),
+    require.resolve('typedoc-plugin-no-inherit'),
+  ],
   out: './docs.warp-drive.io/api',
   sidebar: {
     pretty: true,
   },
   readme: 'none',
   tsconfig: '../tsconfig.json',
+  excludeInternal: true,
+  useCodeBlocks: true,
+  // inheritNone: true,
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "rimraf": "^6.0.1",
     "semver": "^7.7.1",
     "silent-error": "^1.1.1",
+    "typedoc": "^0.28.4",
     "typescript": "^5.8.3",
     "url": "^0.11.4",
     "yuidocjs": "^0.10.2",

--- a/packages/-warp-drive/src/-private/shared/parse-args.ts
+++ b/packages/-warp-drive/src/-private/shared/parse-args.ts
@@ -1,27 +1,22 @@
 export type Command = {
   /**
    * Human Label
-   * @typedoc
    */
   name: string;
   /**
    * Command Name
-   * @typedoc
    */
   cmd: string;
   /**
    * Command Description
-   * @typedoc
    */
   description: string;
   /**
    * Aliases
-   * @typedoc
    */
   alt?: string[];
   /**
    * Examples
-   * @typedoc
    */
   example?: string | string[];
   overview?: string;
@@ -365,7 +360,7 @@ export function getCommands<T extends Record<string, { default?: boolean; alt?: 
     commands.set(cmd, cmd);
     commands.set(command_config[key].cmd, cmd);
     if (command_config[cmd].alt) {
-      command_config[cmd].alt!.forEach((alt: string) => {
+      command_config[cmd].alt.forEach((alt: string) => {
         const alternate = normalizeFlag(alt);
         if (commands.has(alternate) && commands.get(alternate) !== cmd) {
           throw new Error(`Duplicate command alias ${alternate} for ${cmd} and ${commands.get(alternate)}`);

--- a/packages/active-record/README.md
+++ b/packages/active-record/README.md
@@ -68,11 +68,3 @@ URLs are stable. The same query will produce the same URL every time, even if th
 the query or values in an array changes.
 
 URLs follow the most common ActiveRecord format (underscored pluralized resource types).
-
-### Available Builders
-
-- [createRecord]()
-- [deleteRecord]()
-- [findRecord]()
-- [query]()
-- [updateRecord]()

--- a/packages/active-record/src/-private/builders/find-record.ts
+++ b/packages/active-record/src/-private/builders/find-record.ts
@@ -63,10 +63,7 @@ export type FindRecordResultDocument<T> = Omit<SingleResourceDataDocument<T>, 'd
  * const data = await store.request(options);
  * ```
  *
- * @method findRecord
  * @public
- * @static
- * @for @ember-data/active-record/request
  * @param identifier
  * @param options
  */

--- a/packages/active-record/src/-private/builders/query.ts
+++ b/packages/active-record/src/-private/builders/query.ts
@@ -49,10 +49,7 @@ import { copyForwardUrlOptions, extractCacheOptions } from './-utils';
  * const data = await store.request(options);
  * ```
  *
- * @method query
  * @public
- * @static
- * @for @ember-data/active-record/request
  * @param identifier
  * @param query
  * @param options

--- a/packages/active-record/src/-private/builders/save-record.ts
+++ b/packages/active-record/src/-private/builders/save-record.ts
@@ -68,10 +68,7 @@ function isExisting(identifier: StableRecordIdentifier): identifier is StableExi
  * const data = await store.request(options);
  * ```
  *
- * @method deleteRecord
  * @public
- * @static
- * @for @ember-data/active-record/request
  * @param record
  * @param options
  */
@@ -141,10 +138,7 @@ export function deleteRecord(record: unknown, options: ConstrainedRequestOptions
  * const data = await store.request(options);
  * ```
  *
- * @method createRecord
  * @public
- * @static
- * @for @ember-data/active-record/request
  * @param record
  * @param options
  */
@@ -216,10 +210,7 @@ export function createRecord(record: unknown, options: ConstrainedRequestOptions
  * const data = await store.request(options);
  * ```
  *
- * @method updateRecord
  * @public
- * @static
- * @for @ember-data/active-record/request
  * @param record
  * @param options
  */

--- a/packages/active-record/src/request.ts
+++ b/packages/active-record/src/request.ts
@@ -1,62 +1,67 @@
 /**
- * <p align="center">
-  <img
-    class="project-logo"
-    src="https://raw.githubusercontent.com/emberjs/data/4612c9354e4c54d53327ec2cf21955075ce21294/ember-data-logo-light.svg#gh-light-mode-only"
-    alt="EmberData"
-    width="240px"
-    title="EmberData"
-  />
-</p>
-
-This package provides utilities for working with [ActiveRecord](https://guides.rubyonrails.org/active_record_basics.html#convention-over-configuration-in-active-record) APIs with [*Ember***Data**](https://github.com/emberjs/data/).
-
-## Installation
-
-Install using your javascript package manager of choice. For instance with [pnpm](https://pnpm.io/)
-
-```no-highlight
-pnpm add @ember-data/active-record
-```
-
-## Usage
-
-Request builders are functions that produce [Fetch Options](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
-They take a few contextual inputs about the request you want to make, abstracting away the gnarlier details.
-
-For instance, to fetch a resource from your API
-
-```ts
-import { findRecord } from '@ember-data/active-record/request';
-
-const options = findRecord('ember-developer', '1', { include: ['pets', 'friends'] });
-
-/\*
-  => {
-    url: 'https://api.example.com/v1/ember_developers/1?include=friends,pets',
-    method: 'GET',
-    headers: <Headers>, // 'Content-Type': 'application/json;charset=utf-8'
-    op: 'findRecord';
-    records: [{ type: 'ember-developer', id: '1' }]
-  }
-*\/
-```
-
-Request builder output may be used with either `requestManager.request` or `store.request`.
-
-URLs are stable. The same query will produce the same URL every time, even if the order of keys in
-the query or values in an array changes.
-
-URLs follow the most common ActiveRecord format (underscored pluralized resource types).
-
-### Available Builders
-
-- [createRecord](https://api.emberjs.com/ember-data/release/functions/@ember-data%2Factive-record/createRecord)
-- [deleteRecord](https://api.emberjs.com/ember-data/release/functions/@ember-data%2Factive-record/deleteRecord)
-- [findRecord](https://api.emberjs.com/ember-data/release/functions/@ember-data%2Factive-record/findRecord)
-- [query](https://api.emberjs.com/ember-data/release/functions/@ember-data%2Factive-record/query)
-- [updateRecord](https://api.emberjs.com/ember-data/release/functions/@ember-data%2Factive-record/updateRecord)
-
+ *
+ *
+ *This package provides utilities for working with [ActiveRecord](https://guides.rubyonrails.org/active_record_basics.html#convention-over-configuration-in-active-record) APIs.
+ *
+ * ## Installation
+ *
+ * Install using your javascript package manager of choice. For instance with [pnpm](https://pnpm.io/)
+ *
+ * ::: code-group
+ *
+ * ```sh [pnpm]
+ * pnpm add -E @ember-data/active-record
+ * ```
+ *
+ * ```sh [npm]
+ * npm add -E @ember-data/active-record
+ * ```
+ *
+ * ```sh [yarn]
+ * yarn add -E @ember-data/active-record
+ * ```
+ *
+ * ```sh [bun]
+ * bun add --exact @ember-data/active-record
+ * ```
+ *
+ * :::
+ *
+ * ## Usage
+ *
+ * Request builders are functions that produce [Fetch Options](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
+ * They take a few contextual inputs about the request you want to make, abstracting away the gnarlier details.
+ *
+ * For instance, to construct a request that would fetch a resource from your API:
+ *
+ * ```ts
+ * import { findRecord } from '@ember-data/active-record/request';
+ *
+ * const options = findRecord('ember-developer', '1', { include: ['pets', 'friends'] });
+ * ```
+ *
+ * This would produce the following request object:
+ *
+ * ```js
+ * {
+ *   url: 'https://api.example.com/v1/ember_developers/1?include=friends,pets',
+ *   method: 'GET',
+ *   headers: <Headers>, // 'Accept': 'application/json;charset=utf-8'
+ *   op: 'findRecord';
+ *   records: [{ type: 'ember-developer', id: '1' }]
+ * }
+ * ```
+ *
+ * Request builder output may be used with either `requestManager.request` or `store.request`.
+ *
+ * ```ts
+ * const data = await store.request(options);
+ * ```
+ *
+ * URLs are stable. The same query will produce the same URL every time, even if the order of keys in
+ * the query or values in an array changes.
+ *
+ * URLs follow the most common ActiveRecord format (underscored pluralized resource types).
  *
  * @module
  */

--- a/packages/adapter/src/-private/build-url-mixin.ts
+++ b/packages/adapter/src/-private/build-url-mixin.ts
@@ -323,7 +323,7 @@ function _buildURL(this: MixtBuildURLMixin, modelName: string | null | undefined
 
    Example:
 
-   ```app/adapters/user.js
+   ```js [app/adapters/user.js]
    import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
    export default class ApplicationAdapter extends JSONAPIAdapter {
@@ -350,7 +350,7 @@ function urlForFindRecord(this: MixtBuildURLMixin, id: string, modelName: string
 
    Example:
 
-   ```app/adapters/comment.js
+   ```js [app/adapters/comment.js]
    import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
    export default class ApplicationAdapter extends JSONAPIAdapter {
@@ -375,7 +375,7 @@ function urlForFindAll(this: MixtBuildURLMixin, modelName: string, snapshots: Sn
 
    Example:
 
-   ```app/adapters/application.js
+   ```js [app/adapters/application.js]
    import RESTAdapter from '@ember-data/adapter/rest';
 
    export default class ApplicationAdapter extends RESTAdapter {
@@ -405,7 +405,7 @@ function urlForQuery(this: MixtBuildURLMixin, query: Record<string, unknown>, mo
 
    Example:
 
-   ```app/adapters/application.js
+   ```js [app/adapters/application.js]
    import RESTAdapter from '@ember-data/adapter/rest';
 
    export default class ApplicationAdapter extends RESTAdapter {
@@ -432,7 +432,7 @@ function urlForQueryRecord(this: MixtBuildURLMixin, query: Record<string, unknow
 
    Example:
 
-   ```app/adapters/application.js
+   ```js [app/adapters/application.js]
    import RESTAdapter from '@ember-data/adapter/rest';
 
    export default class ApplicationAdapter extends RESTAdapter {
@@ -459,7 +459,7 @@ function urlForFindMany(this: MixtBuildURLMixin, ids: string[], modelName: strin
 
    Example:
 
-   ```app/adapters/application.js
+   ```js [app/adapters/application.js]
    import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
    export default class ApplicationAdapter extends JSONAPIAdapter {
@@ -486,7 +486,7 @@ function urlForFindHasMany(this: MixtBuildURLMixin, id: string, modelName: strin
 
    Example:
 
-   ```app/adapters/application.js
+   ```js [app/adapters/application.js]
    import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
    export default class ApplicationAdapter extends JSONAPIAdapter {
@@ -513,7 +513,7 @@ function urlForFindBelongsTo(this: MixtBuildURLMixin, id: string, modelName: str
 
    Example:
 
-   ```app/adapters/application.js
+   ```js [app/adapters/application.js]
    import RESTAdapter from '@ember-data/adapter/rest';
 
    export default class ApplicationAdapter extends RESTAdapter {
@@ -537,7 +537,7 @@ function urlForCreateRecord(this: MixtBuildURLMixin, modelName: string, snapshot
 
    Example:
 
-   ```app/adapters/application.js
+   ```js [app/adapters/application.js]
    import RESTAdapter from '@ember-data/adapter/rest';
 
    export default class ApplicationAdapter extends RESTAdapter {
@@ -562,7 +562,7 @@ function urlForUpdateRecord(this: MixtBuildURLMixin, id: string, modelName: stri
 
    Example:
 
-   ```app/adapters/application.js
+   ```js [app/adapters/application.js]
    import RESTAdapter from '@ember-data/adapter/rest';
 
    export default class ApplicationAdapter extends RESTAdapter {
@@ -633,7 +633,7 @@ function urlPrefix(this: MixtBuildURLMixin, path?: string | null, parentURL?: st
     For example, if you have an object `LineItem` with an
     endpoint of `/line_items/`.
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import RESTAdapter from '@ember-data/adapter/rest';
     import { undesrcore, pluralize } from '<app-name>/utils/string-utils';
 

--- a/packages/adapter/src/-private/build-url-mixin.ts
+++ b/packages/adapter/src/-private/build-url-mixin.ts
@@ -149,7 +149,6 @@ export interface MixtBuildURLMixin extends BuildURLMixin {
     When called by `RESTAdapter.findMany()` the `id` and `snapshot` parameters
     will be arrays of ids and snapshots.
 
-    @method buildURL
     @public
     @param {String} modelName
     @param {(String|Array|Object)} id single id or array of ids or query
@@ -286,7 +285,6 @@ function buildURL(
 }
 
 /**
-    @method _buildURL
     @private
     @param {String} modelName
     @param {String} id
@@ -336,7 +334,6 @@ function _buildURL(this: MixtBuildURLMixin, modelName: string | null | undefined
    }
    ```
 
-   @method urlForFindRecord
    @public
    @param {String} id
    @param {String} modelName
@@ -364,7 +361,6 @@ function urlForFindRecord(this: MixtBuildURLMixin, id: string, modelName: string
    }
    ```
 
-   @method urlForFindAll
     @public
    @param {String} modelName
    @param {SnapshotRecordArray} snapshot
@@ -395,7 +391,6 @@ function urlForFindAll(this: MixtBuildURLMixin, modelName: string, snapshots: Sn
    }
    ```
 
-   @method urlForQuery
     @public
    @param {Object} query
    @param {String} modelName
@@ -421,7 +416,6 @@ function urlForQuery(this: MixtBuildURLMixin, query: Record<string, unknown>, mo
    }
    ```
 
-   @method urlForQueryRecord
     @public
    @param {Object} query
    @param {String} modelName
@@ -449,7 +443,6 @@ function urlForQueryRecord(this: MixtBuildURLMixin, query: Record<string, unknow
    }
    ```
 
-   @method urlForFindMany
     @public
    @param {Array} ids
    @param {String} modelName
@@ -477,7 +470,6 @@ function urlForFindMany(this: MixtBuildURLMixin, ids: string[], modelName: strin
    }
    ```
 
-   @method urlForFindHasMany
     @public
    @param {String} id
    @param {String} modelName
@@ -505,7 +497,6 @@ function urlForFindHasMany(this: MixtBuildURLMixin, id: string, modelName: strin
    }
    ```
 
-   @method urlForFindBelongsTo
     @public
    @param {String} id
    @param {String} modelName
@@ -532,7 +523,6 @@ function urlForFindBelongsTo(this: MixtBuildURLMixin, id: string, modelName: str
    }
    ```
 
-   @method urlForCreateRecord
     @public
    @param {String} modelName
    @param {Snapshot} snapshot
@@ -557,7 +547,6 @@ function urlForCreateRecord(this: MixtBuildURLMixin, modelName: string, snapshot
    }
    ```
 
-   @method urlForUpdateRecord
     @public
    @param {String} id
    @param {String} modelName
@@ -583,7 +572,6 @@ function urlForUpdateRecord(this: MixtBuildURLMixin, id: string, modelName: stri
    }
    ```
 
-   @method urlForDeleteRecord
     @public
    @param {String} id
    @param {String} modelName
@@ -595,7 +583,6 @@ function urlForDeleteRecord(this: MixtBuildURLMixin, id: string, modelName: stri
 }
 
 /**
-    @method urlPrefix
     @private
     @param {String} path
     @param {String} parentURL
@@ -657,7 +644,6 @@ function urlPrefix(this: MixtBuildURLMixin, path?: string | null, parentURL?: st
     }
     ```
 
-    @method pathForType
     @public
     @param {String} modelName
     @return {String} path

--- a/packages/adapter/src/error.js
+++ b/packages/adapter/src/error.js
@@ -21,7 +21,7 @@ import { getOrSetGlobal } from '@warp-drive/core-types/-private';
   external API exclusively used HTTP `503 Service Unavailable` to indicate
   it was closed for maintenance:
 
-  ```app/adapters/maintenance-error.js
+  ```js [app/adapters/maintenance-error.js]
   import AdapterError from '@ember-data/adapter/error';
 
   export default AdapterError.extend({ message: "Down for maintenance." });
@@ -29,7 +29,7 @@ import { getOrSetGlobal } from '@warp-drive/core-types/-private';
 
   This error would then be returned by an adapter's `handleResponse` method:
 
-  ```app/adapters/application.js
+  ```js [app/adapters/application.js]
   import JSONAPIAdapter from '@ember-data/adapter/json-api';
   import MaintenanceError from './maintenance-error';
 
@@ -47,7 +47,7 @@ import { getOrSetGlobal } from '@warp-drive/core-types/-private';
   And can then be detected in an application and used to send the user to an
   `under-maintenance` route:
 
-  ```app/routes/application.js
+  ```js [app/routes/application.js]
   import MaintenanceError from '../adapters/maintenance-error';
 
   export default class ApplicationRoute extends Route {
@@ -129,7 +129,7 @@ function extend(ParentErrorClass, defaultMessage) {
   the property name. For example, if you had a Post model that
   looked like this.
 
-  ```app/models/post.js
+  ```js [app/models/post.js]
   import Model, { attr } from '@ember-data/model';
 
   export default class PostModel extends Model {
@@ -142,7 +142,7 @@ function extend(ParentErrorClass, defaultMessage) {
   `content` properties your adapter could return a promise that
   rejects with a `InvalidError` object that looks like this:
 
-  ```app/adapters/post.js
+  ```js [app/adapters/post.js]
   import RSVP from 'RSVP';
   import RESTAdapter from '@ember-data/adapter/rest';
   import { InvalidError } from '@ember-data/adapter/error';
@@ -188,7 +188,7 @@ InvalidError.prototype.code = 'InvalidError';
   An example use case would be to warn the user to check their internet
   connection if an adapter operation has timed out:
 
-  ```app/routes/application.js
+  ```js [app/routes/application.js]
   import { TimeoutError } from '@ember-data/adapter/error';
 
   export default class ApplicationRoute extends Route {
@@ -232,7 +232,7 @@ AbortError.prototype.code = 'AbortError';
   An example use case would be to redirect the user to a login route if a
   request is unauthorized:
 
-  ```app/routes/application.js
+  ```js [app/routes/application.js]
   import { UnauthorizedError } from '@ember-data/adapter/error';
 
   export default class ApplicationRoute extends Route {
@@ -282,7 +282,7 @@ ForbiddenError.prototype.code = 'ForbiddenError';
   An example use case would be to detect if the user has entered a route
   for a specific model that does not exist. For example:
 
-  ```app/routes/post.js
+  ```js [app/routes/post.js]
   import { NotFoundError } from '@ember-data/adapter/error';
 
   export default class PostRoute extends Route {

--- a/packages/adapter/src/error.js
+++ b/packages/adapter/src/error.js
@@ -172,7 +172,6 @@ function extend(ParentErrorClass, defaultMessage) {
 
   @class InvalidError
   @public
-  @extends AdapterError
 */
 // TODO @deprecate extractError documentation
 export const InvalidError = getOrSetGlobal(
@@ -208,7 +207,6 @@ InvalidError.prototype.code = 'InvalidError';
 
   @class TimeoutError
   @public
-  @extends AdapterError
 */
 export const TimeoutError = getOrSetGlobal('TimeoutError', extend(AdapterError, 'The adapter operation timed out'));
 TimeoutError.prototype.code = 'TimeoutError';
@@ -221,7 +219,6 @@ TimeoutError.prototype.code = 'TimeoutError';
 
   @class AbortError
   @public
-  @extends AdapterError
 */
 export const AbortError = getOrSetGlobal('AbortError', extend(AdapterError, 'The adapter operation was aborted'));
 AbortError.prototype.code = 'AbortError';
@@ -254,7 +251,6 @@ AbortError.prototype.code = 'AbortError';
 
   @class UnauthorizedError
   @public
-  @extends AdapterError
 */
 export const UnauthorizedError = getOrSetGlobal(
   'UnauthorizedError',
@@ -271,7 +267,6 @@ UnauthorizedError.prototype.code = 'UnauthorizedError';
 
   @class ForbiddenError
   @public
-  @extends AdapterError
 */
 export const ForbiddenError = getOrSetGlobal(
   'ForbiddenError',
@@ -310,7 +305,6 @@ ForbiddenError.prototype.code = 'ForbiddenError';
 
   @class NotFoundError
   @public
-  @extends AdapterError
 */
 export const NotFoundError = getOrSetGlobal(
   'NotFoundError',
@@ -327,7 +321,6 @@ NotFoundError.prototype.code = 'NotFoundError';
 
   @class ConflictError
   @public
-  @extends AdapterError
 */
 export const ConflictError = getOrSetGlobal(
   'ConflictError',
@@ -342,7 +335,6 @@ ConflictError.prototype.code = 'ConflictError';
 
   @class ServerError
   @public
-  @extends AdapterError
 */
 export const ServerError = getOrSetGlobal(
   'ServerError',

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -118,7 +118,7 @@
   that make use of `options` to specify the desired format when making a request, then forwards to the
   request to the desired adapter or serializer as needed.
 
-  ```app/adapters/application.js
+  ```js [app/adapters/application.js]
   export default class Adapter extends EmberObject {
     findRecord(store, schema, id, snapshot) {
       let { apiVersion } = snapshot.adapterOptions;
@@ -211,7 +211,7 @@ const service = s.service ?? s.inject;
 
   Create a new subclass of `Adapter` in the `app/adapters` folder:
 
-  ```app/adapters/application.js
+  ```js [app/adapters/application.js]
   import Adapter from '@ember-data/adapter';
 
   export default Adapter.extend({
@@ -222,7 +222,7 @@ const service = s.service ?? s.inject;
   Model-specific adapters can be created by putting your adapter
   class in an `app/adapters/` + `model-name` + `.js` file of the application.
 
-  ```app/adapters/post.js
+  ```js [app/adapters/post.js]
   import Adapter from '@ember-data/adapter';
 
   export default Adapter.extend({
@@ -267,7 +267,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
 
     Here is an example of the `findRecord` implementation:
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter from '@ember-data/adapter';
     import RSVP from 'RSVP';
     import $ from 'jquery';
@@ -304,7 +304,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
 
     Example
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter from '@ember-data/adapter';
     import RSVP from 'RSVP';
     import $ from 'jquery';
@@ -346,7 +346,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
 
     Example
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter from '@ember-data/adapter';
     import RSVP from 'RSVP';
     import $ from 'jquery';
@@ -391,7 +391,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
 
     Example
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter, { BuildURLMixin } from '@ember-data/adapter';
     import RSVP from 'RSVP';
     import $ from 'jquery';
@@ -461,7 +461,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
 
     Example
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter from '@ember-data/adapter';
 
     export default class ApplicationAdapter extends Adapter {
@@ -496,7 +496,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
 
     Example
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter from '@ember-data/adapter';
     import RSVP from 'RSVP';
     import $ from 'jquery';
@@ -551,7 +551,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
 
     Example
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter from '@ember-data/adapter';
     import RSVP from 'RSVP';
     import $ from 'jquery';
@@ -599,7 +599,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
 
     Example
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter from '@ember-data/adapter';
     import RSVP from 'RSVP';
     import $ from 'jquery';
@@ -666,7 +666,7 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     requests to find multiple records at once if coalesceFindRequests
     is true.
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter from '@ember-data/adapter';
     import RSVP from 'RSVP';
     import $ from 'jquery';

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -252,7 +252,6 @@ const service = s.service ?? s.inject;
 
   @class Adapter
   @public
-  @extends Ember.EmberObject
 */
 export default class Adapter extends EmberObject implements MinimumAdapterInterface {
   @service declare store: Store;
@@ -286,7 +285,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     }
     ```
 
-    @method findRecord
     @param {Store} store
     @param {Model} type
     @param {String} id
@@ -324,7 +322,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     }
     ```
 
-    @method findAll
     @param {Store} store
     @param {Model} type
     @param {null} neverSet a value is never provided to this argument
@@ -367,7 +364,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     }
     ```
 
-    @method query
     @param {Store} store
     @param {Model} type
     @param {Object} query
@@ -413,7 +409,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     }
     ```
 
-    @method queryRecord
     @param {Store} store
     @param {subclass of Model} type
     @param {Object} query
@@ -453,7 +448,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     }
     ```
 
-    @method generateIdForRecord
     @param {Store} store
     @param {Model} type   the Model class of the record
     @param {Object} inputProperties a hash of properties to set on the
@@ -480,7 +474,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     }
     ```
 
-    @method serialize
     @param {Snapshot} snapshot
     @param {Object}   options
     @return {Object} serialized snapshot
@@ -529,7 +522,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     }
     ```
 
-    @method createRecord
     @param {Store} store
     @param {Model} type   the Model class of the record
     @param {Snapshot} snapshot
@@ -586,7 +578,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     }
     ```
 
-    @method updateRecord
     @param {Store} store
     @param {Model} type   the Model class of the record
     @param {Snapshot} snapshot
@@ -635,7 +626,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     }
     ```
 
-    @method deleteRecord
     @param {Store} store
     @param {Model} type   the Model class of the record
     @param {Snapshot} snapshot
@@ -700,7 +690,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     }
     ```
 
-    @method findMany
     @param {Store} store
     @param {Model} type   the Model class of the records
     @param {Array}    ids
@@ -718,7 +707,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
 
     The default implementation returns the records as a single group.
 
-    @method groupRecordsForFindMany
     @public
     @param {Store} store
     @param {Array} snapshots
@@ -770,7 +758,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     suit your use case.
 
     @since 1.13.0
-    @method shouldReloadRecord
     @param {Store} store
     @param {Snapshot} snapshot
     @return {Boolean}
@@ -826,7 +813,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     your use case.
 
     @since 1.13.0
-    @method shouldReloadAll
     @param {Store} store
     @param {SnapshotRecordArray} snapshotRecordArray
     @return {Boolean}
@@ -863,7 +849,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     in the background.
 
     @since 1.13.0
-    @method shouldBackgroundReloadRecord
     @param {Store} store
     @param {Snapshot} snapshot
     @return {Boolean}
@@ -900,7 +885,6 @@ export default class Adapter extends EmberObject implements MinimumAdapterInterf
     should always be triggered.
 
     @since 1.13.0
-    @method shouldBackgroundReloadAll
     @param {Store} store
     @param {SnapshotRecordArray} snapshotRecordArray
     @return {Boolean}

--- a/packages/adapter/src/json-api.ts
+++ b/packages/adapter/src/json-api.ts
@@ -124,7 +124,7 @@ import RESTAdapter from './rest';
   Endpoint paths can be prefixed with a `namespace` by setting the
   namespace property on the adapter:
 
-  ```app/adapters/application.js
+  ```js [app/adapters/application.js]
   import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
   export default class ApplicationAdapter extends JSONAPIAdapter {
@@ -137,7 +137,7 @@ import RESTAdapter from './rest';
 
   An adapter can target other hosts by setting the `host` property.
 
-  ```app/adapters/application.js
+  ```js [app/adapters/application.js]
   import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
   export default class ApplicationAdapter extends JSONAPIAdapter {

--- a/packages/adapter/src/json-api.ts
+++ b/packages/adapter/src/json-api.ts
@@ -152,13 +152,11 @@ import RESTAdapter from './rest';
   @class JSONAPIAdapter
   @public
   @constructor
-  @extends RESTAdapter
 */
 class JSONAPIAdapter extends RESTAdapter {
   _defaultContentType = 'application/vnd.api+json';
 
   /**
-    @method ajaxOptions
     @private
     @param {String} url
     @param {String} type The request type GET, POST, PUT, DELETE etc.
@@ -270,7 +268,6 @@ class JSONAPIAdapter extends RESTAdapter {
     Used by `findAll` and `findRecord` to build the query's `data` hash
     supplied to the ajax method.
 
-    @method buildQuery
     @since 2.5.0
     @public
     @param  {Snapshot} snapshot

--- a/packages/adapter/src/rest.ts
+++ b/packages/adapter/src/rest.ts
@@ -288,7 +288,6 @@ declare const jQuery: JQueryStatic | undefined;
   @class RESTAdapter
   @public
   @constructor
-  @extends Adapter
   @uses BuildURLMixin
 */
 class RESTAdapter extends Adapter.extend(BuildURLMixin) {
@@ -362,7 +361,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     }
     ```
 
-    @method sortQueryParams
     @param {Object} obj
     @return {Object}
     @public
@@ -515,7 +513,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     This method performs an HTTP `GET` request with the id provided as part of the query string.
 
     @since 1.13.0
-    @method findRecord
     @public
     @param {Store} store
     @param {Model} type
@@ -537,7 +534,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     The `findAll` method makes an Ajax (HTTP GET) request to a URL computed by `buildURL`, and returns a
     promise for the resulting payload.
 
-    @method findAll
     @public
     @param {Store} store
     @param {Model} type
@@ -572,7 +568,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     The `query` argument is a simple JavaScript object that will be passed directly
     to the server as parameters.
 
-    @method query
     @public
     @param {Store} store
     @param {Model} type
@@ -603,7 +598,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     to the server as parameters.
 
     @since 1.13.0
-    @method queryRecord
     @public
     @param {Store} store
     @param {Model} type
@@ -652,7 +646,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     The `findMany` method makes an Ajax (HTTP GET) request to a URL computed by `buildURL`, and returns a
     promise for the resulting payload.
 
-    @method findMany
     @public
     @param {Store} store
     @param {Model} type
@@ -694,7 +687,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
 
     * Links with no beginning `/` will have a parentURL prepended to it, via the current adapter's `buildURL`.
 
-    @method findHasMany
     @public
     @param {Store} store
     @param {Snapshot} snapshot
@@ -749,7 +741,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
 
     * Links with no beginning `/` will have a parentURL prepended to it, via the current adapter's `buildURL`.
 
-    @method findBelongsTo
     @public
     @param {Store} store
     @param {Snapshot} snapshot
@@ -779,7 +770,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     See `serialize` for information on how to customize the serialized form
     of a record.
 
-    @method createRecord
     @public
     @param {Store} store
     @param {Model} type
@@ -804,7 +794,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     See `serialize` for information on how to customize the serialized form
     of a record.
 
-    @method updateRecord
     @public
     @param {Store} store
     @param {Model} schema
@@ -826,7 +815,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
 
     The `deleteRecord` method  makes an Ajax (HTTP DELETE) request to a URL computed by `buildURL`.
 
-    @method deleteRecord
     @public
     @param {Store} store
     @param {Model} type
@@ -887,7 +875,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     It does not group records that have differing base urls, such as for example: `/posts/1/comments/2`
     and `/posts/2/comments/3`
 
-    @method groupRecordsForFindMany
     @public
     @param {Store} store
     @param {Array} snapshots
@@ -940,7 +927,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     method.
 
     @since 1.13.0
-    @method handleResponse
     @public
     @param  {Number} status
     @param  {Object} headers
@@ -986,7 +972,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     response is a success.
 
     @since 1.13.0
-    @method isSuccess
     @public
     @param  {Number} status
     @param  {Object} headers
@@ -1002,7 +987,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     response is an invalid error.
 
     @since 1.13.0
-    @method isInvalid
     @public
     @param  {Number} status
     @param  {Object} headers
@@ -1030,7 +1014,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
       data is the serialized record in the case of a save.
     * Registers success and failure handlers.
 
-    @method ajax
     @private
     @param {String} url
     @param {String} type The request type GET, POST, PUT, DELETE etc.
@@ -1061,7 +1044,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
   }
 
   /**
-    @method _ajaxRequest
     @private
     @param {Object} options jQuery ajax options to be used for the ajax request
   */
@@ -1085,7 +1067,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
   }
 
   /**
-    @method ajaxOptions
     @private
     @param {String} url
     @param {String} type The request type GET, POST, PUT, DELETE etc.
@@ -1166,7 +1147,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
   }
 
   /**
-    @method parseErrorResponse
     @private
     @param {String} responseText
     @return {Object}
@@ -1184,7 +1164,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
   }
 
   /**
-    @method normalizeErrorResponse
     @private
     @param  {Number} status
     @param  {Object} headers
@@ -1217,7 +1196,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     Generates a detailed ("friendly") error message, with plenty
     of information for debugging (good luck!)
 
-    @method generatedDetailedMessage
     @private
     @param  {Number} status
     @param  {Object} headers
@@ -1256,7 +1234,6 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     Used by `findAll` and `findRecord` to build the query's `data` hash
     supplied to the ajax method.
 
-    @method buildQuery
     @since 2.5.0
     @public
     @param  {Snapshot} snapshot
@@ -1445,8 +1422,6 @@ function headersToObject(headers: Headers): Record<string, string> {
 /**
  * Helper function that translates the options passed to `jQuery.ajax` into a format that `fetch` expects.
  *
- * @method fetchOptions
- * @for @ember-data/adapter/rest
  * @param {Object} _options
  * @param {Adapter} adapter
  * @private

--- a/packages/adapter/src/rest.ts
+++ b/packages/adapter/src/rest.ts
@@ -151,7 +151,7 @@ declare const jQuery: JQueryStatic | undefined;
 
   For example, if you have a `Person` model:
 
-  ```app/models/person.js
+  ```js [app/models/person.js]
   import Model, { attr } from '@ember-data/model';
 
   export default Model.extend({
@@ -244,7 +244,7 @@ declare const jQuery: JQueryStatic | undefined;
   Endpoint paths can be prefixed with a `namespace` by setting the namespace
   property on the adapter:
 
-  ```app/adapters/application.js
+  ```js [app/adapters/application.js]
   import RESTAdapter from '@ember-data/adapter/rest';
 
   export default class ApplicationAdapter extends RESTAdapter {
@@ -257,7 +257,7 @@ declare const jQuery: JQueryStatic | undefined;
 
   An adapter can target other hosts by setting the `host` property.
 
-  ```app/adapters/application.js
+  ```js [app/adapters/application.js]
   import RESTAdapter from '@ember-data/adapter/rest';
 
   export default class ApplicationAdapter extends RESTAdapter {
@@ -272,7 +272,7 @@ declare const jQuery: JQueryStatic | undefined;
   object and EmberData will send them along with each ajax request.
 
 
-  ```app/adapters/application.js
+  ```js [app/adapters/application.js]
   import RESTAdapter from '@ember-data/adapter/rest';
 
   export default class ApplicationAdapter extends RESTAdapter {
@@ -344,7 +344,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     In case you want to sort the query parameters with a different criteria, set
     `sortQueryParams` to your custom sort function.
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import RESTAdapter from '@ember-data/adapter/rest';
 
     export default class ApplicationAdapter extends RESTAdapter {
@@ -444,7 +444,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     Endpoint paths can be prefixed with a `namespace` by setting the namespace
     property on the adapter:
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import RESTAdapter from '@ember-data/adapter/rest';
 
     export default class ApplicationAdapter extends RESTAdapter {
@@ -462,7 +462,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
   /**
     An adapter can target other hosts by setting the `host` property.
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import RESTAdapter from '@ember-data/adapter/rest';
 
     export default class ApplicationAdapter extends RESTAdapter {
@@ -484,7 +484,7 @@ class RESTAdapter extends Adapter.extend(BuildURLMixin) {
     along with each ajax request. For dynamic headers see [headers
     customization](/ember-data/release/classes/RESTAdapter).
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import RESTAdapter from '@ember-data/adapter/rest';
 
     export default class ApplicationAdapter extends RESTAdapter {

--- a/packages/build-config/src/debugging.ts
+++ b/packages/build-config/src/debugging.ts
@@ -155,6 +155,5 @@ export const DEBUG_RELATIONSHIP_NOTIFICATIONS: boolean = false;
  *
  * LOG_METRIC_COUNTS must also be enabled.
  *
- * @typedoc
  */
 export const __INTERNAL_LOG_NATIVE_MAP_SET_COUNTS: boolean = false;

--- a/packages/core-types/src/cache.ts
+++ b/packages/core-types/src/cache.ts
@@ -72,7 +72,6 @@ export interface Cache {
    * a `content` member and therefor must not assume the existence
    * of `request` and `response` on the document.
    *
-   * @method put
    * @param {StructuredDocument} doc
    * @return {ResourceDocument}
    * @public
@@ -83,7 +82,6 @@ export interface Cache {
    * Update the "remote" or "canonical" (persisted) state of the Cache
    * by merging new information into the existing state.
    *
-   * @method patch
    * @public
    * @param {Operation | Operation[]} op the operation(s) to perform
    * @return {void}
@@ -93,7 +91,6 @@ export interface Cache {
   /**
    * Update the "local" or "current" (unpersisted) state of the Cache
    *
-   * @method mutate
    * @param {Mutation} mutation
    * @return {void}
    * @public
@@ -127,7 +124,6 @@ export interface Cache {
    * of the Graph handling necessary entanglements and
    * notifications for relational data.
    *
-   * @method peek
    * @public
    * @param {StableRecordIdentifier | StableDocumentIdentifier} identifier
    * @return {ResourceDocument | ResourceBlob | null} the known resource data
@@ -164,7 +160,6 @@ export interface Cache {
    * of the Graph handling necessary entanglements and
    * notifications for relational data.
    *
-   * @method peek
    * @public
    * @param {StableRecordIdentifier | StableDocumentIdentifier} identifier
    * @return {ResourceDocument | ResourceBlob | null} the known resource data
@@ -180,7 +175,6 @@ export interface Cache {
    * that it will return the the request, response, and content
    * whereas `peek` will return just the `content`.
    *
-   * @method peekRequest
    * @param {StableDocumentIdentifier}
    * @return {StructuredDocument<ResourceDocument> | null}
    * @public
@@ -190,7 +184,6 @@ export interface Cache {
   /**
    * Push resource data from a remote source into the cache for this identifier
    *
-   * @method upsert
    * @public
    * @param identifier
    * @param data
@@ -209,7 +202,6 @@ export interface Cache {
    * preferring instead to fork at the Store level, which will
    * utilize this method to fork the cache.
    *
-   * @method fork
    * @public
    * @return {Promise<Cache>}
    */
@@ -222,7 +214,6 @@ export interface Cache {
    * preferring instead to merge at the Store level, which will
    * utilize this method to merge the caches.
    *
-   * @method merge
    * @param {Cache} cache
    * @public
    * @return {Promise<void>}
@@ -259,7 +250,6 @@ export interface Cache {
    * }
    * ```
    *
-   * @method diff
    * @public
    */
   diff(): Promise<Change[]>;
@@ -272,7 +262,6 @@ export interface Cache {
    * which may be fed back into a new instance of the same Cache
    * via `cache.hydrate`.
    *
-   * @method dump
    * @return {Promise<ReadableStream>}
    * @public
    */
@@ -290,7 +279,6 @@ export interface Cache {
    * behavior supports optimizing pre/fetching of data for route transitions
    * via data-only SSR modes.
    *
-   * @method hydrate
    * @param {ReadableStream} stream
    * @return {Promise<void>}
    * @public
@@ -306,7 +294,6 @@ export interface Cache {
    * It returns properties from options that should be set on the record during the create
    * process. This return value behavior is deprecated.
    *
-   * @method clientDidCreate
    * @public
    * @param identifier
    * @param createArgs
@@ -317,7 +304,6 @@ export interface Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * will be part of a save transaction.
    *
-   * @method willCommit
    * @public
    * @param identifier
    */
@@ -327,7 +313,6 @@ export interface Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * was successfully updated as part of a save transaction.
    *
-   * @method didCommit
    * @public
    * @param identifier - the primary identifier that was operated on
    * @param data - a document in the cache format containing any updated data
@@ -339,7 +324,6 @@ export interface Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * was update via a save transaction failed.
    *
-   * @method commitWasRejected
    * @public
    * @param identifier
    * @param errors
@@ -352,7 +336,6 @@ export interface Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method unloadRecord
    * @public
    * @param identifier
    */
@@ -364,7 +347,6 @@ export interface Cache {
   /**
    * Retrieve the data for an attribute from the cache
    *
-   * @method getAttr
    * @public
    * @param identifier
    * @param field
@@ -375,7 +357,6 @@ export interface Cache {
   /**
    * Retrieve remote state without any local changes for a specific attribute
    *
-   * @method getRemoteAttr
    * @public
    * @param identifier
    * @param field
@@ -388,7 +369,6 @@ export interface Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method setAttr
    * @public
    * @param identifier
    * @param field
@@ -405,7 +385,6 @@ export interface Cache {
    * { <field>: [<old>, <new>] }
    * ```
    *
-   * @method changedAttrs
    * @public
    * @param identifier
    * @return {Record<string, [unknown, unknown]>} `{ <field>: [<old>, <new>] }`
@@ -415,7 +394,6 @@ export interface Cache {
   /**
    * Query the cache for whether any mutated attributes exist
    *
-   * @method hasChangedAttrs
    * @public
    * @param identifier
    * @return {Boolean}
@@ -427,7 +405,6 @@ export interface Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method rollbackAttrs
    * @public
    * @param identifier
    * @return {String[]} the names of fields that were restored
@@ -456,7 +433,6 @@ export interface Cache {
     };
     ```
    *
-   * @method changedRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {Map<string, RelationshipDiff>}
@@ -466,7 +442,6 @@ export interface Cache {
   /**
    * Query the cache for whether any mutated attributes exist
    *
-   * @method hasChangedRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {Boolean}
@@ -480,7 +455,6 @@ export interface Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method rollbackRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {String[]} the names of relationships that were restored
@@ -490,7 +464,6 @@ export interface Cache {
   /**
    * Query the cache for the current state of a relationship property
    *
-   * @method getRelationship
    * @public
    * @param {StableRecordIdentifier} identifier
    * @param {String} field
@@ -505,7 +478,6 @@ export interface Cache {
   /**
    * Query the cache for the server state of a relationship property without any local changes
    *
-   * @method getRelationship
    * @public
    * @param {StableRecordIdentifier} identifier
    * @param {String} field
@@ -526,7 +498,6 @@ export interface Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method setIsDeleted
    * @public
    * @param identifier
    * @param {Boolean} isDeleted
@@ -536,7 +507,6 @@ export interface Cache {
   /**
    * Query the cache for any validation errors applicable to the given resource.
    *
-   * @method getErrors
    * @public
    * @param identifier
    * @return {JsonApiError[]}
@@ -546,7 +516,6 @@ export interface Cache {
   /**
    * Query the cache for whether a given resource has any available data
    *
-   * @method isEmpty
    * @public
    * @param identifier
    * @return {Boolean}
@@ -557,7 +526,6 @@ export interface Cache {
    * Query the cache for whether a given resource was created locally and not
    * yet persisted.
    *
-   * @method isNew
    * @public
    * @param identifier
    * @return {Boolean}
@@ -568,7 +536,6 @@ export interface Cache {
    * Query the cache for whether a given resource is marked as deleted (but not
    * necessarily persisted yet).
    *
-   * @method isDeleted
    * @public
    * @param identifier
    * @return {Boolean}
@@ -579,7 +546,6 @@ export interface Cache {
    * Query the cache for whether a given resource has been deleted and that deletion
    * has also been persisted.
    *
-   * @method isDeletionCommitted
    * @public
    * @param identifier
    * @return {Boolean}

--- a/packages/core-types/src/record.ts
+++ b/packages/core-types/src/record.ts
@@ -10,7 +10,6 @@ import type { Type } from './symbols';
  * intellisense.
  *
  * @class TypedRecordInstance
- * @typedoc
  */
 export interface TypedRecordInstance {
   /**
@@ -27,7 +26,6 @@ export interface TypedRecordInstance {
    * @property [Type]
    * @type {Type}
    * @type {String}
-   * @typedoc
    */
   [Type]: string;
 }
@@ -36,7 +34,6 @@ export interface TypedRecordInstance {
  * A type utility that extracts the Type if available,
  * otherwise it returns never.
  *
- * @typedoc
  */
 export type TypeFromInstance<T> = T extends TypedRecordInstance ? T[typeof Type] : never;
 
@@ -44,7 +41,6 @@ export type TypeFromInstance<T> = T extends TypedRecordInstance ? T[typeof Type]
  * A type utility that extracts the Type if available,
  * otherwise it returns string
  *
- * @typedoc
  */
 export type TypeFromInstanceOrString<T> = T extends TypedRecordInstance ? T[typeof Type] : string;
 
@@ -129,7 +125,6 @@ type _ExtractUnion<
  * There's a 90% chance this particular implementation belongs being in the JSON:API package instead
  * of core-types, but it's here for now.
  *
- * @typedoc
  */
 type ExtractUnion<
   MAX_DEPTH extends _DEPTHCOUNT,
@@ -158,7 +153,6 @@ type DEFAULT_MAX_DEPTH = 3;
  * A utility that provides the union of all ResourceName for all potential
  * includes for the given TypedRecordInstance.
  *
- * @typedoc
  */
 export type ExtractSuggestedCacheTypes<
   T extends TypedRecordInstance,
@@ -171,7 +165,6 @@ export type ExtractSuggestedCacheTypes<
  *
  * Cyclical paths are filtered out.
  *
- * @typedoc
  */
 export type Includes<T extends TypedRecordInstance, MAX_DEPTH extends _DEPTHCOUNT = DEFAULT_MAX_DEPTH> = ExtractUnion<
   MAX_DEPTH,

--- a/packages/core-types/src/request.ts
+++ b/packages/core-types/src/request.ts
@@ -30,28 +30,24 @@ export type HTTPMethod =
 /**
  * Use these options to adjust CacheHandler behavior for a request.
  *
- * @typedoc
  */
 export type CacheOptions<T = unknown> = {
   /**
    * A key that uniquely identifies this request. If not present, the url wil be used
    * as the key for any GET request, while all other requests will not be cached.
    *
-   * @typedoc
    */
   key?: string;
   /**
    * If true, the request will be made even if a cached response is present
    * and not expired.
    *
-   * @typedoc
    */
   reload?: boolean;
   /**
    * If true, and a cached response is present and not expired, the request
    * will be made in the background and the cached response will be returned.
    *
-   * @typedoc
    */
   backgroundReload?: boolean;
   /**
@@ -68,7 +64,6 @@ export type CacheOptions<T = unknown> = {
    * Generally it is better to patch the cache directly for relationship updates
    * than to invalidate findRecord requests for one.
    *
-   * @typedoc
    */
   types?: T extends TypedRecordInstance ? ExtractSuggestedCacheTypes<T>[] : string[];
 
@@ -79,7 +74,6 @@ export type CacheOptions<T = unknown> = {
    * Generally this is only used for legacy request that manage resource cache
    * updates in a non-standard way via the LegacyNetworkHandler.
    *
-   * @typedoc
    */
   [SkipCache]?: boolean;
 };
@@ -183,7 +177,6 @@ export interface StructuredDataDocument<T> {
   [STRUCTURED]?: true;
   /**
    * @see {@link ImmutableRequestInfo}
-   * @typedoc
    */
   request: ImmutableRequestInfo;
   response: Response | ResponseInfo | null;
@@ -203,66 +196,51 @@ export type StructuredDocument<T> = StructuredDataDocument<T> | StructuredErrorD
  *
  * EmberData provides our own typings due to incompleteness in the native typings.
  *
- * @typedoc
  */
 interface Request {
   /** Returns the cache mode associated with request, which is a string indicating how the request will interact with the browser's cache when fetching.
-   * @typedoc
    */
   cache?: RequestCache;
   /** Returns the credentials mode associated with request, which is a string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL.
-   * @typedoc
    */
   credentials?: RequestCredentials;
   /** Returns the kind of resource requested by request, e.g., "document" or "script".
-   * @typedoc
    */
   destination?: RequestDestination;
   /** Returns a Headers object consisting of the headers associated with request. Note that headers added in the network layer by the user agent will not be accounted for in this object, e.g., the "Host" header.
-   * @typedoc
    */
   headers?: Headers;
   /** Returns request's subresource integrity metadata, which is a cryptographic hash of the resource being fetched. Its value consists of multiple hashes separated by whitespace. [SRI]
-   * @typedoc
    */
   integrity?: string;
   /** Returns a boolean indicating whether or not request can outlive the global in which it was created.
-   * @typedoc
    */
   keepalive?: boolean;
   /** Returns request's HTTP method, which is "GET" by default.
-   * @typedoc
    */
   method?: HTTPMethod;
   /** Returns the mode associated with request, which is a string indicating whether the request will use CORS, or will be restricted to same-origin URLs.
    *
    * `no-cors` is not allowed for streaming request bodies.
    *
-   * @typedoc
    */
   mode?: RequestMode;
   /** Returns the redirect mode associated with request, which is a string indicating how redirects for the request will be handled during fetching. A request will follow redirects by default.
-   * @typedoc
    */
   redirect?: RequestRedirect;
   /** Returns the referrer of request. Its value can be a same-origin URL if explicitly set in init, the empty string to indicate no referrer, and "about:client" when defaulting to the global's default. This is used during fetching to determine the value of the `Referer` header of the request being made.
-   * @typedoc
    */
   referrer?: string;
   /** Returns the referrer policy associated with request. This is used during fetching to compute the value of the request's referrer.
-   * @typedoc
    */
   referrerPolicy?: ReferrerPolicy;
   /** Returns the signal associated with request, which is an AbortSignal object indicating whether or not request has been aborted, and its abort event handler.
-   * @typedoc
    */
   signal?: AbortSignal;
   /** Returns the URL of request as a string.
-   * @typedoc
    */
   url?: string;
   /** Any body that you want to add to your request. Note that a GET or HEAD request may not have a body.
-   * @typedoc
    */
   body?: BodyInit | null;
 
@@ -272,7 +250,6 @@ interface Request {
    *
    * [Half Duplex Further Reading](https://developer.chrome.com/docs/capabilities/web-apis/fetch-streaming-requests#half_duplex)
    *
-   * @typedoc
    */
   duplex?: 'half';
 }
@@ -286,19 +263,16 @@ export interface ImmutableHeaders extends Headers {
  * Extends JavaScript's native {@link Request} object with additional
  * properties specific to the RequestManager's capabilities.
  *
- * @typedoc
  */
 export interface RequestInfo<RT = unknown, T = unknown> extends Request {
   /**
    * If provided, used instead of the AbortController auto-configured for each request by the RequestManager
    *
-   * @typedoc
    */
   controller?: AbortController;
 
   /**
    * @see {@link CacheOptions}
-   * @typedoc
    */
   cacheOptions?: CacheOptions<T>;
   store?: Store;
@@ -310,7 +284,6 @@ export interface RequestInfo<RT = unknown, T = unknown> extends Request {
    * (if any). This may be used by handlers to perform transactional
    * operations on the store.
    *
-   * @typedoc
    */
   records?: StableRecordIdentifier[];
 
@@ -322,14 +295,12 @@ export interface RequestInfo<RT = unknown, T = unknown> extends Request {
    * Note: It is recommended that builders set query params
    * and body directly in most scenarios.
    *
-   * @typedoc
    */
   data?: Record<string, unknown>;
   /**
    * options specifically intended for handlers
    * to utilize to process the request
    *
-   * @typedoc
    */
   options?: Record<string, unknown>;
 
@@ -341,7 +312,6 @@ export interface RequestInfo<RT = unknown, T = unknown> extends Request {
 /**
  * Immutable version of {@link RequestInfo}. This is what is passed to handlers.
  *
- * @typedoc
  */
 export type ImmutableRequestInfo<RT = unknown, T = unknown> = Readonly<Omit<RequestInfo<RT, T>, 'controller'>> & {
   readonly cacheOptions?: Readonly<CacheOptions<T>>;
@@ -350,7 +320,6 @@ export type ImmutableRequestInfo<RT = unknown, T = unknown> = Readonly<Omit<Requ
   readonly options?: Readonly<Record<string, unknown>>;
 
   /** Whether the request body has been read.
-   * @typedoc
    */
   readonly bodyUsed?: boolean;
 };
@@ -368,7 +337,6 @@ export interface ResponseInfo {
 export interface RequestContext {
   /**
    * @see {@link ImmutableRequestInfo}
-   * @typedoc
    */
   request: ImmutableRequestInfo;
   id: number;

--- a/packages/core-types/src/runtime.ts
+++ b/packages/core-types/src/runtime.ts
@@ -32,7 +32,6 @@ export function getRuntimeConfig(): typeof RuntimeConfig {
  *
  * globalThis.setWarpDriveLogging({ LOG_CACHE: true } });
  *
- * @typedoc
  */
 export function setLogging(config: Partial<LOG_CONFIG>): void {
   Object.assign(RuntimeConfig.debug, config);

--- a/packages/core-types/src/schema/fields.ts
+++ b/packages/core-types/src/schema/fields.ts
@@ -562,7 +562,6 @@ export interface SchemaObjectField {
      *
      * If the SchemaObject is polymorphic, `options.type` must also be supplied.
      *
-     * @typedoc
      */
     polymorphic?: boolean;
 
@@ -572,7 +571,6 @@ export interface SchemaObjectField {
      *
      * Defaults to "type".
      *
-     * @typedoc
      */
     type?: string;
   };
@@ -724,7 +722,6 @@ export interface SchemaArrayField {
      *       used when comparing values. The field value should be unique enough to guarantee two schema-objects
      *       of the same type will not collide.
      *
-     * @typedoc
      */
     key?: '@identity' | '@index' | '@hash' | string;
 
@@ -733,7 +730,6 @@ export interface SchemaArrayField {
      *
      * If the SchemaArray is polymorphic, `options.type` must also be supplied.
      *
-     * @typedoc
      */
     polymorphic?: boolean;
 
@@ -743,7 +739,6 @@ export interface SchemaArrayField {
      *
      * Defaults to "type".
      *
-     * @typedoc
      */
     type?: string;
   };
@@ -880,7 +875,6 @@ export interface ResourceField {
      * that can be used to fetch the related
      * resource when needed.
      *
-     * @typedoc
      */
     async?: boolean;
 
@@ -892,7 +886,6 @@ export interface ResourceField {
      *
      * If null, the relationship is unidirectional.
      *
-     * @typedoc
      */
     inverse?: string | null;
 
@@ -902,7 +895,6 @@ export interface ResourceField {
      * should be set to the trait or abstract type
      * that this resource implements.
      *
-     * @typedoc
      */
     as?: string;
 
@@ -912,7 +904,6 @@ export interface ResourceField {
      * resources so long as they implement the trait
      * or abstract type specified in `type`.
      *
-     * @typedoc
      */
     polymorphic?: boolean;
   };
@@ -965,7 +956,6 @@ export interface CollectionField {
    * not present, all options are presumed
    * to be falsey
    *
-   * @typedoc
    */
   options?: {
     /**
@@ -987,7 +977,6 @@ export interface CollectionField {
      * full list of pointers, and loading "page 1" would
      * load all related resources.
      *
-     * @typedoc
      */
     async?: boolean;
 
@@ -999,7 +988,6 @@ export interface CollectionField {
      *
      * If null, the relationship is unidirectional.
      *
-     * @typedoc
      */
     inverse?: string | null;
 
@@ -1009,7 +997,6 @@ export interface CollectionField {
      * should be set to the trait or abstract type
      * that this resource implements.
      *
-     * @typedoc
      */
     as?: string;
 
@@ -1019,7 +1006,6 @@ export interface CollectionField {
      * resources so long as they implement the trait
      * or abstract type specified in `type`.
      *
-     * @typedoc
      */
     polymorphic?: boolean;
   };
@@ -1075,7 +1061,6 @@ export interface LegacyAttributeField {
    * Must comply to the specific transform's options
    * schema.
    *
-   * @typedoc
    */
   options?: ObjectValue;
 }
@@ -1126,7 +1111,6 @@ export interface LegacyBelongsToField {
   /**
    * Options for belongsTo are mandatory.
    *
-   * @typedoc
    */
   options: {
     /**
@@ -1139,7 +1123,6 @@ export interface LegacyBelongsToField {
      *
      * Pointers are highly discouraged.
      *
-     * @typedoc
      */
     async: boolean;
 
@@ -1151,7 +1134,6 @@ export interface LegacyBelongsToField {
      *
      * If null, the relationship is unidirectional.
      *
-     * @typedoc
      */
     inverse: string | null;
 
@@ -1161,7 +1143,6 @@ export interface LegacyBelongsToField {
      * should be set to the trait or abstract type
      * that this resource implements.
      *
-     * @typedoc
      */
     as?: string;
 
@@ -1171,7 +1152,6 @@ export interface LegacyBelongsToField {
      * resources so long as they implement the trait
      * or abstract type specified in `type`.
      *
-     * @typedoc
      */
     polymorphic?: boolean;
 
@@ -1205,7 +1185,6 @@ export interface LegacyBelongsToField {
      *
      * Async relationships will be loaded via their link if needed.
      *
-     * @typedoc
      */
     linksMode?: true;
 
@@ -1220,7 +1199,6 @@ export interface LegacyBelongsToField {
      * local state that are present in the remote data,
      * leaving any remaining changes in local state still.
      *
-     * @typedoc
      */
     resetOnRemoteUpdate?: false;
   };
@@ -1272,7 +1250,6 @@ export interface LinksModeBelongsToField {
   /**
    * Options for belongsTo are mandatory.
    *
-   * @typedoc
    */
   options: {
     /**
@@ -1280,7 +1257,6 @@ export interface LinksModeBelongsToField {
      *
      * MUST be false for PolarisMode + LinksMode
      *
-     * @typedoc
      */
     async: false;
 
@@ -1292,7 +1268,6 @@ export interface LinksModeBelongsToField {
      *
      * If null, the relationship is unidirectional.
      *
-     * @typedoc
      */
     inverse: string | null;
 
@@ -1302,7 +1277,6 @@ export interface LinksModeBelongsToField {
      * should be set to the trait or abstract type
      * that this resource implements.
      *
-     * @typedoc
      */
     as?: string;
 
@@ -1312,7 +1286,6 @@ export interface LinksModeBelongsToField {
      * resources so long as they implement the trait
      * or abstract type specified in `type`.
      *
-     * @typedoc
      */
     polymorphic?: boolean;
 
@@ -1360,7 +1333,6 @@ export interface LinksModeBelongsToField {
      * except for the addition of records still in the "new" state any
      * time the remote data for this field was updated.
      *
-     * @typedoc
      */
     linksMode: true;
   };
@@ -1412,7 +1384,6 @@ export interface LegacyHasManyField {
   /**
    * Options for hasMany are mandatory.
    *
-   * @typedoc
    */
   options: {
     /**
@@ -1430,7 +1401,6 @@ export interface LegacyHasManyField {
      *
      * hasMany relationships do not support pagination.
      *
-     * @typedoc
      */
     async: boolean;
 
@@ -1442,7 +1412,6 @@ export interface LegacyHasManyField {
      *
      * If null, the relationship is unidirectional.
      *
-     * @typedoc
      */
     inverse: string | null;
 
@@ -1452,7 +1421,6 @@ export interface LegacyHasManyField {
      * should be set to the trait or abstract type
      * that this resource implements.
      *
-     * @typedoc
      */
     as?: string;
 
@@ -1462,7 +1430,6 @@ export interface LegacyHasManyField {
      * resources so long as they implement the trait
      * or abstract type specified in `type`.
      *
-     * @typedoc
      */
     polymorphic?: boolean;
 
@@ -1496,7 +1463,6 @@ export interface LegacyHasManyField {
      *
      * Async relationships will be loaded via their link if needed.
      *
-     * @typedoc
      */
     linksMode?: true;
 
@@ -1511,7 +1477,6 @@ export interface LegacyHasManyField {
      * local state that are present in the remote data,
      * leaving any remaining changes in local state still.
      *
-     * @typedoc
      */
     resetOnRemoteUpdate?: false;
   };
@@ -1563,7 +1528,6 @@ export interface LinksModeHasManyField {
   /**
    * Options for hasMany are mandatory.
    *
-   * @typedoc
    */
   options: {
     /**
@@ -1583,7 +1547,6 @@ export interface LinksModeHasManyField {
      *
      * hasMany relationships do not support pagination.
      *
-     * @typedoc
      */
     async: false;
 
@@ -1595,7 +1558,6 @@ export interface LinksModeHasManyField {
      *
      * If null, the relationship is unidirectional.
      *
-     * @typedoc
      */
     inverse: string | null;
 
@@ -1605,7 +1567,6 @@ export interface LinksModeHasManyField {
      * should be set to the trait or abstract type
      * that this resource implements.
      *
-     * @typedoc
      */
     as?: string;
 
@@ -1615,7 +1576,6 @@ export interface LinksModeHasManyField {
      * resources so long as they implement the trait
      * or abstract type specified in `type`.
      *
-     * @typedoc
      */
     polymorphic?: boolean;
 
@@ -1663,7 +1623,6 @@ export interface LinksModeHasManyField {
      * except for the addition of records still in the "new" state any
      * time the remote data for this field was updated.
      *
-     * @typedoc
      */
     linksMode: true;
   };
@@ -1949,7 +1908,6 @@ export interface LegacyResourceSchema {
  * by the SchemaService which provides fields as a Map
  * instead of as an Array.
  *
- * @typedoc
  */
 export type ResourceSchema = PolarisResourceSchema | LegacyResourceSchema;
 
@@ -2017,9 +1975,6 @@ export type Schema = ResourceSchema | ObjectSchema;
  * as doing so would require a full schema graph to be passed in
  * and no cycles in the graph to be present.
  *
- * @method resourceSchema
- * @static
- * @for @warp-drive/core-types
  * @param {ResourceSchema} schema
  * @return {ResourceSchema} the passed in schema
  * @public
@@ -2036,9 +1991,6 @@ export function resourceSchema<T extends LegacyResourceSchema | PolarisResourceS
  *
  * Will return the passed in schema.
  *
- * @method objectSchema
- * @static
- * @for @warp-drive/core-types
  * @param {ObjectSchema} schema
  * @return {ObjectSchema} the passed in schema
  * @public
@@ -2050,9 +2002,6 @@ export function objectSchema<T extends ObjectSchema>(schema: T): T {
 /**
  * A type utility to narrow a schema to a ResourceSchema
  *
- * @method isResourceSchema
- * @static
- * @for @warp-drive/core-types
  * @param schema
  * @return {Boolean}
  * @public
@@ -2064,9 +2013,6 @@ export function isResourceSchema(schema: ResourceSchema | ObjectSchema): schema 
 /**
  * A type utility to narrow a schema to LegacyResourceSchema
  *
- * @method isLegacyResourceSchema
- * @static
- * @for @warp-drive/core-types
  * @param schema
  * @return {Boolean}
  * @public

--- a/packages/core-types/src/symbols.ts
+++ b/packages/core-types/src/symbols.ts
@@ -39,7 +39,6 @@ export const RecordStore: '___(unique) Symbol(Store)' = getOrSetGlobal('Store', 
  * that the name is the same as the transform name.
  *
  * @type {Symbol}
- * @typedoc
  */
 export const Type: '___(unique) Symbol($type)' = getOrSetGlobal('$type', Symbol('$type'));
 
@@ -55,7 +54,6 @@ export const Type: '___(unique) Symbol($type)' = getOrSetGlobal('$type', Symbol(
  * safety and intellisense.
  *
  * @type {Symbol}
- * @typedoc
  */
 export const ResourceType: '___(unique) Symbol($type)' = Type;
 
@@ -74,7 +72,6 @@ export const ResourceType: '___(unique) Symbol($type)' = Type;
  * that the name is the same as the transform name.
  *
  * @type {Symbol}
- * @typedoc
  */
 export const TransformName: '___(unique) Symbol($type)' = Type;
 
@@ -83,7 +80,6 @@ export const TransformName: '___(unique) Symbol($type)' = Type;
  * generic to use for store.request()
  *
  * @type {Symbol}
- * @typedoc
  */
 export const RequestSignature: '___(unique) Symbol(RequestSignature)' = getOrSetGlobal(
   'RequestSignature',

--- a/packages/debug/src/data-adapter.ts
+++ b/packages/debug/src/data-adapter.ts
@@ -126,7 +126,6 @@ function typesMapFor(store: Store): Map<string, boolean> {
   integration with the ember-inspector.
 
   @class InspectorDataAdapter
-  @extends DataAdapter
   @private
 */
 class InspectorDataAdapter extends DataAdapter<Model> {
@@ -137,7 +136,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
     Records returned will need to have a `filterValues`
     property with a key for every name in the returned array
 
-    @method getFilters
     @private
     @return {Array} List of objects defining filters
      The object should have a `name` and `desc` property
@@ -158,7 +156,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
     Fetch the model types and observe them for changes.
     Maintains the list of model types without needing the Model package for detection.
 
-    @method watchModelTypes
     @private
     @param {Function} typesAdded Callback to call to add types.
     Takes an array of objects containing wrapped types (returned from `wrapModelType`).
@@ -209,7 +206,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
    * Loop over the discovered types and use the callbacks from watchModelTypes to notify
    * the consumer of this adapter about the mdoels.
    *
-   * @method watchTypeIfUnseen
    * @param {store} store
    * @param {Map} discoveredTypes
    * @param {String} type
@@ -239,7 +235,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
   /**
     Creates a human readable string used for column headers
 
-    @method columnNameToDesc
     @private
     @param {String} name The attribute name
     @return {String} Human readable string based on the attribute name
@@ -251,7 +246,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
   /**
     Get the columns for a given model type
 
-    @method columnsForType
     @private
     @param {Model} typeClass
     @return {Array} An array of columns of the following format:
@@ -279,7 +273,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
   /**
     Fetches all loaded records for a given type
 
-    @method getRecords
     @private
     @param {Model} modelClass of the record
     @param {String} modelName of the record
@@ -306,7 +299,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
     Gets the values for each column
     This is the attribute values for a given record
 
-    @method getRecordColumnValues
     @private
     @param {Model} record to get values from
     @return {Object} Keys should match column names defined by the model type
@@ -327,7 +319,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
   /**
     Returns keywords to match when searching records
 
-    @method getRecordKeywords
     @private
     @param {Model} record
     @return {Array} Relevant keywords for search based on the record's attribute values
@@ -348,7 +339,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
     Returns the values of filters defined by `getFilters`
     These reflect the state of the record
 
-    @method getRecordFilterValues
     @private
     @param {Model} record
     @return {Object} The record state filter values
@@ -365,7 +355,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
     Returns a color that represents the record's state
     Possible colors: black, blue, green
 
-    @method getRecordColor
     @private
     @param {Model} record
     @return {String} The record color
@@ -384,7 +373,6 @@ class InspectorDataAdapter extends DataAdapter<Model> {
     Observes all relevant properties and re-sends the wrapped record
     when a change occurs
 
-    @method observeRecord
     @private
     @param {Model} record
     @param {Function} recordUpdated Callback used to notify changes

--- a/packages/diagnostic/src/ember.ts
+++ b/packages/diagnostic/src/ember.ts
@@ -161,7 +161,6 @@ class TestLoader extends CLITestLoader {
    * The module name ends with `-test`
    * The module name ends with `.jshint`
 
-   @method loadTests
  */
 function loadTests() {
   TestLoader.load();

--- a/packages/diagnostic/src/internals/diagnostic.ts
+++ b/packages/diagnostic/src/internals/diagnostic.ts
@@ -176,7 +176,6 @@ export class Diagnostic<TC extends TestContext> {
    * higher priority or more stable properties of an object in a dynamic
    * environment.
    *
-   * @typedoc
    */
   satisfies<T extends object, J extends T>(actual: J, expected: T, message?: string): void {
     const isEqual = equiv(actual, expected, false);

--- a/packages/ember/src/-private/request.gts
+++ b/packages/ember/src/-private/request.gts
@@ -63,7 +63,6 @@ interface RequestSignature<RT, T, E> {
      * The request to monitor. This should be a `Future` instance returned
      * by either the `store.request` or `store.requestManager.request` methods.
      *
-     * @typedoc
      */
     request?: Future<RT>;
 
@@ -72,7 +71,6 @@ interface RequestSignature<RT, T, E> {
      * passed to `store.request`. Use this in place of `@request` if you would
      * like the component to also initiate the request.
      *
-     * @typedoc
      */
     query?: StoreRequestInput<RT, T>;
 
@@ -83,7 +81,6 @@ interface RequestSignature<RT, T, E> {
      * This is required if the store is not available via context or should be
      * different from the store provided via context.
      *
-     * @typedoc
      */
     store?: Store;
 
@@ -99,7 +96,6 @@ interface RequestSignature<RT, T, E> {
      *
      * Defaults to `false`.
      *
-     * @typedoc
      */
     autorefresh?: AutorefreshBehaviorCombos;
 
@@ -112,7 +108,6 @@ interface RequestSignature<RT, T, E> {
      *
      * Defaults to `30_000` (30 seconds).
      *
-     * @typedoc
      */
     autorefreshThreshold?: number;
 
@@ -127,7 +122,6 @@ interface RequestSignature<RT, T, E> {
      *
      * Defaults to `'policy'`.
      *
-     * @typedoc
      */
     autorefreshBehavior?: 'refresh' | 'reload' | 'policy';
   };
@@ -135,21 +129,18 @@ interface RequestSignature<RT, T, E> {
     /**
      * The block to render when the component is idle and waiting to be given a request.
      *
-     * @typedoc
      */
     idle: [];
 
     /**
      * The block to render when the request is loading.
      *
-     * @typedoc
      */
     loading: [state: RequestLoadingState];
 
     /**
      * The block to render when the request was cancelled.
      *
-     * @typedoc
      */
     cancelled: [
       error: StructuredErrorDocument<E>,
@@ -163,7 +154,6 @@ interface RequestSignature<RT, T, E> {
      * Thus it is required to provide an error block and proper error handling if
      * you do not want the error to crash the application.
      *
-     * @typedoc
      */
     error: [
       error: StructuredErrorDocument<E>,
@@ -173,7 +163,6 @@ interface RequestSignature<RT, T, E> {
     /**
      * The block to render when the request succeeded.
      *
-     * @typedoc
      */
     content: [value: RT, features: ContentFeatures<RT>];
     always: [state: RequestState<RT, T, StructuredErrorDocument<E>>];

--- a/packages/ember/src/index.ts
+++ b/packages/ember/src/index.ts
@@ -117,10 +117,7 @@ export { Await, Throw } from './-private/await.gts';
  * ```
  *
  * If looking to use in a template, consider also the `<Await />` component.
- *
- * @method getPromiseState
- * @for @warp-drive/ember
- * @static
+
  * @public
  * @param {Promise<T> | Awaitable<T, E>} promise
  * @return {PromiseState<T, E>}
@@ -216,9 +213,6 @@ export { getPromiseState } from '@ember-data/store/-private';
  * which offers a numbe of additional capabilities for requests *beyond* what
  * `RequestState` provides.
  *
- * @method getRequestState
- * @for @warp-drive/ember
- * @static
  * @public
  * @param future
  * @return {RequestState}

--- a/packages/experiments/src/data-worker/cache-handler.ts
+++ b/packages/experiments/src/data-worker/cache-handler.ts
@@ -25,7 +25,6 @@ import type { DataWorker } from './worker';
  * A simplified CacheHandler that hydrates ResourceDataDocuments from the cache
  * with their referenced resources.
  *
- * @typedoc
  */
 export const CacheHandler: CacheHandlerType = {
   request<T>(context: StoreRequestContext, next: NextFn<T>): Promise<T | StructuredDataDocument<T>> | Future<T> | T {

--- a/packages/experiments/src/persisted-cache/cache.ts
+++ b/packages/experiments/src/persisted-cache/cache.ts
@@ -50,7 +50,6 @@ export class PersistedCache implements Cache {
    * a `content` member and therefor must not assume the existence
    * of `request` and `response` on the document.
    *
-   * @method put
    * @param {StructuredDocument} doc
    * @return {ResourceDocument}
    * @internal
@@ -93,7 +92,6 @@ export class PersistedCache implements Cache {
    * Note: currently the only valid operation is a MergeOperation
    * which occurs when a collision of identifiers is detected.
    *
-   * @method patch
    * @internal
    * @param op the operation to perform
    * @return {void}
@@ -106,7 +104,6 @@ export class PersistedCache implements Cache {
    * Update resource data with a local mutation. Currently supports operations
    * on relationships only.
    *
-   * @method mutate
    * @internal
    * @param mutation
    */
@@ -141,7 +138,6 @@ export class PersistedCache implements Cache {
    * of the Graph handling necessary entanglements and
    * notifications for relational data.
    *
-   * @method peek
    * @internal
    * @param {StableRecordIdentifier | StableDocumentIdentifier} identifier
    * @return {ResourceDocument | ResourceBlob | null} the known resource data
@@ -179,7 +175,6 @@ export class PersistedCache implements Cache {
    * of the Graph handling necessary entanglements and
    * notifications for relational data.
    *
-   * @method peek
    * @internal
    * @param {StableRecordIdentifier | StableDocumentIdentifier} identifier
    * @return {ResourceDocument | ResourceBlob | null} the known resource data
@@ -194,7 +189,6 @@ export class PersistedCache implements Cache {
    * Peek the Cache for the existing request data associated with
    * a cacheable request
    *
-   * @method peekRequest
    * @param {StableDocumentIdentifier}
    * @return {StableDocumentIdentifier | null}
    * @internal
@@ -206,7 +200,6 @@ export class PersistedCache implements Cache {
   /**
    * Push resource data from a remote source into the cache for this identifier
    *
-   * @method upsert
    * @internal
    * @param identifier
    * @param data
@@ -227,7 +220,6 @@ export class PersistedCache implements Cache {
    * preferring instead to fork at the Store level, which will
    * utilize this method to fork the cache.
    *
-   * @method fork
    * @internal
    * @return {Promise<Cache>}
    */
@@ -242,7 +234,6 @@ export class PersistedCache implements Cache {
    * preferring instead to merge at the Store level, which will
    * utilize this method to merge the caches.
    *
-   * @method merge
    * @param {Cache} cache
    * @internal
    * @return {Promise<void>}
@@ -281,7 +272,6 @@ export class PersistedCache implements Cache {
    * }
    * ```
    *
-   * @method diff
    * @internal
    */
   diff(): Promise<Change[]> {
@@ -296,7 +286,6 @@ export class PersistedCache implements Cache {
    * which may be fed back into a new instance of the same Cache
    * via `cache.hydrate`.
    *
-   * @method dump
    * @return {Promise<ReadableStream>}
    * @internal
    */
@@ -316,7 +305,6 @@ export class PersistedCache implements Cache {
    * behavior supports optimizing pre/fetching of data for route transitions
    * via data-only SSR modes.
    *
-   * @method hydrate
    * @param {ReadableStream} stream
    * @return {Promise<void>}
    * @internal
@@ -337,7 +325,6 @@ export class PersistedCache implements Cache {
    * It returns properties from options that should be set on the record during the create
    * process. This return value behavior is deprecated.
    *
-   * @method clientDidCreate
    * @internal
    * @param identifier
    * @param options
@@ -350,7 +337,6 @@ export class PersistedCache implements Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * will be part of a save transaction.
    *
-   * @method willCommit
    * @internal
    * @param identifier
    */
@@ -362,7 +348,6 @@ export class PersistedCache implements Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * was successfully updated as part of a save transaction.
    *
-   * @method didCommit
    * @internal
    * @param identifier
    * @param data
@@ -375,7 +360,6 @@ export class PersistedCache implements Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * was update via a save transaction failed.
    *
-   * @method commitWasRejected
    * @internal
    * @param identifier
    * @param errors
@@ -388,7 +372,6 @@ export class PersistedCache implements Cache {
    * [LIFECYCLE] Signals to the cache that all data for a resource
    * should be cleared.
    *
-   * @method unloadRecord
    * @internal
    * @param identifier
    */
@@ -402,7 +385,6 @@ export class PersistedCache implements Cache {
   /**
    * Retrieve the data for an attribute from the cache
    *
-   * @method getAttr
    * @internal
    * @param identifier
    * @param propertyName
@@ -415,7 +397,6 @@ export class PersistedCache implements Cache {
   /**
    * Retrieve the remote state for an attribute from the cache
    *
-   * @method getAttr
    * @internal
    * @param identifier
    * @param propertyName
@@ -428,7 +409,6 @@ export class PersistedCache implements Cache {
   /**
    * Mutate the data for an attribute in the cache
    *
-   * @method setAttr
    * @internal
    * @param identifier
    * @param propertyName
@@ -441,7 +421,6 @@ export class PersistedCache implements Cache {
   /**
    * Query the cache for the changed attributes of a resource.
    *
-   * @method changedAttrs
    * @internal
    * @param identifier
    * @return
@@ -453,7 +432,6 @@ export class PersistedCache implements Cache {
   /**
    * Query the cache for whether any mutated attributes exist
    *
-   * @method hasChangedAttrs
    * @internal
    * @param identifier
    * @return {Boolean}
@@ -465,7 +443,6 @@ export class PersistedCache implements Cache {
   /**
    * Tell the cache to discard any uncommitted mutations to attributes
    *
-   * @method rollbackAttrs
    * @internal
    * @param identifier
    * @return the names of attributes that were restored
@@ -496,7 +473,6 @@ export class PersistedCache implements Cache {
     };
     ```
    *
-   * @method changedRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {Map<string, RelationshipDiff>}
@@ -508,7 +484,6 @@ export class PersistedCache implements Cache {
   /**
    * Query the cache for whether any mutated attributes exist
    *
-   * @method hasChangedRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {Boolean}
@@ -524,7 +499,6 @@ export class PersistedCache implements Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method rollbackRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {String[]} the names of relationships that were restored
@@ -539,7 +513,6 @@ export class PersistedCache implements Cache {
   /**
    * Query the cache for the current state of a relationship property
    *
-   * @method getRelationship
    * @internal
    * @param identifier
    * @param propertyName
@@ -556,7 +529,6 @@ export class PersistedCache implements Cache {
   /**
    * Query the remote state for the current state of a relationship property
    *
-   * @method getRelationship
    * @internal
    * @param identifier
    * @param propertyName
@@ -577,7 +549,6 @@ export class PersistedCache implements Cache {
    * Update the cache state for the given resource to be marked as locally deleted,
    * or remove such a mark.
    *
-   * @method setIsDeleted
    * @internal
    * @param identifier
    * @param isDeleted
@@ -589,7 +560,6 @@ export class PersistedCache implements Cache {
   /**
    * Query the cache for any validation errors applicable to the given resource.
    *
-   * @method getErrors
    * @internal
    * @param identifier
    * @return
@@ -601,7 +571,6 @@ export class PersistedCache implements Cache {
   /**
    * Query the cache for whether a given resource has any available data
    *
-   * @method isEmpty
    * @internal
    * @param identifier
    * @return {Boolean}
@@ -614,7 +583,6 @@ export class PersistedCache implements Cache {
    * Query the cache for whether a given resource was created locally and not
    * yet persisted.
    *
-   * @method isNew
    * @internal
    * @param identifier
    * @return {Boolean}
@@ -627,7 +595,6 @@ export class PersistedCache implements Cache {
    * Query the cache for whether a given resource is marked as deleted (but not
    * necessarily persisted yet).
    *
-   * @method isDeleted
    * @internal
    * @param identifier
    * @return {Boolean}
@@ -640,7 +607,6 @@ export class PersistedCache implements Cache {
    * Query the cache for whether a given resource has been deleted and that deletion
    * has also been persisted.
    *
-   * @method isDeletionCommitted
    * @internal
    * @param identifier
    * @return {Boolean}

--- a/packages/experiments/src/persisted-cache/db.ts
+++ b/packages/experiments/src/persisted-cache/db.ts
@@ -14,7 +14,6 @@ const GlobalStorage = globalThis as typeof globalThis & {
 /**
  * Retrieve the configured IndexedDB database instance
  *
- * @typedoc
  */
 export async function getCache(): Promise<IDBDatabase> {
   if (GlobalStorage.__WarpDriveCache) {
@@ -39,7 +38,6 @@ export async function getCache(): Promise<IDBDatabase> {
  * for the cache. Running this function will run upgrades on the database
  * if necessary.
  *
- * @typedoc
  */
 async function setupCache(): Promise<IDBDatabase> {
   const request = indexedDB.open('WarpDriveCache', WarpDriveCacheVersion);
@@ -80,7 +78,6 @@ async function setupCache(): Promise<IDBDatabase> {
 /**
  * Perform the necessary migrations to upgrade the database
  *
- * @typedoc
  */
 async function upgradeCache(db: IDBDatabase, oldVersion: number): Promise<void> {
   const promises: Promise<void>[] = [];
@@ -117,7 +114,6 @@ async function upgradeCache(db: IDBDatabase, oldVersion: number): Promise<void> 
  *
  * If any resource is not found in the cache, the result will be null.
  *
- * @typedoc
  */
 export async function getCachedRequest(
   db: IDBDatabase,

--- a/packages/graph/src/-private/edges/collection.ts
+++ b/packages/graph/src/-private/edges/collection.ts
@@ -29,7 +29,6 @@ export interface CollectionEdge {
    * if state.hasReceivedData=false we are also
    * not dirty since there is nothing to sync with.
    *
-   * @typedoc
    */
   isDirty: boolean;
   transactionRef: number;
@@ -37,7 +36,6 @@ export interface CollectionEdge {
    * Whether data for this edge has been accessed at least once
    * via `graph.getData`
    *
-   * @typedoc
    */
   accessed: boolean;
 

--- a/packages/graph/src/-private/graph.ts
+++ b/packages/graph/src/-private/graph.ts
@@ -216,7 +216,7 @@ export class Graph {
 
    For example if there was:
 
-   ```app/models/comment.js
+   ```js [app/models/comment.js]
    import Model, { attr } from '@ember-data/model';
 
    export default class Comment extends Model {
@@ -226,7 +226,7 @@ export class Graph {
 
    and there is also:
 
-   ```app/models/post.js
+   ```js [app/models/post.js]
    import Model, { attr, hasMany } from '@ember-data/model';
 
    export default class Post extends Model {

--- a/packages/holodeck/server/index.js
+++ b/packages/holodeck/server/index.js
@@ -324,7 +324,7 @@ export async function createServer(options, useBun = false) {
   if (!useBun) {
     const CURRENT_FILE = new URL(import.meta.url).pathname;
     const START_FILE = path.join(CURRENT_FILE, '../start-node.js');
-    const server = Bun.spawn(['node', '--experimental-default-type=module', START_FILE, JSON.stringify(options)], {
+    const server = Bun.spawn(['node', START_FILE, JSON.stringify(options)], {
       env: process.env,
       cwd: process.cwd(),
       stdin: 'inherit',

--- a/packages/json-api/src/-private/builders/-utils.ts
+++ b/packages/json-api/src/-private/builders/-utils.ts
@@ -54,10 +54,7 @@ export let ACCEPT_HEADER_VALUE = 'application/vnd.api+json';
  * }
  * ```
  *
- * @method setBuildURLConfig
- * @static
  * @public
- * @for @ember-data/json-api/request
  * @param {BuildURLConfig} config
  * @return {void}
  */
@@ -194,10 +191,7 @@ function collapseIncludePaths(basePath: string, include: RelatedObject, paths: s
  * 'repeat': appends the key for every value e.g. `ids=1&ids=2`
  * 'comma' (default): appends the key once with a comma separated list of values e.g. `ids=1,2`
  *
- * @method buildQueryParams
- * @static
  * @public
- * @for @ember-data/json-api/request
  * @param {URLSearchParams | Object} params
  * @param {Object} [options]
  * @return {String} A sorted query params string without the leading `?`

--- a/packages/json-api/src/-private/builders/find-record.ts
+++ b/packages/json-api/src/-private/builders/find-record.ts
@@ -61,10 +61,7 @@ import { ACCEPT_HEADER_VALUE, copyForwardUrlOptions, extractCacheOptions } from 
  * const data = await store.request(options);
  * ```
  *
- * @method findRecord
  * @public
- * @static
- * @for @ember-data/json-api/request
  * @param identifier
  * @param options
  */

--- a/packages/json-api/src/-private/builders/query.ts
+++ b/packages/json-api/src/-private/builders/query.ts
@@ -58,10 +58,7 @@ import { ACCEPT_HEADER_VALUE, copyForwardUrlOptions, extractCacheOptions } from 
  * const data = await store.request(options);
  * ```
  *
- * @method query
  * @public
- * @static
- * @for @ember-data/json-api/request
  * @param identifier
  * @param query
  * @param options
@@ -144,10 +141,7 @@ export function query(
  * const data = await store.request(options);
  * ```
  *
- * @method postQuery
  * @public
- * @static
- * @for @ember-data/json-api/request
  * @param identifier
  * @param query
  * @param options

--- a/packages/json-api/src/-private/builders/save-record.ts
+++ b/packages/json-api/src/-private/builders/save-record.ts
@@ -68,10 +68,7 @@ function isExisting(identifier: StableRecordIdentifier): identifier is StableExi
  * const data = await store.request(options);
  * ```
  *
- * @method deleteRecord
  * @public
- * @static
- * @for @ember-data/json-api/request
  * @param record
  * @param options
  */
@@ -141,10 +138,7 @@ export function deleteRecord(record: unknown, options: ConstrainedRequestOptions
  * const data = await store.request(options);
  * ```
  *
- * @method createRecord
  * @public
- * @static
- * @for @ember-data/json-api/request
  * @param record
  * @param options
  */
@@ -216,10 +210,7 @@ export function createRecord(record: unknown, options: ConstrainedRequestOptions
  * const data = await store.request(options);
  * ```
  *
- * @method updateRecord
  * @public
- * @static
- * @for @ember-data/json-api/request
  * @param record
  * @param options
  */
@@ -304,10 +295,7 @@ export function updateRecord(
  * const data = await store.request(options);
  * ```
  *
- * @method patchRecord
  * @public
- * @static
- * @for @ember-data/json-api/request
  * @param record
  * @param options
  */

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -152,10 +152,16 @@ export default class JSONAPICache implements Cache {
    * @property version
    */
   declare version: '2';
+
+  /** @internal */
   declare _capabilities: CacheCapabilitiesManager;
+  /** @internal */
   declare __cache: Map<StableRecordIdentifier, CachedResource>;
+  /** @internal */
   declare __destroyedCache: Map<StableRecordIdentifier, CachedResource>;
+  /** @internal */
   declare __documents: Map<string, StructuredDocument<ResourceDocument>>;
+  /** @internal */
   declare __graph: Graph;
 
   constructor(capabilities: CacheCapabilitiesManager) {
@@ -319,6 +325,7 @@ export default class JSONAPICache implements Cache {
     );
   }
 
+  /** @internal */
   _putDocument<T extends ResourceErrorDocument>(
     doc: StructuredErrorDocument<T>,
     data: undefined,

--- a/packages/json-api/src/-private/cache.ts
+++ b/packages/json-api/src/-private/cache.ts
@@ -204,7 +204,6 @@ export default class JSONAPICache implements Cache {
    * associated resource membership order and contents preserved but linked
    * into the cache.
    *
-   * @method put
    * @param {StructuredDocument} doc
    * @return {ResourceDocument}
    * @public
@@ -398,7 +397,6 @@ export default class JSONAPICache implements Cache {
    * Update the "remote" or "canonical" (persisted) state of the Cache
    * by merging new information into the existing state.
    *
-   * @method patch
    * @public
    * @param {Operation|Operation[]} op the operation or list of operations to perform
    * @return {void}
@@ -428,7 +426,6 @@ export default class JSONAPICache implements Cache {
   /**
    * Update the "local" or "current" (unpersisted) state of the Cache
    *
-   * @method mutate
    * @param {Mutation} mutation
    * @return {void}
    * @public
@@ -480,7 +477,6 @@ export default class JSONAPICache implements Cache {
    * of the Graph handling necessary entanglements and
    * notifications for relational data.
    *
-   * @method peek
    * @public
    * @param {StableRecordIdentifier | StableDocumentIdentifier} identifier
    * @return {ResourceDocument | ResourceObject | null} the known resource data
@@ -611,7 +607,6 @@ export default class JSONAPICache implements Cache {
    * that it will return the the request, response, and content
    * whereas `peek` will return just the `content`.
    *
-   * @method peekRequest
    * @param {StableDocumentIdentifier}
    * @return {StructuredDocument<ResourceDocument> | null}
    * @public
@@ -623,7 +618,6 @@ export default class JSONAPICache implements Cache {
   /**
    * Push resource data from a remote source into the cache for this identifier
    *
-   * @method upsert
    * @public
    * @param identifier
    * @param data
@@ -658,7 +652,6 @@ export default class JSONAPICache implements Cache {
    * preferring instead to fork at the Store level, which will
    * utilize this method to fork the cache.
    *
-   * @method fork
    * @internal
    * @return {Promise<Cache>}
    */
@@ -673,7 +666,6 @@ export default class JSONAPICache implements Cache {
    * preferring instead to merge at the Store level, which will
    * utilize this method to merge the caches.
    *
-   * @method merge
    * @param {Cache} cache
    * @public
    * @return {Promise<void>}
@@ -712,7 +704,6 @@ export default class JSONAPICache implements Cache {
    * }
    * ```
    *
-   * @method diff
    * @public
    */
   diff(): Promise<Change[]> {
@@ -727,7 +718,6 @@ export default class JSONAPICache implements Cache {
    * which may be fed back into a new instance of the same Cache
    * via `cache.hydrate`.
    *
-   * @method dump
    * @return {Promise<ReadableStream>}
    * @public
    */
@@ -747,7 +737,6 @@ export default class JSONAPICache implements Cache {
    * behavior supports optimizing pre/fetching of data for route transitions
    * via data-only SSR modes.
    *
-   * @method hydrate
    * @param {ReadableStream} stream
    * @return {Promise<void>}
    * @public
@@ -765,7 +754,6 @@ export default class JSONAPICache implements Cache {
    * It returns properties from options that should be set on the record during the create
    * process. This return value behavior is deprecated.
    *
-   * @method clientDidCreate
    * @public
    * @param identifier
    * @param createArgs
@@ -846,7 +834,6 @@ export default class JSONAPICache implements Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * will be part of a save transaction.
    *
-   * @method willCommit
    * @public
    * @param identifier
    */
@@ -908,7 +895,6 @@ export default class JSONAPICache implements Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * was successfully updated as part of a save transaction.
    *
-   * @method didCommit
    * @public
    * @param identifier
    * @param data
@@ -1053,7 +1039,6 @@ export default class JSONAPICache implements Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * was update via a save transaction failed.
    *
-   * @method commitWasRejected
    * @public
    * @param identifier
    * @param errors
@@ -1085,7 +1070,6 @@ export default class JSONAPICache implements Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method unloadRecord
    * @public
    * @param identifier
    */
@@ -1166,7 +1150,6 @@ export default class JSONAPICache implements Cache {
   /**
    * Retrieve the data for an attribute from the cache
    *
-   * @method getAttr
    * @public
    * @param identifier
    * @param field
@@ -1301,7 +1284,6 @@ export default class JSONAPICache implements Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method setAttr
    * @public
    * @param identifier
    * @param field
@@ -1420,7 +1402,6 @@ export default class JSONAPICache implements Cache {
   /**
    * Query the cache for the changed attributes of a resource.
    *
-   * @method changedAttrs
    * @public
    * @param identifier
    * @return {ChangedAttributesHash} `{ <field>: [<old>, <new>] }`
@@ -1445,7 +1426,6 @@ export default class JSONAPICache implements Cache {
   /**
    * Query the cache for whether any mutated attributes exist
    *
-   * @method hasChangedAttrs
    * @public
    * @param identifier
    * @return {Boolean}
@@ -1474,7 +1454,6 @@ export default class JSONAPICache implements Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method rollbackAttrs
    * @public
    * @param identifier
    * @return {String[]} the names of fields that were restored
@@ -1536,7 +1515,6 @@ export default class JSONAPICache implements Cache {
       };
       ```
      *
-     * @method changedRelationships
      * @public
      * @param {StableRecordIdentifier} identifier
      * @return {Map<string, RelationshipDiff>}
@@ -1548,7 +1526,6 @@ export default class JSONAPICache implements Cache {
   /**
    * Query the cache for whether any mutated relationships exist
    *
-   * @method hasChangedRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {Boolean}
@@ -1564,7 +1541,6 @@ export default class JSONAPICache implements Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method rollbackRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {String[]} the names of relationships that were restored
@@ -1581,7 +1557,6 @@ export default class JSONAPICache implements Cache {
   /**
    * Query the cache for the current state of a relationship property
    *
-   * @method getRelationship
    * @public
    * @param identifier
    * @param field
@@ -1607,7 +1582,6 @@ export default class JSONAPICache implements Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method setIsDeleted
    * @public
    * @param identifier
    * @param {Boolean} isDeleted
@@ -1622,7 +1596,6 @@ export default class JSONAPICache implements Cache {
   /**
    * Query the cache for any validation errors applicable to the given resource.
    *
-   * @method getErrors
    * @public
    * @param identifier
    * @return {JsonApiError[]}
@@ -1634,7 +1607,6 @@ export default class JSONAPICache implements Cache {
   /**
    * Query the cache for whether a given resource has any available data
    *
-   * @method isEmpty
    * @public
    * @param identifier
    * @return {Boolean}
@@ -1648,7 +1620,6 @@ export default class JSONAPICache implements Cache {
    * Query the cache for whether a given resource was created locally and not
    * yet persisted.
    *
-   * @method isNew
    * @public
    * @param identifier
    * @return {Boolean}
@@ -1662,7 +1633,6 @@ export default class JSONAPICache implements Cache {
    * Query the cache for whether a given resource is marked as deleted (but not
    * necessarily persisted yet).
    *
-   * @method isDeleted
    * @public
    * @param identifier
    * @return {Boolean}
@@ -1676,7 +1646,6 @@ export default class JSONAPICache implements Cache {
    * Query the cache for whether a given resource has been deleted and that deletion
    * has also been persisted.
    *
-   * @method isDeletionCommitted
    * @public
    * @param identifier
    * @return {Boolean}
@@ -1689,7 +1658,6 @@ export default class JSONAPICache implements Cache {
   /**
    * Private method used to populate an entry for the identifier
    *
-   * @method _createCache
    * @internal
    * @param {StableRecordIdentifier} identifier
    * @return {CachedResource}
@@ -1705,7 +1673,6 @@ export default class JSONAPICache implements Cache {
    * Peek whether we have cached resource data matching the identifier
    * without asserting if the resource data is missing.
    *
-   * @method __safePeek
    * @param {StableRecordIdentifier} identifier
    * @param {Boolean} allowDestroyed
    * @internal
@@ -1723,7 +1690,6 @@ export default class JSONAPICache implements Cache {
    * Peek whether we have cached resource data matching the identifier
    * Asserts if the resource data is missing.
    *
-   * @method __Peek
    * @param {StableRecordIdentifier} identifier
    * @param {Boolean} allowDestroyed
    * @internal

--- a/packages/json-api/src/-private/serialize.ts
+++ b/packages/json-api/src/-private/serialize.ts
@@ -25,10 +25,7 @@ export type JsonApiResourcePatch =
 /**
  * Serializes the current state of a resource or array of resources for use with POST or PUT requests.
  *
- * @method serializeResources
- * @static
  * @public
- * @for @ember-data/json-api/request
  * @param {Cache} cache}
  * @param {StableRecordIdentifier} identifier
  * @return {Object} An object with a `data` property containing the serialized resource patch
@@ -121,10 +118,7 @@ function _serializeResource(cache: Cache, identifier: StableRecordIdentifier): R
  * const relationshipDiffMap = cache.changedRelationships(identifier);
  * ```
  *
- * @method serializePatch
- * @static
  * @public
- * @for @ember-data/json-api/request
  * @param {Cache} cache}
  * @param {StableRecordIdentifier} identifier
  * @return {Object} An object with a `data` property containing the serialized resource patch

--- a/packages/legacy-compat/src/builders/find-all.ts
+++ b/packages/legacy-compat/src/builders/find-all.ts
@@ -27,11 +27,8 @@ type FindAllBuilderOptions<T = unknown> = FindAllOptions<T>;
   This is useful for quickly upgrading an entire app to a unified syntax while a longer incremental migration is made to shift off of adapters and serializers.
   To that end, these builders are deprecated and will be removed in a future version of Ember Data.
 
-  @method findAll
   @deprecated
   @public
-  @static
-  @for @ember-data/legacy-compat/builders
   @param {String} type the name of the resource
   @param {Object} query a query to be used by the adapter
   @param {FindAllBuilderOptions} [options] optional, may include `adapterOptions` hash which will be passed to adapter.findAll

--- a/packages/legacy-compat/src/builders/find-record.ts
+++ b/packages/legacy-compat/src/builders/find-record.ts
@@ -47,11 +47,8 @@ type FindRecordBuilderOptions = Omit<FindRecordOptions, 'preload'>;
   This is useful for quickly upgrading an entire app to a unified syntax while a longer incremental migration is made to shift off of adapters and serializers.
   To that end, these builders are deprecated and will be removed in a future version of Ember Data.
 
-  @method findRecord
   @deprecated
   @public
-  @static
-  @for @ember-data/legacy-compat/builders
   @param {string|object} resource - either a string representing the name of the resource or a ResourceIdentifier object containing both the type (a string) and the id (a string) for the record or an lid (a string) of an existing record
   @param {string|number|object} id - optional object with options for the request only if the first param is a ResourceIdentifier, else the string id of the record to be retrieved
   @param {FindRecordBuilderOptions} [options] - if the first param is a string this will be the optional options for the request. See examples for available options.

--- a/packages/legacy-compat/src/builders/query.ts
+++ b/packages/legacy-compat/src/builders/query.ts
@@ -28,11 +28,8 @@ type QueryBuilderOptions = QueryOptions;
   This is useful for quickly upgrading an entire app to a unified syntax while a longer incremental migration is made to shift off of adapters and serializers.
   To that end, these builders are deprecated and will be removed in a future version of Ember Data.
 
-  @method query
   @deprecated
   @public
-  @static
-  @for @ember-data/legacy-compat/builders
   @param {String} type the name of the resource
   @param {Object} query a query to be used by the adapter
   @param {QueryBuilderOptions} [options] optional, may include `adapterOptions` hash which will be passed to adapter.query
@@ -90,11 +87,8 @@ type QueryRecordRequestInput<T extends string = string, RT = unknown> = StoreReq
   This is useful for quickly upgrading an entire app to a unified syntax while a longer incremental migration is made to shift off of adapters and serializers.
   To that end, these builders are deprecated and will be removed in a future version of Ember Data.
 
-  @method queryRecord
   @deprecated
   @public
-  @static
-  @for @ember-data/legacy-compat/builders
   @param {String} type the name of the resource
   @param {Object} query a query to be used by the adapter
   @param {QueryBuilderOptions} [options] optional, may include `adapterOptions` hash which will be passed to adapter.query

--- a/packages/legacy-compat/src/builders/save-record.ts
+++ b/packages/legacy-compat/src/builders/save-record.ts
@@ -37,11 +37,8 @@ function resourceIsFullyDeleted(instanceCache: InstanceCache, identifier: Stable
   This is useful for quickly upgrading an entire app to a unified syntax while a longer incremental migration is made to shift off of adapters and serializers.
   To that end, these builders are deprecated and will be removed in a future version of Ember Data.
 
-  @method saveRecord
   @deprecated
   @public
-  @static
-  @for @ember-data/legacy-compat/builders
   @param {Object} record a record to save
   @param {SaveRecordBuilderOptions} options optional, may include `adapterOptions` hash which will be passed to adapter.saveRecord
   @return {SaveRecordRequestInput} request config

--- a/packages/legacy-compat/src/index.ts
+++ b/packages/legacy-compat/src/index.ts
@@ -43,7 +43,6 @@ export type CompatStore = Store & LegacyStoreCompat;
     for an `application` adapter (the default adapter for
     your entire application).
 
-    @method adapterFor
     @public
     @param {String} modelName
     @return {Adapter}
@@ -107,7 +106,6 @@ export function adapterFor(this: Store, modelName: string, _allowMissing?: true)
     If a serializer cannot be found on the adapter, it will fall back
     to an instance of `JSONSerializer`.
 
-    @method serializerFor
     @public
     @param {String} modelName the record to serialize
     @return {Serializer}
@@ -168,7 +166,6 @@ export function serializerFor(this: Store, modelName: string): MinimumSerializer
     });
     ```
 
-    @method normalize
     @public
     @param {String} modelName The name of the model type for this payload
     @param {Object} payload
@@ -247,7 +244,6 @@ export function normalize(this: Store, modelName: string, payload: ObjectValue) 
     store.pushPayload('post', pushData); // Will use the post serializer
     ```
 
-    @method pushPayload
     @public
     @param {String} modelName Optionally, a model type used to determine which serializer will be used
     @param {Object} inputPayload

--- a/packages/legacy-compat/src/index.ts
+++ b/packages/legacy-compat/src/index.ts
@@ -202,7 +202,7 @@ export function normalize(this: Store, modelName: string, payload: ObjectValue) 
     All objects should be in the format expected by the
     serializer.
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import RESTSerializer from '@ember-data/serializer/rest';
 
     export default class ApplicationSerializer extends RESTSerializer;
@@ -227,13 +227,13 @@ export function normalize(this: Store, modelName: string, payload: ObjectValue) 
     Alternatively, `pushPayload` will accept a model type which
     will determine which serializer will process the payload.
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import RESTSerializer from '@ember-data/serializer/rest';
 
      export default class ApplicationSerializer extends RESTSerializer;
     ```
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default JSONSerializer;

--- a/packages/legacy-compat/src/legacy-network-handler/minimum-adapter-interface.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/minimum-adapter-interface.ts
@@ -51,7 +51,6 @@ export interface MinimumAdapterInterface {
    * `adapter.findRecord` is called whenever the `store` needs to load, reload, or backgroundReload
    * the resource data for a given `type` and `id`.
    *
-   * @method findRecord
    * @public
    * @param {Store} store The store service that initiated the request being normalized
    * @param {ModelSchema} schema An object with methods for accessing information about
@@ -82,7 +81,6 @@ export interface MinimumAdapterInterface {
    *
    * See also `shouldReloadAll` and `shouldBackgroundReloadAll`
    *
-   * @method findAll
    * @public
    * @param {Store} store The store service that initiated the request being normalized
    * @param {ModelSchema} schema An object with methods for accessing information about
@@ -120,7 +118,6 @@ export interface MinimumAdapterInterface {
    * returned by the `store`. For `findAll` the result is all known records of the `type`,
    * while for `query` it will only be the records returned from `adapter.query`.
    *
-   * @method query
    * @public
    * @param {Store} store The store service that initiated the request being normalized
    * @param {ModelSchema} schema An object with methods for accessing information about
@@ -152,7 +149,6 @@ export interface MinimumAdapterInterface {
    * call will NOT be made. In this scenario you may need to do at least a minimum amount of response
    * processing within the adapter.
    *
-   * @method queryRecord
    * @public
    * @param {Store} store The store service that initiated the request being normalized
    * @param {ModelSchema} schema An object with methods for accessing information about
@@ -211,7 +207,6 @@ export interface MinimumAdapterInterface {
    * throw error;
    * ```
    *
-   * @method createRecord
    * @public
    * @param {Store} store The store service that initiated the request being normalized
    * @param {ModelSchema} schema An object with methods for accessing information about
@@ -264,7 +259,6 @@ export interface MinimumAdapterInterface {
    * throw error;
    * ```
    *
-   * @method updateRecord
    * @public
    * @param {Store} store The store service that initiated the request being normalized
    * @param {ModelSchema} schema An object with methods for accessing information about
@@ -291,7 +285,6 @@ export interface MinimumAdapterInterface {
    * If the adapter rejects or errors the record will need to be saved again once the reason
    * for the error is addressed in order to persist the deleted state.
    *
-   * @method deleteRecord
    * @public
    * @param {Store} store The store service that initiated the request being normalized
    * @param {ModelSchema} schema An object with methods for accessing information about
@@ -322,7 +315,6 @@ export interface MinimumAdapterInterface {
    * call will NOT be made. In this scenario you may need to do at least a minimum amount of response
    * processing within the adapter.
    *
-   * @method findBelongsTo [OPTIONAL]
    * @public
    * @optional
    * @param {Store} store The store service that initiated the request being normalized
@@ -360,7 +352,6 @@ export interface MinimumAdapterInterface {
    * call will NOT be made. In this scenario you may need to do at least a minimum amount of response
    * processing within the adapter.
    *
-   * @method findhasMany [OPTIONAL]
    * @public
    * @optional
    * @param {Store} store The store service that initiated the request being normalized
@@ -395,7 +386,6 @@ export interface MinimumAdapterInterface {
    *
    * See also `groupRecordsForFindMany` and `coalesceFindRequests`
    *
-   * @method findMany [OPTIONAL]
    * @public
    * @optional
    * @param {Store} store The store service that initiated the request being normalized
@@ -418,7 +408,6 @@ export interface MinimumAdapterInterface {
    * let newRecord = store.createRecord(type, { id });
    * ```
    *
-   * @method generateIdForRecord [OPTIONAL]
    * @public
    * @optional
    * @param {Store} store The store service that initiated the request being normalized
@@ -462,7 +451,6 @@ export interface MinimumAdapterInterface {
    *
    * See also `findMany` and `coalesceFindRequests`
    *
-   * @method groupRecordsForFindMany [OPTIONAL]
    * @public
    * @optional
    * @param {Store} store The store service that initiated the request being normalized
@@ -488,7 +476,6 @@ export interface MinimumAdapterInterface {
    *
    * See also the documentation for `shouldBackgroundReloadRecord` which defaults to `true`.
    *
-   * @method shouldReloadRecord [OPTIONAL]
    * @public
    * @optional
    * @param {Store} store The store service that initiated the request being normalized
@@ -515,7 +502,6 @@ export interface MinimumAdapterInterface {
    * returned by `store.peekAll` for that type, and will include all records in the store for
    * the given type, including any previously existing records not returned by the reload request.
    *
-   * @method shouldReloadAll [OPTIONAL]
    * @public
    * @optional
    * @param {Store} store The store service that initiated the request being normalized
@@ -542,7 +528,6 @@ export interface MinimumAdapterInterface {
    * The default behavior if this method is not implemented and the option was not specified is to
    * background reload, the same as a return of `true`.
    *
-   * @method shouldBackgroundReloadRecord [OPTIONAL]
    * @public
    * @optional
    * @param {Store} store The store service that initiated the request being normalized
@@ -566,7 +551,6 @@ export interface MinimumAdapterInterface {
    * The default behavior if this method is not implemented and the option is not specified is to
    * perform a reload, the same as a return of `true`.
    *
-   * @method shouldBackgroundReloadAll [OPTIONAL]
    * @public
    * @optional
    * @param {Store} store The store service that initiated the request being normalized
@@ -581,7 +565,6 @@ export interface MinimumAdapterInterface {
    *
    * If not implemented, the store does not inform the adapter of destruction.
    *
-   * @method destroy [OPTIONAL]
    * @public
    * @optional
    */

--- a/packages/legacy-compat/src/legacy-network-handler/minimum-serializer-interface.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/minimum-serializer-interface.ts
@@ -53,7 +53,6 @@ export interface MinimumSerializerInterface {
    *    a valid optional sibling to `id` and `type` in both [Resources](https://jsonapi.org/format/#document-resource-objects)
    *    and [Resource Identifier Objects](https://jsonapi.org/format/#document-resource-identifier-objects)
    *
-   * @method normalizeResponse
    * @public
    * @param {Store} store The store service that initiated the request being normalized
    * @param {ModelSchema} schema An object with methods for accessing information about
@@ -98,7 +97,6 @@ export interface MinimumSerializerInterface {
    * by `updateRecord` and `createRecord` if `Serializer.serializeIntoHash`
    * is not implemented.
    *
-   * @method serialize
    * @public
    * @param {Snapshot} snapshot A Snapshot for the record to serialize
    * @param {Object} [options]
@@ -147,7 +145,6 @@ export interface MinimumSerializerInterface {
    * your application we recommend implementing this method, but caution that
    * it may lead to unexpected mixing of formats.
    *
-   * @method normalize [OPTIONAL]
    * @public
    * @optional
    * @param {ModelSchema} schema An object with methods for accessing information about
@@ -190,7 +187,6 @@ export interface MinimumSerializerInterface {
    * }
    * ```
    *
-   * @method serializeIntoHash [OPTIONAL]
    * @public
    * @optional
    * @param hash A top most object of the request payload onto
@@ -237,7 +233,6 @@ export interface MinimumSerializerInterface {
    * }
    * ```
    *
-   * @method pushPayload [OPTIONAL]
    * @public
    * @optional
    * @param {Store} store The store service that initiated the request being normalized
@@ -253,7 +248,6 @@ export interface MinimumSerializerInterface {
    *
    * If not implemented, the store does not inform the serializer of destruction.
    *
-   * @method destroy [OPTIONAL]
    * @public
    * @optional
    */

--- a/packages/legacy-compat/src/legacy-network-handler/snapshot-record-array.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/snapshot-record-array.ts
@@ -57,7 +57,7 @@ export class SnapshotRecordArray {
 
       Example
 
-      ```app/adapters/post.js
+      ```js [app/adapters/post.js]
       import MyCustomAdapter from './custom-adapter';
 
       export default class PostAdapter extends MyCustomAdapter {
@@ -81,7 +81,7 @@ export class SnapshotRecordArray {
 
       Example
 
-      ```app/adapters/application.js
+      ```js [app/adapters/application.js]
       import Adapter from '@ember-data/adapter';
 
       export default class ApplicationAdapter extends Adapter {
@@ -116,7 +116,7 @@ export class SnapshotRecordArray {
 
       Example
 
-      ```app/adapters/post.js
+      ```js [app/adapters/post.js]
       import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
       export default class PostAdapter extends JSONAPIAdapter {
@@ -139,7 +139,7 @@ export class SnapshotRecordArray {
 
     Example
 
-    ```app/adapters/post.js
+    ```js [app/adapters/post.js]
     import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
     export default class PostAdapter extends JSONAPIAdapter {

--- a/packages/legacy-compat/src/legacy-network-handler/snapshot-record-array.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/snapshot-record-array.ts
@@ -28,7 +28,6 @@ export class SnapshotRecordArray {
     Instances are provided to consuming application's
     adapters and serializers for certain requests.
 
-    @method constructor
     @private
     @constructor
     @param {Store} store
@@ -159,7 +158,6 @@ export class SnapshotRecordArray {
     }
     ```
 
-    @method snapshots
     @public
     @return {Array} Array of snapshots
   */

--- a/packages/legacy-compat/src/legacy-network-handler/snapshot.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/snapshot.ts
@@ -522,7 +522,7 @@ export class Snapshot<R = unknown> {
 
     Example
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter from '@ember-data/adapter';
 
     export default Adapter.extend({

--- a/packages/legacy-compat/src/legacy-network-handler/snapshot.ts
+++ b/packages/legacy-compat/src/legacy-network-handler/snapshot.ts
@@ -44,7 +44,6 @@ export class Snapshot<R = unknown> {
   declare _store: Store;
 
   /**
-   * @method constructor
    * @constructor
    * @private
    * @param options
@@ -195,7 +194,6 @@ export class Snapshot<R = unknown> {
 
    Note: Values are loaded eagerly and cached when the snapshot is created.
 
-   @method attr
    @param {String} keyName
    @return {Object} The attribute value or undefined
    @public
@@ -217,7 +215,6 @@ export class Snapshot<R = unknown> {
    postSnapshot.attributes(); // => { author: 'Tomster', title: 'Ember.js rocks' }
    ```
 
-   @method attributes
    @return {Object} All attributes of the current snapshot
    @public
    */
@@ -236,7 +233,6 @@ export class Snapshot<R = unknown> {
    postSnapshot.changedAttributes(); // => { title: ['Ember.js rocks', 'Ember.js rocks!'] }
    ```
 
-   @method changedAttributes
    @return {Object} All changed attributes of the current snapshot
    @public
    */
@@ -284,7 +280,6 @@ export class Snapshot<R = unknown> {
 
    Note: Relationships are loaded lazily and cached upon first access.
 
-   @method belongsTo
    @param {String} keyName
    @param {Object} [options]
    @public
@@ -386,7 +381,6 @@ export class Snapshot<R = unknown> {
 
    Note: Relationships are loaded lazily and cached upon first access.
 
-   @method hasMany
    @param {String} keyName
    @param {Object} [options]
    @public
@@ -485,7 +479,6 @@ export class Snapshot<R = unknown> {
     });
     ```
 
-    @method eachAttribute
     @param {Function} callback the callback to execute
     @param {Object} [binding] the value to which the callback's `this` should be bound
     @public
@@ -511,7 +504,6 @@ export class Snapshot<R = unknown> {
     });
     ```
 
-    @method eachRelationship
     @param {Function} callback the callback to execute
     @param {Object} [binding] the value to which the callback's `this` should be bound
     @public
@@ -546,7 +538,6 @@ export class Snapshot<R = unknown> {
     });
     ```
 
-    @method serialize
     @param {Object} options
     @return {Object} an object whose values are primitive JSON values only
     @public

--- a/packages/legacy-compat/src/utils.ts
+++ b/packages/legacy-compat/src/utils.ts
@@ -36,11 +36,8 @@ let NormalizedType: Normalizer = (str: string) => {
  * changes during normalization. This is useful for instrumenting
  * to discover places where usage in the app is not consistent.
  *
- * @method configureMismatchReporter
- * @for @ember-data/legacy-compat/utils
  * @param method a function which takes a mismatch-type ('formatted-id' | 'formatted-type'), actual, and expected value
  * @public
- * @static
  */
 export function configureMismatchReporter(fn: Reporter): void {
   MismatchReporter = fn;
@@ -51,11 +48,8 @@ export function configureMismatchReporter(fn: Reporter): void {
  * fails validation. This is useful for instrumenting
  * to discover places where usage in the app is not consistent.
  *
- * @method configureAssertFn
- * @for @ember-data/legacy-compat/utils
  * @param method a function which takes a message and a condition
  * @public
- * @static
  */
 export function configureAssertFn(fn: (message: string, condition: unknown) => void): void {
   _AssertFn = fn;
@@ -71,11 +65,8 @@ export function configureAssertFn(fn: (message: string, condition: unknown) => v
  * the configured mismatch reporter and assert functions will
  * be called.
  *
- * @method configureTypeNormalization
- * @for @ember-data/legacy-compat/utils
  * @param method a function which takes a string and returns a string
  * @public
- * @static
  */
 export function configureTypeNormalization(fn: (type: string) => string): void {
   NormalizedType = fn;
@@ -108,12 +99,9 @@ const NORMALIZED_TYPES = new Map<string, string>();
  * formattedType('PostComment'); // => 'post-comment'
  * ```
  *
- * @method formattedType
- * @for @ember-data/legacy-compat/utils
  * @param {String} type the potentially un-normalized type
  * @return {String} the normalized type
  * @public
- * @static
  */
 export function formattedType<T extends string>(type: T | string): T {
   AssertFn('formattedType: type must not be null', type !== null);
@@ -150,12 +138,9 @@ export function formattedType<T extends string>(type: T | string): T {
  * formattedId(null); // => null
  *	```
  *
- * @method formattedId
- * @for @ember-data/legacy-compat/utils
  * @param {String | Number | null} id the potentially un-normalized id
  * @return {String | null} the normalized id
  * @public
- * @static
  */
 export function formattedId(id: string | number): string;
 export function formattedId(id: null): null;
@@ -207,13 +192,10 @@ export function expectId(id: string | number | null): string {
  * isEquivType('posts', null); // false
  * ```
  *
- * @method isEquivType
- * @for @ember-data/legacy-compat/utils
  * @param {String} expected a potentially unnormalized type to match against
  * @param {String} actual a potentially unnormalized type to match against
  * @return {Boolean} true if the types are equivalent
  * @public
- * @static
  */
 export function isEquivType(expected: string, actual: string): boolean {
   AssertFn('isEquivType: Expected type must not be null', expected !== null);
@@ -245,13 +227,10 @@ export function isEquivType(expected: string, actual: string): boolean {
  * isEquivId(1, null); // false
  * ```
  *
- * @method isEquivId
- * @for @ember-data/legacy-compat/utils
  * @param {string | number} expected a potentially un-normalized id to match against
  * @param {string | number} actual a potentially un-normalized id to match against
  * @return {Boolean} true if the ids are equivalent
  * @public
- * @static
  */
 export function isEquivId(expected: string | number, actual: string | number | null): boolean {
   AssertFn('isEquivId: Expected id must not be null', expected !== null);

--- a/packages/model/src/-private.ts
+++ b/packages/model/src/-private.ts
@@ -1,7 +1,3 @@
-export { attr } from './-private/attr';
-export { belongsTo } from './-private/belongs-to';
-export { hasMany } from './-private/has-many';
-export { Model } from './-private/model';
 export type { ModelStore } from './-private/model';
 export { Errors } from './-private/errors';
 

--- a/packages/model/src/-private/attr.ts
+++ b/packages/model/src/-private/attr.ts
@@ -197,7 +197,7 @@ export type DataDecorator = (target: object, key: string, desc?: DecoratorProper
 
   Example
 
-  ```app/models/user.js
+  ```js [app/models/user.js]
   import Model, { attr } from '@ember-data/model';
 
   export default class UserModel extends Model {
@@ -210,7 +210,7 @@ export type DataDecorator = (target: object, key: string, desc?: DecoratorProper
   Default value can also be a function. This is useful it you want to return
   a new object for each attribute.
 
-  ```app/models/user.js
+  ```js [app/models/user.js]
   import Model, { attr } from '@ember-data/model';
 
   export default class UserModel extends Model {
@@ -230,7 +230,7 @@ export type DataDecorator = (target: object, key: string, desc?: DecoratorProper
   `serialize` and `deserialize` method. This allows to configure a
   transformation and adapt the corresponding value, based on the config:
 
-  ```app/models/post.js
+  ```js [app/models/post.js]
   import Model, { attr } from '@ember-data/model';
 
   export default class PostModel extends Model {
@@ -241,7 +241,7 @@ export type DataDecorator = (target: object, key: string, desc?: DecoratorProper
   }
   ```
 
-  ```app/transforms/text.js
+  ```js [app/transforms/text.js]
   export default class TextTransform {
     serialize(value, options) {
       if (options.uppercase) {

--- a/packages/model/src/-private/attr.ts
+++ b/packages/model/src/-private/attr.ts
@@ -33,7 +33,6 @@ import { isElementDescriptor } from './util';
  * }
  *
  * @class NOTATHING
- * @typedoc
  */
 export type AttrOptions<DV = PrimitiveValue | object | unknown[]> = {
   /**
@@ -45,7 +44,6 @@ export type AttrOptions<DV = PrimitiveValue | object | unknown[]> = {
    * Default values *should not* be stateful (object, arrays, etc.) as
    * they will be shared across all instances of the record.
    *
-   * @typedoc
    */
   defaultValue?: DV extends PrimitiveValue ? DV : () => DV;
 };
@@ -126,7 +124,6 @@ type LooseTransformInstance<V, Raw, Name extends string> = {
   /**
    * value type must match the return type of the deserialize method
    *
-   * @typedoc
    */
   // see note on Explicit ANY above
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -134,7 +131,6 @@ type LooseTransformInstance<V, Raw, Name extends string> = {
   /**
    * defaultValue type must match the return type of the deserialize method
    *
-   * @typedoc
    */
   // see note on Explicit ANY above
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -180,7 +176,6 @@ export type OptionsFromInstance<T> =
  * is a descriptor, but typescript incorrectly insists that decorator functions return
  * `void` or `any`.
  *
- * @typedoc
  */
 export type DataDecorator = (target: object, key: string, desc?: DecoratorPropertyDescriptor) => void;
 
@@ -266,10 +261,7 @@ export type DataDecorator = (target: object, key: string, desc?: DecoratorProper
   }
   ```
 
-  @method attr
   @public
-  @static
-  @for @ember-data/model
   @param {String|Object} type the attribute type
   @param {Object} options a hash of options
   @return {Attribute}

--- a/packages/model/src/-private/belongs-to.ts
+++ b/packages/model/src/-private/belongs-to.ts
@@ -263,10 +263,7 @@ function _belongsTo<T, Async extends boolean>(
   must be declared as polymorphic, and the `as` option must be used to declare the abstract
   type each record satisfies on both sides.
 
-  @method belongsTo
   @public
-  @static
-  @for @ember-data/model
   @param {String} type (optional) the name of the related resource
   @param {Object} options (optional) a hash of options
   @return {PropertyDescriptor} relationship

--- a/packages/model/src/-private/errors.ts
+++ b/packages/model/src/-private/errors.ts
@@ -97,7 +97,6 @@ const ArrayProxyWithCustomOverrides = ArrayProxy as unknown as new <T>() => Arra
 
   @class Errors
   @public
-  @extends Ember.ArrayProxy
  */
 export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
   declare __record: { currentState: RecordState };
@@ -125,7 +124,6 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
     });
     ```
 
-    @method errorsFor
     @public
     @param {String} attribute
     @return {Array}
@@ -179,7 +177,6 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
   }
 
   /**
-    @method unknownProperty
     @private
   */
   unknownProperty(attribute: string) {
@@ -196,7 +193,7 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
     @property length
     @type {Number}
     @public
-    @readOnly
+    @readonly
   */
 
   /**
@@ -205,7 +202,7 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
     @property isEmpty
     @type {Boolean}
     @public
-    @readOnly
+    @readonly
   */
   @not('length')
   declare isEmpty: boolean;
@@ -242,7 +239,6 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
     //   { attribute: 'username', message: 'This field is required' },
     // ]
    ```
-    @method add
     @public
     @param {String} attribute - the property name of an attribute or relationship
     @param {string[]|string} messages - an error message or array of error messages for the attribute
@@ -258,7 +254,6 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
   }
 
   /**
-    @method _findOrCreateMessages
     @private
   */
   _findOrCreateMessages(attribute: string, messages: string | string[]): ValidationError[] {
@@ -305,7 +300,6 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
     errors.errorsFor('phone');
     // => undefined
    ```
-   @method remove
     @public
    @param {String} member - the property name of an attribute or relationship
    */
@@ -369,7 +363,6 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
    errors.messages
    // => []
    ```
-   @method clear
    @public
    */
   clear(): void {
@@ -408,7 +401,6 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
     }
     ```
 
-    @method has
     @public
     @param {String} attribute
     @return {Boolean} true if there some errors on given attribute

--- a/packages/model/src/-private/errors.ts
+++ b/packages/model/src/-private/errors.ts
@@ -35,7 +35,7 @@ const ArrayProxyWithCustomOverrides = ArrayProxy as unknown as new <T>() => Arra
 
   For Example, if you had a `User` model that looked like this:
 
-  ```app/models/user.js
+  ```js [app/models/user.js]
   import Model, { attr } from '@ember-data/model';
 
   export default class UserModel extends Model {
@@ -389,7 +389,7 @@ export class Errors extends ArrayProxyWithCustomOverrides<ValidationError> {
   /**
     Checks if there are error messages for the given attribute.
 
-    ```app/controllers/user/edit.js
+    ```js [app/controllers/user/edit.js]
     export default class UserEditController extends Controller {
       @action
       save(user) {

--- a/packages/model/src/-private/has-many.ts
+++ b/packages/model/src/-private/has-many.ts
@@ -240,10 +240,7 @@ function _hasMany<T, Async extends boolean>(
   must be declared as polymorphic, and the `as` option must be used to declare the abstract
   type each record satisfies on both sides.
 
-  @method hasMany
   @public
-  @static
-  @for @ember-data/model
   @param {String} type (optional) the name of the related resource
   @param {Object} options (optional) a hash of options
   @return {PropertyDescriptor} relationship

--- a/packages/model/src/-private/model.ts
+++ b/packages/model/src/-private/model.ts
@@ -85,29 +85,54 @@ function computeOnce(target: object, propertyName: string, desc: PropertyDescrip
   return desc;
 }
 
-/**
-  Base class from which Models can be defined.
-
-  ```js
-  import Model, { attr } from '@ember-data/model';
-
-  export default class User extends Model {
-    @attr name;
-  }
-  ```
-
-  Models are used both to define the static schema for a
-  particular resource type as well as the class to instantiate
-  to present that data from cache.
-
-  @class Model
-  @public
-  @extends Ember.EmberObject
-*/
-
 interface Model {
   serialize<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): unknown;
+
+  /**
+    Same as `deleteRecord`, but saves the record immediately.
+
+    Example
+
+    ```js
+    import Component from '@glimmer/component';
+
+    export default class extends Component {
+      delete = () => {
+        this.args.model.destroyRecord().then(function() {
+          this.transitionToRoute('model.index');
+        });
+      }
+    }
+    ```
+
+    If you pass an object on the `adapterOptions` property of the options
+    argument it will be passed to your adapter via the snapshot
+
+    ```js
+    record.destroyRecord({ adapterOptions: { subscribe: false } });
+    ```
+
+    ```app/adapters/post.js
+    import MyCustomAdapter from './custom-adapter';
+
+    export default class PostAdapter extends MyCustomAdapter {
+      deleteRecord(store, type, snapshot) {
+        if (snapshot.adapterOptions.subscribe) {
+          // ...
+        }
+        // ...
+      }
+    }
+    ```
+
+    @method destroyRecord
+    @public
+    @param {Object} options
+    @return {Promise} a promise that will be resolved when the adapter returns
+    successfully or rejected if the adapter returns with an error.
+  */
   destroyRecord<T extends MinimalLegacyRecord>(this: T, options?: Record<string, unknown>): Promise<this>;
+
   unloadRecord<T extends MinimalLegacyRecord>(this: T): void;
   changedAttributes<T extends MinimalLegacyRecord>(this: T): ChangedAttributesHash;
   rollbackAttributes<T extends MinimalLegacyRecord>(this: T): void;
@@ -126,6 +151,24 @@ interface Model {
   hasMany<T extends MinimalLegacyRecord, K extends MaybeHasManyFields<T>>(this: T, prop: K): HasManyReference<T, K>;
   deleteRecord<T extends MinimalLegacyRecord>(this: T): void;
 }
+
+/**
+  Base class from which Models can be defined.
+
+  ```js
+  import Model, { attr } from '@ember-data/model';
+
+  export default class User extends Model {
+    @attr name;
+  }
+  ```
+
+  Models are used both to define the static schema for a
+  particular resource type as well as the class to instantiate
+  to present that data from cache.
+
+  @public
+*/
 class Model extends EmberObject implements MinimalLegacyRecord {
   // set during create by the store
   declare store: Store;
@@ -195,7 +238,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property isEmpty
     @public
     @type {Boolean}
-    @readOnly
+    @readonly
   */
   @memoized
   get isEmpty(): boolean {
@@ -211,7 +254,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property isLoading
     @public
     @type {Boolean}
-    @readOnly
+    @readonly
   */
   @memoized
   get isLoading(): boolean {
@@ -237,7 +280,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property isLoaded
     @public
     @type {Boolean}
-    @readOnly
+    @readonly
   */
   @memoized
   get isLoaded(): boolean {
@@ -267,7 +310,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property hasDirtyAttributes
     @public
     @type {Boolean}
-    @readOnly
+    @readonly
   */
   @memoized
   get hasDirtyAttributes(): boolean {
@@ -295,7 +338,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property isSaving
     @public
     @type {Boolean}
-    @readOnly
+    @readonly
   */
   @memoized
   get isSaving(): boolean {
@@ -338,7 +381,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property isDeleted
     @public
     @type {Boolean}
-    @readOnly
+    @readonly
   */
   @memoized
   get isDeleted(): boolean {
@@ -365,7 +408,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property isNew
     @public
     @type {Boolean}
-    @readOnly
+    @readonly
   */
   @memoized
   get isNew(): boolean {
@@ -381,7 +424,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property isValid
     @public
     @type {Boolean}
-    @readOnly
+    @readonly
   */
   @memoized
   get isValid(): boolean {
@@ -407,7 +450,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property dirtyType
     @public
     @type {String}
-    @readOnly
+    @readonly
   */
   @memoized
   get dirtyType(): 'created' | 'updated' | 'deleted' | '' {
@@ -432,7 +475,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property isError
     @public
     @type {Boolean}
-    @readOnly
+    @readonly
   */
   @memoized
   get isError(): boolean {
@@ -458,7 +501,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @property isReloading
     @public
     @type {Boolean}
-    @readOnly
+    @readonly
   */
   declare isReloading: boolean;
 
@@ -678,50 +721,6 @@ class Model extends EmberObject implements MinimalLegacyRecord {
 
     @method deleteRecord
     @public
-  */
-
-  /**
-    Same as `deleteRecord`, but saves the record immediately.
-
-    Example
-
-    ```js
-    import Component from '@glimmer/component';
-
-    export default class extends Component {
-      delete = () => {
-        this.args.model.destroyRecord().then(function() {
-          this.transitionToRoute('model.index');
-        });
-      }
-    }
-    ```
-
-    If you pass an object on the `adapterOptions` property of the options
-    argument it will be passed to your adapter via the snapshot
-
-    ```js
-    record.destroyRecord({ adapterOptions: { subscribe: false } });
-    ```
-
-    ```app/adapters/post.js
-    import MyCustomAdapter from './custom-adapter';
-
-    export default class PostAdapter extends MyCustomAdapter {
-      deleteRecord(store, type, snapshot) {
-        if (snapshot.adapterOptions.subscribe) {
-          // ...
-        }
-        // ...
-      }
-    }
-    ```
-
-    @method destroyRecord
-    @public
-    @param {Object} options
-    @return {Promise} a promise that will be resolved when the adapter returns
-    successfully or rejected if the adapter returns with an error.
   */
 
   /**
@@ -1295,7 +1294,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @public
    @static
    @type Map
-   @readOnly
+   @readonly
    */
 
   @computeOnce
@@ -1354,7 +1353,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @public
    @static
    @type Object
-   @readOnly
+   @readonly
    */
   @computeOnce
   static get relationshipNames() {
@@ -1407,7 +1406,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
    @public
    @static
    @type Array
-   @readOnly
+   @readonly
    */
   @computeOnce
   static get relatedTypes(): string[] {
@@ -1470,7 +1469,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @public
    @static
    @type Map
-   @readOnly
+   @readonly
    */
   @computeOnce
   static get relationshipsByName(): Map<string, LegacyRelationshipField> {
@@ -1558,7 +1557,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @public
    @static
    @type Map
-   @readOnly
+   @readonly
    */
   @computeOnce
   static get fields(): Map<string, 'attribute' | 'belongsTo' | 'hasMany'> {
@@ -1636,7 +1635,6 @@ class Model extends EmberObject implements MinimalLegacyRecord {
 
   /**
    *
-   * @method determineRelationshipType
    * @private
    * @deprecated
    */
@@ -1704,7 +1702,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @public
    @static
    @type {Map}
-   @readOnly
+   @readonly
    */
   @computeOnce
   static get attributes(): Map<string, LegacyAttributeField> {
@@ -1769,7 +1767,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     @public
    @static
    @type {Map}
-   @readOnly
+   @readonly
    */
   @computeOnce
   static get transformedAttributes() {

--- a/packages/model/src/-private/promise-belongs-to.ts
+++ b/packages/model/src/-private/promise-belongs-to.ts
@@ -40,7 +40,6 @@ const Extended: PromiseObjectType<OpaqueRecordInstance> =
   Right now we proxy:
     * `reload()`
   @class PromiseBelongsTo
-  @extends PromiseObject
   @private
 */
 class PromiseBelongsTo<T = unknown> extends Extended<T> {

--- a/packages/model/src/-private/promise-many-array.ts
+++ b/packages/model/src/-private/promise-many-array.ts
@@ -71,7 +71,6 @@ export class PromiseManyArray<T = unknown> {
    * We do not guarantee that forEach will always be available. This
    * may eventually be made to use Symbol.Iterator once glimmer supports it.
    *
-   * @method forEach
    * @param cb
    * @return
    * @private
@@ -84,7 +83,6 @@ export class PromiseManyArray<T = unknown> {
 
   /**
    * Reload the relationship
-   * @method reload
    * @public
    * @param options
    * @return
@@ -133,7 +131,6 @@ export class PromiseManyArray<T = unknown> {
   /**
    * chain this promise
    *
-   * @method then
    * @public
    * @param success
    * @param fail
@@ -145,7 +142,6 @@ export class PromiseManyArray<T = unknown> {
 
   /**
    * catch errors thrown by this promise
-   * @method catch
    * @public
    * @param callback
    * @return {Promise}
@@ -157,7 +153,6 @@ export class PromiseManyArray<T = unknown> {
   /**
    * run cleanup after this promise completes
    *
-   * @method finally
    * @public
    * @param callback
    * @return {Promise}

--- a/packages/model/src/-private/references/belongs-to.ts
+++ b/packages/model/src/-private/references/belongs-to.ts
@@ -334,7 +334,7 @@ export default class BelongsToReference<
 
    Example
 
-   ```app/models/post.js
+   ```js [app/models/post.js]
    import Model, { hasMany } from '@ember-data/model';
 
    export default class PostModel extends Model {
@@ -384,7 +384,7 @@ export default class BelongsToReference<
 
    Example model
 
-   ```app/models/blog.js
+   ```js [app/models/blog.js]
    import Model, { belongsTo } from '@ember-data/model';
 
    export default class BlogModel extends Model {
@@ -608,7 +608,7 @@ export default class BelongsToReference<
      userRef.value() === user;
    });
    ```
-   ```app/adapters/user.js
+   ```js [app/adapters/user.js]
    import Adapter from '@ember-data/adapter';
 
    export default class UserAdapter extends Adapter {

--- a/packages/model/src/-private/references/belongs-to.ts
+++ b/packages/model/src/-private/references/belongs-to.ts
@@ -202,7 +202,6 @@ export default class BelongsToReference<
     }
    ```
 
-   @method id
    @public
    @return {String} The id of the record in this belongsTo relationship.
    */
@@ -244,7 +243,6 @@ export default class BelongsToReference<
     }
    ```
 
-   @method link
    @public
    @return {String} The link Ember Data will use to fetch or reload this belongs-to relationship.
    */
@@ -263,7 +261,6 @@ export default class BelongsToReference<
   /**
    * any links that have been received for this relationship
    *
-   * @method links
    * @public
    * @return
    */
@@ -309,7 +306,6 @@ export default class BelongsToReference<
    userRef.meta() // { lastUpdated: 1458014400000 }
    ```
 
-   @method meta
     @public
    @return {Object} The meta information for the belongs-to relationship.
    */
@@ -369,7 +365,6 @@ export default class BelongsToReference<
    }
    ```
 
-   @method remoteType
    @public
    @return {String} The name of the remote type. This should either be `link` or `id`
    */
@@ -468,7 +463,6 @@ export default class BelongsToReference<
    particularly useful if you want to update the state of the relationship without
    forcing the load of all of the associated record.
 
-   @method push
    @public
    @param {Object} doc a JSONAPI document object describing the new value of this relationship.
    @param {Boolean} [skipFetch] if `true`, do not attempt to fetch unloaded records
@@ -560,7 +554,6 @@ export default class BelongsToReference<
     });
    ```
 
-   @method value
     @public
    @return {Model} the record in this relationship
    */
@@ -626,7 +619,6 @@ export default class BelongsToReference<
    });
    ```
 
-   @method load
     @public
    @param {Object} options the options to pass in.
    @return {Promise} a promise that resolves with the record in this belongs-to relationship.
@@ -689,7 +681,6 @@ export default class BelongsToReference<
    userRef.reload({ adapterOptions: { isPrivate: true } })
    ```
 
-   @method reload
     @public
    @param {Object} options the options to pass in.
    @return {Promise} a promise that resolves with the record in this belongs-to relationship after the reload has completed.

--- a/packages/model/src/-private/references/has-many.ts
+++ b/packages/model/src/-private/references/has-many.ts
@@ -230,7 +230,6 @@ export default class HasManyReference<
    }
    ```
 
-   @method remoteType
    @public
    @return {String} The name of the remote type. This should either be `link` or `ids`
    */
@@ -274,7 +273,6 @@ export default class HasManyReference<
    commentsRef.ids(); // ['1']
    ```
 
-   @method ids
     @public
    @return {Array} The ids in this has-many relationship
    */
@@ -316,7 +314,6 @@ export default class HasManyReference<
     }
    ```
 
-   @method link
    @public
    @return {String} The link Ember Data will use to fetch or reload this belongs-to relationship.
    */
@@ -335,7 +332,6 @@ export default class HasManyReference<
   /**
    * any links that have been received for this relationship
    *
-   * @method links
    * @public
    * @return
    */
@@ -381,7 +377,6 @@ export default class HasManyReference<
    usersRef.meta() // { lastUpdated: 1458014400000 }
    ```
 
-  @method meta
   @public
   @return {Object|null} The meta information for the belongs-to relationship.
   */
@@ -486,7 +481,6 @@ export default class HasManyReference<
    particularly useful if you want to update the state of the relationship without
    forcing the load of all of the associated records.
 
-   @method push
    @public
    @param {Array|Object} doc a JSONAPI document object describing the new value of this relationship.
    @param {Boolean} [skipFetch] if `true`, do not attempt to fetch unloaded records
@@ -594,7 +588,6 @@ export default class HasManyReference<
    })
    ```
 
-   @method value
     @public
    @return {ManyArray}
    */
@@ -670,7 +663,6 @@ export default class HasManyReference<
    });
    ```
 
-   @method load
    @public
    @param {Object} options the options to pass in.
    @return {Promise} a promise that resolves with the ManyArray in
@@ -734,7 +726,6 @@ export default class HasManyReference<
    commentsRef.reload({ adapterOptions: { isPrivate: true } })
    ```
 
-   @method reload
     @public
    @param {Object} options the options to pass in.
    @return {Promise} a promise that resolves with the ManyArray in this has-many relationship.

--- a/packages/model/src/-private/references/has-many.ts
+++ b/packages/model/src/-private/references/has-many.ts
@@ -199,7 +199,7 @@ export default class HasManyReference<
 
    Example
 
-   ```app/models/post.js
+   ```js [app/models/post.js]
    import Model, { hasMany } from '@ember-data/model';
 
    export default class PostModel extends Model {
@@ -247,7 +247,7 @@ export default class HasManyReference<
 
    Example
 
-   ```app/models/post.js
+   ```js [app/models/post.js]
    import Model, { hasMany } from '@ember-data/model';
 
    export default class PostModel extends Model {
@@ -397,7 +397,7 @@ export default class HasManyReference<
 
    Example model
 
-   ```app/models/post.js
+   ```js [app/models/post.js]
    import Model, { hasMany } from '@ember-data/model';
 
    export default class PostModel extends Model {
@@ -560,7 +560,7 @@ export default class HasManyReference<
 
    Example
 
-   ```app/models/post.js
+   ```js [app/models/post.js]
    import Model, { hasMany } from '@ember-data/model';
 
    export default class PostModel extends Model {
@@ -613,7 +613,7 @@ export default class HasManyReference<
 
    Example
 
-   ```app/models/post.js
+   ```js [app/models/post.js]
    import Model, { hasMany } from '@ember-data/model';
 
    export default class PostModel extends Model {
@@ -654,7 +654,7 @@ export default class HasManyReference<
      });
    ```
 
-   ```app/adapters/comment.js
+   ```js [app/adapters/comment.js]
    export default ApplicationAdapter.extend({
      findMany(store, type, id, snapshots) {
        // In the adapter you will have access to adapterOptions.
@@ -687,7 +687,7 @@ export default class HasManyReference<
 
    Example
 
-   ```app/models/post.js
+   ```js [app/models/post.js]
    import Model, { hasMany } from '@ember-data/model';
 
    export default class PostModel extends Model {

--- a/packages/model/src/-private/type-utils.ts
+++ b/packages/model/src/-private/type-utils.ts
@@ -15,7 +15,6 @@ type GetMappedKey<M, V> = { [K in keyof M]-?: ExcludeNull<M[K]> extends V ? K : 
  * "Maybe" because getter/computed fields might be returning values that look
  * like relationships, but are not.
  *
- * @typedoc
  */
 export type MaybeBelongsToFields<ThisType> =
   _TrueKeys<ThisType> extends never ? string : _MaybeBelongsToFields<ThisType>;
@@ -27,7 +26,6 @@ export type _MaybeBelongsToFields<ThisType> = GetMappedKey<ThisType, PromiseBelo
  * "Maybe" because getter/computed fields might be returning values that look
  * like relationships, but are not.
  *
- * @typedoc
  */
 export type MaybeHasManyFields<ThisType> = _TrueKeys<ThisType> extends never ? string : _MaybeHasManyFields<ThisType>;
 type _MaybeHasManyFields<ThisType> = GetMappedKey<ThisType, RelatedCollection | PromiseManyArray>;
@@ -41,7 +39,6 @@ type _MaybeHasManyFields<ThisType> = GetMappedKey<ThisType, RelatedCollection | 
  * This is computed by excluding the keys that are defined as `belongsTo` or `hasMany`
  * as well as the keys on EmberObject and the Model base class
  *
- * @typedoc
  */
 export type MaybeAttrFields<ThisType> = Exclude<
   _TrueKeys<ThisType>,
@@ -54,7 +51,6 @@ export type MaybeAttrFields<ThisType> = Exclude<
  * "Maybe" because getter/computed fields might be returning values that look
  * like relationships, but are not.
  *
- * @typedoc
  */
 export type MaybeRelationshipFields<ThisType> =
   _TrueKeys<ThisType> extends never ? string : _MaybeBelongsToFields<ThisType> | _MaybeHasManyFields<ThisType>;
@@ -65,6 +61,5 @@ export type isSubClass<ThisType> = _TrueKeys<ThisType> extends never ? false : t
  * Get the keys of all fields defined on the given subclass of Model
  * that don't exist on EmberObject or Model.
  *
- * @typedoc
  */
 export type SubclassKeys<ThisType> = _TrueKeys<ThisType> extends never ? string : _TrueKeys<ThisType>;

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -16,7 +16,7 @@
 
   ### Defining a Model
 
-  ```app/models/person.js
+  ```js [app/models/person.js]
   import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
   export default class PersonModel extends Model {
@@ -36,7 +36,11 @@
 
   @module
  */
-export { Model as default, attr, belongsTo, hasMany } from './-private';
+export { attr } from './-private/attr';
+export { belongsTo } from './-private/belongs-to';
+export { hasMany } from './-private/has-many';
+export { Model } from './-private/model';
+export { Model as default } from './-private/model';
 
 export type { PromiseBelongsTo as AsyncBelongsTo } from './-private/promise-belongs-to';
 export type { PromiseManyArray as AsyncHasMany } from './-private/promise-many-array';

--- a/packages/model/src/migration-support.ts
+++ b/packages/model/src/migration-support.ts
@@ -175,7 +175,6 @@ const LegacyFields = [
  * }>
  * ```
  *
- * @typedoc
  */
 export type WithLegacy<T extends TypedRecordInstance> = T & LegacyModeRecord<T>;
 
@@ -301,9 +300,6 @@ legacySupport[Type] = '@legacy';
  * registerDerivations(schema);
  * ```
  *
- * @method withDefaults
- * @for @ember-data/model/migration-support
- * @static
  * @param {LegacyResourceSchema} schema The schema to add legacy support to.
  * @return {LegacyResourceSchema} The schema with legacy support added.
  * @public
@@ -350,9 +346,6 @@ export function withDefaults(schema: WithPartial<LegacyResourceSchema, 'legacy' 
  * import { withDefaults } from '@ember-data/model/migration-support';
  * ```
  *
- * @method registerDerivations
- * @for @ember-data/model/migration-support
- * @static
  * @param {SchemaService} schema The schema service to register the derivations with.
  * @return {void}
  * @public
@@ -390,7 +383,6 @@ export function registerDerivations(schema: SchemaService) {
  * etc. will be delegated to the primary schema service.
  *
  * @class DelegatingSchemaService
- * @extends SchemaService
  * @public
  */
 export interface DelegatingSchemaService {

--- a/packages/request-utils/src/-private/handlers/auto-compress.ts
+++ b/packages/request-utils/src/-private/handlers/auto-compress.ts
@@ -26,35 +26,30 @@ interface Constraints {
    * The minimum size at which to compress blobs
    *
    * @default 1000
-   * @typedoc
    */
   Blob?: number;
   /**
    * The minimum size at which to compress array buffers
    *
    * @default 1000
-   * @typedoc
    */
   ArrayBuffer?: number;
   /**
    * The minimum size at which to compress typed arrays
    *
    * @default 1000
-   * @typedoc
    */
   TypedArray?: number;
   /**
    * The minimum size at which to compress data views
    *
    * @default 1000
-   * @typedoc
    */
   DataView?: number;
   /**
    * The minimum size at which to compress strings
    *
    * @default 1000
-   * @typedoc
    */
   String?: number;
 }
@@ -62,7 +57,6 @@ interface Constraints {
 /**
  * Options for configuring the AutoCompress handler.
  *
- * @typedoc
  */
 interface CompressionOptions {
   /**
@@ -71,7 +65,6 @@ interface CompressionOptions {
    *
    * The default is `gzip`.
    *
-   * @typedoc
    */
   format?: CompressionFormat;
 
@@ -100,7 +93,6 @@ interface CompressionOptions {
    * in the chain can handle the request body as a stream.
    *
    * @default false
-   * @typedoc
    */
   allowStreaming?: boolean;
 
@@ -110,7 +102,6 @@ interface CompressionOptions {
    * in the chain can handle the request body as a stream.
    *
    * @default false
-   * @typedoc
    */
   forceStreaming?: boolean;
 
@@ -144,7 +135,6 @@ interface CompressionOptions {
    * enable compression for all values, and a value of `-1` will
    * disable compression.
    *
-   * @typedoc
    */
   constraints?: Constraints;
 }
@@ -183,7 +173,6 @@ const TypedArray = Object.getPrototypeOf(Uint8Array.prototype) as typeof Uint8Ar
  * ```
  *
  * @class AutoCompress
- * @extends Handler
  * @public
  * @since 5.5.0
  */

--- a/packages/request-utils/src/-private/string/inflect.ts
+++ b/packages/request-utils/src/-private/string/inflect.ts
@@ -24,10 +24,7 @@ const PLURAL_RULES = new Map(defaultRules.plurals.reverse());
  * Marks a word as uncountable. Uncountable words are not pluralized
  * or singularized.
  *
- * @method uncountable
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {String} word
  * @return {void}
  * @since 4.13.0
@@ -40,10 +37,7 @@ export function uncountable(word: string) {
  * Marks a list of words as uncountable. Uncountable words are not pluralized
  * or singularized.
  *
- * @method loadUncountable
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {Array<String>} uncountables
  * @return {void}
  * @since 4.13.0
@@ -58,10 +52,7 @@ export function loadUncountable(uncountables: string[]) {
  * Marks a word as irregular. Irregular words have unique
  * pluralization and singularization rules.
  *
- * @method irregular
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {String} single
  * @param {String} plur
  * @return {void}
@@ -81,10 +72,7 @@ export function irregular(single: string, plur: string) {
  * Marks a list of word pairs as irregular. Irregular words have unique
  * pluralization and singularization rules.
  *
- * @method loadIrregular
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {Array<Array<String>>} irregularPairs
  * @return {void}
  * @since 4.13.0
@@ -105,10 +93,7 @@ loadIrregular(defaultRules.irregularPairs);
 /**
  * Clears the caches for singularize and pluralize.
  *
- * @method clear
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @return {void}
  * @since 4.13.0
  */
@@ -120,10 +105,7 @@ export function clear() {
 /**
  * Resets the inflection rules to the defaults.
  *
- * @method resetToDefaults
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @return {void}
  * @since 4.13.0
  */
@@ -139,10 +121,7 @@ export function resetToDefaults() {
  * Clears all inflection rules
  * and resets the caches for singularize and pluralize.
  *
- * @method clearRules
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @return {void}
  * @since 4.13.0
  */
@@ -159,10 +138,7 @@ export function clearRules() {
 /**
  * Singularizes a word.
  *
- * @method singularize
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {String} word
  * @return {String}
  * @since 4.13.0
@@ -176,10 +152,7 @@ export function singularize(word: string) {
 /**
  * Pluralizes a word.
  *
- * @method pluralize
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {String} word
  * @return {String}
  * @since 4.13.0
@@ -202,10 +175,7 @@ function unshiftMap<K, V>(v: [K, V], map: Map<K, V>) {
 /**
  * Adds a pluralization rule.
  *
- * @method plural
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {RegExp} regex
  * @param {String} string
  * @return {void}
@@ -224,10 +194,7 @@ export function plural(regex: RegExp, string: string) {
 /**
  * Adds a singularization rule.
  *
- * @method singular
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {RegExp} regex
  * @param {String} string
  * @return {void}

--- a/packages/request-utils/src/-private/string/transform.ts
+++ b/packages/request-utils/src/-private/string/transform.ts
@@ -104,10 +104,7 @@ const CAPITALIZE_CACHE = new LRUCache<string, string>((str: string) =>
  * dasherize('privateDocs/ownerInvoice';  // 'private-docs/owner-invoice'
  * ```
  *
- * @method dasherize
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {String} str
  * @return {String}
  * @since 4.13.0
@@ -130,10 +127,7 @@ export function dasherize(str: string): string {
  * camelize('private-docs/owner-invoice');  // 'privateDocs/ownerInvoice'
  * ```
  *
- * @method camelize
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {String} str
  * @return {String}
  * @since 4.13.0
@@ -155,10 +149,7 @@ export function camelize(str: string): string {
  * underscore('privateDocs/ownerInvoice');  // 'private_docs/owner_invoice'
  * ```
  *
- * @method underscore
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {String} str
  * @return {String}
  * @since 4.13.0
@@ -180,10 +171,7 @@ export function underscore(str: string): string {
  * capitalize('privateDocs/ownerInvoice'); // 'PrivateDocs/ownerInvoice'
  * ```
  *
- * @method capitalize
- * @static
  * @public
- * @for @ember-data/request-utils/string
  * @param {String} str
  * @return {String}
  * @since 4.13.0
@@ -196,10 +184,7 @@ export function capitalize(str: string): string {
  * Sets the maximum size of the LRUCache for all string transformation functions.
  * The default size is 10,000.
  *
- * @method setMaxLRUCacheSize
  * @public
- * @static
- * @for @ember-data/request-utils/string
  * @param {Number} size
  * @return {void}
  * @since 4.13.0

--- a/packages/request-utils/src/index.ts
+++ b/packages/request-utils/src/index.ts
@@ -135,10 +135,7 @@ const CONFIG: BuildURLConfig = getOrSetGlobal('CONFIG', {
  * });
  * ```
  *
- * @method setBuildURLConfig
- * @static
  * @public
- * @for @ember-data/request-utils
  * @param {BuildURLConfig} config
  * @return {void}
  */
@@ -313,10 +310,7 @@ function resourcePathForType(options: UrlOptions): string {
  *   - 'findRecord' 'query' 'findMany' 'findRelatedCollection' 'findRelatedRecord'` 'createRecord' 'updateRecord' 'deleteRecord'
  * - Depending on the value of `op`, `identifier` or `identifiers` will be required.
  *
- * @method buildBaseURL
- * @static
  * @public
- * @for @ember-data/request-utils
  * @param urlOptions
  * @return {String}
  */
@@ -440,10 +434,7 @@ function handleInclude(include: string | string[]): string[] {
  * filter out keys of an object that have falsy values or point to empty arrays
  * returning a new object with only those keys that have truthy values / non-empty arrays
  *
- * @method filterEmpty
- * @static
  * @public
- * @for @ember-data/request-utils
  * @param {Record<string, Serializable>} source object to filter keys with empty values from
  * @return {Record<string, Serializable>} A new object with the keys that contained empty values removed
  */
@@ -475,10 +466,7 @@ export function filterEmpty(source: Record<string, Serializable>): Record<string
  * 'repeat': appends the key for every value e.g. `&ids=1&ids=2`
  * 'comma' (default): appends the key once with a comma separated list of values e.g. `&ids=1,2`
  *
- * @method sortQueryParams
- * @static
  * @public
- * @for @ember-data/request-utils
  * @param {URLSearchParams | object} params
  * @param {Object} options
  * @return {URLSearchParams} A URLSearchParams with keys inserted in sorted order
@@ -556,10 +544,7 @@ export function sortQueryParams(params: QueryParamsSource, options?: QueryParams
  * 'repeat': appends the key for every value e.g. `ids=1&ids=2`
  * 'comma' (default): appends the key once with a comma separated list of values e.g. `ids=1,2`
  *
- * @method buildQueryParams
- * @static
  * @public
- * @for @ember-data/request-utils
  * @param {URLSearchParams | Object} params
  * @param {Object} [options]
  * @return {String} A sorted query params string without the leading `?`
@@ -609,10 +594,7 @@ const NUMERIC_KEYS = new Set(['max-age', 's-maxage', 'stale-if-error', 'stale-wh
  *   'stale-while-revalidate'?: number;
  * }
  * ```
- * @method parseCacheControl
- * @static
  * @public
- * @for @ember-data/request-utils
  * @param {String} header
  * @return {CacheControlValue}
  */
@@ -818,7 +800,6 @@ function isExpired(
  * });
  * ```
  *
- * @typedoc
  */
 export type PolicyConfig = {
   /**
@@ -834,7 +815,6 @@ export type PolicyConfig = {
    * it to responses if it is not present. Responses without a `date`
    * header will be considered stale immediately.
    *
-   * @typedoc
    */
   apiCacheSoftExpires: number;
   /**
@@ -850,7 +830,6 @@ export type PolicyConfig = {
    * it to responses if it is not present. Responses without a `date`
    * header will be considered hard expired immediately.
    *
-   * @typedoc
    */
   apiCacheHardExpires: number;
   /**
@@ -864,7 +843,6 @@ export type PolicyConfig = {
    *
    * This behavior can be opted out of by setting this value to `true`.
    *
-   * @typedoc
    */
   disableTestOptimization?: boolean;
 
@@ -898,13 +876,11 @@ export type PolicyConfig = {
    * -  ↳ (if null) Cache-Control header
    * -  ↳ (if null) Expires header
    *
-   * @typedoc
    */
   constraints?: {
     /**
      * Headers that should be checked for expiration.
      *
-     * @typedoc
      */
     headers?: {
       /**
@@ -917,7 +893,6 @@ export type PolicyConfig = {
        * 'Cache-Control' will take precedence over 'Expires' if both are present
        * and both configured to be checked.
        *
-       * @typedoc
        */
       'Cache-Control'?: boolean;
 
@@ -929,7 +904,6 @@ export type PolicyConfig = {
        *
        * 'Cache-Control' will take precedence over 'Expires' if both are present.
        *
-       * @typedoc
        */
       Expires?: boolean;
 
@@ -943,7 +917,6 @@ export type PolicyConfig = {
        *
        * The header's value should be a [UTC date string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString).
        *
-       * @typedoc
        */
       'X-WarpDrive-Expires'?: boolean;
     };
@@ -957,7 +930,6 @@ export type PolicyConfig = {
      *
      * If the function does not return `null`,
      *
-     * @typedoc
      */
     isExpired?: (request: StructuredDocument<ResourceDocument>) => boolean | null;
   };
@@ -1087,7 +1059,6 @@ export class CachePolicy {
    * store.lifetimes.invalidateRequest(store, identifier);
    * ```
    *
-   * @method invalidateRequest
    * @public
    * @param {StableDocumentIdentifier} identifier
    * @param {Store} store
@@ -1111,7 +1082,6 @@ export class CachePolicy {
    * store.lifetimes.invalidateRequestsForType(store, 'person');
    * ```
    *
-   * @method invalidateRequestsForType
    * @public
    * @param {String} type
    * @param {Store} store
@@ -1140,7 +1110,6 @@ export class CachePolicy {
    *
    * This method should not be invoked directly by consumers.
    *
-   * @method didRequest
    * @public
    * @param {ImmutableRequestInfo} request
    * @param {ImmutableResponse} response
@@ -1196,7 +1165,6 @@ export class CachePolicy {
    * the request will be fulfilled from the configured request handlers
    * and the cache will be updated before returning the response.
    *
-   * @method isHardExpired
    * @public
    * @param {StableDocumentIdentifier} identifier
    * @param {Store} store
@@ -1232,7 +1200,6 @@ export class CachePolicy {
    * If true, the request will be fulfilled from cache while a backgrounded
    * request is made to update the cache via the configured request handlers.
    *
-   * @method isSoftExpired
    * @public
    * @param {StableDocumentIdentifier} identifier
    * @param {Store} store

--- a/packages/request/src/-private/manager.ts
+++ b/packages/request/src/-private/manager.ts
@@ -113,7 +113,6 @@ export class RequestManager {
    * RequestManager as the Store instance the Store
    * registers itself as a Cache handler.
    *
-   * @method useCache
    * @public
    * @param {Handler[]} cacheHandler
    * @return {ThisType}
@@ -142,7 +141,6 @@ export class RequestManager {
    * Each Handler is given the opportunity to handle the request,
    * curry the request, or pass along a modified request.
    *
-   * @method use
    * @public
    * @param {Handler[]} newHandlers
    * @return {ThisType}
@@ -175,7 +173,6 @@ export class RequestManager {
    *
    * Returns a Future that fulfills with a StructuredDocument
    *
-   * @method request
    * @public
    * @param {RequestInfo} request
    * @return {Future}

--- a/packages/request/src/-private/types.ts
+++ b/packages/request/src/-private/types.ts
@@ -38,15 +38,13 @@ export type DeferredStream = {
  * `getStream` the response before the outer promise resolves;
  *
  * @class Future
- * @extends Promise
  * @public
  */
-export type Future<T> = Promise<StructuredDataDocument<T>> & {
+export interface Future<T> extends Promise<StructuredDataDocument<T>> {
   [IS_FUTURE]: true;
   /**
    * Cancel this request by firing the AbortController's signal.
    *
-   * @method abort
    * @param {String} [reason] optional reason for aborting the request
    * @public
    * @return {void}
@@ -55,7 +53,6 @@ export type Future<T> = Promise<StructuredDataDocument<T>> & {
   /**
    * Get the response stream, if any, once made available.
    *
-   * @method getStream
    * @public
    * @return {Promise<ReadableStream | null>}
    */
@@ -65,7 +62,6 @@ export type Future<T> = Promise<StructuredDataDocument<T>> & {
    *  Run a callback when this request completes. Use sparingly,
    *  mostly useful for instrumentation and infrastructure.
    *
-   * @method onFinalize
    * @param cb the callback to run
    * @public
    * @return {void}
@@ -91,7 +87,7 @@ export type Future<T> = Promise<StructuredDataDocument<T>> & {
    * @public
    */
   id: number;
-};
+}
 
 export type DeferredFuture<T> = {
   resolve(v: StructuredDataDocument<T>): void;
@@ -218,7 +214,6 @@ export interface Handler {
    * context and a nextFn to call to pass-along the request to
    * other handlers.
    *
-   * @method request
    * @public
    * @param context
    * @param next
@@ -243,7 +238,6 @@ export interface CacheHandler {
    * context and a nextFn to call to pass-along the request to
    * other handlers.
    *
-   * @method request
    * @public
    * @param context
    * @param next

--- a/packages/rest/src/-private/builders/find-record.ts
+++ b/packages/rest/src/-private/builders/find-record.ts
@@ -61,10 +61,7 @@ import { copyForwardUrlOptions, extractCacheOptions } from './-utils';
  * const data = await store.request(options);
  * ```
  *
- * @method findRecord
  * @public
- * @static
- * @for @ember-data/rest/request
  * @param identifier
  * @param options
  */

--- a/packages/rest/src/-private/builders/query.ts
+++ b/packages/rest/src/-private/builders/query.ts
@@ -49,10 +49,7 @@ import { copyForwardUrlOptions, extractCacheOptions } from './-utils';
  * const data = await store.request(options);
  * ```
  *
- * @method query
  * @public
- * @static
- * @for @ember-data/rest/request
  * @param identifier
  * @param query
  * @param options

--- a/packages/rest/src/-private/builders/save-record.ts
+++ b/packages/rest/src/-private/builders/save-record.ts
@@ -68,10 +68,7 @@ function isExisting(identifier: StableRecordIdentifier): identifier is StableExi
  * const data = await store.request(options);
  * ```
  *
- * @method deleteRecord
  * @public
- * @static
- * @for @ember-data/rest/request
  * @param record
  * @param options
  */
@@ -141,10 +138,7 @@ export function deleteRecord(record: unknown, options: ConstrainedRequestOptions
  * const data = await store.request(options);
  * ```
  *
- * @method createRecord
  * @public
- * @static
- * @for @ember-data/rest/request
  * @param record
  * @param options
  */
@@ -216,10 +210,7 @@ export function createRecord(record: unknown, options: ConstrainedRequestOptions
  * const data = await store.request(options);
  * ```
  *
- * @method updateRecord
  * @public
- * @static
- * @for @ember-data/rest/request
  * @param record
  * @param options
  */

--- a/packages/schema-record/src/-private/schema.ts
+++ b/packages/schema-record/src/-private/schema.ts
@@ -75,9 +75,6 @@ _constructor[Type] = '@constructor';
  * registerDerivations(schema);
  * ```
  *
- * @method withDefaults
- * @for @warp-drive/schema-record
- * @static
  * @public
  * @param schema
  * @return {PolarisResourceSchema}
@@ -112,9 +109,6 @@ export function withDefaults(schema: WithPartial<PolarisResourceSchema, 'identit
  *
  * `^` returns the entire identifier object.
  *
- * @method fromIdentity
- * @for @warp-drive/schema-record
- * @static
  * @public
  */
 export function fromIdentity(record: SchemaRecord, options: { key: 'lid' } | { key: 'type' }, key: string): string;
@@ -145,9 +139,6 @@ fromIdentity[Type] = '@identity';
  * import { withDefaults } from '@warp-drive/schema-record';
  * ```
  *
- * @method registerDerivations
- * @for @warp-drive/schema-record
- * @static
  * @public
  * @param {SchemaService} schema
  */

--- a/packages/schema/src/parser/utils/process-file.ts
+++ b/packages/schema/src/parser/utils/process-file.ts
@@ -66,7 +66,6 @@ function numToIndexStr(num: number): string {
 /**
  * Extracts the type signature from a ClassProperty
  *
- * @typedoc
  */
 function extractType(field: ClassProperty) {
   if (field.typeAnnotation) {

--- a/packages/serializer/src/-private/embedded-records-mixin.js
+++ b/packages/serializer/src/-private/embedded-records-mixin.js
@@ -17,7 +17,7 @@ import { camelize } from '@ember-data/request-utils/string';
 
   Below is an example of a per-type serializer (`post` type).
 
-  ```app/serializers/post.js
+  ```js [app/serializers/post.js]
   import RESTSerializer, { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
 
   export default class PostSerializer extends RESTSerializer.extend(EmbeddedRecordsMixin) {
@@ -163,7 +163,7 @@ export const EmbeddedRecordsMixin = Mixin.create({
 
     Use a custom (type) serializer for the post model to configure embedded author
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import RESTSerializer, { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
 
     export default class PostSerializer extends RESTSerializer.extend(EmbeddedRecordsMixin) {
@@ -266,7 +266,7 @@ export const EmbeddedRecordsMixin = Mixin.create({
 
     Use a custom (type) serializer for the post model to configure embedded comments
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import RESTSerializer, { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
 
     export default class PostSerializer extends RESTSerializer.extend(EmbeddedRecordsMixin) {
@@ -305,7 +305,7 @@ export const EmbeddedRecordsMixin = Mixin.create({
 
     To embed the `ids` for a related object (using a hasMany relationship):
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import RESTSerializer, { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
 
     export default class PostSerializer extends RESTSerializer.extend(EmbeddedRecordsMixin) {
@@ -353,7 +353,7 @@ export const EmbeddedRecordsMixin = Mixin.create({
     });
     ```
 
-    ```app/serializers/user.js
+    ```js [app/serializers/user.js]
     import RESTSerializer, { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
 
     export default class UserSerializer extends RESTSerializer.extend(EmbeddedRecordsMixin) {

--- a/packages/serializer/src/-private/embedded-records-mixin.js
+++ b/packages/serializer/src/-private/embedded-records-mixin.js
@@ -119,7 +119,6 @@ export const EmbeddedRecordsMixin = Mixin.create({
       }
     }
     ```
-   @method normalize
     @public
    @param {Model} typeClass
    @param {Object} hash to be normalized
@@ -190,7 +189,6 @@ export const EmbeddedRecordsMixin = Mixin.create({
     }
     ```
 
-    @method serializeBelongsTo
     @public
     @param {Snapshot} snapshot
     @param {Object} json
@@ -378,7 +376,6 @@ export const EmbeddedRecordsMixin = Mixin.create({
     }
     ```
 
-    @method serializeHasMany
     @public
     @param {Snapshot} snapshot
     @param {Object} json
@@ -472,7 +469,6 @@ export const EmbeddedRecordsMixin = Mixin.create({
     Serializing a `hasMany` relationship does not remove the property that refers to
     the parent record.
 
-    @method removeEmbeddedForeignKey
     @public
     @param {Snapshot} snapshot
     @param {Snapshot} embeddedSnapshot
@@ -542,7 +538,6 @@ export const EmbeddedRecordsMixin = Mixin.create({
   },
 
   /**
-   @method _extractEmbeddedRecords
    @private
   */
   _extractEmbeddedRecords(serializer, store, typeClass, partial) {
@@ -560,7 +555,6 @@ export const EmbeddedRecordsMixin = Mixin.create({
   },
 
   /**
-   @method _extractEmbeddedHasMany
    @private
   */
   _extractEmbeddedHasMany(store, key, hash, relationshipMeta) {
@@ -592,7 +586,6 @@ export const EmbeddedRecordsMixin = Mixin.create({
   },
 
   /**
-   @method _extractEmbeddedBelongsTo
    @private
   */
   _extractEmbeddedBelongsTo(store, key, hash, relationshipMeta) {
@@ -619,7 +612,6 @@ export const EmbeddedRecordsMixin = Mixin.create({
   },
 
   /**
-   @method _normalizeEmbeddedRelationship
    @private
   */
   _normalizeEmbeddedRelationship(store, relationshipMeta, relationshipHash) {

--- a/packages/serializer/src/-private/transforms/boolean.ts
+++ b/packages/serializer/src/-private/transforms/boolean.ts
@@ -8,7 +8,7 @@ import type { TransformName } from '@warp-drive/core-types/symbols';
 
   Usage
 
-  ```app/models/user.js
+  ```js [app/models/user.js]
   import Model, { attr } from '@ember-data/model';
 
   export default class UserModel extends Model {
@@ -22,7 +22,7 @@ import type { TransformName } from '@warp-drive/core-types/symbols';
   `false`. You can opt into allowing `null` values for
   boolean attributes via `attr('boolean', { allowNull: true })`
 
-  ```app/models/user.js
+  ```js [app/models/user.js]
   import Model, { attr } from '@ember-data/model';
 
   export default class UserModel extends Model {

--- a/packages/serializer/src/-private/transforms/date.ts
+++ b/packages/serializer/src/-private/transforms/date.ts
@@ -7,7 +7,7 @@ import { TransformName } from '@warp-drive/core-types/symbols';
  [attr](/ember-data/release/functions/@ember-data%2Fmodel/attr) function. It uses the [`ISO 8601`](https://en.wikipedia.org/wiki/ISO_8601)
  standard.
 
- ```app/models/score.js
+ ```js [app/models/score.js]
  import Model, { attr, belongsTo } from '@ember-data/model';
 
  export default class ScoreModel extends Model {

--- a/packages/serializer/src/-private/transforms/number.ts
+++ b/packages/serializer/src/-private/transforms/number.ts
@@ -12,7 +12,7 @@ function isNumber(value: number) {
 
   Usage
 
-  ```app/models/score.js
+  ```js [app/models/score.js]
   import Model, { attr, belongsTo } from '@ember-data/model';
 
   export default class ScoreModel extends Model {

--- a/packages/serializer/src/-private/transforms/string.ts
+++ b/packages/serializer/src/-private/transforms/string.ts
@@ -8,7 +8,7 @@ import { TransformName } from '@warp-drive/core-types/symbols';
 
   Usage
 
-  ```app/models/user.js
+  ```js [app/models/user.js]
   import Model, { attr, belongsTo } from '@ember-data/model';
 
   export default class UserModel extends Model {

--- a/packages/serializer/src/-private/transforms/transform.ts
+++ b/packages/serializer/src/-private/transforms/transform.ts
@@ -91,7 +91,6 @@ import type { LegacyAttributeField } from '@warp-drive/core-types/schema/fields'
   }
   ```
 
-  @method serialize
   @public
   @param deserialized The deserialized value
   @param options hash of options passed to `attr`
@@ -109,7 +108,6 @@ import type { LegacyAttributeField } from '@warp-drive/core-types/schema/fields'
   }
   ```
 
-  @method deserialize
   @public
   @param serialized The serialized value
   @param options hash of options passed to `attr`

--- a/packages/serializer/src/-private/transforms/transform.ts
+++ b/packages/serializer/src/-private/transforms/transform.ts
@@ -11,7 +11,7 @@ import type { LegacyAttributeField } from '@warp-drive/core-types/schema/fields'
 
   Example
 
-  ```app/transforms/temperature.js
+  ```js [app/transforms/temperature.js]
 
   // Converts centigrade in the JSON to fahrenheit in the app
   export default class TemperatureTransform {
@@ -31,7 +31,7 @@ import type { LegacyAttributeField } from '@warp-drive/core-types/schema/fields'
 
   Usage
 
-  ```app/models/requirement.js
+  ```js [app/models/requirement.js]
   import Model, { attr } from '@ember-data/model';
 
   export default class RequirementModel extends Model {
@@ -43,7 +43,7 @@ import type { LegacyAttributeField } from '@warp-drive/core-types/schema/fields'
   The options passed into the `attr` function when the attribute is
   declared on the model is also available in the transform.
 
-  ```app/models/post.js
+  ```js [app/models/post.js]
   import Model, { attr } from '@ember-data/model';
 
   export default class PostModel extends Model {
@@ -58,7 +58,7 @@ import type { LegacyAttributeField } from '@warp-drive/core-types/schema/fields'
   }
   ```
 
-  ```app/transforms/markdown.js
+  ```js [app/transforms/markdown.js]
   export default class MarkdownTransform {
     serialize(deserialized, options) {
       return deserialized.raw;

--- a/packages/serializer/src/index.ts
+++ b/packages/serializer/src/index.ts
@@ -135,7 +135,6 @@ const service = s.service ?? s.inject;
 
   @class Serializer
   @public
-  @extends Ember.EmberObject
 */
 
 export default class extends EmberObject {
@@ -188,7 +187,6 @@ export default class extends EmberObject {
     ```
 
     @since 1.13.0
-    @method normalizeResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -233,7 +231,6 @@ export default class extends EmberObject {
     });
     ```
 
-    @method serialize
     @public
     @param {Snapshot} snapshot
     @param {Object} [options]
@@ -261,7 +258,6 @@ export default class extends EmberObject {
     })
     ```
 
-    @method normalize
     @public
     @param {Model} typeClass
     @param {Object} hash

--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -25,7 +25,7 @@ import JSONSerializer from './json';
 
   This serializer normalizes a JSON API payload that looks like:
 
-  ```app/models/player.js
+  ```js [app/models/player.js]
   import Model, { attr, belongsTo } from '@ember-data/model';
 
   export default class Player extends Model {
@@ -36,7 +36,7 @@ import JSONSerializer from './json';
   }
   ```
 
-  ```app/models/club.js
+  ```js [app/models/club.js]
   import Model, { attr, hasMany } from '@ember-data/model';
 
   export default class Club extends Model {
@@ -101,7 +101,7 @@ import JSONSerializer from './json';
   below shows how this could be done using `normalizeArrayResponse` and
   `extractRelationship`.
 
-  ```app/serializers/application.js
+  ```js [app/serializers/application.js]
   import JSONAPISerializer from '@ember-data/serializer/json-api';
 
   export default class ApplicationSerializer extends JSONAPISerializer {
@@ -401,7 +401,7 @@ const JSONAPISerializer = JSONSerializer.extend({
 
     Example
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import JSONAPISerializer from '@ember-data/serializer/json-api';
     import { dasherize } from '<app-name>/utils/string-utils';
 
@@ -432,7 +432,7 @@ const JSONAPISerializer = JSONSerializer.extend({
 
    Example
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import JSONAPISerializer from '@ember-data/serializer/json-api';
     import { underscore } from '<app-name>/utils/string-utils';
 
@@ -458,7 +458,7 @@ const JSONAPISerializer = JSONSerializer.extend({
 
     For example, consider this model:
 
-    ```app/models/comment.js
+    ```js [app/models/comment.js]
     import Model, { attr, belongsTo } from '@ember-data/model';
 
     export default class CommentModel extends Model {
@@ -523,7 +523,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     consider authoring your own adapter and serializer instead of extending
     this class.
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import JSONAPISerializer from '@ember-data/serializer/json-api';
 
     export default class PostSerializer extends JSONAPISerializer {
@@ -549,7 +549,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     application, you'll probably want to use `eachAttribute`
     and `eachRelationship` on the record.
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import JSONAPISerializer from '@ember-data/serializer/json-api';
     import { underscore, singularize } from '<app-name>/utils/string-utils';
 
@@ -600,7 +600,7 @@ const JSONAPISerializer = JSONSerializer.extend({
     you can call `super.serialize` first and make the tweaks
     on the returned object.
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import JSONAPISerializer from '@ember-data/serializer/json-api';
 
     export default class PostSerializer extends JSONAPISerializer {

--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -128,11 +128,9 @@ import JSONSerializer from './json';
   @since 1.13.0
   @class JSONAPISerializer
   @public
-  @extends JSONSerializer
 */
 const JSONAPISerializer = JSONSerializer.extend({
   /**
-    @method _normalizeDocumentHelper
     @param {Object} documentHash
     @return {Object}
     @private
@@ -169,7 +167,6 @@ const JSONAPISerializer = JSONSerializer.extend({
   },
 
   /**
-    @method _normalizeRelationshipDataHelper
     @param {Object} relationshipDataHash
     @return {Object}
     @private
@@ -181,7 +178,6 @@ const JSONAPISerializer = JSONSerializer.extend({
   },
 
   /**
-    @method _normalizeResourceHelper
     @param {Object} resourceHash
     @return {Object}
     @private
@@ -209,7 +205,6 @@ const JSONAPISerializer = JSONSerializer.extend({
   /**
     Normalize some data and push it into the store.
 
-    @method pushPayload
     @public
     @param {Store} store
     @param {Object} payload
@@ -220,7 +215,6 @@ const JSONAPISerializer = JSONSerializer.extend({
   },
 
   /**
-    @method _normalizeResponse
     @param {Store} store
     @param {Model} primaryModelClass
     @param {Object} payload
@@ -274,7 +268,6 @@ const JSONAPISerializer = JSONSerializer.extend({
 
      http://jsonapi.org/format/#document-resource-object-relationships
 
-     @method extractRelationship
     @public
      @param {Object} relationshipHash
      @return {Object}
@@ -301,7 +294,6 @@ const JSONAPISerializer = JSONSerializer.extend({
 
      http://jsonapi.org/format/#document-resource-object-relationships
 
-     @method extractRelationships
     @public
      @param {Object} modelClass
      @param {Object} resourceHash
@@ -335,7 +327,6 @@ const JSONAPISerializer = JSONSerializer.extend({
   },
 
   /**
-    @method _extractType
     @param {Model} modelClass
     @param {Object} resourceHash
     @return {String}
@@ -352,7 +343,6 @@ const JSONAPISerializer = JSONSerializer.extend({
     For example the key `posts` would be converted to `post` and the
     key `studentAssesments` would be converted to `student-assesment`.
 
-    @method modelNameFromPayloadKey
     @public
     @param {String} key
     @return {String} the model's modelName
@@ -367,7 +357,6 @@ const JSONAPISerializer = JSONSerializer.extend({
     For example `post` would be converted to `posts` and
     `student-assesment` would be converted to `student-assesments`.
 
-    @method payloadKeyFromModelName
     @public
     @param {String} modelName
     @return {String}
@@ -423,7 +412,6 @@ const JSONAPISerializer = JSONSerializer.extend({
     }
     ```
 
-    @method keyForAttribute
     @public
     @param {String} key
     @param {String} method
@@ -454,7 +442,6 @@ const JSONAPISerializer = JSONSerializer.extend({
       }
     }
     ```
-   @method keyForRelationship
     @public
    @param {String} key
    @param {String} typeClass
@@ -628,7 +615,6 @@ const JSONAPISerializer = JSONSerializer.extend({
     }
     ```
 
-    @method serialize
     @public
     @param {Snapshot} snapshot
     @param {Object} options

--- a/packages/serializer/src/json.js
+++ b/packages/serializer/src/json.js
@@ -85,7 +85,6 @@ const PRIMARY_ATTRIBUTE_KEY = 'base';
 
   @class JSONSerializer
   @public
-  @extends Serializer
 */
 const JSONSerializer = Serializer.extend({
   /**
@@ -189,7 +188,6 @@ const JSONSerializer = Serializer.extend({
    JSON object.  This method is typically called after the
    serializer's `normalize` method.
 
-   @method applyTransforms
    @private
    @param {Model} typeClass
    @param {Object} data The data to transform
@@ -238,7 +236,6 @@ const JSONSerializer = Serializer.extend({
     ```
 
     @since 1.13.0
-    @method normalizeResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -277,7 +274,6 @@ const JSONSerializer = Serializer.extend({
     type of request is `findRecord`
 
     @since 1.13.0
-    @method normalizeFindRecordResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -295,7 +291,6 @@ const JSONSerializer = Serializer.extend({
     type of request is `queryRecord`
 
     @since 1.13.0
-    @method normalizeQueryRecordResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -313,7 +308,6 @@ const JSONSerializer = Serializer.extend({
     type of request is `findAll`
 
     @since 1.13.0
-    @method normalizeFindAllResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -331,7 +325,6 @@ const JSONSerializer = Serializer.extend({
     type of request is `findBelongsTo`
 
     @since 1.13.0
-    @method normalizeFindBelongsToResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -349,7 +342,6 @@ const JSONSerializer = Serializer.extend({
     type of request is `findHasMany`
 
     @since 1.13.0
-    @method normalizeFindHasManyResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -367,7 +359,6 @@ const JSONSerializer = Serializer.extend({
     type of request is `findMany`
 
     @since 1.13.0
-    @method normalizeFindManyResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -385,7 +376,6 @@ const JSONSerializer = Serializer.extend({
     type of request is `query`
 
     @since 1.13.0
-    @method normalizeQueryResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -403,7 +393,6 @@ const JSONSerializer = Serializer.extend({
     type of request is `createRecord`
 
     @since 1.13.0
-    @method normalizeCreateRecordResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -421,7 +410,6 @@ const JSONSerializer = Serializer.extend({
     type of request is `deleteRecord`
 
     @since 1.13.0
-    @method normalizeDeleteRecordResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -439,7 +427,6 @@ const JSONSerializer = Serializer.extend({
     type of request is `updateRecord`
 
     @since 1.13.0
-    @method normalizeUpdateRecordResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -457,7 +444,6 @@ const JSONSerializer = Serializer.extend({
     normalizeDeleteRecordResponse delegate to this method by default.
 
     @since 1.13.0
-    @method normalizeSaveResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -475,7 +461,6 @@ const JSONSerializer = Serializer.extend({
     method by default.
 
     @since 1.13.0
-    @method normalizeSingleResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -493,7 +478,6 @@ const JSONSerializer = Serializer.extend({
     to this method by default.
 
     @since 1.13.0
-    @method normalizeArrayResponse
     @public
     @param {Store} store
     @param {Model} primaryModelClass
@@ -507,7 +491,6 @@ const JSONSerializer = Serializer.extend({
   },
 
   /**
-    @method _normalizeResponse
     @param {Store} store
     @param {Model} primaryModelClass
     @param {Object} payload
@@ -591,7 +574,6 @@ const JSONSerializer = Serializer.extend({
     }
     ```
 
-    @method normalize
     @public
     @param {Model} typeClass
     @param {Object} hash
@@ -626,7 +608,6 @@ const JSONSerializer = Serializer.extend({
   /**
     Returns the resource's ID.
 
-    @method extractId
     @public
     @param {Object} modelClass
     @param {Object} resourceHash
@@ -643,7 +624,6 @@ const JSONSerializer = Serializer.extend({
 
     http://jsonapi.org/format/#document-resource-object-attributes
 
-    @method extractAttributes
     @public
     @param {Object} modelClass
     @param {Object} resourceHash
@@ -668,7 +648,6 @@ const JSONSerializer = Serializer.extend({
 
     http://jsonapi.org/format/#document-resource-object-relationships
 
-    @method extractRelationship
     @public
     @param {Object} relationshipModelName
     @param {Object} relationshipHash
@@ -711,7 +690,6 @@ const JSONSerializer = Serializer.extend({
         extracted from the resourceHash
       - `relationshipMeta` meta information about the relationship
 
-    @method extractPolymorphicRelationship
     @public
     @param {Object} relationshipModelName
     @param {Object} relationshipHash
@@ -727,7 +705,6 @@ const JSONSerializer = Serializer.extend({
 
     http://jsonapi.org/format/#document-resource-object-relationships
 
-    @method extractRelationships
     @public
     @param {Object} modelClass
     @param {Object} resourceHash
@@ -797,7 +774,6 @@ const JSONSerializer = Serializer.extend({
   /**
     Dasherizes the model name in the payload
 
-    @method modelNameFromPayloadKey
     @public
     @param {String} key
     @return {String} the model's modelName
@@ -807,7 +783,6 @@ const JSONSerializer = Serializer.extend({
   },
 
   /**
-    @method normalizeRelationships
     @private
   */
   normalizeRelationships(typeClass, hash) {
@@ -830,7 +805,6 @@ const JSONSerializer = Serializer.extend({
   },
 
   /**
-    @method normalizeUsingDeclaredMapping
     @private
   */
   normalizeUsingDeclaredMapping(modelClass, hash) {
@@ -866,7 +840,6 @@ const JSONSerializer = Serializer.extend({
     Looks up the property key that was set by the custom `attr` mapping
     passed to the serializer.
 
-    @method _getMappedKey
     @private
     @param {String} key
     @return {String} key
@@ -905,7 +878,6 @@ const JSONSerializer = Serializer.extend({
     Check attrs.key.serialize property to inform if the `key`
     can be serialized
 
-    @method _canSerialize
     @private
     @param {String} key
     @return {Boolean} true if the key can be serialized
@@ -921,7 +893,6 @@ const JSONSerializer = Serializer.extend({
     it takes priority over the other checks and the related
     attribute/relationship will be serialized
 
-    @method _mustSerialize
     @private
     @param {String} key
     @return {Boolean} true if the key must be serialized
@@ -938,7 +909,6 @@ const JSONSerializer = Serializer.extend({
     By default only many-to-many and many-to-none relationships are serialized.
     This could be configured per relationship by Serializer's `attrs` object.
 
-    @method shouldSerializeHasMany
     @public
     @param {Snapshot} snapshot
     @param {String} key
@@ -1102,7 +1072,6 @@ const JSONSerializer = Serializer.extend({
     }
     ```
 
-    @method serialize
     @public
     @param {Snapshot} snapshot
     @param {Object} options
@@ -1155,7 +1124,6 @@ const JSONSerializer = Serializer.extend({
     }
     ```
 
-    @method serializeIntoHash
     @public
     @param {Object} hash
     @param {Model} typeClass
@@ -1185,7 +1153,6 @@ const JSONSerializer = Serializer.extend({
     }
     ```
 
-    @method serializeAttribute
     @public
     @param {Snapshot} snapshot
     @param {Object} json
@@ -1235,7 +1202,6 @@ const JSONSerializer = Serializer.extend({
     }
     ```
 
-    @method serializeBelongsTo
     @public
     @param {Snapshot} snapshot
     @param {Object} json
@@ -1289,7 +1255,6 @@ const JSONSerializer = Serializer.extend({
    }
    ```
 
-   @method serializeHasMany
     @public
    @param {Snapshot} snapshot
    @param {Object} json
@@ -1342,7 +1307,6 @@ const JSONSerializer = Serializer.extend({
     }
     ```
 
-    @method serializePolymorphicType
     @public
     @param {Snapshot} snapshot
     @param {Object} json
@@ -1371,7 +1335,6 @@ const JSONSerializer = Serializer.extend({
     }
     ```
 
-    @method extractMeta
     @public
     @param {Store} store
     @param {Model} modelClass
@@ -1463,7 +1426,6 @@ const JSONSerializer = Serializer.extend({
     }
     ```
 
-    @method extractErrors
     @public
     @param {Store} store
     @param {Model} typeClass
@@ -1537,7 +1499,6 @@ const JSONSerializer = Serializer.extend({
     }
     ```
 
-    @method keyForAttribute
     @public
     @param {String} key
     @param {String} method
@@ -1565,7 +1526,6 @@ const JSONSerializer = Serializer.extend({
       }
       ```
 
-    @method keyForRelationship
     @public
     @param {String} key
     @param {String} typeClass
@@ -1580,7 +1540,6 @@ const JSONSerializer = Serializer.extend({
    `keyForLink` can be used to define a custom key when deserializing link
    properties.
 
-   @method keyForLink
     @public
    @param {String} key
    @param {String} kind `belongsTo` or `hasMany`
@@ -1593,7 +1552,6 @@ const JSONSerializer = Serializer.extend({
   // HELPERS
 
   /**
-   @method transformFor
    @private
    @param {String} attributeType
    @param {Boolean} skipAssertion

--- a/packages/serializer/src/json.js
+++ b/packages/serializer/src/json.js
@@ -32,7 +32,7 @@ const PRIMARY_ATTRIBUTE_KEY = 'base';
 
   For example, given the following `User` model and JSON payload:
 
-  ```app/models/user.js
+  ```js [app/models/user.js]
   import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
   export default class UserModel extends Model {
@@ -97,7 +97,7 @@ const JSONSerializer = Serializer.extend({
 
     Example
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default class ApplicationSerializer extends JSONSerializer {
@@ -121,7 +121,7 @@ const JSONSerializer = Serializer.extend({
 
     Example
 
-    ```app/models/person.js
+    ```js [app/models/person.js]
     import Model, { attr } from '@ember-data/model';
 
     export default class PersonModel extends Model {
@@ -132,7 +132,7 @@ const JSONSerializer = Serializer.extend({
     }
     ```
 
-    ```app/serializers/person.js
+    ```js [app/serializers/person.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default class PersonSerializer extends JSONSerializer {
@@ -148,7 +148,7 @@ const JSONSerializer = Serializer.extend({
 
     Example
 
-    ```app/serializers/person.js
+    ```js [app/serializers/person.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default class PostSerializer extends JSONSerializer {
@@ -552,7 +552,7 @@ const JSONSerializer = Serializer.extend({
 
     Example
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import JSONSerializer from '@ember-data/serializer/json';
     import { underscore } from '<app-name>/utils/string-utils';
     import { get } from '@ember/object';
@@ -934,7 +934,7 @@ const JSONSerializer = Serializer.extend({
 
     For example, consider this model:
 
-    ```app/models/comment.js
+    ```js [app/models/comment.js]
     import Model, { attr, belongsTo } from '@ember-data/model';
 
     export default class CommentModel extends Model {
@@ -980,7 +980,7 @@ const JSONSerializer = Serializer.extend({
     In that case, you can implement `serialize` yourself and
     return a JSON hash of your choosing.
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default class PostSerializer extends JSONSerializer {
@@ -1006,7 +1006,7 @@ const JSONSerializer = Serializer.extend({
     application, you'll probably want to use `eachAttribute`
     and `eachRelationship` on the record.
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import JSONSerializer from '@ember-data/serializer/json';
     import { singularize } from '<app-name>/utils/string-utils';
 
@@ -1057,7 +1057,7 @@ const JSONSerializer = Serializer.extend({
     you can call `super.serialize` first and make the tweaks on
     the returned JSON.
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default class PostSerializer extends JSONSerializer {
@@ -1112,7 +1112,7 @@ const JSONSerializer = Serializer.extend({
 
     For example, your server may expect underscored root objects.
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import RESTSerializer from '@ember-data/serializer/rest';
     import { underscoren} from '<app-name>/utils/string-utils';
 
@@ -1142,7 +1142,7 @@ const JSONSerializer = Serializer.extend({
     serialized as properties on an `attributes` object you could
     write:
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default class ApplicationSerializer extends JSONSerializer {
@@ -1187,7 +1187,7 @@ const JSONSerializer = Serializer.extend({
 
     Example
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default class PostSerializer extends JSONSerializer {
@@ -1240,7 +1240,7 @@ const JSONSerializer = Serializer.extend({
 
    Example
 
-   ```app/serializers/post.js
+   ```js [app/serializers/post.js]
    import JSONSerializer from '@ember-data/serializer/json';
 
    export default class PostSerializer extends JSONSerializer {
@@ -1288,7 +1288,7 @@ const JSONSerializer = Serializer.extend({
 
     Example
 
-    ```app/serializers/comment.js
+    ```js [app/serializers/comment.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default class CommentSerializer extends JSONSerializer {
@@ -1321,7 +1321,7 @@ const JSONSerializer = Serializer.extend({
 
     Example
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default class PostSerializer extends JSONSerializer {
@@ -1412,7 +1412,7 @@ const JSONSerializer = Serializer.extend({
     Example of alternative implementation, overriding the default
     behavior to deal with a different format of errors:
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import JSONSerializer from '@ember-data/serializer/json';
 
     export default class PostSerializer extends JSONSerializer {
@@ -1488,7 +1488,7 @@ const JSONSerializer = Serializer.extend({
 
     Example
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import JSONSerializer from '@ember-data/serializer/json';
     import { underscore } from '<app-name>/utils/string-utils';
 
@@ -1515,7 +1515,7 @@ const JSONSerializer = Serializer.extend({
 
     Example
 
-      ```app/serializers/post.js
+      ```js [app/serializers/post.js]
       import JSONSerializer from '@ember-data/serializer/json';
       import { underscore } from '<app-name>/utils/string-utils';
 

--- a/packages/serializer/src/rest.js
+++ b/packages/serializer/src/rest.js
@@ -60,7 +60,6 @@ function makeArray(value) {
 
   @class RESTSerializer
   @public
-  @extends JSONSerializer
 */
 const RESTSerializer = JSONSerializer.extend({
   /**
@@ -82,7 +81,6 @@ const RESTSerializer = JSONSerializer.extend({
     }
     ```
 
-   @method keyForPolymorphicType
     @public
    @param {String} key
    @param {String} typeClass
@@ -155,7 +153,6 @@ const RESTSerializer = JSONSerializer.extend({
     one of the keys that were in the original payload or in the result of another
     normalization as `normalizeResponse`.
 
-    @method normalize
     @public
     @param {Model} modelClass
     @param {Object} resourceHash
@@ -167,7 +164,6 @@ const RESTSerializer = JSONSerializer.extend({
     Normalizes an array of resource payloads and returns a JSON-API Document
     with primary data and, if any, included data as `{ data, included }`.
 
-    @method _normalizeArray
     @param {Store} store
     @param {String} modelName
     @param {Object} arrayHash
@@ -215,7 +211,6 @@ const RESTSerializer = JSONSerializer.extend({
   },
 
   /**
-    @method _normalizeResponse
     @param {Store} store
     @param {Model} primaryModelClass
     @param {Object} payload
@@ -385,7 +380,6 @@ const RESTSerializer = JSONSerializer.extend({
     in data streaming in from your server structured the same way
     that fetches and saves are structured.
 
-    @method pushPayload
     @public
     @param {Store} store
     @param {Object} payload
@@ -474,7 +468,6 @@ const RESTSerializer = JSONSerializer.extend({
     can use the correct inflection to do this for you. Most of the time, you won't
     need to override `modelNameFromPayloadKey` for this purpose.
 
-    @method modelNameFromPayloadKey
     @public
     @param {String} key
     @return {String} the model's modelName
@@ -632,7 +625,6 @@ const RESTSerializer = JSONSerializer.extend({
     }
     ```
 
-    @method serialize
     @public
     @param {Snapshot} snapshot
     @param {Object} options
@@ -662,7 +654,6 @@ const RESTSerializer = JSONSerializer.extend({
     }
     ```
 
-    @method serializeIntoHash
     @public
     @param {Object} hash
     @param {Model} typeClass
@@ -716,7 +707,6 @@ const RESTSerializer = JSONSerializer.extend({
     }
     ```
 
-    @method payloadKeyFromModelName
     @public
     @param {String} modelName
     @return {String}
@@ -730,7 +720,6 @@ const RESTSerializer = JSONSerializer.extend({
     By default the REST Serializer creates the key by appending `Type` to
     the attribute and value from the model's camelcased model name.
 
-    @method serializePolymorphicType
     @public
     @param {Snapshot} snapshot
     @param {Object} json
@@ -752,7 +741,6 @@ const RESTSerializer = JSONSerializer.extend({
     You can use this method to customize how a polymorphic relationship should
     be extracted.
 
-    @method extractPolymorphicRelationship
     @public
     @param {Object} relationshipType
     @param {Object} relationshipHash

--- a/packages/serializer/src/rest.js
+++ b/packages/serializer/src/rest.js
@@ -42,7 +42,7 @@ function makeArray(value) {
   can implement across-the-board rules for how to convert an attribute
   name in your model to a key in your JSON.
 
-  ```app/serializers/application.js
+  ```js [app/serializers/application.js]
   import RESTSerializer from '@ember-data/serializer/rest';
   import { underscore } from '<app-name>/utils/string-utils';
 
@@ -69,7 +69,7 @@ const RESTSerializer = JSONSerializer.extend({
 
    Example
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import RESTSerializer from '@ember-data/serializer/rest';
 
     export default class ApplicationSerializer extends RESTSerializer {
@@ -134,7 +134,7 @@ const RESTSerializer = JSONSerializer.extend({
     For example, if the `IDs` under `"comments"` are provided as `_id` instead of
     `id`, you can specify how to normalize just the comments:
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import RESTSerializer from '@ember-data/serializer/rest';
 
     export default class ApplicationSerializer extends RESTSerializer {
@@ -424,7 +424,7 @@ const RESTSerializer = JSONSerializer.extend({
     the name of the model in your app. Let's take a look at an example model,
     and an example payload:
 
-    ```app/models/post.js
+    ```js [app/models/post.js]
     import Model from '@ember-data/model';
 
     export default class Post extends Model {}
@@ -446,7 +446,7 @@ const RESTSerializer = JSONSerializer.extend({
     Since we want to remove this namespace, we can define a serializer for the application that will
     remove "blog/" from the payload key whenver it's encountered by Ember Data:
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import RESTSerializer from '@ember-data/serializer/rest';
 
     export default class ApplicationSerializer extends RESTSerializer {
@@ -487,7 +487,7 @@ const RESTSerializer = JSONSerializer.extend({
 
     For example, consider this model:
 
-    ```app/models/comment.js
+    ```js [app/models/comment.js]
     import Model, { attr, belongsTo } from '@ember-data/model';
 
     export default class Comment extends Model {
@@ -533,7 +533,7 @@ const RESTSerializer = JSONSerializer.extend({
     In that case, you can implement `serialize` yourself and
     return a JSON hash of your choosing.
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import RESTSerializer from '@ember-data/serializer/rest';
 
     export default class ApplicationSerializer extends RESTSerializer {
@@ -559,7 +559,7 @@ const RESTSerializer = JSONSerializer.extend({
     application, you'll probably want to use `eachAttribute`
     and `eachRelationship` on the record.
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import RESTSerializer from '@ember-data/serializer/rest';
     import { pluralize } from '<app-name>/utils/string-utils';
 
@@ -610,7 +610,7 @@ const RESTSerializer = JSONSerializer.extend({
     you can call super first and make the tweaks on the returned
     JSON.
 
-    ```app/serializers/post.js
+    ```js [app/serializers/post.js]
     import RESTSerializer from '@ember-data/serializer/rest';
 
     export default class ApplicationSerializer extends RESTSerializer {
@@ -642,7 +642,7 @@ const RESTSerializer = JSONSerializer.extend({
 
     For example, your server may expect underscored root objects.
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import RESTSerializer from '@ember-data/serializer/rest';
     import { underscore } from '<app-name>/utils/string-utils';
 
@@ -684,7 +684,7 @@ const RESTSerializer = JSONSerializer.extend({
 
     For example, your server may expect dasherized root objects:
 
-    ```app/serializers/application.js
+    ```js [app/serializers/application.js]
     import RESTSerializer from '@ember-data/serializer/rest';
     import { dasherize } from '<app-name>/utils/string-utils';
 

--- a/packages/store/src/-private/cache-handler/handler.ts
+++ b/packages/store/src/-private/cache-handler/handler.ts
@@ -82,7 +82,6 @@ export interface StoreRequestContext extends RequestContext {
  *   [EnableHydration]: true
  * });
  *
- * @typedoc
  */
 export const CacheHandler: CacheHandlerType = {
   request<T>(

--- a/packages/store/src/-private/cache-handler/types.ts
+++ b/packages/store/src/-private/cache-handler/types.ts
@@ -28,7 +28,6 @@ export interface CachePolicy {
    * the request will be fulfilled from the configured request handlers
    * and the cache will be updated before returning the response.
    *
-   * @method isHardExpired
    * @public
    * @param {StableDocumentIdentifier} identifier
    * @param {Store} store
@@ -44,7 +43,6 @@ export interface CachePolicy {
    * If true, the request will be fulfilled from cache while a backgrounded
    * request is made to update the cache via the configured request handlers.
    *
-   * @method isSoftExpired
    * @public
    * @param {StableDocumentIdentifier} identifier
    * @param {Store} store
@@ -58,7 +56,6 @@ export interface CachePolicy {
    *
    * Note, this is invoked regardless of whether the request has a cache-key.
    *
-   * @method willRequest [Optional]
    * @public
    * @param {ImmutableRequestInfo} request
    * @param {StableDocumentIdentifier | null} identifier
@@ -94,7 +91,6 @@ export interface CachePolicy {
    * ```
    *
    *
-   * @method didRequest [Optional]
    * @public
    * @param {ImmutableRequestInfo} request
    * @param {ImmutableResponse} response

--- a/packages/store/src/-private/caches/identifier-cache.ts
+++ b/packages/store/src/-private/caches/identifier-cache.ts
@@ -264,7 +264,6 @@ export class IdentifierCache {
    * we allow late binding of this private internal merge so that
    * the cache can insert itself here to handle elimination of duplicates
    *
-   * @method __configureMerge
    * @private
    */
   __configureMerge(method: MergeMethod | null) {
@@ -276,7 +275,6 @@ export class IdentifierCache {
   }
 
   /**
-   * @method _getRecordIdentifier
    * @private
    */
   _getRecordIdentifier(
@@ -359,7 +357,6 @@ export class IdentifierCache {
    * useful for the "create" case when we need to see if
    * we are accidentally overwritting something
    *
-   * @method peekRecordIdentifier
    * @param resource
    * @return {StableRecordIdentifier | undefined}
    * @private
@@ -372,7 +369,6 @@ export class IdentifierCache {
     Returns the DocumentIdentifier for the given Request, creates one if it does not yet exist.
     Returns `null` if the request does not have a `cacheKey` or `url`.
 
-    @method getOrCreateDocumentIdentifier
     @param request
     @return {StableDocumentIdentifier | null}
     @public
@@ -412,7 +408,6 @@ export class IdentifierCache {
       `id` + `type` or `lid` will return the same `lid` value)
     - this referential stability of the object itself is guaranteed
 
-    @method getOrCreateRecordIdentifier
     @param resource
     @return {StableRecordIdentifier}
     @public
@@ -429,7 +424,6 @@ export class IdentifierCache {
    Delegates generation to the user supplied `GenerateMethod` if one has been provided
    with the signature `generateMethod({ type }, 'record')`.
 
-   @method createIdentifierForNewRecord
    @param data
    @return {StableRecordIdentifier}
    @public
@@ -475,7 +469,6 @@ export class IdentifierCache {
     provided identifier. In this case the abandoned identifier will go through the usual
     `forgetRecordIdentifier` codepaths.
 
-    @method updateRecordIdentifier
     @param identifierObject
     @param data
     @return {StableRecordIdentifier}
@@ -550,7 +543,6 @@ export class IdentifierCache {
   }
 
   /**
-   * @method _mergeRecordIdentifiers
    * @private
    */
   _mergeRecordIdentifiers(
@@ -602,7 +594,6 @@ export class IdentifierCache {
    we do not care about the record anymore. Especially useful when an `id` of a
    deleted record might be reused later for a new record.
 
-   @method forgetRecordIdentifier
    @param identifierObject
    @public
   */

--- a/packages/store/src/-private/caches/instance-cache.ts
+++ b/packages/store/src/-private/caches/instance-cache.ts
@@ -44,6 +44,7 @@ export function peekRecordIdentifier(record: OpaqueRecordInstance): StableRecord
 /**
   Retrieves the unique referentially-stable [RecordIdentifier](/ember-data/release/classes/StableRecordIdentifier)
   assigned to the given record instance.
+
   ```js
   import { recordIdentifierFor } from "@ember-data/store";
   // ... gain access to a record, for instance with peekRecord or findRecord
@@ -53,10 +54,8 @@ export function peekRecordIdentifier(record: OpaqueRecordInstance): StableRecord
   // access the identifier's properties.
   const { id, type, lid } = identifier;
   ```
-  @method recordIdentifierFor
+
   @public
-  @static
-  @for @ember-data/store
   @param {Object} record a record instance previously obstained from the store.
   @return {StableRecordIdentifier}
  */

--- a/packages/store/src/-private/document.ts
+++ b/packages/store/src/-private/document.ts
@@ -148,7 +148,6 @@ export class ReactiveDocument<T> {
    * with the document when the request completes. If no related link is present,
    * will fallback to the self link if present
    *
-   * @method fetch
    * @public
    * @param {Object} options
    * @return {Promise<Document>}
@@ -167,7 +166,6 @@ export class ReactiveDocument<T> {
    * with the new document when the request completes, or null  if there is no
    * next link.
    *
-   * @method next
    * @public
    * @param {Object} options
    * @return {Promise<Document | null>}
@@ -181,7 +179,6 @@ export class ReactiveDocument<T> {
    * with the new document when the request completes, or null if there is no
    * prev link.
    *
-   * @method prev
    * @public
    * @param {Object} options
    * @return {Promise<Document | null>}
@@ -195,7 +192,6 @@ export class ReactiveDocument<T> {
    * with the new document when the request completes, or null if there is no
    * first link.
    *
-   * @method first
    * @public
    * @param {Object} options
    * @return {Promise<Document | null>}
@@ -209,7 +205,6 @@ export class ReactiveDocument<T> {
    * with the new document when the request completes, or null if there is no
    * last link.
    *
-   * @method last
    * @public
    * @param {Object} options
    * @return {Promise<Document | null>}
@@ -227,7 +222,6 @@ export class ReactiveDocument<T> {
    * the document's contents, leaving that to the individual record
    * instances to determine how to do, if at all.
    *
-   * @method toJSON
    * @public
    * @return
    */

--- a/packages/store/src/-private/legacy-model-support/record-reference.ts
+++ b/packages/store/src/-private/legacy-model-support/record-reference.ts
@@ -57,7 +57,6 @@ export default class RecordReference {
      userRef.id(); // '1'
      ```
 
-     @method id
     @public
      @return {String} The id of the record.
   */
@@ -81,7 +80,6 @@ export default class RecordReference {
      userRef.identifier(); // '1'
      ```
 
-     @method identifier
     @public
      @return {String} The identifier of the record.
   */
@@ -102,7 +100,6 @@ export default class RecordReference {
      userRef.remoteType(); // 'identity'
      ```
 
-     @method remoteType
      @public
      @return {String} 'identity'
   */
@@ -144,7 +141,6 @@ export default class RecordReference {
      });
      ```
 
-    @method push
     @public
     @param objectOrPromise a JSON:API ResourceDocument or a promise resolving to one
     @return a promise for the value (record or relationship)
@@ -169,7 +165,6 @@ export default class RecordReference {
      userRef.value(); // user
      ```
 
-     @method value
     @public
      @return {Model} the record for this RecordReference
   */
@@ -190,7 +185,6 @@ export default class RecordReference {
      userRef.load().then(...)
      ```
 
-     @method load
     @public
      @return {Promise<record>} the record for this RecordReference
   */
@@ -215,7 +209,6 @@ export default class RecordReference {
      userRef.reload().then(...)
      ```
 
-     @method reload
     @public
      @return {Promise<record>} the record for this RecordReference
   */

--- a/packages/store/src/-private/managers/cache-manager.ts
+++ b/packages/store/src/-private/managers/cache-manager.ts
@@ -59,7 +59,6 @@ export class CacheManager implements Cache {
    * a `content` member and therefor must not assume the existence
    * of `request` and `response` on the document.
    *
-   * @method put
    * @param {StructuredDocument} doc
    * @return {ResourceDocument}
    * @public
@@ -74,7 +73,6 @@ export class CacheManager implements Cache {
    * Note: currently the only valid operation is a MergeOperation
    * which occurs when a collision of identifiers is detected.
    *
-   * @method patch
    * @public
    * @param op the operation to perform
    * @return {void}
@@ -87,7 +85,6 @@ export class CacheManager implements Cache {
    * Update resource data with a local mutation. Currently supports operations
    * on relationships only.
    *
-   * @method mutate
    * @public
    * @param mutation
    */
@@ -122,7 +119,6 @@ export class CacheManager implements Cache {
    * of the Graph handling necessary entanglements and
    * notifications for relational data.
    *
-   * @method peek
    * @public
    * @param {StableRecordIdentifier | StableDocumentIdentifier} identifier
    * @return {ResourceDocument | ResourceBlob | null} the known resource data
@@ -142,7 +138,6 @@ export class CacheManager implements Cache {
    * Peek the Cache for the existing request data associated with
    * a cacheable request
    *
-   * @method peekRequest
    * @param {StableDocumentIdentifier}
    * @return {StableDocumentIdentifier | null}
    * @public
@@ -154,7 +149,6 @@ export class CacheManager implements Cache {
   /**
    * Push resource data from a remote source into the cache for this identifier
    *
-   * @method upsert
    * @public
    * @param identifier
    * @param data
@@ -175,7 +169,6 @@ export class CacheManager implements Cache {
    * preferring instead to fork at the Store level, which will
    * utilize this method to fork the cache.
    *
-   * @method fork
    * @public
    * @return {Promise<Cache>}
    */
@@ -190,7 +183,6 @@ export class CacheManager implements Cache {
    * preferring instead to merge at the Store level, which will
    * utilize this method to merge the caches.
    *
-   * @method merge
    * @param {Cache} cache
    * @public
    * @return {Promise<void>}
@@ -229,7 +221,6 @@ export class CacheManager implements Cache {
    * }
    * ```
    *
-   * @method diff
    * @public
    */
   diff(): Promise<Change[]> {
@@ -244,7 +235,6 @@ export class CacheManager implements Cache {
    * which may be fed back into a new instance of the same Cache
    * via `cache.hydrate`.
    *
-   * @method dump
    * @return {Promise<ReadableStream>}
    * @public
    */
@@ -264,7 +254,6 @@ export class CacheManager implements Cache {
    * behavior supports optimizing pre/fetching of data for route transitions
    * via data-only SSR modes.
    *
-   * @method hydrate
    * @param {ReadableStream} stream
    * @return {Promise<void>}
    * @public
@@ -285,7 +274,6 @@ export class CacheManager implements Cache {
    * It returns properties from options that should be set on the record during the create
    * process. This return value behavior is deprecated.
    *
-   * @method clientDidCreate
    * @public
    * @param identifier
    * @param options
@@ -298,7 +286,6 @@ export class CacheManager implements Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * will be part of a save transaction.
    *
-   * @method willCommit
    * @public
    * @param identifier
    */
@@ -310,7 +297,6 @@ export class CacheManager implements Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * was successfully updated as part of a save transaction.
    *
-   * @method didCommit
    * @public
    * @param identifier
    * @param data
@@ -323,7 +309,6 @@ export class CacheManager implements Cache {
    * [LIFECYCLE] Signals to the cache that a resource
    * was update via a save transaction failed.
    *
-   * @method commitWasRejected
    * @public
    * @param identifier
    * @param errors
@@ -336,7 +321,6 @@ export class CacheManager implements Cache {
    * [LIFECYCLE] Signals to the cache that all data for a resource
    * should be cleared.
    *
-   * @method unloadRecord
    * @public
    * @param identifier
    */
@@ -350,7 +334,6 @@ export class CacheManager implements Cache {
   /**
    * Retrieve the data for an attribute from the cache
    *
-   * @method getAttr
    * @public
    * @param identifier
    * @param propertyName
@@ -363,7 +346,6 @@ export class CacheManager implements Cache {
   /**
    * Retrieve the remote state for an attribute from the cache
    *
-   * @method getRemoteAttr
    * @public
    * @param identifier
    * @param propertyName
@@ -376,7 +358,6 @@ export class CacheManager implements Cache {
   /**
    * Mutate the data for an attribute in the cache
    *
-   * @method setAttr
    * @public
    * @param identifier
    * @param propertyName
@@ -389,7 +370,6 @@ export class CacheManager implements Cache {
   /**
    * Query the cache for the changed attributes of a resource.
    *
-   * @method changedAttrs
    * @public
    * @param identifier
    * @return
@@ -401,7 +381,6 @@ export class CacheManager implements Cache {
   /**
    * Query the cache for whether any mutated attributes exist
    *
-   * @method hasChangedAttrs
    * @public
    * @param identifier
    * @return {Boolean}
@@ -413,7 +392,6 @@ export class CacheManager implements Cache {
   /**
    * Tell the cache to discard any uncommitted mutations to attributes
    *
-   * @method rollbackAttrs
    * @public
    * @param identifier
    * @return the names of attributes that were restored
@@ -447,7 +425,6 @@ export class CacheManager implements Cache {
     };
     ```
    *
-   * @method changedRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {Map<string, RelationshipDiff>}
@@ -459,7 +436,6 @@ export class CacheManager implements Cache {
   /**
    * Query the cache for whether any mutated attributes exist
    *
-   * @method hasChangedRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {Boolean}
@@ -475,7 +451,6 @@ export class CacheManager implements Cache {
    *
    * This method is a candidate to become a mutation
    *
-   * @method rollbackRelationships
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {String[]} the names of relationships that were restored
@@ -487,7 +462,6 @@ export class CacheManager implements Cache {
   /**
    * Query the cache for the current state of a relationship property
    *
-   * @method getRelationship
    * @public
    * @param identifier
    * @param propertyName
@@ -503,7 +477,6 @@ export class CacheManager implements Cache {
   /**
    * Query the cache for the remote state of a relationship property
    *
-   * @method getRelationship
    * @public
    * @param identifier
    * @param propertyName
@@ -523,7 +496,6 @@ export class CacheManager implements Cache {
    * Update the cache state for the given resource to be marked as locally deleted,
    * or remove such a mark.
    *
-   * @method setIsDeleted
    * @public
    * @param identifier
    * @param isDeleted
@@ -535,7 +507,6 @@ export class CacheManager implements Cache {
   /**
    * Query the cache for any validation errors applicable to the given resource.
    *
-   * @method getErrors
    * @public
    * @param identifier
    * @return
@@ -547,7 +518,6 @@ export class CacheManager implements Cache {
   /**
    * Query the cache for whether a given resource has any available data
    *
-   * @method isEmpty
    * @public
    * @param identifier
    * @return {Boolean}
@@ -560,7 +530,6 @@ export class CacheManager implements Cache {
    * Query the cache for whether a given resource was created locally and not
    * yet persisted.
    *
-   * @method isNew
    * @public
    * @param identifier
    * @return {Boolean}
@@ -573,7 +542,6 @@ export class CacheManager implements Cache {
    * Query the cache for whether a given resource is marked as deleted (but not
    * necessarily persisted yet).
    *
-   * @method isDeleted
    * @public
    * @param identifier
    * @return {Boolean}
@@ -586,7 +554,6 @@ export class CacheManager implements Cache {
    * Query the cache for whether a given resource has been deleted and that deletion
    * has also been persisted.
    *
-   * @method isDeletionCommitted
    * @public
    * @param identifier
    * @return {Boolean}

--- a/packages/store/src/-private/managers/notification-manager.ts
+++ b/packages/store/src/-private/managers/notification-manager.ts
@@ -130,7 +130,6 @@ export default class NotificationManager {
    * }
    * ```
    *
-   * @method subscribe
    * @public
    * @param {StableDocumentIdentifier | StableRecordIdentifier | 'resource' | 'document'} identifier
    * @param {NotificationCallback | ResourceOperationCallback | DocumentOperationCallback} callback
@@ -169,7 +168,6 @@ export default class NotificationManager {
   /**
    * remove a previous subscription
    *
-   * @method unsubscribe
    * @public
    * @param {UnsubscribeToken} token
    */
@@ -182,7 +180,6 @@ export default class NotificationManager {
   /**
    * Custom Caches and Application Code should not call this method directly.
    *
-   * @method notify
    * @param identifier
    * @param value
    * @param key

--- a/packages/store/src/-private/managers/record-array-manager.ts
+++ b/packages/store/src/-private/managers/record-array-manager.ts
@@ -163,7 +163,6 @@ export class RecordArrayManager {
     Get the `RecordArray` for a modelName, which contains all loaded records of
     given modelName.
 
-    @method liveArrayFor
     @internal
     @param {String} modelName
     @return {RecordArray}

--- a/packages/store/src/-private/network/request-cache.ts
+++ b/packages/store/src/-private/network/request-cache.ts
@@ -212,7 +212,6 @@ export class RequestStateService {
    * with the RequestManager for these purposes is likely to be a better long-term
    * design.
    *
-   * @method subscribeForRecord
    * @public
    * @param {StableRecordIdentifier} identifier
    * @param {(state: RequestCacheRequestState) => void} callback
@@ -229,7 +228,6 @@ export class RequestStateService {
   /**
    * Retrieve all active requests for a given resource identity.
    *
-   * @method getPendingRequestsForRecord
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {RequestCacheRequestState[]} an array of request states for any pending requests for the given identifier
@@ -241,7 +239,6 @@ export class RequestStateService {
   /**
    * Retrieve the last completed request for a given resource identity.
    *
-   * @method getLastRequestForRecord
    * @public
    * @param {StableRecordIdentifier} identifier
    * @return {RequestCacheRequestState | null} the state of the most recent request for the given identifier

--- a/packages/store/src/-private/new-core-tmp/promise-state.ts
+++ b/packages/store/src/-private/new-core-tmp/promise-state.ts
@@ -9,20 +9,17 @@ const PromiseCache = new WeakMap<Awaitable, PromiseState>();
  * The state of a promise in the "pending"
  * state. This is the default initial state.
  *
- * @typedoc
  */
 export interface PendingPromise {
   /**
    * The status of the promise.
    *
-   * @typedoc
    */
   status: 'pending';
 
   /**
    * Whether the promise is pending.
    *
-   * @typedoc
    */
   isPending: true;
 
@@ -30,7 +27,6 @@ export interface PendingPromise {
    * Whether the promise is pending.
    *
    * @deprecated use `isPending` instead
-   * @typedoc
    */
   isLoading: true;
 
@@ -38,7 +34,6 @@ export interface PendingPromise {
    * Whether the promise has resolved
    * successfully.
    *
-   * @typedoc
    */
   isSuccess: false;
 
@@ -46,7 +41,6 @@ export interface PendingPromise {
    * Whether the promise has rejected
    * with an error.
    *
-   * @typedoc
    */
   isError: false;
 
@@ -54,7 +48,6 @@ export interface PendingPromise {
    * Once the promise has resolved, this will
    * be the value the promise resolved to.
    *
-   * @typedoc
    */
   value: null;
   /**
@@ -62,7 +55,6 @@ export interface PendingPromise {
    * be the value the promise resolved to.
    *
    * @deprecated use `value` instead
-   * @typedoc
    */
   result: null;
 
@@ -72,7 +64,6 @@ export interface PendingPromise {
    *
    *
    * @deprecated use `reason` instead
-   * @typedoc
    */
   error: null;
 
@@ -80,7 +71,6 @@ export interface PendingPromise {
    * Once the promise has rejected, this will
    * be the error the promise rejected with.
    *
-   * @typedoc
    */
   reason: null;
 }
@@ -90,20 +80,17 @@ export interface PendingPromise {
  * This is the state of a promise that has resolved
  * successfully.
  *
- * @typedoc
  */
 export interface ResolvedPromise<T> {
   /**
    * The status of the promise.
    *
-   * @typedoc
    */
   status: 'fulfilled';
 
   /**
    * Whether the promise is pending.
    *
-   * @typedoc
    */
   isPending: false;
 
@@ -111,14 +98,12 @@ export interface ResolvedPromise<T> {
    * Whether the promise is pending.
    *
    * @deprecated use `isPending` instead
-   * @typedoc
    */
   isLoading: false;
   /**
    * Whether the promise has resolved
    * successfully.
    *
-   * @typedoc
    */
   isSuccess: true;
 
@@ -126,7 +111,6 @@ export interface ResolvedPromise<T> {
    * Whether the promise has rejected
    * with an error.
    *
-   * @typedoc
    */
   isError: false;
 
@@ -134,7 +118,6 @@ export interface ResolvedPromise<T> {
    * Once the promise has resolved, this will
    * be the value the promise resolved to.
    *
-   * @typedoc
    */
   value: T;
 
@@ -143,7 +126,6 @@ export interface ResolvedPromise<T> {
    * be the value the promise resolved to.
    *
    * @deprecated use `value` instead
-   * @typedoc
    */
   result: T;
 
@@ -153,7 +135,6 @@ export interface ResolvedPromise<T> {
    *
    *
    * @deprecated use `reason` instead
-   * @typedoc
    */
   error: null;
 
@@ -161,7 +142,6 @@ export interface ResolvedPromise<T> {
    * Once the promise has rejected, this will
    * be the error the promise rejected with.
    *
-   * @typedoc
    */
   reason: null;
 }
@@ -171,20 +151,17 @@ export interface ResolvedPromise<T> {
  * This is the state of a promise that has rejected
  * with an error.
  *
- * @typedoc
  */
 export interface RejectedPromise<E> {
   /**
    * The status of the promise.
    *
-   * @typedoc
    */
   status: 'rejected';
 
   /**
    * Whether the promise is pending.
    *
-   * @typedoc
    */
   isPending: false;
 
@@ -192,7 +169,6 @@ export interface RejectedPromise<E> {
    * Whether the promise is pending.
    *
    * @deprecated use `isPending` instead
-   * @typedoc
    */
   isLoading: false;
 
@@ -200,7 +176,6 @@ export interface RejectedPromise<E> {
    * Whether the promise has resolved
    * successfully.
    *
-   * @typedoc
    */
   isSuccess: false;
 
@@ -208,7 +183,6 @@ export interface RejectedPromise<E> {
    * Whether the promise has rejected
    * with an error.
    *
-   * @typedoc
    */
   isError: true;
 
@@ -216,7 +190,6 @@ export interface RejectedPromise<E> {
    * Once the promise has resolved, this will
    * be the value the promise resolved to.
    *
-   * @typedoc
    */
   value: null;
 
@@ -225,7 +198,6 @@ export interface RejectedPromise<E> {
    * be the value the promise resolved to.
    *
    * @deprecated use `value` instead
-   * @typedoc
    */
   result: null;
 
@@ -235,7 +207,6 @@ export interface RejectedPromise<E> {
    *
    *
    * @deprecated use `reason` instead
-   * @typedoc
    */
   error: E;
 
@@ -243,7 +214,6 @@ export interface RejectedPromise<E> {
    * Once the promise has rejected, this will
    * be the error the promise rejected with.
    *
-   * @typedoc
    */
   reason: E;
 }
@@ -257,7 +227,6 @@ export interface RejectedPromise<E> {
  * - {@link ResolvedPromise}
  * - {@link RejectedPromise}
  *
- * @typedoc
  */
 export type PromiseState<T = unknown, E = unknown> = PendingPromise | ResolvedPromise<T> | RejectedPromise<E>;
 
@@ -383,7 +352,6 @@ function getPromise<T, E>(promise: Promise<T> | Awaitable<T, E> | LegacyAwaitabl
  *
  * If looking to use in a template, consider also the `<Await />` component.
  *
- * @typedoc
  */
 export function getPromiseState<T = unknown, E = unknown>(
   promise: Promise<T> | Awaitable<T, E>

--- a/packages/store/src/-private/new-core-tmp/reactivity/configure.ts
+++ b/packages/store/src/-private/new-core-tmp/reactivity/configure.ts
@@ -57,7 +57,6 @@ export type SignalRef = unknown;
  * method, and consuming the correct one via the correct framework via
  * the `consumeSignal` and `notifySignal` methods.
  *
- * @typedoc
  */
 export interface SignalHooks<T = SignalRef> {
   createSignal: (obj: object, key: string | symbol) => T;

--- a/packages/store/src/-private/new-core-tmp/request-state.ts
+++ b/packages/store/src/-private/new-core-tmp/request-state.ts
@@ -78,7 +78,6 @@ async function watchStream(stream: ReadableStream<Uint8Array>, state: RequestLoa
  * reactive properties that can be used to build UIs that respond
  * to the progress of a request.
  *
- * @typedoc
  */
 export class RequestLoadingState {
   declare _sizeHint: number;
@@ -243,13 +242,11 @@ defineNonEnumerableSignal(RequestLoadingState.prototype, '_lastPacketTime', 0);
  *
  * Extends the {@link PendingPromise} interface.
  *
- * @typedoc
  */
 export interface PendingRequest extends PendingPromise {
   /**
    * Whether the request is cancelled.
    *
-   * @typedoc
    */
   isCancelled: false;
 
@@ -264,13 +261,11 @@ export interface PendingRequest extends PendingPromise {
  *
  * Extends the {@link ResolvedPromise} interface.
  *
- * @typedoc
  */
 export interface ResolvedRequest<RT, T> extends ResolvedPromise<RT> {
   /**
    * Whether the request is cancelled.
    *
-   * @typedoc
    */
   isCancelled: false;
 
@@ -285,14 +280,12 @@ export interface ResolvedRequest<RT, T> extends ResolvedPromise<RT> {
  *
  * Extends the {@link RejectedPromise} interface.
  *
- * @typedoc
  */
 export interface RejectedRequest<RT, T, E extends StructuredErrorDocument = StructuredErrorDocument>
   extends RejectedPromise<E> {
   /**
    * Whether the request is cancelled.
    *
-   * @typedoc
    */
   isCancelled: false;
 
@@ -305,27 +298,23 @@ export interface RejectedRequest<RT, T, E extends StructuredErrorDocument = Stru
  * This is the state of a promise that has been
  * cancelled.
  *
- * @typedoc
  */
 export interface CancelledRequest<RT, T, E extends StructuredErrorDocument = StructuredErrorDocument> {
   /**
    * The status of the request.
    *
-   * @typedoc
    */
   status: 'cancelled';
 
   /**
    * Whether the request is pending.
    *
-   * @typedoc
    */
   isPending: false;
 
   /**
    * Whether the request is pending.
    *
-   * @typedoc
    */
   isLoading: false;
 
@@ -333,7 +322,6 @@ export interface CancelledRequest<RT, T, E extends StructuredErrorDocument = Str
    * Whether the request has resolved
    * successfully.
    *
-   * @typedoc
    */
   isSuccess: false;
 
@@ -341,7 +329,6 @@ export interface CancelledRequest<RT, T, E extends StructuredErrorDocument = Str
    * Whether the request has rejected
    * with an error.
    *
-   * @typedoc
    */
   isError: true;
 
@@ -349,7 +336,6 @@ export interface CancelledRequest<RT, T, E extends StructuredErrorDocument = Str
    * Once the request has resolved, this will
    * be the value the request resolved to.
    *
-   * @typedoc
    */
   value: null;
   /**
@@ -357,7 +343,6 @@ export interface CancelledRequest<RT, T, E extends StructuredErrorDocument = Str
    * be the value the request resolved to.
    *
    * @deprecated use `value` instead
-   * @typedoc
    */
   result: null;
 
@@ -367,7 +352,6 @@ export interface CancelledRequest<RT, T, E extends StructuredErrorDocument = Str
    *
    *
    * @deprecated use `reason` instead
-   * @typedoc
    */
   error: E;
 
@@ -375,14 +359,12 @@ export interface CancelledRequest<RT, T, E extends StructuredErrorDocument = Str
    * Once the request has rejected, this will
    * be the error the request rejected with.
    *
-   * @typedoc
    */
   reason: E;
 
   /**
    * Whether the request is cancelled.
    *
-   * @typedoc
    */
   isCancelled: true;
 
@@ -427,7 +409,6 @@ interface PrivateRequestState {
  * - {@link RejectedRequest}
  * - {@link CancelledRequest}
  *
- * @typedoc
  */
 export type RequestCacheRequestState<
   RT = unknown,
@@ -575,7 +556,6 @@ export function createRequestState<RT, T, E>(
  * which offers a numbe of additional capabilities for requests *beyond* what
  * `RequestState` provides.
  *
- * @typedoc
  */
 export function getRequestState<RT, T, E>(
   future: Future<RT>

--- a/packages/store/src/-private/record-arrays/identifier-array.ts
+++ b/packages/store/src/-private/record-arrays/identifier-array.ts
@@ -475,7 +475,6 @@ export class IdentifierArray<T = unknown> {
     people.isUpdating; // true
     ```
 
-    @method update
     @public
   */
   update(): Promise<IdentifierArray<T>> {
@@ -526,7 +525,6 @@ export class IdentifierArray<T = unknown> {
     messages.save();
     ```
 
-    @method save
     @public
     @return {Promise<IdentifierArray>} promise
   */

--- a/packages/store/src/-private/record-arrays/many-array.ts
+++ b/packages/store/src/-private/record-arrays/many-array.ts
@@ -55,7 +55,7 @@ export interface ManyArrayCreateArgs<T> {
   an inverse. For example, imagine the following models are
   defined:
 
-  ```app/models/post.js
+  ```js [app/models/post.js]
   import Model, { hasMany } from '@ember-data/model';
 
   export default class PostModel extends Model {
@@ -63,7 +63,7 @@ export interface ManyArrayCreateArgs<T> {
   }
   ```
 
-  ```app/models/comment.js
+  ```js [app/models/comment.js]
   import Model, { belongsTo } from '@ember-data/model';
 
   export default class CommentModel extends Model {
@@ -412,6 +412,22 @@ export class RelatedCollection<T = unknown> extends IdentifierArray<T> {
   }
 
   /**
+    Create a child record within the owner
+
+    @public
+    @param {Object} hash
+    @return {Model} record
+  */
+  createRecord(hash: CreateRecordProperties<T>): T {
+    const { store } = this;
+    assert(`Expected modelName to be set`, this.modelName);
+    const record = store.createRecord<T>(this.modelName as TypeFromInstance<T>, hash);
+    this.push(record);
+
+    return record;
+  }
+
+  /**
     Saves all of the records in the `ManyArray`.
 
     Note: this API can only be used in legacy mode with a configured Adapter.
@@ -428,27 +444,12 @@ export class RelatedCollection<T = unknown> extends IdentifierArray<T> {
     messages.save();
     ```
 
-    @method save
     @public
     @return {PromiseArray} promise
   */
+  declare save: () => Promise<IdentifierArray<T>>;
 
-  /**
-    Create a child record within the owner
-
-    @public
-    @param {Object} hash
-    @return {Model} record
-  */
-  createRecord(hash: CreateRecordProperties<T>): T {
-    const { store } = this;
-    assert(`Expected modelName to be set`, this.modelName);
-    const record = store.createRecord<T>(this.modelName as TypeFromInstance<T>, hash);
-    this.push(record);
-
-    return record;
-  }
-
+  /** @internal */
   destroy() {
     super.destroy(false);
   }

--- a/packages/store/src/-private/record-arrays/many-array.ts
+++ b/packages/store/src/-private/record-arrays/many-array.ts
@@ -400,7 +400,6 @@ export class RelatedCollection<T = unknown> extends IdentifierArray<T> {
     await permissions.reload();
     ```
 
-    @method reload
     @public
   */
   reload(options?: BaseFinderOptions): Promise<this> {
@@ -437,7 +436,6 @@ export class RelatedCollection<T = unknown> extends IdentifierArray<T> {
   /**
     Create a child record within the owner
 
-    @method createRecord
     @public
     @param {Object} hash
     @return {Model} record

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -281,7 +281,7 @@ export type CreateRecordProperties<T = MaybeHasId & Record<string, unknown>> = T
  * and sources of data (such as your API or a local persistence layer)
  * accessed via a [RequestManager](https://github.com/emberjs/data/tree/main/packages/request).
  *
- * ```app/services/store.js
+ * ```js [app/services/store.js]
  * import Store from '@ember-data/store';
  *
  * export default class extends Store {}
@@ -539,6 +539,7 @@ export interface Store {
 }
 
 export class Store extends BaseClass {
+  /** @internal */
   declare recordArrayManager: RecordArrayManager;
 
   /**
@@ -571,6 +572,7 @@ export class Store extends BaseClass {
     }
     return this._schema as ReturnType<this['createSchemaService']>;
   }
+  /** @internal */
   declare _schema: SchemaService;
 
   /**
@@ -645,11 +647,15 @@ export class Store extends BaseClass {
   declare lifetimes?: CachePolicy;
 
   // Private
+  /** @internal */
   declare _graph?: Graph;
+  /** @internal */
   declare _requestCache: RequestStateService;
+  /** @internal */
   declare _instanceCache: InstanceCache;
-
+  /** @internal */
   declare _cbs: { coalesce?: () => void; sync?: () => void; notify?: () => void } | null;
+  /** @internal */
   declare _forceShim: boolean;
   /**
    * Async flush buffers notifications until flushed
@@ -664,17 +670,21 @@ export class Store extends BaseClass {
   declare _enableAsyncFlush: boolean | null;
 
   // DEBUG-only properties
+  /** @internal */
   declare DISABLE_WAITER?: boolean;
-
+  /** @internal */
   declare _isDestroying: boolean;
+  /** @internal */
   declare _isDestroyed: boolean;
 
+  /** @internal */
   get isDestroying(): boolean {
     return this._isDestroying;
   }
   set isDestroying(value: boolean) {
     this._isDestroying = value;
   }
+  /** @internal */
   get isDestroyed(): boolean {
     return this._isDestroyed;
   }
@@ -704,6 +714,7 @@ export class Store extends BaseClass {
     this.isDestroyed = false;
   }
 
+  /** @internal */
   _run(cb: () => void) {
     assert(`EmberData should never encounter a nested run`, !this._cbs);
     const _cbs: { coalesce?: () => void; sync?: () => void; notify?: () => void } = (this._cbs = {});
@@ -754,6 +765,7 @@ export class Store extends BaseClass {
     }
   }
 
+  /** @internal */
   _schedule(name: 'coalesce' | 'sync' | 'notify', cb: () => void): void {
     assert(`EmberData expects to schedule only when there is an active run`, !!this._cbs);
     assert(`EmberData expects only one flush per queue name, cannot schedule ${name}`, !this._cbs[name]);
@@ -775,6 +787,7 @@ export class Store extends BaseClass {
     return this._requestCache;
   }
 
+  /** @internal */
   _getAllPending(): (Promise<unknown[]> & { length: number }) | void {
     if (TESTING) {
       const all: Promise<unknown>[] = [];
@@ -1130,7 +1143,7 @@ export class Store extends BaseClass {
 
     **Example 1**
 
-    ```app/routes/post.js
+    ```js [app/routes/post.js]
     export default class PostRoute extends Route {
       model({ post_id }) {
         return this.store.findRecord('post', post_id);
@@ -1144,7 +1157,7 @@ export class Store extends BaseClass {
     of `type` (modelName) and `id` as separate arguments. You may recognize this combo as
     the typical pairing from [JSON:API](https://jsonapi.org/format/#document-resource-object-identification)
 
-    ```app/routes/post.js
+    ```js [app/routes/post.js]
     export default class PostRoute extends Route {
       model({ post_id: id }) {
         return this.store.findRecord({ type: 'post', id });
@@ -1157,7 +1170,7 @@ export class Store extends BaseClass {
     If you have previously received an lid via an Identifier for this record, and the record
     has already been assigned an id, you can find the record again using just the lid.
 
-    ```app/routes/post.js
+    ```js [app/routes/post.js]
     store.findRecord({ lid });
     ```
 
@@ -1175,7 +1188,7 @@ export class Store extends BaseClass {
     for the comment also looks like `/posts/1/comments/2` if you want to fetch the comment
     without also fetching the post you can pass in the post to the `findRecord` call:
 
-    ```app/routes/post-comments.js
+    ```js [app/routes/post-comments.js]
     export default class PostRoute extends Route {
       model({ post_id, comment_id: id }) {
         return this.store.findRecord({ type: 'comment', id, { preload: { post: post_id }} });
@@ -1186,7 +1199,7 @@ export class Store extends BaseClass {
     In your adapter you can then access this id without triggering a network request via the
     snapshot:
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     export default class Adapter {
 
       findRecord(store, schema, id, snapshot) {
@@ -1209,7 +1222,7 @@ export class Store extends BaseClass {
     This could also be achieved by supplying the post id to the adapter via the adapterOptions
     property on the options hash.
 
-    ```app/routes/post-comments.js
+    ```js [app/routes/post-comments.js]
     export default class PostRoute extends Route {
       model({ post_id, comment_id: id }) {
         return this.store.findRecord({ type: 'comment', id, { adapterOptions: { post: post_id }} });
@@ -1217,7 +1230,7 @@ export class Store extends BaseClass {
     }
     ```
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     export default class Adapter {
       findRecord(store, schema, id, snapshot) {
         let type = schema.modelName;
@@ -1327,7 +1340,7 @@ export class Store extends BaseClass {
     boolean value for `backgroundReload` in the options object for
     `findRecord`.
 
-    ```app/routes/post/edit.js
+    ```js [app/routes/post/edit.js]
     export default class PostEditRoute extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id, { backgroundReload: false });
@@ -1338,7 +1351,7 @@ export class Store extends BaseClass {
     If you pass an object on the `adapterOptions` property of the options
     argument it will be passed to your adapter via the snapshot
 
-    ```app/routes/post/edit.js
+    ```js [app/routes/post/edit.js]
     export default class PostEditRoute extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id, {
@@ -1348,7 +1361,7 @@ export class Store extends BaseClass {
     }
     ```
 
-    ```app/adapters/post.js
+    ```js [app/adapters/post.js]
     import MyCustomAdapter from './custom-adapter';
 
     export default class PostAdapter extends MyCustomAdapter {
@@ -1377,7 +1390,7 @@ export class Store extends BaseClass {
     model, when we retrieve a specific post we can have the server also return that post's
     comments in the same request:
 
-    ```app/routes/post.js
+    ```js [app/routes/post.js]
     export default class PostRoute extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id, { include: ['comments'] });
@@ -1385,7 +1398,7 @@ export class Store extends BaseClass {
     }
     ```
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     export default class Adapter {
       findRecord(store, schema, id, snapshot) {
         let type = schema.modelName;
@@ -1412,7 +1425,7 @@ export class Store extends BaseClass {
     using a dot-separated sequence of relationship names. So to request both the post's
     comments and the authors of those comments the request would look like this:
 
-    ```app/routes/post.js
+    ```js [app/routes/post.js]
     export default class PostRoute extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id, { include: ['comments','comments.author'] });
@@ -1427,7 +1440,7 @@ export class Store extends BaseClass {
 
     1. Implement `buildQuery` in your adapter.
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     buildQuery(snapshot) {
       let query = super.buildQuery(...arguments);
 
@@ -1445,7 +1458,7 @@ export class Store extends BaseClass {
 
     Given a `post` model with attributes body, title, publishDate and meta, you can retrieve a filtered list of attributes.
 
-    ```app/routes/post.js
+    ```js [app/routes/post.js]
     export default class extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id, { adapterOptions: { fields: { post: 'body,title' } });
@@ -1456,7 +1469,7 @@ export class Store extends BaseClass {
     Moreover, you can filter attributes on related models as well. If a `post` has a `belongsTo` relationship to a user,
     just include the relationship key and attributes.
 
-    ```app/routes/post.js
+    ```js [app/routes/post.js]
     export default class extends Route {
       model(params) {
         return this.store.findRecord('post', params.post_id, { adapterOptions: { fields: { post: 'body,title', user: 'name,email' } });
@@ -1783,7 +1796,7 @@ export class Store extends BaseClass {
 
     The request is made through the adapters' `queryRecord`:
 
-    ```app/adapters/user.js
+    ```js [app/adapters/user.js]
     import Adapter from '@ember-data/adapter';
     import $ from 'jquery';
 
@@ -1881,7 +1894,7 @@ export class Store extends BaseClass {
     this type present in the store, even if the adapter only returns a subset
     of them.
 
-    ```app/routes/authors.js
+    ```js [app/routes/authors.js]
     export default class AuthorsRoute extends Route {
       model(params) {
         return this.store.findAll('author');
@@ -1929,7 +1942,7 @@ export class Store extends BaseClass {
     which the promise resolves, is updated automatically so it contains all the
     records in the store:
 
-    ```app/adapters/application.js
+    ```js [app/adapters/application.js]
     import Adapter from '@ember-data/adapter';
 
     export default class ApplicationAdapter extends Adapter {
@@ -1973,7 +1986,7 @@ export class Store extends BaseClass {
     boolean value for `backgroundReload` in the options object for
     `findAll`.
 
-    ```app/routes/post/edit.js
+    ```js [app/routes/post/edit.js]
     export default class PostEditRoute extends Route {
       model() {
         return this.store.findAll('post', { backgroundReload: false });
@@ -1984,7 +1997,7 @@ export class Store extends BaseClass {
     If you pass an object on the `adapterOptions` property of the options
     argument it will be passed to you adapter via the `snapshotRecordArray`
 
-    ```app/routes/posts.js
+    ```js [app/routes/posts.js]
     export default class PostsRoute extends Route {
       model(params) {
         return this.store.findAll('post', {
@@ -1994,7 +2007,7 @@ export class Store extends BaseClass {
     }
     ```
 
-    ```app/adapters/post.js
+    ```js [app/adapters/post.js]
     import MyCustomAdapter from './custom-adapter';
 
     export default class UserAdapter extends MyCustomAdapter {
@@ -2024,7 +2037,7 @@ export class Store extends BaseClass {
     model, when we retrieve all of the post records we can have the server also return
     all of the posts' comments in the same request:
 
-    ```app/routes/posts.js
+    ```js [app/routes/posts.js]
     export default class PostsRoute extends Route {
       model() {
         return this.store.findAll('post', { include: ['comments'] });
@@ -2036,7 +2049,7 @@ export class Store extends BaseClass {
     using a dot-separated sequence of relationship names. So to request both the posts'
     comments and the authors of those comments the request would look like this:
 
-    ```app/routes/posts.js
+    ```js [app/routes/posts.js]
     export default class PostsRoute extends Route {
       model() {
         return this.store.findAll('post', { include: ['comments','comments.author'] });
@@ -2219,7 +2232,7 @@ export class Store extends BaseClass {
 
     For this model:
 
-    ```app/models/person.js
+    ```js [app/models/person.js]
     import Model, { attr, hasMany } from '@ember-data/model';
 
     export default class PersonRoute extends Route {

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -269,7 +269,6 @@ type MaybeHasId = { id?: string | null };
  * TODO: These are limitations we want to (and can) address. If you
  * have need of lifting these limitations, please open an issue.
  *
- * @typedoc
  */
 export type CreateRecordProperties<T = MaybeHasId & Record<string, unknown>> = T extends TypedRecordInstance
   ? Partial<FilteredKeys<T>>
@@ -409,7 +408,6 @@ export interface Store {
    * be sourced from directly registered schemas, then will fallback
    * to sourcing a schema from available models if no schema is found.
    *
-   * @method createSchemaService (hook)
    * @return {SchemaService}
    * @public
    */
@@ -424,7 +422,6 @@ export interface Store {
    * The SchemaDefinitionService can be used to query for
    * information about the schema of a resource.
    *
-   * @method getSchemaDefinitionService
    * @deprecated
    * @public
    */
@@ -479,7 +476,6 @@ export interface Store {
    * }
    * ```
    *
-   * @method registerSchemaDefinitionService
    * @param {SchemaService} schema
    * @deprecated
    * @public
@@ -535,7 +531,6 @@ export interface Store {
    * }
    * ```
    *
-   * @method registerSchema
    * @param {SchemaService} schema
    * @deprecated
    * @public
@@ -688,7 +683,6 @@ export class Store extends BaseClass {
   }
 
   /**
-    @method init
     @private
   */
   constructor(createArgs?: unknown) {
@@ -774,7 +768,6 @@ export class Store extends BaseClass {
    * This can be used to query the status of requests
    * that have been initiated for a given identifier.
    *
-   * @method getRequestStateService
    * @return {RequestStateService}
    * @public
    */
@@ -847,7 +840,6 @@ export class Store extends BaseClass {
    * is that `store.request` will attempt to hydrate the response content into
    * a response Document containing RecordInstances.
    *
-   * @method request
    * @param {StoreRequestInput} requestConfig
    * @return {Future}
    * @public
@@ -925,7 +917,6 @@ export class Store extends BaseClass {
    * mechanism of presenting cache data to the ui for access
    * mutation, and interaction.
    *
-   * @method instantiateRecord (hook)
    * @param identifier
    * @param createRecordArgs
    * @param recordDataFor deprecated use this.cache
@@ -940,7 +931,6 @@ export class Store extends BaseClass {
    * be used to teardown any custom record instances instantiated
    * with `instantiateRecord`.
    *
-   * @method teardownRecord (hook)
    * @public
    * @param record
    */
@@ -962,7 +952,6 @@ export class Store extends BaseClass {
     [`relationshipNames`](/ember-data/release/classes/Model?anchor=relationshipNames)
     for example.
 
-    @method modelFor
     @public
     @deprecated
     @param {String} type
@@ -1004,7 +993,6 @@ export class Store extends BaseClass {
     });
     ```
 
-    @method createRecord
     @public
     @param {String} type the name of the resource
     @param {Object} inputProperties a hash of properties to set on the
@@ -1087,7 +1075,6 @@ export class Store extends BaseClass {
     store.deleteRecord(post);
     ```
 
-    @method deleteRecord
     @public
     @param {unknown} record
   */
@@ -1119,7 +1106,6 @@ export class Store extends BaseClass {
     store.unloadRecord(post);
     ```
 
-    @method unloadRecord
     @public
     @param {Model} record
   */
@@ -1479,7 +1465,6 @@ export class Store extends BaseClass {
     ```
 
     @since 1.13.0
-    @method findRecord
     @public
     @param {String|object} type - either a string representing the name of the resource or a ResourceIdentifier object containing both the type (a string) and the id (a string) for the record or an lid (a string) of an existing record
     @param {(String|Integer|Object)} id - optional object with options for the request only if the first param is a ResourceIdentifier, else the string id of the record to be retrieved
@@ -1575,7 +1560,6 @@ export class Store extends BaseClass {
     });
     ```
 
-    @method getReference
     @public
     @param {String|object} resource - modelName (string) or Identifier (object)
     @param {String|Integer} id
@@ -1649,7 +1633,6 @@ export class Store extends BaseClass {
 
 
     @since 1.13.0
-    @method peekRecord
     @public
     @param {String|object} modelName - either a string representing the modelName or a ResourceIdentifier object containing both the type (a string) and the id (a string) for the record or an lid (a string) of an existing record
     @param {String|Integer} id - optional only if the first param is a ResourceIdentifier, else the string id of the record to be retrieved.
@@ -1733,7 +1716,6 @@ export class Store extends BaseClass {
     once the server returns.
 
     @since 1.13.0
-    @method query
     @public
     @param {String} type the name of the resource
     @param {Object} query a query to be used by the adapter
@@ -1857,7 +1839,6 @@ export class Store extends BaseClass {
     ```
 
     @since 1.13.0
-    @method queryRecord
     @public
     @param {String} type
     @param {Object} query an opaque query to be used by the adapter
@@ -2066,7 +2047,6 @@ export class Store extends BaseClass {
     See [query](../methods/query?anchor=query) to only get a subset of records from the server.
 
     @since 1.13.0
-    @method findAll
     @public
     @param {String} type the name of the resource
     @param {Object} options
@@ -2116,7 +2096,6 @@ export class Store extends BaseClass {
     ```
 
     @since 1.13.0
-    @method peekAll
     @public
     @param {String} type the name of the resource
     @return {RecordArray}
@@ -2147,7 +2126,6 @@ export class Store extends BaseClass {
     store.unloadAll('post');
     ```
 
-    @method unloadAll
     @param {String} type the name of the resource
     @public
   */
@@ -2322,7 +2300,6 @@ export class Store extends BaseClass {
     This method can be used both to push in brand new
     records, as well as to update existing records.
 
-    @method push
     @public
     @param {Object} data
     @return the record(s) that was created or
@@ -2354,7 +2331,6 @@ export class Store extends BaseClass {
     Push some data in the form of a json-api document into the store,
     without creating materialized records.
 
-    @method _push
     @private
     @param {Object} jsonApiDoc
     @return {StableRecordIdentifier|Array<StableRecordIdentifier>|null} identifiers for the primary records that had data loaded
@@ -2385,7 +2361,6 @@ export class Store extends BaseClass {
    *
    * Returns a promise resolving with the same record when the save is complete.
    *
-   * @method saveRecord
    * @public
    * @param {unknown} record
    * @param options
@@ -2443,7 +2418,6 @@ export class Store extends BaseClass {
    * This hook should not be called directly by consuming applications or libraries.
    * Use `Store.cache` to access the Cache instance.
    *
-   * @method createCache (hook)
    * @public
    * @param storeWrapper
    * @return {Cache}

--- a/packages/store/src/-types/q/cache-capabilities-manager.ts
+++ b/packages/store/src/-types/q/cache-capabilities-manager.ts
@@ -39,7 +39,6 @@ export type CacheCapabilitiesManager = {
    * The SchemaService can be used to query for
    * information about the schema of a resource.
    *
-   * @method getSchemaDefinitionService
    * @deprecated
    * @public
    */
@@ -61,7 +60,6 @@ export type CacheCapabilitiesManager = {
    * Update the `id` for the record corresponding to the identifier
    * This operation can only be done for records whose `id` is `null`.
    *
-   * @method setRecordId
    * @param {StableRecordIdentifier} identifier;
    * @param {String} id;
    * @public
@@ -74,7 +72,6 @@ export type CacheCapabilitiesManager = {
    * data exist for the identified resource, no known relationships still
    * point to it either.
    *
-   * @method disconnectRecord
    * @param {StableRecordIdentifier} identifier
    * @public
    */
@@ -84,7 +81,6 @@ export type CacheCapabilitiesManager = {
    * Use this method to determine if the Store has an instantiated record associated
    * with an identifier.
    *
-   * @method hasRecord
    * @param identifier
    * @return {Boolean}
    * @public
@@ -99,7 +95,6 @@ export type CacheCapabilitiesManager = {
    *
    * No other namespaces currently expect the `key` argument.
    *
-   * @method notifyChange
    * @param {StableRecordIdentifier} identifier
    * @param {'attributes' | 'relationships' | 'identity' | 'errors' | 'meta' | 'state'} namespace
    * @param {string|undefined} key

--- a/packages/store/src/-types/q/ds-model.ts
+++ b/packages/store/src/-types/q/ds-model.ts
@@ -11,7 +11,6 @@ export type KeyOrString<T> = keyof T & string extends never ? string : keyof T &
  * for @ember-data/model or when wrapping schema for legacy
  * Adapters/Serializers.
  *
- * @typedoc
  */
 export interface ModelSchema<T = unknown> {
   modelName: T extends TypedRecordInstance ? TypeFromInstance<T> : string;

--- a/packages/store/src/-types/q/identifier.ts
+++ b/packages/store/src/-types/q/identifier.ts
@@ -70,11 +70,8 @@ import type { IdentifierBucket, StableIdentifier, StableRecordIdentifier } from 
 
   ⚠️ Caution: Requests that do not have a `method` assigned are assumed to be `GET`
 
-  @method setIdentifierGenerationMethod
-  @for @ember-data/store
   @param method
   @public
-  @static
 */
 export interface GenerationMethod {
   (data: ImmutableRequestInfo, bucket: 'document'): string | null;
@@ -111,11 +108,8 @@ export interface GenerationMethod {
   `updateRecordIdentifier` that attempt to change the `id` or calling update
   without providing an `id` when one is missing will throw an error.
 
-  @method setIdentifierUpdateMethod
-  @for @ember-data/store
   @param method
   @public
-  @static
 */
 
 export type UpdateMethod = {
@@ -135,11 +129,8 @@ export type UpdateMethod = {
  Takes method which can expect to receive an existing `Identifier` that should be eliminated
  from any secondary lookup tables or caches that the user has populated for it.
 
-  @method setIdentifierForgetMethod
-  @for @ember-data/store
   @param method
   @public
-  @static
 */
 export type ForgetMethod = (identifier: StableIdentifier | StableRecordIdentifier, bucket: IdentifierBucket) => void;
 
@@ -157,11 +148,8 @@ export type ForgetMethod = (identifier: StableIdentifier | StableRecordIdentifie
  If you have properly used a WeakMap to encapsulate the state of your customization
  to the application instance, you may not need to implement the `resetMethod`.
 
-  @method setIdentifierResetMethod
-  @for @ember-data/store
   @param method
   @public
-  @static
 */
 export type ResetMethod = () => void;
 
@@ -178,11 +166,8 @@ export type ResetMethod = () => void;
  import { setKeyInfoForResource } from '@ember-data/store';
  ```
 
-  @method setKeyInfoForResource
-  @for @ember-data/store
   @param method
   @public
-  @static
  */
 export type KeyInfo = {
   id: string | null;

--- a/packages/store/src/-types/q/record-instance.ts
+++ b/packages/store/src/-types/q/record-instance.ts
@@ -17,7 +17,5 @@
   also allows EmberData to provide typechecking and intellisense for the record
   based on a special symbol prsent on record instances that implement the
   `TypedRecordInstance` interface.
-
-  @typedoc
 */
 export type OpaqueRecordInstance = unknown;

--- a/packages/store/src/-types/q/schema-service.ts
+++ b/packages/store/src/-types/q/schema-service.ts
@@ -77,7 +77,6 @@ export interface SchemaService {
    *
    * Queries whether the SchemaService recognizes `type` as a resource type
    *
-   * @method doesTypeExist
    * @public
    * @deprecated
    * @param {String} type
@@ -88,7 +87,6 @@ export interface SchemaService {
   /**
    * Queries whether the SchemaService recognizes `type` as a resource type
    *
-   * @method hasResource
    * @public
    * @param {StableRecordIdentifier|ObjectWithStringTypeProperty} resource
    * @return {Boolean}
@@ -98,7 +96,6 @@ export interface SchemaService {
   /**
    * Queries whether the SchemaService recognizes `type` as a resource trait
    *
-   * @method hasTrait
    * @public
    * @param {String} type
    * @return {Boolean}
@@ -108,7 +105,6 @@ export interface SchemaService {
   /**
    * Queries whether the given resource has the given trait
    *
-   * @method resourceHasTrait
    * @public
    * @param {StableRecordIdentifier|ObjectWithStringTypeProperty} resource
    * @param {String} trait
@@ -121,7 +117,6 @@ export interface SchemaService {
    *
    * Should error if the resource type is not recognized.
    *
-   * @method fields
    * @public
    * @param {StableRecordIdentifier|ObjectWithStringTypeProperty} resource
    * @return {Map<string, FieldSchema>}
@@ -132,7 +127,6 @@ export interface SchemaService {
    * Returns the transformation registered with the name provided
    * by `field.type`. Validates that the field is a valid transformable.
    *
-   * @method transformation
    * @public
    * @param {TransformableField|ObjectWithStringTypeProperty} field
    * @return {Transformation}
@@ -143,7 +137,6 @@ export interface SchemaService {
    * Returns the hash function registered with the name provided
    * by `field.type`. Validates that the field is a valid HashField.
    *
-   * @method hashFn
    * @public
    * @param {HashField|ObjectWithStringTypeProperty} field
    * @return {HashFn}
@@ -154,7 +147,6 @@ export interface SchemaService {
    * Returns the derivation registered with the name provided
    * by `field.type`. Validates that the field is a valid DerivedField.
    *
-   * @method derivation
    * @public
    * @param {DerivedField|ObjectWithStringTypeProperty} field
    * @return {Derivation}
@@ -164,7 +156,6 @@ export interface SchemaService {
   /**
    * Returns the schema for the provided resource type.
    *
-   * @method resource
    * @public
    * @param {StableRecordIdentifier|ObjectWithStringTypeProperty} resource
    * @return {ResourceSchema}
@@ -178,7 +169,6 @@ export interface SchemaService {
    * or for registering schema information delivered by API calls
    * or other sources just-in-time.
    *
-   * @method registerResources
    * @public
    * @param {Schema[]} schemas
    */
@@ -193,7 +183,6 @@ export interface SchemaService {
    * or for registering schema information delivered by API calls
    * or other sources just-in-time.
    *
-   * @method registerResource
    * @public
    * @param {Schema} schema
    */
@@ -205,7 +194,6 @@ export interface SchemaService {
    * The transformation can later be retrieved by the name
    * attached to it's `[Type]` property.
    *
-   * @method registerTransformations
    * @public
    * @param {Transformation} transform
    */
@@ -217,7 +205,6 @@ export interface SchemaService {
    * The derivation can later be retrieved by the name
    * attached to it's `[Type]` property.
    *
-   * @method registerDerivations
    * @public
    * @param {Derivation} derivation
    */
@@ -229,7 +216,6 @@ export interface SchemaService {
    * The hashing function can later be retrieved by the name
    * attached to it's `[Type]` property.
    *
-   * @method registerHashFn
    * @public
    * @param {HashFn} hashfn
    */
@@ -273,7 +259,6 @@ export interface SchemaService {
    * }
    * ```
    *
-   * @method attributesDefinitionFor
    * @public
    * @deprecated
    * @param {RecordIdentifier|ObjectWithStringTypeProperty} identifier
@@ -356,7 +341,6 @@ export interface SchemaService {
    * }
    * ```
    *
-   * @method relationshipsDefinitionFor
    * @public
    * @deprecated
    * @param {RecordIdentifier|ObjectWithStringTypeProperty} identifier
@@ -367,7 +351,6 @@ export interface SchemaService {
   /**
    * Returns all known resource types
    *
-   * @method resourceTypes
    * @public
    * @return {String[]}
    */

--- a/packages/store/src/-types/q/store.ts
+++ b/packages/store/src/-types/q/store.ts
@@ -22,7 +22,6 @@ export interface FindRecordOptions<T = unknown> extends BaseFinderOptions<T> {
    * resource type, or be record instances from which the identifier
    * will be extracted.
    *
-   * @typedoc
    */
   preload?: Record<string, Value>;
 }

--- a/packages/store/src/configure.ts
+++ b/packages/store/src/configure.ts
@@ -8,9 +8,6 @@
  * Configures the signals implementation to use. Supports multiple
  * implementations simultaneously.
  *
- * @method setupSignals
- * @static
- * @for @ember-data/store/configure
  * @public
  * @param {function} buildConfig - a function that takes options and returns a configuration object
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       typedoc-plugin-markdown:
         specifier: ^4.6.3
         version: 4.6.3(typedoc@0.28.4(typescript@5.8.3))
+      typedoc-plugin-no-inherit:
+        specifier: ^1.6.1
+        version: 1.6.1(typedoc@0.28.4(typescript@5.8.3))
       typedoc-vitepress-theme:
         specifier: ^1.1.2
         version: 1.1.2(6e46de4d5b133f483635fea0188673b2)
@@ -12907,6 +12910,11 @@ packages:
     peerDependencies:
       typedoc: 0.28.x
 
+  typedoc-plugin-no-inherit@1.6.1:
+    resolution: {integrity: sha512-+qf0RkO5YR9kUBBS1HqzzDOsWOnLcXTtGL0f2ia4jDQAjGrtF0+po/0R8k3UNtBqyDzL273aaV3FIGHEX+U/tg==}
+    peerDependencies:
+      typedoc: 0.26.x || 0.27.x || 0.28.x
+
   typedoc-vitepress-theme@1.1.2:
     resolution: {integrity: sha512-hQvCZRr5uKDqY1bRuY1+eNTNn6d4TE4OP5pnw65Y7WGgajkJW9X1/lVJK2UJpcwCmwkdjw1QIO49H9JQlxWhhw==}
     peerDependencies:
@@ -18207,6 +18215,7 @@ snapshots:
       debug: 4.4.0
       typedoc: 0.28.4(typescript@5.8.3)
       typedoc-plugin-markdown: 4.6.3(typedoc@0.28.4(typescript@5.8.3))
+      typedoc-plugin-no-inherit: 1.6.1(typedoc@0.28.4(typescript@5.8.3))
       typedoc-vitepress-theme: 1.1.2(6e46de4d5b133f483635fea0188673b2)
       typescript: 5.8.3
       vite: 5.4.19
@@ -26411,6 +26420,10 @@ snapshots:
       is-typedarray: 1.0.0
 
   typedoc-plugin-markdown@4.6.3(typedoc@0.28.4(typescript@5.8.3)):
+    dependencies:
+      typedoc: 0.28.4(typescript@5.8.3)
+
+  typedoc-plugin-no-inherit@1.6.1(typedoc@0.28.4(typescript@5.8.3)):
     dependencies:
       typedoc: 0.28.4(typescript@5.8.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       silent-error:
         specifier: ^1.1.1
         version: 1.1.1
+      typedoc:
+        specifier: ^0.28.4
+        version: 0.28.4(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3

--- a/tests/docs/index.js
+++ b/tests/docs/index.js
@@ -70,7 +70,7 @@ QUnit.module('Docs coverage', function (hooks) {
         assert.ok(docs.files[def.file], `${className} has a file`);
         assert.true(
           def.access === 'public' || def.access === 'private',
-          `${def.name} must declare either as either @typedoc @internal @private or @public`
+          `${def.name} must declare either as either @internal @private or @public`
         );
         if (def.access !== 'private') {
           assert.true(isNonEmptyString(def.description), `${className} must provide a description.`);
@@ -146,7 +146,7 @@ QUnit.module('Docs coverage', function (hooks) {
         } has a complete definition`, function (assert) {
           assert.true(
             item.access === 'public' || item.access === 'private',
-            `${item.name} must declare either as either @typedoc @internal @private or @public in ${linkItem(item)}`
+            `${item.name} must declare either as either @internal @private or @public in ${linkItem(item)}`
           );
           assert.true(
             item.access === 'private' || (item.class && classIsPublic(item.class)),

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["typedoc/tsdoc.json"],
+  "noStandardTags": false,
+  "tagDefinitions": [
+    {
+      "tagName": "@required",
+      "syntaxKind": "modifier"
+    },
+    {
+      "tagName": "@optional",
+      "syntaxKind": "modifier"
+    },
+    {
+      "tagName": "@recommended",
+      "syntaxKind": "modifier"
+    },
+    {
+      "tagName": "@legacy",
+      "syntaxKind": "modifier"
+    },
+    {
+      "tagName": "@polaris",
+      "syntaxKind": "modifier"
+    }
+  ]
+}


### PR DESCRIPTION
drops use of

- `@typedoc` (indicated a public doc comment we didn't want to publish into the docs since we had no way to document types)
- `@method` (no longer needed since the method name is auto-associated)
- `@static` and `@for` (also no longer needed since auto associated)

Fixes various syntax bugs, moves a few comments around to ensure they get associated correctly ... lots more to do