### PR TITLE
fix: address issues with import modernization lint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,12 +50,5 @@
   "bun.debugTerminal.enabled": true,
   "eslint.debug": true,
   "eslint.runtime": "node",
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "workbench.colorCustomizations": {
-    "titleBar.activeBackground": "#27ae60",
-    "titleBar.activeForeground": "#ffffff",
-    "titleBar.inactiveBackground": "#27ae60",
-    "titleBar.inactiveForeground": "#ffffff99"
-  },
-  "window.title": "⎇ runspired/fix-lint-imports   ${rootName}${separator}${appName}"
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,5 +50,12 @@
   "bun.debugTerminal.enabled": true,
   "eslint.debug": true,
   "eslint.runtime": "node",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "workbench.colorCustomizations": {
+    "titleBar.activeBackground": "#27ae60",
+    "titleBar.activeForeground": "#ffffff",
+    "titleBar.inactiveBackground": "#27ae60",
+    "titleBar.inactiveForeground": "#ffffff99"
+  },
+  "window.title": "⎇ runspired/fix-lint-imports   ${rootName}${separator}${appName}"
 }

--- a/packages/eslint-plugin-warp-drive/src/public-exports-mapping-5.5.enriched.json
+++ b/packages/eslint-plugin-warp-drive/src/public-exports-mapping-5.5.enriched.json
@@ -173,9 +173,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/adapter/error",
+      "export": "AdapterError",
+      "sourceFile": "warp-drive-packages/legacy/src/adapter/error.ts",
       "typeOnly": false
     }
   },
@@ -281,9 +281,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/adapter/json-api",
+      "export": "JSONAPIAdapter",
+      "sourceFile": "warp-drive-packages/legacy/src/adapter/json-api.ts",
       "typeOnly": false
     }
   },
@@ -293,9 +293,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/adapter/rest",
+      "export": "RESTAdapter",
+      "sourceFile": "warp-drive-packages/legacy/src/adapter/rest.ts",
       "typeOnly": false
     }
   },
@@ -365,10 +365,7 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false
+      "notFound": true
     }
   },
   {
@@ -377,10 +374,7 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false
+      "notFound": true
     }
   },
   {
@@ -389,10 +383,7 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false
+      "notFound": true
     }
   },
   {
@@ -449,9 +440,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/json-api",
+      "export": "JSONAPICache",
+      "sourceFile": "warp-drive-packages/json-api/src/index.ts",
       "typeOnly": false
     }
   },
@@ -1835,9 +1826,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/json",
+      "export": "JSONSerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/json.ts",
       "typeOnly": false
     }
   },
@@ -1847,9 +1838,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/json-api",
+      "export": "JSONAPISerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/json-api.ts",
       "typeOnly": false
     }
   },
@@ -1859,9 +1850,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/rest",
+      "export": "RESTSerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/rest.ts",
       "typeOnly": false
     }
   },
@@ -5480,10 +5471,7 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false
+      "notFound": true
     }
   },
   {
@@ -5492,10 +5480,7 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false
+      "notFound": true
     }
   },
   {
@@ -5762,9 +5747,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/adapter/json-api",
+      "export": "JSONAPIAdapter",
+      "sourceFile": "warp-drive-packages/legacy/src/adapter/json-api.ts",
       "typeOnly": false
     }
   },
@@ -5774,9 +5759,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/adapter/rest",
+      "export": "RESTAdapter",
+      "sourceFile": "warp-drive-packages/legacy/src/adapter/rest.ts",
       "typeOnly": false
     }
   },
@@ -5787,7 +5772,7 @@
     "typeOnly": false,
     "replacement": {
       "module": "@warp-drive/legacy/model",
-      "export": "default",
+      "export": "attr",
       "sourceFile": "warp-drive-packages/legacy/src/model.ts",
       "typeOnly": false
     }
@@ -5846,9 +5831,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/rest",
+      "export": "EmbeddedRecordsMixin",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/rest.ts",
       "typeOnly": false
     }
   },
@@ -5858,9 +5843,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/json",
+      "export": "JSONSerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/json.ts",
       "typeOnly": false
     }
   },
