### PR TITLE
feat: enable pushing remote deletions more simply

### DIFF
--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -2407,12 +2407,13 @@ function didCommit(
       : committedIdentifier;
 
   const cached = cache.__peek(identifier, false);
-  if (cached.isDeleted) {
+  if (cached.isDeleted || op === 'deleteRecord') {
     cache.__graph.push({
       op: 'deleteRecord',
       record: identifier,
       isNew: false,
     });
+    cached.isDeleted = true;
     cached.isDeletionCommitted = true;
     cache._capabilities.notifyChange(identifier, 'removed', null);
     // TODO @runspired should we early exit here?


### PR DESCRIPTION
when the op-code is deleteRecord, we should perform deletions even when a prior mutation to delete does not exist.