### PR TITLE
chore(codemods): add ast-grep related skills

### DIFF
--- a/.claude/skills/ast-grep-codemods/SKILL.md
+++ b/.claude/skills/ast-grep-codemods/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: ast-grep-codemods
+description: ast-grep NAPI reference and patterns for the packages/codemods project. Use when working with @ast-grep/napi in schema-migration codemods or packages/codemods/ directory, writing AST queries, or debugging tree-sitter node matching.
+user-invocable: false
+---
+
+# ast-grep NAPI Reference for Codemods
+
+This skill provides the ast-grep rule system reference used by `packages/codemods/src/schema-migration/`.
+The codemods use `@ast-grep/napi` (the Node.js binding) to parse and transform TypeScript/JavaScript ASTs.
+
+## Parsing
+
+```typescript
+import { parse, Lang, type SgNode } from '@ast-grep/napi';
+
+const ast = parse(Lang.TypeScript, sourceCode);
+const root: SgNode = ast.root();
+```
+
+## SgNode Core Methods
+
+### Search
+
+```typescript
+// Find first match (returns null if not found)
+node.find(matcher: string | number | NapiConfig): SgNode | null
+
+// Find all matches
+node.findAll(matcher: string | number | NapiConfig): SgNode[]
+
+// Boolean checks
+node.matches(pattern: string): boolean
+node.inside(pattern: string): boolean
+node.has(pattern: string): boolean
+```
+
+### Traversal
+
+```typescript
+node.children(): SgNode[]           // Direct children
+node.parent(): SgNode | null        // Parent node
+node.child(nth: number): SgNode | null
+node.field(name: string): SgNode | null  // Named field (e.g., 'name', 'body', 'source')
+node.ancestors(): SgNode[]
+node.next(): SgNode | null          // Next sibling
+node.nextAll(): SgNode[]
+node.prev(): SgNode | null          // Previous sibling
+node.prevAll(): SgNode[]
+```
+
+### Inspection
+
+```typescript
+node.kind(): string       // Tree-sitter node type (e.g., 'field_definition', 'class_body')
+node.text(): string       // Full source text
+node.isLeaf(): boolean
+node.isNamed(): boolean
+node.range(): Range       // { start: Pos, end: Pos } (0-indexed)
+```
+
+### Meta-variable Extraction
+
+```typescript
+// After finding with a pattern containing $VAR or $$$VARS:
+node.getMatch('VAR'): SgNode | null
+node.getMultipleMatches('VARS'): SgNode[]
+```
+
+### Code Editing
+
+```typescript
+const edit = node.replace('newCode');  // Returns Edit object
+const newSource = root.commitEdits([edit1, edit2]);  // Apply batch edits
+```
+
+## NapiConfig Rule Object
+
+The `find` and `findAll` methods accept a `NapiConfig` object for complex queries:
+
+```typescript
+node.findAll({
+  rule: { /* rule object */ },
+  constraints?: { /* meta-variable constraints */ },
+})
+```
+
+## Rule Types
+
+### 1. Atomic Rules
+
+Match individual nodes by their properties.
+
+#### `kind` - Match by tree-sitter node type
+
+```typescript
+// Find all class declarations
+root.findAll({ rule: { kind: 'class_declaration' } })
+
+// Common TypeScript/JavaScript kinds:
+// class_declaration, class_body, field_definition, method_definition,
+// import_statement, identifier, property_identifier, decorator,
+// call_expression, member_expression, string, template_string
+```
+
+**Gotcha:** Not all kind names are valid in all grammars. TypeScript uses `field_definition`,
+some JavaScript grammars use `public_field_definition` or `class_field`. Wrap in try/catch
+when iterating over multiple possible kinds.
+
+#### `pattern` - Match by code pattern with meta-variables
+
+```typescript
+// Simple pattern
+root.findAll({ rule: { pattern: 'console.log($ARG)' } })
+
+// Pattern with context (for ambiguous syntax like class members)
+root.findAll({
+  rule: {
+    pattern: {
+      context: 'class A { $FIELD = $INIT }',
+      selector: 'field_definition',
+    }
+  }
+})
+```
+
+Meta-variables:
+- `$NAME` - matches a single AST node
+- `$$NAME` - matches zero or more nodes (non-greedy)
+- `$$$NAME` - matches zero or more nodes (greedy)
+
+#### `regex` - Match node text against regex
+
+```typescript
+// Match identifiers starting with underscore
+root.findAll({ rule: { kind: 'identifier', regex: '^_' } })
+```
+
+### 2. Composite Rules
+
+Combine rules with boolean logic.
+
+#### `all` - Every rule must match (AND)
+
+```typescript
+root.findAll({
+  rule: {
+    all: [
+      { kind: 'call_expression' },
+      { pattern: '$OBJ.$METHOD($$$ARGS)' },
+    ]
+  }
+})
+```
+
+#### `any` - At least one rule must match (OR)
+
+```typescript
+root.findAll({
+  rule: {
+    any: [
+      { kind: 'field_definition' },
+      { kind: 'public_field_definition' },
+      { kind: 'class_field' },
+    ]
+  }
+})
+```
+
+#### `not` - Negate a rule
+
+```typescript
+// Find all identifiers that aren't 'constructor'
+root.findAll({
+  rule: {
+    kind: 'identifier',
+    not: { regex: '^constructor$' },
+  }
+})
+```
+
+#### `matches` - Reference a utility rule by ID
+
+```typescript
+root.findAll({
+  rule: { matches: 'is-ember-decorator' },
+  utils: {
+    'is-ember-decorator': {
+      kind: 'decorator',
+      has: { pattern: '@$NAME', inside: { kind: 'class_body' } },
+    }
+  }
+})
+```
+
+### 3. Relational Rules
+
+Filter nodes by their position relative to other nodes in the AST.
+
+#### `inside` - Node is contained within a matching ancestor
+
+```typescript
+// Find field_definition nodes that are DIRECT children of class_body
+root.findAll({
+  rule: {
+    kind: 'field_definition',
+    inside: {
+      kind: 'class_body',
+      stopBy: 'neighbor',  // Only check immediate parent
+    }
+  }
+})
+```
+
+#### `has` - Node contains a matching descendant
+
+```typescript
+// Find class declarations that have a decorator
+root.findAll({
+  rule: {
+    kind: 'class_declaration',
+    has: {
+      kind: 'decorator',
+      stopBy: 'neighbor',  // Only check direct children
+    }
+  }
+})
+```
+
+#### `follows` - Node appears after a matching sibling
+
+```typescript
+// Find nodes that follow a decorator
+root.findAll({
+  rule: {
+    kind: 'field_definition',
+    follows: { kind: 'decorator' },
+  }
+})
+```
+
+#### `precedes` - Node appears before a matching sibling
+
+```typescript
+root.findAll({
+  rule: {
+    kind: 'decorator',
+    precedes: { kind: 'method_definition' },
+  }
+})
+```
+
+### The `stopBy` Parameter (Critical)
+
+Controls how far relational rules search. **This is the most important parameter for correct queries.**
+
+| Value | Behavior |
+|-------|----------|
+| `'neighbor'` | **(Default)** Only checks one level (immediate parent for `inside`, direct children for `has`) |
+| `'end'` | Searches all the way (all ancestors for `inside`, all descendants for `has`) |
+| `{ rule }` | Stops when a node matching the rule is found (inclusive) |
+
+**Common pattern: matching only direct class members**
+
+```typescript
+// WRONG: findAll with just kind searches ALL descendants recursively
+classBody.findAll({ rule: { kind: 'field_definition' } })
+// ^ This picks up nested properties inside object literals!
+
+// RIGHT: Use inside rule with stopBy: 'neighbor' to match direct children only
+classBody.findAll({
+  rule: {
+    kind: 'field_definition',
+    inside: { kind: 'class_body', stopBy: 'neighbor' },
+  }
+})
+```
+
+### The `field` Parameter
+
+Restricts matches to a specific named field position in the parent node.
+
+```typescript
+// Match only the KEY in a key-value pair, not values that happen to match
+root.findAll({
+  rule: {
+    kind: 'pair',
+    has: {
+      field: 'key',         // Only match the 'key' field position
+      regex: 'prototype',
+    }
+  }
+})
+```
+
+Common tree-sitter fields: `name`, `body`, `source`, `key`, `value`, `left`, `right`,
+`arguments`, `decorator`, `type_annotation`.
+
+## Patterns Used in This Codebase
+
+### Finding direct class members (not nested)
+
+```typescript
+import { NODE_KIND_CLASS_BODY, NODE_KIND_FIELD_DEFINITION, NODE_KIND_METHOD_DEFINITION } from './code-processing.js';
+
+const DIRECT_CLASS_MEMBER = { inside: { kind: NODE_KIND_CLASS_BODY, stopBy: 'neighbor' } } as const;
+
+// Properties - try multiple kinds since grammar varies
+function findPropertyDefinitions(classBody: SgNode): SgNode[] {
+  for (const nodeType of ['field_definition', 'public_field_definition', 'class_field']) {
+    try {
+      const props = classBody.findAll({ rule: { kind: nodeType, ...DIRECT_CLASS_MEMBER } });
+      if (props.length > 0) return props;
+    } catch {
+      // Kind not valid in this grammar
+    }
+  }
+  return [];
+}
+
+// Methods
+function findMethodDefinitions(classBody: SgNode): SgNode[] {
+  return classBody.findAll({ rule: { kind: NODE_KIND_METHOD_DEFINITION, ...DIRECT_CLASS_MEMBER } });
+}
+```
+
+### Finding import statements and extracting source
+
+```typescript
+const imports = root.findAll({ rule: { kind: 'import_statement' } });
+for (const imp of imports) {
+  const source = imp.field('source');     // The string literal after 'from'
+  const clause = imp.field('import');     // The import clause (specifiers)
+  const sourcePath = source?.text();      // e.g., "'@ember-data/model'"
+}
+```
+
+### Finding decorators preceding a node
+
+```typescript
+// Walk backwards through siblings collecting decorator nodes
+function collectPrecedingDecorators(node: SgNode): string[] {
+  const decorators: string[] = [];
+  const siblings = node.parent()?.children() ?? [];
+  const idx = siblings.indexOf(node);
+  for (let i = idx - 1; i >= 0; i--) {
+    const sib = siblings[i];
+    if (!sib) continue;
+    if (sib.kind() === 'decorator') decorators.unshift(sib.text());
+    else if (sib.text().trim() !== '') break;
+  }
+  return decorators;
+}
+```
+
+### Finding a class that extends a specific base
+
+```typescript
+// Find class with heritage clause
+const classDecl = root.find({ rule: { kind: 'class_declaration' } });
+const heritage = classDecl?.find({ rule: { kind: 'class_heritage' } });
+const identifiers = heritage?.findAll({ rule: { kind: 'identifier' } }) ?? [];
+const baseClasses = identifiers.map((id) => id.text());
+```
+
+### Pattern matching with context for class fields
+
+```typescript
+// Match decorated class fields like: @attr('string') name;
+root.findAll({
+  rule: {
+    pattern: {
+      context: 'class A { @$DECORATOR $FIELD = $VALUE }',
+      selector: 'field_definition',
+    }
+  }
+})
+```
+
+## Debugging Tips
+
+1. **Use `node.kind()` liberally** - When a rule isn't matching, log the actual kinds: `classBody.children().map(c => c.kind())`
+2. **Try/catch around `findAll` with rules** - Invalid kind names throw at runtime, not compile time
+3. **Check `stopBy` behavior** - The default `'neighbor'` only searches one level. Use `'end'` for recursive search.
+4. **Use the ast-grep playground** - https://ast-grep.github.io/playground.html to test rules interactively

