### PR TITLE
feat: Traits!

### DIFF
--- a/tests/warp-drive__schema-record/tests/schema/traits-test.ts
+++ b/tests/warp-drive__schema-record/tests/schema/traits-test.ts
@@ -1,0 +1,139 @@
+import type { TestContext } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+
+import type { Store } from '@warp-drive/core';
+import { registerDerivations, withDefaults } from '@warp-drive/core/reactive';
+
+module('SchemaService | Traits', function (hooks) {
+  setupTest(hooks);
+
+  test('We can register and use a trait', function (this: TestContext, assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+
+    registerDerivations(schema);
+
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+        ],
+        traits: ['timestamped'],
+      })
+    );
+    schema.registerTrait!({
+      name: 'timestamped',
+      mode: 'polaris' as const,
+      fields: [
+        {
+          name: 'createdAt',
+          kind: 'field',
+        },
+        {
+          name: 'deletedAt',
+          kind: 'field',
+        },
+      ],
+    });
+
+    const fields = schema.fields({ type: 'user' });
+    assert.deepEqual(
+      fields.get('name'),
+      {
+        name: 'name',
+        kind: 'field',
+      },
+      'name field exists'
+    );
+    assert.deepEqual(
+      fields.get('createdAt'),
+      {
+        name: 'createdAt',
+        kind: 'field',
+      },
+      'createdAt field exists'
+    );
+    assert.deepEqual(
+      fields.get('deletedAt'),
+      {
+        name: 'deletedAt',
+        kind: 'field',
+      },
+      'deletedAt field exists'
+    );
+  });
+
+  test('Traits may have traits', function (this: TestContext, assert) {
+    const store = this.owner.lookup('service:store') as Store;
+    const { schema } = store;
+
+    registerDerivations(schema);
+
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+        ],
+        traits: ['timestamped'],
+      })
+    );
+    schema.registerTrait!({
+      name: 'timestamped',
+      mode: 'polaris' as const,
+      fields: [
+        {
+          name: 'createdAt',
+          kind: 'field',
+        },
+      ],
+      traits: ['deleteable'],
+    });
+    schema.registerTrait!({
+      name: 'deleteable',
+      mode: 'polaris' as const,
+      fields: [
+        {
+          name: 'deletedAt',
+          kind: 'field',
+        },
+      ],
+    });
+
+    const fields = schema.fields({ type: 'user' });
+    assert.deepEqual(
+      fields.get('name'),
+      {
+        name: 'name',
+        kind: 'field',
+      },
+      'name field exists'
+    );
+    assert.deepEqual(
+      fields.get('createdAt'),
+      {
+        name: 'createdAt',
+        kind: 'field',
+      },
+      'createdAt field exists'
+    );
+    assert.deepEqual(
+      fields.get('deletedAt'),
+      {
+        name: 'deletedAt',
+        kind: 'field',
+      },
+      'deletedAt field exists'
+    );
+  });
+});

--- a/warp-drive-packages/build-config/src/canary-features.ts
+++ b/warp-drive-packages/build-config/src/canary-features.ts
@@ -136,3 +136,15 @@ export const SAMPLE_FEATURE_FLAG: boolean | null = null;
  * @public
  */
 export const JSON_API_CACHE_VALIDATION_ERRORS: boolean | null = false;
+
+/**
+ * This upcoming feature adds a validation step when `schema.fields({ type })`
+ * is called for the first time for a resource.
+ *
+ * When active, if any trait specified by the resource or one of its traits is
+ * missing an error will be thrown in development.
+ *
+ * @since 5.7
+ * @public
+ */
+export const ENFORCE_STRICT_RESOURCE_FINALIZATION: boolean | null = false;

--- a/warp-drive-packages/core/src/reactive/-private/schema.ts
+++ b/warp-drive-packages/core/src/reactive/-private/schema.ts
@@ -1,6 +1,6 @@
 import { deprecate, warn } from '@ember/debug';
 
-import { ENFORCE_STRICT_RESOURCE_FINALIZATION } from '@warp-drive/build-config/canary-features.js';
+import { ENFORCE_STRICT_RESOURCE_FINALIZATION } from '@warp-drive/build-config/canary-features';
 import { DEBUG } from '@warp-drive/build-config/env';
 import { ENABLE_LEGACY_SCHEMA_SERVICE } from '@warp-drive/core/build-config/deprecations';
 import { assert } from '@warp-drive/core/build-config/macros';