@@ -5870,9 +5855,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/json-api",
+      "export": "JSONAPISerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/json-api.ts",
       "typeOnly": false
     }
   },
@@ -5882,9 +5867,9 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/rest",
+      "export": "RESTSerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/rest.ts",
       "typeOnly": false
     }
   },
@@ -5894,10 +5879,7 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false
+      "notFound": true
     }
   },
   {
@@ -5930,10 +5912,7 @@
     "export": "default",
     "typeOnly": false,
     "replacement": {
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false
+      "notFound": true
     }
   }
 ]

--- a/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.js
@@ -114,7 +114,9 @@ function createHelpers(context) {
       return { kind: 'default', text: localName };
     }
     const text =
-      descriptor.targetExportName === localName ? descriptor.targetExportName : `${descriptor.targetExportName} as ${localName}`;
+      descriptor.targetExportName === localName
+        ? descriptor.targetExportName
+        : `${descriptor.targetExportName} as ${localName}`;
     return { kind: 'named', text };
   }
 

--- a/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.js
@@ -31,19 +31,21 @@ function buildMapping() {
 
   /**
    * Map key: `${module}::${exportName}` where exportName can be 'default'.
-   * Map value: replacement module string
+   * Map value: `{ module, export }` describing the replacement module and the
+   * (possibly renamed, possibly default<->named) export to use from it.
    */
   const lookup = new Map();
 
   if (Array.isArray(mappingArray)) {
     for (const entry of mappingArray) {
-      // Only consider non-type exports and entries that have a clear replacement.module
+      // Only consider non-type exports and entries that have a clear replacement
       if (!entry || entry.typeOnly) continue;
       const srcMod = entry.module;
       const exp = entry.export;
-      const repl = entry.replacement && entry.replacement.module;
-      if (!srcMod || !exp || !repl) continue;
-      lookup.set(`${srcMod}::${exp}`, repl);
+      const replModule = entry.replacement && entry.replacement.module;
+      const replExport = entry.replacement && entry.replacement.export;
+      if (!srcMod || !exp || !replModule || !replExport) continue;
+      lookup.set(`${srcMod}::${exp}`, { module: replModule, export: replExport });
     }
   }
 
@@ -69,50 +71,69 @@ function createHelpers(context) {
     return null;
   }
 
+  /**
+   * @typedef {{ spec: any, originalExportName: string | null, targetExportName: string | null }} SpecifierDescriptor
+   */
+
+  /** @returns {Record<string, SpecifierDescriptor[]>} */
   function groupImportSpecifiersByTarget(moduleName, specifiers) {
-    /** @type {Record<string, import('estree').ImportSpecifier[] | any[]>} */
     const groups = Object.create(null);
     for (const spec of specifiers) {
       const expName = getImportExportNameFromImportSpecifier(spec);
       if (!expName) {
-        // namespace or unknown – keep under original module
+        // namespace or unknown – keep under original module, verbatim
         groups[moduleName] ||= [];
-        groups[moduleName].push(spec);
+        groups[moduleName].push({ spec, originalExportName: null, targetExportName: null });
         continue;
       }
-      const key = `${moduleName}::${expName}`;
-      const target = MAPPING.get(key);
-      const targetModule = target || moduleName; // unknowns remain under original module
+      const target = MAPPING.get(`${moduleName}::${expName}`);
+      const targetModule = target ? target.module : moduleName; // unknowns remain under original module
+      const targetExportName = target ? target.export : expName; // unknowns keep their own export name
       groups[targetModule] ||= [];
-      groups[targetModule].push(spec);
+      groups[targetModule].push({ spec, originalExportName: expName, targetExportName });
     }
     return groups;
   }
 
   function hasAnyMappedTarget(groups, originalModule) {
-    return Object.keys(groups).some((mod) => mod !== originalModule);
+    return Object.keys(groups).some((mod) => {
+      if (mod !== originalModule) return true;
+      // Module didn't change, but the export itself may still have been renamed
+      // (e.g. default -> a named export, or a named export -> a different name).
+      return groups[mod].some((d) => d.originalExportName && d.targetExportName !== d.originalExportName);
+    });
   }
 
-  function buildImportTextForGroup(groupModule, specs, quote) {
-    const defaultSpecs = specs.filter((s) => s.type === 'ImportDefaultSpecifier');
-    const namedSpecs = specs.filter((s) => s.type === 'ImportSpecifier');
+  function buildSpecifierText(descriptor) {
+    if (descriptor.targetExportName == null) {
+      // namespace or unrecognized specifier – keep it exactly as written
+      return { kind: 'verbatim', text: sourceCode.getText(descriptor.spec) };
+    }
+    const localName = descriptor.spec.local.name;
+    if (descriptor.targetExportName === 'default') {
+      return { kind: 'default', text: localName };
+    }
+    const text =
+      descriptor.targetExportName === localName ? descriptor.targetExportName : `${descriptor.targetExportName} as ${localName}`;
+    return { kind: 'named', text };
+  }
 
-    const parts = ['import '];
-    if (defaultSpecs.length) {
-      // There can only be one default spec per declaration originally, but after grouping we still guard
-      parts.push(defaultSpecs.map((s) => sourceCode.getText(s)).join(', '));
-    }
-    if (namedSpecs.length) {
-      if (defaultSpecs.length) parts.push(', ');
-      const body = namedSpecs.map((s) => sourceCode.getText(s)).join(', ');
-      parts.push('{ ', body, ' }');
-    }
-    if (!defaultSpecs.length && !namedSpecs.length) {
+  function buildImportTextForGroup(groupModule, descriptors, quote) {
+    const rendered = descriptors.map(buildSpecifierText);
+    const defaults = rendered.filter((r) => r.kind === 'default').map((r) => r.text);
+    const verbatim = rendered.filter((r) => r.kind === 'verbatim').map((r) => r.text);
+    const named = rendered.filter((r) => r.kind === 'named').map((r) => r.text);
+
+    const segments = [];
+    if (defaults.length) segments.push(defaults.join(', '));
+    if (verbatim.length) segments.push(verbatim.join(', '));
+    if (named.length) segments.push(`{ ${named.join(', ')} }`);
+    if (!segments.length) {
       // Should not happen, but avoid generating invalid code
       return '';
     }
-    parts.push(' from ', quote, groupModule, quote, ';');
-    return parts.join('');
+
+    return ['import ', segments.join(', '), ' from ', quote, groupModule, quote, ';'].join('');
   }
 
   return {
@@ -154,22 +175,9 @@ module.exports = {
       const groupKeys = Object.keys(groups);
       const quote = helpers.getQuoteChar(node);
 
-      // Simple case: all specifiers map to a single replacement module and none remain at original
-      if (groupKeys.length === 1 && groupKeys[0] !== fromModule) {
-        const target = groupKeys[0];
-        context.report({
-          node,
-          messageId: RULE_ID,
-          data: { kind: 'import', from: fromModule },
-          fix(fixer) {
-            const newText = `${quote}${target}${quote}`;
-            return fixer.replaceText(node.source, newText);
-          },
-        });
-        return;
-      }
-
-      // Split into multiple imports
+      // Rebuild every group's specifier text from scratch (rather than only swapping the
+      // module string) since a replacement export may differ in name and/or default-vs-named
+      // kind from the original specifier.
       context.report({
         node,
         messageId: RULE_ID,

--- a/packages/eslint-plugin-warp-drive/tests/no-legacy-imports.js
+++ b/packages/eslint-plugin-warp-drive/tests/no-legacy-imports.js
@@ -61,5 +61,23 @@ eslintTester.run('no-legacy-imports', rule, {
       output: `import Model, { hasMany } from '@warp-drive/legacy/model';\nimport { Unknown } from '@ember-data/model';`,
       errors: [{ messageId: msg }],
     },
+    // Default import whose replacement is a named export must be rewritten to a
+    // named import, not just have its module string swapped (regression for #10525)
+    {
+      code: `import JSONAPIAdapter from '@ember-data/adapter/json-api';`,
+      output: `import { JSONAPIAdapter } from '@warp-drive/legacy/adapter/json-api';`,
+      errors: [{ messageId: msg }],
+    },
+    {
+      code: `import JSONAPISerializer from '@ember-data/serializer/json-api';`,
+      output: `import { JSONAPISerializer } from '@warp-drive/legacy/serializer/json-api';`,
+      errors: [{ messageId: msg }],
+    },
+    // Default import renamed locally must keep its local alias when converted to named
+    {
+      code: `import Adapter from '@ember-data/adapter/rest';`,
+      output: `import { RESTAdapter as Adapter } from '@warp-drive/legacy/adapter/rest';`,
+      errors: [{ messageId: msg }],
+    },
   ],
 });

--- a/public-exports-mapping-5.5.enriched.json
+++ b/public-exports-mapping-5.5.enriched.json
@@ -471,12 +471,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/adapter/error",
+      "export": "AdapterError",
+      "sourceFile": "warp-drive-packages/legacy/src/adapter/error.ts",
       "typeOnly": false,
-      "score": 3,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -769,12 +767,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/adapter/json-api",
+      "export": "JSONAPIAdapter",
+      "sourceFile": "warp-drive-packages/legacy/src/adapter/json-api.ts",
       "typeOnly": false,
-      "score": 3,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -795,12 +791,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/adapter/rest",
+      "export": "RESTAdapter",
+      "sourceFile": "warp-drive-packages/legacy/src/adapter/rest.ts",
       "typeOnly": false,
-      "score": 3,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -946,14 +940,7 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false,
-      "score": -0.5,
-      "missing": true,
-      "userAction": "auto",
-      "userSelectedIndex": 0
+      "notFound": true
     }
   },
   {
@@ -972,14 +959,7 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false,
-      "score": 0,
-      "missing": true,
-      "userAction": "auto",
-      "userSelectedIndex": 0
+      "notFound": true
     }
   },
   {
@@ -998,13 +978,7 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false,
-      "score": 0,
-      "userAction": "auto",
-      "userSelectedIndex": 0
+      "notFound": true
     }
   },
   {
@@ -1147,11 +1121,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/json-api",
+      "export": "JSONAPICache",
+      "sourceFile": "warp-drive-packages/json-api/src/index.ts",
       "typeOnly": false,
-      "score": -0.5,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -4553,12 +4526,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/json",
+      "export": "JSONSerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/json.ts",
       "typeOnly": false,
-      "score": 3,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -4579,12 +4550,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/json-api",
+      "export": "JSONAPISerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/json-api.ts",
       "typeOnly": false,
-      "score": 3,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -4605,12 +4574,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/rest",
+      "export": "RESTSerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/rest.ts",
       "typeOnly": false,
-      "score": 3,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -12779,13 +12746,7 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false,
-      "score": 0,
-      "userAction": "auto",
-      "userSelectedIndex": 0
+      "notFound": true
     }
   },
   {
@@ -12804,13 +12765,7 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false,
-      "score": 0,
-      "userAction": "auto",
-      "userSelectedIndex": 0
+      "notFound": true
     }
   },
   {
@@ -13417,12 +13372,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/adapter/json-api",
+      "export": "JSONAPIAdapter",
+      "sourceFile": "warp-drive-packages/legacy/src/adapter/json-api.ts",
       "typeOnly": false,
-      "score": 0,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -13443,12 +13396,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/adapter/rest",
+      "export": "RESTAdapter",
+      "sourceFile": "warp-drive-packages/legacy/src/adapter/rest.ts",
       "typeOnly": false,
-      "score": 0,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -13470,11 +13421,9 @@
         }
       ],
       "module": "@warp-drive/legacy/model",