--- a/.claude/skills/ast-grep/SKILL.md
+++ b/.claude/skills/ast-grep/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: ast-grep
+description: Guide for writing ast-grep rules to perform structural code search and analysis. Use when users need to search codebases using Abstract Syntax Tree (AST) patterns, find specific code structures, write new rules, working with @ast-grep/napi or perform complex code queries that go beyond simple text search. This skill should be used when users ask to search for code patterns, find specific language constructs, or locate code with particular structural characteristics.
+---
+
+# ast-grep Code Search
+
+## Overview
+
+This skill helps translate natural language queries into ast-grep rules for structural code search. ast-grep uses Abstract Syntax Tree (AST) patterns to match code based on its structure rather than just text, enabling powerful and precise code search across large codebases.
+
+## When to Use This Skill
+
+Use this skill when users:
+- Need to search for code patterns using structural matching (e.g., "find all async functions that don't have error handling")
+- Want to locate specific language constructs (e.g., "find all function calls with specific parameters")
+- Request searches that require understanding code structure rather than just text
+- Ask to search for code with particular AST characteristics
+- Need to perform complex code queries that traditional text search cannot handle
+
+## General Workflow
+
+Follow this process to help users write effective ast-grep rules:
+
+### Step 1: Understand the Query
+
+Clearly understand what the user wants to find. Ask clarifying questions if needed:
+- What specific code pattern or structure are they looking for?
+- Which programming language?
+- Are there specific edge cases or variations to consider?
+- What should be included or excluded from matches?
+
+### Step 2: Create Example Code
+
+Write a simple code snippet that represents what the user wants to match. Save this to a temporary file for testing.
+
+**Example:**
+If searching for "async functions that use await", create a test file:
+
+```javascript
+// test_example.js
+async function example() {
+  const result = await fetchData();
+  return result;
+}
+```
+
+### Step 3: Write the ast-grep Rule
+
+Translate the pattern into an ast-grep rule. Start simple and add complexity as needed.
+
+**Key principles:**
+- Always use `stopBy: end` for relational rules (`inside`, `has`) to ensure search goes to the end of the direction
+- Use `pattern` for simple structures
+- Use `kind` with `has`/`inside` for complex structures
+- Break complex queries into smaller sub-rules using `all`, `any`, or `not`
+
+**Example rule file (test_rule.yml):**
+```yaml
+id: async-with-await
+language: javascript
+rule:
+  kind: function_declaration
+  has:
+    pattern: await $EXPR
+    stopBy: end
+```
+
+See `references/rule_reference.md` for comprehensive rule documentation.
+
+### Step 4: Test the Rule
+
+Use ast-grep CLI to verify the rule matches the example code. There are two main approaches:
+
+**Option A: Test with inline rules (for quick iterations)**
+```bash
+echo "async function test() { await fetch(); }" | ast-grep scan --inline-rules "id: test
+language: javascript
+rule:
+  kind: function_declaration
+  has:
+    pattern: await \$EXPR
+    stopBy: end" --stdin
+```
+
+**Option B: Test with rule files (recommended for complex rules)**
+```bash
+ast-grep scan --rule test_rule.yml test_example.js
+```
+
+**Debugging if no matches:**
+1. Simplify the rule (remove sub-rules)
+2. Add `stopBy: end` to relational rules if not present
+3. Use `--debug-query` to understand the AST structure (see below)
+4. Check if `kind` values are correct for the language
+
+### Step 5: Search the Codebase
+
+Once the rule matches the example code correctly, search the actual codebase:
+
+**For simple pattern searches:**
+```bash
+ast-grep run --pattern 'console.log($ARG)' --lang javascript /path/to/project
+```
+
+**For complex rule-based searches:**
+```bash
+ast-grep scan --rule my_rule.yml /path/to/project
+```
+
+**For inline rules (without creating files):**
+```bash
+ast-grep scan --inline-rules "id: my-rule
+language: javascript
+rule:
+  pattern: \$PATTERN" /path/to/project
+```
+
+## ast-grep CLI Commands
+
+### Inspect Code Structure (--debug-query)
+
+Dump the AST structure to understand how code is parsed:
+
+```bash
+ast-grep run --pattern 'async function example() { await fetch(); }' \
+  --lang javascript \
+  --debug-query=cst
+```
+
+**Available formats:**
+- `cst`: Concrete Syntax Tree (shows all nodes including punctuation)
+- `ast`: Abstract Syntax Tree (shows only named nodes)
+- `pattern`: Shows how ast-grep interprets your pattern
+
+**Use this to:**
+- Find the correct `kind` values for nodes
+- Understand the structure of code you want to match
+- Debug why patterns aren't matching
+
+**Example:**
+```bash
+# See the structure of your target code
+ast-grep run --pattern 'class User { constructor() {} }' \
+  --lang javascript \
+  --debug-query=cst
+
+# See how ast-grep interprets your pattern
+ast-grep run --pattern 'class $NAME { $$$BODY }' \
+  --lang javascript \
+  --debug-query=pattern
+```
+
+### Test Rules (scan with --stdin)
+
+Test a rule against code snippet without creating files:
+
+```bash
+echo "const x = await fetch();" | ast-grep scan --inline-rules "id: test
+language: javascript
+rule:
+  pattern: await \$EXPR" --stdin
+```
+
+**Add --json for structured output:**
+```bash
+echo "const x = await fetch();" | ast-grep scan --inline-rules "..." --stdin --json
+```
+
+### Search with Patterns (run)
+
+Simple pattern-based search for single AST node matches:
+
+```bash
+# Basic pattern search
+ast-grep run --pattern 'console.log($ARG)' --lang javascript .
+
+# Search specific files
+ast-grep run --pattern 'class $NAME' --lang python /path/to/project
+
+# JSON output for programmatic use
+ast-grep run --pattern 'function $NAME($$$)' --lang javascript --json .
+```
+
+**When to use:**
+- Simple, single-node matches
+- Quick searches without complex logic
+- When you don't need relational rules (inside/has)
+
+### Search with Rules (scan)
+
+YAML rule-based search for complex structural queries:
+
+```bash
+# With rule file
+ast-grep scan --rule my_rule.yml /path/to/project
+
+# With inline rules
+ast-grep scan --inline-rules "id: find-async
+language: javascript
+rule:
+  kind: function_declaration
+  has:
+    pattern: await \$EXPR
+    stopBy: end" /path/to/project
+
+# JSON output
+ast-grep scan --rule my_rule.yml --json /path/to/project
+```
+
+**When to use:**
+- Complex structural searches
+- Relational rules (inside, has, precedes, follows)
+- Composite logic (all, any, not)
+- When you need the power of full YAML rules
+
+**Tip:** For relational rules (inside/has), always add `stopBy: end` to ensure complete traversal.
+
+## Tips for Writing Effective Rules
+
+### Always Use stopBy: end
+
+For relational rules, always use `stopBy: end` unless there's a specific reason not to:
+
+```yaml
+has:
+  pattern: await $EXPR
+  stopBy: end
+```
+
+This ensures the search traverses the entire subtree rather than stopping at the first non-matching node.
+
+### Start Simple, Then Add Complexity
+
+Begin with the simplest rule that could work:
+1. Try a `pattern` first
+2. If that doesn't work, try `kind` to match the node type
+3. Add relational rules (`has`, `inside`) as needed
+4. Combine with composite rules (`all`, `any`, `not`) for complex logic
+
+### Use the Right Rule Type
+
+- **Pattern**: For simple, direct code matching (e.g., `console.log($ARG)`)
+- **Kind + Relational**: For complex structures (e.g., "function containing await")
+- **Composite**: For logical combinations (e.g., "function with await but not in try-catch")
+
+### Debug with AST Inspection
+
+When rules don't match:
+1. Use `--debug-query=cst` to see the actual AST structure
+2. Check if metavariables are being detected correctly
+3. Verify the node `kind` matches what you expect
+4. Ensure relational rules are searching in the right direction
+
+### Escaping in Inline Rules
+
+When using `--inline-rules`, escape metavariables in shell commands:
+- Use `\$VAR` instead of `$VAR` (shell interprets `$` as variable)
+- Or use single quotes: `'$VAR'` works in most shells
+
+**Example:**
+```bash
+# Correct: escaped $
+ast-grep scan --inline-rules "rule: {pattern: 'console.log(\$ARG)'}" .
+
+# Or use single quotes
+ast-grep scan --inline-rules 'rule: {pattern: "console.log($ARG)"}' .
+```
+
+## Common Use Cases
+
+### Find Functions with Specific Content
+
+Find async functions that use await:
+```bash
+ast-grep scan --inline-rules "id: async-await
+language: javascript
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        pattern: await \$EXPR
+        stopBy: end" /path/to/project
+```
+
+### Find Code Inside Specific Contexts
+
+Find console.log inside class methods:
+```bash
+ast-grep scan --inline-rules "id: console-in-class
+language: javascript
+rule:
+  pattern: console.log(\$\$\$)
+  inside:
+    kind: method_definition
+    stopBy: end" /path/to/project
+```
+
+### Find Code Missing Expected Patterns
+
+Find async functions without try-catch:
+```bash
+ast-grep scan --inline-rules "id: async-no-trycatch
+language: javascript
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        pattern: await \$EXPR
+        stopBy: end
+    - not:
+        has:
+          pattern: try { \$\$\$ } catch (\$E) { \$\$\$ }
+          stopBy: end" /path/to/project
+```
+
+## Resources
+
+### references/
+Contains detailed documentation for ast-grep rule syntax:
+- `rule_reference.md`: Comprehensive ast-grep rule documentation covering atomic rules, relational rules, composite rules, and metavariables
+
+Load these references when detailed rule syntax information is needed.

