### PR TITLE
add ember-cli-deprecation-workflow to all Ember test apps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1613,6 +1613,9 @@ importers:
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.6.0)
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -1805,6 +1808,10 @@ importers:
       webpack:
         specifier: 5.101.3
         version: 5.101.3
+    devDependencies:
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
 
   tests/ember-data__graph:
     devDependencies:
@@ -1871,6 +1878,9 @@ importers:
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.6.0)
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -1994,6 +2004,9 @@ importers:
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.6.0)
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -2096,6 +2109,9 @@ importers:
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.6.0)
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -2231,6 +2247,9 @@ importers:
       decorator-transforms:
         specifier: ^2.3.0
         version: 2.3.0(@babel/core@7.28.3)
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
       ember-page-title:
         specifier: ^9.0.3
         version: 9.0.3(102b6eb8bd5c8762c16e3c7c1e24111d)
@@ -2459,6 +2478,9 @@ importers:
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.6.0)
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
       ember-cli-fastboot:
         specifier: ^4.1.5
         version: 4.1.5(99f756e609cd4fbefef47807d2112fb4)
@@ -2870,6 +2892,9 @@ importers:
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.6.0)
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -3095,6 +3120,9 @@ importers:
       ember-cli-babel:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.28.3)
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -3218,6 +3246,9 @@ importers:
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.6.0)
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -3389,6 +3420,9 @@ importers:
       ember-cli-babel:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.28.3)
+      ember-cli-deprecation-workflow:
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.28.3)
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -9014,6 +9048,9 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       ember-cli: ^3.2.0 || >=4.0.0
+
+  ember-cli-deprecation-workflow@4.0.1:
+    resolution: {integrity: sha512-XJzUZVXyb6/nFKU7GzGRlHlcAl4KtkioBTjfuIHp1aysbRZ6XxYLSPtP090EbOxQBtYwAPsH2kPAtPS86tL2RA==}
 
   ember-cli-fastboot-testing@0.6.2:
     resolution: {integrity: sha512-RwOM0Y2fT5PtiMkG7yXWCaCLGFatwKpfPT4Xt6Hxqf2ZAEkbVQWJw/aFaKLLOAo2kfted8nKdkRvZM6Jm647Pg==}
@@ -21744,6 +21781,14 @@ snapshots:
       is-git-url: 1.0.0
       resolve: 1.22.10
       semver: 5.7.2
+
+  ember-cli-deprecation-workflow@4.0.1(@babel/core@7.28.3):
+    dependencies:
+      '@embroider/addon-shim': 1.10.2
+      decorator-transforms: 2.3.0(@babel/core@7.28.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   ember-cli-fastboot-testing@0.6.2(7aa7b21109ac11426f1256bfd742b487):
     dependencies:

--- a/tests/dont-write-new-tests-here/app/app.ts
+++ b/tests/dont-write-new-tests-here/app/app.ts
@@ -1,4 +1,5 @@
 import '@warp-drive/ember/install';
+import './deprecation-workflow';
 
 // disable the normalization cache as we no longer normalize, the cache has become a bottle neck.
 // import { Registry } from '@ember/-internals/container';

--- a/tests/dont-write-new-tests-here/app/deprecation-workflow.ts
+++ b/tests/dont-write-new-tests-here/app/deprecation-workflow.ts
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/dont-write-new-tests-here/app/deprecation-workflow.ts
+++ b/tests/dont-write-new-tests-here/app/deprecation-workflow.ts
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/dont-write-new-tests-here/package.json
+++ b/tests/dont-write-new-tests-here/package.json
@@ -99,7 +99,8 @@
     "qunit-dom": "^3.5.0",
     "testem": "^3.12.0",
     "typescript": "^5.9.2",
-    "webpack": "^5.101.3"
+    "webpack": "^5.101.3",
+    "ember-cli-deprecation-workflow": "^4.0.1"
   },
   "ember": {
     "edition": "octane"

--- a/tests/ember-data__adapter/app/app.js
+++ b/tests/ember-data__adapter/app/app.js
@@ -1,4 +1,5 @@
 import '@warp-drive/ember/install';
+import './deprecation-workflow';
 
 import Application from '@ember/application';
 

--- a/tests/ember-data__adapter/app/deprecation-workflow.js
+++ b/tests/ember-data__adapter/app/deprecation-workflow.js
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/ember-data__adapter/app/deprecation-workflow.js
+++ b/tests/ember-data__adapter/app/deprecation-workflow.js
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/ember-data__adapter/package.json
+++ b/tests/ember-data__adapter/package.json
@@ -69,5 +69,8 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "packageManager": "pnpm@10.15.0"
+  "packageManager": "pnpm@10.15.0",
+  "devDependencies": {
+    "ember-cli-deprecation-workflow": "^4.0.1"
+  }
 }

