### PR TITLE
feat: @warp-drive/core/reactive

### DIFF
--- a/packages/schema-record/eslint.config.mjs
+++ b/packages/schema-record/eslint.config.mjs
@@ -11,7 +11,7 @@ export default [
   // browser (js/ts) ================
   typescript.browser({
     srcDirs: ['src'],
-    allowedImports: ['@ember/debug', '@ember/-internals/metal'],
+    allowedImports: [],
   }),
 
   // node (module) ================

--- a/packages/schema-record/package.json
+++ b/packages/schema-record/package.json
@@ -42,36 +42,18 @@
       "default": "./dist/*.js"
     }
   },
-  "peerDependencies": {
-    "@ember-data/request": "workspace:*",
-    "@ember-data/model": "workspace:*",
-    "@ember-data/store": "workspace:*",
-    "@warp-drive/core-types": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@ember-data/model": {
-      "optional": true
-    }
-  },
+  "peerDependencies": {},
   "dependencies": {
     "@embroider/macros": "^1.16.12",
-    "@warp-drive/build-config": "workspace:*"
+    "@warp-drive/build-config": "workspace:*",
+    "@warp-drive/core": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",
     "@babel/plugin-transform-typescript": "^7.27.0",
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-typescript": "^7.27.0",
-    "@ember-data/request": "workspace:*",
-    "@ember-data/model": "workspace:*",
-    "@ember-data/store": "workspace:*",
-    "@ember-data/legacy-compat": "workspace:*",
-    "@ember-data/request-utils": "workspace:*",
-    "@ember/test-waiters": "^4.1.0",
-    "@glimmer/component": "^2.0.0",
-    "@warp-drive/core-types": "workspace:*",
     "@warp-drive/internal-config": "workspace:*",
-    "ember-source": "~6.3.0",
     "vite": "^5.4.15"
   },
   "ember": {

--- a/packages/schema-record/src/-private.ts
+++ b/packages/schema-record/src/-private.ts
@@ -1,1 +1,1 @@
-export { Editable, Legacy } from './-private/symbols';
+export { Editable, Legacy } from '@warp-drive/core/reactive/-private';

--- a/packages/schema-record/tsconfig.json
+++ b/packages/schema-record/tsconfig.json
@@ -27,22 +27,10 @@
     "declarationDir": "unstable-preview-types",
     "inlineSourceMap": true,
     "inlineSources": true,
-    "types": ["ember-source/types"],
+    "types": [],
     "paths": {
-      "@ember-data/request": ["../request/unstable-preview-types"],
-      "@ember-data/request/*": ["../request/unstable-preview-types/*"],
-      "@ember-data/store": ["../store/unstable-preview-types"],
-      "@ember-data/store/*": ["../store/unstable-preview-types/*"],
-      "@ember-data/model": ["../model/unstable-preview-types"],
-      "@ember-data/model/*": ["../model/unstable-preview-types/*"],
       "@warp-drive/build-config": ["../build-config/unstable-preview-types"],
-      "@warp-drive/build-config/*": ["../build-config/unstable-preview-types/*"],
-      "@warp-drive/core-types": ["../core-types/unstable-preview-types"],
-      "@warp-drive/core-types/*": ["../core-types/unstable-preview-types/*"],
-      "@ember-data/legacy-compat": ["../legacy-compat/unstable-preview-types"],
-      "@ember-data/legacy-compat/*": ["../legacy-compat/unstable-preview-types/*"],
-      "@ember-data/request-utils": ["../request-utils/unstable-preview-types"],
-      "@ember-data/request-utils/*": ["../request-utils/unstable-preview-types/*"]
+      "@warp-drive/build-config/*": ["../build-config/unstable-preview-types/*"]
     },
     "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
@@ -50,25 +38,7 @@
   },
   "references": [
     {
-      "path": "../request"
-    },
-    {
-      "path": "../model"
-    },
-    {
-      "path": "../store"
-    },
-    {
-      "path": "../core-types"
-    },
-    {
       "path": "../build-config"
-    },
-    {
-      "path": "../legacy-compat"
-    },
-    {
-      "path": "../request-utils"
     }
   ]
 }

