### PR TITLE
Update the JSONAPI adapter and serializer import paths

### DIFF
--- a/warp-drive-packages/legacy/src/adapter/json-api.ts
+++ b/warp-drive-packages/legacy/src/adapter/json-api.ts
@@ -125,7 +125,7 @@ import { RESTAdapter } from './rest.ts';
   namespace property on the adapter:
 
   ```js [app/adapters/application.js]
-  import JSONAPIAdapter from '@warp-drive/legacy/adapter/json-api';
+  import { JSONAPIAdapter } from '@warp-drive/legacy/adapter/json-api';
 
   export default class ApplicationAdapter extends JSONAPIAdapter {
     namespace = 'api/1';

--- a/warp-drive-packages/legacy/src/serializer/json-api.ts
+++ b/warp-drive-packages/legacy/src/serializer/json-api.ts
@@ -111,7 +111,7 @@ import { JSONSerializer } from './json';
   `extractRelationship`.
 
   ```js [app/serializers/application.js]
-  import JSONAPISerializer from '@warp-drive/legacy/serializer/json-api';
+  import { JSONAPISerializer } from '@warp-drive/legacy/serializer/json-api';
 
   export default class ApplicationSerializer extends JSONAPISerializer {
     normalizeArrayResponse(store, primaryModelClass, payload, id, requestType) {


### PR DESCRIPTION
Small docs issue I noticed while converting our EmberData based app to the new WarpDrive packages.