### PR TITLE
chore(internal-tooling): fix volta.extends path

### DIFF
--- a/tools/internal-tooling/package.json
+++ b/tools/internal-tooling/package.json
@@ -33,6 +33,6 @@
     "@pnpm/logger": "1001.0.0"
   },
   "volta": {
-    "extends": "../package.json"
+    "extends": "../../package.json"
   }
 }


### PR DESCRIPTION
- Fix `volta.extends` setting for `tools/internal-tooling`.