### PR TITLE
add missing comma to Warp Drive setup guide for Existing Ember Apps

### DIFF
--- a/guides/1-configuration/2-setup/1-universal.md
+++ b/guides/1-configuration/2-setup/1-universal.md
@@ -102,7 +102,7 @@ module.exports = async function (defaults) {
     // this should be the most recent <major>.<minor> version for
     // which all deprecations have been fully resolved
     // and should be updated when that changes
-    compatWith: '4.12'
+    compatWith: '4.12',
     deprecations: {
       // ... list individual deprecations that have been resolved here
     }


### PR DESCRIPTION
There was a comma that was missing while I was copying this into my project. So I added it.