### PR TITLE
Fix `serializeResource` (avoid adding all belongsTo as `null` & remove emtpy relationships)

### DIFF
--- a/warp-drive-packages/utilities/src/-private/json-api/serialize.ts
+++ b/warp-drive-packages/utilities/src/-private/json-api/serialize.ts
@@ -90,11 +90,12 @@ function _serializeResource(cache: Cache, identifier: StableRecordIdentifier): R
   if (record.relationships) {
     for (const key of Object.keys(record.relationships)) {
       const relationship = record.relationships[key];
-      relationship.data = fixRelData(relationship.data);
       if (Array.isArray(relationship.data)) {
         relationship.data = relationship.data.map((ref) => fixRef(ref));
       } else if (typeof relationship.data === 'object' && relationship.data !== null) {
         relationship.data = fixRef(relationship.data);
+      } else if (Object.keys(relationship ?? {}).length === 0) {
+        delete record.relationships[key];
       }
     }
   }


### PR DESCRIPTION
fix #10025 

The `serializeResources` returns after accessing a belongsTo (`this.model.father`) which is not loaded to API `null` as value. This means, that the API removes the relation, which is incorrectly.

Bug Example:
```
console.log(serializeResources(this.store.cache, recordIdentifierFor(this.model)));
console.log(this.model.hotel);
console.log(serializeResources(this.store.cache, recordIdentifierFor(this.model)));
```

The bug was introduced here: https://github.com/emberjs/data/pull/9692/files#diff-95214a0755a845deee5df27f8b6c90016ad9e0b4ea77500579882748262e43d6R92

After removing the line 92, we are running into the issue that we are getting belongsTo like `father: {}` in payload, which is also unwanted / incorrect and should be removed before returing the `serializeResources` object.