--- a/tests/ember-data__graph/app/app.ts
+++ b/tests/ember-data__graph/app/app.ts
@@ -1,4 +1,5 @@
 import '@warp-drive/ember/install';
+import './deprecation-workflow';
 
 import Application from '@ember/application';
 

--- a/tests/ember-data__graph/app/deprecation-workflow.ts
+++ b/tests/ember-data__graph/app/deprecation-workflow.ts
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/ember-data__graph/app/deprecation-workflow.ts
+++ b/tests/ember-data__graph/app/deprecation-workflow.ts
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/ember-data__graph/package.json
+++ b/tests/ember-data__graph/package.json
@@ -59,7 +59,8 @@
     "loader.js": "^4.7.0",
     "silent-error": "^1.1.1",
     "typescript": "^5.9.2",
-    "webpack": "^5.101.3"
+    "webpack": "^5.101.3",
+    "ember-cli-deprecation-workflow": "^4.0.1"
   },
   "ember": {
     "edition": "octane"

--- a/tests/ember-data__model/app/app.js
+++ b/tests/ember-data__model/app/app.js
@@ -1,4 +1,5 @@
 import '@warp-drive/ember/install';
+import './deprecation-workflow';
 
 import Application from '@ember/application';
 

--- a/tests/ember-data__model/app/deprecation-workflow.js
+++ b/tests/ember-data__model/app/deprecation-workflow.js
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/ember-data__model/app/deprecation-workflow.js
+++ b/tests/ember-data__model/app/deprecation-workflow.js
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/ember-data__model/package.json
+++ b/tests/ember-data__model/package.json
@@ -60,7 +60,8 @@
     "ember-source": "~6.6.0",
     "loader.js": "^4.7.0",
     "typescript": "^5.9.2",
-    "webpack": "^5.101.3"
+    "webpack": "^5.101.3",
+    "ember-cli-deprecation-workflow": "^4.0.1"
   },
   "ember": {
     "edition": "octane"

--- a/tests/ember-data__request/app/app.ts
+++ b/tests/ember-data__request/app/app.ts
@@ -1,3 +1,5 @@
+import './deprecation-workflow';
+
 import Application from '@ember/application';
 
 import loadInitializers from 'ember-load-initializers';

--- a/tests/ember-data__request/app/deprecation-workflow.ts
+++ b/tests/ember-data__request/app/deprecation-workflow.ts
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/ember-data__request/app/deprecation-workflow.ts
+++ b/tests/ember-data__request/app/deprecation-workflow.ts
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/ember-data__request/package.json
+++ b/tests/ember-data__request/package.json
@@ -63,7 +63,8 @@
     "loader.js": "^4.7.0",
     "silent-error": "^1.1.1",
     "typescript": "^5.9.2",
-    "webpack": "^5.101.3"
+    "webpack": "^5.101.3",
+    "ember-cli-deprecation-workflow": "^4.0.1"
   },
   "ember": {
     "edition": "octane"

--- a/tests/example-app-ember/app/app.gts
+++ b/tests/example-app-ember/app/app.gts
@@ -1,4 +1,5 @@
 import '@warp-drive/ember/install';
+import './deprecation-workflow';
 
 import EmberRouter from '@ember/routing/router';
 

--- a/tests/example-app-ember/app/deprecation-workflow.ts
+++ b/tests/example-app-ember/app/deprecation-workflow.ts
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/example-app-ember/app/deprecation-workflow.ts
+++ b/tests/example-app-ember/app/deprecation-workflow.ts
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/example-app-ember/package.json
+++ b/tests/example-app-ember/package.json
@@ -75,7 +75,8 @@
     "qunit-dom": "^3.5.0",
     "typescript": "^5.9.2",
     "testem": "^3.16.0",
-    "vite": "^7.1.3"
+    "vite": "^7.1.3",
+    "ember-cli-deprecation-workflow": "^4.0.1"
   },
   "ember": {
     "edition": "octane"

--- a/tests/fastboot/app/app.ts
+++ b/tests/fastboot/app/app.ts
@@ -1,4 +1,5 @@
 import '@warp-drive/ember/install';
+import './deprecation-workflow';
 
 import Application from '@ember/application';
 

--- a/tests/fastboot/app/deprecation-workflow.ts
+++ b/tests/fastboot/app/deprecation-workflow.ts
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/fastboot/app/deprecation-workflow.ts
+++ b/tests/fastboot/app/deprecation-workflow.ts
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/fastboot/package.json
+++ b/tests/fastboot/package.json
@@ -56,7 +56,8 @@
     "qunit": "^2.20.1",
     "typescript": "^5.9.2",
     "testem": "^3.12.0",
-    "webpack": "^5.101.3"
+    "webpack": "^5.101.3",
+    "ember-cli-deprecation-workflow": "^4.0.1"
   },
   "ember": {
     "edition": "octane"

--- a/tests/json-api/app/app.ts
+++ b/tests/json-api/app/app.ts
@@ -1,3 +1,5 @@
+import './deprecation-workflow';
+
 import Application from '@ember/application';
 
 import loadInitializers from 'ember-load-initializers';

--- a/tests/json-api/app/deprecation-workflow.ts
+++ b/tests/json-api/app/deprecation-workflow.ts
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/json-api/app/deprecation-workflow.ts
+++ b/tests/json-api/app/deprecation-workflow.ts
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/json-api/package.json
+++ b/tests/json-api/package.json
@@ -61,7 +61,8 @@
     "loader.js": "^4.7.0",
     "silent-error": "^1.1.1",
     "typescript": "^5.9.2",
-    "webpack": "^5.101.3"
+    "webpack": "^5.101.3",
+    "ember-cli-deprecation-workflow": "^4.0.1"
   },
   "ember": {
     "edition": "octane"

--- a/tests/performance/app/app.js
+++ b/tests/performance/app/app.js
@@ -2,6 +2,7 @@
 // prior to app boot
 // import './services/store';
 import '@warp-drive/ember/install';
+import './deprecation-workflow';
 
 import Application from '@ember/application';
 

--- a/tests/performance/app/deprecation-workflow.js
+++ b/tests/performance/app/deprecation-workflow.js
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/performance/app/deprecation-workflow.js
+++ b/tests/performance/app/deprecation-workflow.js
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/performance/package.json
+++ b/tests/performance/package.json
@@ -55,7 +55,8 @@
     "vite": "^7.1.3",
     "vite-bundle-analyzer": "^1.2.1",
     "vite-plugin-compression2": "^2.2.0",
-    "zlib": "1.0.5"
+    "zlib": "1.0.5",
+    "ember-cli-deprecation-workflow": "^4.0.1"
   },
   "sideEffects": [
     "@warp-drive/ember/install"

--- a/tests/utilities/app/app.ts
+++ b/tests/utilities/app/app.ts
@@ -1,4 +1,5 @@
 import '@warp-drive/ember/install';
+import './deprecation-workflow';
 
 import Application from '@ember/application';
 

--- a/tests/utilities/app/deprecation-workflow.ts
+++ b/tests/utilities/app/deprecation-workflow.ts
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/utilities/app/deprecation-workflow.ts
+++ b/tests/utilities/app/deprecation-workflow.ts
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/utilities/package.json
+++ b/tests/utilities/package.json
@@ -68,7 +68,8 @@
     "loader.js": "^4.7.0",
     "silent-error": "^1.1.1",
     "typescript": "^5.9.2",
-    "webpack": "^5.101.3"
+    "webpack": "^5.101.3",
+    "ember-cli-deprecation-workflow": "^4.0.1"
   },
   "ember": {
     "edition": "octane"

--- a/tests/vite-basic-compat/app/app.ts
+++ b/tests/vite-basic-compat/app/app.ts
@@ -1,4 +1,5 @@
 import '@warp-drive/ember/install';
+import './deprecation-workflow';
 
 import Application from '@ember/application';
 import compatModules from '@embroider/virtual/compat-modules';

--- a/tests/vite-basic-compat/app/deprecation-workflow.ts
+++ b/tests/vite-basic-compat/app/deprecation-workflow.ts
@@ -1,0 +1,6 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  throwOnUnhandled: false,
+  workflow: [],
+});