--- a/.claude/skills/ast-grep/references/rule_reference.md
+++ b/.claude/skills/ast-grep/references/rule_reference.md
@@ -1,0 +1,297 @@
+# ast-grep Rule Reference
+
+This document provides comprehensive documentation for ast-grep rule syntax, covering all rule types and metavariables.
+
+## Introduction to ast-grep Rules
+
+ast-grep rules are declarative specifications for matching and filtering Abstract Syntax Tree (AST) nodes. They enable structural code search and analysis by defining conditions an AST node must meet to be matched.
+
+### Rule Categories
+
+ast-grep rules are categorized into three types:
+
+* **Atomic Rules**: Match individual AST nodes based on intrinsic properties like code patterns (`pattern`), node type (`kind`), or text content (`regex`).
+* **Relational Rules**: Define conditions based on a target node's position or relationship to other nodes (e.g., `inside`, `has`, `precedes`, `follows`).
+* **Composite Rules**: Combine other rules using logical operations (AND, OR, NOT) to form complex matching criteria (e.g., `all`, `any`, `not`, `matches`).
+
+## Anatomy of an ast-grep Rule Object
+
+The ast-grep rule object is the core configuration unit defining how ast-grep identifies and filters AST nodes. It's typically written in YAML format.
+
+### General Structure
+
+Every field within an ast-grep Rule Object is optional, but at least one "positive" key (e.g., `kind`, `pattern`) must be present.
+
+A node matches a rule if it satisfies all fields defined within that rule object, implying an implicit logical AND operation.
+
+For rules using metavariables that depend on prior matching, explicit `all` composite rules are recommended to guarantee execution order.
+
+### Rule Object Properties
+
+| Property | Type | Category | Purpose | Example |
+| :--- | :--- | :--- | :--- | :--- |
+| `pattern` | String or Object | Atomic | Matches AST node by code pattern. | `pattern: console.log($ARG)` |
+| `kind` | String | Atomic | Matches AST node by its kind name. | `kind: call_expression` |
+| `regex` | String | Atomic | Matches node's text by Rust regex. | `regex: ^[a-z]+$` |
+| `nthChild` | number, string, Object | Atomic | Matches nodes by their index within parent's children. | `nthChild: 1` |
+| `range` | RangeObject | Atomic | Matches node by character-based start/end positions. | `range: { start: { line: 0, column: 0 }, end: { line: 0, column: 10 } }` |
+| `inside` | Object | Relational | Target node must be inside node matching sub-rule. | `inside: { pattern: class $C { $$$ }, stopBy: end }` |
+| `has` | Object | Relational | Target node must have descendant matching sub-rule. | `has: { pattern: await $EXPR, stopBy: end }` |
+| `precedes` | Object | Relational | Target node must appear before node matching sub-rule. | `precedes: { pattern: return $VAL }` |
+| `follows` | Object | Relational | Target node must appear after node matching sub-rule. | `follows: { pattern: import $M from '$P' }` |
+| `all` | Array<Rule> | Composite | Matches if all sub-rules match. | `all: [ { kind: call_expression }, { pattern: foo($A) } ]` |
+| `any` | Array<Rule> | Composite | Matches if any sub-rules match. | `any: [ { pattern: foo() }, { pattern: bar() } ]` |
+| `not` | Object | Composite | Matches if sub-rule does not match. | `not: { pattern: console.log($ARG) }` |
+| `matches` | String | Composite | Matches if predefined utility rule matches. | `matches: my-utility-rule-id` |
+
+## Atomic Rules
+
+Atomic rules match individual AST nodes based on their intrinsic properties.
+
+### pattern: String and Object Forms
+
+The `pattern` rule matches a single AST node based on a code pattern.
+
+**String Pattern**: Directly matches using ast-grep's pattern syntax with metavariables.
+
+```yaml
+pattern: console.log($ARG)
+```
+
+**Object Pattern**: Offers granular control for ambiguous patterns or specific contexts.
+
+* `selector`: Pinpoints a specific part of the parsed pattern to match.
+  ```yaml
+  pattern:
+    selector: field_definition
+    context: class { $F }
+  ```
+
+* `context`: Provides surrounding code context for correct parsing.
+
+* `strictness`: Modifies the pattern's matching algorithm (`cst`, `smart`, `ast`, `relaxed`, `signature`).
+  ```yaml
+  pattern:
+    context: foo($BAR)
+    strictness: relaxed
+  ```
+
+### kind: Matching by Node Type
+
+The `kind` rule matches an AST node by its `tree_sitter_node_kind` name, derived from the language's Tree-sitter grammar. Useful for targeting constructs like `call_expression` or `function_declaration`.
+
+```yaml
+kind: call_expression
+```
+
+### regex: Text-Based Node Matching
+
+The `regex` rule matches the entire text content of an AST node using a Rust regular expression. It's not a "positive" rule, meaning it matches any node whose text satisfies the regex, regardless of its structural kind.
+
+### nthChild: Positional Node Matching
+
+The `nthChild` rule finds nodes by their 1-based index within their parent's children list, counting only named nodes by default.
+
+* `number`: Matches the exact nth child. Example: `nthChild: 1`
+* `string`: Matches positions using An+B formula. Example: `2n+1`
+* `Object`: Provides granular control:
+  * `position`: `number` or An+B string.
+  * `reverse`: `true` to count from the end.
+  * `ofRule`: An ast-grep rule to filter the sibling list before counting.
+
+### range: Position-Based Node Matching
+
+The `range` rule matches an AST node based on its character-based start and end positions. A `RangeObject` defines `start` and `end` fields, each with 0-based `line` and `column`. `start` is inclusive, `end` is exclusive.
+
+## Relational Rules
+
+Relational rules filter targets based on their position relative to other AST nodes. They can include `stopBy` and `field` options.
+
+### inside: Matching Within a Parent Node
+
+Requires the target node to be inside another node matching the `inside` sub-rule.
+
+```yaml
+inside:
+  pattern: class $C { $$$ }
+  stopBy: end
+```
+
+### has: Matching with a Descendant Node
+
+Requires the target node to have a descendant node matching the `has` sub-rule.
+
+```yaml
+has:
+  pattern: await $EXPR
+  stopBy: end
+```
+
+### precedes and follows: Sequential Node Matching
+
+* `precedes`: Target node must appear before a node matching the `precedes` sub-rule.
+* `follows`: Target node must appear after a node matching the `follows` sub-rule.
+
+Both include `stopBy` but not `field`.
+
+### stopBy and field: Refining Relational Searches
+
+**stopBy**: Controls search termination for relational rules.
+
+* `"neighbor"` (default): Stops when immediate surrounding node doesn't match.
+* `"end"`: Searches to the end of the direction (root for `inside`, leaf for `has`).
+* `Rule object`: Stops when a surrounding node matches the provided rule (inclusive).
+
+**field**: Specifies a sub-node within the target node that should match the relational rule. Only for `inside` and `has`.
+
+**Best Practice**: When unsure, always use `stopBy: end` to ensure the search goes to the end of the direction.
+
+## Composite Rules
+
+Composite rules combine atomic and relational rules using logical operations.
+
+### all: Conjunction (AND) of Rules
+
+Matches a node only if all sub-rules in the list match. Guarantees order of rule matching, important for metavariables.
+
+```yaml
+all:
+  - kind: call_expression
+  - pattern: console.log($ARG)
+```
+
+### any: Disjunction (OR) of Rules
+
+Matches a node if any sub-rules in the list match.
+
+```yaml
+any:
+  - pattern: console.log($ARG)
+  - pattern: console.warn($ARG)
+  - pattern: console.error($ARG)
+```
+
+### not: Negation (NOT) of a Rule
+
+Matches a node if the single sub-rule does not match.
+
+```yaml
+not:
+  pattern: console.log($ARG)
+```
+
+### matches: Rule Reuse and Utility Rules
+
+Takes a rule-id string, matching if the referenced utility rule matches. Enables rule reuse and recursive rules.
+
+## Metavariables
+
+Metavariables are placeholders in patterns to match dynamic content in the AST.
+
+### $VAR: Single Named Node Capture
+
+Captures a single named node in the AST.
+
+* **Valid**: `$META`, `$META_VAR`, `$_`
+* **Invalid**: `$invalid`, `$123`, `$KEBAB-CASE`
+* **Example**: `console.log($GREETING)` matches `console.log('Hello World')`.
+* **Reuse**: `$A == $A` matches `a == a` but not `a == b`.
+
+### $$VAR: Single Unnamed Node Capture
+
+Captures a single unnamed node (e.g., operators, punctuation).
+
+**Example**: To match the operator in `a + b`, use `$$OP`.
+
+```yaml
+rule:
+  kind: binary_expression
+  has:
+    field: operator
+    pattern: $$OP
+```
+
+### $$$MULTI_META_VARIABLE: Multi-Node Capture
+
+Matches zero or more AST nodes (non-greedy). Useful for variable numbers of arguments or statements.
+
+* **Example**: `console.log($$$)` matches `console.log()`, `console.log('hello')`, and `console.log('debug:', key, value)`.
+* **Example**: `function $FUNC($$$ARGS) { $$$ }` matches functions with varying parameters/statements.
+
+### Non-Capturing Metavariables (_VAR)
+
+Metavariables starting with an underscore (`_`) are not captured. They can match different content even if named identically, optimizing performance.
+
+* **Example**: `$_FUNC($_FUNC)` matches `test(a)` and `testFunc(1 + 1)`.
+
+### Important Considerations for Metavariable Detection
+
+* **Syntax Matching**: Only exact metavariable syntax (e.g., `$A`, `$$B`, `$$$C`) is recognized.
+* **Exclusive Content**: Metavariable text must be the only text within an AST node.
+* **Non-working**: `obj.on$EVENT`, `"Hello $WORLD"`, `a $OP b`, `$jq`.
+
+The ast-grep playground is useful for debugging patterns and visualizing metavariables.
+
+## Common Patterns and Examples
+
+### Finding Functions with Specific Content
+
+Find functions that contain await expressions:
+
+```yaml
+rule:
+  kind: function_declaration
+  has:
+    pattern: await $EXPR
+    stopBy: end
+```
+
+### Finding Code Inside Specific Contexts
+
+Find console.log calls inside class methods:
+
+```yaml
+rule:
+  pattern: console.log($$$)
+  inside:
+    kind: method_definition
+    stopBy: end
+```
+
+### Combining Multiple Conditions
+
+Find async functions that use await but don't have try-catch:
+
+```yaml
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        pattern: await $EXPR
+        stopBy: end
+    - not:
+        has:
+          pattern: try { $$$ } catch ($E) { $$$ }
+          stopBy: end
+```
+
+### Matching Multiple Alternatives
+
+Find any type of console method call:
+
+```yaml
+rule:
+  any:
+    - pattern: console.log($$$)
+    - pattern: console.warn($$$)
+    - pattern: console.error($$$)
+    - pattern: console.debug($$$)
+```
+
+## Troubleshooting Tips
+
+1. **Rule doesn't match**: Use `dump_syntax_tree` to see the actual AST structure
+2. **Relational rule issues**: Ensure `stopBy: end` is set for deep searches
+3. **Wrong node kind**: Check the language's Tree-sitter grammar for correct kind names
+4. **Metavariable not working**: Ensure it's the only content in its AST node
+5. **Pattern too complex**: Break it down into simpler sub-rules using `all`


### PR DESCRIPTION
- Adds/clones the official `ast-grep` skill https://github.com/ast-grep/agent-skill/tree/main
- Adds a custom `ast-grep-codemods` skill that's loaded anytime agents are to interact with packages/codemods.
It's a distilled version of the ["Rule Essentials" documentation ](https://ast-grep.github.io/guide/introduction.html)