### PR TITLE
fix(fragments): Fix withArrayDefaults to take a primitive type parameter and correctly output the type

### DIFF
--- a/tests/legacy/tests/-test-store/schemas/info.ts
+++ b/tests/legacy/tests/-test-store/schemas/info.ts
@@ -7,7 +7,7 @@ import { withArrayDefaults } from '@warp-drive/legacy/model-fragments';
 export const InfoSchema = {
   type: 'fragment:info',
   identity: null,
-  fields: [{ kind: 'field', name: 'name' }, withArrayDefaults('string', 'notes')],
+  fields: [{ kind: 'field', name: 'name' }, withArrayDefaults('notes', 'string')],
   objectExtensions: ['ember-object', 'fragment'],
 } satisfies ObjectSchema;
 

--- a/tests/legacy/tests/-test-store/schemas/person.ts
+++ b/tests/legacy/tests/-test-store/schemas/person.ts
@@ -19,7 +19,7 @@ export const PersonSchema = withLegacy({
     withFragmentDefaults('name'),
     withFragmentArrayDefaults('names'),
     withFragmentArrayDefaults('addresses'),
-    withArrayDefaults('string', 'titles'),
+    withArrayDefaults('titles', 'string'),
   ],
 });
 

--- a/tests/legacy/tests/integration/app-test.ts
+++ b/tests/legacy/tests/integration/app-test.ts
@@ -27,7 +27,11 @@ module<AppTestContext>('Integration | Application', function (hooks) {
   test('Fragment and FragmentArray are setup correctly', function (this: AppTestContext, assert) {
     const PersonSchema = withLegacy({
       type: 'person',
-      fields: [withFragmentDefaults('name'), withFragmentArrayDefaults('addresses'), withArrayDefaults('string', 'titles')],
+      fields: [
+        withFragmentDefaults('name'),
+        withFragmentArrayDefaults('addresses'),
+        withArrayDefaults('titles', 'string'),
+      ],
     });
 
     const NameSchema = {

--- a/tests/legacy/tests/unit/utilities/with-array-defaults-test.ts
+++ b/tests/legacy/tests/unit/utilities/with-array-defaults-test.ts
@@ -2,11 +2,22 @@ import { module, test } from '@warp-drive/diagnostic/ember';
 import { withArrayDefaults } from '@warp-drive/legacy/model-fragments';
 
 module('Unit | withArrayDefaults', function () {
-  test('Creates correct schema for an array', function (assert) {
-    assert.deepEqual(withArrayDefaults('string', 'titles'), {
+  test('Creates correct schema for an array with primitiveType', function (assert) {
+    assert.deepEqual(withArrayDefaults('titles', 'string'), {
       kind: 'array' as const,
       name: 'titles',
       type: 'array:string',
+      options: {
+        arrayExtensions: ['ember-object', 'ember-array-like', 'fragment-array'],
+      },
+    });
+  });
+
+  test('Creates correct schema for an array without primitiveType', function (assert) {
+    assert.deepEqual(withArrayDefaults('titles'), {
+      kind: 'array' as const,
+      name: 'titles',
+      type: 'array',
       options: {
         arrayExtensions: ['ember-object', 'ember-array-like', 'fragment-array'],
       },

--- a/warp-drive-packages/legacy/src/model-fragments/utilities/with-array-defaults.ts
+++ b/warp-drive-packages/legacy/src/model-fragments/utilities/with-array-defaults.ts
@@ -2,25 +2,40 @@
  * Used as a helper to setup the relevant parts of an array
  * schema and add extensions etc.
  *
- * @param primitiveType The primitive type of items in the array
  * @param arrayName The name of the array
+ * @param primitiveType The primitive type of items in the array (optional)
  * @returns The schema for an array
  */
-export function withArrayDefaults<PrimitiveType extends string, ArrayName extends string>(
-  primitiveType: PrimitiveType,
-  arrayName: ArrayName
-): {
-  kind: 'array';
-  name: ArrayName;
-  type: `array:${PrimitiveType}`;
-  options: {
-    arrayExtensions: string[];
-  };
-} {
+export function withArrayDefaults<ArrayName extends string, PrimitiveType extends string>(
+  arrayName: ArrayName,
+  primitiveType?: PrimitiveType
+): PrimitiveType extends undefined
+  ? {
+      kind: 'array';
+      name: ArrayName;
+      type: 'array';
+      options: {
+        arrayExtensions: string[];
+      };
+    }
+  : {
+      kind: 'array';
+      name: ArrayName;
+      type: `array:${PrimitiveType}`;
+      options: {
+        arrayExtensions: string[];
+      };
+    };
+
+export function withArrayDefaults<ArrayName extends string, PrimitiveType extends string>(
+  arrayName: ArrayName,
+  primitiveType?: PrimitiveType
+) {
+  const type = primitiveType ? (`array:${primitiveType}` as const) : ('array' as const);
   return {
     kind: 'array' as const,
     name: arrayName,
-    type: `array:${primitiveType}` as const,
+    type,
     options: {
       arrayExtensions: ['ember-object', 'ember-array-like', 'fragment-array'],
     },


### PR DESCRIPTION
We were using the name of the array to generate type. This should actually be the primitive type. 

<!-- Thank you for opening up this PR! -->

If this PR updates API docs, preview them by:

- install [bun](https://bun.sh/docs/installation) (if needed)
- install [volta](https://docs.volta.sh/guide/getting-started) and configure it for [pnpm](https://docs.volta.sh/advanced/pnpm) (if needed)
- run `pnpm install` in the root (if needed)
- run `pnpm preview` in the root

---

- Read the full [contributing documentation](https://github.com/warp-drive-data/warp-drive/blob/main/contributing/become-a-contributor.md)
- If you do not have permission to add labels or run the test-suite in CI, a team member will do this for you.
