### PR TITLE
feat: framework agnostic test helpers

### DIFF
--- a/packages/diagnostic/babel.config.mjs
+++ b/packages/diagnostic/babel.config.mjs
@@ -1,3 +1,5 @@
+import { macros } from '@warp-drive/core/build-config/babel-macros';
+
 export default {
   presets: [
     [
@@ -6,6 +8,7 @@ export default {
     ],
   ],
   plugins: [
+    ...macros(),
     [
       '@babel/plugin-transform-typescript',
       { allExtensions: true, isTSX: true, onlyRemoveTypeImports: true, allowDeclareFields: true },

--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warp-drive/diagnostic",
-  "version": "0.0.3-alpha.71",
+  "version": "0.0.3-alpha.70",
   "private": true,
   "description": "⚡️ A Lightweight Modern Test Runner",
   "keywords": [
@@ -98,6 +98,7 @@
     "debug": "^4.4.0",
     "tmp": "^0.2.3",
     "@warp-drive/core": "workspace:*",
+    "dom-element-descriptors": "^0.5.1",
     "qunit-dom": "^3.4.0"
   },
   "devDependencies": {

--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -98,6 +98,7 @@
     "debug": "^4.4.0",
     "tmp": "^0.2.3",
     "@warp-drive/core": "workspace:*",
+    "@embroider/macros": "^1.16.12",
     "dom-element-descriptors": "^0.5.1",
     "qunit-dom": "^3.4.0"
   },

--- a/packages/diagnostic/src/ember.ts
+++ b/packages/diagnostic/src/ember.ts
@@ -91,7 +91,6 @@ export function setupTest<TC extends TestContext>(hooks: Hooks<TC>, opts?: Setup
     Object.defineProperty(this, 'h', {
       configurable: true,
       enumerable: true,
-      writable: false,
       get() {
         if (!helpers) {
           helpers = buildHelpers(this, {
@@ -191,7 +190,6 @@ export function setupRenderingTest<TC extends TestContext>(hooks: Hooks<TC>, opt
     Object.defineProperty(this, 'h', {
       configurable: true,
       enumerable: true,
-      writable: false,
       get() {
         if (!helpers) {
           helpers = buildHelpers(this, {

--- a/packages/diagnostic/src/helpers/-dom/-get-description.ts
+++ b/packages/diagnostic/src/helpers/-dom/-get-description.ts
@@ -1,0 +1,20 @@
+import { isDescriptor, lookupDescriptorData } from 'dom-element-descriptors';
+
+import type { Target } from './-target';
+
+/**
+  Used internally by the DOM interaction helpers to get a description of a
+  target for debug/error messaging.
+
+  @private
+  @param {Target} target the target
+  @returns {string} a description of the target
+*/
+export default function getDescription(target: Target): string {
+  const data = isDescriptor(target) ? lookupDescriptorData(target) : null;
+  if (data) {
+    return data.description || '<unknown descriptor>';
+  } else {
+    return `${String(target)}`;
+  }
+}

--- a/packages/diagnostic/src/helpers/-dom/-get-element.ts
+++ b/packages/diagnostic/src/helpers/-dom/-get-element.ts
@@ -1,0 +1,41 @@
+import { type IDOMElementDescriptor, lookupDescriptorData, resolveDOMElement } from 'dom-element-descriptors';
+
+import { isDocument, isElement, type Target } from './-target.ts';
+
+function getElement<K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)>(
+  target: K,
+  rootElement: HTMLElement
+): (HTMLElementTagNameMap[K] | SVGElementTagNameMap[K]) | null;
+function getElement<K extends keyof HTMLElementTagNameMap>(
+  target: K,
+  rootElement: HTMLElement
+): HTMLElementTagNameMap[K] | null;
+function getElement<K extends keyof SVGElementTagNameMap>(
+  target: K,
+  rootElement: HTMLElement
+): SVGElementTagNameMap[K] | null;
+function getElement(target: string, rootElement: HTMLElement): Element | null;
+function getElement(target: Element, rootElement: HTMLElement): Element;
+function getElement(target: IDOMElementDescriptor, rootElement: HTMLElement): Element | null;
+function getElement(target: Document, rootElement: HTMLElement): Document;
+function getElement(target: Window, rootElement: HTMLElement): Document;
+function getElement(target: string | IDOMElementDescriptor, rootElement: HTMLElement): Element | null;
+function getElement(target: Target, rootElement: HTMLElement): Element | Document | null;
+function getElement(target: Target, rootElement: HTMLElement): Element | Document | null {
+  if (typeof target === 'string') {
+    return rootElement.querySelector(target);
+  } else if (isElement(target) || isDocument(target)) {
+    return target;
+  } else if (target instanceof Window) {
+    return target.document;
+  } else {
+    const descriptorData = lookupDescriptorData(target);
+    if (descriptorData) {
+      return resolveDOMElement(descriptorData);
+    } else {
+      throw new Error('Must use an element, selector string, or DOM element descriptor');
+    }
+  }
+}
+
+export { getElement };

--- a/packages/diagnostic/src/helpers/-dom/-get-elements.ts
+++ b/packages/diagnostic/src/helpers/-dom/-get-elements.ts
@@ -1,0 +1,29 @@
+import { type IDOMElementDescriptor, lookupDescriptorData, resolveDOMElements } from 'dom-element-descriptors';
+
+function getElements(target: string, rootElement: HTMLElement): NodeListOf<Element>;
+function getElements(target: IDOMElementDescriptor, rootElement: HTMLElement): Iterable<Element>;
+function getElements(target: string | IDOMElementDescriptor, rootElement: HTMLElement): Iterable<Element>;
+/**
+  Used internally by the DOM interaction helpers to find multiple elements.
+
+  @private
+  @param {string} target the selector to retrieve
+  @returns {NodeList} the matched elements
+*/
+function getElements(
+  target: string | IDOMElementDescriptor,
+  rootElement: HTMLElement
+): NodeListOf<Element> | Iterable<Element> {
+  if (typeof target === 'string') {
+    return rootElement.querySelectorAll(target);
+  } else {
+    const descriptorData = lookupDescriptorData(target);
+    if (descriptorData) {
+      return resolveDOMElements(descriptorData);
+    } else {
+      throw new Error('Must use a selector string or DOM element descriptor');
+    }
+  }
+}
+
+export default getElements;

--- a/packages/diagnostic/src/helpers/-dom/-get-window-or-element.ts
+++ b/packages/diagnostic/src/helpers/-dom/-get-window-or-element.ts
@@ -1,0 +1,16 @@
+import { getElement } from './-get-element.ts';
+import { isWindow, type Target } from './-target.ts';
+
+/**
+  Used internally by the DOM interaction helpers to find either window or an element.
+
+  @private
+  @param target the window, an element or selector to retrieve
+*/
+export function getWindowOrElement(target: Target, rootElement: HTMLElement): Element | Document | Window | null {
+  if (isWindow(target)) {
+    return target;
+  }
+
+  return getElement(target, rootElement);
+}

--- a/packages/diagnostic/src/helpers/-dom/-guard-for-maxlength.ts
+++ b/packages/diagnostic/src/helpers/-dom/-guard-for-maxlength.ts
@@ -1,0 +1,31 @@
+import type { FormControl } from './-is-form-control';
+
+// ref: https://html.spec.whatwg.org/multipage/input.html#concept-input-apply
+const constrainedInputTypes = ['text', 'search', 'url', 'tel', 'email', 'password'];
+
+/**
+  @private
+  @param {Element} element - the element to check
+  @returns {boolean} `true` when the element should constrain input by the maxlength attribute, `false` otherwise
+*/
+function isMaxLengthConstrained(element: Element): element is HTMLInputElement | HTMLTextAreaElement {
+  return (
+    !!Number(element.getAttribute('maxlength')) &&
+    (element instanceof HTMLTextAreaElement ||
+      (element instanceof HTMLInputElement && constrainedInputTypes.includes(element.type)))
+  );
+}
+
+/**
+ * @private
+ * @param {Element} element - the element to check
+ * @param {string} text - the text being added to element
+ * @param {string} testHelper - the test helper context the guard is called from (for Error message)
+ * @throws if `element` has `maxlength` & `value` exceeds `maxlength`
+ */
+export default function guardForMaxlength(element: FormControl, text: string, testHelper: string): void {
+  const maxlength = element.getAttribute('maxlength');
+  if (isMaxLengthConstrained(element) && maxlength && text && text.length > Number(maxlength)) {
+    throw new Error(`Can not \`${testHelper}\` with text: '${text}' that exceeds maxlength: '${maxlength}'.`);
+  }
+}

--- a/packages/diagnostic/src/helpers/-dom/-helper-context.ts
+++ b/packages/diagnostic/src/helpers/-dom/-helper-context.ts
@@ -1,0 +1,28 @@
+/**
+ * The public API for the test context, which test authors can depend on being
+ * available.
+ *
+ * Note: this is *not* user-constructible; it becomes available by calling
+ * `setupContext()` with a base context object.
+ */
+export interface HelperContext {
+  element: HTMLElement | null;
+  config: HelperConfig;
+}
+
+export interface HelperConfig {
+  render<T>(fn: () => T): Promise<Awaited<T>>;
+  rerender: () => Promise<void>;
+  settled: () => Promise<void>;
+}
+
+export function assertRenderContext<T>(context: T): asserts context is T & { element: HTMLElement } {
+  const element = (
+    context as {
+      element?: HTMLElement | null;
+    }
+  ).element;
+  if (!element || !(element instanceof HTMLElement)) {
+    throw new Error('[TestHelper Error] No `element` was provided on the test context.');
+  }
+}

--- a/packages/diagnostic/src/helpers/-dom/-is-focusable.ts
+++ b/packages/diagnostic/src/helpers/-dom/-is-focusable.ts
@@ -1,0 +1,39 @@
+import isFormControl from './-is-form-control.ts';
+import { isContentEditable, isDocument, isWindow } from './-target.ts';
+
+// For reference:
+// https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute
+const FOCUSABLE_TAGS = ['A', 'SUMMARY'];
+
+type FocusableElement = HTMLAnchorElement;
+
+function isFocusableElement(element: Element): element is FocusableElement {
+  return FOCUSABLE_TAGS.includes(element.tagName);
+}
+
+/**
+  @private
+  @param {Element} element the element to check
+  @returns {boolean} `true` when the element is focusable, `false` otherwise
+*/
+export default function isFocusable(
+  element: HTMLElement | SVGElement | Element | Document | Window
+): element is HTMLElement | SVGElement {
+  if (isWindow(element)) {
+    return false;
+  }
+
+  if (isDocument(element)) {
+    return false;
+  }
+
+  if (isFormControl(element)) {
+    return !element.disabled;
+  }
+
+  if (isContentEditable(element) || isFocusableElement(element)) {
+    return true;
+  }
+
+  return element.hasAttribute('tabindex');
+}

--- a/packages/diagnostic/src/helpers/-dom/-is-form-control.ts
+++ b/packages/diagnostic/src/helpers/-dom/-is-form-control.ts
@@ -1,0 +1,19 @@
+import { isDocument, isWindow } from './-target.ts';
+
+const FORM_CONTROL_TAGS = ['INPUT', 'BUTTON', 'SELECT', 'TEXTAREA'];
+
+export type FormControl = HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement;
+
+/**
+  @private
+  @param {Element} element the element to check
+  @returns {boolean} `true` when the element is a form control, `false` otherwise
+*/
+export default function isFormControl(element: Element | Document | Window): element is FormControl {
+  return (
+    !isWindow(element) &&
+    !isDocument(element) &&
+    FORM_CONTROL_TAGS.includes(element.tagName) &&
+    (element as HTMLInputElement).type !== 'hidden'
+  );
+}

--- a/packages/diagnostic/src/helpers/-dom/-is-select-element.ts
+++ b/packages/diagnostic/src/helpers/-dom/-is-select-element.ts
@@ -1,0 +1,10 @@
+import { isDocument } from './-target.ts';
+
+/**
+  @private
+  @param {Element} element the element to check
+  @returns {boolean} `true` when the element is a select element, `false` otherwise
+*/
+export default function isSelectElement(element: Element | Document): element is HTMLSelectElement {
+  return !isDocument(element) && element.tagName === 'SELECT';
+}

--- a/packages/diagnostic/src/helpers/-dom/-target.ts
+++ b/packages/diagnostic/src/helpers/-dom/-target.ts
@@ -1,0 +1,23 @@
+import type { IDOMElementDescriptor } from 'dom-element-descriptors';
+
+export type Target = string | Element | IDOMElementDescriptor | Document | Window;
+
+export interface HTMLElementContentEditable extends HTMLElement {
+  isContentEditable: true;
+}
+
+export function isElement(target: unknown): target is Element {
+  return target !== null && typeof target === 'object' && Reflect.get(target, 'nodeType') === Node.ELEMENT_NODE;
+}
+
+export function isWindow(target: Target): target is Window {
+  return target instanceof Window;
+}
+
+export function isDocument(target: unknown): target is Document {
+  return target !== null && typeof target === 'object' && Reflect.get(target, 'nodeType') === Node.DOCUMENT_NODE;
+}
+
+export function isContentEditable(element: Element): element is HTMLElementContentEditable {
+  return 'isContentEditable' in element && (element as HTMLElement).isContentEditable;
+}

--- a/packages/diagnostic/src/helpers/-dom/-to-array.ts
+++ b/packages/diagnostic/src/helpers/-dom/-to-array.ts
@@ -1,0 +1,13 @@
+/**
+  @private
+  @param {NodeList} nodelist the nodelist to convert to an array
+  @returns {Array} an array
+*/
+export default function toArray<T extends Node>(nodelist: NodeListOf<T>): T[] {
+  const array = new Array(nodelist.length) as T[];
+  for (let i = 0; i < nodelist.length; i++) {
+    array[i] = nodelist[i];
+  }
+
+  return array;
+}

--- a/packages/diagnostic/src/helpers/-dom/-utils.ts
+++ b/packages/diagnostic/src/helpers/-dom/-utils.ts
@@ -1,0 +1,43 @@
+/* globals Promise */
+
+import isFormControl from './-is-form-control.ts';
+
+export const nextTick = (cb: () => void): Promise<void> => Promise.resolve().then(cb);
+export const futureTick: typeof setTimeout = setTimeout;
+
+/**
+ Returns whether the passed in string consists only of numeric characters.
+
+ @private
+ @param {string} n input string
+ @returns {boolean} whether the input string consists only of numeric characters
+ */
+export function isNumeric(n: string): boolean {
+  return !isNaN(parseFloat(n)) && isFinite(Number(n));
+}
+
+/**
+  Checks if an element is considered visible by the focus area spec.
+
+  @private
+  @param {Element} element the element to check
+  @returns {boolean} `true` when the element is visible, `false` otherwise
+*/
+export function isVisible(element: Element): boolean {
+  const styles = window.getComputedStyle(element);
+  return styles.display !== 'none' && styles.visibility !== 'hidden';
+}
+
+/**
+  Checks if an element is disabled.
+
+  @private
+  @param {Element} element the element to check
+  @returns {boolean} `true` when the element is disabled, `false` otherwise
+*/
+export function isDisabled(element: HTMLElement): boolean {
+  if (isFormControl(element)) {
+    return (element as HTMLInputElement).disabled;
+  }
+  return false;
+}

--- a/packages/diagnostic/src/helpers/-dom/blur.ts
+++ b/packages/diagnostic/src/helpers/-dom/blur.ts
@@ -1,0 +1,89 @@
+import getDescription from './-get-description.ts';
+import { getElement } from './-get-element.ts';
+import { assertRenderContext, type HelperContext } from './-helper-context.ts';
+import isFocusable from './-is-focusable.ts';
+import type { Target } from './-target.ts';
+import { fireEvent } from './fire-event.ts';
+import { withHooks } from './helper-hooks.ts';
+
+/**
+  @private
+  @param {Element} element the element to trigger events on
+  @param {Element} relatedTarget the element that is focused after blur
+  @return {Promise<Event | void>} resolves when settled
+*/
+export function __blur__(
+  scope: HelperContext,
+  element: HTMLElement | Element | Document | SVGElement,
+  relatedTarget: HTMLElement | Element | Document | SVGElement | null = null
+): Promise<void> {
+  if (!isFocusable(element)) {
+    throw new Error(`${String(element)} is not focusable`);
+  }
+
+  const browserIsNotFocused = document.hasFocus && !document.hasFocus();
+  const needsCustomEventOptions = relatedTarget !== null;
+
+  if (!needsCustomEventOptions) {
+    // makes `document.activeElement` be `body`.
+    // If the browser is focused, it also fires a blur event
+    element.blur();
+  }
+
+  // Chrome/Firefox does not trigger the `blur` event if the window
+  // does not have focus. If the document does not have focus then
+  // fire `blur` event via native event.
+  const options = { relatedTarget };
+  return browserIsNotFocused || needsCustomEventOptions
+    ? Promise.resolve()
+        .then(() => fireEvent(scope, element, 'blur', { bubbles: false, ...options }))
+        .then(() => fireEvent(scope, element, 'focusout', options))
+        .then(() => {
+          return;
+        }) // avoid leaking fireEvent return value
+    : Promise.resolve();
+}
+
+/**
+  Unfocus the specified target.
+
+  Sends a number of events intending to simulate a "real" user unfocusing an
+  element.
+
+  The following events are triggered (in order):
+
+  - `blur`
+  - `focusout`
+
+  The exact listing of events that are triggered may change over time as needed
+  to continue to emulate how actual browsers handle unfocusing a given element.
+
+  @public
+  @param {string|Element|IDOMElementDescriptor} [target=document.activeElement] the element, selector, or descriptor to unfocus
+  @return {Promise<void>} resolves when settled
+
+  @example
+  <caption>
+    Emulating blurring an input using `blur`
+  </caption>
+
+  blur('input');
+*/
+export function blur<T extends HelperContext>(this: T, target: Target = document.activeElement!): Promise<void> {
+  return withHooks({
+    scope: this,
+    name: 'blur',
+    render: true,
+    args: [target],
+    cb: () => {
+      assertRenderContext(this);
+      const element = getElement(target, this.element);
+      if (!element) {
+        const description = getDescription(target);
+        throw new Error(`Element not found when calling \`blur('${description}')\`.`);
+      }
+
+      return __blur__(this, element);
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/click.ts
+++ b/packages/diagnostic/src/helpers/-dom/click.ts
@@ -1,0 +1,121 @@
+import getDescription from './-get-description.ts';
+import { getWindowOrElement } from './-get-window-or-element.ts';
+import type { HelperContext } from './-helper-context.ts';
+import { assertRenderContext } from './-helper-context.ts';
+import isFormControl from './-is-form-control.ts';
+import { isWindow, type Target } from './-target.ts';
+import { fireEvent } from './fire-event.ts';
+import { __focus__ } from './focus.ts';
+import { withHooks } from './helper-hooks.ts';
+
+const PRIMARY_BUTTON = 1 as const;
+const MAIN_BUTTON_PRESSED = 0 as const;
+
+/**
+ * Represent a particular mouse button being clicked.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons for available options.
+ */
+export const DEFAULT_CLICK_OPTIONS: {
+  readonly buttons: 1;
+  readonly button: 0;
+} = {
+  buttons: PRIMARY_BUTTON,
+  button: MAIN_BUTTON_PRESSED,
+} as const;
+
+/**
+  @private
+  @param {Element} element the element to click on
+  @param {MouseEventInit} options the options to be merged into the mouse events
+  @return {Promise<Event | void>} resolves when settled
+*/
+export function __click__(
+  scope: HelperContext,
+  element: Element | Document | Window,
+  options: MouseEventInit
+): Promise<void> {
+  return Promise.resolve()
+    .then(() => fireEvent(scope, element, 'mousedown', options))
+    .then((mouseDownEvent) =>
+      !isWindow(element) && !mouseDownEvent?.defaultPrevented ? __focus__(scope, element) : Promise.resolve()
+    )
+    .then(() => fireEvent(scope, element, 'mouseup', options))
+    .then(() => fireEvent(scope, element, 'click', options))
+    .then(() => {
+      return;
+    }); // avoid leaking fireEvent return value;
+}
+
+/**
+  Clicks on the specified target.
+
+  Sends a number of events intending to simulate a "real" user clicking on an
+  element.
+
+  For non-focusable elements the following events are triggered (in order):
+
+  - `mousedown`
+  - `mouseup`
+  - `click`
+
+  For focusable (e.g. form control) elements the following events are triggered
+  (in order):
+
+  - `mousedown`
+  - `focus`
+  - `focusin`
+  - `mouseup`
+  - `click`
+
+  The exact listing of events that are triggered may change over time as needed
+  to continue to emulate how actual browsers handle clicking a given element.
+
+  Use the `options` hash to change the parameters of the [MouseEvents](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent).
+  You can use this to specify modifier keys as well.
+
+  @public
+  @param {string|Element|IDOMElementDescriptor} target the element, selector, or descriptor to click on
+  @param {MouseEventInit} _options the options to be merged into the mouse events.
+  @return {Promise<void>} resolves when settled
+
+  @example
+  <caption>
+    Emulating clicking a button using `click`
+  </caption>
+  click('button');
+
+  @example
+  <caption>
+    Emulating clicking a button and pressing the `shift` key simultaneously using `click` with `options`.
+  </caption>
+
+  click('button', { shiftKey: true });
+*/
+export function click<T extends HelperContext>(this: T, target: Target, _options: MouseEventInit = {}): Promise<void> {
+  const options = { ...DEFAULT_CLICK_OPTIONS, ..._options };
+
+  return withHooks({
+    scope: this,
+    name: 'click',
+    render: true,
+    args: [target, options],
+    cb: () => {
+      if (!target) {
+        throw new Error('Must pass an element, selector, or descriptor to `click`.');
+      }
+
+      assertRenderContext(this);
+      const element = getWindowOrElement(target, this.element);
+      if (!element) {
+        const description = getDescription(target);
+        throw new Error(`Element not found when calling \`click('${description}')\`.`);
+      }
+
+      if (isFormControl(element) && element.disabled) {
+        throw new Error(`Can not \`click\` disabled ${String(element)}`);
+      }
+
+      return __click__(this, element, options);
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/double-click.ts
+++ b/packages/diagnostic/src/helpers/-dom/double-click.ts
@@ -1,0 +1,123 @@
+import getDescription from './-get-description.ts';
+import { getWindowOrElement } from './-get-window-or-element.ts';
+import type { HelperContext } from './-helper-context.ts';
+import { assertRenderContext } from './-helper-context.ts';
+import isFormControl from './-is-form-control.ts';
+import { isWindow, type Target } from './-target.ts';
+import { DEFAULT_CLICK_OPTIONS } from './click.ts';
+import { fireEvent } from './fire-event.ts';
+import { __focus__ } from './focus.ts';
+import { withHooks } from './helper-hooks.ts';
+
+/**
+  @private
+  @param {Element} element the element to double-click on
+  @param {MouseEventInit} options the options to be merged into the mouse events
+  @returns {Promise<void>} resolves when settled
+*/
+export function __doubleClick__(
+  scope: HelperContext,
+  element: Element | Document | Window,
+  options: MouseEventInit
+): Promise<void> {
+  return Promise.resolve()
+    .then(() => fireEvent(scope, element, 'mousedown', options))
+    .then((mouseDownEvent) => {
+      return !isWindow(element) && !mouseDownEvent?.defaultPrevented ? __focus__(scope, element) : Promise.resolve();
+    })
+    .then(() => fireEvent(scope, element, 'mouseup', options))
+    .then(() => fireEvent(scope, element, 'click', options))
+    .then(() => fireEvent(scope, element, 'mousedown', options))
+    .then(() => fireEvent(scope, element, 'mouseup', options))
+    .then(() => fireEvent(scope, element, 'click', options))
+    .then(() => fireEvent(scope, element, 'dblclick', options))
+    .then(() => {
+      return;
+    }); // avoid leaking fireEvent return value;
+}
+
+/**
+  Double-clicks on the specified target.
+
+  Sends a number of events intending to simulate a "real" user clicking on an
+  element.
+
+  For non-focusable elements the following events are triggered (in order):
+
+  - `mousedown`
+  - `mouseup`
+  - `click`
+  - `mousedown`
+  - `mouseup`
+  - `click`
+  - `dblclick`
+
+  For focusable (e.g. form control) elements the following events are triggered
+  (in order):
+
+  - `mousedown`
+  - `focus`
+  - `focusin`
+  - `mouseup`
+  - `click`
+  - `mousedown`
+  - `mouseup`
+  - `click`
+  - `dblclick`
+
+  The exact listing of events that are triggered may change over time as needed
+  to continue to emulate how actual browsers handle clicking a given element.
+
+  Use the `options` hash to change the parameters of the [MouseEvents](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent).
+
+  @public
+  @param {string|Element|IDOMElementDescriptor} target the element, selector, or descriptor to double-click on
+  @param {MouseEventInit} _options the options to be merged into the mouse events
+  @return {Promise<void>} resolves when settled
+
+  @example
+  <caption>
+    Emulating double clicking a button using `doubleClick`
+  </caption>
+
+  doubleClick('button');
+
+  @example
+  <caption>
+    Emulating double clicking a button and pressing the `shift` key simultaneously using `click` with `options`.
+  </caption>
+
+  doubleClick('button', { shiftKey: true });
+*/
+export function doubleClick<T extends HelperContext>(
+  this: T,
+  target: Target,
+  _options: MouseEventInit = {}
+): Promise<void> {
+  const options = { ...DEFAULT_CLICK_OPTIONS, ..._options };
+
+  return withHooks({
+    scope: this,
+    name: 'doubleClick',
+    render: true,
+    args: [target, _options],
+    cb: () => {
+      if (!target) {
+        throw new Error('Must pass an element, selector, or descriptor to `doubleClick`.');
+      }
+
+      assertRenderContext(this);
+      const element = getWindowOrElement(target, this.element);
+      if (!element) {
+        const description = getDescription(target);
+        throw new Error(`Element not found when calling \`doubleClick('${description}')\`.`);
+      }
+
+      if (isFormControl(element) && element.disabled) {
+        throw new Error(`Can not \`doubleClick\` disabled ${String(element)}`);
+      }
+
+      return __doubleClick__(this, element, options);
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/fill-in.ts
+++ b/packages/diagnostic/src/helpers/-dom/fill-in.ts
@@ -1,0 +1,75 @@
+import getDescription from './-get-description.ts';
+import { getElement } from './-get-element.ts';
+import guardForMaxlength from './-guard-for-maxlength.ts';
+import type { HelperContext } from './-helper-context.ts';
+import { assertRenderContext } from './-helper-context.ts';
+import isFormControl, { type FormControl } from './-is-form-control.ts';
+import { isContentEditable, type Target } from './-target.ts';
+import { fireEvent } from './fire-event.ts';
+import { __focus__ } from './focus.ts';
+import { withHooks } from './helper-hooks.ts';
+
+/**
+  Fill the provided text into the `value` property (or set `.innerHTML` when
+  the target is a content editable element) then trigger `change` and `input`
+  events on the specified target.
+
+  @public
+  @param {string|Element|IDOMElementDescriptor} target the element, selector, or descriptor to enter text into
+  @param {string} text the text to fill into the target element
+  @return {Promise<void>} resolves when the application is settled
+
+  @example
+  <caption>
+    Emulating filling an input with text using `fillIn`
+  </caption>
+
+  fillIn('input', 'hello world');
+*/
+export function fillIn<T extends HelperContext>(this: T, target: Target, text: string): Promise<void> {
+  return withHooks({
+    scope: this,
+    name: 'fillIn',
+    render: true,
+    args: [target, text],
+    cb: async () => {
+      if (!target) {
+        throw new Error('Must pass an element, selector, or descriptor to `fillIn`.');
+      }
+
+      assertRenderContext(this);
+      const element = getElement(target, this.element) as Element | HTMLElement;
+      if (!element) {
+        const description = getDescription(target);
+        throw new Error(`Element not found when calling \`fillIn('${description}')\`.`);
+      }
+
+      if (typeof text === 'undefined' || text === null) {
+        throw new Error('Must provide `text` when calling `fillIn`.');
+      }
+
+      if (isFormControl(element)) {
+        if (element.disabled) {
+          throw new Error(`Can not \`fillIn\` disabled '${getDescription(target)}'.`);
+        }
+
+        if ('readOnly' in element && element.readOnly) {
+          throw new Error(`Can not \`fillIn\` readonly '${getDescription(target)}'.`);
+        }
+
+        guardForMaxlength(element, text, 'fillIn');
+
+        await __focus__(this, element);
+        (element as FormControl).value = text;
+      } else if (isContentEditable(element)) {
+        await __focus__(this, element);
+        element.innerHTML = text;
+      } else {
+        throw new Error('`fillIn` is only usable on form controls or contenteditable elements.');
+      }
+
+      await fireEvent(this, element, 'input');
+      await fireEvent(this, element, 'change');
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/find-all.ts
+++ b/packages/diagnostic/src/helpers/-dom/find-all.ts
@@ -1,0 +1,41 @@
+import getElements from './-get-elements.ts';
+import type { HelperContext } from './-helper-context.ts';
+import { assertRenderContext } from './-helper-context.ts';
+
+// Derived, with modification, from the types for `querySelectorAll`. These
+// would simply be defined as a tweaked re-export as `querySelector` is, but it
+// is non-trivial (to say the least!) to preserve overloads like this while also
+// changing the return type (from `NodeListOf` to `Array`).
+export function findAll<K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)>(
+  selector: K
+): Array<HTMLElementTagNameMap[K] | SVGElementTagNameMap[K]>;
+export function findAll<K extends keyof HTMLElementTagNameMap>(selector: K): Array<HTMLElementTagNameMap[K]>;
+export function findAll<K extends keyof SVGElementTagNameMap>(selector: K): Array<SVGElementTagNameMap[K]>;
+export function findAll(selector: string): Element[];
+/**
+  Find all elements matched by the given selector. Similar to calling
+  `querySelectorAll()` on the test root element, but returns an array instead
+  of a `NodeList`.
+
+  @public
+  @param {string} selector the selector to search for
+  @return {Array} array of matched elements
+
+  @example
+  <caption>
+    Find all of the elements matching '.my-selector'.
+  </caption>
+  findAll('.my-selector');
+*/
+export function findAll<T extends HelperContext>(this: T, selector: string): Element[] {
+  if (!selector) {
+    throw new Error('Must pass a selector to `findAll`.');
+  }
+
+  if (arguments.length > 1) {
+    throw new Error('The `findAll` test helper only takes a single argument.');
+  }
+
+  assertRenderContext(this);
+  return Array.from(getElements(selector, this.element));
+}

--- a/packages/diagnostic/src/helpers/-dom/find.ts
+++ b/packages/diagnostic/src/helpers/-dom/find.ts
@@ -1,0 +1,37 @@
+import { getElement } from './-get-element.ts';
+import type { HelperContext } from './-helper-context.ts';
+import { assertRenderContext } from './-helper-context.ts';
+
+// Derived from `querySelector` types.
+export function find<K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)>(
+  selector: K
+): HTMLElementTagNameMap[K] | SVGElementTagNameMap[K] | null;
+export function find<K extends keyof HTMLElementTagNameMap>(selector: K): HTMLElementTagNameMap[K] | null;
+export function find<K extends keyof SVGElementTagNameMap>(selector: K): SVGElementTagNameMap[K] | null;
+export function find(selector: string): Element | null;
+/**
+  Find the first element matched by the given selector. Equivalent to calling
+  `querySelector()` on the test root element.
+
+  @public
+  @param {string} selector the selector to search for
+  @return {Element | null} matched element or null
+
+  @example
+  <caption>
+    Finding the first element with id 'foo'
+  </caption>
+  find('#foo');
+*/
+export function find<T extends HelperContext>(this: T, selector: string): Element | null {
+  if (!selector) {
+    throw new Error('Must pass a selector to `find`.');
+  }
+
+  if (arguments.length > 1) {
+    throw new Error('The `find` test helper only takes a single argument.');
+  }
+
+  assertRenderContext(this);
+  return getElement(selector, this.element);
+}

--- a/packages/diagnostic/src/helpers/-dom/fire-event.ts
+++ b/packages/diagnostic/src/helpers/-dom/fire-event.ts
@@ -1,0 +1,344 @@
+import type { HelperContext } from './-helper-context.ts';
+import { isDocument, isElement } from './-target.ts';
+import { withHooks } from './helper-hooks.ts';
+
+const MOUSE_EVENT_CONSTRUCTOR = (() => {
+  try {
+    new MouseEvent('test');
+    return true;
+  } catch {
+    return false;
+  }
+})();
+const DEFAULT_EVENT_OPTIONS = { bubbles: true, cancelable: true };
+
+export const KEYBOARD_EVENT_TYPES = ['keydown', 'keypress', 'keyup'] as const;
+export type KeyboardEventType = (typeof KEYBOARD_EVENT_TYPES)[number];
+
+export function isKeyboardEventType(eventType: unknown): eventType is KeyboardEventType {
+  return KEYBOARD_EVENT_TYPES.includes(eventType as KeyboardEventType);
+}
+
+const MOUSE_EVENT_TYPES = [
+  'click',
+  'mousedown',
+  'mouseup',
+  'dblclick',
+  'mouseenter',
+  'mouseleave',
+  'mousemove',
+  'mouseout',
+  'mouseover',
+] as const;
+export type MouseEventType = (typeof MOUSE_EVENT_TYPES)[number];
+
+export function isMouseEventType(eventType: unknown): eventType is MouseEventType {
+  return MOUSE_EVENT_TYPES.includes(eventType as MouseEventType);
+}
+
+const FILE_SELECTION_EVENT_TYPES = ['change'] as const;
+export type FileSelectionEventType = (typeof FILE_SELECTION_EVENT_TYPES)[number];
+
+export function isFileSelectionEventType(eventType: unknown): eventType is FileSelectionEventType {
+  return FILE_SELECTION_EVENT_TYPES.includes(eventType as FileSelectionEventType);
+}
+
+export function isFileSelectionInput(element: unknown): element is HTMLInputElement {
+  return !!(element as HTMLInputElement).files;
+}
+
+export function fireEvent(
+  scope: HelperContext,
+  element: Element | Document | Window,
+  eventType: KeyboardEventType,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options?: any
+): Promise<Event>;
+export function fireEvent(
+  scope: HelperContext,
+  element: Element | Document | Window,
+  eventType: MouseEventType,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options?: any
+): Promise<Event | void>;
+
+export function fireEvent(
+  scope: HelperContext,
+  element: Element | Document | Window,
+  eventType: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options?: any
+): Promise<Event>;
+/**
+  Internal helper used to build and dispatch events throughout the other DOM helpers.
+
+  @private
+  @param {Element} element the element to dispatch the event to
+  @param {string} eventType the type of event
+  @param {Object} [options] additional properties to be set on the event
+  @returns {Event} the event that was dispatched
+*/
+export function fireEvent(
+  scope: HelperContext,
+  element: Element | Document | Window,
+  eventType: string,
+  options = {}
+): Promise<Event | void> {
+  return withHooks({
+    scope,
+    name: `fireEvent:${eventType}`,
+    render: false,
+    args: [element],
+    cb: () => {
+      if (!element) {
+        throw new Error('Must pass an element to `fireEvent`');
+      }
+
+      let event;
+      if (isKeyboardEventType(eventType)) {
+        event = _buildKeyboardEvent(eventType, options);
+      } else if (isMouseEventType(eventType)) {
+        let rect;
+        if (element instanceof Window && element.document.documentElement) {
+          rect = element.document.documentElement.getBoundingClientRect();
+        } else if (isDocument(element)) {
+          rect = element.documentElement.getBoundingClientRect();
+        } else if (isElement(element)) {
+          rect = element.getBoundingClientRect();
+        } else {
+          return;
+        }
+
+        const x = rect.left + 1;
+        const y = rect.top + 1;
+        const simulatedCoordinates = {
+          screenX: x + 5, // Those numbers don't really mean anything.
+          screenY: y + 95, // They're just to make the screenX/Y be different of clientX/Y..
+          clientX: x,
+          clientY: y,
+          ...options,
+        };
+
+        event = buildMouseEvent(eventType, simulatedCoordinates);
+      } else if (isFileSelectionEventType(eventType) && isFileSelectionInput(element)) {
+        event = buildFileEvent(eventType, element, options);
+      } else {
+        event = buildBasicEvent(eventType, options);
+      }
+
+      element.dispatchEvent(event);
+      return event;
+    },
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildBasicEvent(type: string, options: any = {}): Event {
+  const event = document.createEvent('Events');
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+  const bubbles = options.bubbles !== undefined ? options.bubbles : true;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+  const cancelable = options.cancelable !== undefined ? options.cancelable : true;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  delete options.bubbles;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  delete options.cancelable;
+
+  // bubbles and cancelable are readonly, so they can be
+  // set when initializing event
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  event.initEvent(type, bubbles, cancelable);
+  for (const prop in options) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    (event as any)[prop] = options[prop];
+  }
+  return event;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildMouseEvent(type: MouseEventType, options: any = {}) {
+  let event;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  const eventOpts: any = { view: window, ...DEFAULT_EVENT_OPTIONS, ...options };
+  if (MOUSE_EVENT_CONSTRUCTOR) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    event = new MouseEvent(type, eventOpts);
+  } else {
+    try {
+      event = document.createEvent('MouseEvents');
+      event.initMouseEvent(
+        type,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.bubbles,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.cancelable,
+        window,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.detail,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.screenX,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.screenY,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.clientX,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.clientY,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.ctrlKey,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.altKey,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.shiftKey,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.metaKey,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.button,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        eventOpts.relatedTarget
+      );
+    } catch {
+      event = buildBasicEvent(type, options);
+    }
+  }
+
+  return event;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function _buildKeyboardEvent(type: KeyboardEventType, options: any = {}): Event {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  const eventOpts: any = { ...DEFAULT_EVENT_OPTIONS, ...options };
+  let event: Event | undefined;
+  let eventMethodName: 'initKeyboardEvent' | 'initKeyEvent' | undefined;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    event = new KeyboardEvent(type, eventOpts);
+
+    // Property definitions are required for B/C for keyboard event usage
+    // If this properties are not defined, when listening for key events
+    // keyCode/which will be 0. Also, keyCode and which now are string
+    // and if app compare it with === with integer key definitions,
+    // there will be a fail.
+    //
+    // https://w3c.github.io/uievents/#interface-keyboardevent
+    // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+    Object.defineProperty(event, 'keyCode', {
+      get() {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        return parseInt(eventOpts.keyCode);
+      },
+    });
+
+    Object.defineProperty(event, 'which', {
+      get() {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        return parseInt(eventOpts.which);
+      },
+    });
+
+    return event;
+  } catch {
+    // left intentionally blank
+  }
+
+  try {
+    event = document.createEvent('KeyboardEvents');
+    eventMethodName = 'initKeyboardEvent';
+  } catch {
+    // left intentionally blank
+  }
+
+  if (!event) {
+    try {
+      event = document.createEvent('KeyEvents');
+      eventMethodName = 'initKeyEvent';
+    } catch {
+      // left intentionally blank
+    }
+  }
+
+  if (event && eventMethodName) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    (event as any)[eventMethodName](
+      type,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      eventOpts.bubbles,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      eventOpts.cancelable,
+      window,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      eventOpts.ctrlKey,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      eventOpts.altKey,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      eventOpts.shiftKey,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      eventOpts.metaKey,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      eventOpts.keyCode,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      eventOpts.charCode
+    );
+  } else {
+    event = buildBasicEvent(type, options);
+  }
+
+  return event;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildFileEvent(type: FileSelectionEventType, element: HTMLInputElement, options: any = {}): Event {
+  const event = buildBasicEvent(type);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+  const files = options.files;
+
+  if (Array.isArray(options)) {
+    throw new Error(
+      'Please pass an object with a files array to `triggerEvent` instead of passing the `options` param as an array to.'
+    );
+  }
+
+  if (Array.isArray(files)) {
+    Object.defineProperty(files, 'item', {
+      value(index: number) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+        return typeof index === 'number' ? this[index] : null;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(element, 'files', {
+      value: files,
+      configurable: true,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const elementProto = Object.getPrototypeOf(element);
+    const valueProp = Object.getOwnPropertyDescriptor(elementProto, 'value');
+    Object.defineProperty(element, 'value', {
+      configurable: true,
+      get() {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return valueProp!.get!.call(element);
+      },
+      set(value) {
+        valueProp!.set!.call(element, value);
+
+        // We are sure that the value is empty here.
+        // For a non-empty value the original setter must raise an exception.
+        Object.defineProperty(element, 'files', {
+          configurable: true,
+          value: [],
+        });
+      },
+    });
+  }
+
+  Object.defineProperty(event, 'target', {
+    value: element,
+  });
+
+  return event;
+}

--- a/packages/diagnostic/src/helpers/-dom/focus.ts
+++ b/packages/diagnostic/src/helpers/-dom/focus.ts
@@ -1,0 +1,146 @@
+import getDescription from './-get-description.ts';
+import { getElement } from './-get-element.ts';
+import type { HelperContext } from './-helper-context.ts';
+import { assertRenderContext } from './-helper-context.ts';
+import isFocusable from './-is-focusable.ts';
+import { isDocument, type Target } from './-target.ts';
+import { __blur__ } from './blur.ts';
+import { fireEvent } from './fire-event.ts';
+import { withHooks } from './helper-hooks.ts';
+
+/**
+   Get the closest focusable ancestor of a given element (or the element itself
+   if it's focusable)
+
+   @private
+   @param {Element} element the element to trigger events on
+   @returns {HTMLElement|SVGElement|null} the focusable element/ancestor or null
+   if there is none
+ */
+function getClosestFocusable(element: HTMLElement | Element | Document | SVGElement): HTMLElement | SVGElement | null {
+  if (isDocument(element)) {
+    return null;
+  }
+
+  let maybeFocusable: Element | null = element;
+  while (maybeFocusable && !isFocusable(maybeFocusable)) {
+    maybeFocusable = maybeFocusable.parentElement;
+  }
+
+  return maybeFocusable;
+}
+
+/**
+  @private
+  @param element the element to trigger events on
+  @return resolves when settled
+*/
+export function __focus__(scope: HelperContext, element: HTMLElement | Element | Document | SVGElement): Promise<void> {
+  return scope.config.render(() => {
+    return Promise.resolve()
+      .then(() => {
+        const focusTarget = getClosestFocusable(element);
+
+        const previousFocusedElement =
+          document.activeElement && document.activeElement !== focusTarget && isFocusable(document.activeElement)
+            ? document.activeElement
+            : null;
+
+        // fire __blur__ manually with the null relatedTarget when the target is not focusable
+        // and there was a previously focused element
+        return !focusTarget && previousFocusedElement
+          ? __blur__(scope, previousFocusedElement, null).then(() =>
+              Promise.resolve({ focusTarget, previousFocusedElement })
+            )
+          : Promise.resolve({ focusTarget, previousFocusedElement });
+      })
+      .then(({ focusTarget, previousFocusedElement }) => {
+        if (!focusTarget) {
+          throw new Error('There was a previously focused element');
+        }
+
+        const browserIsNotFocused = !document?.hasFocus();
+
+        // fire __blur__ manually with the correct relatedTarget when the browser is not
+        // already in focus and there was a previously focused element
+        return previousFocusedElement && browserIsNotFocused
+          ? __blur__(scope, previousFocusedElement, focusTarget).then(() => Promise.resolve({ focusTarget }))
+          : Promise.resolve({ focusTarget });
+      })
+      .then(({ focusTarget }) => {
+        // makes `document.activeElement` be `element`. If the browser is focused, it also fires a focus event
+        focusTarget.focus();
+
+        // Firefox does not trigger the `focusin` event if the window
+        // does not have focus. If the document does not have focus then
+        // fire `focusin` event as well.
+        const browserIsFocused = document?.hasFocus();
+        return browserIsFocused
+          ? Promise.resolve()
+          : // if the browser is not focused the previous `el.focus()` didn't fire an event, so we simulate it
+            Promise.resolve()
+              .then(() =>
+                fireEvent(scope, focusTarget, 'focus', {
+                  bubbles: false,
+                })
+              )
+              .then(() => fireEvent(scope, focusTarget, 'focusin'))
+              .then(() => {
+                return;
+              }); // avoid leaking fireEvent return value;
+      })
+      .catch(() => {});
+  });
+}
+
+/**
+  Focus the specified target.
+
+  Sends a number of events intending to simulate a "real" user focusing an
+  element.
+
+  The following events are triggered (in order):
+
+  - `focus`
+  - `focusin`
+
+  The exact listing of events that are triggered may change over time as needed
+  to continue to emulate how actual browsers handle focusing a given element.
+
+  @public
+  @param {string|Element|IDOMElementDescriptor} target the element, selector, or descriptor to focus
+  @return {Promise<void>} resolves when the application is settled
+
+  @example
+  <caption>
+    Emulating focusing an input using `focus`
+  </caption>
+
+  focus('input');
+*/
+export function focus<T extends HelperContext>(this: T, target: Target): Promise<void> {
+  return withHooks({
+    scope: this,
+    name: 'focus',
+    render: true,
+    args: [target],
+    cb: async () => {
+      if (!target) {
+        throw new Error('Must pass an element, selector, or descriptor to `focus`.');
+      }
+
+      assertRenderContext(this);
+      const element = getElement(target, this.element);
+      if (!element) {
+        const description = getDescription(target);
+        throw new Error(`Element not found when calling \`focus('${description}')\`.`);
+      }
+
+      if (!isFocusable(element)) {
+        throw new Error(`${String(element)} is not focusable`);
+      }
+
+      return __focus__(this, element);
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/helper-hooks.ts
+++ b/packages/diagnostic/src/helpers/-dom/helper-hooks.ts
@@ -1,0 +1,109 @@
+import type { HelperContext } from './-helper-context';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Hook = (...args: any[]) => void | Promise<void>;
+export type HookLabel = 'start' | 'end' | 'targetFound';
+export type HookUnregister = {
+  unregister: () => void;
+};
+
+const registeredHooks = new Map<string, Set<Hook>>();
+
+/**
+ * @private
+ * @param {string} helperName The name of the test helper in which to run the hook.
+ * @param {string} label A label to help identify the hook.
+ * @returns {string} The compound key for the helper.
+ */
+function getHelperKey(helperName: string, label: string): string {
+  return `${helperName}:${label}`;
+}
+
+/**
+ * Registers a function to be run during the invocation of a test helper.
+ *
+ * @param {string} helperName The name of the test helper in which to run the hook.
+ *                            Test helper names include `blur`, `click`, `doubleClick`, `fillIn`,
+ *                            `fireEvent`, `focus`, `render`, `scrollTo`, `select`, `tab`, `tap`, `triggerEvent`,
+ *                            `triggerKeyEvent`, `typeIn`, and `visit`.
+ * @param {string} label A label to help identify the hook. Built-in labels include `start`, `end`,
+ *                       and `targetFound`, the former designating either the start or end of
+ *                       the helper invocation.
+ * @param {Function} hook The hook function to run when the test helper is invoked.
+ * @returns {HookUnregister} An object containing an `unregister` function that unregisters
+ *                           the specific hook initially registered to the helper.
+ * @example
+ * <caption>
+ *   Registering a hook for the `end` point of the `click` test helper invocation
+ * </caption>
+ *
+ * const hook = registerHook('click', 'end', () => {
+ *   console.log('Running `click:end` test helper hook');
+ * });
+ *
+ * // Unregister the hook at some later point in time
+ * hook.unregister();
+ */
+export function registerHook(helperName: string, label: HookLabel, hook: Hook): HookUnregister {
+  const helperKey = getHelperKey(helperName, label);
+  let hooksForHelper = registeredHooks.get(helperKey);
+
+  if (hooksForHelper === undefined) {
+    hooksForHelper = new Set<Hook>();
+    registeredHooks.set(helperKey, hooksForHelper);
+  }
+
+  hooksForHelper.add(hook);
+
+  return {
+    unregister() {
+      hooksForHelper.delete(hook);
+    },
+  };
+}
+
+/**
+ * Runs all hooks registered for a specific test helper.
+ *
+ * @param {string} helperName The name of the test helper in which to run the hook.
+ *                            Test helper names include `blur`, `click`, `doubleClick`, `fillIn`,
+ *                            `fireEvent`, `focus`, `render`, `scrollTo`, `select`, `tab`, `tap`, `triggerEvent`,
+ *                            `triggerKeyEvent`, `typeIn`, and `visit`.
+ * @param {string} label A label to help identify the hook. Built-in labels include `start`, `end`,
+ *                       and `targetFound`, the former designating either the start or end of
+ *                       the helper invocation.
+ * @param {unknown[]} args Any arguments originally passed to the test helper.
+ * @returns {Promise<void>} A promise representing the serial invocation of the hooks.
+ */
+export function runHooks(helperName: string, label: HookLabel, ...args: unknown[]): Promise<void> {
+  const hooks = registeredHooks.get(getHelperKey(helperName, label)) || new Set<Hook>();
+  const promises: Array<void | Promise<void>> = [];
+
+  hooks.forEach((hook) => {
+    const hookResult = hook(...args);
+
+    promises.push(hookResult);
+  });
+
+  return Promise.all(promises).then(() => {});
+}
+
+export async function withHooks<T = Promise<void>>(options: {
+  scope: HelperContext;
+  name: string;
+  render: boolean;
+  cb: () => T;
+  args?: unknown[];
+}): Promise<Awaited<T>> {
+  if (options.render) {
+    return await options.scope.config.render(() =>
+      runHooks(options.name, 'start', ...(options.args ?? []))
+        .then(options.cb)
+        .finally(() => runHooks(options.name, 'end', ...(options.args ?? [])))
+    );
+  }
+  return await Promise.resolve()
+    .then(() => runHooks(options.name, 'start', ...(options.args ?? [])))
+    .then(options.cb)
+    .finally(() => runHooks(options.name, 'end', ...(options.args ?? [])));
+}

--- a/packages/diagnostic/src/helpers/-dom/scroll-to.ts
+++ b/packages/diagnostic/src/helpers/-dom/scroll-to.ts
@@ -1,0 +1,80 @@
+import type { IDOMElementDescriptor } from 'dom-element-descriptors';
+
+import getDescription from './-get-description.ts';
+import { getElement } from './-get-element.ts';
+import { assertRenderContext, type HelperContext } from './-helper-context.ts';
+import type { Target } from './-target.ts';
+import { isDocument, isElement } from './-target.ts';
+import { fireEvent } from './fire-event.ts';
+import { withHooks } from './helper-hooks.ts';
+
+function errorMessage(message: string, target: Target) {
+  const description = getDescription(target);
+  return `${message} when calling \`scrollTo('${description}')\`.`;
+}
+
+/**
+  Scrolls DOM element, selector, or descriptor to the given coordinates.
+  @public
+  @param {string|HTMLElement|IDOMElementDescriptor} target the element, selector, or descriptor to trigger scroll on
+  @param {Number} x x-coordinate
+  @param {Number} y y-coordinate
+  @return {Promise<void>} resolves when settled
+
+  @example
+  <caption>
+    Scroll DOM element to specific coordinates
+  </caption>
+
+  scrollTo('#my-long-div', 0, 0); // scroll to top
+  scrollTo('#my-long-div', 0, 100); // scroll down
+*/
+export function scrollTo<T extends HelperContext>(
+  this: T,
+  target: string | HTMLElement | IDOMElementDescriptor,
+  x: number,
+  y: number
+): Promise<void> {
+  return withHooks({
+    scope: this,
+    name: 'scrollTo',
+    render: true,
+    args: [target, x, y],
+    cb: async () => {
+      if (!target) {
+        throw new Error('Must pass an element, selector, or descriptor to `scrollTo`.');
+      }
+
+      if (x === undefined || y === undefined) {
+        throw new Error('Must pass both x and y coordinates to `scrollTo`.');
+      }
+
+      assertRenderContext(this);
+      const element = getElement(target, this.element);
+      if (!element) {
+        throw new Error(errorMessage('Element not found', target));
+      }
+
+      if (!isElement(element)) {
+        let nodeType: string;
+        if (isDocument(element)) {
+          nodeType = 'Document';
+        } else {
+          // This is an error check for non-typescript callers passing in the
+          // wrong type for `target`, so we have to cast `element` (which is
+          // `never` inside this block) to something that will allow us to
+          // access `nodeType`.
+          const notElement = element as { nodeType: string };
+          nodeType = notElement.nodeType;
+        }
+
+        throw new Error(errorMessage(`"target" must be an element, but was a ${nodeType}`, target));
+      }
+
+      element.scrollTop = y;
+      element.scrollLeft = x;
+
+      await fireEvent(this, element, 'scroll');
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/select.ts
+++ b/packages/diagnostic/src/helpers/-dom/select.ts
@@ -1,0 +1,101 @@
+import getDescription from './-get-description.ts';
+import { getElement } from './-get-element.ts';
+import type { HelperContext } from './-helper-context.ts';
+import { assertRenderContext } from './-helper-context.ts';
+import isSelectElement from './-is-select-element.ts';
+import type { Target } from './-target.ts';
+import { fireEvent } from './fire-event.ts';
+import { __focus__ } from './focus.ts';
+import { withHooks } from './helper-hooks.ts';
+
+function errorMessage(message: string, target: Target) {
+  const description = getDescription(target);
+  return `${message} when calling \`select('${description}')\`.`;
+}
+
+/**
+  Set the `selected` property true for the provided option the target is a
+  select element (or set the select property true for multiple options if the
+  multiple attribute is set true on the HTMLSelectElement) then trigger
+  `change` and `input` events on the specified target.
+
+  @public
+  @param {string|Element|IDOMElementDescriptor} target the element, selector, or descriptor for the select element
+  @param {string|string[]} options the value/values of the items to select
+  @param {boolean} keepPreviouslySelected a flag keep any existing selections
+  @return {Promise<void>} resolves when the application is settled
+
+  @example
+  <caption>
+    Emulating selecting an option or multiple options using `select`
+  </caption>
+
+  select('select', 'apple');
+
+  select('select', ['apple', 'orange']);
+
+  select('select', ['apple', 'orange'], true);
+*/
+export function select<T extends HelperContext>(
+  this: T,
+  target: Target,
+  options: string | string[],
+  keepPreviouslySelected = false
+): Promise<void> {
+  return withHooks({
+    scope: this,
+    name: 'select',
+    render: true,
+    args: [target, options, keepPreviouslySelected],
+    cb: async () => {
+      if (!target) {
+        throw new Error('Must pass an element, selector, or descriptor to `select`.');
+      }
+
+      if (typeof options === 'undefined' || options === null) {
+        throw new Error('Must provide an `option` or `options` to select when calling `select`.');
+      }
+
+      assertRenderContext(this);
+      const element = getElement(target, this.element);
+      if (!element) {
+        throw new Error(errorMessage('Element not found', target));
+      }
+
+      if (!isSelectElement(element)) {
+        throw new Error(errorMessage('Element is not a HTMLSelectElement', target));
+      }
+
+      if (element.disabled) {
+        throw new Error(errorMessage('Element is disabled', target));
+      }
+
+      options = Array.isArray(options) ? options : [options];
+
+      if (!element.multiple && options.length > 1) {
+        throw new Error(
+          errorMessage(
+            'HTMLSelectElement `multiple` attribute is set to `false` but multiple options were passed',
+            target
+          )
+        );
+      }
+
+      await __focus__(this, element);
+
+      for (let i = 0; i < element.options.length; i++) {
+        const elementOption = element.options.item(i);
+        if (elementOption) {
+          if (options.includes(elementOption.value)) {
+            elementOption.selected = true;
+          } else if (!keepPreviouslySelected) {
+            elementOption.selected = false;
+          }
+        }
+      }
+
+      await fireEvent(this, element, 'input');
+      await fireEvent(this, element, 'change');
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/tab.ts
+++ b/packages/diagnostic/src/helpers/-dom/tab.ts
@@ -1,0 +1,223 @@
+import { assertRenderContext, type HelperContext } from './-helper-context.ts';
+import { isDocument } from './-target.ts';
+import { isDisabled, isVisible } from './-utils.ts';
+import { __blur__ } from './blur.ts';
+import { _buildKeyboardEvent, fireEvent } from './fire-event.ts';
+import { __focus__ } from './focus.ts';
+import { withHooks } from './helper-hooks.ts';
+
+const SUPPORTS_INERT = 'inert' in Element.prototype;
+const FALLBACK_ELEMENTS = ['CANVAS', 'VIDEO', 'PICTURE'];
+
+/**
+  Gets the active element of a document. IE11 may return null instead of the body as
+  other user-agents does when there isn’t an active element.
+  @private
+  @param {Document} ownerDocument the element to check
+  @returns {HTMLElement} the active element of the document
+*/
+function getActiveElement(ownerDocument: Document): HTMLElement {
+  return (ownerDocument.activeElement as HTMLElement) || ownerDocument.body;
+}
+
+interface InertHTMLElement extends HTMLElement {
+  inert: boolean;
+}
+
+/**
+  Compiles a list of nodes that can be focused. Walks the tree, discards hidden elements and a few edge cases. To calculate the right.
+  @private
+  @param {Element} root the root element to start traversing on
+  @returns {Array} list of focusable nodes
+*/
+function compileFocusAreas(root: Element = document.body) {
+  const { ownerDocument } = root;
+
+  if (!ownerDocument) {
+    throw new Error('Element must be in the DOM');
+  }
+
+  const activeElement = getActiveElement(ownerDocument);
+  const treeWalker = ownerDocument.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
+    acceptNode: (node: HTMLElement) => {
+      // Only visible nodes can be focused, with, at least, one exception; the "area" element.
+      // reference: https://html.spec.whatwg.org/multipage/interaction.html#data-model
+      if (node.tagName !== 'AREA' && isVisible(node) === false) {
+        return NodeFilter.FILTER_REJECT;
+      }
+
+      // Reject any fallback elements. Fallback elements’s children are only rendered if the UA
+      // doesn’t support the element. We make an assumption that they are always supported, we
+      // could consider feature detecting every node type, or making it configurable.
+      const parentNode = node.parentNode as HTMLElement | null;
+      if (parentNode && FALLBACK_ELEMENTS.includes(parentNode.tagName)) {
+        return NodeFilter.FILTER_REJECT;
+      }
+
+      // Rejects inert containers, if the user agent supports the feature (or if a polyfill is installed.)
+      if (SUPPORTS_INERT && (node as InertHTMLElement).inert) {
+        return NodeFilter.FILTER_REJECT;
+      }
+
+      if (isDisabled(node)) {
+        return NodeFilter.FILTER_REJECT;
+      }
+
+      // Always accept the 'activeElement' of the document, as it might fail the next check, elements with tabindex="-1"
+      // can be focused programmatically, we'll therefor ensure the current active element is in the list.
+      if (node === activeElement) {
+        return NodeFilter.FILTER_ACCEPT;
+      }
+
+      // UA parses the tabindex attribute and applies its default values, If the tabIndex is non negative, the UA can
+      // focus it.
+      return node.tabIndex >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+    },
+  });
+
+  let node: Node | null;
+  const elements: HTMLElement[] = [];
+
+  while ((node = treeWalker.nextNode())) {
+    elements.push(node as HTMLElement);
+  }
+
+  return elements;
+}
+
+/**
+  Sort elements by their tab indices.
+  As older browsers doesn't necessarily implement stabile sort, we'll have to
+  manually compare with the index in the original array.
+  @private
+  @param {Array<HTMLElement>} elements to sort
+  @returns {Array<HTMLElement>} list of sorted focusable nodes by their tab index
+*/
+function sortElementsByTabIndices(elements: HTMLElement[]): HTMLElement[] {
+  return elements
+    .map((element, index) => {
+      return { index, element };
+    })
+    .sort((a, b) => {
+      if (a.element.tabIndex === b.element.tabIndex) {
+        return a.index - b.index;
+      } else if (a.element.tabIndex === 0 || b.element.tabIndex === 0) {
+        return b.element.tabIndex - a.element.tabIndex;
+      }
+      return a.element.tabIndex - b.element.tabIndex;
+    })
+    .map((entity) => entity.element);
+}
+
+/**
+  @private
+  @param {Element} root The root element or node to start traversing on.
+  @param {HTMLElement} activeElement The element to find the next and previous focus areas of
+  @returns {object} The next and previous focus areas of the active element
+ */
+function findNextResponders(root: Element, activeElement: HTMLElement) {
+  const focusAreas = compileFocusAreas(root);
+  const sortedFocusAreas = sortElementsByTabIndices(focusAreas);
+  const elements = activeElement.tabIndex === -1 ? focusAreas : sortedFocusAreas;
+
+  const index = elements.indexOf(activeElement);
+  if (index === -1) {
+    return {
+      next: sortedFocusAreas[0],
+      previous: sortedFocusAreas[sortedFocusAreas.length - 1],
+    };
+  }
+
+  return {
+    next: elements[index + 1],
+    previous: elements[index - 1],
+  };
+}
+
+/**
+  Emulates the user pressing the tab button.
+
+  Sends a number of events intending to simulate a "real" user pressing tab on their
+  keyboard.
+
+  @public
+  @param {Object} [options] optional tab behaviors
+  @param {boolean} [options.backwards=false] indicates if the the user navigates backwards
+  @param {boolean} [options.unRestrainTabIndex=false] indicates if tabbing should throw an error when tabindex is greater than 0
+  @return {Promise<void>} resolves when settled
+
+  @example
+  <caption>
+    Emulating pressing the `TAB` key
+  </caption>
+  tab();
+
+  @example
+  <caption>
+    Emulating pressing the `SHIFT`+`TAB` key combination
+  </caption>
+  tab({ backwards: true });
+*/
+export function tab<T extends HelperContext>(
+  this: T,
+  options: { backwards?: boolean; unRestrainTabIndex?: boolean } = {}
+): Promise<void> {
+  const { backwards = false, unRestrainTabIndex = false } = options;
+  return withHooks({
+    scope: this,
+    name: 'tab',
+    render: true,
+    args: [backwards, unRestrainTabIndex],
+    cb: async () => {
+      assertRenderContext(this);
+      const root = this.element;
+      let ownerDocument: Document;
+      let rootElement: HTMLElement;
+      if (isDocument(root)) {
+        // @ts-expect-error root is always supposed to be an HTMLDivElement
+        // but in case we ever loosen that, we ignore the type error here.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        rootElement = root.body;
+        ownerDocument = root;
+      } else {
+        rootElement = root;
+        ownerDocument = root.ownerDocument;
+      }
+
+      const keyboardEventOptions = {
+        keyCode: 9,
+        which: 9,
+        key: 'Tab',
+        code: 'Tab',
+        shiftKey: backwards,
+      };
+
+      let activeElement = getActiveElement(ownerDocument);
+      const event = _buildKeyboardEvent('keydown', keyboardEventOptions);
+      const defaultNotPrevented = activeElement.dispatchEvent(event);
+
+      if (defaultNotPrevented) {
+        // Query the active element again, as it might change during event phase
+        activeElement = getActiveElement(ownerDocument);
+        const target = findNextResponders(rootElement, activeElement);
+        if (target) {
+          if (backwards && target.previous) {
+            return __focus__(this, target.previous);
+          } else if (!backwards && target.next) {
+            return __focus__(this, target.next);
+          } else {
+            return __blur__(this, activeElement);
+          }
+        }
+      }
+
+      await Promise.resolve();
+      activeElement = getActiveElement(ownerDocument);
+      await fireEvent(this, activeElement, 'keyup', keyboardEventOptions);
+
+      if (!unRestrainTabIndex && activeElement.tabIndex > 0) {
+        throw new Error(`tabindex of greater than 0 is not allowed. Found tabindex=${activeElement.tabIndex}`);
+      }
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/tap.ts
+++ b/packages/diagnostic/src/helpers/-dom/tap.ts
@@ -1,0 +1,82 @@
+import getDescription from './-get-description.ts';
+import { getElement } from './-get-element.ts';
+import { assertRenderContext, type HelperContext } from './-helper-context.ts';
+import isFormControl from './-is-form-control.ts';
+import type { Target } from './-target.ts';
+import { __click__ } from './click.ts';
+import { fireEvent } from './fire-event.ts';
+import { withHooks } from './helper-hooks.ts';
+
+/**
+  Taps on the specified target.
+
+  Sends a number of events intending to simulate a "real" user tapping on an
+  element.
+
+  For non-focusable elements the following events are triggered (in order):
+
+  - `touchstart`
+  - `touchend`
+  - `mousedown`
+  - `mouseup`
+  - `click`
+
+  For focusable (e.g. form control) elements the following events are triggered
+  (in order):
+
+  - `touchstart`
+  - `touchend`
+  - `mousedown`
+  - `focus`
+  - `focusin`
+  - `mouseup`
+  - `click`
+
+  The exact listing of events that are triggered may change over time as needed
+  to continue to emulate how actual browsers handle tapping on a given element.
+
+  Use the `options` hash to change the parameters of the tap events.
+
+  @public
+  @param {string|Element|IDOMElementDescriptor} target the element, selector, or descriptor to tap on
+  @param {Object} options the options to be merged into the touch events
+  @return {Promise<void>} resolves when settled
+
+  @example
+  <caption>
+    Emulating tapping a button using `tap`
+  </caption>
+
+  tap('button');
+*/
+export function tap<T extends HelperContext>(this: T, target: Target, options: TouchEventInit = {}): Promise<void> {
+  return withHooks({
+    scope: this,
+    name: 'tap',
+    render: true,
+    args: [target, options],
+    cb: async () => {
+      if (!target) {
+        throw new Error('Must pass an element, selector, or descriptor to `tap`.');
+      }
+
+      assertRenderContext(this);
+      const element = getElement(target, this.element);
+      if (!element) {
+        const description = getDescription(target);
+        throw new Error(`Element not found when calling \`tap('${description}')\`.`);
+      }
+
+      if (isFormControl(element) && element.disabled) {
+        throw new Error(`Can not \`tap\` disabled ${String(element)}`);
+      }
+
+      const touchStartEv = await fireEvent(this, element, 'touchstart', options);
+      const touchEndEv = await fireEvent(this, element, 'touchend', options);
+
+      if (!touchStartEv.defaultPrevented && !touchEndEv.defaultPrevented) {
+        await __click__(this, element, options);
+      }
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/trigger-event.ts
+++ b/packages/diagnostic/src/helpers/-dom/trigger-event.ts
@@ -1,0 +1,86 @@
+import getDescription from './-get-description.ts';
+import { getWindowOrElement } from './-get-window-or-element.ts';
+import { assertRenderContext, type HelperContext } from './-helper-context.ts';
+import isFormControl from './-is-form-control.ts';
+import type { Target } from './-target.ts';
+import { fireEvent } from './fire-event.ts';
+import { withHooks } from './helper-hooks.ts';
+
+/**
+ * Triggers an event on the specified target.
+ *
+ * @public
+ * @param {string|Element|IDOMElementDescriptor} target the element, selector, or descriptor to trigger the event on
+ * @param {string} eventType the type of event to trigger
+ * @param {Object} options additional properties to be set on the event
+ * @return {Promise<void>} resolves when the application is settled
+ *
+ * @example
+ * <caption>
+ * Using `triggerEvent` to upload a file
+ *
+ * When using `triggerEvent` to upload a file the `eventType` must be `change` and you must pass the
+ * `options` param as an object with a key `files` containing an array of
+ * [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
+ * </caption>
+ *
+ * triggerEvent(
+ *   'input.fileUpload',
+ *   'change',
+ *   { files: [new Blob(['Ember Rules!'])] }
+ * );
+ *
+ *
+ * @example
+ * <caption>
+ * Using `triggerEvent` to upload a dropped file
+ *
+ * When using `triggerEvent` to handle a dropped (via drag-and-drop) file, the `eventType` must be `drop`. Assuming your `drop` event handler uses the [DataTransfer API](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer),
+ * you must pass the `options` param as an object with a key of `dataTransfer`. The `options.dataTransfer`     object should have a `files` key, containing an array of [File](https://developer.mozilla.org/en-US/docs/Web/API/File).
+ * </caption>
+ *
+ * triggerEvent(
+ *   '[data-test-drop-zone]',
+ *   'drop',
+ *   {
+ *     dataTransfer: {
+ *       files: [new File(['Ember Rules!'], 'ember-rules.txt')]
+ *     }
+ *   }
+ * )
+ */
+export function triggerEvent<T extends HelperContext>(
+  this: T,
+  target: Target,
+  eventType: string,
+  options?: Record<string, unknown>
+): Promise<void> {
+  return withHooks({
+    scope: this,
+    name: 'triggerEvent',
+    render: true,
+    args: [target, eventType, options],
+    cb: async () => {
+      if (!target) {
+        throw new Error('Must pass an element, selector, or descriptor to `triggerEvent`.');
+      }
+
+      if (!eventType) {
+        throw new Error(`Must provide an \`eventType\` to \`triggerEvent\``);
+      }
+
+      assertRenderContext(this);
+      const element = getWindowOrElement(target, this.element);
+      if (!element) {
+        const description = getDescription(target);
+        throw new Error(`Element not found when calling \`triggerEvent('${description}', ...)\`.`);
+      }
+
+      if (isFormControl(element) && element.disabled) {
+        throw new Error(`Can not \`triggerEvent\` on disabled ${String(element)}`);
+      }
+
+      await fireEvent(this, element, eventType, options);
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/trigger-key-event.ts
+++ b/packages/diagnostic/src/helpers/-dom/trigger-key-event.ts
@@ -1,0 +1,261 @@
+import getDescription from './-get-description.ts';
+import { getElement } from './-get-element.ts';
+import type { HelperContext } from './-helper-context.ts';
+import { assertRenderContext } from './-helper-context.ts';
+import isFormControl from './-is-form-control.ts';
+import type { Target } from './-target.ts';
+import { isNumeric } from './-utils.ts';
+import { fireEvent } from './fire-event.ts';
+import { isKeyboardEventType, KEYBOARD_EVENT_TYPES, type KeyboardEventType } from './fire-event.ts';
+import { withHooks } from './helper-hooks.ts';
+
+export interface KeyModifiers {
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+  metaKey?: boolean;
+}
+
+const DEFAULT_MODIFIERS: KeyModifiers = Object.freeze({
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  metaKey: false,
+});
+
+// This is not a comprehensive list, but it is better than nothing.
+const keyFromKeyCode: { [key: number]: string } = {
+  8: 'Backspace',
+  9: 'Tab',
+  13: 'Enter',
+  16: 'Shift',
+  17: 'Control',
+  18: 'Alt',
+  20: 'CapsLock',
+  27: 'Escape',
+  32: ' ',
+  37: 'ArrowLeft',
+  38: 'ArrowUp',
+  39: 'ArrowRight',
+  40: 'ArrowDown',
+  48: '0',
+  49: '1',
+  50: '2',
+  51: '3',
+  52: '4',
+  53: '5',
+  54: '6',
+  55: '7',
+  56: '8',
+  57: '9',
+  65: 'a',
+  66: 'b',
+  67: 'c',
+  68: 'd',
+  69: 'e',
+  70: 'f',
+  71: 'g',
+  72: 'h',
+  73: 'i',
+  74: 'j',
+  75: 'k',
+  76: 'l',
+  77: 'm',
+  78: 'n',
+  79: 'o',
+  80: 'p',
+  81: 'q',
+  82: 'r',
+  83: 's',
+  84: 't',
+  85: 'u',
+  86: 'v',
+  87: 'w',
+  88: 'x',
+  89: 'y',
+  90: 'z',
+  91: 'Meta',
+  93: 'Meta', // There is two keys that map to meta,
+  186: ';',
+  187: '=',
+  188: ',',
+  189: '-',
+  190: '.',
+  191: '/',
+  219: '[',
+  220: '\\',
+  221: ']',
+  222: "'",
+};
+
+const keyFromKeyCodeWithShift: { [key: number]: string } = {
+  48: ')',
+  49: '!',
+  50: '@',
+  51: '#',
+  52: '$',
+  53: '%',
+  54: '^',
+  55: '&',
+  56: '*',
+  57: '(',
+  186: ':',
+  187: '+',
+  188: '<',
+  189: '_',
+  190: '>',
+  191: '?',
+  219: '{',
+  220: '|',
+  221: '}',
+  222: '"',
+};
+
+/**
+  Calculates the value of KeyboardEvent#key given a keycode and the modifiers.
+  Note that this works if the key is pressed in combination with the shift key, but it cannot
+  detect if caps lock is enabled.
+  @param {number} keycode The keycode of the event.
+  @param {object} modifiers The modifiers of the event.
+  @returns {string} The key string for the event.
+ */
+function keyFromKeyCodeAndModifiers(keycode: number, modifiers: KeyModifiers): string | void {
+  if (keycode > 64 && keycode < 91) {
+    if (modifiers.shiftKey) {
+      return String.fromCharCode(keycode);
+    } else {
+      return String.fromCharCode(keycode).toLocaleLowerCase();
+    }
+  }
+
+  return (modifiers.shiftKey && keyFromKeyCodeWithShift[keycode]) || keyFromKeyCode[keycode];
+}
+
+/**
+ * Infers the keycode from the given key
+ * @param {string} key The KeyboardEvent#key string
+ * @returns {number} The keycode for the given key
+ */
+function keyCodeFromKey(key: string) {
+  const keys = Object.keys(keyFromKeyCode);
+  const keyCode =
+    keys.find((code: string) => keyFromKeyCode[Number(code)] === key) ||
+    keys.find((code: string) => keyFromKeyCode[Number(code)] === key.toLowerCase());
+
+  return keyCode !== undefined ? parseInt(keyCode) : undefined;
+}
+
+/**
+  @private
+  @param {Element | Document} element the element to trigger the key event on
+  @param {'keydown' | 'keyup' | 'keypress'} eventType the type of event to trigger
+  @param {number|string} key the `keyCode`(number) or `key`(string) of the event being triggered
+  @param {Object} [modifiers] the state of various modifier keys
+  @return {Promise<Event>} resolves when settled
+ */
+export function __triggerKeyEvent__(
+  scope: HelperContext,
+  element: Element | Document,
+  eventType: KeyboardEventType,
+  key: number | string,
+  modifiers: KeyModifiers = DEFAULT_MODIFIERS
+): Promise<Event> {
+  return Promise.resolve().then(() => {
+    let props;
+    if (typeof key === 'number') {
+      props = {
+        keyCode: key,
+        which: key,
+        key: keyFromKeyCodeAndModifiers(key, modifiers),
+        ...modifiers,
+      };
+    } else if (typeof key === 'string' && key.length !== 0) {
+      const firstCharacter = key[0];
+      if (!firstCharacter || firstCharacter !== firstCharacter.toUpperCase()) {
+        throw new Error(
+          `Must provide a \`key\` to \`triggerKeyEvent\` that starts with an uppercase character but you passed \`${key}\`.`
+        );
+      }
+
+      if (isNumeric(key) && key.length > 1) {
+        throw new Error(
+          `Must provide a numeric \`keyCode\` to \`triggerKeyEvent\` but you passed \`${key}\` as a string.`
+        );
+      }
+
+      const keyCode = keyCodeFromKey(key);
+      props = { keyCode, which: keyCode, key, ...modifiers };
+    } else {
+      throw new Error(`Must provide a \`key\` or \`keyCode\` to \`triggerKeyEvent\``);
+    }
+
+    return fireEvent(scope, element, eventType, props);
+  });
+}
+
+/**
+  Triggers a keyboard event of given type in the target element.
+  It also requires the developer to provide either a string with the [`key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
+  or the numeric [`keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) of the pressed key.
+  Optionally the user can also provide a POJO with extra modifiers for the event.
+
+  @public
+  @param {string|Element|IDOMElementDescriptor} target the element, selector, or descriptor to trigger the event on
+  @param {'keydown' | 'keyup' | 'keypress'} eventType the type of event to trigger
+  @param {number|string} key the `keyCode`(number) or `key`(string) of the event being triggered
+  @param {Object} [modifiers] the state of various modifier keys
+  @param {boolean} [modifiers.ctrlKey=false] if true the generated event will indicate the control key was pressed during the key event
+  @param {boolean} [modifiers.altKey=false] if true the generated event will indicate the alt key was pressed during the key event
+  @param {boolean} [modifiers.shiftKey=false] if true the generated event will indicate the shift key was pressed during the key event
+  @param {boolean} [modifiers.metaKey=false] if true the generated event will indicate the meta key was pressed during the key event
+  @return {Promise<void>} resolves when the application is settled unless awaitSettled is false
+
+  @example
+  <caption>
+    Emulating pressing the `ENTER` key on a button using `triggerKeyEvent`
+  </caption>
+  triggerKeyEvent('button', 'keydown', 'Enter');
+*/
+export function triggerKeyEvent<T extends HelperContext>(
+  this: T,
+  target: Target,
+  eventType: KeyboardEventType,
+  key: number | string,
+  modifiers: KeyModifiers = DEFAULT_MODIFIERS
+): Promise<void> {
+  return withHooks({
+    scope: this,
+    name: 'triggerKeyEvent',
+    render: true,
+    args: [target, eventType, key, modifiers],
+    cb: async () => {
+      if (!target) {
+        throw new Error('Must pass an element, selector, or descriptor to `triggerKeyEvent`.');
+      }
+
+      assertRenderContext(this);
+      const element = getElement(target, this.element);
+      if (!element) {
+        const description = getDescription(target);
+        throw new Error(`Element not found when calling \`triggerKeyEvent('${description}')\`.`);
+      }
+
+      if (!eventType) {
+        throw new Error(`Must provide an \`eventType\` to \`triggerKeyEvent\``);
+      }
+
+      if (!isKeyboardEventType(eventType)) {
+        const validEventTypes = KEYBOARD_EVENT_TYPES.join(', ');
+        throw new Error(
+          `Must provide an \`eventType\` of ${validEventTypes} to \`triggerKeyEvent\` but you passed \`${String(eventType)}\`.`
+        );
+      }
+
+      if (isFormControl(element) && element.disabled) {
+        throw new Error(`Can not \`triggerKeyEvent\` on disabled ${String(element)}`);
+      }
+
+      await __triggerKeyEvent__(this, element, eventType, key, modifiers);
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/type-in.ts
+++ b/packages/diagnostic/src/helpers/-dom/type-in.ts
@@ -1,0 +1,132 @@
+import getDescription from './-get-description.ts';
+import { getElement } from './-get-element.ts';
+import guardForMaxlength from './-guard-for-maxlength.ts';
+import type { HelperContext } from './-helper-context.ts';
+import { assertRenderContext } from './-helper-context.ts';
+import isFormControl, { type FormControl } from './-is-form-control.ts';
+import { type HTMLElementContentEditable, isContentEditable, isDocument, type Target } from './-target.ts';
+import { fireEvent } from './fire-event.ts';
+import { __focus__ } from './focus.ts';
+import { withHooks } from './helper-hooks.ts';
+import { __triggerKeyEvent__ } from './trigger-key-event.ts';
+
+export interface Options {
+  delay?: number;
+}
+
+/**
+ * Mimics character by character entry into the target `input` or `textarea` element.
+ *
+ * Allows for simulation of slow entry by passing an optional millisecond delay
+ * between key events.
+
+ * The major difference between `typeIn` and `fillIn` is that `typeIn` triggers
+ * keyboard events as well as `input` and `change`.
+ * Typically this looks like `focus` -> `focusin` -> `keydown` -> `keypress` -> `keyup` -> `input` -> `change`
+ * per character of the passed text (this may vary on some browsers).
+ *
+ * @public
+ * @param {string|Element|IDOMElementDescriptor} target the element, selector, or descriptor to enter text into
+ * @param {string} text the test to fill the element with
+ * @param {Object} options {delay: x} (default 50) number of milliseconds to wait per keypress
+ * @return {Promise<void>} resolves when the application is settled
+ *
+ * @example
+ * <caption>
+ *   Emulating typing in an input using `typeIn`
+ * </caption>
+ *
+ * typeIn('input', 'hello world');
+ */
+export function typeIn<T extends HelperContext>(
+  this: T,
+  target: Target,
+  text: string,
+  options: Options = {}
+): Promise<void> {
+  return withHooks({
+    scope: this,
+    name: 'typeIn',
+    render: true,
+    args: [target, text, options],
+    cb: async () => {
+      if (!target) {
+        throw new Error('Must pass an element, selector, or descriptor to `typeIn`.');
+      }
+
+      assertRenderContext(this);
+      const element = getElement(target, this.element);
+
+      if (!element) {
+        const description = getDescription(target);
+        throw new Error(`Element not found when calling \`typeIn('${description}')\``);
+      }
+
+      if (isDocument(element) || (!isFormControl(element) && !isContentEditable(element))) {
+        throw new Error('`typeIn` is only usable on form controls or contenteditable elements.');
+      }
+
+      if (typeof text === 'undefined' || text === null) {
+        throw new Error('Must provide `text` when calling `typeIn`.');
+      }
+
+      if (isFormControl(element)) {
+        if (element.disabled) {
+          throw new Error(`Can not \`typeIn\` disabled '${getDescription(target)}'.`);
+        }
+
+        if ('readOnly' in element && element.readOnly) {
+          throw new Error(`Can not \`typeIn\` readonly '${getDescription(target)}'.`);
+        }
+      }
+
+      const { delay = 50 } = options;
+
+      await __focus__(this, element);
+      await fillOut(this, element, text, delay);
+      await fireEvent(this, element, 'change');
+    },
+  });
+}
+
+function fillOut(scope: HelperContext, element: FormControl | HTMLElementContentEditable, text: string, delay: number) {
+  const inputFunctions = text.split('').map((character) => keyEntry(scope, element, character));
+  return inputFunctions.reduce((currentPromise, func) => {
+    return currentPromise.then(() => delayedExecute(delay)).then(func);
+  }, Promise.resolve());
+}
+
+function keyEntry(
+  scope: HelperContext,
+  element: FormControl | HTMLElementContentEditable,
+  character: string
+): () => void {
+  const shiftKey = character === character.toUpperCase() && character !== character.toLowerCase();
+  const options = { shiftKey };
+  const characterKey = character.toUpperCase();
+
+  return function () {
+    return Promise.resolve()
+      .then(() => __triggerKeyEvent__(scope, element, 'keydown', characterKey, options))
+      .then(() => __triggerKeyEvent__(scope, element, 'keypress', characterKey, options))
+      .then(() => {
+        if (isFormControl(element)) {
+          const newValue = element.value + character;
+          guardForMaxlength(element, newValue, 'typeIn');
+
+          element.value = newValue;
+        } else {
+          const newValue = element.innerHTML + character;
+          element.innerHTML = newValue;
+        }
+        return fireEvent(scope, element, 'input');
+      })
+      .then(() => __triggerKeyEvent__(scope, element, 'keyup', characterKey, options));
+  };
+}
+
+function delayedExecute(delay: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delay);
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/wait-for.ts
+++ b/packages/diagnostic/src/helpers/-dom/wait-for.ts
@@ -1,0 +1,72 @@
+import { type IDOMElementDescriptor, lookupDescriptorData } from 'dom-element-descriptors';
+
+import getDescription from './-get-description.ts';
+import { getElement } from './-get-element.ts';
+import getElements from './-get-elements.ts';
+import { assertRenderContext, type HelperContext } from './-helper-context.ts';
+import { withHooks } from './helper-hooks.ts';
+import { waitUntil } from './wait-until.ts';
+
+export interface Options {
+  timeout?: number;
+  count?: number | null;
+  timeoutMessage?: string;
+}
+
+/**
+  Used to wait for a particular selector to appear in the DOM. Due to the fact
+  that it does not wait for general settledness, this is quite useful for testing
+  interim DOM states (e.g. loading states, pending promises, etc).
+
+  @param {string|IDOMElementDescriptor} target the selector or DOM element descriptor to wait for
+  @param {Object} [options] the options to be used
+  @param {number} [options.timeout=1000] the time to wait (in ms) for a match
+  @param {number} [options.count=null] the number of elements that should match the provided selector (null means one or more)
+  @return {Promise<Element|Element[]>} resolves when the element(s) appear on the page
+
+  @example
+  <caption>
+    Waiting until a selector is rendered:
+  </caption>
+  await waitFor('.my-selector', { timeout: 2000 })
+*/
+export function waitFor<T extends HelperContext>(
+  this: T,
+  target: string | IDOMElementDescriptor,
+  options: Options = {}
+): Promise<Element | Element[]> {
+  return withHooks({
+    scope: this,
+    name: 'waitFor',
+    render: false,
+    args: [target, options],
+    cb: () => {
+      if (typeof target !== 'string' && !lookupDescriptorData(target)) {
+        throw new Error('Must pass a selector or DOM element descriptor to `waitFor`.');
+      }
+
+      assertRenderContext(this);
+      const { timeout = 1000, count = null } = options;
+      let { timeoutMessage } = options;
+
+      if (!timeoutMessage) {
+        const description = getDescription(target);
+        timeoutMessage = `waitFor timed out waiting for selector "${description}"`;
+      }
+
+      let callback: () => Element | Element[] | void | null;
+      if (count !== null) {
+        callback = () => {
+          const elements = Array.from(getElements(target, this.element));
+          if (elements.length === count) {
+            return elements;
+          }
+          return;
+        };
+      } else {
+        callback = () => getElement(target, this.element);
+      }
+      return waitUntil(callback, { timeout, timeoutMessage });
+    },
+  });
+}

--- a/packages/diagnostic/src/helpers/-dom/wait-until.ts
+++ b/packages/diagnostic/src/helpers/-dom/wait-until.ts
@@ -1,0 +1,72 @@
+import { futureTick } from './-utils.ts';
+
+const TIMEOUTS = [0, 1, 2, 5, 7];
+const MAX_TIMEOUT = 10;
+
+export type Falsy = false | 0 | '' | null | undefined;
+
+export interface Options {
+  timeout?: number;
+  timeoutMessage?: string;
+}
+
+/**
+  Wait for the provided callback to return a truthy value.
+
+  This does not leverage `settled()`, and as such can be used to manage async
+  while _not_ settled (e.g. "loading" or "pending" states).
+
+  @public
+  @param {Function} callback the callback to use for testing when waiting should stop
+  @param {Object} [options] options used to override defaults
+  @param {number} [options.timeout=1000] the maximum amount of time to wait
+  @param {string} [options.timeoutMessage='waitUntil timed out'] the message to use in the reject on timeout
+  @returns {Promise} resolves with the callback value when it returns a truthy value
+
+  @example
+  <caption>
+    Waiting until a selected element displays text:
+  </caption>
+  await waitUntil(function() {
+    return find('.my-selector').textContent.includes('something')
+  }, { timeout: 2000 })
+*/
+export function waitUntil<T>(callback: () => T | void | Falsy, options: Options = {}): Promise<T> {
+  const timeout = 'timeout' in options ? (options.timeout as number) : 1000;
+  const timeoutMessage = 'timeoutMessage' in options ? options.timeoutMessage : 'waitUntil timed out';
+
+  // creating this error eagerly so it has the proper invocation stack
+  const waitUntilTimedOut = new Error(timeoutMessage);
+
+  return new Promise(function (resolve, reject) {
+    let time = 0;
+
+    function scheduleCheck(timeoutsIndex: number) {
+      const knownTimeout = TIMEOUTS[timeoutsIndex];
+      const interval = knownTimeout === undefined ? MAX_TIMEOUT : knownTimeout;
+
+      futureTick(function () {
+        time += interval;
+
+        let value: T | void | Falsy;
+        try {
+          value = callback();
+        } catch (error: unknown) {
+          reject(error as Error);
+          return;
+        }
+
+        if (value) {
+          resolve(value);
+        } else if (time < timeout) {
+          scheduleCheck(timeoutsIndex + 1);
+        } else {
+          reject(waitUntilTimedOut);
+          return;
+        }
+      }, interval);
+    }
+
+    scheduleCheck(0);
+  });
+}

--- a/packages/diagnostic/src/helpers/install.ts
+++ b/packages/diagnostic/src/helpers/install.ts
@@ -1,0 +1,145 @@
+import type { IDOMElementDescriptor } from 'dom-element-descriptors';
+
+import { assert } from '../-utils.ts';
+import type { HelperConfig } from './-dom/-helper-context.ts';
+import type { Target } from './-dom/-target.ts';
+import { blur } from './-dom/blur.ts';
+import { click } from './-dom/click.ts';
+import { doubleClick } from './-dom/double-click.ts';
+import { fillIn } from './-dom/fill-in.ts';
+import { find } from './-dom/find.ts';
+import { findAll } from './-dom/find-all.ts';
+import type { KeyboardEventType } from './-dom/fire-event.ts';
+import { focus } from './-dom/focus.ts';
+import { scrollTo } from './-dom/scroll-to.ts';
+import { select } from './-dom/select.ts';
+import { tab } from './-dom/tab.ts';
+import { tap } from './-dom/tap.ts';
+import { triggerEvent } from './-dom/trigger-event.ts';
+import type { KeyModifiers } from './-dom/trigger-key-event.ts';
+import { triggerKeyEvent } from './-dom/trigger-key-event.ts';
+import type { Options as TypeInOptions } from './-dom/type-in.ts';
+import { typeIn } from './-dom/type-in.ts';
+import type { Options as WaitForOptions } from './-dom/wait-for.ts';
+import { waitFor } from './-dom/wait-for.ts';
+import type { Falsy, Options as WaitUntilOptions } from './-dom/wait-until.ts';
+import { waitUntil } from './-dom/wait-until.ts';
+
+export interface TestHelpers {
+  blur(target?: Target): Promise<void>;
+  click(target: Target, options?: MouseEventInit): Promise<void>;
+  doubleClick(target: Target, options?: MouseEventInit): Promise<void>;
+  fillIn(target: Target, text: string): Promise<void>;
+
+  findAll<K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)>(
+    selector: K
+  ): Array<HTMLElementTagNameMap[K] | SVGElementTagNameMap[K]>;
+  findAll<K extends keyof HTMLElementTagNameMap>(selector: K): Array<HTMLElementTagNameMap[K]>;
+  findAll<K extends keyof SVGElementTagNameMap>(selector: K): Array<SVGElementTagNameMap[K]>;
+  findAll(selector: string): Element[];
+
+  focus(target: Target): Promise<void>;
+
+  find<K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)>(
+    selector: K
+  ): HTMLElementTagNameMap[K] | SVGElementTagNameMap[K] | null;
+  find<K extends keyof HTMLElementTagNameMap>(selector: K): HTMLElementTagNameMap[K] | null;
+  find<K extends keyof SVGElementTagNameMap>(selector: K): SVGElementTagNameMap[K] | null;
+  find(selector: string): Element | null;
+
+  scrollTo(target: string | HTMLElement | IDOMElementDescriptor, x: number, y: number): Promise<void>;
+  select(target: Target, options: string | string[], keepPreviouslySelected?: boolean): Promise<void>;
+  tab(options?: { backwards?: boolean; unRestrainTabIndex?: boolean }): Promise<void>;
+  tap(target: Target, options?: TouchEventInit): Promise<void>;
+  triggerEvent(target: Target, eventType: string, options?: Record<string, unknown>): Promise<void>;
+  triggerKeyEvent(
+    target: Target,
+    eventType: KeyboardEventType,
+    key: number | string,
+    modifiers?: KeyModifiers
+  ): Promise<void>;
+  typeIn(target: Target, text: string, options?: TypeInOptions): Promise<void>;
+  waitFor(target: string | IDOMElementDescriptor, options?: WaitForOptions): Promise<Element | Element[]>;
+  waitUntil<T>(callback: () => T | void | Falsy, options?: WaitUntilOptions): Promise<T>;
+  rerender: () => Promise<void>;
+  settled: () => Promise<void>;
+  pauseTest(): Promise<void>;
+  resumeTest(): void;
+}
+
+const DEFAULT_RENDER_CONFIG = {
+  render: async <T>(fn: () => T): Promise<Awaited<T>> => {
+    return await fn();
+  },
+  rerender: async () => {
+    // let any initial things scheduled complete
+    await Promise.resolve();
+    // bounce over any work that then got done
+    await Promise.resolve();
+    // a last bounce for good measure
+    await Promise.resolve();
+  },
+  settled: async () => {
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        setTimeout(resolve, 0);
+      });
+    });
+  },
+};
+
+/**
+  Used by test frameworks to setup the provided context for testing.
+
+  @public
+*/
+export function buildHelpers<T extends { element?: HTMLElement | null }>(
+  context: T,
+  config?: HelperConfig
+): TestHelpers {
+  const element = context.element ?? null;
+  const scope = {
+    element,
+    config: config ?? DEFAULT_RENDER_CONFIG,
+  };
+  let resume: ((value?: void | PromiseLike<void>) => void) | undefined;
+
+  const helpers = {
+    blur: blur.bind(scope),
+    click: click.bind(scope),
+    doubleClick: doubleClick.bind(scope),
+    fillIn: fillIn.bind(scope),
+    findAll: findAll.bind(scope),
+    find: find.bind(scope),
+    focus: focus.bind(scope),
+    scrollTo: scrollTo.bind(scope),
+    select: select.bind(scope),
+    tab: tab.bind(scope),
+    tap: tap.bind(scope),
+    triggerEvent: triggerEvent.bind(scope),
+    triggerKeyEvent: triggerKeyEvent.bind(scope),
+    typeIn: typeIn.bind(scope),
+    waitFor: waitFor.bind(scope),
+    waitUntil: waitUntil.bind(scope),
+    rerender: scope.config.rerender,
+    settled: scope.config.settled,
+    resumeTest: () => {
+      assert('Testing has not been paused. There is nothing to resume.', !!resume);
+      resume();
+      // @ts-expect-error - this is a global variable that we set to resume the test
+      globalThis.resumeTest = resume = undefined;
+    },
+    pauseTest: () => {
+      console.info('Testing paused. Use `resumeTest()` to continue.');
+
+      return new Promise((resolve) => {
+        resume = resolve;
+        // @ts-expect-error - this is a global variable that we set to resume the test
+
+        globalThis.resumeTest = helpers.resumeTest;
+      });
+    },
+  } satisfies TestHelpers;
+
+  return helpers;
+}

--- a/packages/diagnostic/src/react.tsx
+++ b/packages/diagnostic/src/react.tsx
@@ -1,15 +1,16 @@
 import { module as _module, skip as _skip, test as _test, todo as _todo } from "./-define";
 import type { Hooks, ModuleCallback, TestCallback, TestContext } from "./-types";
 import { createRoot, type Root } from "react-dom/client";
-import { flushSync } from "react-dom";
-import { StrictMode, type ReactNode } from "react";
+import { act, StrictMode, type ReactNode } from "react";
 import { setup } from "qunit-dom";
+import { buildHelpers, TestHelpers } from "./helpers/install";
 
 export interface ReactTestContext extends TestContext {
   [IsRenderingContext]: boolean;
   element: HTMLDivElement;
   root: Root;
   render(app: ReactNode): Promise<void>;
+  h: TestHelpers;
 }
 
 export const IsRenderingContext: unique symbol = Symbol("isRenderingContext");
@@ -49,6 +50,9 @@ declare module "./-types" {
   }
 }
 
+// @ts-expect-error This is a private property used by the test framework
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 export function setupTest<TC extends ReactTestContext>(hooks: Hooks<TC>, options?: SetupContextOptions): void {
   hooks.beforeEach(async function (assert) {
     this.element = document.createElement("div");
@@ -68,10 +72,43 @@ export function setupTest<TC extends ReactTestContext>(hooks: Hooks<TC>, options
     assert.dom.rootElement = rootElement;
 
     this.render = async (App: ReactNode) => {
-      flushSync(() => {
+      await act(async () => {
         this.root!.render(useStrict ? <StrictMode>{App}</StrictMode> : App);
       });
     };
+
+    let helpers: TestHelpers | null = null;
+    Object.defineProperty(this, "h", {
+      configurable: true,
+      enumerable: true,
+      writable: false,
+      get() {
+        if (!helpers) {
+          helpers = buildHelpers(this, {
+            render: async <T,>(fn: () => T): Promise<Awaited<T>> => {
+              let result: Awaited<T>;
+              await act(async () => {
+                result = await fn();
+              });
+              return result!;
+            },
+            rerender: async () => {
+              await act(async () => {});
+            },
+            settled: async () => {
+              // TODO integrate with WarpDrive's waitFor
+              // create a generic test-waiter registration system
+              await new Promise((resolve) => {
+                requestAnimationFrame(() => {
+                  setTimeout(resolve, 0);
+                });
+              });
+            },
+          });
+        }
+        return helpers;
+      },
+    });
   });
 
   hooks.afterEach(function () {

--- a/packages/diagnostic/src/react.tsx
+++ b/packages/diagnostic/src/react.tsx
@@ -81,7 +81,6 @@ export function setupTest<TC extends ReactTestContext>(hooks: Hooks<TC>, options
     Object.defineProperty(this, "h", {
       configurable: true,
       enumerable: true,
-      writable: false,
       get() {
         if (!helpers) {
           helpers = buildHelpers(this, {

--- a/packages/diagnostic/src/react.tsx
+++ b/packages/diagnostic/src/react.tsx
@@ -1,9 +1,23 @@
 import { module as _module, skip as _skip, test as _test, todo as _todo } from "./-define";
 import type { Hooks, ModuleCallback, TestCallback, TestContext } from "./-types";
 import { createRoot, type Root } from "react-dom/client";
-import { act, StrictMode, type ReactNode } from "react";
+import { act as reactAct, StrictMode, type ReactNode } from "react";
 import { setup } from "qunit-dom";
 import { buildHelpers, TestHelpers } from "./helpers/install";
+import { DEBUG } from "@warp-drive/core/build-config/env";
+import { flushSync } from "react-dom";
+
+const act = DEBUG
+  ? reactAct
+  : async (fn: () => void | Promise<void>) => {
+      await flushSync(fn);
+
+      // make extra sure we caught everything since
+      // in prod builds we don't use react-act
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    };
 
 export interface ReactTestContext extends TestContext {
   [IsRenderingContext]: boolean;

--- a/packages/diagnostic/vite.config.mjs
+++ b/packages/diagnostic/vite.config.mjs
@@ -12,6 +12,7 @@ export const entryPoints = [
   './src/index.ts',
   './src/reporters/dom.ts',
   './src/runners/dom.ts',
+  './src/helpers/install.ts',
   './src/ember.ts',
   './src/react.tsx',
   './src/react/test-helpers.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,6 +687,9 @@ importers:
       debug:
         specifier: ^4.4.0
         version: 4.4.0
+      dom-element-descriptors:
+        specifier: ^0.5.1
+        version: 0.5.1
       qunit-dom:
         specifier: ^3.4.0
         version: 3.4.0
@@ -18778,6 +18781,7 @@ snapshots:
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.27.1)
       chalk: 5.4.1
       debug: 4.4.0
+      dom-element-descriptors: 0.5.1
       qunit-dom: 3.4.0
       tmp: 0.2.3
     optionalDependencies:
@@ -18792,6 +18796,7 @@ snapshots:
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.27.1)
       chalk: 5.4.1
       debug: 4.4.0
+      dom-element-descriptors: 0.5.1
       qunit-dom: 3.4.0
       tmp: 0.2.3
     optionalDependencies:
@@ -18805,6 +18810,7 @@ snapshots:
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.27.1)
       chalk: 5.4.1
       debug: 4.4.0
+      dom-element-descriptors: 0.5.1
       qunit-dom: 3.4.0
       tmp: 0.2.3
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -678,6 +678,9 @@ importers:
 
   packages/diagnostic:
     dependencies:
+      '@embroider/macros':
+        specifier: ^1.16.12
+        version: 1.17.3(@babel/core@7.27.1)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.27.1)
@@ -18778,6 +18781,7 @@ snapshots:
 
   '@warp-drive/diagnostic@file:packages/diagnostic(91fa9405ded66bcb0704e914732448b6)':
     dependencies:
+      '@embroider/macros': 1.17.3(@babel/core@7.27.1)
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.27.1)
       chalk: 5.4.1
       debug: 4.4.0
@@ -18793,6 +18797,7 @@ snapshots:
 
   '@warp-drive/diagnostic@file:packages/diagnostic(b4f72904c966d6a0c2e84aaa4afdc14f)':
     dependencies:
+      '@embroider/macros': 1.17.3(@babel/core@7.27.1)
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.27.1)
       chalk: 5.4.1
       debug: 4.4.0
@@ -18807,6 +18812,7 @@ snapshots:
 
   '@warp-drive/diagnostic@file:packages/diagnostic(e4702f19c50cf386d1a9755f3bc0f463)':
     dependencies:
+      '@embroider/macros': 1.17.3(@babel/core@7.27.1)
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.27.1)
       chalk: 5.4.1
       debug: 4.4.0

--- a/tests/warp-drive__ember/tests/integration/await-component-test.gts
+++ b/tests/warp-drive__ember/tests/integration/await-component-test.gts
@@ -1,5 +1,3 @@
-import { rerender, settled } from '@ember/test-helpers';
-
 import { type Awaitable, setPromiseResult } from '@warp-drive/core/request';
 import type { RenderingTestContext } from '@warp-drive/diagnostic/ember';
 import { module, setupRenderingTest, test } from '@warp-drive/diagnostic/ember';
@@ -29,11 +27,11 @@ module('Integration | <Await />', function (hooks) {
 
     assert.equal(state.result, null);
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Loading...Count: 1');
-    await rerender();
+    assert.dom().hasText('Loading...Count: 1');
+    await this.h.rerender();
     assert.equal(state.result, 'Our Data');
     assert.equal(counter, 2);
-    assert.equal(this.element.textContent?.trim(), 'Our DataCount: 2');
+    assert.dom().hasText('Our DataCount: 2');
   });
 
   test('it renders only once when the promise already has a result cached', async function (this: RenderingTestContext, assert) {
@@ -57,10 +55,10 @@ module('Integration | <Await />', function (hooks) {
       </template>
     );
 
-    assert.equal(this.element.textContent?.trim(), 'Our DataCount: 1');
-    await settled();
+    assert.dom().hasText('Our DataCount: 1');
+    await this.h.rerender();
 
-    assert.equal(this.element.textContent?.trim(), 'Our DataCount: 1');
+    assert.dom().hasText('Our DataCount: 1');
   });
 
   test('it transitions to error state correctly', async function (this: RenderingTestContext, assert) {
@@ -87,13 +85,13 @@ module('Integration | <Await />', function (hooks) {
     assert.equal(state.result, null);
     assert.equal(state.error, null);
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Loading...Count: 1');
-    await rerender();
+    assert.dom().hasText('Loading...Count: 1');
+    await this.h.rerender();
     assert.equal(state.result, null);
     assert.true(state.error instanceof Error);
     assert.equal((state.error as Error | undefined)?.message, 'Our Error');
     assert.equal(counter, 2);
-    assert.equal(this.element.textContent?.trim(), 'Our ErrorCount: 2');
+    assert.dom().hasText('Our ErrorCount: 2');
   });
 
   test('it renders only once when the promise error state is already cached', async function (this: RenderingTestContext, assert) {
@@ -128,12 +126,12 @@ module('Integration | <Await />', function (hooks) {
     assert.true(state.error instanceof Error);
     assert.equal((state.error as Error | undefined)?.message, 'Our Error');
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Our ErrorCount: 1');
-    await rerender();
+    assert.dom().hasText('Our ErrorCount: 1');
+    await this.h.rerender();
     assert.equal(state.result, null);
     assert.true(state.error instanceof Error);
     assert.equal((state.error as Error | undefined)?.message, 'Our Error');
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Our ErrorCount: 1');
+    assert.dom().hasText('Our ErrorCount: 1');
   });
 });

--- a/tests/warp-drive__ember/tests/integration/get-promise-state-test.gts
+++ b/tests/warp-drive__ember/tests/integration/get-promise-state-test.gts
@@ -1,5 +1,3 @@
-import { rerender, settled } from '@ember/test-helpers';
-
 import { type Awaitable, createDeferred, setPromiseResult } from '@warp-drive/core/request';
 import type { RenderingTestContext } from '@warp-drive/diagnostic/ember';
 import { module, setupRenderingTest, test } from '@warp-drive/diagnostic/ember';
@@ -61,14 +59,14 @@ module('Integration | get-promise-state', function (hooks) {
     );
     assert.equal(state1!.result, null);
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Count:\n          1');
+    assert.dom().hasText('Count:\n          1');
     defer.resolve('Our Data');
     await defer.promise;
-    await rerender();
+    await this.h.rerender();
     assert.equal(state1!, getPromiseState(defer.promise));
     assert.equal(state1!.result, 'Our Data');
     assert.equal(counter, 2);
-    assert.equal(this.element.textContent?.trim(), 'Our DataCount:\n          2');
+    assert.dom().hasText('Our DataCount:\n          2');
   });
 
   test('it renders each stage of a promise resolving in the same microtask queue', async function (this: RenderingTestContext, assert) {
@@ -95,11 +93,11 @@ module('Integration | get-promise-state', function (hooks) {
     assert.equal(state1!, getPromiseState(promise));
     assert.equal(state1!.result, null);
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Count:\n          1');
-    await rerender();
+    assert.dom().hasText('Count:\n          1');
+    await this.h.rerender();
     assert.equal(state1!.result, 'Our Data');
     assert.equal(counter, 2);
-    assert.equal(this.element.textContent?.trim(), 'Our DataCount:\n          2');
+    assert.dom().hasText('Our DataCount:\n          2');
   });
 
   test('it renders only once when the promise already has a result cached', async function (this: RenderingTestContext, assert) {
@@ -127,10 +125,10 @@ module('Integration | get-promise-state', function (hooks) {
       </template>
     );
 
-    assert.equal(this.element.textContent?.trim(), 'Our DataCount:\n          1');
-    await settled();
+    assert.dom().hasText('Our DataCount:\n          1');
+    await this.h.rerender();
 
-    assert.equal(this.element.textContent?.trim(), 'Our DataCount:\n          1');
+    assert.dom().hasText('Our DataCount:\n          1');
   });
 
   test('it transitions to error state correctly', async function (this: RenderingTestContext, assert) {
@@ -167,13 +165,13 @@ module('Integration | get-promise-state', function (hooks) {
     assert.equal(state1!.result, null);
     assert.equal(state1!.error, null);
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Pending\n          Count:\n          1');
-    await rerender();
+    assert.dom().hasText('Pending\n          Count:\n          1');
+    await this.h.rerender();
     assert.equal(state1!.result, null);
     assert.true(state1!.error instanceof Error);
     assert.equal((state1!.error as Error | undefined)?.message, 'Our Error');
     assert.equal(counter, 2);
-    assert.equal(this.element.textContent?.trim(), 'Our Error\n          Count:\n          2');
+    assert.dom().hasText('Our Error\n          Count:\n          2');
   });
 
   test('it renders only once when the promise error state is already cached', async function (this: RenderingTestContext, assert) {
@@ -216,13 +214,13 @@ module('Integration | get-promise-state', function (hooks) {
     assert.true(state1!.error instanceof Error);
     assert.equal((state1!.error as Error | undefined)?.message, 'Our Error');
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Our Error\n          Count:\n          1');
-    await rerender();
+    assert.dom().hasText('Our Error\n          Count:\n          1');
+    await this.h.rerender();
     assert.equal(state1!.result, null);
     assert.true(state1!.error instanceof Error);
     assert.equal((state1!.error as Error | undefined)?.message, 'Our Error');
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Our Error\n          Count:\n          1');
+    assert.dom().hasText('Our Error\n          Count:\n          1');
   });
 
   test('it unwraps promise-proxies that utilize the secret symbol for error states', async function (this: RenderingTestContext, assert) {
@@ -267,13 +265,13 @@ module('Integration | get-promise-state', function (hooks) {
     assert.true(state1!.error instanceof Error);
     assert.equal((state1!.error as Error | undefined)?.message, 'Our Error');
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Our Error\n          Count:\n          1');
-    await rerender();
+    assert.dom().hasText('Our Error\n          Count:\n          1');
+    await this.h.rerender();
     assert.equal(state1!.result, null);
     assert.true(state1!.error instanceof Error);
     assert.equal((state1!.error as Error | undefined)?.message, 'Our Error');
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Our Error\n          Count:\n          1');
+    assert.dom().hasText('Our Error\n          Count:\n          1');
     assert.equal(state1!, getPromiseState<never, Error>(_promise));
   });
 
@@ -302,10 +300,10 @@ module('Integration | get-promise-state', function (hooks) {
       </template>
     );
 
-    assert.equal(this.element.textContent?.trim(), 'Our DataCount:\n          1');
-    await settled();
+    assert.dom().hasText('Our DataCount:\n          1');
+    await this.h.rerender();
 
-    assert.equal(this.element.textContent?.trim(), 'Our DataCount:\n          1');
+    assert.dom().hasText('Our DataCount:\n          1');
     assert.equal(state1!, getPromiseState(_promise));
   });
 });

--- a/tests/warp-drive__ember/tests/integration/get-request-state-test.gts
+++ b/tests/warp-drive__ember/tests/integration/get-request-state-test.gts
@@ -1,5 +1,3 @@
-import { rerender, settled } from '@ember/test-helpers';
-
 import { Fetch, RequestManager } from '@warp-drive/core';
 import type { CacheHandler, Future, NextFn } from '@warp-drive/core/request';
 import type { RequestContext, StructuredDataDocument } from '@warp-drive/core/types/request';
@@ -298,9 +296,9 @@ module<LocalTestContext>('Integration | get-request-state', function (hooks) {
 
     assert.equal(state1!.result, null);
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Count:\n          1');
+    assert.dom().hasText('Count:\n          1');
     await request;
-    await rerender();
+    await this.h.rerender();
     assert.equal(state1, getRequestState(request));
     assert.deepEqual(state1!.result, {
       data: {
@@ -312,7 +310,7 @@ module<LocalTestContext>('Integration | get-request-state', function (hooks) {
       },
     });
     assert.equal(counter, 2);
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount:\n          2');
+    assert.dom().hasText('Chris ThoburnCount:\n          2');
   });
 
   test('it renders only once when the promise already has a result cached', async function (assert) {
@@ -349,9 +347,9 @@ module<LocalTestContext>('Integration | get-request-state', function (hooks) {
       },
     });
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount:\n          1');
+    assert.dom().hasText('Chris ThoburnCount:\n          1');
 
-    await settled();
+    await this.h.rerender();
 
     assert.deepEqual(state1!.result, {
       data: {
@@ -363,7 +361,7 @@ module<LocalTestContext>('Integration | get-request-state', function (hooks) {
       },
     });
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount:\n          1');
+    assert.dom().hasText('Chris ThoburnCount:\n          1');
   });
 
   test('it transitions to error state correctly', async function (assert) {
@@ -400,13 +398,13 @@ module<LocalTestContext>('Integration | get-request-state', function (hooks) {
     assert.equal(state1!.result, null, 'result is null');
     assert.equal(state1!.error, null, 'error is null');
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), 'Pending\n          Count:\n          1');
+    assert.dom().hasText('Pending\n          Count:\n          1');
     try {
       await request;
     } catch {
       // ignore the error
     }
-    await rerender();
+    await this.h.rerender();
     assert.equal(state1!.result, null, 'after rerender result is still null');
     assert.true(state1!.error instanceof Error, 'error is an instance of Error');
     assert.equal(
@@ -415,10 +413,11 @@ module<LocalTestContext>('Integration | get-request-state', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 2, 'counter is 2');
-    assert.equal(
-      this.element.textContent?.trim(),
-      `[404 Not Found] GET (cors) - ${buildBaseURL({ resourcePath: 'users/2' })}\n          Count:\n          2`
-    );
+    assert
+      .dom()
+      .hasText(
+        `[404 Not Found] GET (cors) - ${buildBaseURL({ resourcePath: 'users/2' })}\n          Count:\n          2`
+      );
   });
 
   test('it renders only once when the promise error state is already cached', async function (assert) {
@@ -464,11 +463,12 @@ module<LocalTestContext>('Integration | get-request-state', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(
-      this.element.textContent?.trim(),
-      `[404 Not Found] GET (cors) - ${buildBaseURL({ resourcePath: 'users/2' })}\n          Count:\n          1`
-    );
-    await rerender();
+    assert
+      .dom()
+      .hasText(
+        `[404 Not Found] GET (cors) - ${buildBaseURL({ resourcePath: 'users/2' })}\n          Count:\n          1`
+      );
+    await this.h.rerender();
     assert.equal(state1!.result, null, 'after rerender result is still null');
     assert.true(state1!.error instanceof Error, 'error is an instance of Error');
     assert.equal(
@@ -477,9 +477,10 @@ module<LocalTestContext>('Integration | get-request-state', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(
-      this.element.textContent?.trim(),
-      `[404 Not Found] GET (cors) - ${buildBaseURL({ resourcePath: 'users/2' })}\n          Count:\n          1`
-    );
+    assert
+      .dom()
+      .hasText(
+        `[404 Not Found] GET (cors) - ${buildBaseURL({ resourcePath: 'users/2' })}\n          Count:\n          1`
+      );
   });
 });

--- a/tests/warp-drive__ember/tests/integration/request-component-invalidation-test.gts
+++ b/tests/warp-drive__ember/tests/integration/request-component-invalidation-test.gts
@@ -1,5 +1,3 @@
-import { rerender } from '@ember/test-helpers';
-
 import { CacheHandler, Fetch, RequestManager, Store } from '@warp-drive/core';
 import {
   instantiateRecord,
@@ -23,17 +21,6 @@ import { MockServerHandler } from '@warp-drive/holodeck';
 import { GET } from '@warp-drive/holodeck/mock';
 import { JSONAPICache } from '@warp-drive/json-api';
 import { buildBaseURL } from '@warp-drive/utilities';
-
-function trim(str?: string | null): string {
-  if (!str) {
-    return '';
-  }
-  return str
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .join(' ');
-}
 
 type User = {
   id: string;
@@ -152,9 +139,9 @@ module<LocalTestContext>('Integration | <Request /> | Subscription', function (h
       </template>
     );
     await request;
-    await rerender();
+    await this.h.rerender();
 
-    assert.equal(trim(this.element.textContent), 'Chris Thoburn | is fresh');
+    assert.dom().hasText('Chris Thoburn | is fresh');
     assert.verifySteps([`request: GET ${url}`]);
 
     const req2 = this.store.request<SingleResourceDataDocument<User>>({
@@ -162,12 +149,12 @@ module<LocalTestContext>('Integration | <Request /> | Subscription', function (h
       method: 'GET',
       cacheOptions: { types: ['user'], backgroundReload: true },
     });
-    await rerender();
-    assert.equal(trim(this.element.textContent), 'Chris Thoburn | is refreshing');
+    await this.h.rerender();
+    assert.dom().hasText('Chris Thoburn | is refreshing');
 
     await req2;
     await this.store._getAllPending();
-    assert.equal(trim(this.element.textContent), 'Chris Thoburn x2 | is fresh');
+    assert.dom().hasText('Chris Thoburn x2 | is fresh');
     assert.verifySteps([`request: GET ${url}`]);
   });
 
@@ -192,9 +179,9 @@ module<LocalTestContext>('Integration | <Request /> | Subscription', function (h
       </template>
     );
     await request;
-    await rerender();
+    await this.h.rerender();
 
-    assert.equal(trim(this.element.textContent), 'Chris Thoburn');
+    assert.dom().hasText('Chris Thoburn');
     assert.verifySteps([`request: GET ${url}`]);
 
     // force expiration
@@ -204,12 +191,12 @@ module<LocalTestContext>('Integration | <Request /> | Subscription', function (h
       method: 'GET',
       cacheOptions: { types: ['user'] },
     });
-    await rerender();
-    assert.equal(trim(this.element.textContent), 'Loading...');
+    await this.h.rerender();
+    assert.dom().hasText('Loading...');
 
     await req2;
-    await rerender();
-    assert.equal(trim(this.element.textContent), 'Chris Thoburn x2');
+    await this.h.rerender();
+    assert.dom().hasText('Chris Thoburn x2');
     assert.verifySteps([`request: GET ${url}`]);
   });
 });

--- a/tests/warp-drive__ember/tests/integration/request-component-test.gts
+++ b/tests/warp-drive__ember/tests/integration/request-component-test.gts
@@ -1,14 +1,13 @@
 /* eslint-disable no-console */
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
-import { click, rerender, settled } from '@ember/test-helpers';
 import Component from '@glimmer/component';
-import { cached, tracked } from '@glimmer/tracking';
 
 import type { Store } from '@warp-drive/core';
 import { CacheHandler as StoreHandler, Fetch, RequestManager } from '@warp-drive/core';
 import { registerDerivations, withDefaults } from '@warp-drive/core/reactive';
 import type { CacheHandler, Future, NextFn } from '@warp-drive/core/request';
+import { memoized, signal } from '@warp-drive/core/store/-private';
 import type { RequestContext, StructuredDataDocument } from '@warp-drive/core/types/request';
 import type { SingleResourceDataDocument } from '@warp-drive/core/types/spec/document';
 import type { Type } from '@warp-drive/core/types/symbols';
@@ -183,9 +182,9 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
 
     assert.equal(state.result, null);
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'PendingCount: 1');
+    assert.dom().hasText('PendingCount: 1');
     await request;
-    await rerender();
+    await this.h.rerender();
     assert.equal(state, getRequestState(request));
     assert.deepEqual(state.result, {
       data: {
@@ -197,7 +196,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       },
     });
     assert.equal(counter, 2);
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount: 2');
+    assert.dom().hasText('Chris ThoburnCount: 2');
   });
 
   test('it renders only once when the promise already has a result cached', async function (assert) {
@@ -232,9 +231,9 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       },
     });
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount: 1');
+    assert.dom().hasText('Chris ThoburnCount: 1');
 
-    await settled();
+    await this.h.settled();
 
     assert.deepEqual(state.result, {
       data: {
@@ -246,7 +245,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       },
     });
     assert.equal(counter, 1);
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount: 1');
+    assert.dom().hasText('Chris ThoburnCount: 1');
   });
 
   test('it transitions to error state correctly', async function (assert) {
@@ -273,13 +272,13 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     assert.equal(state.result, null, 'result is null');
     assert.equal(state.error, null, 'error is null');
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), 'PendingCount: 1');
+    assert.dom().hasText('PendingCount: 1');
     try {
       await request;
     } catch {
       // ignore the error
     }
-    await rerender();
+    await this.h.rerender();
     assert.equal(state.result, null, 'after rerender result is still null');
     assert.true(state.error instanceof Error, 'error is an instance of Error');
     assert.equal(
@@ -288,7 +287,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 2, 'counter is 2');
-    assert.equal(this.element.textContent?.trim(), `[404 Not Found] GET (cors) - ${url}Count: 2`);
+    assert.dom().hasText(`[404 Not Found] GET (cors) - ${url}Count: 2`);
   });
 
   test('we can retry from error state', async function (assert) {
@@ -326,13 +325,13 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     assert.equal(state2.result, null, 'result is null');
     assert.equal(state2.error, null, 'error is null');
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), 'PendingCount: 1');
+    assert.dom().hasText('PendingCount: 1');
     try {
       await request;
     } catch {
       // ignore the error
     }
-    await rerender();
+    await this.h.rerender();
     assert.equal(state2.result, null, 'after rerender result is still null');
     assert.true(state2.error instanceof Error, 'error is an instance of Error');
     assert.equal(
@@ -341,13 +340,13 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 2, 'counter is 2');
-    assert.equal(this.element.textContent?.trim(), `[404 Not Found] GET (cors) - ${url}Count:2Retry`);
+    assert.dom().hasText(`[404 Not Found] GET (cors) - ${url}Count:2Retry`);
 
-    await click('[test-id="retry-button"]');
+    await this.h.click('[test-id="retry-button"]');
 
     assert.verifySteps(['retry']);
     assert.equal(counter, 4, 'counter is 4');
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount: 4');
+    assert.dom().hasText('Chris ThoburnCount: 4');
   });
 
   test('externally retriggered request works as expected', async function (assert) {
@@ -356,7 +355,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     const state2 = getRequestState(request);
 
     class RequestSource {
-      @tracked request: Future<UserResource> = request;
+      @signal request: Future<UserResource> = request;
     }
     const source = new RequestSource();
 
@@ -384,21 +383,21 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
 
     assert.equal(state2, getRequestState(request), 'state is a stable reference');
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), 'PendingCount: 1');
+    assert.dom().hasText('PendingCount: 1');
 
     await request;
-    await rerender();
+    await this.h.rerender();
 
     assert.equal(counter, 2, 'counter is 2');
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount: 2');
+    assert.dom().hasText('Chris ThoburnCount: 2');
 
     const request2 = this.manager.request<UserResource>({ url, method: 'GET' });
     source.request = request2;
 
-    await rerender();
+    await this.h.rerender();
 
     assert.equal(counter, 3, 'counter is 3');
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount: 3');
+    assert.dom().hasText('Chris ThoburnCount: 3');
   });
 
   test('externally retriggered request works as expected (store CacheHandler)', async function (assert) {
@@ -432,7 +431,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     const state2 = getRequestState(request);
 
     class RequestSource {
-      @tracked request: Future<SingleResourceDataDocument<User>> = request;
+      @signal request: Future<SingleResourceDataDocument<User>> = request;
     }
     const source = new RequestSource();
 
@@ -460,26 +459,26 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
 
     assert.equal(state2, getRequestState(request), 'state is a stable reference');
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), 'PendingCount: 1');
+    assert.dom().hasText('PendingCount: 1');
 
     await request;
-    await rerender();
+    await this.h.rerender();
     assert.equal(counter, 2, 'counter is 2');
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount: 2');
+    assert.dom().hasText('Chris ThoburnCount: 2');
 
     const request2 = store.request<SingleResourceDataDocument<User>>({ url, method: 'GET' });
     source.request = request2;
 
-    await rerender();
+    await this.h.rerender();
 
     assert.equal(counter, 3, 'counter is 3');
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount: 3');
+    assert.dom().hasText('Chris ThoburnCount: 3');
 
     await request2;
-    await rerender();
+    await this.h.rerender();
 
     assert.equal(counter, 3, 'counter is 3');
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount: 3');
+    assert.dom().hasText('Chris ThoburnCount: 3');
   });
 
   test('it rethrows if error block is not present', async function (assert) {
@@ -505,7 +504,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     assert.equal(state.result, null, 'result is null');
     assert.equal(state.error, null, 'error is null');
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), 'PendingCount: 1');
+    assert.dom().hasText('PendingCount: 1');
     const cleanup = setupOnError((message) => {
       assert.step('render-error');
       assert.true(
@@ -518,7 +517,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     } catch {
       // ignore the error
     }
-    await rerender();
+    await this.h.rerender();
     cleanup();
     assert.verifySteps(['render-error']);
     assert.equal(state.result, null, 'after rerender result is still null');
@@ -529,7 +528,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 1, 'counter is still 1');
-    assert.equal(this.element.textContent?.trim(), '');
+    assert.dom().hasText('');
   });
 
   test('it transitions to cancelled state correctly', async function (assert) {
@@ -557,7 +556,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     assert.equal(state.result, null, 'result is null');
     assert.equal(state.error, null, 'error is null');
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), 'PendingCount: 1');
+    assert.dom().hasText('PendingCount: 1');
 
     request.abort();
 
@@ -566,7 +565,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     } catch {
       // ignore the error
     }
-    await rerender();
+    await this.h.rerender();
     assert.equal(state.result, null, 'after rerender result is still null');
     assert.true(state.error instanceof Error, 'error is an instance of Error');
     assert.equal(
@@ -575,7 +574,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 2, 'counter is 2');
-    assert.equal(this.element.textContent?.trim(), 'Cancelled The user aborted a request.Count: 2');
+    assert.dom().hasText('Cancelled The user aborted a request.Count: 2');
   });
 
   test('we can retry from cancelled state', async function (assert) {
@@ -615,7 +614,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     assert.equal(state1.result, null, 'result is null');
     assert.equal(state1.error, null, 'error is null');
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), 'PendingCount: 1');
+    assert.dom().hasText('PendingCount: 1');
 
     request.abort();
 
@@ -624,7 +623,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     } catch {
       // ignore the error
     }
-    await rerender();
+    await this.h.rerender();
     assert.equal(state1.result, null, 'after rerender result is still null');
     assert.true(state1.error instanceof Error, 'error is an instance of Error');
     assert.equal(
@@ -633,13 +632,13 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 2, 'counter is 2');
-    assert.equal(this.element.textContent?.trim(), 'Cancelled:The user aborted a request.Count:2Retry');
+    assert.dom().hasText('Cancelled:The user aborted a request.Count:2Retry');
 
-    await click('[test-id="retry-button"]');
+    await this.h.click('[test-id="retry-button"]');
 
     assert.verifySteps(['retry']);
     assert.equal(counter, 4, 'counter is 4');
-    assert.equal(this.element.textContent?.trim(), 'Chris ThoburnCount: 4');
+    assert.dom().hasText('Chris ThoburnCount: 4');
   });
 
   test('it transitions to error state if cancelled block is not present', async function (assert) {
@@ -666,7 +665,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     assert.equal(state.result, null, 'result is null');
     assert.equal(state.error, null, 'error is null');
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), 'PendingCount: 1');
+    assert.dom().hasText('PendingCount: 1');
 
     request.abort();
 
@@ -675,7 +674,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     } catch {
       // ignore the error
     }
-    await rerender();
+    await this.h.rerender();
     assert.equal(state.result, null, 'after rerender result is still null');
     assert.true(state.error instanceof Error, 'error is an instance of Error');
     assert.equal(
@@ -684,7 +683,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 2, 'counter is 2');
-    assert.equal(this.element.textContent?.trim(), 'The user aborted a request.Count: 2');
+    assert.dom().hasText('The user aborted a request.Count: 2');
   });
 
   test('it does not rethrow for cancelled', async function (assert) {
@@ -710,7 +709,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     assert.equal(state.result, null, 'result is null');
     assert.equal(state.error, null, 'error is null');
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), 'PendingCount: 1');
+    assert.dom().hasText('PendingCount: 1');
 
     const cleanup = setupOnError((message) => {
       assert.step('render-error');
@@ -722,7 +721,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     } catch {
       // ignore the error
     }
-    await rerender();
+    await this.h.rerender();
     cleanup();
     assert.equal(state.result, null, 'after rerender result is still null');
     assert.true(state.error instanceof Error, 'error is an instance of Error');
@@ -732,7 +731,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), '');
+    assert.dom().hasText('');
     assert.verifySteps([], 'no error should be thrown');
   });
 
@@ -770,8 +769,8 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), `[404 Not Found] GET (cors) - ${url}Count: 1`);
-    await rerender();
+    assert.dom().hasText(`[404 Not Found] GET (cors) - ${url}Count: 1`);
+    await this.h.rerender();
     assert.equal(state.result, null, 'after rerender result is still null');
     assert.true(state.error instanceof Error, 'error is an instance of Error');
     assert.equal(
@@ -780,7 +779,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       'error message is correct'
     );
     assert.equal(counter, 1, 'counter is 1');
-    assert.equal(this.element.textContent?.trim(), `[404 Not Found] GET (cors) - ${url}Count: 1`);
+    assert.dom().hasText(`[404 Not Found] GET (cors) - ${url}Count: 1`);
   });
 
   test('isOnline updates when expected', async function (assert) {
@@ -795,19 +794,19 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       </template>
     );
     await request;
-    await rerender();
+    await this.h.rerender();
 
-    assert.equal(this.element.textContent?.trim(), 'Online: true');
+    assert.dom().hasText('Online: true');
     window.dispatchEvent(new Event('offline'));
 
-    await rerender();
+    await this.h.rerender();
 
-    assert.equal(this.element.textContent?.trim(), 'Online: false');
+    assert.dom().hasText('Online: false');
     window.dispatchEvent(new Event('online'));
 
-    await rerender();
+    await this.h.rerender();
 
-    assert.equal(this.element.textContent?.trim(), 'Online: true');
+    assert.dom().hasText('Online: true');
   });
 
   test('@autorefreshBehavior="reload" works as expected', async function (assert) {
@@ -831,23 +830,23 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       </template>
     );
     await request;
-    await rerender();
+    await this.h.rerender();
 
-    assert.equal(this.element.textContent?.trim(), 'Chris Thoburn | Online: true');
+    assert.dom().hasText('Chris Thoburn | Online: true');
     window.dispatchEvent(new Event('offline'));
 
-    await rerender();
+    await this.h.rerender();
 
     // enable the auto-refresh threshold to trigger
     await new Promise((resolve) => setTimeout(resolve, 1));
 
-    assert.equal(this.element.textContent?.trim(), 'Chris Thoburn | Online: false');
+    assert.dom().hasText('Chris Thoburn | Online: false');
     window.dispatchEvent(new Event('online'));
 
     // let the event dispatch complete
     await new Promise((resolve) => setTimeout(resolve, 1));
-    await settled();
-    assert.equal(this.element.textContent?.trim(), 'James Thoburn | Online: true');
+    await this.h.settled();
+    assert.dom().hasText('James Thoburn | Online: true');
   });
 
   test('idle state does not error', async function (assert) {
@@ -864,7 +863,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       </template>
     );
 
-    assert.equal(this.element.textContent?.trim(), 'Waiting');
+    assert.dom().hasText('Waiting');
     assert.verifySteps([], 'no error should be thrown');
     cleanup();
   });
@@ -897,7 +896,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       );
     }
 
-    assert.equal(this.element.textContent?.trim(), '');
+    assert.dom().hasText('');
     assert.verifySteps(['render-error', 'render-error-caught'], 'error should be thrown');
     cleanup();
   });
@@ -909,7 +908,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     const url = await mockGETSuccess(this);
 
     class State {
-      @tracked request: ReturnType<typeof store.request> | undefined = undefined;
+      @signal request: ReturnType<typeof store.request> | undefined = undefined;
     }
     const state = new State();
     await this.render(
@@ -922,15 +921,15 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
       </template>
     );
 
-    assert.equal(this.element.textContent?.trim(), 'Waiting');
+    assert.dom().hasText('Waiting');
 
     const request = store.request<UserResource>({ url, method: 'GET' });
     state.request = request;
 
     await request;
-    await rerender();
+    await this.h.rerender();
 
-    assert.equal(this.element.textContent?.trim(), 'Content');
+    assert.dom().hasText('Content');
   });
 
   test('request with an identity does not trigger a second request', async function (assert) {
@@ -968,14 +967,14 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     await mockGETSuccess(this); // need this because we are planning on making two requests
 
     class Dependency {
-      @tracked trackedThing = 'value';
+      @signal trackedThing = 'value';
     }
     const dependency = new Dependency();
 
     let request: ReturnType<typeof store.request<SingleResourceDataDocument<User>>>;
     class Issuer extends Component {
       // Ensure that the request doesn't kick off until after the Request component renders.
-      @cached
+      @memoized
       get request() {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- This is intentional.
         dependency.trackedThing; // subscribe to something tracked
@@ -1002,7 +1001,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     assert.equal(state.result, null);
     assert.verifySteps(['loading'], 'loading');
     await request!;
-    await rerender();
+    await this.h.rerender();
     assert.equal(state, getRequestState(request!));
     const record = store.peekRecord<User>('user', '1');
     assert.notEqual(record, null);
@@ -1012,7 +1011,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
 
     dependency.trackedThing = 'value'; // trigger a notification
 
-    await rerender();
+    await this.h.rerender();
     assert.notEqual(state, getRequestState(request!));
     assert.equal(state.result?.data, record);
     assert.equal(record!.name, 'Chris Thoburn');

--- a/tests/warp-drive__ember/tests/integration/request-component-test.gts
+++ b/tests/warp-drive__ember/tests/integration/request-component-test.gts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
@@ -11,6 +10,7 @@ import { memoized, signal } from '@warp-drive/core/store/-private';
 import type { RequestContext, StructuredDataDocument } from '@warp-drive/core/types/request';
 import type { SingleResourceDataDocument } from '@warp-drive/core/types/spec/document';
 import type { Type } from '@warp-drive/core/types/symbols';
+import { setupOnError } from '@warp-drive/diagnostic';
 import type { RenderingTestContext } from '@warp-drive/diagnostic/ember';
 import { module, setupRenderingTest, test as _test } from '@warp-drive/diagnostic/ember';
 import { getRequestState, Request } from '@warp-drive/ember';
@@ -25,35 +25,6 @@ interface LocalTestContext extends RenderingTestContext {
 type DiagnosticTest = Parameters<typeof _test<LocalTestContext>>[1];
 function test(name: string, callback: DiagnosticTest): void {
   return _test<LocalTestContext>(name, callback);
-}
-
-function setupOnError(cb: (message: Error | string) => void) {
-  const originalLog = console.error;
-  // eslint-disable-next-line prefer-const
-  let cleanup!: () => void;
-  const handler = function (e: ErrorEvent | (Event & { reason: Error | string })) {
-    if (e instanceof ErrorEvent || e instanceof Event) {
-      e.preventDefault();
-      e.stopPropagation();
-      e.stopImmediatePropagation();
-      cb('error' in e ? (e.error as string | Error) : e.reason);
-    } else {
-      cb(e);
-    }
-    cleanup();
-    return false;
-  };
-  cleanup = () => {
-    window.removeEventListener('unhandledrejection', handler, { capture: true });
-    window.removeEventListener('error', handler, { capture: true });
-    console.error = originalLog;
-  };
-  console.error = handler;
-
-  window.addEventListener('unhandledrejection', handler, { capture: true });
-  window.addEventListener('error', handler, { capture: true });
-
-  return cleanup;
 }
 
 type UserResource = {

--- a/tests/warp-drive__ember/tests/integration/request-component-test.gts
+++ b/tests/warp-drive__ember/tests/integration/request-component-test.gts
@@ -1009,7 +1009,7 @@ module<LocalTestContext>('Integration | <Request />', function (hooks) {
     assert.equal(record!.name, 'Chris Thoburn');
     assert.verifySteps(['Chris Thoburn']);
 
-    dependency.trackedThing = 'value'; // trigger a notification
+    dependency.trackedThing = 'new-value'; // trigger a notification
 
     await this.h.rerender();
     assert.notEqual(state, getRequestState(request!));

--- a/warp-drive-packages/core/src/request/-private/future.ts
+++ b/warp-drive-packages/core/src/request/-private/future.ts
@@ -1,3 +1,5 @@
+import { DEBUG } from '@warp-drive/build-config/env';
+
 import { IS_FUTURE, type StructuredDocument } from '../../types/request';
 import type { ContextOwner } from './context';
 import type { Deferred, DeferredFuture, Future } from './types';
@@ -29,6 +31,17 @@ export function upgradePromise<T>(promise: Promise<StructuredDocument<T>>, futur
   (promise as Future<T>).lid = future.lid;
   (promise as Future<T>).requester = future.requester;
 
+  if (DEBUG) {
+    // @ts-expect-error
+    promise.toJSON = () => {
+      const id = 'Future<' + (promise as Future<T>).id + '>';
+      if ((promise as Future<T>).lid) {
+        return `${id} (${(promise as Future<T>).lid!.lid})`;
+      }
+      return id;
+    };
+  }
+
   return promise as Future<T>;
 }
 
@@ -56,6 +69,17 @@ export function createFuture<T>(owner: ContextOwner): DeferredFuture<T> {
   promise.id = owner.requestId;
   promise.lid = owner.god.identifier;
   promise.requester = owner.god.requester;
+
+  if (DEBUG) {
+    // @ts-expect-error
+    promise.toJSON = () => {
+      const id = 'Future<' + promise.id + '>';
+      if (promise.lid) {
+        return `${id} (${promise.lid.lid})`;
+      }
+      return id;
+    };
+  }
 
   deferred.promise = promise;
   return deferred;


### PR DESCRIPTION
ports @ember/test-helpers into diagnostic and converts them to be scoped to tests and framework agnostic + adapter for waiters.

Still need to develop better react waiters for general async, but `act` covers rerender and render.

With this, the tests for @warp-drive/ember are likely generic enough a lightweight adapter could allow them to run in other frameworks like react as well.