### PR TITLE
FIx SignalHooks import path in @warp-drive/ember

### DIFF
--- a/warp-drive-packages/ember/src/install.ts
+++ b/warp-drive-packages/ember/src/install.ts
@@ -6,8 +6,7 @@ import { importSync } from '@embroider/macros';
 
 import { DEPRECATE_COMPUTED_CHAINS } from '@warp-drive/core/build-config/deprecations';
 import { TESTING } from '@warp-drive/core/build-config/env';
-import { setupSignals } from '@warp-drive/core/configure';
-import type { SignalHooks } from '@warp-drive/core/store/-private';
+import { setupSignals, type SignalHooks } from '@warp-drive/core/configure';
 
 type Tag = ReturnType<typeof tagForProperty>;
 const emberDirtyTag = dirtyTag as unknown as (tag: Tag) => void;


### PR DESCRIPTION
<!-- Thank you for opening up this PR! -->

Noticed broken import path when tried to use latest version in the app.

If this PR updates API docs, preview them by:

- install [bun](https://bun.sh/docs/installation) (if needed)
- install [volta](https://docs.volta.sh/guide/getting-started) and configure it for [pnpm](https://docs.volta.sh/advanced/pnpm) (if needed)
- run `pnpm install` in the root (if needed)
- run `pnpm preview` in the root

---

- Read the full [contributing documentation](https://github.com/warp-drive-data/warp-drive/blob/main/contributing/become-a-contributor.md)
- If you do not have permission to add labels or run the test-suite in CI, a team member will do this for you.
