### PR TITLE
refactor(codemods): simplify TypeScript output config options

### DIFF
--- a/guides/migrating/codemods.md
+++ b/guides/migrating/codemods.md
@@ -49,6 +49,12 @@ This codemod transforms EmberData models and mixins into WarpDrive's schema form
 
 The codemod is **non-destructive** - original model files are not removed. New files are generated in the `app/data/` by default.
 
+> [!WARNING]
+> On large projects the codemod's AST parsing may exceed the default stack size, causing a segfault. If you hit this, raise the limit before running:
+> ```bash
+> ulimit -s unlimited
+> ```
+
 ### Basic Usage
 
 ```bash
@@ -69,6 +75,7 @@ npx @ember-data/codemods apply migrate-to-schema --project-name my-app --warp-dr
 | `--config <path>` | Path to a JSON configuration file |
 | `--skip-processed` | Skip files that have already been processed |
 | `--force-typescript` | Force all output files to TypeScript (`.ts`) |
+| `--separate-types` | Emit a separate `.type.ts` file alongside each `.schema` file. By default, type interfaces are combined into the `.schema` file |
 | `--model-source-dir <path>` | Directory containing model files (default: `./app/models`) |
 | `--mixin-source-dir <path>` | Directory containing mixin files (default: `./app/mixins`) |
 | `--output-dir <path>` | Output directory for generated schemas (default: `./app/data`) |
@@ -150,6 +157,8 @@ Key configuration options:
 
 - **`projectName`** - The Ember app name, used for resolving classic module imports like `example-app/models/user`.
 - **`emberDataImportSource`** / **`warpDriveImports`** - Tell the codemod where your app imports EmberData and WarpDrive APIs from, when they differ from the defaults (`@ember-data/model`, `@warp-drive/core`, etc.).
+- **`forceTypeScript`** - When `true`, all output is `.ts` with type interfaces, even when source files are JavaScript. When `false` (default), `.js` sources produce plain `.js` output without type annotations.
+- **`combineSchemasAndTypes`** - When `false`, emit a separate `.type.ts` file alongside each `.schema` file. By default (`true`), type interfaces are merged into the `.schema` file.
 - **`typeMapping`** - Maps custom EmberData transform names (e.g., `@attr('uuid')`) to TypeScript types for the generated type files.
 - **`intermediateModelPaths`** - Import paths of base classes between `Model` and your concrete models. The codemod will analyze these and convert them to traits.
 - **`importSubstitutes`** - For base classes whose source can't be analyzed, tells the codemod what trait/extension names to reference.

--- a/packages/codemods/src/cli/apply.ts
+++ b/packages/codemods/src/cli/apply.ts
@@ -59,6 +59,7 @@ function createMigrateToSchemaCommand(applyCommand: Command) {
     )
     .addOption(new Option('--skip-processed', 'Skip files that have already been processed'))
     .addOption(new Option('--force-typescript', 'Force all output files to TypeScript (.ts)'))
+    .addOption(new Option('--separate-types', 'Generate .type.ts files'))
     .addOption(new Option('--model-source-dir <path>', 'Directory containing model files').default('./app/models'))
     .addOption(new Option('--mixin-source-dir <path>', 'Directory containing mixin files').default('./app/mixins'))
     .addOption(new Option('--output-dir <path>', 'Output directory for generated schemas').default('./app/data'))
@@ -134,7 +135,6 @@ async function handleMigrateToSchema(
   }
 
   const cliOptions: ConfigOptions = {
-    ...(options as ConfigOptions),
     inputDir,
     ...(options.dry !== undefined && { dryRun: Boolean(options.dry) }),
     ...(options.verbose !== undefined && { verbose: options.verbose === '1' || options.verbose === '2' }),
@@ -143,6 +143,7 @@ async function handleMigrateToSchema(
     ...(options.mixinsOnly !== undefined && { mixinsOnly: Boolean(options.mixinsOnly) }),
     ...(options.skipProcessed !== undefined && { skipProcessed: Boolean(options.skipProcessed) }),
     ...(options.forceTypescript !== undefined && { forceTypeScript: Boolean(options.forceTypescript) }),
+    ...(options.separateTypes !== undefined && { combineSchemasAndTypes: !options.separateTypes }),
     ...(options.projectName !== undefined && { projectName: String(options.projectName) }),
     ...(options.warpDriveImports !== undefined && {
       warpDriveImports: options.warpDriveImports as 'legacy' | 'modern' | 'mirror',

--- a/packages/codemods/src/schema-migration/config-schema.json
+++ b/packages/codemods/src/schema-migration/config-schema.json
@@ -36,6 +36,11 @@
       "description": "Force all output files to be TypeScript (.ts) even when input files are JavaScript (.js).",
       "default": false
     },
+    "combineSchemasAndTypes": {
+      "type": "boolean",
+      "description": "Combine schema and type interface into a single file. When true, each model produces one .schema file. Set to false to emit a separate .type.ts file.",
+      "default": true
+    },
     "mirror": {
       "type": "boolean",
       "description": "Use @warp-drive-mirror instead of @warp-drive for imports",

--- a/packages/codemods/src/schema-migration/config.ts
+++ b/packages/codemods/src/schema-migration/config.ts
@@ -98,6 +98,12 @@ export function getConfiguredImport(
   } else if (importName === 'AsyncHasMany' || importName === 'HasMany') {
     // typically these imports are from the same source as model
     return { imported: importName, source: packageImports.Model.source, isType: true };
+  } else if (importName === 'LegacyTrait') {
+    const schemaImport = packageImports['LegacyResourceSchema' as keyof typeof packageImports];
+    if (schemaImport) {
+      return { imported: 'LegacyTrait', source: schemaImport.source, isType: true };
+    }
+    return { imported: 'LegacyTrait', source: ModernPackageImports.LegacyTrait.source, isType: true };
   } else {
     return undefined;
   }
@@ -123,20 +129,27 @@ export interface TransformOptions {
    * import paths from other project files. Defaults to false.
    */
   projectImportsUseExtensions?: boolean;
-  /** Combine schemas and types into a single file. By default these will be in separate files */
-  combineSchemasAndTypes?: boolean;
-  /** By default, schemas will be output in TS files even when generated from untyped models. */
-  disableTypescriptSchemas?: boolean;
-  /** Force all output files to be TypeScript (.ts) even when input files are JavaScript (.js). */
-  forceTypeScript?: boolean;
   /**
-   * By default, the codemod will attempt to generate TypeScript types for models that don't
-   * have them by analyzing the model file and various transforms that are in use.
+   * Combine schemas and types into a single file. Defaults to true.
    *
-   * We heavily discourage turning this off as field level documentation comments are
-   * associated to the type artifact, not the schema.
+   * When true, each model/mixin produces a single `.schema` file containing
+   * both the schema object and the TypeScript type interface.
+   *
+   * Set to false to emit a separate `.type.ts` file alongside the `.schema` file.
    */
-  disableMissingTypeAutoGen?: boolean;
+  combineSchemasAndTypes: boolean;
+  /**
+   * Force all output files to be TypeScript (.ts) even when input files are JavaScript (.js).
+   * Defaults to false.
+   *
+   * When false, output file extensions match the source file:
+   * - `.js` source files produce `.schema.js` and `.ext.js` (no type interfaces)
+   * - `.ts` source files produce `.schema.ts` and `.ext.ts` (with type interfaces)
+   *
+   * When true, all output is `.ts` regardless of source language, and type
+   * interfaces are generated even for JavaScript source files.
+   */
+  forceTypeScript?: boolean;
   /**
    * By default, the codemod will insert useful comments
    * to the generated types for inline/editor documentation
@@ -230,7 +243,17 @@ export interface MigrateOptions extends Partial<TransformOptions> {
 
 export type FinalOptions = TransformOptions &
   MigrateOptions &
-  Required<Pick<TransformOptions, 'modelSourceDir' | 'mixinSourceDir' | 'warpDriveImports' | 'projectName'>> &
+  Required<
+    Pick<
+      TransformOptions,
+      | 'modelSourceDir'
+      | 'mixinSourceDir'
+      | 'warpDriveImports'
+      | 'projectName'
+      | 'forceTypeScript'
+      | 'combineSchemasAndTypes'
+    >
+  > &
   Required<Pick<MigrateOptions, 'inputDir'>> & {
     kind: 'finalized';
     outputDir: string;

--- a/packages/codemods/src/schema-migration/processors/mixin.ts
+++ b/packages/codemods/src/schema-migration/processors/mixin.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 
 import { logger } from '../../../utils/logger.js';
 import type { TransformerResult } from '../codemod.js';
-import type { TransformOptions } from '../config.js';
+import type { FinalOptions } from '../config.js';
 import type { SchemaArtifact, SchemaArtifactRegistry } from '../utils/artifact.js';
 import { createTraitArtifactConfig, isConnectedToModel as isConnectedToModelInRegistry } from '../utils/artifact.js';
 import type { PropertyInfo, SchemaField, TransformArtifact } from '../utils/ast-utils.js';
@@ -27,7 +27,7 @@ const log = logger.for('mixin-processor');
  */
 function ensureResourceTypeFileExists(
   modelType: string,
-  options: TransformOptions,
+  options: FinalOptions,
   artifacts: TransformArtifact[]
 ): boolean {
   const pascalCaseType = toPascalCase(modelType);
@@ -81,7 +81,7 @@ export interface ${typeName} {
  */
 export function toArtifacts(
   entity: SchemaArtifact,
-  options: TransformOptions,
+  options: FinalOptions,
   registry: SchemaArtifactRegistry = new Map()
 ): TransformerResult {
   const parsedFile = entity.parsedFile;
@@ -145,7 +145,7 @@ function generateMixinArtifacts(
   traitFields: Array<{ name: string; kind: string; type?: string; options?: Record<string, unknown> }>,
   extensionProperties: PropertyInfo[],
   extendedTraits: string[],
-  options: TransformOptions,
+  options: FinalOptions,
   registry: SchemaArtifactRegistry
 ): TransformArtifact[] {
   const artifacts: TransformArtifact[] = [];

--- a/packages/codemods/src/schema-migration/processors/model.ts
+++ b/packages/codemods/src/schema-migration/processors/model.ts
@@ -4,7 +4,7 @@ import { dirname, join, resolve } from 'path';
 
 import { logger } from '../../../utils/logger.js';
 import type { TransformerResult } from '../codemod.js';
-import { getConfiguredImport, type TransformOptions } from '../config.js';
+import { getConfiguredImport, type FinalOptions, type TransformOptions } from '../config.js';
 import type { SchemaArtifactRegistry } from '../utils/artifact.js';
 import { createResourceArtifactConfig, createTraitArtifactConfig, SchemaArtifact } from '../utils/artifact.js';
 import type { ExtractedType, SchemaField, TransformArtifact } from '../utils/ast-utils.js';
@@ -308,7 +308,7 @@ export function processIntermediateModelsToTraits(
   intermediateModelPaths: string[],
   additionalModelSources: Array<{ pattern: string; dir: string }> | undefined,
   additionalMixinSources: Array<{ pattern: string; dir: string }> | undefined,
-  options: TransformOptions,
+  options: FinalOptions,
   registry: SchemaArtifactRegistry
 ): { artifacts: TransformArtifact[]; errors: string[] } {
   const artifacts: TransformArtifact[] = [];
@@ -612,7 +612,7 @@ function generateRegularModelArtifacts(
 
 export function toArtifacts(
   entity: SchemaArtifact,
-  options: TransformOptions,
+  options: FinalOptions,
   registry: SchemaArtifactRegistry = new Map()
 ): TransformerResult {
   log.debug(`=== DEBUG: Processing ${entity.path} ===`);

--- a/packages/codemods/src/schema-migration/tasks/migrate.ts
+++ b/packages/codemods/src/schema-migration/tasks/migrate.ts
@@ -4,7 +4,7 @@ import { basename, dirname, join, resolve } from 'path';
 import { type InstanciatedLogger, logger } from '../../../utils/logger.js';
 import type { SkippedFile, TransformerResult } from '../codemod.js';
 import { Codemod } from '../codemod.js';
-import type { FinalOptions, MigrateOptions, TransformOptions } from '../config.js';
+import type { FinalOptions, MigrateOptions } from '../config.js';
 import {
   DEFAULT_INPUT_DIR,
   DEFAULT_MIXIN_SOURCE_DIR,
@@ -311,7 +311,7 @@ function writeIntermediateArtifacts(
 
 type ArtifactTransformer = (
   entity: SchemaArtifact,
-  options: TransformOptions,
+  options: FinalOptions,
   registry: SchemaArtifactRegistry
 ) => TransformerResult;
 
@@ -384,6 +384,8 @@ export async function runMigration(options: MigrateOptions): Promise<void> {
     mixinSourceDir: options.mixinSourceDir || DEFAULT_MIXIN_SOURCE_DIR,
     projectName: options.projectName || '',
     ...options,
+    combineSchemasAndTypes: options.combineSchemasAndTypes ?? true,
+    forceTypeScript: options.forceTypeScript ?? false,
   };
 
   const log = logger.for('migrate-to-schema');

--- a/packages/codemods/src/schema-migration/utils/artifact.ts
+++ b/packages/codemods/src/schema-migration/utils/artifact.ts
@@ -203,31 +203,28 @@ export function createTraitArtifactConfig(
   hasExtensionProperties: boolean,
   isTypeScript: boolean
 ): ArtifactConfig {
-  const hasTypes = isTypeScript || !options.disableMissingTypeAutoGen;
-  const schemaIsTyped = (hasTypes && options.combineSchemasAndTypes) || !options.disableTypescriptSchemas;
-  const extensionIsTyped = isTypeScript;
   const hasExtension = hasExtensionProperties;
 
   return {
     type: 'trait',
     name,
     isFragment: false,
-    hasTypes,
-    schemaIsTyped,
-    extensionIsTyped,
+    hasTypes: isTypeScript,
+    schemaIsTyped: isTypeScript,
+    extensionIsTyped: isTypeScript,
     hasExtension,
     identifiers: {
       schema: deriveTraitSchemaName(name),
-      fieldsInterface: hasTypes ? deriveTraitInterfaceName(name) : null,
-      type: hasTypes ? classified : null,
+      fieldsInterface: isTypeScript ? deriveTraitInterfaceName(name) : null,
+      type: isTypeScript ? classified : null,
       extension: hasExtension ? deriveTraitExtensionName(name) : null,
-      extensionAlias: hasTypes && hasExtension ? `${classified}TraitWithExtensions` : null,
+      extensionAlias: isTypeScript && hasExtension ? `${classified}TraitWithExtensions` : null,
     },
     traits: traits.map((trait) => ({
       name: trait,
       identifiers: {
-        fieldsInterface: hasTypes ? deriveTraitInterfaceName(trait) : null,
-        extension: hasTypes ? deriveTraitExtensionName(trait) : null,
+        fieldsInterface: isTypeScript ? deriveTraitInterfaceName(trait) : null,
+        extension: isTypeScript ? deriveTraitExtensionName(trait) : null,
       },
     })),
   };
@@ -246,20 +243,6 @@ export function createResourceArtifactConfig(
 ): ArtifactConfig {
   const name = analysis.baseName;
   const classified = analysis.modelName;
-
-  /**
-   * types are required IF the model was typed OR
-   * the options don't disable automatic type generation
-   * for untyped models
-   */
-  const hasTypes = modelWasTyped || !options.disableMissingTypeAutoGen;
-  const schemaIsTyped = (hasTypes && options.combineSchemasAndTypes) || !options.disableTypescriptSchemas;
-  const extensionIsTyped = modelWasTyped;
-
-  /**
-   * an extension is required IF
-   * we have a trait OR we have our own extension
-   */
   const hasExtension =
     analysis.mixinTraits.length > 0 || analysis.mixinExtensions.length > 0 || analysis.extensionProperties.length > 0;
 
@@ -267,22 +250,22 @@ export function createResourceArtifactConfig(
     type: 'resource',
     name,
     isFragment: analysis.isFragment ?? false,
-    hasTypes,
-    schemaIsTyped,
-    extensionIsTyped,
+    hasTypes: modelWasTyped,
+    schemaIsTyped: modelWasTyped,
+    extensionIsTyped: modelWasTyped,
     hasExtension,
     identifiers: {
       schema: deriveResourceSchemaName(name),
-      fieldsInterface: hasTypes ? `${classified}Resource` : null,
-      type: hasTypes ? classified : null,
+      fieldsInterface: modelWasTyped ? `${classified}Resource` : null,
+      type: modelWasTyped ? classified : null,
       extension: hasExtension ? deriveResourceExtensionName(name) : null,
-      extensionAlias: hasTypes && hasExtension ? `${classified}WithExtensions` : null,
+      extensionAlias: modelWasTyped && hasExtension ? `${classified}WithExtensions` : null,
     },
     traits: analysis.mixinTraits.map((trait) => ({
       name: trait,
       identifiers: {
-        fieldsInterface: hasTypes ? deriveTraitInterfaceName(trait) : null,
-        extension: hasTypes ? deriveTraitExtensionName(trait) : null,
+        fieldsInterface: modelWasTyped ? deriveTraitInterfaceName(trait) : null,
+        extension: modelWasTyped ? deriveTraitExtensionName(trait) : null,
       },
     })),
   };

--- a/packages/codemods/src/schema-migration/utils/config.ts
+++ b/packages/codemods/src/schema-migration/utils/config.ts
@@ -6,6 +6,7 @@ export interface ConfigOptions {
   verbose?: boolean;
   debug?: boolean;
   forceTypeScript?: boolean;
+  combineSchemasAndTypes?: boolean;
   mirror?: boolean;
   projectName?: string;
   warpDriveImports?: 'legacy' | 'modern' | 'mirror';

--- a/packages/codemods/src/schema-migration/utils/import-utils.ts
+++ b/packages/codemods/src/schema-migration/utils/import-utils.ts
@@ -84,9 +84,9 @@ export function generateWarpDriveTypeImport(
  * When `hasTypes` is `false` the trait never produced a `.type` file,
  * so the suffix is always `.schema` regardless of config.
  */
-export function resolveTraitImportPath(baseName: string, options?: TransformOptions, hasTypes = true): string {
-  const suffix = !options?.combineSchemasAndTypes && hasTypes ? 'type' : 'schema';
-  const base = options?.traitsImport ?? '../traits';
+export function resolveTraitImportPath(baseName: string, options: TransformOptions, hasTypes = true): string {
+  const suffix = !options.combineSchemasAndTypes && hasTypes ? 'type' : 'schema';
+  const base = options.traitsImport ?? '../traits';
   return `${base}/${baseName}.${suffix}`;
 }
 
@@ -95,7 +95,7 @@ export function resolveTraitImportPath(baseName: string, options?: TransformOpti
  * e.g., generateTraitImport('shareable', options) returns:
  *   "type { ShareableTrait } from '../traits/shareable.type'"
  */
-export function generateTraitImport(traitName: string, options?: TransformOptions): string {
+export function generateTraitImport(traitName: string, options: TransformOptions): string {
   const traitTypeName = deriveTraitInterfaceName(traitName);
   return `type { ${traitTypeName} } from '${resolveTraitImportPath(traitName, options)}'`;
 }
@@ -188,8 +188,8 @@ export function transformModelToResourceImport(
 
   let useTypeFile = false;
   if (!options.combineSchemasAndTypes) {
-    const isTargetTyped = modelEntity ? modelEntity.parsedFile.isTypeScript : false;
-    useTypeFile = isTargetTyped || !options.disableMissingTypeAutoGen;
+    const isTargetTyped = modelEntity ? modelEntity.parsedFile.isTypeScript : true;
+    useTypeFile = isTargetTyped;
   }
 
   const typeFileName = useTypeFile ? `${relatedType}.type${ext}` : `${relatedType}.schema${ext}`;

--- a/packages/codemods/src/schema-migration/utils/schema-generation.ts
+++ b/packages/codemods/src/schema-migration/utils/schema-generation.ts
@@ -572,7 +572,7 @@ export function collectRelationshipImports(
 export function collectTraitImports(
   traits: string[],
   imports: Set<string>,
-  options?: TransformOptions,
+  options: TransformOptions,
   checkExistence = false
 ): void {
   for (const trait of traits) {
@@ -890,7 +890,7 @@ export function generateMergedSchemaCode(opts: MergedSchemaOptions): GeneratedSc
   const withDefaultsImport =
     config.type === 'resource' && !config.isFragment ? getConfiguredImport(opts.options, 'withDefaults') : undefined;
 
-  if (!opts.options?.disableTypescriptSchemas && !withDefaultsImport) {
+  if (config.schemaIsTyped && !withDefaultsImport) {
     const schemaTypeKey = config.type === 'trait' ? 'LegacyTrait' : 'LegacyResourceSchema';
     const importLocation = getConfiguredImport(opts.options, schemaTypeKey);
     schemaImportParts.push(`import type { ${importLocation.imported} } from '${importLocation.source}';`);

--- a/tests/codemods/tests/schema-migration/__snapshots__/migrate-to-schema.test.ts.snap
+++ b/tests/codemods/tests/schema-migration/__snapshots__/migrate-to-schema.test.ts.snap
@@ -767,7 +767,7 @@ export interface AuditableTrait {
 exports[`migrate-to-schema batch operation > does not misclassify model extending base model via relative import as fragment > generated file structure 1`] = `
 [
   "resources/",
-  "resources/action-plan.ext.js",
+  "resources/action-plan.ext.ts",
   "resources/action-plan.schema.ts",
   "resources/action-plan.type.ts",
   "traits/",
@@ -779,9 +779,12 @@ exports[`migrate-to-schema batch operation > does not misclassify model extendin
 exports[`migrate-to-schema batch operation > does not misclassify model extending base model via relative import as fragment > generated files 1`] = `
 {
   "resources/": "__dir__",
-  "resources/action-plan.ext.js": "
+  "resources/action-plan.ext.ts": "
 import BaseModel from 'test-app/models/base-model';
+import type { ActionPlan } from './action-plan.type.ts';
 
+// @ts-ignore-error in reality fields are not merged, they are overridden
+export interface ActionPlanExtension extends ActionPlan, BaseModel {}
 export class ActionPlanExtension {
   get displayName() {
       return this.name;
@@ -1097,7 +1100,7 @@ export interface WorkstreamableTrait {
 exports[`migrate-to-schema batch operation > ensures resources and traits include .schema with matching suffixes > schema naming file structure 1`] = `
 [
   "resources/",
-  "resources/js-test-model.ext.js",
+  "resources/js-test-model.ext.ts",
   "resources/js-test-model.schema.ts",
   "resources/js-test-model.type.ts",
   "resources/ts-test-model.schema.ts",
@@ -1139,7 +1142,7 @@ exports[`migrate-to-schema batch operation > extracts intermediate model trait w
   "traits/",
   "traits/-base-model.schema.ts",
   "traits/-base-model.type.ts",
-  "traits/base-model.ext.js",
+  "traits/base-model.ext.ts",
   "traits/base-model.schema.ts",
   "traits/base-model.type.ts",
 ]
@@ -1238,8 +1241,12 @@ export interface BaseModelTrait {
   id: string | null;
 }
 ",
-  "traits/base-model.ext.js": "
+  "traits/base-model.ext.ts": "
 
+
+import type { BaseModelTrait } from 'test-app/data/traits/base-model.type';
+
+export interface BaseModelTraitExtension extends BaseModelTrait {}
 
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
@@ -1711,7 +1718,7 @@ export interface LocalMixinTrait {
 exports[`migrate-to-schema batch operation > handles mixed js and ts files correctly with proper type file extensions > mixed js/ts file structure 1`] = `
 [
   "resources/",
-  "resources/js-model-with-mixin.ext.js",
+  "resources/js-model-with-mixin.ext.ts",
   "resources/js-model-with-mixin.schema.ts",
   "resources/js-model-with-mixin.type.ts",
   "resources/ts-model-with-mixin.schema.ts",
@@ -1728,9 +1735,12 @@ exports[`migrate-to-schema batch operation > handles mixed js and ts files corre
 exports[`migrate-to-schema batch operation > handles mixed js and ts files correctly with proper type file extensions > mixed js/ts files 1`] = `
 {
   "resources/": "__dir__",
-  "resources/js-model-with-mixin.ext.js": "
+  "resources/js-model-with-mixin.ext.ts": "
 import JsMixin from '../../mixins/js-mixin';
+import type { JsModelWithMixin } from './js-model-with-mixin.type.ts';
 
+// @ts-ignore-error in reality fields are not merged, they are overridden
+export interface JsModelWithMixinExtension extends JsModelWithMixin, JsMixin {}
 export class JsModelWithMixinExtension {
   get displayName() {
       return this.name + ' (JS)';
@@ -2492,7 +2502,7 @@ export interface DataFieldModelTrait extends BaseModelTrait {
 exports[`migrate-to-schema batch operation > model with relative base-class import and mixins extracts fields and extensions > generated file structure 1`] = `
 [
   "resources/",
-  "resources/action-plan.ext.js",
+  "resources/action-plan.ext.ts",
   "resources/action-plan.schema.ts",
   "resources/action-plan.type.ts",
   "traits/",
@@ -2506,10 +2516,13 @@ exports[`migrate-to-schema batch operation > model with relative base-class impo
 exports[`migrate-to-schema batch operation > model with relative base-class import and mixins extracts fields and extensions > generated files 1`] = `
 {
   "resources/": "__dir__",
-  "resources/action-plan.ext.js": "
+  "resources/action-plan.ext.ts": "
 import BaseModel from 'test-app/models/base-model';
 import Commentable from '../../mixins/commentable';
+import type { ActionPlan } from './action-plan.type.ts';
 
+// @ts-ignore-error in reality fields are not merged, they are overridden
+export interface ActionPlanExtension extends ActionPlan, BaseModel, Commentable {}
 export class ActionPlanExtension {
   get displayName() {
       return this.name;

--- a/tests/codemods/tests/schema-migration/migrate-to-schema.test.ts
+++ b/tests/codemods/tests/schema-migration/migrate-to-schema.test.ts
@@ -29,6 +29,8 @@ describe('migrate-to-schema batch operation', () => {
       mixinImportSource: 'test-app/mixins',
       emberDataImportSource: '@ember-data/model',
       intermediateModelPaths: [],
+      combineSchemasAndTypes: false,
+      forceTypeScript: true,
       dryRun: false,
       verbose: false,
     };

--- a/tests/codemods/tests/schema-migration/resources/basic-native-model-class.test.ts
+++ b/tests/codemods/tests/schema-migration/resources/basic-native-model-class.test.ts
@@ -146,9 +146,9 @@ describe('Basic model class transformation', function () {
       `,
     },
   });
-  test('[JS] We can transform basic native class models (disableTypescriptSchemas: true)', {
+  test('[JS] JS models produce plain JS output by default', {
     config: {
-      disableTypescriptSchemas: true,
+      forceTypeScript: false,
     },
     input: {
       [F.jsmodel('user')]: js`
@@ -226,81 +226,14 @@ describe('Basic model class transformation', function () {
 
         export default UserSchema;
       `,
-      [F.resourceType('user')]: ts`
-        import type { Type } from '@warp-drive/core-types/symbols';
-        import type { WithLegacy } from '@ember-data/model/migration-support';
-        import type { AsyncHasMany } from '@ember-data/model';
-        import type { Company } from './company.type.ts';
-        import type { Post } from './post.type.ts';
-
-        /**
-         * A user of the application.
-         *
-         * ---
-         *
-         * This type represents the full set schema derived fields of
-         * the 'user' resource, without any of the legacy mode features
-         * and without any extensions.
-         *
-         * > [!TIP]
-         * > It is likely that you will want a more specific type tailored
-         * > to the context of where some data has been loaded, for instance
-         * > one that marks specific fields as readonly, or which only enables
-         * > some fields to be null during create, or which only includes
-         * > a subset of fields based on a specific API response.
-         * >
-         * > For those cases, you can create a more specific type that derives
-         * > from this type to ensure that your type definitions stay consistent
-         * > with the schema. For more details read about {@link https://warp-drive.io/api/@warp-drive/core/types/record/type-aliases/Mask | Masking}
-         *
-         * See also {@link User} for fields + legacy mode features
-         */
-        export interface UserResource {
-          readonly [Type]: 'user';
-          id: string | null;
-
-          /**
-           * The first name of the user.
-           */
-          firstName: unknown;
-          lastName: string | null;
-          age: number;
-
-          /**
-           * The company the user works for
-           */
-          company: Company | null;
-
-          /**
-           * The posts that the user has written.
-           */
-          posts: AsyncHasMany<Post>;
-        }
-
-        /**
-         * A user of the application.
-         *
-         * ---
-         *
-         * This type represents the full set schema derived fields of
-         * the 'user' resource, including all legacy mode features but
-         * without any extensions.
-         *
-         * See also {@link UserResource} for just the fields
-         */
-        export interface User extends WithLegacy<UserResource> {}
-      `,
     },
   });
-  test(
-    '[JS] We can transform basic native class models (disableTypescriptSchemas: true, disableMissingTypeAutoGen: true)',
-    {
-      config: {
-        disableTypescriptSchemas: true,
-        disableMissingTypeAutoGen: true,
-      },
-      input: {
-        [F.jsmodel('user')]: js`
+  test('[JS] JS models produce plain JS output without types by default', {
+    config: {
+      forceTypeScript: false,
+    },
+    input: {
+      [F.jsmodel('user')]: js`
         import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
         /**
@@ -325,9 +258,9 @@ describe('Basic model class transformation', function () {
           @hasMany('post', { async: true, inverse: 'author', resetOnRemoteUpdate: true, polymorphic: true }) posts;
         }
       `,
-      },
-      output: {
-        [F.resource('user', 'js')]: js`
+    },
+    output: {
+      [F.resource('user', 'js')]: js`
         import { withDefaults } from '@ember-data/model/migration-support';
 
         const UserSchema = withDefaults({
@@ -375,9 +308,8 @@ describe('Basic model class transformation', function () {
 
         export default UserSchema;
       `,
-      },
-    }
-  );
+    },
+  });
   test('[TS] We can transform basic native class models', {
     input: {
       [F.tsmodel('user')]: ts`

--- a/tests/codemods/tests/schema-migration/resources/combined-schemas-and-types.test.ts
+++ b/tests/codemods/tests/schema-migration/resources/combined-schemas-and-types.test.ts
@@ -176,6 +176,7 @@ describe('combineSchemasAndTypes: true', function () {
   test('[JS] multiple models with relationships produce combined schema+type files', {
     config: {
       combineSchemasAndTypes: true,
+      forceTypeScript: true,
     },
     input: {
       [F.jsmodel('user')]: js`
@@ -322,7 +323,11 @@ describe('combineSchemasAndTypes: true', function () {
          */
         export interface Company extends WithLegacy<CompanyResource> {}
       `,
-      [F.extension('company', 'js')]: ts`
+      [F.extension('company')]: ts`
+        import type { Company } from './company.schema.ts';
+
+        // @ts-ignore-error in reality fields are not merged, they are overridden
+        export interface CompanyExtension extends Company {}
         export class CompanyExtension {
           get userCount() {
             return this.users.length;
@@ -481,6 +486,7 @@ describe('combineSchemasAndTypes: true', function () {
   test('[JS] model with belongsTo uses combined .schema imports', {
     config: {
       combineSchemasAndTypes: true,
+      forceTypeScript: true,
     },
     input: {
       [F.jsmodel('post')]: js`

--- a/tests/codemods/tests/schema-migration/resources/custom-ember-data-import.test.ts
+++ b/tests/codemods/tests/schema-migration/resources/custom-ember-data-import.test.ts
@@ -137,8 +137,12 @@ describe('custom emberDataImportSource', function () {
           allowedTeams?: HasMany<AllowedTeam>;
         }
       `,
-      [F.extension('teamable', 'js')]: js`
+      [F.extension('teamable')]: ts`
         import { filterBy } from '@ember/object/computed';
+
+        import type { TeamableTrait } from '../traits/teamable.type';
+
+        export interface TeamableTraitExtension extends TeamableTrait {}
 
         // TODO: migrate this extension to a class so that TypeScript declaration merging works.
         // Object extensions do not support interface merging.

--- a/tests/codemods/tests/schema-migration/resources/native-model-class-with-ext.test.ts
+++ b/tests/codemods/tests/schema-migration/resources/native-model-class-with-ext.test.ts
@@ -174,9 +174,10 @@ describe('Basic model class transformation', function () {
          */
         export interface User extends WithLegacy<UserResource> {}
       `,
-      [F.extension('user', 'js')]: ts`
+      [F.extension('user')]: ts`
         import { cached, tracked } from '@glimmer/tracking';
         import { computed } from '@ember/object';
+        import type { User } from './user.type.ts';
 
         export const BIRTHAGE = 0;
         export const ValidAges = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -185,6 +186,8 @@ describe('Basic model class transformation', function () {
         /**
          * A user of the application.
          */
+        // @ts-ignore-error in reality fields are not merged, they are overridden
+        export interface UserExtension extends User {}
         export class UserExtension {
           @tracked randomProp = 'hello';
 
@@ -453,6 +456,7 @@ describe('Basic model class transformation', function () {
   test('[JS] We can transform basic native class models (combineSchemasAndTypes: true)', {
     config: {
       combineSchemasAndTypes: true,
+      forceTypeScript: true,
     },
     input: {
       [F.jsmodel('user')]: js`
@@ -623,9 +627,10 @@ describe('Basic model class transformation', function () {
          */
         export interface User extends WithLegacy<UserResource> {}
       `,
-      [F.extension('user', 'js')]: ts`
+      [F.extension('user')]: ts`
         import { cached, tracked } from '@glimmer/tracking';
         import { computed } from '@ember/object';
+        import type { User } from './user.schema.ts';
 
         export const BIRTHAGE = 0;
         export const ValidAges = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -634,6 +639,8 @@ describe('Basic model class transformation', function () {
         /**
          * A user of the application.
          */
+        // @ts-ignore-error in reality fields are not merged, they are overridden
+        export interface UserExtension extends User {}
         export class UserExtension {
           @tracked randomProp = 'hello';
 

--- a/tests/codemods/tests/schema-migration/resources/separate-trait-type-files.test.ts
+++ b/tests/codemods/tests/schema-migration/resources/separate-trait-type-files.test.ts
@@ -377,8 +377,12 @@ describe('combineSchemasAndTypes: false (default) - trait type files', function 
           allowedTeams?: HasMany<AllowedTeam>;
         }
       `,
-      [F.extension('teamable', 'js')]: js`
+      [F.extension('teamable')]: ts`
         import { filterBy } from '@ember/object/computed';
+
+        import type { TeamableTrait } from '../traits/teamable.type';
+
+        export interface TeamableTraitExtension extends TeamableTrait {}
 
         // TODO: migrate this extension to a class so that TypeScript declaration merging works.
         // Object extensions do not support interface merging.

--- a/tests/codemods/tests/schema-migration/test-helpers.ts
+++ b/tests/codemods/tests/schema-migration/test-helpers.ts
@@ -72,7 +72,7 @@ export function collectFileStructure(baseDir: string, dir: string = baseDir): st
  */
 export const DEFAULT_TEST_OPTIONS: TransformOptions = {
   modelImportSource: 'test-app/models',
-  disableTypescriptSchemas: false,
+  forceTypeScript: true,
   warpDriveImports: 'legacy',
   projectImportsUseExtensions: true,
   projectName: 'test-app',

--- a/tests/codemods/tests/schema-migration/transforms/__snapshots__/mixin-to-schema.test.ts.snap
+++ b/tests/codemods/tests/schema-migration/transforms/__snapshots__/mixin-to-schema.test.ts.snap
@@ -32,6 +32,10 @@ exports[`mixin-to-schema transform (artifacts) > TypeScript type artifacts > gen
 
 import { computed } from '@ember/object';
 
+import type { NameableTrait } from 'test-app/data/traits/nameable.type';
+
+export interface NameableTraitExtension extends NameableTrait {}
+
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
 export const NameableTraitExtension = {
@@ -154,7 +158,7 @@ exports[`mixin-to-schema transform (artifacts) > basic functionality > collects 
   },
   {
     "name": "FileableTraitExtension",
-    "suggestedFileName": "fileable.ext.js",
+    "suggestedFileName": "fileable.ext.ts",
     "type": "trait-extension",
   },
 ]
@@ -169,6 +173,10 @@ import { arrayHasLength } from '@auditboard/client-core/core/computed-extensions
 
 
 import { sortBy } from 'soxhub-client/utils/sort-by';
+
+import type { FileableTrait } from 'test-app/data/traits/fileable.type';
+
+export interface FileableTraitExtension extends FileableTrait {}
 
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
@@ -230,6 +238,10 @@ exports[`mixin-to-schema transform (artifacts) > basic functionality > converts 
 "
 import { computed } from '@ember/object';
 
+import type { NoTraitsTrait } from 'test-app/data/traits/no-traits.type';
+
+export interface NoTraitsTraitExtension extends NoTraitsTrait {}
+
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
 export const NoTraitsTraitExtension = {
@@ -259,7 +271,7 @@ exports[`mixin-to-schema transform (artifacts) > basic functionality > converts 
   },
   {
     "name": "NoTraitsTraitExtension",
-    "suggestedFileName": "no-traits.ext.js",
+    "suggestedFileName": "no-traits.ext.ts",
     "type": "trait-extension",
   },
 ]
@@ -269,6 +281,10 @@ exports[`mixin-to-schema transform (artifacts) > basic functionality > preserves
 "
 import { computed } from '@ember/object';
 import { service } from '@ember/service';
+
+import type { PlannableTrait } from 'test-app/data/traits/plannable.type';
+
+export interface PlannableTraitExtension extends PlannableTrait {}
 
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
@@ -303,7 +319,7 @@ exports[`mixin-to-schema transform (artifacts) > basic functionality > preserves
   },
   {
     "name": "PlannableTraitExtension",
-    "suggestedFileName": "plannable.ext.js",
+    "suggestedFileName": "plannable.ext.ts",
     "type": "trait-extension",
   },
 ]
@@ -451,6 +467,10 @@ export interface CustomSourceTrait {
 
 import { computed } from '@ember/object';
 
+import type { CustomSourceTrait } from 'test-app/data/traits/custom-source.type';
+
+export interface CustomSourceTraitExtension extends CustomSourceTrait {}
+
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
 export const CustomSourceTraitExtension = {
@@ -464,7 +484,7 @@ const Registration = {
 };
 export default Registration;",
     "name": "CustomSourceTraitExtension",
-    "suggestedFileName": "custom-source.ext.js",
+    "suggestedFileName": "custom-source.ext.ts",
     "type": "trait-extension",
   },
 ]
@@ -542,6 +562,10 @@ export interface RenamedMixedSourcesTrait {
 
 import { attr as attribute } from '@unsupported/source';
 
+import type { RenamedMixedSourcesTrait } from 'test-app/data/traits/renamed-mixed-sources.type';
+
+export interface RenamedMixedSourcesTraitExtension extends RenamedMixedSourcesTrait {}
+
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
 export const RenamedMixedSourcesTraitExtension = {
@@ -555,7 +579,7 @@ const Registration = {
 };
 export default Registration;",
     "name": "RenamedMixedSourcesTraitExtension",
-    "suggestedFileName": "renamed-mixed-sources.ext.js",
+    "suggestedFileName": "renamed-mixed-sources.ext.ts",
     "type": "trait-extension",
   },
 ]
@@ -766,6 +790,10 @@ export interface UnsupportedSourceTrait {
 import { hasMany } from '@unsupported/source';
 import { computed } from '@ember/object';
 
+import type { UnsupportedSourceTrait } from 'test-app/data/traits/unsupported-source.type';
+
+export interface UnsupportedSourceTraitExtension extends UnsupportedSourceTrait {}
+
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
 export const UnsupportedSourceTraitExtension = {
@@ -780,7 +808,7 @@ const Registration = {
 };
 export default Registration;",
     "name": "UnsupportedSourceTraitExtension",
-    "suggestedFileName": "unsupported-source.ext.js",
+    "suggestedFileName": "unsupported-source.ext.ts",
     "type": "trait-extension",
   },
 ]
@@ -864,6 +892,10 @@ export interface DefaultSourceTrait {
   "
 
 import { computed } from '@ember/object';
+
+import type { DefaultSourceTrait } from 'test-app/data/traits/default-source.type';
+
+export interface DefaultSourceTraitExtension extends DefaultSourceTrait {}
 
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
@@ -1000,6 +1032,10 @@ export interface NoValidImportsTrait {
 import { computed } from '@ember/object';
 import { attr } from '@unsupported/source';
 
+import type { NoValidImportsTrait } from 'test-app/data/traits/no-valid-imports.type';
+
+export interface NoValidImportsTraitExtension extends NoValidImportsTrait {}
+
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
 export const NoValidImportsTraitExtension = {
@@ -1014,7 +1050,7 @@ const Registration = {
 };
 export default Registration;",
     "name": "NoValidImportsTraitExtension",
-    "suggestedFileName": "no-valid-imports.ext.js",
+    "suggestedFileName": "no-valid-imports.ext.ts",
     "type": "trait-extension",
   },
 ]
@@ -1098,6 +1134,10 @@ export interface AuditboardSourceTrait {
 
 import { computed } from '@ember/object';
 
+import type { AuditboardSourceTrait } from 'test-app/data/traits/auditboard-source.type';
+
+export interface AuditboardSourceTraitExtension extends AuditboardSourceTrait {}
+
 // TODO: migrate this extension to a class so that TypeScript declaration merging works.
 // Object extensions do not support interface merging.
 export const AuditboardSourceTraitExtension = {
@@ -1111,7 +1151,7 @@ const Registration = {
 };
 export default Registration;",
     "name": "AuditboardSourceTraitExtension",
-    "suggestedFileName": "auditboard-source.ext.js",
+    "suggestedFileName": "auditboard-source.ext.ts",
     "type": "trait-extension",
   },
 ]

--- a/tests/codemods/tests/schema-migration/transforms/__snapshots__/model-to-schema.test.ts.snap
+++ b/tests/codemods/tests/schema-migration/transforms/__snapshots__/model-to-schema.test.ts.snap
@@ -1,8 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`model-to-schema transform (artifacts) > TypeScript type artifacts > generates schema and extension artifacts when model has methods and computed properties > model extension code 1`] = `
-"
+"import type { ProcessedModel } from './processed-model.schema.ts';
 
+
+// @ts-ignore-error in reality fields are not merged, they are overridden
+export interface ProcessedModelExtension extends ProcessedModel {}
 export class ProcessedModelExtension {
   get displayName() {
   		return \`Processed: \${this.name}\`;
@@ -652,15 +655,18 @@ exports[`model-to-schema transform (artifacts) > basic functionality > produces 
   },
   {
     "name": "UserExtension",
-    "suggestedFileName": "user.ext.js",
+    "suggestedFileName": "user.ext.ts",
     "type": "resource-extension",
   },
 ]
 `;
 
 exports[`model-to-schema transform (artifacts) > basic functionality > produces schema and extension artifacts for basic model > extension code 1`] = `
-"
+"import type { User } from './user.schema.ts';
 
+
+// @ts-ignore-error in reality fields are not merged, they are overridden
+export interface UserExtension extends User {}
 export class UserExtension {
   get displayName() {
   		return this.name || this.email;

--- a/tests/codemods/tests/schema-migration/transforms/mixin-to-schema.test.ts
+++ b/tests/codemods/tests/schema-migration/transforms/mixin-to-schema.test.ts
@@ -74,6 +74,7 @@ describe('mixin-to-schema transform (artifacts)', () => {
       mixinImportSource: 'test-app/mixins',
       emberDataImportSource: '@ember-data/model',
       intermediateModelPaths: [],
+      forceTypeScript: true,
       dryRun: false,
       verbose: false,
     };
@@ -178,6 +179,10 @@ export default Mixin.create({
 
         import { computed } from '@ember/object';
 
+        import type { FileableTrait } from 'test-app/data/traits/fileable.type';
+
+        export interface FileableTraitExtension extends FileableTrait {}
+
         // TODO: migrate this extension to a class so that TypeScript declaration merging works.
         // Object extensions do not support interface merging.
         export const FileableTraitExtension = {
@@ -191,7 +196,7 @@ export default Mixin.create({
         };
         export default Registration;",
           "name": "FileableTraitExtension",
-          "suggestedFileName": "fileable.ext.js",
+          "suggestedFileName": "fileable.ext.ts",
           "type": "trait-extension",
         }
       `);
@@ -518,7 +523,7 @@ export default Mixin.create({
       expect(trait?.code).toMatchSnapshot('mixin trait type interface');
       expect(extension?.code).toMatchSnapshot('mixin extension code');
       expect(trait?.suggestedFileName).toBe('nameable.schema.ts');
-      expect(extension?.suggestedFileName).toBe('nameable.ext.js');
+      expect(extension?.suggestedFileName).toBe('nameable.ext.ts');
     });
 
     it('generates only trait artifact when mixin has only data fields', () => {
@@ -828,6 +833,7 @@ export default Mixin.create({
         modelImportSource: 'test-app/models',
         resourcesImport: 'test-app/data/resources',
         resourcesDir: './test-output/resources',
+        forceTypeScript: true,
         verbose: false,
         debug: false,
       };
@@ -870,6 +876,7 @@ export default Mixin.create({
         modelImportSource: 'test-app/models',
         resourcesImport: 'test-app/data/resources',
         resourcesDir: './test-output/resources',
+        forceTypeScript: true,
         verbose: false,
         debug: false,
       };

--- a/tests/codemods/tests/schema-migration/transforms/model-to-schema.test.ts
+++ b/tests/codemods/tests/schema-migration/transforms/model-to-schema.test.ts
@@ -648,7 +648,7 @@ export default class ProcessedModel extends Model {
       expect(schema?.code).toMatchSnapshot('model schema with merged types');
       expect(extension?.code).toMatchSnapshot('model extension code');
       expect(schema?.suggestedFileName).toBe('processed-model.schema.ts');
-      expect(extension?.suggestedFileName).toBe('processed-model.ext.js');
+      expect(extension?.suggestedFileName).toBe('processed-model.ext.ts');
     });
 
     it('handles custom type mappings in merged schema files', () => {
@@ -1193,7 +1193,10 @@ export default class Translatable extends Model {
         {
           "baseName": "test-model",
           "code": "import { memberAction } from 'test-app/decorators/api-actions';
+        import type { TestModel } from './test-model.schema.ts';
 
+        // @ts-ignore-error in reality fields are not merged, they are overridden
+        export interface TestModelExtension extends TestModel {}
         export class TestModelExtension {
           startProcess = memberAction({
                       path: 'start_process',
@@ -1220,7 +1223,7 @@ export default class Translatable extends Model {
         };
         export default Registration;",
           "name": "TestModelExtension",
-          "suggestedFileName": "test-model.ext.js",
+          "suggestedFileName": "test-model.ext.ts",
           "type": "resource-extension",
         }
       `);


### PR DESCRIPTION
The main goal of this PR is to simplify the configuration as well as provide sensible defaults. I.e. currently the typescript output is forced even though source files were `.js`.
Makes sure that just running the CLI doesn't do anything extraneous. Larger projects can provide their own config via `--config=my-config.json`.

- Removes `disableTypescriptSchemas` and `disableMissingTypeAutoGen`
- Changes `forceTypeScript` to correctly generate `.ext.ts` files now.
- Adds `--separate-types` to the cli
This effectively sets `combineSchemasAndTypes` to `false` which will generate `.type.ts` files.
- Changes the defaults to be more sensible for projects.
Previously the codemod would force typescript output even when not available.
We don't infer whether typescript is present as a dependency at this time.