### PR TITLE
Holodeck: Change ResponseGenerator to return JSONValue

### DIFF
--- a/packages/holodeck/src/mock.ts
+++ b/packages/holodeck/src/mock.ts
@@ -18,10 +18,17 @@ export interface Scaffold {
  */
 export type ScaffoldGenerator = () => Scaffold;
 
+// JSON shape that permits arrays, objects, primitives, and null
+type JSONPrimitive = string | number | boolean | null;
+type JSONValue =
+  | JSONPrimitive
+  | { [k: string]: JSONValue }
+  | JSONValue[];
+
 /**
  * @public
  */
-export type ResponseGenerator = () => Record<string, unknown>;
+export type ResponseGenerator = () => JSONValue;
 
 /**
  * Sets up Mocking for a GET request on the mock server


### PR DESCRIPTION
Holodeck should be able to support mocking of servers that aren't following JSON:API spec.

```
async function registerProjectMessages(ctx: TestContext, id: string) {
  // @ts-expect-error - Holodeck types don't support empty arrays yet? but this should be valid
  await GET(ctx, `projects/${id}/messages`, () => [], { RECORD: true });
}

```