-      "export": "default",
+      "export": "attr",
       "sourceFile": "warp-drive-packages/legacy/src/model.ts",
       "typeOnly": false,
-      "score": -0.5,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -13621,12 +13570,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/rest",
+      "export": "EmbeddedRecordsMixin",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/rest.ts",
       "typeOnly": false,
-      "score": 0,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -13647,12 +13594,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/json",
+      "export": "JSONSerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/json.ts",
       "typeOnly": false,
-      "score": 0,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -13673,12 +13618,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/json-api",
+      "export": "JSONAPISerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/json-api.ts",
       "typeOnly": false,
-      "score": 0,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -13699,12 +13642,10 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
+      "module": "@warp-drive/legacy/serializer/rest",
+      "export": "RESTSerializer",
+      "sourceFile": "warp-drive-packages/legacy/src/serializer/rest.ts",
       "typeOnly": false,
-      "score": 0,
-      "missing": true,
       "userAction": "auto",
       "userSelectedIndex": 0
     }
@@ -13725,13 +13666,7 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false,
-      "score": -0.5,
-      "userAction": "auto",
-      "userSelectedIndex": 0
+      "notFound": true
     }
   },
   {
@@ -13833,14 +13768,7 @@
           "isRoot": false
         }
       ],
-      "module": "@warp-drive/legacy/model",
-      "export": "default",
-      "sourceFile": "warp-drive-packages/legacy/src/model.ts",
-      "typeOnly": false,
-      "score": -0.5,
-      "missing": true,
-      "userAction": "auto",
-      "userSelectedIndex": 0
+      "notFound": true
     }
   }
 ]


