### PR TITLE
chore: use explicit index files

### DIFF
--- a/guides/index.md
+++ b/guides/index.md
@@ -183,7 +183,7 @@ heavy immutability tricks such as spread, slice, and map.
 
 ## Mutation Management {#mutations}
 
-[Mutation](./the-manual/mutations) is handled within controlled contexts. The data to edit is "checked out" for editing, giving access to a mutable version. Local edits are seamlessly preserved if the user navigates away and returns without saving, and the changes are buffered from appearing elsewhere in your app until they are also committed to the server.
+[Mutation](./the-manual/mutations/index.md) is handled within controlled contexts. The data to edit is "checked out" for editing, giving access to a mutable version. Local edits are seamlessly preserved if the user navigates away and returns without saving, and the changes are buffered from appearing elsewhere in your app until they are also committed to the server.
 
 ```ts
 import { checkout } from '@warp-drive/core/reactive';

--- a/guides/the-manual/caching/index.md
+++ b/guides/the-manual/caching/index.md
@@ -277,7 +277,7 @@ By default, The Graph uses **upsert semantics** for a relationship payload with 
 
 This means that a field being absent from a relationship payload is semantically different from that field being present but with a value of `null` or an empty array. Being not-present means we do not replace the existing value.
 
-The Graph also has the ability to receive op-codes that deliver more granular modifications to relationships to add or remove specific values. For instance, if your application were to use WebSockets to receive streaming changes to a relationship, those changes could be applied directly without needing to fully replace the existing value. We'll cover these operations in the guide for [RealTime Support](../realtime).
+The Graph also has the ability to receive op-codes that deliver more granular modifications to relationships to add or remove specific values. For instance, if your application were to use WebSockets to receive streaming changes to a relationship, those changes could be applied directly without needing to fully replace the existing value. We'll cover these operations in the guide for [RealTime Support](../realtime/index.md).
 
 ## What about Mutation?
 


### PR DESCRIPTION
the last fix used a relative path that didn't include the final file