--- a/packages/schema-record/tsconfig.json
+++ b/packages/schema-record/tsconfig.json
@@ -30,13 +30,18 @@
     "types": [],
     "paths": {
       "@warp-drive/build-config": ["../build-config/unstable-preview-types"],
-      "@warp-drive/build-config/*": ["../build-config/unstable-preview-types/*"]
+      "@warp-drive/build-config/*": ["../build-config/unstable-preview-types/*"],
+      "@warp-drive/core": ["../../warp-drive-packages/core/declarations"],
+      "@warp-drive/core/*": ["../../warp-drive-packages/core/declarations/*"]
     },
     "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "checkJs": false
   },
   "references": [
+    {
+      "path": "../../warp-drive-packages/core"
+    },
     {
       "path": "../build-config"
     }

--- a/packages/schema-record/vite.config.mjs
+++ b/packages/schema-record/vite.config.mjs
@@ -1,6 +1,6 @@
 import { createConfig } from '@warp-drive/internal-config/vite/config.js';
 
-export const externals = ['@ember/debug'];
+export const externals = [];
 
 export const entryPoints = ['src/index.ts', 'src/-private.ts'];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1094,6 +1094,9 @@ importers:
       '@warp-drive/build-config':
         specifier: workspace:*
         version: file:packages/build-config(@babel/core@7.27.1)
+      '@warp-drive/core':
+        specifier: workspace:*
+        version: file:warp-drive-packages/core(@babel/core@7.27.1)
     devDependencies:
       '@babel/core':
         specifier: ^7.26.10
@@ -1107,36 +1110,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.27.0
         version: 7.27.1(@babel/core@7.27.1)
-      '@ember-data/legacy-compat':
-        specifier: workspace:*
-        version: file:packages/legacy-compat(71230f815b7f822a1df7a93bc6010582)
-      '@ember-data/model':
-        specifier: workspace:*
-        version: file:packages/model(71230f815b7f822a1df7a93bc6010582)
-      '@ember-data/request':
-        specifier: workspace:*
-        version: file:packages/request(71230f815b7f822a1df7a93bc6010582)
-      '@ember-data/request-utils':
-        specifier: workspace:*
-        version: file:packages/request-utils(71230f815b7f822a1df7a93bc6010582)
-      '@ember-data/store':
-        specifier: workspace:*
-        version: file:packages/store(71230f815b7f822a1df7a93bc6010582)
-      '@ember/test-waiters':
-        specifier: ^4.1.0
-        version: 4.1.0(@babel/core@7.27.1)
-      '@glimmer/component':
-        specifier: ^2.0.0
-        version: 2.0.0
-      '@warp-drive/core-types':
-        specifier: workspace:*
-        version: file:packages/core-types(71230f815b7f822a1df7a93bc6010582)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:config
-      ember-source:
-        specifier: ~6.3.0
-        version: 6.3.0(@glimmer/component@2.0.0)
       vite:
         specifier: ^5.4.15
         version: 5.4.19
@@ -1928,7 +1904,7 @@ importers:
         version: file:config
       '@warp-drive/schema-record':
         specifier: workspace:*
-        version: file:packages/schema-record(9650994a82842d137399bf263558682d)
+        version: file:packages/schema-record(71230f815b7f822a1df7a93bc6010582)
       ember-auto-import:
         specifier: ^2.10.0
         version: 2.10.0
@@ -2951,7 +2927,7 @@ importers:
         version: file:config
       '@warp-drive/schema-record':
         specifier: workspace:*
-        version: file:packages/schema-record(9650994a82842d137399bf263558682d)
+        version: file:packages/schema-record(71230f815b7f822a1df7a93bc6010582)
       broccoli-concat:
         specifier: ^4.2.5
         version: 4.2.5
@@ -3492,7 +3468,7 @@ importers:
         version: file:config
       '@warp-drive/schema-record':
         specifier: workspace:*
-        version: file:packages/schema-record(9650994a82842d137399bf263558682d)
+        version: file:packages/schema-record(71230f815b7f822a1df7a93bc6010582)
       ember-auto-import:
         specifier: ^2.10.0
         version: 2.10.0
@@ -3643,7 +3619,7 @@ importers:
         version: file:config
       '@warp-drive/schema-record':
         specifier: workspace:*
-        version: file:packages/schema-record(9650994a82842d137399bf263558682d)
+        version: file:packages/schema-record(71230f815b7f822a1df7a93bc6010582)
       ember-auto-import:
         specifier: ^2.10.0
         version: 2.10.0
@@ -3791,7 +3767,7 @@ importers:
         version: file:config
       '@warp-drive/schema-record':
         specifier: workspace:*
-        version: file:packages/schema-record(9650994a82842d137399bf263558682d)
+        version: file:packages/schema-record(71230f815b7f822a1df7a93bc6010582)
       ember-auto-import:
         specifier: ^2.10.0
         version: 2.10.0
@@ -6592,14 +6568,6 @@ packages:
 
   '@warp-drive/schema-record@file:packages/schema-record':
     resolution: {directory: packages/schema-record, type: directory}
-    peerDependencies:
-      '@ember-data/model': workspace:*
-      '@ember-data/request': workspace:*
-      '@ember-data/store': workspace:*
-      '@warp-drive/core-types': workspace:*
-    peerDependenciesMeta:
-      '@ember-data/model':
-        optional: true
 
   '@warp-drive/utilities@file:warp-drive-packages/utilities':
     resolution: {directory: warp-drive-packages/utilities, type: directory}
@@ -17756,17 +17724,14 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@warp-drive/schema-record@file:packages/schema-record(9650994a82842d137399bf263558682d)':
+  '@warp-drive/schema-record@file:packages/schema-record(71230f815b7f822a1df7a93bc6010582)':
     dependencies:
-      '@ember-data/request': file:packages/request(71230f815b7f822a1df7a93bc6010582)
-      '@ember-data/store': file:packages/store(71230f815b7f822a1df7a93bc6010582)
       '@embroider/macros': 1.17.3(@babel/core@7.27.1)
       '@warp-drive/build-config': file:packages/build-config(@babel/core@7.27.1)
-      '@warp-drive/core-types': file:packages/core-types(71230f815b7f822a1df7a93bc6010582)
-    optionalDependencies:
-      '@ember-data/model': file:packages/model(71230f815b7f822a1df7a93bc6010582)
+      '@warp-drive/core': file:warp-drive-packages/core(71230f815b7f822a1df7a93bc6010582)
     transitivePeerDependencies:
       - '@babel/core'
+      - '@ember/test-waiters'
       - supports-color
 
   '@warp-drive/utilities@file:warp-drive-packages/utilities(71230f815b7f822a1df7a93bc6010582)':

--- a/tests/warp-drive__experiments/tsconfig.json
+++ b/tests/warp-drive__experiments/tsconfig.json
@@ -55,8 +55,8 @@
       "@warp-drive/build-config/*": ["../../packages/build-config/unstable-preview-types/*"],
       "@warp-drive/holodeck": ["../../packages/holodeck/unstable-preview-types"],
       "@warp-drive/holodeck/*": ["../../packages/holodeck/unstable-preview-types/*"],
-      "@warp-drive/experiments": ["../../warp-drive-packages/experiments/unstable-preview-types"],
-      "@warp-drive/experiments/*": ["../../warp-drive-packages/experiments/unstable-preview-types/*"]
+      "@warp-drive/experiments": ["../../warp-drive-packages/experiments/declarations"],
+      "@warp-drive/experiments/*": ["../../warp-drive-packages/experiments/declarations/*"]
     },
     "allowImportingTsExtensions": true,
     "composite": true,