### PR DESCRIPTION
resolves #10525

## Problem

The `no-legacy-imports` autofixer rewrote some legacy `@ember-data/*` imports to the wrong replacement. For example:

```diff
- import JSONAPIAdapter from '@ember-data/adapter/json-api';
+ import JSONAPIAdapter from '@warp-drive/legacy/model';
```

instead of the correct:

```diff
- import JSONAPIAdapter from '@ember-data/adapter/json-api';
+ import { JSONAPIAdapter } from '@warp-drive/legacy/adapter/json-api';
```

## Root causes

There were two independent bugs, one in the mapping data and one in the rule itself.

**1. Bad data in `public-exports-mapping-5.5.enriched.json`.** The generator script (`scripts/enrich-public-exports-mapping.ts`) guesses a canonical export name for a module's `default` export by capitalizing the last path segment (e.g. `rest` → `Rest`). That guess doesn't hold for names like `json-api` (real export: `JSONAPIAdapter`) or `rest` (real export: `RESTAdapter`). When the guessed name didn't match anything, the script fell back to whatever scored highest among *every* `default` export in the codebase — which happened to be `@warp-drive/legacy/model`'s default (`Model`) for essentially all adapter/serializer entries, plus a handful of unrelated ones (`@ember-data/debug`, the classic `ember-data` `DS` namespace, `ember-data/version`, etc.).

