### PR TITLE
add missing @types/semver for build-config package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3604,6 +3604,9 @@ importers:
       '@types/node':
         specifier: ^20.19.11
         version: 20.19.11
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(08d339ab80698bc6d2b26efaef736218)

--- a/warp-drive-packages/build-config/package.json
+++ b/warp-drive-packages/build-config/package.json
@@ -53,6 +53,7 @@
     "@warp-drive/internal-config": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "@types/node": "^20.19.11",
+    "@types/semver": "^7.7.1",
     "@babel/plugin-transform-typescript": "^7.28.0",
     "@babel/preset-typescript": "^7.27.1",
     "@babel/core": "^7.28.3",


### PR DESCRIPTION
when trying to run the documentation site locally typedoc was failing because of missing types for `semver` in the build-config package. This just adds the missing `@types/semver` devDependency 👍 