### PR TITLE
chore: improve isDocumentIdentifier and isRecordIdentifier checks

### DIFF
--- a/tests/ember-data__json-api/tests/integration/cache/collection-data-documents-test.ts
+++ b/tests/ember-data__json-api/tests/integration/cache/collection-data-documents-test.ts
@@ -111,7 +111,11 @@ module('Integration | @ember-data/json-api Cache.put(<CollectionDataDocument>)',
 
     assert.deepEqual(responseDocument.data, [identifier, identifier2], 'We were given the correct data back');
 
-    const structuredDocument = store.cache.peekRequest({ lid: 'https://api.example.com/v1/users' });
+    const reqIdentifier = store.identifierCache.getOrCreateDocumentIdentifier({
+      method: 'GET',
+      url: 'https://api.example.com/v1/users',
+    })!;
+    const structuredDocument = store.cache.peekRequest(reqIdentifier);
     assert.deepEqual(
       structuredDocument as Partial<StructuredDataDocument<CollectionResourceDocument>>,
       {
@@ -123,7 +127,7 @@ module('Integration | @ember-data/json-api Cache.put(<CollectionDataDocument>)',
       },
       'We got the cached structured document back'
     );
-    const cachedResponse = store.cache.peek({ lid: 'https://api.example.com/v1/users' });
+    const cachedResponse = store.cache.peek(reqIdentifier);
     assert.deepEqual(
       cachedResponse,
       {

--- a/tests/ember-data__json-api/tests/integration/cache/meta-documents-test.ts
+++ b/tests/ember-data__json-api/tests/integration/cache/meta-documents-test.ts
@@ -51,8 +51,12 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
     assert.deepEqual(responseDocument.meta, { count: 4 }, 'meta is correct');
     assert.equal(JSON.stringify(responseDocument.meta), JSON.stringify({ count: 4 }), 'meta is correct');
     assert.equal(responseDocument.lid, 'https://api.example.com/v1/users', 'lid is correct');
+    const reqIdentifier = store.identifierCache.getOrCreateDocumentIdentifier({
+      method: 'GET',
+      url: 'https://api.example.com/v1/users',
+    })!;
 
-    const structuredDocument = store.cache.peekRequest({ lid: 'https://api.example.com/v1/users' });
+    const structuredDocument = store.cache.peekRequest(reqIdentifier);
     assert.deepEqual(
       structuredDocument as Partial<StructuredDocument<ResourceMetaDocument>>,
       {
@@ -64,7 +68,7 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
       },
       'We got the cached structured document back'
     );
-    const cachedResponse = store.cache.peek({ lid: 'https://api.example.com/v1/users' });
+    const cachedResponse = store.cache.peek(reqIdentifier);
     assert.deepEqual(
       cachedResponse,
       {
@@ -86,15 +90,19 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
         },
       })
     );
+    const reqIdentifier = store.identifierCache.getOrCreateDocumentIdentifier({
+      method: 'GET',
+      url: 'https://api.example.com/v1/users',
+      cacheOptions: { key: 'users' },
+    })!;
 
     assert.false('data' in responseDocument, 'No data is associated');
     assert.deepEqual(responseDocument.meta, { count: 4 }, 'meta is correct');
     assert.equal(JSON.stringify(responseDocument.meta), JSON.stringify({ count: 4 }), 'meta is correct');
     assert.equal(responseDocument.lid, 'users', 'lid is correct');
+    assert.equal(reqIdentifier?.lid, 'users', 'identifier lid is correct');
 
-    const structuredDocument = store.cache.peekRequest({ lid: 'users' });
-    const structuredDocument2 = store.cache.peekRequest({ lid: 'https://api.example.com/v1/users' });
-    assert.equal(structuredDocument2, null, 'url is not cache key');
+    const structuredDocument = store.cache.peekRequest(reqIdentifier);
     assert.deepEqual(
       structuredDocument as Partial<StructuredDocument<ResourceMetaDocument>>,
       {
@@ -106,9 +114,7 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
       },
       'We got the cached structured document back'
     );
-    const cachedResponse = store.cache.peek({ lid: 'users' });
-    const cachedResponse2 = store.cache.peek({ lid: 'https://api.example.com/v1/users' });
-    assert.equal(cachedResponse2, null, 'url is not cache key');
+    const cachedResponse = store.cache.peek(reqIdentifier);
     assert.deepEqual(
       cachedResponse,
       {
@@ -130,13 +136,17 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
         },
       })
     );