@@ -867,7 +867,10 @@ function walkTrait(
       } else {
         warn(
           `The trait ${traitName} used by the trait ${trait.name} MUST be supplied before the resource ${type} can be finalized for use.`,
-          !!subtrait
+          !!subtrait,
+          {
+            id: 'warp-drive:missing-trait-schema-for-resource',
+          }
         );
       }
       if (!subtrait) continue;

--- a/warp-drive-packages/core/src/reactive/-private/schema.ts
+++ b/warp-drive-packages/core/src/reactive/-private/schema.ts
@@ -1,6 +1,6 @@
 import { deprecate } from '@ember/debug';
 
-import { DEBUG } from '@warp-drive/build-config/env.js';
+import { DEBUG } from '@warp-drive/build-config/env';
 import { ENABLE_LEGACY_SCHEMA_SERVICE } from '@warp-drive/core/build-config/deprecations';
 import { assert } from '@warp-drive/core/build-config/macros';
 

--- a/warp-drive-packages/core/src/reactive/-private/schema.ts
+++ b/warp-drive-packages/core/src/reactive/-private/schema.ts
@@ -1,5 +1,6 @@
 import { deprecate } from '@ember/debug';
 
+import { DEBUG } from '@warp-drive/build-config/env.js';
 import { ENABLE_LEGACY_SCHEMA_SERVICE } from '@warp-drive/core/build-config/deprecations';
 import { assert } from '@warp-drive/core/build-config/macros';
 
@@ -30,6 +31,7 @@ import {
   type ResourceSchema,
   type SchemaArrayField,
   type SchemaObjectField,
+  type Trait,
 } from '../../types/schema/fields.ts';
 import { Type } from '../../types/symbols.ts';
 import type { WithPartial } from '../../types/utils.ts';
