### PR TITLE
docs(migration to v5): fix typos in the code snippets

### DIFF
--- a/guides/migrating/index.md
+++ b/guides/migrating/index.md
@@ -502,7 +502,7 @@ export default class User extends Model.extend(Timestamped) {
 import { withDefaults } from '@warp-drive-mirror/legacy/model/migration-support';
 
 export const UserSchema = withDefaults({
-  type: 'user';
+  type: 'user',
   fields: [
     { kind: 'attribute', name: 'firstName' },
     { kind: 'attribute', name: 'lastName' },
@@ -564,7 +564,7 @@ export class UserExtension {
   }
 }
 
-export const UserExtension = {
+export const UserExtensionSchema = {
   name: 'user-extension',
   kind: 'object',
   features: UserExtension,
@@ -788,7 +788,7 @@ export default class User extends Model {
 import { withDefaults } from '@warp-drive-mirror/legacy/model/migration-support';
 
 export const UserSchema = withDefaults({
-  type: 'user';
+  type: 'user',
   fields: [
     { kind: 'attribute', name: 'firstName' },
     { kind: 'attribute', name: 'lastName' },
@@ -845,7 +845,7 @@ export class UserExtension {
   }
 }
 
-export const UserExtension = {
+export const UserExtensionSchema = {
   name: 'user-extension',
   kind: 'object',
   features: UserExtension,
@@ -908,7 +908,7 @@ export default Mixin.create({
 import { withDefaults } from '@warp-drive-mirror/legacy/model/migration-support';
 
 export const UserSchema = withDefaults({
-  type: 'user';
+  type: 'user',
   fields: [
     { kind: 'attribute', name: 'firstName' },
     { kind: 'attribute', name: 'lastName' },


### PR DESCRIPTION
This PR fixes a few minor typos in the code snippets from the document _Migrating 4.x to 5.x_:
- `;` instead of `,` when defining the `UserSchema`.
- `data/user/ext.ts` exporting the same name twice. I renamed the exported constant to `UserExtensionSchema` based on the next example with `TimestampedExtensionSchema` if that makes sense.