### PR TITLE
remove import Ember from 'ember'

### DIFF
--- a/warp-drive-packages/legacy/src/compat/extensions.ts
+++ b/warp-drive-packages/legacy/src/compat/extensions.ts
@@ -1,6 +1,13 @@
-import { type default as EmberObject, get, set } from '@ember/object';
+import {
+  type default as EmberObject,
+  get,
+  getProperties,
+  notifyPropertyChange,
+  set,
+  setProperties,
+} from '@ember/object';
+import { addObserver, removeObserver } from '@ember/object/observers';
 import { compare } from '@ember/utils';
-import Ember from 'ember';
 
 import { assert } from '@warp-drive/core/build-config/macros';
 import type { CAUTION_MEGA_DANGER_ZONE_Extension } from '@warp-drive/core/reactive';
@@ -21,7 +28,41 @@ const EmberObjectMethods = [
 ] as const;
 EmberObjectMethods.forEach((method) => {
   EmberObjectFeatures[method] = function delegatedMethod(...args: unknown[]): unknown {
-    return (Ember[method] as (...args: unknown[]) => unknown)(this, ...args);
+    switch (method) {
+      case 'addObserver':
+        return (addObserver as (...args: unknown[]) => unknown)(this, ...args);
+        break;
+      case 'cacheFor':
+        throw new Error('this has been removed and will not be replaced');
+        break;
+      case 'decrementProperty':
+        throw new Error('Ember.decrementProperty never existed');
+        break;
+      case 'get':
+        return (get as (...args: unknown[]) => unknown)(this, ...args);
+        break;
+      case 'getProperties':
+        return (getProperties as (...args: unknown[]) => unknown)(this, ...args);
+        break;
+      case 'incrementProperty':
+        throw new Error('Ember.incrementProperty never existed');
+        break;
+      case 'notifyPropertyChange':
+        return (notifyPropertyChange as (...args: unknown[]) => unknown)(this, ...args);
+        break;
+      case 'removeObserver':
+        return (removeObserver as (...args: unknown[]) => unknown)(this, ...args);
+        break;
+      case 'set':
+        return (set as (...args: unknown[]) => unknown)(this, ...args);
+        break;
+      case 'setProperties':
+        return (setProperties as (...args: unknown[]) => unknown)(this, ...args);
+        break;
+      case 'toggleProperty':
+        throw new Error('Ember.toggleProperty never existed');
+        break;
+    }
   };
 });
 export const EmberObjectArrayExtension: CAUTION_MEGA_DANGER_ZONE_Extension = {


### PR DESCRIPTION
I'm not even sure when this file is being loaded but if we keep the `import Ember from "ember"` call it will break **eagerly** in Ember 7.0 because Vite freaks out.

Unfortunately, this isn't a complete 1-1 migration because:

- Ember.cacheFor was removed and will not be replaced https://deprecations.emberjs.com/id/deprecate-import-cache-for-from-ember
- I could not find any evidence of `decrementProperty`, `incrementProperty`, or `toggleProperty` exports from the global Ember namespace 🤔 or at least they weren't listed in the deprecation and the API docs seem to suggest they are member functions on EmberObjects not individiual functions 🤔 

I would appreciate some feedback on how to proceed here since this is blocking the Ember 7.0 release 