--- a/warp-drive-packages/core/src/reactive.ts
+++ b/warp-drive-packages/core/src/reactive.ts
@@ -336,14 +336,13 @@
  *
  * @module
  */
+export { instantiateRecord, teardownRecord } from './reactive/-private/hooks';
 export {
-  instantiateRecord,
-  teardownRecord,
   type Transformation,
   SchemaService,
   withDefaults,
   fromIdentity,
   registerDerivations,
-  type SchemaRecord,
-  Checkout,
-} from '@warp-drive/core/reactive';
+} from './reactive/-private/schema';
+export { type SchemaRecord } from './reactive/-private/record';
+export { Checkout } from './reactive/-private/symbols';

--- a/warp-drive-packages/core/src/reactive/-private.ts
+++ b/warp-drive-packages/core/src/reactive/-private.ts
@@ -1,0 +1,1 @@
+export { Editable, Legacy } from './-private/symbols';

--- a/warp-drive-packages/core/src/reactive/-private/fields/compute.ts
+++ b/warp-drive-packages/core/src/reactive/-private/fields/compute.ts
@@ -1,19 +1,19 @@
-import type { Future } from '@ember-data/request';
-import type Store from '@ember-data/store';
-import type { StoreRequestInput } from '@ember-data/store';
+import { DEBUG } from '@warp-drive/build-config/env';
+
+import type { Store, StoreRequestInput } from '../../../index.ts';
+import type { Future } from '../../../request.ts';
 import {
   consumeInternalSignal,
   defineSignal,
   getOrCreateInternalSignal,
   RelatedCollection as ManyArray,
   withSignalStore,
-} from '@ember-data/store/-private';
-import { DEBUG } from '@warp-drive/build-config/env';
-import type { StableRecordIdentifier } from '@warp-drive/core-types';
-import { getOrSetGlobal } from '@warp-drive/core-types/-private';
-import type { Cache } from '@warp-drive/core-types/cache';
-import type { ResourceRelationship as SingleResourceRelationship } from '@warp-drive/core-types/cache/relationship';
-import type { ObjectValue } from '@warp-drive/core-types/json/raw';
+} from '../../../store/-private.ts';
+import { getOrSetGlobal } from '../../../types/-private.ts';
+import type { Cache } from '../../../types/cache.ts';
+import type { ResourceRelationship as SingleResourceRelationship } from '../../../types/cache/relationship.ts';
+import type { StableRecordIdentifier } from '../../../types/identifier.ts';
+import type { ObjectValue } from '../../../types/json/raw.ts';
 import type {
   ArrayField,
   DerivedField,
@@ -24,16 +24,15 @@ import type {
   ObjectField,
   SchemaArrayField,
   SchemaObjectField,
-} from '@warp-drive/core-types/schema/fields';
-import type { CollectionResourceRelationship, Link, Links } from '@warp-drive/core-types/spec/json-api-raw';
-import { RecordStore } from '@warp-drive/core-types/symbols';
-
-import { SchemaRecord } from '../record';
-import type { SchemaService } from '../schema';
-import { Editable, Identifier, Legacy, Parent } from '../symbols';
-import { ManagedArray } from './managed-array';
-import { ManagedObject } from './managed-object';
-import { ManyArrayManager } from './many-array-manager';
+} from '../../../types/schema/fields.ts';
+import type { CollectionResourceRelationship, Link, Links } from '../../../types/spec/json-api-raw.ts';
+import { RecordStore } from '../../../types/symbols.ts';
+import { SchemaRecord } from '../record.ts';
+import type { SchemaService } from '../schema.ts';
+import { Editable, Identifier, Legacy, Parent } from '../symbols.ts';
+import { ManagedArray } from './managed-array.ts';
+import { ManagedObject } from './managed-object.ts';
+import { ManyArrayManager } from './many-array-manager.ts';
 
 export const ManagedArrayMap = getOrSetGlobal(
   'ManagedArrayMap',

--- a/warp-drive-packages/core/src/reactive/-private/fields/managed-array.ts
+++ b/warp-drive-packages/core/src/reactive/-private/fields/managed-array.ts
@@ -1,16 +1,16 @@
-import type Store from '@ember-data/store';
-import type { WarpDriveSignal } from '@ember-data/store/-private';
-import { ARRAY_SIGNAL, consumeInternalSignal, entangleSignal, withSignalStore } from '@ember-data/store/-private';
 import { assert } from '@warp-drive/build-config/macros';
-import type { StableRecordIdentifier } from '@warp-drive/core-types';
-import type { Cache } from '@warp-drive/core-types/cache';
-import type { ArrayValue, ObjectValue, Value } from '@warp-drive/core-types/json/raw';
-import type { OpaqueRecordInstance } from '@warp-drive/core-types/record';
-import type { ArrayField, HashField, SchemaArrayField } from '@warp-drive/core-types/schema/fields';
 
-import { SchemaRecord } from '../record';
-import type { SchemaService } from '../schema';
-import { Editable, Identifier, Legacy, MUTATE, Parent, SOURCE } from '../symbols';
+import type { Store } from '../../../index.ts';
+import type { WarpDriveSignal } from '../../../store/-private.ts';
+import { ARRAY_SIGNAL, consumeInternalSignal, entangleSignal, withSignalStore } from '../../../store/-private.ts';
+import type { Cache } from '../../../types/cache.ts';
+import type { StableRecordIdentifier } from '../../../types/identifier.ts';
+import type { ArrayValue, ObjectValue, Value } from '../../../types/json/raw.ts';
+import type { OpaqueRecordInstance } from '../../../types/record.ts';
+import type { ArrayField, HashField, SchemaArrayField } from '../../../types/schema/fields.ts';
+import { SchemaRecord } from '../record.ts';
+import type { SchemaService } from '../schema.ts';
+import { Editable, Identifier, Legacy, MUTATE, Parent, SOURCE } from '../symbols.ts';
 
 type KeyType = string | symbol | number;
 const ARRAY_GETTER_METHODS = new Set<KeyType>([

--- a/warp-drive-packages/core/src/reactive/-private/fields/managed-object.ts
+++ b/warp-drive-packages/core/src/reactive/-private/fields/managed-object.ts
@@ -1,3 +1,5 @@
+import { assert } from '@warp-drive/build-config/macros';
+
 import {
   consumeInternalSignal,
   entangleSignal,
@@ -5,17 +7,14 @@ import {
   OBJECT_SIGNAL,
   type WarpDriveSignal,
   withSignalStore,
-} from '@ember-data/store/-private';
-import { assert } from '@warp-drive/build-config/macros';
-import type { StableRecordIdentifier } from '@warp-drive/core-types';
-import type { Cache } from '@warp-drive/core-types/cache';
-import type { ObjectValue, Value } from '@warp-drive/core-types/json/raw';
-// import { STRUCTURED } from '@warp-drive/core-types/request';
-import type { ObjectField, SchemaObjectField } from '@warp-drive/core-types/schema/fields';
-
-import type { SchemaRecord } from '../record';
-import type { SchemaService } from '../schema';
-import { Editable, EmbeddedPath, Legacy, MUTATE, Parent, SOURCE } from '../symbols';
+} from '../../../store/-private.ts';
+import type { Cache } from '../../../types/cache.ts';
+import type { StableRecordIdentifier } from '../../../types/identifier.ts';
+import type { ObjectValue, Value } from '../../../types/json/raw.ts';
+import type { ObjectField, SchemaObjectField } from '../../../types/schema/fields.ts';
+import type { SchemaRecord } from '../record.ts';
+import type { SchemaService } from '../schema.ts';
+import { Editable, EmbeddedPath, Legacy, MUTATE, Parent, SOURCE } from '../symbols.ts';
 
 export function notifyObject(obj: ManagedObject) {
   notifyInternalSignal(obj[OBJECT_SIGNAL]);

--- a/warp-drive-packages/core/src/reactive/-private/fields/many-array-manager.ts
+++ b/warp-drive-packages/core/src/reactive/-private/fields/many-array-manager.ts
@@ -1,17 +1,17 @@
-import type Store from '@ember-data/store';
-import type { RelatedCollection as ManyArray } from '@ember-data/store/-private';
-import { fastPush, SOURCE } from '@ember-data/store/-private';
 import { assert } from '@warp-drive/build-config/macros';
-import type { StableRecordIdentifier } from '@warp-drive/core-types';
-import type { CollectionRelationship } from '@warp-drive/core-types/cache/relationship';
-import type { LocalRelationshipOperation } from '@warp-drive/core-types/graph';
-import type { CacheOptions } from '@warp-drive/core-types/request';
-import { EnableHydration } from '@warp-drive/core-types/request';
-import type { CollectionResourceRelationship } from '@warp-drive/core-types/spec/json-api-raw';
-import { RecordStore } from '@warp-drive/core-types/symbols';
 
-import type { SchemaRecord } from '../record';
-import { Identifier } from '../symbols';
+import type { Store } from '../../../index.ts';
+import type { RelatedCollection as ManyArray } from '../../../store/-private.ts';
+import { fastPush, SOURCE } from '../../../store/-private.ts';
+import type { CollectionRelationship } from '../../../types/cache/relationship.ts';
+import type { LocalRelationshipOperation } from '../../../types/graph.ts';
+import type { StableRecordIdentifier } from '../../../types/identifier.ts';
+import type { CacheOptions } from '../../../types/request.ts';
+import { EnableHydration } from '../../../types/request.ts';
+import type { CollectionResourceRelationship } from '../../../types/spec/json-api-raw.ts';
+import { RecordStore } from '../../../types/symbols.ts';
+import type { SchemaRecord } from '../record.ts';
+import { Identifier } from '../symbols.ts';
 
 export interface FindHasManyOptions {
   reload?: boolean;

--- a/warp-drive-packages/core/src/reactive/-private/hooks.ts
+++ b/warp-drive-packages/core/src/reactive/-private/hooks.ts
@@ -1,11 +1,11 @@
-import type Store from '@ember-data/store';
 import { assert } from '@warp-drive/build-config/macros';
-import type { StableRecordIdentifier } from '@warp-drive/core-types';
-import { isResourceSchema } from '@warp-drive/core-types/schema/fields';
 
-import { SchemaRecord } from './record';
-import type { SchemaService } from './schema';
-import { Destroy, Editable, Legacy } from './symbols';
+import type { Store } from '../../index.ts';
+import type { StableRecordIdentifier } from '../../types.ts';
+import { isResourceSchema } from '../../types/schema/fields.ts';
+import { SchemaRecord } from './record.ts';
+import type { SchemaService } from './schema.ts';
+import { Destroy, Editable, Legacy } from './symbols.ts';
 
 export function instantiateRecord(
   store: Store,

--- a/warp-drive-packages/core/src/reactive/-private/schema.ts
+++ b/warp-drive-packages/core/src/reactive/-private/schema.ts
@@ -246,6 +246,7 @@ export class SchemaService implements SchemaServiceInterface {
     this._hashFns = new Map();
     this._derivations = new Map();
     this._traits = new Set();
+    this._modes = new Map();
   }
 
   resourceTypes(): Readonly<string[]> {

--- a/warp-drive-packages/core/src/reactive/-private/symbols.ts
+++ b/warp-drive-packages/core/src/reactive/-private/symbols.ts
@@ -2,7 +2,7 @@
 ///// WARNING /////
 ///////////////////
 
-import { getOrSetGlobal } from '@warp-drive/core-types/-private';
+import { getOrSetGlobal } from '../../types/-private';
 
 // Great, got your attention with that warning didn't we?
 // Good. Here's the deal: typescript treats symbols as unique types.

--- a/warp-drive-packages/core/tsconfig.json
+++ b/warp-drive-packages/core/tsconfig.json
@@ -22,7 +22,7 @@
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
     "strictPropertyInitialization": true,
-    "allowUnreachableCode": false,
+    "allowUnreachableCode": true,
     "allowUnusedLabels": false,
     "noEmitOnError": false,
     "strictNullChecks": true,

--- a/warp-drive-packages/core/vite.config.mjs
+++ b/warp-drive-packages/core/vite.config.mjs
@@ -42,6 +42,10 @@ export const entryPoints = [
 
   // graph
   './src/graph/-private.ts',
+
+  // schema-record
+  './src/reactive.ts',
+  './src/reactive/-private.ts',
 ];
 
 export default createConfig(

--- a/warp-drive-packages/experiments/tsconfig.json
+++ b/warp-drive-packages/experiments/tsconfig.json
@@ -24,7 +24,7 @@
     "baseUrl": ".",
     "declaration": true,
     "declarationMap": true,
-    "declarationDir": "unstable-preview-types",
+    "declarationDir": "declarations",
     "inlineSourceMap": true,
     "inlineSources": true,
     "types": [],


### PR DESCRIPTION
in order to land this we will need to decide how to deal with the optional dep between schema-record and legacy model that exists for legacy mode.

I suspect the answer is to implement some version of #9534 where the "kind" functions are registered with the schema service and the model provides its own kind function for hasMany/belongsTo

It may be simpler to put an optional peer-dep on @warp-drive/legacy from @warp-drive/core but because there are only two packages now this may create a circular type dependency that is unfixable.