### PR TITLE
Fix `[Checkout]` typing in documentation

### DIFF
--- a/packages/schema-record/README.md
+++ b/packages/schema-record/README.md
@@ -210,7 +210,7 @@ interface User {
   readonly lastName: string;
   readonly name: string;
   readonly pets: Readonly<Array<Dog | Pet>>;
-  [Checkout]: Promise<EditableUser>
+  [Checkout](): Promise<EditableUser>
 }>
 ```
 

--- a/packages/schema-record/src/index.ts
+++ b/packages/schema-record/src/index.ts
@@ -232,7 +232,7 @@
  *   readonly lastName: string;
  *   readonly name: string;
  *   readonly pets: Readonly<Array<Dog | Pet>>;
- *   [Checkout]: Promise<EditableUser>
+ *   [Checkout](): Promise<EditableUser>
  * }>
  * ```
  *

--- a/warp-drive-packages/core/src/reactive.ts
+++ b/warp-drive-packages/core/src/reactive.ts
@@ -171,7 +171,7 @@
  *   readonly lastName: string;
  *   readonly name: string;
  *   readonly pets: Readonly<Array<Dog | Pet>>;
- *   [Checkout]: Promise<EditableUser>
+ *   [Checkout](): Promise<EditableUser>
  * }>
  * ```
  *


### PR DESCRIPTION
While making some tests with warp-drive i have seen that in docs the typings are incorrect.

All the usages in ember-data code base tests are `[Checkout](): Promise<SchemaRecord>`, but docs are saying `[Checkout]: Promise<SchemaRecord>`

The issue in TS:
<img width="742" height="196" alt="grafik" src="https://github.com/user-attachments/assets/cda07354-7ce2-4fd1-b6f7-a1e639902da7" />
