### PR TITLE
feat: improved signal debug util

### DIFF
--- a/warp-drive-packages/core/src/reactive/-private/kind/attribute-field.ts
+++ b/warp-drive-packages/core/src/reactive/-private/kind/attribute-field.ts
@@ -1,10 +1,10 @@
-import { entangleSignal } from '../../../store/-private';
+import { entangleInitiallyStaleSignal } from '../../../store/-private';
 import type { Value } from '../../../types/json/raw';
 import type { LegacyAttributeField } from '../../../types/schema/fields';
 import type { KindContext } from '../default-mode';
 
 export function getAttributeField(context: KindContext<LegacyAttributeField>): unknown {
-  entangleSignal(context.signals, context.record, context.path.at(-1)!, null);
+  entangleInitiallyStaleSignal(context.signals, context.record, context.path.at(-1)!, null);
   const { cache } = context.store;
   return context.editable
     ? cache.getAttr(context.resourceKey, context.path)

--- a/warp-drive-packages/core/src/reactive/-private/schema.ts
+++ b/warp-drive-packages/core/src/reactive/-private/schema.ts
@@ -7,7 +7,7 @@ import { assert } from '@warp-drive/core/build-config/macros';
 
 import { recordIdentifierFor } from '../../index.ts';
 import type { Store, WarpDriveSignal } from '../../store/-private.ts';
-import { createMemo, withSignalStore } from '../../store/-private.ts';
+import { createInternalMemo, withSignalStore } from '../../store/-private.ts';
 import type { SchemaService as SchemaServiceInterface } from '../../types.ts';
 import { getOrSetGlobal } from '../../types/-private.ts';
 import type { ResourceKey } from '../../types/identifier.ts';
@@ -423,10 +423,9 @@ function makeCachedDerivation<R, T, FM extends ObjectValue | null>(
     const signals = withSignalStore(record as object);
     let signal = signals.get(prop);
     if (!signal) {
-      signal = createMemo(record as object, prop, () => {
+      signal = createInternalMemo(signals, record as object, prop, () => {
         return derivation(record, options, prop);
       }) as unknown as WarpDriveSignal; // a total lie, for convenience of reusing the storage
-      signals.set(prop, signal);
     }
 
     return (signal as unknown as () => T)();

--- a/warp-drive-packages/core/src/store/-private.ts
+++ b/warp-drive-packages/core/src/store/-private.ts
@@ -83,12 +83,13 @@ export {
   type RequestCacheRequestState as RequestState,
 } from './-private/new-core-tmp/request-state.ts';
 
-export { createMemo, type SignalHooks, waitFor } from './-private/new-core-tmp/reactivity/configure.ts';
+export { type SignalHooks, waitFor } from './-private/new-core-tmp/reactivity/configure.ts';
 export {
   signal,
   memoized,
   gate,
   entangleSignal,
+  entangleInitiallyStaleSignal,
   defineSignal,
   defineGate,
   defineNonEnumerableSignal,
@@ -99,6 +100,7 @@ export {
   Signals,
   type WarpDriveSignal,
   peekInternalSignal,
+  createInternalMemo,
   withSignalStore,
   notifyInternalSignal,
   consumeInternalSignal,


### PR DESCRIPTION
adds a new debug utility for inspecting the information exposed on the SignalStore on each reactive object/array/proxy, including for memos.

memoizes generic fields and attributes.