+    const reqIdentifier = store.identifierCache.getOrCreateDocumentIdentifier({
+      method: 'GET',
+      url: 'https://api.example.com/v1/users',
+    })!;
 
     assert.false('data' in responseDocument, 'No data is associated');
     assert.deepEqual(responseDocument.meta, { count: 4, last: 4 }, 'meta is correct');
     assert.equal(JSON.stringify(responseDocument.meta), JSON.stringify({ count: 4, last: 4 }), 'meta is correct');
     assert.equal(responseDocument.lid, 'https://api.example.com/v1/users', 'lid is correct');
 
-    const structuredDocument = store.cache.peekRequest({ lid: 'https://api.example.com/v1/users' });
+    const structuredDocument = store.cache.peekRequest(reqIdentifier);
     assert.deepEqual(
       structuredDocument as Partial<StructuredDocument<ResourceMetaDocument>>,
       {
@@ -148,7 +158,7 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
       },
       'We got the cached structured document back'
     );
-    const cachedResponse = store.cache.peek({ lid: 'https://api.example.com/v1/users' });
+    const cachedResponse = store.cache.peek(reqIdentifier);
     assert.deepEqual(
       cachedResponse,
       {
@@ -172,7 +182,7 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
     assert.equal(JSON.stringify(responseDocument2.meta), JSON.stringify({ count: 3, next: 8 }), 'meta is correct');
     assert.equal(responseDocument2.lid, 'https://api.example.com/v1/users', 'lid is correct');
 
-    const structuredDocument2 = store.cache.peekRequest({ lid: 'https://api.example.com/v1/users' });
+    const structuredDocument2 = store.cache.peekRequest(reqIdentifier);
     assert.deepEqual(
       structuredDocument2 as Partial<StructuredDocument<ResourceMetaDocument>>,
       {
@@ -184,7 +194,7 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
       },
       'We got the cached structured document back'
     );
-    const cachedResponse2 = store.cache.peek({ lid: 'https://api.example.com/v1/users' });
+    const cachedResponse2 = store.cache.peek(reqIdentifier);
     assert.deepEqual(
       cachedResponse2,
       {
@@ -211,13 +221,17 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
       type: 'user',
       id: '1',
     }) as StableExistingRecordIdentifier;
+    const reqIdentifier = store.identifierCache.getOrCreateDocumentIdentifier({
+      method: 'GET',
+      url: 'https://api.example.com/v1/users',
+    })!;
 
     assert.deepEqual(responseDocument.data, [identifier], 'data is associated');
     assert.deepEqual(responseDocument.meta, { count: 4, last: 4 }, 'meta is correct');
     assert.equal(JSON.stringify(responseDocument.meta), JSON.stringify({ count: 4, last: 4 }), 'meta is correct');
     assert.equal(responseDocument.lid, 'https://api.example.com/v1/users', 'lid is correct');
 
-    const structuredDocument = store.cache.peekRequest({ lid: 'https://api.example.com/v1/users' });
+    const structuredDocument = store.cache.peekRequest(reqIdentifier);
     assert.deepEqual(
       structuredDocument as Partial<StructuredDocument<CollectionResourceDataDocument>>,
       {
@@ -230,7 +244,7 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
       },
       'We got the cached structured document back'
     );
-    const cachedResponse = store.cache.peek({ lid: 'https://api.example.com/v1/users' });
+    const cachedResponse = store.cache.peek(reqIdentifier);
     assert.deepEqual(
       cachedResponse,
       {
@@ -255,7 +269,7 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
     assert.equal(JSON.stringify(responseDocument2.meta), JSON.stringify({ count: 3, next: 8 }), 'meta is correct');
     assert.equal(responseDocument2.lid, 'https://api.example.com/v1/users', 'lid is correct');
 
-    const structuredDocument2 = store.cache.peekRequest({ lid: 'https://api.example.com/v1/users' });
+    const structuredDocument2 = store.cache.peekRequest(reqIdentifier);
     assert.deepEqual(
       structuredDocument2 as Partial<StructuredDocument<ResourceMetaDocument>>,
       {
@@ -267,7 +281,7 @@ module('Integration | @ember-data/json-api Cach.put(<MetaDocument>)', function (
       },
       'We got the cached structured document back'
     );
-    const cachedResponse2 = store.cache.peek({ lid: 'https://api.example.com/v1/users' });
+    const cachedResponse2 = store.cache.peek(reqIdentifier);
     assert.deepEqual(
       cachedResponse2,
       {

--- a/tests/ember-data__json-api/tests/integration/cache/resource-data-documents-test.ts
+++ b/tests/ember-data__json-api/tests/integration/cache/resource-data-documents-test.ts
@@ -102,10 +102,14 @@ module('Integration | @ember-data/json-api Cache.put(<ResourceDataDocument>)', f
       type: 'user',
       id: '1',
     }) as StableExistingRecordIdentifier;
+    const reqIdentifier = store.identifierCache.getOrCreateDocumentIdentifier({
+      method: 'GET',
+      url: 'https://api.example.com/v1/users/1',
+    })!;
 
     assert.equal(responseDocument.data, identifier, 'We were given the correct data back');
 
-    const structuredDocument = store.cache.peekRequest({ lid: 'https://api.example.com/v1/users/1' });
+    const structuredDocument = store.cache.peekRequest(reqIdentifier);
     assert.deepEqual(
       structuredDocument as Partial<StructuredDocument<SingleResourceDocument>>,
       {
@@ -117,7 +121,7 @@ module('Integration | @ember-data/json-api Cache.put(<ResourceDataDocument>)', f
       },
       'We got the cached structured document back'
     );
-    const cachedResponse = store.cache.peek({ lid: 'https://api.example.com/v1/users/1' });
+    const cachedResponse = store.cache.peek(reqIdentifier);
     assert.deepEqual(
       cachedResponse,
       {
@@ -143,12 +147,15 @@ module('Integration | @ember-data/json-api Cache.put(<ResourceDataDocument>)', f
       type: 'user',
       id: '1',
     }) as StableExistingRecordIdentifier;
-
+    const reqIdentifier = store.identifierCache.getOrCreateDocumentIdentifier({
+      method: 'GET',
+      url: 'https://api.example.com/v1/users/1',
+      cacheOptions: { key: 'user-1' },
+    })!;
+    assert.equal(reqIdentifier?.lid, 'user-1', 'respects cacheOptions.key');
     assert.equal(responseDocument.data, identifier, 'We were given the correct data back');
 
-    const structuredDocument = store.cache.peekRequest({ lid: 'user-1' });
-    const structuredDocument2 = store.cache.peekRequest({ lid: 'https://api.example.com/v1/users/1' });
-    assert.equal(structuredDocument2, null, 'we did not use the url as the key');
+    const structuredDocument = store.cache.peekRequest(reqIdentifier);
     assert.deepEqual(
       structuredDocument as Partial<StructuredDocument<SingleResourceDocument>>,
       {
@@ -161,9 +168,7 @@ module('Integration | @ember-data/json-api Cache.put(<ResourceDataDocument>)', f
       'We got the cached structured document back'
     );
 
-    const cachedResponse = store.cache.peek({ lid: 'user-1' });
-    const cachedResponse2 = store.cache.peek({ lid: 'https://api.example.com/v1/users/1' });
-    assert.equal(cachedResponse2, null, 'we did not use the url as the key');
+    const cachedResponse = store.cache.peek(reqIdentifier);
     assert.deepEqual(
       cachedResponse,
       {

--- a/warp-drive-packages/core/src/types/identifier.ts
+++ b/warp-drive-packages/core/src/types/identifier.ts
@@ -35,6 +35,9 @@ export interface NewRecordIdentifier<T extends string = string> extends Identifi
 
 export type StableDocumentIdentifier = {
   lid: string;
+  type: '@document';
+  /** @internal */
+  [CACHE_OWNER]: number | undefined;
 };
 export type RequestKey = StableDocumentIdentifier;
 
@@ -73,20 +76,26 @@ export interface StableIdentifier extends Identifier {
  */
 export interface StableExistingRecordIdentifier<T extends string = string> extends StableIdentifier {
   /**
+   * the primary `ResourceType` or "model name" this ResourceKey belongs to.
+   *
+   * @public
+   */
+  type: T;
+
+  /** @internal */
+  [CACHE_OWNER]: number | undefined;
+
+  /**
    * the PrimaryKey for the resource this ResourceKey belongs to. `null`
    * if not yet assigned a PrimaryKey value.
    *
    * @public
    */
   id: string;
-  /**
-   * the primary `ResourceType` or "model name" this ResourceKey belongs to.
-   *
-   * @public
-   */
-  type: T;
+
+  /** @internal */
   [DEBUG_CLIENT_ORIGINATED]?: boolean;
-  [CACHE_OWNER]: number | undefined;
+  /** @internal */
   [DEBUG_STALE_CACHE_OWNER]?: number | undefined;
 }
 
@@ -103,22 +112,25 @@ export interface StableExistingRecordIdentifier<T extends string = string> exten
  */
 export interface StableNewRecordIdentifier<T extends string = string> extends StableIdentifier {
   /**
+   * the primary resource `type` or `modelName` this identity belongs to.
+   *
+   * @public
+   */
+  type: T;
+
+  /** @internal */
+  [CACHE_OWNER]: number | undefined;
+
+  /**
    * the primary id for the record this identity belongs to. `null`
    * if not yet assigned an id.
    *
    * @public
    */
   id: string | null;
-  /**
-   * the primary resource `type` or `modelName` this identity belongs to.
-   *
-   * @public
-   */
-  type: T;
+
   /** @internal */
   [DEBUG_CLIENT_ORIGINATED]?: boolean;
-  /** @internal */
-  [CACHE_OWNER]: number | undefined;
   /** @internal */
   [DEBUG_STALE_CACHE_OWNER]?: number | undefined;
 }

--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -559,7 +559,7 @@ export class JSONAPICache implements Cache {
   peek(identifier: ResourceKey): ResourceObject | null;
   peek(identifier: StableDocumentIdentifier): ResourceDocument | null;
   peek(identifier: StableDocumentIdentifier | ResourceKey): ResourceObject | ResourceDocument | null {
-    if ('type' in identifier) {
+    if (isStableIdentifier(identifier)) {
       const peeked = this.__safePeek(identifier, false);
 
       if (!peeked) {
@@ -622,7 +622,7 @@ export class JSONAPICache implements Cache {
   peekRemoteState(identifier: ResourceKey): ResourceObject | null;
   peekRemoteState(identifier: StableDocumentIdentifier): ResourceDocument | null;
   peekRemoteState(identifier: StableDocumentIdentifier | ResourceKey): ResourceObject | ResourceDocument | null {
-    if ('type' in identifier) {
+    if (isStableIdentifier(identifier)) {
       const peeked = this.__safePeek(identifier, false);
 
       if (!peeked) {


### PR DESCRIPTION
shifts request-key to same key-owner strategy as resource-key, prepares for additional type/naming cleanup