--- a/tests/vite-basic-compat/app/deprecation-workflow.ts
+++ b/tests/vite-basic-compat/app/deprecation-workflow.ts
@@ -1,6 +1,6 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  throwOnUnhandled: false,
+  throwOnUnhandled: true,
   workflow: [],
 });

--- a/tests/vite-basic-compat/package.json
+++ b/tests/vite-basic-compat/package.json
@@ -90,7 +90,8 @@
     "tracked-built-ins": "^4.0.0",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.40.0",
-    "vite": "^7.1.3"
+    "vite": "^7.1.3",
+    "ember-cli-deprecation-workflow": "^4.0.1"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## Summary

- Adds `ember-cli-deprecation-workflow` v4 to all 11 Ember test applications
- Creates `app/deprecation-workflow.{ts,js}` config files with empty workflow lists
- Imports the deprecation workflow in each app's entry point (`app/app.{ts,js,gts}`)

This enables deprecation management across the test suite, which is useful for the Ember 7.0 upgrade — deprecations can be silenced/tracked per-app rather than flooding test output.

### Apps updated

- `dont-write-new-tests-here`
- `ember-data__adapter`
- `ember-data__graph`
- `ember-data__model`
- `ember-data__request`
- `example-app-ember`
- `fastboot`
- `json-api`
- `performance`
- `utilities`
- `vite-basic-compat`

### CI verification (local)

- Prettier: pass
- Lint: 78/78 tasks pass
- Type check: 47/47 tasks pass

## Test plan

- [ ] CI passes
- [ ] Verify `deprecationWorkflow.flushDeprecations()` works in browser console during `pnpm test --serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)