### PR TITLE
remove all `import Ember from 'ember'`

### DIFF
--- a/packages/-ember-data/src/-private/core.ts
+++ b/packages/-ember-data/src/-private/core.ts
@@ -1,5 +1,4 @@
 import Namespace from '@ember/application/namespace';
-import Ember from 'ember';
 
 import VERSION from '../version';
 
@@ -14,9 +13,5 @@ export const DS: DS = (Namespace as unknown as { create(args: CreateArgs): DS })
   VERSION: VERSION,
   name: 'DS',
 });
-
-if (Ember.libraries) {
-  Ember.libraries.registerCoreLibrary('Ember Data', VERSION);
-}
 
 export default DS;

--- a/packages/-ember-data/vite.config.mjs
+++ b/packages/-ember-data/vite.config.mjs
@@ -2,7 +2,6 @@ import { createConfig } from '@warp-drive/internal-config/vite/config.js';
 
 export const externals = [
   '@ember/application/namespace',
-  'ember',
   '@ember/debug',
   '@ember/array/proxy',
   '@ember/object/promise-proxy-mixin',

--- a/warp-drive-packages/legacy/src/compat/extensions.ts
+++ b/warp-drive-packages/legacy/src/compat/extensions.ts
@@ -36,7 +36,7 @@ EmberObjectMethods.forEach((method) => {
       case 'decrementProperty': {
         const key = args[0] as string;
         const decrement = (args[1] as number | undefined) ?? 1;
-        return set(this, key, (get(this, key) as number) - decrement);
+        return set(this, key, ((get(this, key) as number) || 0) - decrement);
       }
       case 'get':
         return (get as (...args: unknown[]) => unknown)(this, ...args);
@@ -45,7 +45,7 @@ EmberObjectMethods.forEach((method) => {
       case 'incrementProperty': {
         const key = args[0] as string;
         const increment = (args[1] as number | undefined) ?? 1;
-        return set(this, key, (get(this, key) as number) + increment);
+        return set(this, key, (parseFloat(get(this, key) as string) || 0) + increment);
       }
       case 'notifyPropertyChange':
         return (notifyPropertyChange as (...args: unknown[]) => unknown)(this, ...args);

--- a/warp-drive-packages/legacy/src/compat/extensions.ts
+++ b/warp-drive-packages/legacy/src/compat/extensions.ts
@@ -34,18 +34,26 @@ EmberObjectMethods.forEach((method) => {
       case 'cacheFor':
         throw new Error('cacheFor has been removed and will not be replaced');
       case 'decrementProperty': {
-        const key = args[0] as string;
-        const decrement = (args[1] as number | undefined) ?? 1;
-        return set(this, key, (parseFloat(get(this, key) as string) || 0) - decrement);
+        const keyName = args[0] as string;
+        const decrement = (args[1] as number) ?? 1;
+        assert(
+          'Must pass a numeric value to decrementProperty',
+          (typeof decrement === 'number' || !isNaN(parseFloat(decrement as unknown as string))) && isFinite(decrement)
+        );
+        return set(this, keyName, ((get(this, keyName) as number) || 0) - decrement);
       }
       case 'get':
         return (get as (...args: unknown[]) => unknown)(this, ...args);
       case 'getProperties':
         return (getProperties as (...args: unknown[]) => unknown)(this, ...args);
       case 'incrementProperty': {
-        const key = args[0] as string;
-        const increment = (args[1] as number | undefined) ?? 1;
-        return set(this, key, (parseFloat(get(this, key) as string) || 0) + increment);
+        const keyName = args[0] as string;
+        const increment = (args[1] as number) ?? 1;
+        assert(
+          'Must pass a numeric value to incrementProperty',
+          !isNaN(parseFloat(String(increment))) && isFinite(increment)
+        );
+        return set(this, keyName, (parseFloat(get(this, keyName) as string) || 0) + increment);
       }
       case 'notifyPropertyChange':
         return (notifyPropertyChange as (...args: unknown[]) => unknown)(this, ...args);

--- a/warp-drive-packages/legacy/src/compat/extensions.ts
+++ b/warp-drive-packages/legacy/src/compat/extensions.ts
@@ -36,7 +36,7 @@ EmberObjectMethods.forEach((method) => {
       case 'decrementProperty': {
         const key = args[0] as string;
         const decrement = (args[1] as number | undefined) ?? 1;
-        return set(this, key, ((get(this, key) as number) || 0) - decrement);
+        return set(this, key, (parseFloat(get(this, key) as string) || 0) - decrement);
       }
       case 'get':
         return (get as (...args: unknown[]) => unknown)(this, ...args);

--- a/warp-drive-packages/legacy/src/compat/extensions.ts
+++ b/warp-drive-packages/legacy/src/compat/extensions.ts
@@ -1,6 +1,13 @@
-import { type default as EmberObject, get, set } from '@ember/object';
+import {
+  type default as EmberObject,
+  get,
+  getProperties,
+  notifyPropertyChange,
+  set,
+  setProperties,
+} from '@ember/object';
+import { addObserver, removeObserver } from '@ember/object/observers';
 import { compare } from '@ember/utils';
-import Ember from 'ember';
 
 import { assert } from '@warp-drive/core/build-config/macros';
 import type { CAUTION_MEGA_DANGER_ZONE_Extension } from '@warp-drive/core/reactive';
@@ -21,7 +28,38 @@ const EmberObjectMethods = [
 ] as const;
 EmberObjectMethods.forEach((method) => {
   EmberObjectFeatures[method] = function delegatedMethod(...args: unknown[]): unknown {
-    return (Ember[method] as (...args: unknown[]) => unknown)(this, ...args);
+    switch (method) {
+      case 'addObserver':
+        return (addObserver as (...args: unknown[]) => unknown)(this, ...args);
+      case 'cacheFor':
+        throw new Error('cacheFor has been removed and will not be replaced');
+      case 'decrementProperty': {
+        const key = args[0] as string;
+        const decrement = (args[1] as number | undefined) ?? 1;
+        return set(this, key, (get(this, key) as number) - decrement);
+      }
+      case 'get':
+        return (get as (...args: unknown[]) => unknown)(this, ...args);
+      case 'getProperties':
+        return (getProperties as (...args: unknown[]) => unknown)(this, ...args);
+      case 'incrementProperty': {
+        const key = args[0] as string;
+        const increment = (args[1] as number | undefined) ?? 1;
+        return set(this, key, (get(this, key) as number) + increment);
+      }
+      case 'notifyPropertyChange':
+        return (notifyPropertyChange as (...args: unknown[]) => unknown)(this, ...args);
+      case 'removeObserver':
+        return (removeObserver as (...args: unknown[]) => unknown)(this, ...args);
+      case 'set':
+        return (set as (...args: unknown[]) => unknown)(this, ...args);
+      case 'setProperties':
+        return (setProperties as (...args: unknown[]) => unknown)(this, ...args);
+      case 'toggleProperty': {
+        const key = args[0] as string;
+        return set(this, key, !get(this, key));
+      }
+    }
   };
 });
 export const EmberObjectArrayExtension: CAUTION_MEGA_DANGER_ZONE_Extension = {

--- a/warp-drive-packages/legacy/vite.config.mjs
+++ b/warp-drive-packages/legacy/vite.config.mjs
@@ -2,12 +2,12 @@ import { createConfig } from '@warp-drive/internal-config/vite/config.js';
 
 // FIXME audit this list
 export const externals = [
-  'ember',
   '@ember/utils',
   '@ember/service', // inject the store to base Adapter
   '@ember/debug',
   '@ember/object', // Adapter base, computed for headers
   '@ember/object/mixin', // BuildURLMixin
+  '@ember/object/observers',
   '@ember/application', // getOwner
   '@ember/object/computed',
   '@ember/object/internals',


### PR DESCRIPTION
## Summary

Completes the work started in #10509 to remove all `import Ember from 'ember'` calls, which break eagerly under Ember 7.0 + Vite.

### Changes

- **`warp-drive-packages/legacy/src/compat/extensions.ts`**: Replace the `Ember[method](this, ...args)` dynamic dispatch with a `switch`/`case` using specific imports from `@ember/object` and `@ember/object/observers`. `decrementProperty`, `incrementProperty`, and `toggleProperty` are implemented inline using `get`/`set` since they are EmberObject instance methods without standalone function equivalents. `cacheFor` throws as it has been [removed with no replacement](https://deprecations.emberjs.com/id/deprecate-import-cache-for-from-ember).
- **`packages/-ember-data/src/-private/core.ts`**: Remove `Ember.libraries.registerCoreLibrary()` entirely — `Ember.libraries` is deprecated with no replacement per [RFC 1003](https://rfcs.emberjs.com/id/1003-deprecation-import-ember-from-ember/).
- **`vite.config.mjs` (both packages)**: Remove `'ember'` from externals lists, add `'@ember/object/observers'`.

### CI verification (local)

- Build: 33/33 tasks pass
- Lint: 78/78 tasks pass
- Type check: 47/47 tasks pass

## Test plan

- [ ] CI passes on this PR
- [ ] Verify extensions still work correctly in Ember 6.x (backward compatible — all replaced APIs exist in Ember 6.x)
- [ ] Verify no eager failures in Ember 7.0 environment

Supersedes #10509

🤖 Generated with [Claude Code](https://claude.com/claude-code)