### PR TITLE
chore: begin renaming identifier => key|cacheKey

### DIFF
--- a/guides/1-configuration/2-setup/1-universal.md
+++ b/guides/1-configuration/2-setup/1-universal.md
@@ -179,8 +179,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createArgs?: Record<string, unknown>) {
-    return instantiateRecord(this, identifier, createArgs);
+  instantiateRecord(key: ResourceKey, createArgs?: Record<string, unknown>) {
+    return instantiateRecord(this, key, createArgs);
   }
 
   teardownRecord(record: unknown): void {
@@ -238,8 +238,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createRecordArgs: Record<string, unknown>) {
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  instantiateRecord(key: ResourceKey, createRecordArgs: Record<string, unknown>) {
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   teardownRecord(record: unknown): void {
@@ -311,16 +311,16 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createArgs?: Record<string, unknown>) {
-    if (this.schema.isDelegated(identifier)) {
-      return instantiateModel.call(this, identifier, createRecordArgs)
+  instantiateRecord(key: ResourceKey, createArgs?: Record<string, unknown>) {
+    if (this.schema.isDelegated(key)) {
+      return instantiateModel.call(this, key, createRecordArgs)
     }
-    return instantiateRecord(this, identifier, createArgs);
+    return instantiateRecord(this, key, createArgs);
   }
 
   teardownRecord(record: unknown): void {
-    const identifier = recordIdentifierFor(record);
-    if (this.schema.isDelegated(identifier)) {
+    const key = recordIdentifierFor(record);
+    if (this.schema.isDelegated(key)) {
       return teardownModel.call(this, record as Model);
     }
     return teardownRecord(record);
@@ -558,8 +558,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createArgs?: Record<string, unknown>) { // [!code focus:3]
-    return instantiateRecord(this, identifier, createArgs);
+  instantiateRecord(key: ResourceKey, createArgs?: Record<string, unknown>) { // [!code focus:3]
+    return instantiateRecord(this, key, createArgs);
   }
 
   teardownRecord(record: unknown): void { // [!code focus:3]
@@ -604,8 +604,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createRecordArgs: Record<string, unknown>) {  // [!code focus:3]
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  instantiateRecord(key: ResourceKey, createRecordArgs: Record<string, unknown>) {  // [!code focus:3]
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   teardownRecord(record: unknown): void {  // [!code focus:3]
@@ -664,16 +664,16 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createArgs?: Record<string, unknown>) {  // [!code focus:6]
-    if (this.schema.isDelegated(identifier)) {
-      return instantiateModel.call(this, identifier, createRecordArgs)
+  instantiateRecord(key: ResourceKey, createArgs?: Record<string, unknown>) {  // [!code focus:6]
+    if (this.schema.isDelegated(key)) {
+      return instantiateModel.call(this, key, createRecordArgs)
     }
-    return instantiateRecord(this, identifier, createArgs);
+    return instantiateRecord(this, key, createArgs);
   }
 
   teardownRecord(record: unknown): void {  // [!code focus:7]
-    const identifier = recordIdentifierFor(record);
-    if (this.schema.isDelegated(identifier)) {
+    const key = recordIdentifierFor(record);
+    if (this.schema.isDelegated(key)) {
       return teardownModel.call(this, record as Model);
     }
     return teardownRecord(record);
@@ -750,8 +750,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createArgs?: Record<string, unknown>) {
-    return instantiateRecord(this, identifier, createArgs);
+  instantiateRecord(key: ResourceKey, createArgs?: Record<string, unknown>) {
+    return instantiateRecord(this, key, createArgs);
   }
 
   teardownRecord(record: unknown): void {

--- a/guides/1-configuration/2-setup/2-ember.md
+++ b/guides/1-configuration/2-setup/2-ember.md
@@ -92,8 +92,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createRecordArgs: Record<string, unknown>) {
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  instantiateRecord(key: ResourceKey, createRecordArgs: Record<string, unknown>) {
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   teardownRecord(record: unknown): void {

--- a/guides/1-configuration/4-legacy-package-setup/2-setup/1-universal.md
+++ b/guides/1-configuration/4-legacy-package-setup/2-setup/1-universal.md
@@ -180,8 +180,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createArgs?: Record<string, unknown>) {
-    return instantiateRecord(this, identifier, createArgs);
+  instantiateRecord(key: ResourceKey, createArgs?: Record<string, unknown>) {
+    return instantiateRecord(this, key, createArgs);
   }
 
   teardownRecord(record: unknown): void {
@@ -237,8 +237,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createRecordArgs: Record<string, unknown>) {
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  instantiateRecord(key: ResourceKey, createRecordArgs: Record<string, unknown>) {
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   teardownRecord(record: unknown): void {
@@ -308,16 +308,16 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createArgs?: Record<string, unknown>) {
-    if (this.schema.isDelegated(identifier)) {
-      return instantiateModel.call(this, identifier, createRecordArgs)
+  instantiateRecord(key: ResourceKey, createArgs?: Record<string, unknown>) {
+    if (this.schema.isDelegated(key)) {
+      return instantiateModel.call(this, key, createRecordArgs)
     }
-    return instantiateRecord(this, identifier, createArgs);
+    return instantiateRecord(this, key, createArgs);
   }
 
   teardownRecord(record: unknown): void {
-    const identifier = recordIdentifierFor(record);
-    if (this.schema.isDelegated(identifier)) {
+    const key = recordIdentifierFor(record);
+    if (this.schema.isDelegated(key)) {
       return teardownModel.call(this, record as Model);
     }
     return teardownRecord(record);
@@ -560,8 +560,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createArgs?: Record<string, unknown>) { // [!code focus:3]
-    return instantiateRecord(this, identifier, createArgs);
+  instantiateRecord(key: ResourceKey, createArgs?: Record<string, unknown>) { // [!code focus:3]
+    return instantiateRecord(this, key, createArgs);
   }
 
   teardownRecord(record: unknown): void { // [!code focus:3]
@@ -604,8 +604,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createRecordArgs: Record<string, unknown>) {  // [!code focus:3]
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  instantiateRecord(key: ResourceKey, createRecordArgs: Record<string, unknown>) {  // [!code focus:3]
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   teardownRecord(record: unknown): void {  // [!code focus:3]
@@ -663,16 +663,16 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createArgs?: Record<string, unknown>) {  // [!code focus:6]
-    if (this.schema.isDelegated(identifier)) {
-      return instantiateModel.call(this, identifier, createRecordArgs)
+  instantiateRecord(key: ResourceKey, createArgs?: Record<string, unknown>) {  // [!code focus:6]
+    if (this.schema.isDelegated(key)) {
+      return instantiateModel.call(this, key, createRecordArgs)
     }
-    return instantiateRecord(this, identifier, createArgs);
+    return instantiateRecord(this, key, createArgs);
   }
 
   teardownRecord(record: unknown): void {  // [!code focus:7]
-    const identifier = recordIdentifierFor(record);
-    if (this.schema.isDelegated(identifier)) {
+    const key = recordIdentifierFor(record);
+    if (this.schema.isDelegated(key)) {
       return teardownModel.call(this, record as Model);
     }
     return teardownRecord(record);
@@ -754,8 +754,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createArgs?: Record<string, unknown>) {
-    return instantiateRecord(this, identifier, createArgs);
+  instantiateRecord(key: ResourceKey, createArgs?: Record<string, unknown>) {
+    return instantiateRecord(this, key, createArgs);
   }
 
   teardownRecord(record: unknown): void {

--- a/guides/1-configuration/4-legacy-package-setup/2-setup/2-ember.md
+++ b/guides/1-configuration/4-legacy-package-setup/2-setup/2-ember.md
@@ -125,8 +125,8 @@ export default class AppStore extends Store {
     return new JSONAPICache(capabilities);
   }
 
-  instantiateRecord(identifier: ResourceKey, createRecordArgs: Record<string, unknown>) {
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  instantiateRecord(key: ResourceKey, createRecordArgs: Record<string, unknown>) {
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   teardownRecord(record: unknown): void {

--- a/packages/-ember-data/src/store.ts
+++ b/packages/-ember-data/src/store.ts
@@ -49,8 +49,8 @@ export default class Store extends BaseStore {
     return new JSONAPICache(storeWrapper);
   }
 
-  instantiateRecord(identifier: ResourceKey, createRecordArgs: Record<string, unknown>): Model {
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  instantiateRecord(key: ResourceKey, createRecordArgs: Record<string, unknown>): Model {
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   teardownRecord(record: unknown): void {

--- a/tests/builders/app/services/store.ts
+++ b/tests/builders/app/services/store.ts
@@ -26,8 +26,8 @@ export default class Store extends DataStore {
     return new JSONAPICache(capabilities);
   }
 
-  override instantiateRecord(identifier: ResourceKey, createRecordArgs: { [key: string]: unknown }): unknown {
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  override instantiateRecord(key: ResourceKey, createRecordArgs: { [key: string]: unknown }): unknown {
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   override teardownRecord(record: Model): void {

--- a/tests/builders/tests/integration/create-record-test.ts
+++ b/tests/builders/tests/integration/create-record-test.ts
@@ -32,8 +32,8 @@ class TestStore extends DataStore {
     return new JSONAPICache(capabilities);
   }
 
-  override instantiateRecord(identifier: ResourceKey, createRecordArgs: { [key: string]: unknown }): unknown {
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  override instantiateRecord(key: ResourceKey, createRecordArgs: { [key: string]: unknown }): unknown {
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   override teardownRecord(record: Model): void {
@@ -65,9 +65,9 @@ module('Integration - createRecord', function (hooks) {
 
     // intercept cache APIs to ensure they are called as expected
     class TestCache extends JSONAPICache {
-      override willCommit(identifier: ResourceKey): void {
-        assert.step(`willCommit ${identifier.lid}`);
-        return super.willCommit(identifier, null);
+      override willCommit(key: ResourceKey): void {
+        assert.step(`willCommit ${key.lid}`);
+        return super.willCommit(key, null);
       }
       override didCommit(
         committedIdentifier: ResourceKey,
@@ -76,9 +76,9 @@ module('Integration - createRecord', function (hooks) {
         assert.step(`didCommit ${committedIdentifier.lid}`);
         return super.didCommit(committedIdentifier, result);
       }
-      override commitWasRejected(identifier: ResourceKey, errors?: ApiError[]): void {
-        assert.step(`commitWasRejected ${identifier.lid}`);
-        return super.commitWasRejected(identifier, errors);
+      override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
+        assert.step(`commitWasRejected ${key.lid}`);
+        return super.commitWasRejected(key, errors);
       }
     }
 
@@ -112,7 +112,7 @@ module('Integration - createRecord', function (hooks) {
     owner.register('model:user', User);
     const store = owner.lookup('service:store') as Store;
     const user = store.createRecord('user', { name: 'John' }) as User;
-    const identifier = recordIdentifierFor(user);
+    const key = recordIdentifierFor(user);
     assert.false(user.isSaving, 'The user is not saving');
     assert.true(user.isNew, 'The user is new');
     assert.true(user.hasDirtyAttributes, 'The user is dirty');
@@ -138,7 +138,7 @@ module('Integration - createRecord', function (hooks) {
     assert.false(user.isNew, 'The user is no longer new');
     assert.false(user.isSaving, 'The user is no longer saving');
 
-    assert.verifySteps([`willCommit ${identifier.lid}`, 'handle createRecord request', `didCommit ${identifier.lid}`]);
+    assert.verifySteps([`willCommit ${key.lid}`, 'handle createRecord request', `didCommit ${key.lid}`]);
   });
 
   test('Rejecting during Save of a new record with a createRecord op works as expected', async function (this: TestContext, assert) {
@@ -146,9 +146,9 @@ module('Integration - createRecord', function (hooks) {
 
     // intercept cache APIs to ensure they are called as expected
     class TestCache extends JSONAPICache {
-      override willCommit(identifier: ResourceKey): void {
-        assert.step(`willCommit ${identifier.lid}`);
-        return super.willCommit(identifier, null);
+      override willCommit(key: ResourceKey): void {
+        assert.step(`willCommit ${key.lid}`);
+        return super.willCommit(key, null);
       }
       override didCommit(
         committedIdentifier: ResourceKey,
@@ -157,9 +157,9 @@ module('Integration - createRecord', function (hooks) {
         assert.step(`didCommit ${committedIdentifier.lid}`);
         return super.didCommit(committedIdentifier, result);
       }
-      override commitWasRejected(identifier: ResourceKey, errors?: ApiError[]): void {
-        assert.step(`commitWasRejected ${identifier.lid}`);
-        return super.commitWasRejected(identifier, errors);
+      override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
+        assert.step(`commitWasRejected ${key.lid}`);
+        return super.commitWasRejected(key, errors);
       }
     }
 
@@ -193,7 +193,7 @@ module('Integration - createRecord', function (hooks) {
     owner.register('model:user', User);
     const store = owner.lookup('service:store') as Store;
     const user = store.createRecord('user', { name: 'John' }) as User;
-    const identifier = recordIdentifierFor(user);
+    const key = recordIdentifierFor(user);
     assert.false(user.isSaving, 'The user is not saving');
     assert.true(user.isNew, 'The user is new');
     assert.true(user.hasDirtyAttributes, 'The user is dirty');
@@ -251,10 +251,6 @@ module('Integration - createRecord', function (hooks) {
     assert.equal(nameErrors.length, 1, 'The user has the expected number of errors');
     assert.equal(nameErrors[0]?.message, 'Name must be capitalized', 'The user has the expected error for the field');
 
-    assert.verifySteps([
-      `willCommit ${identifier.lid}`,
-      'handle createRecord request',
-      `commitWasRejected ${identifier.lid}`,
-    ]);
+    assert.verifySteps([`willCommit ${key.lid}`, 'handle createRecord request', `commitWasRejected ${key.lid}`]);
   });
 });

--- a/tests/builders/tests/integration/delete-record-test.ts
+++ b/tests/builders/tests/integration/delete-record-test.ts
@@ -32,8 +32,8 @@ class TestStore extends DataStore {
     return new JSONAPICache(capabilities);
   }
 
-  override instantiateRecord(identifier: ResourceKey, createRecordArgs: { [key: string]: unknown }): unknown {
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  override instantiateRecord(key: ResourceKey, createRecordArgs: { [key: string]: unknown }): unknown {
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   override teardownRecord(record: Model): void {
@@ -65,9 +65,9 @@ module('Integration - deleteRecord', function (hooks) {
 
     // intercept cache APIs to ensure they are called as expected
     class TestCache extends JSONAPICache {
-      override willCommit(identifier: ResourceKey): void {
-        assert.step(`willCommit ${identifier.lid}`);
-        return super.willCommit(identifier, null);
+      override willCommit(key: ResourceKey): void {
+        assert.step(`willCommit ${key.lid}`);
+        return super.willCommit(key, null);
       }
       override didCommit(
         committedIdentifier: ResourceKey,
@@ -76,9 +76,9 @@ module('Integration - deleteRecord', function (hooks) {
         assert.step(`didCommit ${committedIdentifier.lid}`);
         return super.didCommit(committedIdentifier, result);
       }
-      override commitWasRejected(identifier: ResourceKey, errors?: ApiError[]): void {
-        assert.step(`commitWasRejected ${identifier.lid}`);
-        return super.commitWasRejected(identifier, errors);
+      override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
+        assert.step(`commitWasRejected ${key.lid}`);
+        return super.commitWasRejected(key, errors);
       }
     }
 
@@ -112,7 +112,7 @@ module('Integration - deleteRecord', function (hooks) {
     owner.register('model:user', User);
     const store = owner.lookup('service:store') as Store;
     const user = store.push({ data: { type: 'user', id: '1', attributes: { name: 'Chris' } } }) as User;
-    const identifier = recordIdentifierFor(user);
+    const key = recordIdentifierFor(user);
     assert.false(user.isSaving, 'The user is not saving');
     assert.false(user.isDeleted, 'The user is not deleted');
     assert.false(user.hasDirtyAttributes, 'The user is not dirty');
@@ -150,7 +150,7 @@ module('Integration - deleteRecord', function (hooks) {
     assert.true(user.isDeleted, 'The user is deleted');
     assert.false(user.isSaving, 'The user is no longer saving');
 
-    assert.verifySteps([`willCommit ${identifier.lid}`, 'handle deleteRecord request', `didCommit ${identifier.lid}`]);
+    assert.verifySteps([`willCommit ${key.lid}`, 'handle deleteRecord request', `didCommit ${key.lid}`]);
 
     const user2 = store.peekRecord('user', '2') as User;
     assert.notEqual(user2, null, 'The user is in the store');
@@ -162,9 +162,9 @@ module('Integration - deleteRecord', function (hooks) {
 
     // intercept cache APIs to ensure they are called as expected
     class TestCache extends JSONAPICache {
-      override willCommit(identifier: ResourceKey): void {
-        assert.step(`willCommit ${identifier.lid}`);
-        return super.willCommit(identifier, null);
+      override willCommit(key: ResourceKey): void {
+        assert.step(`willCommit ${key.lid}`);
+        return super.willCommit(key, null);
       }
       override didCommit(
         committedIdentifier: ResourceKey,
@@ -173,9 +173,9 @@ module('Integration - deleteRecord', function (hooks) {
         assert.step(`didCommit ${committedIdentifier.lid}`);
         return super.didCommit(committedIdentifier, result);
       }
-      override commitWasRejected(identifier: ResourceKey, errors?: ApiError[]): void {
-        assert.step(`commitWasRejected ${identifier.lid}`);
-        return super.commitWasRejected(identifier, errors);
+      override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
+        assert.step(`commitWasRejected ${key.lid}`);
+        return super.commitWasRejected(key, errors);
       }
     }
 
@@ -208,7 +208,7 @@ module('Integration - deleteRecord', function (hooks) {
     owner.register('model:user', User);
     const store = owner.lookup('service:store') as Store;
     const user = store.push({ data: { type: 'user', id: '1', attributes: { name: 'Chris' } } }) as User;
-    const identifier = recordIdentifierFor(user);
+    const key = recordIdentifierFor(user);
     assert.false(user.isSaving, 'The user is not saving');
     assert.false(user.isDeleted, 'The user is not deleted');
     assert.false(user.hasDirtyAttributes, 'The user is not dirty');
@@ -282,10 +282,6 @@ module('Integration - deleteRecord', function (hooks) {
     assert.true(user.isDeleted, 'The user is still deleted');
     assert.false(user.isSaving, 'The user is no longer saving');
 
-    assert.verifySteps([
-      `willCommit ${identifier.lid}`,
-      'handle deleteRecord request',
-      `commitWasRejected ${identifier.lid}`,
-    ]);
+    assert.verifySteps([`willCommit ${key.lid}`, 'handle deleteRecord request', `commitWasRejected ${key.lid}`]);
   });
 });

--- a/tests/builders/tests/integration/update-record-test.ts
+++ b/tests/builders/tests/integration/update-record-test.ts
@@ -32,8 +32,8 @@ class TestStore extends DataStore {
     return new JSONAPICache(capabilities);
   }
 
-  override instantiateRecord(identifier: ResourceKey, createRecordArgs: { [key: string]: unknown }): unknown {
-    return instantiateRecord.call(this, identifier, createRecordArgs);
+  override instantiateRecord(key: ResourceKey, createRecordArgs: { [key: string]: unknown }): unknown {
+    return instantiateRecord.call(this, key, createRecordArgs);
   }
 
   override teardownRecord(record: Model): void {
@@ -65,9 +65,9 @@ module('Integration - updateRecord', function (hooks) {
 
     // intercept cache APIs to ensure they are called as expected
     class TestCache extends JSONAPICache {
-      override willCommit(identifier: ResourceKey): void {
-        assert.step(`willCommit ${identifier.lid}`);
-        return super.willCommit(identifier, null);
+      override willCommit(key: ResourceKey): void {
+        assert.step(`willCommit ${key.lid}`);
+        return super.willCommit(key, null);
       }
       override didCommit(
         committedIdentifier: ResourceKey,
@@ -76,9 +76,9 @@ module('Integration - updateRecord', function (hooks) {
         assert.step(`didCommit ${committedIdentifier.lid}`);
         return super.didCommit(committedIdentifier, result);
       }
-      override commitWasRejected(identifier: ResourceKey, errors?: ApiError[]): void {
-        assert.step(`commitWasRejected ${identifier.lid}`);
-        return super.commitWasRejected(identifier, errors);
+      override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
+        assert.step(`commitWasRejected ${key.lid}`);
+        return super.commitWasRejected(key, errors);
       }
     }
 
@@ -112,7 +112,7 @@ module('Integration - updateRecord', function (hooks) {
     owner.register('model:user', User);
     const store = owner.lookup('service:store') as Store;
     const user = store.push({ data: { type: 'user', id: '1', attributes: { name: 'Chris' } } }) as User;
-    const identifier = recordIdentifierFor(user);
+    const key = recordIdentifierFor(user);
     assert.false(user.isSaving, 'The user is not saving');
     assert.false(user.isNew, 'The user is not new');
     assert.false(user.hasDirtyAttributes, 'The user is not dirty');
@@ -139,7 +139,7 @@ module('Integration - updateRecord', function (hooks) {
     assert.false(user.hasDirtyAttributes, 'The user is no longer dirty');
     assert.false(user.isSaving, 'The user is no longer saving');
 
-    assert.verifySteps([`willCommit ${identifier.lid}`, 'handle updateRecord request', `didCommit ${identifier.lid}`]);
+    assert.verifySteps([`willCommit ${key.lid}`, 'handle updateRecord request', `didCommit ${key.lid}`]);
   });
 
   test('Rejecting during Save of a new record with a createRecord op works as expected', async function (this: TestContext, assert) {
@@ -147,9 +147,9 @@ module('Integration - updateRecord', function (hooks) {
 
     // intercept cache APIs to ensure they are called as expected
     class TestCache extends JSONAPICache {
-      override willCommit(identifier: ResourceKey): void {
-        assert.step(`willCommit ${identifier.lid}`);
-        return super.willCommit(identifier, null);
+      override willCommit(key: ResourceKey): void {
+        assert.step(`willCommit ${key.lid}`);
+        return super.willCommit(key, null);
       }
       override didCommit(
         committedIdentifier: ResourceKey,
@@ -158,9 +158,9 @@ module('Integration - updateRecord', function (hooks) {
         assert.step(`didCommit ${committedIdentifier.lid}`);
         return super.didCommit(committedIdentifier, result);
       }
-      override commitWasRejected(identifier: ResourceKey, errors?: ApiError[]): void {
-        assert.step(`commitWasRejected ${identifier.lid}`);
-        return super.commitWasRejected(identifier, errors);
+      override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
+        assert.step(`commitWasRejected ${key.lid}`);
+        return super.commitWasRejected(key, errors);
       }
     }
 
@@ -194,7 +194,7 @@ module('Integration - updateRecord', function (hooks) {
     owner.register('model:user', User);
     const store = owner.lookup('service:store') as Store;
     const user = store.push({ data: { type: 'user', id: '1', attributes: { name: 'Chris' } } }) as User;
-    const identifier = recordIdentifierFor(user);
+    const key = recordIdentifierFor(user);
     assert.false(user.isSaving, 'The user is not saving');
     assert.false(user.isNew, 'The user is not new');
     assert.false(user.hasDirtyAttributes, 'The user is not dirty');
@@ -253,10 +253,6 @@ module('Integration - updateRecord', function (hooks) {
     assert.equal(nameErrors.length, 1, 'The user has the expected number of errors');
     assert.equal(nameErrors[0]?.message, 'Name must be capitalized', 'The user has the expected error for the field');
 
-    assert.verifySteps([
-      `willCommit ${identifier.lid}`,
-      'handle updateRecord request',
-      `commitWasRejected ${identifier.lid}`,
-    ]);
+    assert.verifySteps([`willCommit ${key.lid}`, 'handle updateRecord request', `commitWasRejected ${key.lid}`]);
   });
 });


### PR DESCRIPTION
TL;DR begin scrubbing "identifier" from the terminology except when used in the json-api sense