### PR TITLE
fix(deploy): @ember-data/codemods fails on different platforms 

### DIFF
--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "bin": "dist/index.js",
   "scripts": {
-    "build:cli": "bun build src/cli/index.ts --target node --outdir dist --sourcemap",
+    "build:cli": "bun build src/cli/index.ts --target node --outdir dist --sourcemap --external @ast-grep/napi",
     "build:pkg": "tsc",
     "prepack": "pnpm run build:cli",
     "lint": "eslint . --quiet --cache --cache-strategy=content"

--- a/packages/codemods/src/schema-migration/processors/mixin.ts
+++ b/packages/codemods/src/schema-migration/processors/mixin.ts
@@ -17,7 +17,7 @@ import {
   toPascalCase,
 } from '../utils/ast-utils.js';
 import { createExtensionFromOriginalFile } from '../utils/extension-generation.js';
-import { getResourcesImport, resolveTraitImportPath, transformModelToResourceImport } from '../utils/import-utils.js';
+import { resolveTraitImportPath, transformModelToResourceImport } from '../utils/import-utils.js';
 import { pascalToKebab } from '../utils/string.js';
 
 const log = logger.for('mixin-processor');

--- a/packages/codemods/src/schema-migration/processors/model.ts
+++ b/packages/codemods/src/schema-migration/processors/model.ts
@@ -43,12 +43,12 @@ import {
   NODE_KIND_PROPERTY_IDENTIFIER,
 } from '../utils/code-processing.js';
 import { createExtensionFromOriginalFile } from '../utils/extension-generation.js';
-import { resolveTraitImportPath } from '../utils/import-utils.js';
 import type { ParsedFile } from '../utils/file-parser.js';
 import { parseFile } from '../utils/file-parser.js';
+import { resolveTraitImportPath } from '../utils/import-utils.js';
 import { extractBaseName, removeQuotes, replaceWildcardPattern } from '../utils/path-utils.js';
 import type { FieldTypeInfo } from '../utils/schema-generation.js';
-import { normalizePath, pascalToKebab, removeFileExtension, toKebabCase } from '../utils/string.js';
+import { normalizePath, removeFileExtension, toKebabCase } from '../utils/string.js';
 
 /**
  * Find and return the source text of export declarations (e.g. `export const BIRTHAGE = 0;`)


### PR DESCRIPTION
- Adds `--external @ast-grep/napi` so bun doesn't bundle it inside `dist/`.
The dependency for a correct architecture should be downloaded automatically via `npx` or `pnpx`
- Fixes some failing lints