### PR TITLE
Add default block for request state access

### DIFF
--- a/warp-drive-packages/ember/src/-private/request.gts
+++ b/warp-drive-packages/ember/src/-private/request.gts
@@ -107,6 +107,15 @@ interface RequestSignature<RT, E> {
      */
     content: [value: RT, features: ContentFeatures<RT>];
     always: [state: RequestState<RT, StructuredErrorDocument<E>>];
+
+    /**
+     * Exposes low-level access to the state and current request state directly.
+     *
+     * The default block may be used instead of the other blocks,
+     * but the other blocks may not be used with the default block.
+     * Most of the time, you'll want to use the specific blocks.
+     */
+    default: [state:  RequestSubscription<RT, E>, requsetState: RequestState<RT, StructuredErrorDocument<E>>]
   };
 }
 
@@ -389,7 +398,10 @@ export class Request<RT, E> extends Component<RequestSignature<RT, E>> {
 
   <template>
     <this.Chrome @state={{if this.state.isIdle null this.state.reqState}} @features={{this.state.contentFeatures}}>
-      {{#if (and this.state.isIdle (has-block "idle"))}}
+      {{#if (has-block "default")}}
+        {{yield this.state this.state.reqState}}
+
+      {{else if (and this.state.isIdle (has-block "idle"))}}
         {{yield to="idle"}}
 
       {{else if this.state.isIdle}}


### PR DESCRIPTION
Added a default block for request state handling in the request.gts file.

<!-- Thank you for opening up this PR! -->

If this PR updates API docs, preview them by:

- install [bun](https://bun.sh/docs/installation) (if needed)
- install [volta](https://docs.volta.sh/guide/getting-started) and configure it for [pnpm](https://docs.volta.sh/advanced/pnpm) (if needed)
- run `pnpm install` in the root (if needed)
- run `pnpm preview` in the root

---

- Read the full [contributing documentation](https://github.com/emberjs/data/blob/main/contributing/become-a-contributor.md)
- If you do not have permission to add labels or run the test-suite in CI, a team member will do this for you.
