### PR TITLE
feat: cleanup Snapshot and make it defer to modelFor for schema iteration

### DIFF
--- a/tests/main/tests/integration/emergent-behavior/recovery/belongs-to-test.ts
+++ b/tests/main/tests/integration/emergent-behavior/recovery/belongs-to-test.ts
@@ -240,7 +240,7 @@ module('Emergent Behavior > Recovery | belongsTo', function (hooks) {
       class {
         findRecord(_store: Store, schema: ModelSchema, id: string, snapshot: Snapshot) {
           assert.step('findRecord');
-          // @ts-expect-error
+          // @ts-expect-errorw
           assert.deepEqual(snapshot._attributes, { name: undefined }, 'the snapshot has the correct attributes');
 
           return Promise.reject(new Error('404 - Not Found'));

--- a/tests/main/tests/integration/emergent-behavior/recovery/belongs-to-test.ts
+++ b/tests/main/tests/integration/emergent-behavior/recovery/belongs-to-test.ts
@@ -181,6 +181,7 @@ module('Emergent Behavior > Recovery | belongsTo', function (hooks) {
       class {
         findRecord(_store: Store, schema: ModelSchema, id: string, snapshot: Snapshot) {
           assert.step('findRecord');
+          // @ts-expect-error
           assert.deepEqual(snapshot._attributes, { name: undefined }, 'the snapshot has the correct attributes');
           return Promise.resolve({
             data: {
@@ -239,6 +240,7 @@ module('Emergent Behavior > Recovery | belongsTo', function (hooks) {
       class {
         findRecord(_store: Store, schema: ModelSchema, id: string, snapshot: Snapshot) {
           assert.step('findRecord');
+          // @ts-expect-error
           assert.deepEqual(snapshot._attributes, { name: undefined }, 'the snapshot has the correct attributes');
 
           return Promise.reject(new Error('404 - Not Found'));

--- a/tests/main/tests/integration/emergent-behavior/recovery/has-many-test.ts
+++ b/tests/main/tests/integration/emergent-behavior/recovery/has-many-test.ts
@@ -762,6 +762,7 @@ module('Emergent Behavior > Recovery | hasMany', function (hooks) {
       class {
         findRecord(_store: Store, schema: ModelSchema, id: string, snapshot: Snapshot) {
           assert.step('findRecord');
+          // @ts-expect-error
           assert.deepEqual(snapshot._attributes, { name: undefined }, 'the snapshot has the correct attributes');
           return Promise.resolve({
             data: {
@@ -951,6 +952,7 @@ module('Emergent Behavior > Recovery | hasMany', function (hooks) {
         findRecord(_store: Store, schema: ModelSchema, id: string, snapshot: Snapshot) {
           assert.step('findRecord');
           if (snapshot.include === 'frenemies') {
+            // @ts-expect-error
             assert.deepEqual(snapshot._attributes, { name: 'Rey' }, 'the snapshot has the correct attributes');
 
             return Promise.resolve({
@@ -968,6 +970,7 @@ module('Emergent Behavior > Recovery | hasMany', function (hooks) {
               },
             });
           }
+          // @ts-expect-error
           assert.deepEqual(snapshot._attributes, { name: undefined }, 'the snapshot has the correct attributes');
 
           return Promise.resolve({
@@ -1176,6 +1179,7 @@ module('Emergent Behavior > Recovery | hasMany', function (hooks) {
       class {
         findRecord(_store: Store, schema: ModelSchema, id: string, snapshot: Snapshot) {
           assert.step('findRecord');
+          // @ts-expect-error
           assert.deepEqual(snapshot._attributes, { name: undefined }, 'the snapshot has the correct attributes');
 
           return Promise.reject(new Error('404 - Not Found'));

--- a/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -201,19 +201,31 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
             count++;
           });
 
-          assert.verifySteps([
-            'Adapter:createRecord',
-            'TestSchema:hasResource',
-            'TestSchema:hasResource',
-            'TestSchema:fields',
-            'Adapter:createRecord:attr:name',
-            'Adapter:createRecord:attr:age',
-            'TestSchema:hasResource',
-            'TestSchema:hasResource',
-            'TestSchema:fields',
-            'Adapter:createRecord:rel:boats',
-            'Adapter:createRecord:rel:house',
-          ]);
+          assert.verifySteps(
+            DEBUG
+              ? [
+                  'Adapter:createRecord',
+                  'TestSchema:hasResource',
+                  'TestSchema:hasResource',
+                  'TestSchema:fields',
+                  'Adapter:createRecord:attr:name',
+                  'Adapter:createRecord:attr:age',
+                  'TestSchema:hasResource',
+                  'TestSchema:hasResource',
+                  'TestSchema:fields',
+                  'Adapter:createRecord:rel:boats',
+                  'Adapter:createRecord:rel:house',
+                ]
+              : [
+                  'Adapter:createRecord',
+                  'TestSchema:fields',
+                  'Adapter:createRecord:attr:name',
+                  'Adapter:createRecord:attr:age',
+                  'TestSchema:fields',
+                  'Adapter:createRecord:rel:boats',
+                  'Adapter:createRecord:rel:house',
+                ]
+          );
           return Promise.resolve({ data: { type: 'person', id: '1' } });
         };
       }

--- a/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -142,7 +142,7 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
                   'TestSchema:hasResource',
                   'TestSchema:hasResource',
                 ]
-              : ['TestSchema:hasResource', 'TestSchema:hasResource', 'TestSchema:fields', 'TestSchema:fields'],
+              : ['TestSchema:fields', 'TestSchema:fields'],
             'serialization of record for save'
           );
           assert.step('Adapter:createRecord');

--- a/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -134,8 +134,15 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
           let count = 0;
           assert.verifySteps(
             DEBUG
-              ? ['TestSchema:fields', 'TestSchema:fields', 'TestSchema:hasResource', 'TestSchema:hasResource']
-              : ['TestSchema:fields', 'TestSchema:fields'],
+              ? [
+                  'TestSchema:hasResource',
+                  'TestSchema:hasResource',
+                  'TestSchema:fields',
+                  'TestSchema:fields',
+                  'TestSchema:hasResource',
+                  'TestSchema:hasResource',
+                ]
+              : ['TestSchema:hasResource', 'TestSchema:hasResource', 'TestSchema:fields', 'TestSchema:fields'],
             'serialization of record for save'
           );
           assert.step('Adapter:createRecord');

--- a/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/main/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -200,11 +200,16 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
             }
             count++;
           });
+
           assert.verifySteps([
             'Adapter:createRecord',
+            'TestSchema:hasResource',
+            'TestSchema:hasResource',
             'TestSchema:fields',
             'Adapter:createRecord:attr:name',
             'Adapter:createRecord:attr:age',
+            'TestSchema:hasResource',
+            'TestSchema:hasResource',
             'TestSchema:fields',
             'Adapter:createRecord:rel:boats',
             'Adapter:createRecord:rel:house',


### PR DESCRIPTION
Serializers that handle ModelFragments need to be able to handle the modern version of them we are working to build as a compat layer.

This change allows a custom `modelFor` implementation to produce a `ModelSchema` that serializers designed to work with fragments might understand a bit better out of the box.