**2. The rule discarded the replacement's export name.** Even with correct data, `no-legacy-imports.js` only tracked the replacement *module* and, in the common single-target case, swapped just the module string in place — it never checked whether the replacement export was a different name or a different kind (default vs. named). So `import JSONAPIAdapter from '...'` would keep being emitted as a default import even when the new module only exports it as a named export.

## Fixes

- Corrected 21 mapping entries (in both `packages/eslint-plugin-warp-drive/src/public-exports-mapping-5.5.enriched.json` and the root copy) against the actual current re-export shims (e.g. `packages/adapter/src/json-api.ts`, `packages/serializer/src/rest.ts`):
  - `@ember-data/adapter/{error,json-api,rest}`, `@ember-data/serializer/{json,json-api,rest}`, their classic `ember-data/adapters/*` / `ember-data/serializers/*` equivalents, `ember-data/attr`, and `@ember-data/json-api` now point at their real target module/export instead of `@warp-drive/legacy/model`.
  - `@ember-data/debug*`, classic `ember-data` (the `DS` namespace), `ember-data/-private/core`, `ember-data/setup-container`, and `ember-data/version` have no modern equivalent, so they're now marked `notFound` — the rule leaves these imports alone instead of rewriting them to something unrelated.
- Reworked `no-legacy-imports.js` to track the replacement's export name end-to-end and rebuild each specifier (handling default↔named conversion and renames, preserving local aliases) rather than only swapping the module string.
- Added regression tests covering the exact scenario from the issue (`JSONAPIAdapter`, `JSONAPISerializer`) plus a locally-aliased default import.

## Test plan

- [x] `no-legacy-imports.js` mocha suite passes, including new regression cases
- [x] Existing rule test suite for the eslint plugin package passes (one pre-existing, unrelated failure in `no-external-request-patterns.js` exists on `main` too)
- [x] Verified both copies of the enriched mapping file are internally consistent for all changed entries
