### PR TITLE
Fix incorrect `console.log` warning when `belongsTo` has `linkMode: true`

### DIFF
--- a/warp-drive-packages/core/src/graph/-private/-utils.ts
+++ b/warp-drive-packages/core/src/graph/-private/-utils.ts
@@ -46,7 +46,7 @@ export function assertValidRelationshipPayload(
   if (payload.links) {
     warn(
       `You pushed a record of type '${type}' with a relationship '${field}' configured as 'async: false'. You've included a link but no primary data, this may be an error in your payload. WarpDrive will treat this relationship as known-to-be-empty.`,
-      isAsync || !!payload.data || state.hasReceivedData,
+      isAsync || payload.data === null || !!payload.data || state.hasReceivedData,
       {
         id: 'ds.store.push-link-for-sync-relationship',
       }


### PR DESCRIPTION
fix #10441

There is a valid case passing `data: null`, but today there appears the warning. It should only comes out when `data` is missing or is `undefined` in payload