@@ -385,6 +387,7 @@ export function registerDerivations(schema: SchemaServiceInterface): void {
 
 interface InternalSchema {
   original: ResourceSchema | ObjectSchema;
+  finalized: boolean;
   traits: Set<string>;
   fields: Map<string, FieldSchema>;
   attributes: Record<string, LegacyAttributeField>;
@@ -453,6 +456,13 @@ export interface SchemaService {
   relationshipsDefinitionFor(identifier: { type: string }): InternalSchema['relationships'];
 }
 
+interface InternalTrait {
+  name: string;
+  mode: 'legacy' | 'polaris';
+  fields: Map<string, FieldSchema>;
+  traits: string[];
+}
+
 /**
  * A SchemaService designed to work with dynamically registered schemas.
  *
@@ -470,7 +480,7 @@ export class SchemaService implements SchemaServiceInterface {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   declare _derivations: Map<string, Derivation<any, any, any>>;
   /** @internal */
-  declare _traits: Set<string>;
+  declare _traits: Map<string, InternalTrait>;
   /** @internal */
   declare _modes: Map<string, KindFns>;
   /** @internal */
@@ -488,7 +498,7 @@ export class SchemaService implements SchemaServiceInterface {
     this._transforms = new Map();
     this._hashFns = new Map();
     this._derivations = new Map();
-    this._traits = new Set();
+    this._traits = new Map();
     this._modes = new Map();
     this._extensions = {
       object: new Map(),
@@ -575,7 +585,7 @@ export class SchemaService implements SchemaServiceInterface {
     const relationships: Record<string, LegacyRelationshipField> = {};
     const attributes: Record<string, LegacyAttributeField> = {};
 
-    schema.fields.forEach((field) => {
+    for (const field of schema.fields) {
       assert(
         `${field.kind} is not valid inside a ResourceSchema's fields.`,
         // @ts-expect-error we are checking for mistakes at runtime
@@ -587,15 +597,48 @@ export class SchemaService implements SchemaServiceInterface {
       } else if (field.kind === 'belongsTo' || field.kind === 'hasMany') {
         relationships[field.name] = field;
       }
-    });
+    }
 
     const traits = new Set<string>(isResourceSchema(schema) ? schema.traits : []);
-    traits.forEach((trait) => {
-      this._traits.add(trait);
-    });
-
-    const internalSchema: InternalSchema = { original: schema, fields, relationships, attributes, traits };
+    const finalized = traits.size === 0;
+    const internalSchema: InternalSchema = { original: schema, finalized, fields, relationships, attributes, traits };
     this._schemas.set(schema.type, internalSchema);
+  }
+
+  /**
+   * Registers a {@link Trait} for use by resource schemas.
+   *
+   * Traits are re-usable collections of fields that can be composed to
+   * build up a resource schema. Often they represent polymorphic behaviors
+   * a resource should exhibit.
+   *
+   * When we finalize a resource, we walk its traits and apply their fields
+   * to the resource's fields. All specified traits must be registered by
+   * this time or an error will be thrown.
+   *
+   * Traits are applied left-to-right, with traits of traits being applied in the same
+   * way. Thus for the most part, application of traits is a post-order graph traversal
+   * problem.
+   *
+   * A trait is only ever processed once. If multiple traits (A, B, C) have the same
+   * trait (D) as a dependency, D will be included only once when first encountered by
+   * A.
+   *
+   * If a cycle exists such that trait A has trait B which has Trait A, trait A will
+   * be applied *after* trait B in production. In development a cycle error will be thrown.
+   *
+   * Fields are finalized on a "last wins principle". Thus traits appearing higher in
+   * the tree and further to the right of a traits array take precedence, with the
+   * resource's fields always being applied last and winning out.
+   *
+   * @public
+   */
+  registerTrait(trait: Trait): void {
+    const internalTrait = Object.assign({}, trait, { fields: new Map() }) as InternalTrait;
+    for (const field of trait.fields) {
+      internalTrait.fields.set(field.name, field);
+    }
+    this._traits.set(trait.name, internalTrait);
   }
 
   registerTransformation<T extends Value = string, PT = unknown>(transformation: Transformation<T, PT>): void {
@@ -673,9 +716,10 @@ export class SchemaService implements SchemaServiceInterface {
 
   fields({ type }: { type: string }): InternalSchema['fields'] {
     const schema = this._schemas.get(type);
+    assert(`No schema defined for ${type}`, schema);
 
-    if (!schema) {
-      throw new Error(`No schema defined for ${type}`);
+    if (!schema.finalized) {
+      finalizeResource(this, schema);
     }
 
     return schema.fields;
@@ -745,4 +789,89 @@ if (ENABLE_LEGACY_SCHEMA_SERVICE) {
     });
     return this._schemas.has(type);
   };
+}
+
+/**
+ * When we finalize a resource, we walk its traits and apply their fields
+ * to the resource's fields.
+ *
+ * Traits are applied left-to-right, with traits of traits being applied in the same
+ * way. Thus for the most part, application of traits is a post-order graph traversal
+ * problem.
+ *
+ * A trait is only ever processed once. If multiple traits (A, B, C) have the same
+ * trait (D) as a dependency, D will be included only once when first encountered by
+ * A.
+ *
+ * If a cycle exists such that trait A has trait B which has Trait A, trait A will
+ * be applied *after* trait B in production. In development a cycle error will be thrown.
+ *
+ * Fields are finalized on a "last wins principle". Thus traits appearing higher in
+ * the tree and further to the right of a traits array take precedence, with the
+ * resource's fields always being applied last and winning out.
+ */
+function finalizeResource(schema: SchemaService, resource: InternalSchema): void {
+  const fields: Map<string, FieldSchema> = new Map();
+  const seen: Set<InternalTrait> = new Set();
+
+  for (const traitName of resource.traits) {
+    const trait = schema._traits.get(traitName);
+    assert(
+      `The trait ${traitName} MUST be supplied before the resource ${resource.original.type} can be finalized for use.`,
+      trait
+    );
+
+    walkTrait(schema, trait, fields, seen, resource.original.type, DEBUG ? [] : null);
+  }
+
+  mergeMap(fields, resource.fields);
+  resource.fields = fields;
+  resource.finalized = true;
+}
+
+function walkTrait(
+  schema: SchemaService,
+  trait: InternalTrait,
+  fields: Map<string, FieldSchema>,
+  seen: Set<InternalTrait>,
+  type: string,
+  debugPath: string[] | null
+): void {
+  if (seen.has(trait)) {
+    // if the trait is in the current path, we throw a cycle error in dev.
+    if (DEBUG) {
+      if (debugPath!.includes(trait.name)) {
+        throw new Error(
+          `CycleError: The Trait '${trait.name}' utilized by the Resource '${type}' includes the following circular reference "${debugPath!.join(' > ')} > ${trait.name}"`
+        );
+      }
+    }
+    return;
+  }
+  const ownPath = DEBUG ? [...debugPath!, trait.name] : null;
+
+  // immediately mark as seen to prevent cycles
+  // further down the tree from looping back
+  seen.add(trait);
+
+  // first apply any child traits
+  if (trait.traits?.length) {
+    for (const traitName of trait.traits) {
+      const subtrait = schema._traits.get(traitName);
+      assert(
+        `The trait ${traitName} used by the trait ${trait.name} MUST be supplied before the resource ${type} can be finalized for use.`,
+        subtrait
+      );
+      walkTrait(schema, subtrait, fields, seen, type, ownPath);
+    }
+  }
+
+  // then apply our own fields
+  mergeMap(fields, trait.fields);
+}
+
+function mergeMap(base: Map<string, unknown>, toApply: Map<string, unknown>) {
+  for (const [key, value] of toApply) {
+    base.set(key, value);
+  }
 }

--- a/warp-drive-packages/core/src/store/-types/q/schema-service.ts
+++ b/warp-drive-packages/core/src/store/-types/q/schema-service.ts
@@ -13,6 +13,7 @@ import type {
   LegacyRelationshipField,
   ObjectField,
   Schema,
+  Trait,
 } from '../../../types/schema/fields.ts';
 
 export type AttributesSchema = Record<string, LegacyAttributeField>;
@@ -221,6 +222,36 @@ export interface SchemaService {
    * @param {HashFn} hashfn
    */
   registerHashFn(hashFn: HashFn): void;
+
+  /**
+   * Registers a {@link Trait} for use by resource schemas.
+   *
+   * Traits are re-usable collections of fields that can be composed to
+   * build up a resource schema. Often they represent polymorphic behaviors
+   * a resource should exhibit.
+   *
+   * When we finalize a resource, we walk its traits and apply their fields
+   * to the resource's fields. All specified traits must be registered by
+   * this time or an error will be thrown.
+   *
+   * Traits are applied left-to-right, with traits of traits being applied in the same
+   * way. Thus for the most part, application of traits is a post-order graph traversal
+   * problem.
+   *
+   * A trait is only ever processed once. If multiple traits (A, B, C) have the same
+   * trait (D) as a dependency, D will be included only once when first encountered by
+   * A.
+   *
+   * If a cycle exists such that trait A has trait B which has Trait A, trait A will
+   * be applied *after* trait B in production. In development a cycle error will be thrown.
+   *
+   * Fields are finalized on a "last wins principle". Thus traits appearing higher in
+   * the tree and further to the right of a traits array take precedence, with the
+   * resource's fields always being applied last and winning out.
+   *
+   * @public
+   */
+  registerTrait?(trait: Trait): void;
 
   /**
    * DEPRECATED - use `fields` instead

--- a/warp-drive-packages/core/src/types/schema/fields.ts
+++ b/warp-drive-packages/core/src/types/schema/fields.ts
@@ -1952,6 +1952,22 @@ export interface ObjectSchema {
 
 export type Schema = ResourceSchema | ObjectSchema;
 
+export interface PolarisTrait {
+  name: string;
+  mode: 'polaris';
+  fields: PolarisModeFieldSchema[];
+  traits: string[];
+}
+
+export interface LegacyTrait {
+  name: string;
+  mode: 'legacy';
+  fields: LegacyModeFieldSchema[];
+  traits: string[];
+}
+
+export type Trait = LegacyTrait | PolarisTrait;
+
 /**
  * A no-op type utility that enables type-checking resource schema
  * definitions.

--- a/warp-drive-packages/core/src/types/schema/fields.ts
+++ b/warp-drive-packages/core/src/types/schema/fields.ts
@@ -1956,14 +1956,14 @@ export interface PolarisTrait {
   name: string;
   mode: 'polaris';
   fields: PolarisModeFieldSchema[];
-  traits: string[];
+  traits?: string[];
 }
 
 export interface LegacyTrait {
   name: string;
   mode: 'legacy';
   fields: LegacyModeFieldSchema[];
-  traits: string[];
+  traits?: string[];
 }
 
 export type Trait = LegacyTrait | PolarisTrait;


### PR DESCRIPTION
resolves #10036 

We've been allowing resources to specify traits they have, but to this point it still meant they needed to include all of that trait's fields on their own. The original motivation was to encourage pre-flattening of the schemas by build-tools.

However, this composition at runtime is not particularly hard and in the absence of a DSL and compiler for doing said pre-flattening it appears better to enable runtime composition. This in theory also reduces the payload size of delivering resource schemas that rely heavily on traits.

TODO

- [x] add a few tests
- [x] make missing traits a warning vs error with opt-in to error (so that existing schemas that were specifying traits do not immediately break)