### PR TITLE
feat: Diagnostic Timeline

### DIFF
--- a/packages/diagnostic/src/-types.ts
+++ b/packages/diagnostic/src/-types.ts
@@ -7,7 +7,7 @@ export type CompatTestReport = {
   failed: number;
   passed: number;
   total: number;
-  runDuration: number;
+  runDuration: number | null;
   skipped: boolean;
   todo: boolean;
   testId: string;
@@ -18,11 +18,21 @@ export interface Emitter {
   emit(name: 'test-start' | 'test-finish', data: CompatTestReport): void;
 }
 
-export type ParamConfig = {
-  id: string;
-  label: string;
-  value: boolean | string;
-};
+export type ParamConfig =
+  | {
+      id: string;
+      label: string;
+      value: boolean;
+      defaultValue: boolean;
+      reload?: boolean;
+    }
+  | {
+      id: string;
+      label: string;
+      value: string;
+      defaultValue: string;
+      reload?: boolean;
+    };
 
 export type GlobalHooksStorage<TC extends TestContext> = {
   onSuiteStart: GlobalCallback[];
@@ -34,17 +44,22 @@ export type GlobalHooksStorage<TC extends TestContext> = {
 };
 
 export type GlobalConfig<TC extends TestContext = TestContext> = {
+  name: {
+    org: string;
+    package: string;
+  };
   params: {
     [key in
       | 'search'
-      | 'concurrency'
-      | 'tryCatch'
+      | 'useConcurrency'
+      | 'noTryCatch'
       | 'instrument'
       | 'hideReport'
       | 'memory'
       | 'groupLogs'
       | 'debug'
-      | 'container']: ParamConfig;
+      | 'hidecontainer'
+      | 'timeline']: ParamConfig;
   };
   tests: Set<string>;
   modules: Set<string>;

--- a/packages/diagnostic/src/-types/report.ts
+++ b/packages/diagnostic/src/-types/report.ts
@@ -28,7 +28,20 @@ export interface TestReport {
     failed: boolean;
   };
   module: ModuleReport;
+  timeline: TimelineEntry[];
 }
+
+export interface InteractionEvent {
+  type: string;
+  subtype: string;
+  series: string | null;
+}
+
+export interface TimelineEntry {
+  event: DiagnosticReport | InteractionEvent;
+  timestamp: number | null;
+}
+
 export interface ModuleReport {
   id: string;
   name: string;
@@ -55,4 +68,5 @@ export interface Reporter {
   onModuleStart: (module: ModuleReport) => void;
   onModuleFinish: (module: ModuleReport) => void;
   onDiagnostic: (diagnostic: DiagnosticReport) => void;
+  updateTimeline: (test: TestReport) => void;
 }

--- a/packages/diagnostic/src/helpers/-dom/-helper-context.ts
+++ b/packages/diagnostic/src/helpers/-dom/-helper-context.ts
@@ -1,3 +1,5 @@
+import type { Diagnostic } from '../../internals/diagnostic';
+
 /**
  * The public API for the test context, which test authors can depend on being
  * available.
@@ -8,6 +10,8 @@
 export interface HelperContext {
   element: HTMLElement | null;
   config: HelperConfig;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assert: Diagnostic<any>;
 }
 
 export interface HelperConfig {

--- a/packages/diagnostic/src/helpers/-dom/helper-hooks.ts
+++ b/packages/diagnostic/src/helpers/-dom/helper-hooks.ts
@@ -62,6 +62,23 @@ export function registerHook(helperName: string, label: HookLabel, hook: Hook): 
   };
 }
 
+function registerStarHook(hook: Hook): HookUnregister {
+  let hooksForHelper = registeredHooks.get('*');
+
+  if (hooksForHelper === undefined) {
+    hooksForHelper = new Set<Hook>();
+    registeredHooks.set('*', hooksForHelper);
+  }
+
+  hooksForHelper.add(hook);
+
+  return {
+    unregister() {
+      hooksForHelper.delete(hook);
+    },
+  };
+}
+
 /**
  * Runs all hooks registered for a specific test helper.
  *
@@ -79,6 +96,13 @@ export function runHooks(helperName: string, label: HookLabel, ...args: unknown[
   const hooks = registeredHooks.get(getHelperKey(helperName, label)) || new Set<Hook>();
   const promises: Array<void | Promise<void>> = [];
 
+  const starHooks = registeredHooks.get('*') || new Set<Hook>();
+  starHooks.forEach((hook) => {
+    const hookResult = hook(helperName, label);
+
+    promises.push(hookResult);
+  });
+
   hooks.forEach((hook) => {
     const hookResult = hook(...args);
 
@@ -88,6 +112,9 @@ export function runHooks(helperName: string, label: HookLabel, ...args: unknown[
   return Promise.all(promises).then(() => {});
 }
 
+export const TEST_CONTEXT: unique symbol = Symbol('scope');
+
+let EventSeries = 0;
 export async function withHooks<T = Promise<void>>(options: {
   scope: HelperContext;
   name: string;
@@ -95,15 +122,21 @@ export async function withHooks<T = Promise<void>>(options: {
   cb: () => T;
   args?: unknown[];
 }): Promise<Awaited<T>> {
+  const series = `traceId:${EventSeries++}`;
+  const token = registerStarHook((type: string, subtype: string) => {
+    options.scope.assert.pushInteraction({ type, subtype, series });
+  });
   if (options.render) {
     return await options.scope.config.render(() =>
       runHooks(options.name, 'start', ...(options.args ?? []))
         .then(options.cb)
         .finally(() => runHooks(options.name, 'end', ...(options.args ?? [])))
+        .finally(token.unregister)
     );
   }
   return await Promise.resolve()
     .then(() => runHooks(options.name, 'start', ...(options.args ?? [])))
     .then(options.cb)
-    .finally(() => runHooks(options.name, 'end', ...(options.args ?? [])));
+    .finally(() => runHooks(options.name, 'end', ...(options.args ?? [])))
+    .finally(token.unregister);
 }

--- a/packages/diagnostic/src/internals/config.ts
+++ b/packages/diagnostic/src/internals/config.ts
@@ -1,4 +1,6 @@
 /* global Testem */
+import { IS_CI } from '@warp-drive/core/build-config/env';
+
 import type {
   GlobalCallback,
   GlobalConfig,
@@ -10,13 +12,52 @@ import type {
 } from '../-types';
 import { assert } from '../-utils';
 
-const urlParams = new URLSearchParams(window.location.search);
+const url = new URL(window.location.href);
+const urlParams = url.searchParams;
 
-const search = urlParams.get('search');
 const tests = new Set(urlParams.getAll('t'));
 const modules = new Set(urlParams.getAll('m'));
 
+export type ParamConfigScaffold =
+  | {
+      id: string;
+      label: string;
+      value: boolean;
+      reload?: boolean;
+    }
+  | {
+      id: string;
+      label: string;
+      value: string;
+      reload?: boolean;
+    };
+
+function withParam<T extends ParamConfigScaffold>(value: T): ParamConfig {
+  const val = value as ParamConfig;
+  val.defaultValue = value.value;
+  const param = urlParams.get(value.id);
+
+  if (param === null) {
+    return val;
+  }
+
+  if (typeof value.value === 'boolean') {
+    // '' is treated as true, 'false' or '0' as false
+    value.value = param === 'false' || param === '0' ? false : true;
+  } else if (typeof value.value === 'string') {
+    value.value = param;
+  } else {
+    throw new Error(`Unexpected parameter type for ${(value as ParamConfig).id}: ${typeof param}`);
+  }
+
+  return val;
+}
+
 export const Config: GlobalConfig = {
+  name: {
+    org: '@warp-drive/',
+    package: 'diagnostic',
+  },
   globalHooks: {
     beforeEach: [],
     afterEach: [],
@@ -34,51 +75,61 @@ export const Config: GlobalConfig = {
   modules,
   tests,
   params: {
-    search: {
+    search: withParam({
       id: 'search',
       label: 'Filter Tests',
-      value: search ?? '',
-    },
-    hideReport: {
+      value: '',
+      reload: true,
+    }),
+    hideReport: withParam({
       id: 'hideReport',
       label: 'Hide Report',
-      value: true,
-    },
-    concurrency: {
-      id: 'concurrency',
+      value: IS_CI ? true : false,
+    }),
+    useConcurrency: withParam({
+      id: 'useConcurrency',
       label: 'Enable Concurrency',
       value: false,
-    },
-    memory: {
+      reload: true,
+    }),
+    memory: withParam({
       id: 'memory',
       label: 'Instrument Memory',
       value: false,
-    },
-    instrument: {
+      reload: true,
+    }),
+    instrument: withParam({
       id: 'performance',
       label: 'Instrument Performance',
-      value: true,
-    },
-    groupLogs: {
+      value: IS_CI ? false : true,
+      reload: true,
+    }),
+    groupLogs: withParam({
       id: 'groupLogs',
       label: 'Group Logs',
       value: true,
-    },
-    debug: {
+    }),
+    debug: withParam({
       id: 'debug',
       label: 'Debug Mode',
-      value: false,
-    },
-    container: {
-      id: 'container',
+      value: IS_CI ? false : true,
+    }),
+    timeline: withParam({
+      id: 'timeline',
+      label: 'Show Timeline',
+      value: IS_CI ? false : true,
+    }),
+    hidecontainer: withParam({
+      id: 'hidecontainer',
       label: 'Hide Container',
       value: true,
-    },
-    tryCatch: {
-      id: 'tryCatch',
+    }),
+    noTryCatch: withParam({
+      id: 'noTryCatch',
       label: 'No Try/Catch',
-      value: true,
-    },
+      value: false,
+      reload: true,
+    }),
   },
   totals: {
     tests: 0,
@@ -151,13 +202,17 @@ export function setupGlobalHooks<TC extends TestContext>(cb: (hooks: GlobalHooks
 }
 
 export type ConfigOptions = {
+  org: string;
+  package: string;
   concurrency: number;
+  useConcurrency: boolean;
   instrument: boolean;
-  tryCatch: boolean;
+  noTryCatch: boolean;
   debug: boolean;
   groupLogs: boolean;
   memory: boolean;
-  container: boolean;
+  hidecontainer: boolean;
+  timeline: boolean;
   hideReport: boolean;
   params: Record<string, ParamConfig>;
   useTestem: boolean;
@@ -165,14 +220,15 @@ export type ConfigOptions = {
   testTimeoutMs: number;
 };
 const configOptions = [
-  'concurrency',
-  'tryCatch',
+  'useConcurrency',
+  'noTryCatch',
   'instrument',
   'hideReport',
+  'timeline',
   'memory',
   'groupLogs',
   'debug',
-  'container',
+  'hidecontainer',
 ] as const;
 export function configure(options: Partial<ConfigOptions>): void {
   if (options.useTestem && options.useDiagnostic) {
@@ -191,12 +247,28 @@ export function configure(options: Partial<ConfigOptions>): void {
 
   if ('concurrency' in options && typeof options.concurrency === 'number') {
     Config.concurrency = options.concurrency;
-    // @ts-expect-error
-    options.concurrency = options.concurrency > 1;
   }
+
+  Config.name = { org: '@warp-drive/', package: 'diagnostic' };
+
+  if ('org' in options && typeof options.org === 'string') {
+    Config.name.org = options.org;
+  } else if ('package' in options && typeof options.package === 'string') {
+    Config.name.org = '';
+  }
+  if ('package' in options && typeof options.package === 'string') {
+    Config.name.package = options.package;
+  } else if ('org' in options && typeof options.org === 'string') {
+    Config.name.package = '';
+  }
+
   configOptions.forEach((key) => {
     if (key in options && typeof options[key] === 'boolean') {
-      Config.params[key].value = options[key];
+      const param = Config.params[key];
+      // only copy over if not overridden by the URL
+      if (param.value === param.defaultValue) {
+        Config.params[key].value = options[key];
+      }
     }
     // don't allow setting these params via configure
     if (options.params?.[key]) {
@@ -215,14 +287,14 @@ export function getSettings(): {
   useDiagnostic: boolean;
   concurrency: number;
   params: {
-    concurrency: ParamConfig;
-    tryCatch: ParamConfig;
+    useConcurrency: ParamConfig;
+    noTryCatch: ParamConfig;
     instrument: ParamConfig;
     hideReport: ParamConfig;
     memory: ParamConfig;
     groupLogs: ParamConfig;
     debug: ParamConfig;
-    container: ParamConfig;
+    hidecontainer: ParamConfig;
     search: ParamConfig;
   };
 } {
@@ -248,4 +320,20 @@ export function groupLogs(): string | boolean {
 // 3 - forward
 // 4 - restart
 export function updateSuiteState(value: number): void {}
-export function updateConfigValue(key: string, value: boolean): void {}
+export function updateConfigValue<T extends ParamConfig>(paramConfig: T, newValue: T['value']): void {
+  // update our value
+  paramConfig.value = newValue;
+  // update the URL
+  if (paramConfig.value === paramConfig.defaultValue) {
+    urlParams.delete(paramConfig.id);
+  } else if (typeof paramConfig.value === 'boolean') {
+    urlParams.set(paramConfig.id, paramConfig.value ? 'true' : 'false');
+  }
+
+  history.replaceState(null, '', url.toString());
+
+  // if the config specifies reload, reload
+  if (paramConfig.reload) {
+    location.reload();
+  }
+}

--- a/packages/diagnostic/src/internals/config.ts
+++ b/packages/diagnostic/src/internals/config.ts
@@ -107,7 +107,7 @@ export const Config: GlobalConfig = {
     groupLogs: withParam({
       id: 'groupLogs',
       label: 'Group Logs',
-      value: true,
+      value: false,
     }),
     debug: withParam({
       id: 'debug',

--- a/packages/diagnostic/src/internals/delegating-reporter.ts
+++ b/packages/diagnostic/src/internals/delegating-reporter.ts
@@ -51,6 +51,11 @@ export const DelegatingReporter: Reporter = {
       reporter.onModuleFinish(report);
     }
   },
+  updateTimeline(test): void {
+    for (const reporter of Reporters) {
+      reporter.updateTimeline(test);
+    }
+  },
   onDiagnostic(report) {
     for (const reporter of Reporters) {
       reporter.onDiagnostic(report);

--- a/packages/diagnostic/src/internals/diagnostic.ts
+++ b/packages/diagnostic/src/internals/diagnostic.ts
@@ -43,9 +43,11 @@ export class Diagnostic<TC extends TestContext> {
   }
 
   pushInteraction(interaction: InteractionEvent): void {
-    const timestamp = this.__config.params.instrument ? performance.now() : null;
-    this.__report.timeline.push({ event: interaction, timestamp });
-    this.__reporter.updateTimeline(this.__report);
+    if (this.__config.params.timeline.value) {
+      const timestamp = this.__config.params.instrument ? performance.now() : null;
+      this.__report.timeline.push({ event: interaction, timestamp });
+      this.__reporter.updateTimeline(this.__report);
+    }
   }
 
   pushResult(
@@ -56,9 +58,11 @@ export class Diagnostic<TC extends TestContext> {
     });
     this.__report.result.diagnostics.push(diagnostic);
 
-    const timestamp = this.__config.params.instrument ? performance.now() : null;
-    this.__report.timeline.push({ event: diagnostic, timestamp });
-    this.__reporter.updateTimeline(this.__report);
+    if (this.__config.params.timeline.value) {
+      const timestamp = this.__config.params.instrument ? performance.now() : null;
+      this.__report.timeline.push({ event: diagnostic, timestamp });
+      this.__reporter.updateTimeline(this.__report);
+    }
 
     if (!diagnostic.passed) {
       this.__report.result.passed = false;
@@ -70,7 +74,7 @@ export class Diagnostic<TC extends TestContext> {
 
   equal<T>(actual: T, expected: T, message?: string): void {
     if (actual !== expected) {
-      if (this.__config.params.tryCatch.value) {
+      if (!this.__config.params.noTryCatch.value) {
         try {
           throw new Error(message || `Expected ${String(actual)} to equal ${String(expected)}`);
         } catch (err) {
@@ -104,7 +108,7 @@ export class Diagnostic<TC extends TestContext> {
 
   notEqual<T>(actual: T, expected: T, message?: string): void {
     if (actual === expected) {
-      if (this.__config.params.tryCatch.value) {
+      if (!this.__config.params.noTryCatch.value) {
         try {
           throw new Error(message || `Expected ${String(actual)} to not equal ${String(expected)}`);
         } catch (err) {
@@ -139,7 +143,7 @@ export class Diagnostic<TC extends TestContext> {
   deepEqual<T>(actual: T, expected: T, message?: string): void {
     const isEqual = equiv(actual, expected, true);
     if (!isEqual) {
-      if (this.__config.params.tryCatch.value) {
+      if (!this.__config.params.noTryCatch.value) {
         try {
           throw new Error(message || `Expected items to be equivalent`);
         } catch (err) {
@@ -190,7 +194,7 @@ export class Diagnostic<TC extends TestContext> {
   satisfies<T extends object, J extends T>(actual: J, expected: T, message?: string): void {
     const isEqual = equiv(actual, expected, false);
     if (!isEqual) {
-      if (this.__config.params.tryCatch.value) {
+      if (!this.__config.params.noTryCatch.value) {
         try {
           throw new Error(message || `Expected items to be equivalent`);
         } catch (err) {
@@ -225,7 +229,7 @@ export class Diagnostic<TC extends TestContext> {
   notDeepEqual<T>(actual: T, expected: T, message?: string): void {
     const isEqual = equiv(actual, expected, true);
     if (isEqual) {
-      if (this.__config.params.tryCatch.value) {
+      if (!this.__config.params.noTryCatch.value) {
         try {
           throw new Error(message || `Expected items to not be equivalent`);
         } catch (err) {

--- a/packages/diagnostic/src/internals/run.ts
+++ b/packages/diagnostic/src/internals/run.ts
@@ -1,6 +1,7 @@
 import type { HooksCallback, ModuleInfo, TestContext, TestInfo } from '../-types';
 import type { ModuleReport, TestReport } from '../-types/report';
 import { getChain } from '../-utils';
+import { TEST_CONTEXT } from '../helpers/-dom/helper-hooks';
 import { Config, groupLogs, instrument } from './config';
 import { DelegatingReporter } from './delegating-reporter';
 import { Diagnostic } from './diagnostic';
@@ -26,12 +27,6 @@ export async function runTest<TC extends TestContext>(
     return;
   }
 
-  const testContext = {
-    [PublicTestInfo]: {
-      id: test.id,
-      name: test.testName,
-    },
-  } as unknown as TC;
   const testReport: TestReport = {
     id: test.id,
     name: test.name,
@@ -46,9 +41,17 @@ export async function runTest<TC extends TestContext>(
       failed: false,
     },
     module: moduleReport,
+    timeline: [],
   };
   testReport.start = instrument() && performance.mark(`test:${test.module.moduleName} > ${test.name}:start`);
   const Assert = new Diagnostic(DelegatingReporter, Config, test, testReport);
+  const testContext = {
+    [PublicTestInfo]: {
+      id: test.id,
+      name: test.testName,
+    },
+    [TEST_CONTEXT]: Assert,
+  } as unknown as TC;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   groupLogs() && console.groupCollapsed(test.name);

--- a/packages/diagnostic/src/internals/run.ts
+++ b/packages/diagnostic/src/internals/run.ts
@@ -80,7 +80,7 @@ export async function runTest<TC extends TestContext>(
         actual: false,
         expected: true,
       });
-      if (!Config.params.tryCatch.value) {
+      if (Config.params.noTryCatch.value) {
         throw err;
       }
     }
@@ -102,7 +102,7 @@ export async function runTest<TC extends TestContext>(
       actual: false,
       expected: true,
     });
-    if (!Config.params.tryCatch.value) {
+    if (Config.params.noTryCatch.value) {
       throw err;
     }
   } finally {
@@ -117,7 +117,7 @@ export async function runTest<TC extends TestContext>(
           actual: false,
           expected: true,
         });
-        if (!Config.params.tryCatch.value) {
+        if (Config.params.noTryCatch.value) {
           // eslint-disable-next-line no-unsafe-finally
           throw e;
         }
@@ -171,7 +171,11 @@ export async function runModule<TC extends TestContext>(
   const beforeChain = getChain<TC>(Config.globalHooks, module, parents, 'beforeEach');
   const afterChain = getChain<TC>(Config.globalHooks, module, parents, 'afterEach');
 
-  if (Config.params.concurrency.value && Config.concurrency > 1) {
+  console.log({
+    value: Config.params.useConcurrency.value,
+    concurrency: Config.concurrency,
+  });
+  if (Config.params.useConcurrency.value && Config.concurrency > 1) {
     const tests = module.tests.byOrder;
     let remainingTests = tests.length;
     let currentTest = 0;

--- a/packages/diagnostic/src/reporters/dom.ts
+++ b/packages/diagnostic/src/reporters/dom.ts
@@ -131,7 +131,13 @@ export class DOMReporter implements Reporter {
     this.scheduleUpdate();
   }
 
-  onDiagnostic(_diagnostic: DiagnosticReport): void {
+  updateTimeline(test: TestReport): void {
+    console.log(test.timeline.slice());
+    // TODO fancy timeline rendering
+    this.scheduleUpdate();
+  }
+
+  onDiagnostic(diagnostic: DiagnosticReport): void {
     this.scheduleUpdate();
   }
 

--- a/packages/diagnostic/src/reporters/dom.ts
+++ b/packages/diagnostic/src/reporters/dom.ts
@@ -60,7 +60,6 @@ export class DOMReporter implements Reporter {
 
   onTestStart(test: TestReport): void {
     this.suite.results.set(test, { finalized: false, dom: null });
-    this.scheduleUpdate();
     if (this._socket) {
       const compatTestReport = {
         id: this.nextTestId++,
@@ -77,6 +76,10 @@ export class DOMReporter implements Reporter {
       this.currentTests.set(test.id, compatTestReport);
       this._socket.emit('test-start', compatTestReport);
     }
+    if (this.settings.params.hideReport.value) {
+      return;
+    }
+    this.scheduleUpdate();
   }
 
   onTestFinish(test: TestReport): void {
@@ -91,7 +94,7 @@ export class DOMReporter implements Reporter {
       compatTestReport.skipped = test.skipped;
       compatTestReport.todo = test.todo;
       compatTestReport.total = test.result.diagnostics.length;
-      compatTestReport.runDuration = test.end!.startTime - test.start!.startTime;
+      compatTestReport.runDuration = test.end ? test.end.startTime - test.start!.startTime : null;
       compatTestReport.items = test.result.diagnostics.map((d) => {
         // more expensive to serialize the whole diagnostic
         if (this.settings.params.debug.value) {
@@ -114,12 +117,13 @@ export class DOMReporter implements Reporter {
       this.settings.params.debug.value && console.log(test);
     }
 
-    if (this.settings.params.hideReport.value) {
-      return;
-    }
     // @ts-expect-error
     test.moduleName = test.module.name;
     this.suite.results.get(test)!.finalized = true;
+
+    if (this.settings.params.hideReport.value) {
+      return;
+    }
     this.scheduleUpdate();
   }
 
@@ -132,12 +136,17 @@ export class DOMReporter implements Reporter {
   }
 
   updateTimeline(test: TestReport): void {
-    console.log(test.timeline.slice());
-    // TODO fancy timeline rendering
+    if (this.settings.params.hideReport.value) {
+      return;
+    }
+    console.log('timeline', test.timeline.slice());
     this.scheduleUpdate();
   }
 
   onDiagnostic(diagnostic: DiagnosticReport): void {
+    if (this.settings.params.hideReport.value) {
+      return;
+    }
     this.scheduleUpdate();
   }
 
@@ -153,15 +162,37 @@ export class DOMReporter implements Reporter {
 
   _updateRender(): void {
     const frame = document.getElementById('warp-drive__diagnostic-fixture');
-    if (this.settings.params.container.value === false) {
+    if (this.settings.params.hidecontainer.value === false) {
       frame?.classList.add('visible');
     } else {
       frame?.classList.remove('visible');
     }
+
+    if (this.settings.params.hideReport.value) {
+      if (!this.suite.resultsList.hidden) {
+        this.suite.resultsList.innerHTML = '';
+        this.suite.resultsList.hidden = true;
+      }
+      this.suite.updateStats();
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    if (this.suite.resultsList.hidden) {
+      // render the DOM we have so far again
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for (const [_test, state] of this.suite.results) {
+        if (state.dom) {
+          fragment.appendChild(state.dom[0]);
+          fragment.appendChild(state.dom[1]);
+        }
+      }
+      this.suite.resultsList.hidden = false;
+    }
+
     // render infos
     // render any tests
     let i = 0;
-    const fragment = document.createDocumentFragment();
     const isDebug = this.settings.params.debug.value;
 
     const updateResultHTMLForTest = (test: TestReport, state: { finalized: boolean; dom: HTMLElement[] }) => {
@@ -345,7 +376,10 @@ function getURL(id: string, type: 'test' | 'module' = 'test') {
   return currentURL.href;
 }
 
-function durationForTest(test: TestReport) {
+function durationForTest(test: TestReport | SuiteReport) {
+  if (test.start && !test.end) {
+    return '--';
+  }
   if (!test.start || !test.end) {
     return 'N/A';
   }
@@ -454,7 +488,8 @@ function renderSuite(reporter: DOMReporter, element: DocumentFragment, suiteRepo
     input.id = value.id;
     input.name = value.id;
 
-    if (typeof value.value === 'string') {
+    const isText = typeof value.defaultValue === 'string';
+    if (typeof value.defaultValue === 'string') {
       input.type = 'text';
       input.value = value.value;
     } else {
@@ -463,8 +498,7 @@ function renderSuite(reporter: DOMReporter, element: DocumentFragment, suiteRepo
     }
 
     function update() {
-      value.value = input.checked;
-      updateConfigValue(key, value.value);
+      updateConfigValue(value, isText ? input.value : input.checked);
       // schedule re-render
       reporter.scheduleUpdate();
     }
@@ -548,6 +582,8 @@ function renderSuite(reporter: DOMReporter, element: DocumentFragment, suiteRepo
   statsHeader.appendChild(document.createElement('th')).innerText = 'Under Construction';
   statsHeader.appendChild(document.createElement('th')).innerText = 'Skipped';
   statsHeader.appendChild(document.createElement('th')).innerText = 'Todo';
+  statsHeader.appendChild(document.createElement('th')).innerText = 'Pending';
+  statsHeader.appendChild(document.createElement('th')).innerText = 'Elapsed';
   statsHeader.appendChild(document.createElement('th')).innerText = 'Total';
 
   const clipboardButton = document.createElement('th');
@@ -558,9 +594,9 @@ function renderSuite(reporter: DOMReporter, element: DocumentFragment, suiteRepo
       '',
       `### Testing Status`,
       '',
-      `| Passing | Failing | Broken | Under Construction | Skipped | Todo | Total |`,
-      `| ------- | ------- | ------ | ------------------ | ------- | ---- | ----- |`,
-      `| ${STATS_CELLS.passing.innerText} | ${STATS_CELLS.failing.innerText} | ${STATS_CELLS.broken.innerText} | ${STATS_CELLS.underConstruction.innerText} | ${STATS_CELLS.skipped.innerText} | ${STATS_CELLS.todo.innerText} | ${STATS_CELLS.total.innerText} |`,
+      `| Passing | Failing | Broken | Under Construction | Skipped | Todo | Pending | Elapsed | Total |`,
+      `| ------- | ------- | ------ | ------------------ | ------- | ---- | ------- | ------- | ----- |`,
+      `| ${STATS_CELLS.passing.innerText} | ${STATS_CELLS.failing.innerText} | ${STATS_CELLS.broken.innerText} | ${STATS_CELLS.underConstruction.innerText} | ${STATS_CELLS.skipped.innerText} | ${STATS_CELLS.todo.innerText} | ${STATS_CELLS.pending.innerText} | ${STATS_CELLS.elapsed.innerText} | ${STATS_CELLS.total.innerText} |`,
       '',
     ].join('\n');
     const statusText = Array.from(results.keys())
@@ -583,6 +619,8 @@ function renderSuite(reporter: DOMReporter, element: DocumentFragment, suiteRepo
     underConstruction: statsRow.appendChild(document.createElement('td')),
     skipped: statsRow.appendChild(document.createElement('td')),
     todo: statsRow.appendChild(document.createElement('td')),
+    pending: statsRow.appendChild(document.createElement('td')),
+    elapsed: statsRow.appendChild(document.createElement('td')),
     total: statsRow.appendChild(document.createElement('td')),
   };
   statsRow.appendChild(document.createElement('td'));
@@ -591,13 +629,17 @@ function renderSuite(reporter: DOMReporter, element: DocumentFragment, suiteRepo
     const passed = suiteReport.passed - suiteReport.skipped - suiteReport.todo;
     const tests = Array.from(results.keys());
     const broken = tests.filter((test) => statusForTest(test) === 'broken').length;
+    const pending = tests.filter((test) => results.get(test)!.finalized !== true).length;
     const underConstruction = tests.filter((test) => statusForTest(test) === 'underConstruction').length;
     const failed = suiteReport.failed - broken - underConstruction;
     const total = suiteReport.passed + suiteReport.failed;
+    const elapsed = durationForTest(suiteReport);
 
     STATS_CELLS.passing.innerText = `✅ ${passed}`;
     STATS_CELLS.failing.innerText = `❌ ${failed}`;
     STATS_CELLS.broken.innerText = `💥 ${broken}`;
+    STATS_CELLS.pending.innerText = `🕝 ${pending}`;
+    STATS_CELLS.elapsed.innerText = `⌛️ ${elapsed}`;
     STATS_CELLS.underConstruction.innerText = `🚧 ${underConstruction}`;
     STATS_CELLS.skipped.innerText = `⚠️ ${suiteReport.skipped}`;
     STATS_CELLS.todo.innerText = `🛠️ ${suiteReport.todo}`;

--- a/packages/diagnostic/src/styles/dom-reporter.css
+++ b/packages/diagnostic/src/styles/dom-reporter.css
@@ -113,6 +113,10 @@ tr.diagnostic-checks.expanded {
   border-bottom: 1px solid var(--brand-main);
 }
 
+#warp-drive__diagnostic h1 span.logo-main::before {
+  background-image: url("/NCC-1701-a-gold_100.svg");
+}
+
 #warp-drive__diagnostic h1 span.logo-main {
   color: var(--brand-main);
   font-weight: 300;

--- a/tests/builders/tests/test-helper.js
+++ b/tests/builders/tests/test-helper.js
@@ -16,11 +16,5 @@ setupGlobalHooks((hooks) => {
 
 setApplication(Application.create(config.APP));
 start({
-  tryCatch: false,
-  // concurrency: 1,
-  debug: true,
-  groupLogs: false,
-  instrument: true,
-  hideReport: false,
   useDiagnostic: true,
 });

--- a/tests/ember-data__adapter/tests/test-helper.js
+++ b/tests/ember-data__adapter/tests/test-helper.js
@@ -22,9 +22,5 @@ configure();
 
 setApplication(Application.create(config.APP));
 start({
-  tryCatch: false,
-  groupLogs: false,
-  instrument: true,
-  hideReport: true,
   useDiagnostic: true,
 });

--- a/tests/ember-data__graph/tests/test-helper.ts
+++ b/tests/ember-data__graph/tests/test-helper.ts
@@ -23,10 +23,5 @@ configure();
 
 setApplication(Application.create(config.APP));
 void start({
-  tryCatch: false,
-  debug: IS_CI ? false : true,
-  groupLogs: false,
-  instrument: true,
-  hideReport: IS_CI ? true : false,
   useDiagnostic: true,
 });

--- a/tests/ember-data__graph/tests/test-helper.ts
+++ b/tests/ember-data__graph/tests/test-helper.ts
@@ -5,7 +5,6 @@ import config from 'ember-data__graph/config/environment';
 
 import configureAsserts from '@ember-data/unpublished-test-infra/test-support/asserts/index';
 import { Store } from '@warp-drive/core';
-import { IS_CI } from '@warp-drive/core/build-config/env';
 import { setupGlobalHooks } from '@warp-drive/diagnostic';
 import { configure } from '@warp-drive/diagnostic/ember-classic';
 import { start } from '@warp-drive/diagnostic/runners/dom';

--- a/tests/ember-data__json-api/tests/test-helper.js
+++ b/tests/ember-data__json-api/tests/test-helper.js
@@ -25,10 +25,5 @@ setupGlobalHooks((hooks) => {
 configure();
 
 start({
-  tryCatch: true,
-  debug: IS_CI ? false : true,
-  groupLogs: false,
-  instrument: true,
-  hideReport: IS_CI ? true : false,
   useDiagnostic: true,
 });

--- a/tests/ember-data__model/tests/test-helper.js
+++ b/tests/ember-data__model/tests/test-helper.js
@@ -4,9 +4,5 @@ import { start } from '@warp-drive/diagnostic/runners/dom';
 configure();
 
 start({
-  tryCatch: false,
-  groupLogs: false,
-  instrument: true,
-  hideReport: true,
   useDiagnostic: true,
 });

--- a/tests/ember-data__request/tests/test-helper.ts
+++ b/tests/ember-data__request/tests/test-helper.ts
@@ -28,11 +28,7 @@ setupGlobalHooks((hooks) => {
 configure();
 
 void start({
-  tryCatch: false,
-  debug: true, // IS_CI ? false : true,
-  hideReport: IS_CI ? true : false,
   concurrency: 10,
-  groupLogs: false,
-  instrument: true,
+  useConcurrency: true,
   useDiagnostic: true,
 });

--- a/tests/ember-data__request/tests/test-helper.ts
+++ b/tests/ember-data__request/tests/test-helper.ts
@@ -1,7 +1,6 @@
 import '@warp-drive/ember/install';
 
 import { setBuildURLConfig } from '@ember-data/request-utils';
-import { IS_CI } from '@warp-drive/build-config/env';
 import { setupGlobalHooks } from '@warp-drive/diagnostic';
 import { configure } from '@warp-drive/diagnostic/ember-classic';
 import { start } from '@warp-drive/diagnostic/runners/dom';

--- a/tests/framework-ember/start.ts
+++ b/tests/framework-ember/start.ts
@@ -60,11 +60,7 @@ setApplication(
 );
 
 void start({
-  tryCatch: false,
-  debug: true,
-  concurrency: 1,
-  groupLogs: false,
-  instrument: true,
-  hideReport: false,
-  useDiagnostic: true,
+  org: '@warp-drive/',
+  package: 'ember',
+  concurrency: 2,
 });

--- a/tests/warp-drive__experiments/tests/test-helper.ts
+++ b/tests/warp-drive__experiments/tests/test-helper.ts
@@ -37,11 +37,5 @@ setupGlobalHooks((hooks) => {
 setApplication(Application.create(config.APP));
 
 void start({
-  tryCatch: false,
-  debug: true,
-  concurrency: 1,
-  groupLogs: false,
-  instrument: true,
-  hideReport: false,
   useDiagnostic: true,
 });

--- a/tests/warp-drive__react/tests/test-helper.ts
+++ b/tests/warp-drive__react/tests/test-helper.ts
@@ -35,11 +35,5 @@ setupGlobalHooks((hooks) => {
 });
 
 void start({
-  tryCatch: false,
-  debug: true,
-  concurrency: 1,
-  groupLogs: false,
-  instrument: true,
-  hideReport: false,
   useDiagnostic: true,
 });


### PR DESCRIPTION
TL;DR plumbing to be able to provide tracing in tests to understand visually the outcome.

- [ ] needs a UI
- [x] needs to be gated on a setting
- would be nice ... integrate with app code somehow to capture stuff like requests. Potentially use a performanceobserver